### PR TITLE
[268489] Use existing cells from the table to render active changes

### DIFF
--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -89,6 +89,14 @@ export class WorkPackageChangeset {
   }
 
   /**
+   * Get attributes
+   * @returns {string[]}
+   */
+  public get changedAttributes() {
+    return _.keys(this.changes);
+  }
+
+  /**
    * Retrieve the editing value for the given attribute
    *
    * @param {string} key The attribute to read

--- a/frontend/app/components/wp-fast-table/helpers/wp-table-row-helpers.ts
+++ b/frontend/app/components/wp-fast-table/helpers/wp-table-row-helpers.ts
@@ -10,6 +10,10 @@ export function locateTableRow(workPackageId:string):JQuery {
   return jQuery('.' + rowId(workPackageId));
 }
 
+export function locateTableRowByIdentifier(identifier:string) {
+  return jQuery(`.${identifier}-table`);
+}
+
 export function scrollTableRowIntoView(workPackageId:string):void {
   try {
     const element = locateTableRow(workPackageId);

--- a/frontend/app/components/wp-fast-table/wp-table-editing.ts
+++ b/frontend/app/components/wp-fast-table/wp-table-editing.ts
@@ -3,6 +3,7 @@ import {WorkPackageEditForm} from "../wp-edit-form/work-package-edit-form";
 import {TableRowEditContext} from "../wp-edit-form/table-row-edit-context";
 import {WorkPackageEditingService} from "../wp-edit-form/work-package-editing-service";
 import {$injectFields} from "../angular/angular-injector-bridge.functions";
+import {WorkPackageChangeset} from 'core-components/wp-edit-form/work-package-changeset';
 
 export class WorkPackageTableEditingContext {
   public wpEditing:WorkPackageEditingService;
@@ -16,6 +17,10 @@ export class WorkPackageTableEditingContext {
   public reset() {
     _.each(this.forms, (form) => form.destroy());
     this.forms = {};
+  }
+
+  public changeset(workPackageId:string):WorkPackageChangeset|undefined {
+    return this.wpEditing.state(workPackageId).value;
   }
 
   public stopEditing(workPackageId:string) {


### PR DESCRIPTION
This is a hack to identify old rows in the table when rendering new ones, should the associated work package have an active changeset.

This does not resolve the issue of opening a new column while the table reloads. A change is only marked in the changeset once the user entered/selected something so empty new columns are replaced.

https://community.openproject.com/wp/26848
  