### PR TITLE
[26829] Patch reform-rails to use activerecord i18n_scope

### DIFF
--- a/config/initializers/reform.rb
+++ b/config/initializers/reform.rb
@@ -38,6 +38,16 @@ Reform::Contract.class_eval do
   include Reform::Form::ActiveModel::Validations
 end
 
+Reform::Form::ActiveModel::Validations::Validator.class_eval do
+  ##
+  # use activerecord as the base scope instead of 'activemodel' to be compatible
+  # to the messages we have already stored
+  def self.i18n_scope
+    :activerecord
+  end
+end
+
+
 require 'reform/contract'
 
 require 'open_project/patches/reform'

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -260,6 +260,18 @@ describe WorkPackages::BaseContract do
   describe 'due date' do
     it_behaves_like 'a parent unwritable property', :due_date
     it_behaves_like 'a date attribute', :due_date
+
+    it 'returns an error when trying to set it before the start date' do
+      work_package.start_date = Date.today + 2.days
+      work_package.due_date = Date.today
+
+      contract.validate
+
+      message = I18n.t('activerecord.errors.messages.greater_than_or_equal_to_start_date')
+
+      expect(contract.errors[:due_date])
+        .to include message
+    end
   end
 
   describe 'percentage done' do


### PR DESCRIPTION
The validator passed to AM::Error does not use the `i18n_scope` we
define on either Reform::Form or the model, but is delegated from the
included AM::Translations module.

This in turn causes I18n to lookup the scope `:activemodel`, failing the
localization.

https://github.com/trailblazer/reform-rails/issues/56
https://github.com/trailblazer/reform-rails/pull/35
  
https://community.openproject.com/wp/26829