### PR TITLE
[26830] Fix updating a relation type

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -130,12 +130,12 @@ class Relation < ActiveRecord::Base
   end
 
   def self.hierarchy_or_follows
-    with_type_columns_0(WorkPackage._dag_options.type_columns - %i(hierarchy follows))
+    with_type_columns_0(self.class._dag_options.type_columns - %i(hierarchy follows))
       .non_reflexive
   end
 
   def self.hierarchy_or_reflexive
-    with_type_columns_0(WorkPackage._dag_options.type_columns - %i(hierarchy))
+    with_type_columns_0(self.class._dag_options.type_columns - %i(hierarchy))
   end
 
   def self.non_hierarchy_of_work_package(work_package)

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -130,12 +130,12 @@ class Relation < ActiveRecord::Base
   end
 
   def self.hierarchy_or_follows
-    with_type_columns_0(self.class._dag_options.type_columns - %i(hierarchy follows))
+    with_type_columns_0(_dag_options.type_columns - %i(hierarchy follows))
       .non_reflexive
   end
 
   def self.hierarchy_or_reflexive
-    with_type_columns_0(self.class._dag_options.type_columns - %i(hierarchy))
+    with_type_columns_0(_dag_options.type_columns - %i(hierarchy))
   end
 
   def self.non_hierarchy_of_work_package(work_package)

--- a/frontend/app/components/wp-relations/wp-relation-row/wp-relation-row.template.html
+++ b/frontend/app/components/wp-relations/wp-relation-row/wp-relation-row.template.html
@@ -5,7 +5,7 @@
 
         <div class="grid-content medium-3 collapse">
             <span class="relation-row--type"
-                  ng-click="$ctrl.userInputs.showRelationTypesForm = true"
+                  ng-click="$ctrl.activateRelationTypeEdit()"
                   tabindex="0"
                   ng-if="!$ctrl.userInputs.showRelationTypesForm">
 
@@ -22,6 +22,7 @@
                         ng-model="$ctrl.selectedRelationType"
                         role="listbox"
                         focus
+                        ng-keydown="$ctrl.cancelRelationTypeEditOnEscape($event)"
                         ng-options="relationType.name for relationType in $ctrl.availableRelationTypes"
                         ng-change="$ctrl.saveRelationType()"></select>
             </div>

--- a/frontend/app/components/wp-relations/wp-relations.service.ts
+++ b/frontend/app/components/wp-relations/wp-relations.service.ts
@@ -83,9 +83,21 @@ export class WorkPackageRelationsService extends StateCacheService<RelationsStat
   }
 
   /**
-   * Update the given relation
+   * Update the given relation type, setting new values for from and to
    */
-  public updateRelation(workPackageId:string, relation:RelationResourceInterface, params:any) {
+  public updateRelationType(from:WorkPackageResourceInterface, to:WorkPackageResourceInterface, relation:RelationResourceInterface, type:string) {
+    const params = {
+      _links: {
+        from: {href: from.href},
+        to: {href: to.href}
+      },
+      type: type
+    };
+
+    return this.updateRelation(relation, params);
+  }
+
+  public updateRelation(relation:RelationResourceInterface, params:{[key:string]: any}) {
     return relation.updateImmediately(params)
       .then((savedRelation:RelationResourceInterface) => {
         this.insertIntoStates(savedRelation);

--- a/spec/features/work_packages/details/details_relations_spec.rb
+++ b/spec/features/work_packages/details/details_relations_spec.rb
@@ -104,13 +104,15 @@ describe 'Work package relations tab', js: true, selenium: true do
     let(:toggle_btn_selector) { '#wp-relation-group-by-toggle' }
     let(:visit) { false }
 
-    it 'allows to toggle how relations are grouped' do
+    before do
       visit_relations
 
       work_packages_page.visit_tab!('relations')
       work_packages_page.expect_subject
       loading_indicator_saveguard
+    end
 
+    it 'allows to toggle how relations are grouped' do
       # Expect to be grouped by relation type by default
       expect(page).to have_selector(toggle_btn_selector,
                                     text: 'Group by work package type', wait: 10)
@@ -129,6 +131,23 @@ describe 'Work package relations tab', js: true, selenium: true do
 
       expect(page).to have_selector('.relation-row--type', text: 'Follows')
       expect(page).to have_selector('.relation-row--type', text: 'Related To')
+    end
+
+    it 'allows to edit relation types when toggled' do
+      find(toggle_btn_selector).click
+      expect(page).to have_selector(toggle_btn_selector, text: 'Group by relation type', wait: 10)
+
+      expect(page).to have_selector('.relation-row--type', text: 'Follows')
+      expect(page).to have_selector('.relation-row--type', text: 'Related To')
+
+      # Expect current to be follows, then edit to blocks
+      relations.edit_relation_type(to_1, to_type: 'blocks')
+
+      expect(page).to have_selector('.relation-row--type', text: 'Blocks')
+      expect(page).to have_selector('.relation-row--type', text: 'Related To')
+
+      updated_relation = Relation.find(relation_1.id)
+      expect(updated_relation.relation_type).to eq(:blocks) # ! Reports mixed
     end
   end
 

--- a/spec/features/work_packages/details/details_relations_spec.rb
+++ b/spec/features/work_packages/details/details_relations_spec.rb
@@ -147,7 +147,7 @@ describe 'Work package relations tab', js: true, selenium: true do
       expect(page).to have_selector('.relation-row--type', text: 'Related To')
 
       updated_relation = Relation.find(relation_1.id)
-      expect(updated_relation.relation_type).to eq(:blocks) # ! Reports mixed
+      expect(updated_relation.relation_type).to eq('blocks')
     end
   end
 

--- a/spec/models/relation_spec.rb
+++ b/spec/models/relation_spec.rb
@@ -120,19 +120,20 @@ describe Relation, type: :model do
   end
 
   describe '#relation_type=' do
-    let(:column_name) { :relates }
+    let(:column_name) { 'relates' }
     let(:type) { :relates }
     let(:relation) do
-      FactoryGirl.build_stubbed(:relation,
-                                relation_type: :relates,
-                                relates: 1)
+      FactoryGirl.build(:relation,
+                        relation_type: 'relates')
     end
 
     it 'updates the column value' do
+      relation.save!
       expect(relation.relates).to eq 1
 
-      relation.relation_type = :duplicates
-      expect(relation.relation_type).to eq(:duplicates)
+      relation.relation_type = 'duplicates'
+      relation.save!
+      expect(relation.relation_type).to eq('duplicates')
 
       expect(relation.relates).to eq 0
       expect(relation.duplicates).to eq 1

--- a/spec/models/relation_spec.rb
+++ b/spec/models/relation_spec.rb
@@ -119,6 +119,26 @@ describe Relation, type: :model do
     end
   end
 
+  describe '#relation_type=' do
+    let(:column_name) { :relates }
+    let(:type) { :relates }
+    let(:relation) do
+      FactoryGirl.build_stubbed(:relation,
+                                relation_type: :relates,
+                                relates: 1)
+    end
+
+    it 'updates the column value' do
+      expect(relation.relates).to eq 1
+
+      relation.relation_type = :duplicates
+      expect(relation.relation_type).to eq(:duplicates)
+
+      expect(relation.relates).to eq 0
+      expect(relation.duplicates).to eq 1
+    end
+  end
+
   describe 'follows / precedes' do
     context 'for FOLLOWS' do
       let(:type) { Relation::TYPE_FOLLOWS }

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -49,6 +49,14 @@ module Components
         page.find(".relation-row-#{relatable.id} .wp-relations--subject-field").click
       end
 
+      def edit_relation_type(relatable, to_type:)
+        row = find_row(relatable)
+        row.find('.relation-row--type').click
+
+        expect(row).to have_selector('select.wp-inline-edit--field')
+        row.find('.wp-inline-edit--field option', text: to_type).select_option
+      end
+
       def hover_action(relatable, action)
         retry_block do
           # Focus type edit to expose buttons


### PR DESCRIPTION
https://community.openproject.com/wp/26830


**Issues**

- Updating a relation sets the new relation column + 1, but does not remove the old one (that should be the case for a direct relationship)
