### PR TITLE
tweak circular dependency detection when siblings already have a follows relation

### DIFF
--- a/spec/requests/api/v3/relations/relations_api_spec.rb
+++ b/spec/requests/api/v3/relations/relations_api_spec.rb
@@ -136,13 +136,17 @@ describe  'API v3 Relation resource', type: :request, content_type: :json do
       let(:sibling) do
         FactoryGirl.create(:work_package)
       end
+      let(:other_sibling) do
+        FactoryGirl.create(:work_package)
+      end
       let(:parent) do
         wp = FactoryGirl.create(:work_package)
 
-        wp.children = [sibling, from, to]
+        wp.children = [sibling, from, to, other_sibling]
       end
       let(:existing_follows) do
         FactoryGirl.create(:relation, relation_type: 'follows', from: to, to: sibling)
+        FactoryGirl.create(:relation, relation_type: 'follows', from: other_sibling, to: from)
       end
 
       let(:setup) do


### PR DESCRIPTION
Instead of going to root, we now only go up till to's first ancestor not shared with from. That way, we avoid wrongfully detecting transitive follows + hierarchy relations from to's root pointing to from.

https://community.openproject.com/projects/openproject/work_packages/26852