### PR TITLE
[26855] Implement macro button for WP create

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1560,6 +1560,13 @@ en:
 
   macro_execution_error: "Error executing the macro %{macro_name}"
   macro_unavailable: "Macro %{macro_name} cannot be displayed."
+  macros:
+    create_work_package_link:
+      errors:
+        no_project_context: 'Calling create_work_package_link macro from outside project context.'
+        invalid_type: "No type found with name '%{type}' in project '%{project}'."
+      link_name: 'New work package'
+      link_name_type: 'New %{type_name}'
 
   mail:
     actions: 'Actions'

--- a/lib/open_project/wiki_formatting/macros/work_package_button.rb
+++ b/lib/open_project/wiki_formatting/macros/work_package_button.rb
@@ -1,0 +1,66 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject
+  module WikiFormatting
+    module Macros
+      module WorkPackageButton
+        Redmine::WikiFormatting::Macros.register do
+          desc 'Inserts a link or button to the create form of a work package'
+          macro :create_work_package_link do |_obj, args, options|
+            project = @project || options[:project]
+            if project.nil?
+              raise I18n.t('macros.create_work_package_link.errors.no_project_context')
+            end
+
+            type_name = args.shift
+            class_name = args.shift == 'button' ? 'button' : nil
+            if type_name.present?
+              type = project.types.find_by(name: type_name)
+              if type.nil?
+                raise I18n.t(
+                  'macros.create_work_package_link.errors.invalid_type',
+                  type: type_name,
+                  project: project.name
+                )
+              end
+
+              link_to I18n.t('macros.create_work_package_link.link_name_type', type_name: type_name),
+                      new_project_work_packages_path(project_id: project.identifier, type: type.id),
+                      class: class_name
+            else
+              link_to I18n.t('macros.create_work_package_link.link_name'),
+                      new_project_work_packages_path(project_id: project.identifier),
+                      class: class_name
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/redmine/wiki_formatting/macros.rb
+++ b/lib/redmine/wiki_formatting/macros.rb
@@ -93,6 +93,7 @@ module Redmine
         end
 
         include OpenProject::WikiFormatting::Macros::Default
+        include OpenProject::WikiFormatting::Macros::WorkPackageButton
       end
     end
   end

--- a/spec/lib/open_project/macros/work_package_buttons_macro_spec.rb
+++ b/spec/lib/open_project/macros/work_package_buttons_macro_spec.rb
@@ -1,0 +1,85 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'OpenProject work package button macros' do
+  include ActionView::Helpers::UrlHelper
+  include OpenProject::StaticRouting::UrlHelpers
+  include OpenProject::TextFormatting
+
+  def controller
+    # no-op
+  end
+
+  let(:type) { FactoryGirl.create :type, name: 'MyTaskName' }
+  let(:project) { FactoryGirl.create :valid_project, identifier: 'my-project', name: 'My project name', types: [type] }
+  let(:user) { FactoryGirl.create :admin }
+
+  let(:input) { }
+  subject { format_text(input, project: project) }
+
+  before do
+    login_as user
+    allow(Setting).to receive(:text_formatting).and_return('textile')
+  end
+
+  def error_html(exception_msg)
+    "<p><span class=\"flash error macro-unavailable permanent\"> " \
+          "Error executing the macro create_work_package_link (#{exception_msg}) </span></p>"
+  end
+
+  context 'when nothing passed' do
+    let(:input) { '{{create_work_package_link}}' }
+    it { is_expected.to be_html_eql("<p><a href=\"/projects/my-project/work_packages/new\">New work package</a></p>") }
+  end
+
+  context 'with invalid type' do
+    let(:input) { '{{create_work_package_link(InvalidType)}}' }
+    it { is_expected.to be_html_eql(error_html("No type found with name 'InvalidType' in project 'My project name'.")) }
+  end
+
+  context 'with valid type' do
+    let(:input) { '{{create_work_package_link(MyTaskName)}}' }
+    it { is_expected.to be_html_eql("<p><a href=\"/projects/my-project/work_packages/new?type=#{type.id}\">New MyTaskName</a></p>") }
+
+    context 'with button style' do
+      let(:input) { '{{create_work_package_link(MyTaskName, button)}}' }
+      it { is_expected.to be_html_eql("<p><a class=\"button\" href=\"/projects/my-project/work_packages/new?type=#{type.id}\">New MyTaskName</a></p>") }
+    end
+
+    context 'without project context' do
+      subject { format_text(input, project: nil) }
+
+      it 'does not raise, but print error' do
+        expect { subject }.not_to raise_error
+        is_expected.to be_html_eql(error_html('Calling create_work_package_link macro from outside project context.'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds `{{create_work_package_link(Typename)}}` macro with an optional second argument `button` to output as button style.

  https://community.openproject.com/wp/26855