### PR TITLE
allow AR to alias on distinct

### DIFF
--- a/app/helpers/sort_helper.rb
+++ b/app/helpers/sort_helper.rb
@@ -113,12 +113,16 @@ module SortHelper
     end
 
     def to_sql
-      sql = @criteria.map { |k, o|
-        if s = @available_criteria[k]
-          (o ? Array(s) : Array(s).map { |c| append_desc(c) }).join(', ')
-        end
-      }.compact.join(', ')
+      sql = to_a.join(', ')
       sql.blank? ? nil : sql
+    end
+
+    def to_a
+      @criteria
+        .map { |c, o| [@available_criteria[c], o] }
+        .reject { |c, _| c.nil? }
+        .map { |c, o| append_direction(Array(c), o) }
+        .compact
     end
 
     def add!(key, asc)
@@ -160,6 +164,14 @@ module SortHelper
 
       @criteria.slice!(3)
       self
+    end
+
+    def append_direction(criterion, asc = true)
+      if asc
+        criterion
+      else
+        criterion.map { |c| append_desc(c) }
+      end
     end
 
     # Appends DESC to the sort criterion unless it has a fixed order

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -85,7 +85,7 @@ class ::Query::Results
   # If there is a reason: This is a somewhat DRY way of using the sort criteria.
   # If there is no reason: The :work_package method can die over time and be replaced by this one.
   def sorted_work_packages
-    work_packages.order(sort_criteria_sql)
+    work_packages.order(sort_criteria_array)
   end
 
   def versions
@@ -219,11 +219,11 @@ class ::Query::Results
     columns.compact.uniq.map(&:to_sym)
   end
 
-  def sort_criteria_sql
+  def sort_criteria_array
     criteria = SortHelper::SortCriteria.new
     criteria.available_criteria = aliased_sorting_by_column_name
     criteria.criteria = query.sort_criteria
-    criteria.to_sql
+    criteria.to_a
   end
 
   def aliased_sorting_by_column_name


### PR DESCRIPTION
When passing a string to #order AR has no chance to alias columns. This can clash when two columns from different tables having the same name are part of the query (e.g. id). By providing an array, AR applies aliases to columns it needs to have in the projection on SELECT DISTINCT ... ORDER BY statements.

https://community.openproject.com/projects/openproject/work_packages/26815