### PR TITLE
bump rails to 5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,8 +106,7 @@ gem 'rack-attack', '~> 5.0.1'
 gem 'okcomputer', '~> 1.16.0'
 
 # Patch Rails HTML whitelisting for Angular curly braces
-# TODO: reactivate after compatibility with 5.1 has been established
-# gem 'rails-angular-xss', git: 'https://github.com/opf/rails-angular-xss', ref: 'a45267d5'
+gem 'rails-angular-xss', git: 'https://github.com/opf/rails-angular-xss', ref: '00b588b8b8b18c0f53fcb5232be1a2c34dbd1fac'
 
 gem 'gon', '~> 6.2.0'
 gem "syck", '~> 1.3.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -33,14 +33,14 @@ ruby '~> 2.4.2'
 gem 'actionpack-xml_parser', '~> 2.0.0'
 gem 'activemodel-serializers-xml', '~> 1.0.1'
 gem 'activerecord-session_store', '~> 1.1.0'
-gem 'rails', '~> 5.0.6'
+gem 'rails', '~> 5.1.5'
 gem 'responders', '~> 2.4'
 
 gem 'coderay', '~> 1.1.2'
 gem 'rubytree', git: 'https://github.com/dr0verride/RubyTree.git', ref: '06f53ee'
 gem 'rdoc', '>= 2.4.2'
 
-gem 'globalize', git: 'https://github.com/globalize/globalize', ref: '38443bcd', require: false
+gem 'globalize', '~> 5.1.0.beta2', require: false
 gem 'omniauth', git: 'https://github.com/oliverguenther/omniauth', ref: '40c6f5f751d2da7cce5444bbd96c390c450440a9'
 gem 'request_store', '~> 1.3.1'
 
@@ -106,7 +106,8 @@ gem 'rack-attack', '~> 5.0.1'
 gem 'okcomputer', '~> 1.16.0'
 
 # Patch Rails HTML whitelisting for Angular curly braces
-gem 'rails-angular-xss', git: 'https://github.com/opf/rails-angular-xss', ref: 'a45267d5'
+# TODO: reactivate after compatibility with 5.1 has been established
+# gem 'rails-angular-xss', git: 'https://github.com/opf/rails-angular-xss', ref: 'a45267d5'
 
 gem 'gon', '~> 6.2.0'
 gem "syck", '~> 1.3.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,14 @@ GIT
       rubyzip
 
 GIT
+  remote: https://github.com/opf/rails-angular-xss
+  revision: 00b588b8b8b18c0f53fcb5232be1a2c34dbd1fac
+  ref: 00b588b8b8b18c0f53fcb5232be1a2c34dbd1fac
+  specs:
+    rails-angular-xss (0.3.0.pre.pre)
+      rails (>= 5.0.0)
+
+GIT
   remote: https://github.com/rspec/rspec-activemodel-mocks
   revision: 5cd4c9d552bcc75d60ea4b7dda96e7377197ab8d
   specs:
@@ -674,6 +682,7 @@ DEPENDENCIES
   rack-test (~> 0.6.3)
   rack_session_access
   rails (~> 5.1.5)
+  rails-angular-xss!
   rails-controller-testing (~> 1.0.2)
   rails_12factor
   rails_autolink (~> 1.1.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,16 +21,6 @@ GIT
       activerecord (>= 4.0)
 
 GIT
-  remote: https://github.com/globalize/globalize
-  revision: 38443bcd07da78b7b8a9433e4c6c32dd51f964a3
-  ref: 38443bcd
-  specs:
-    globalize (5.1.0)
-      activemodel (>= 4.2, < 5.1)
-      activerecord (>= 4.2, < 5.1)
-      request_store (~> 1.0)
-
-GIT
   remote: https://github.com/goodwill/capybara-select2
   revision: 585192e4bb0db8d52e761ab68f08c17294806447
   ref: 585192e
@@ -59,14 +49,6 @@ GIT
       rubyzip
 
 GIT
-  remote: https://github.com/opf/rails-angular-xss
-  revision: a45267d53d32610bad01f903e9f1b49a81b7c37b
-  ref: a45267d5
-  specs:
-    rails-angular-xss (0.3.0.pre.pre)
-      rails (>= 5.0.0, < 5.1)
-
-GIT
   remote: https://github.com/rspec/rspec-activemodel-mocks
   revision: 5cd4c9d552bcc75d60ea4b7dda96e7377197ab8d
   specs:
@@ -78,54 +60,54 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (5.0.6)
-      actionpack (= 5.0.6)
-      nio4r (>= 1.2, < 3.0)
+    actioncable (5.1.5)
+      actionpack (= 5.1.5)
+      nio4r (~> 2.0)
       websocket-driver (~> 0.6.1)
-    actionmailer (5.0.6)
-      actionpack (= 5.0.6)
-      actionview (= 5.0.6)
-      activejob (= 5.0.6)
+    actionmailer (5.1.5)
+      actionpack (= 5.1.5)
+      actionview (= 5.1.5)
+      activejob (= 5.1.5)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (5.0.6)
-      actionview (= 5.0.6)
-      activesupport (= 5.0.6)
+    actionpack (5.1.5)
+      actionview (= 5.1.5)
+      activesupport (= 5.1.5)
       rack (~> 2.0)
-      rack-test (~> 0.6.3)
+      rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
     actionpack-xml_parser (2.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    actionview (5.0.6)
-      activesupport (= 5.0.6)
+    actionview (5.1.5)
+      activesupport (= 5.1.5)
       builder (~> 3.1)
-      erubis (~> 2.7.0)
+      erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
     active_record_query_trace (1.5.4)
-    activejob (5.0.6)
-      activesupport (= 5.0.6)
+    activejob (5.1.5)
+      activesupport (= 5.1.5)
       globalid (>= 0.3.6)
-    activemodel (5.0.6)
-      activesupport (= 5.0.6)
+    activemodel (5.1.5)
+      activesupport (= 5.1.5)
     activemodel-serializers-xml (1.0.1)
       activemodel (> 5.x)
       activerecord (> 5.x)
       activesupport (> 5.x)
       builder (~> 3.1)
-    activerecord (5.0.6)
-      activemodel (= 5.0.6)
-      activesupport (= 5.0.6)
-      arel (~> 7.0)
+    activerecord (5.1.5)
+      activemodel (= 5.1.5)
+      activesupport (= 5.1.5)
+      arel (~> 8.0)
     activerecord-session_store (1.1.0)
       actionpack (>= 4.0, < 5.2)
       activerecord (>= 4.0, < 5.2)
       multi_json (~> 1.11, >= 1.11.2)
       rack (>= 1.5.2, < 3)
       railties (>= 4.0, < 5.2)
-    activesupport (5.0.6)
+    activesupport (5.1.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -139,7 +121,7 @@ GEM
     airbrake (5.1.0)
       airbrake-ruby (~> 1.1)
     airbrake-ruby (1.5.0)
-    arel (7.1.4)
+    arel (8.0.0)
     ast (2.3.0)
     autoprefixer-rails (7.1.5)
       execjs
@@ -205,7 +187,7 @@ GEM
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.2)
+    crass (1.0.3)
     crowdin-api (0.5.0)
       rest-client (~> 2.0)
     cucumber (3.0.1)
@@ -262,7 +244,7 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erbse (0.0.2)
-    erubis (2.7.0)
+    erubi (1.7.0)
     eventmachine (1.2.3)
     excon (0.52.0)
     execjs (2.7.0)
@@ -297,8 +279,12 @@ GEM
       ruby-progressbar (~> 1.4)
     get_process_mem (0.2.1)
     gherkin (4.1.3)
-    globalid (0.4.0)
+    globalid (0.4.1)
       activesupport (>= 4.2.0)
+    globalize (5.1.0)
+      activemodel (>= 4.2, < 5.2)
+      activerecord (>= 4.2, < 5.2)
+      request_store (~> 1.0)
     gon (6.2.0)
       actionpack (>= 3.0)
       multi_json
@@ -317,7 +303,7 @@ GEM
     htmldiff (0.0.1)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.9.0)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     i18n-js (3.0.1)
       i18n (~> 0.6, >= 0.6.6)
@@ -341,7 +327,7 @@ GEM
       sass
       thor
       tilt
-    loofah (2.1.1)
+    loofah (2.2.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -349,11 +335,13 @@ GEM
     meta-tags (2.6.0)
       actionpack (>= 3.2.0, < 5.3)
     method_source (0.8.2)
-    mime-types (2.99.3)
-    mini_mime (0.1.4)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minisyntax (0.2.5)
-    minitest (5.10.3)
+    minitest (5.11.3)
     mixlib-shellout (2.1.0)
     msgpack (1.1.0)
     multi_json (1.12.2)
@@ -365,7 +353,7 @@ GEM
     net-ldap (0.16.0)
     netrc (0.11.0)
     newrelic_rpm (4.5.0.337)
-    nio4r (2.1.0)
+    nio4r (2.2.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     oj (3.3.8)
@@ -410,7 +398,7 @@ GEM
     public_suffix (3.0.0)
     rabl (0.13.1)
       activesupport (>= 2.3.14)
-    rack (2.0.3)
+    rack (2.0.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-attack (5.0.1)
@@ -422,17 +410,17 @@ GEM
     rack_session_access (0.1.1)
       builder (>= 2.0.0)
       rack (>= 1.0.0)
-    rails (5.0.6)
-      actioncable (= 5.0.6)
-      actionmailer (= 5.0.6)
-      actionpack (= 5.0.6)
-      actionview (= 5.0.6)
-      activejob (= 5.0.6)
-      activemodel (= 5.0.6)
-      activerecord (= 5.0.6)
-      activesupport (= 5.0.6)
+    rails (5.1.5)
+      actioncable (= 5.1.5)
+      actionmailer (= 5.1.5)
+      actionpack (= 5.1.5)
+      actionview (= 5.1.5)
+      activejob (= 5.1.5)
+      activemodel (= 5.1.5)
+      activerecord (= 5.1.5)
+      activesupport (= 5.1.5)
       bundler (>= 1.3.0)
-      railties (= 5.0.6)
+      railties (= 5.1.5)
       sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.2)
       actionpack (~> 5.x, >= 5.0.1)
@@ -450,16 +438,16 @@ GEM
       rails (> 3.1)
     rails_serve_static_assets (0.0.5)
     rails_stdout_logging (0.0.5)
-    railties (5.0.6)
-      actionpack (= 5.0.6)
-      activesupport (= 5.0.6)
+    railties (5.1.5)
+      actionpack (= 5.1.5)
+      activesupport (= 5.1.5)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
     raindrops (0.19.0)
-    rake (12.1.0)
+    rake (12.3.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -573,7 +561,7 @@ GEM
     ttfunk (1.5.0)
     typed_dag (2.0.2)
       rails (>= 5.0.4)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     tzinfo-data (1.2017.2)
       tzinfo (>= 1.0.0)
@@ -603,7 +591,7 @@ GEM
       hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.3)
     will_paginate (3.1.6)
     xpath (2.1.0)
       nokogiri (~> 1.3)
@@ -649,7 +637,7 @@ DEPENDENCIES
   fog-aws
   friendly_id (~> 5.2.1)
   fuubar (~> 2.2.0)
-  globalize!
+  globalize (~> 5.1.0.beta2)
   gon (~> 6.2.0)
   grape (~> 1.0)
   health_check
@@ -685,8 +673,7 @@ DEPENDENCIES
   rack-protection (~> 2.0.0)
   rack-test (~> 0.6.3)
   rack_session_access
-  rails (~> 5.0.6)
-  rails-angular-xss!
+  rails (~> 5.1.5)
   rails-controller-testing (~> 1.0.2)
   rails_12factor
   rails_autolink (~> 1.1.6)

--- a/app/contracts/relations/base_contract.rb
+++ b/app/contracts/relations/base_contract.rb
@@ -42,6 +42,7 @@ module Relations
     validate :validate_from_exists
     validate :validate_to_exists
     validate :validate_only_one_follow_direction_between_hierarchies
+    validate :validate_accepted_type
 
     attr_reader :user
 
@@ -77,6 +78,12 @@ module Relations
       if follow_relations_in_opposite_direction.exists?
         errors.add :base, I18n.t(:'activerecord.errors.messages.circular_dependency')
       end
+    end
+
+    def validate_accepted_type
+      return if (Relation::TYPES.keys + [Relation::TYPE_HIERARCHY]).include?(model.relation_type)
+
+      errors.add :relation_type, :inclusion
     end
 
     def manage_relations_permission?

--- a/app/models/concerns/virtual_attribute.rb
+++ b/app/models/concerns/virtual_attribute.rb
@@ -1,0 +1,77 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module Concerns
+  module VirtualAttribute
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def virtual_attribute(attribute, cast_type: nil, &block)
+        attribute attribute, cast_type
+        define_attribute_method attribute
+
+        include InstanceMethods
+
+        define_method "#{attribute}=" do |value|
+          set_virtual_attribute(attribute, value) if send(attribute) != value
+          instance_variable_set(:"@#{attribute}", value)
+        end
+
+        if block_given?
+          define_method attribute do
+            if instance_variable_get(:"@#{attribute}").present?
+              instance_variable_get(:"@#{attribute}")
+            else
+              value = instance_eval(&block)
+
+              set_virtual_attribute_was(attribute, value)
+
+              instance_variable_set(:"@#{attribute}", value)
+            end
+          end
+        end
+      end
+    end
+
+    module InstanceMethods
+      # Used to persists the changes to the virtual attribute in the mutation_tracker used by
+      # AR::Dirty so that it looks like every other attribute.
+      # Using attribute_will_change! does not place the value in the tracker but merely forces
+      # the attribute to be returned when asking the object for changes.
+      def set_virtual_attribute_was(attribute, value)
+        attributes = mutation_tracker.send(:attributes)
+        attributes[attribute.to_s].instance_variable_set(:@value_before_type_cast, value)
+      end
+
+      def set_virtual_attribute(attribute, value)
+        attributes = mutation_tracker.send(:attributes)
+        attributes[attribute.to_s] = attributes[attribute.to_s].with_value_from_user(value)
+      end
+    end
+  end
+end

--- a/app/models/concerns/virtual_attribute.rb
+++ b/app/models/concerns/virtual_attribute.rb
@@ -31,7 +31,7 @@ module Concerns
     extend ActiveSupport::Concern
 
     class_methods do
-      def virtual_attribute(attribute, cast_type: nil, &block)
+      def virtual_attribute(attribute, cast_type: :string, &block)
         attribute attribute, cast_type
         define_attribute_method attribute
 

--- a/app/models/custom_action.rb
+++ b/app/models/custom_action.rb
@@ -38,6 +38,7 @@ class CustomAction < ActiveRecord::Base
 
   after_save :persist_conditions
 
+  attribute :conditions
   define_attribute_method 'conditions'
 
   acts_as_list

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -44,8 +44,8 @@ class Journal < ActiveRecord::Base
   belongs_to :user
   belongs_to :journable, polymorphic: true
 
-  has_many :attachable_journals, class_name: Journal::AttachableJournal, dependent: :destroy
-  has_many :customizable_journals, class_name: Journal::CustomizableJournal, dependent: :destroy
+  has_many :attachable_journals, class_name: 'Journal::AttachableJournal', dependent: :destroy
+  has_many :customizable_journals, class_name: 'Journal::CustomizableJournal', dependent: :destroy
 
   after_create :save_data, if: :data
   after_save :save_data, :touch_journable

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -132,7 +132,7 @@ class Message < ActiveRecord::Base
       .or(with_parent_id)
       .update_all("board_id = #{board_id}")
 
-    Board.reset_counters!(board_id_was)
+    Board.reset_counters!(board_id_before_last_save)
     Board.reset_counters!(board_id)
   end
 

--- a/app/models/project/activity.rb
+++ b/app/models/project/activity.rb
@@ -52,7 +52,8 @@ module Project::Activity
 
     def with_latest_activity
       Project
-        .select('projects.*, activity.latest_activity_at')
+        .select('projects.*')
+        .select('activity.latest_activity_at')
         .joins("LEFT JOIN (#{latest_activity_sql}) activity ON projects.id = activity.project_id")
     end
 

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -107,7 +107,6 @@ class Relation < ActiveRecord::Base
     }
   }.freeze
 
-  validates_inclusion_of :relation_type, in: TYPES.keys + [TYPE_HIERARCHY]
   validates_numericality_of :delay, allow_nil: true
 
   validate :validate_sanity_of_relation

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -115,6 +115,20 @@ class Relation < ActiveRecord::Base
 
   before_save :set_type_column
 
+  [TYPE_RELATES,
+   TYPE_DUPLICATES,
+   TYPE_BLOCKS,
+   TYPE_PRECEDES,
+   TYPE_FOLLOWS,
+   TYPE_INCLUDES,
+   TYPE_REQUIRES,
+   TYPE_HIERARCHY].each do |type|
+    define_method "#{type}=" do |value|
+      instance_variable_set(:"@relation_type_set", nil)
+      super(value)
+    end
+  end
+
   def self.relation_column(type)
     if TYPES.key?(type) && TYPES[type][:reverse]
       TYPES[type][:reverse]
@@ -262,7 +276,7 @@ class Relation < ActiveRecord::Base
   def set_type_column
     if relation_type_changed? && relation_type_was
       was_column = self.class.relation_column(relation_type_was)
-      send("#{was_column}=", 0)
+      write_attribute was_column, 0
     end
 
     return unless relation_type

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -32,6 +32,8 @@ class Relation < ActiveRecord::Base
   scope :of_work_package,
         ->(work_package) { where('from_id = ? OR to_id = ?', work_package, work_package) }
 
+  attribute :relation_type
+
   TYPE_RELATES      = 'relates'.freeze
   TYPE_DUPLICATES   = 'duplicates'.freeze
   TYPE_DUPLICATED   = 'duplicated'.freeze

--- a/app/models/relation/hierarchy_paths.rb
+++ b/app/models/relation/hierarchy_paths.rb
@@ -63,20 +63,20 @@ module Relation::HierarchyPaths
         remove_hierarchy_path
       elsif now_hierarchy_relation_or_former_id_changed?
         add_hierarchy_path
-      elsif hierarchy_relatin_and_to_id_changed?
+      elsif hierarchy_relation_and_to_id_changed?
         alter_hierarchy_path
       end
     end
 
     def was_hierarchy_relation?
-      relation_type_changed? && relation_type_was == Relation::TYPE_HIERARCHY
+      saved_change_to_relation_type? && relation_type_before_last_save == Relation::TYPE_HIERARCHY
     end
 
     def now_hierarchy_relation_or_former_id_changed?
-      (relation_type_changed? || from_id_changed?) && hierarchy?
+      (saved_change_to_relation_type? || saved_change_to_from_id?) && hierarchy?
     end
 
-    def hierarchy_relatin_and_to_id_changed?
+    def hierarchy_relation_and_to_id_changed?
       hierarchy? && to_id_changed?
     end
 

--- a/app/models/relation/hierarchy_paths.rb
+++ b/app/models/relation/hierarchy_paths.rb
@@ -77,11 +77,11 @@ module Relation::HierarchyPaths
     end
 
     def hierarchy_relation_and_to_id_changed?
-      hierarchy? && to_id_changed?
+      hierarchy? && saved_change_to_to_id?
     end
 
     def alter_hierarchy_path
-      self.class.execute_sql self.class.remove_hierarchy_path_sql(to_id_was)
+      self.class.execute_sql self.class.remove_hierarchy_path_sql(to_id_before_last_save)
       self.class.execute_sql self.class.add_hierarchy_path_sql(to_id)
     end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -33,7 +33,7 @@ class Version < ActiveRecord::Base
 
   include Version::ProjectSharing
 
-  after_update :update_issues_from_sharing_change
+  after_update :update_issues_from_sharing_change, if: :saved_change_to_sharing?
   belongs_to :project
   has_many :fixed_issues, class_name: 'WorkPackage', foreign_key: 'fixed_version_id', dependent: :nullify
   has_many :work_packages, foreign_key: :fixed_version_id
@@ -228,12 +228,10 @@ class Version < ActiveRecord::Base
 
   # Update the issue's fixed versions. Used if a version's sharing changes.
   def update_issues_from_sharing_change
-    if sharing_changed?
-      if VERSION_SHARINGS.index(sharing_was).nil? ||
-         VERSION_SHARINGS.index(sharing).nil? ||
-         VERSION_SHARINGS.index(sharing_was) > VERSION_SHARINGS.index(sharing)
-        WorkPackage.update_versions_from_sharing_change self
-      end
+    if VERSION_SHARINGS.index(sharing_was).nil? ||
+       VERSION_SHARINGS.index(sharing).nil? ||
+       VERSION_SHARINGS.index(sharing_was) > VERSION_SHARINGS.index(sharing)
+      WorkPackage.update_versions_from_sharing_change self
     end
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -228,9 +228,9 @@ class Version < ActiveRecord::Base
 
   # Update the issue's fixed versions. Used if a version's sharing changes.
   def update_issues_from_sharing_change
-    if VERSION_SHARINGS.index(sharing_was).nil? ||
+    if VERSION_SHARINGS.index(sharing_before_last_save).nil? ||
        VERSION_SHARINGS.index(sharing).nil? ||
-       VERSION_SHARINGS.index(sharing_was) > VERSION_SHARINGS.index(sharing)
+       VERSION_SHARINGS.index(sharing_before_last_save) > VERSION_SHARINGS.index(sharing)
       WorkPackage.update_versions_from_sharing_change self
     end
   end

--- a/app/models/wiki_content.rb
+++ b/app/models/wiki_content.rb
@@ -39,7 +39,7 @@ class WikiContent < ActiveRecord::Base
 
   before_save :comments_to_journal_notes
   after_create :send_content_added_mail
-  after_update :send_content_updated_mail
+  after_update :send_content_updated_mail, if: :saved_change_to_text?
 
   acts_as_journalized
 
@@ -94,8 +94,7 @@ class WikiContent < ActiveRecord::Base
   end
 
   def send_content_updated_mail
-    return unless text_changed? &&
-                  Setting.notified_events.include?('wiki_content_updated')
+    return unless Setting.notified_events.include?('wiki_content_updated')
 
     update_recipients.uniq.each do |user|
       UserMailer.wiki_content_updated(user, self, User.current).deliver_now

--- a/config.ru
+++ b/config.ru
@@ -29,7 +29,7 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 
 ##
 # Use the worker killer when Unicorn is being used

--- a/config/initializers/reload_api.rb
+++ b/config/initializers/reload_api.rb
@@ -33,7 +33,7 @@ if Rails.env.development?
   api_reloader = ActiveSupport::FileUpdateChecker.new(api_files) do
     Rails.application.reload_routes!
   end
-  ActionDispatch::Callbacks.to_prepare do
+  ActiveSupport::Reloader.to_prepare do
     api_reloader.execute_if_updated
   end
 end

--- a/db/migrate/000_aggregated_migrations.rb
+++ b/db/migrate/000_aggregated_migrations.rb
@@ -29,7 +29,7 @@
 
 # This migration aggregates the migrations detailed in the @@migrations
 # heredoc
-class AggregatedMigrations < ActiveRecord::Migration[4.2]
+class AggregatedMigrations < ActiveRecord::Migration[5.1]
   class IncompleteMigrationsError < ::StandardError
   end
 

--- a/db/migrate/20110211160100_add_summary_to_projects.rb
+++ b/db/migrate/20110211160100_add_summary_to_projects.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddSummaryToProjects < ActiveRecord::Migration[4.2]
+class AddSummaryToProjects < ActiveRecord::Migration[5.1]
   def self.up
     add_column :projects, :summary, :text
   end

--- a/db/migrate/20110817142220_add_display_sums_field_to_migration.rb
+++ b/db/migrate/20110817142220_add_display_sums_field_to_migration.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddDisplaySumsFieldToMigration < ActiveRecord::Migration[4.2]
+class AddDisplaySumsFieldToMigration < ActiveRecord::Migration[5.1]
   def self.up
     add_column :queries, :display_sums, :boolean, null: true
   end

--- a/db/migrate/20111114124552_add_user_first_logged_in_and_impaired_fields.rb
+++ b/db/migrate/20111114124552_add_user_first_logged_in_and_impaired_fields.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddUserFirstLoggedInAndImpairedFields < ActiveRecord::Migration[4.2]
+class AddUserFirstLoggedInAndImpairedFields < ActiveRecord::Migration[5.1]
   def self.up
     add_column :users, :first_login, :boolean, null: false, default: true
     add_column :user_preferences, :impaired, :boolean, default: false

--- a/db/migrate/20120319095930_localize_email_header_and_footer.rb
+++ b/db/migrate/20120319095930_localize_email_header_and_footer.rb
@@ -28,7 +28,9 @@
 #++
 
 # store email header and footer localized (take Setting.default_language first, then english)
-class LocalizeEmailHeaderAndFooter < ActiveRecord::Migration[4.2]
+class LocalizeEmailHeaderAndFooter < ActiveRecord::Migration[5.1]
+  require 'globalize'
+
   def self.up
     emails_header = Setting.find_by name: 'emails_header'
     emails_footer = Setting.find_by name: 'emails_footer'

--- a/db/migrate/20120319135006_add_custom_field_translation_table.rb
+++ b/db/migrate/20120319135006_add_custom_field_translation_table.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddCustomFieldTranslationTable < ActiveRecord::Migration[4.2]
+class AddCustomFieldTranslationTable < ActiveRecord::Migration[5.1]
   class OldCustomField < ActiveRecord::Base
     self.table_name = :custom_fields
     self.inheritance_column = nil

--- a/db/migrate/20120529090411_create_delayed_jobs.rb
+++ b/db/migrate/20120529090411_create_delayed_jobs.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateDelayedJobs < ActiveRecord::Migration[4.2]
+class CreateDelayedJobs < ActiveRecord::Migration[5.1]
   def self.up
     create_table :delayed_jobs, force: true do |table|
       table.integer :priority, default: 0      # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20120731091543_use_the_full_sti_class_names_for_repositories.rb
+++ b/db/migrate/20120731091543_use_the_full_sti_class_names_for_repositories.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class UseTheFullStiClassNamesForRepositories < ActiveRecord::Migration[4.2]
+class UseTheFullStiClassNamesForRepositories < ActiveRecord::Migration[5.1]
   def self.up
     concatenation = "('Repository::' || type)"
 

--- a/db/migrate/20120731135140_create_wiki_menu_items.rb
+++ b/db/migrate/20120731135140_create_wiki_menu_items.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateWikiMenuItems < ActiveRecord::Migration[4.2]
+class CreateWikiMenuItems < ActiveRecord::Migration[5.1]
   def self.up
     create_table :wiki_menu_items do |t|
       t.column :name, :string

--- a/db/migrate/20120802152122_rename_auth_source_ldap.rb
+++ b/db/migrate/20120802152122_rename_auth_source_ldap.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RenameAuthSourceLdap < ActiveRecord::Migration[4.2]
+class RenameAuthSourceLdap < ActiveRecord::Migration[5.1]
   def self.up
     AuthSource.where(['type = ?', 'AuthSourceLdap']).update_all ['type = ?', 'LdapAuthSource']
   end

--- a/db/migrate/20120809131659_create_wiki_menu_item_for_existing_wikis.rb
+++ b/db/migrate/20120809131659_create_wiki_menu_item_for_existing_wikis.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateWikiMenuItemForExistingWikis < ActiveRecord::Migration[4.2]
+class CreateWikiMenuItemForExistingWikis < ActiveRecord::Migration[5.1]
   class OldWikiMenuItem < ActiveRecord::Base
     self.table_name = "wiki_menu_items"
 

--- a/db/migrate/20120828171423_make_groups_users_a_model.rb
+++ b/db/migrate/20120828171423_make_groups_users_a_model.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class MakeGroupsUsersAModel < ActiveRecord::Migration[4.2]
+class MakeGroupsUsersAModel < ActiveRecord::Migration[5.1]
   def self.up
     remove_index :groups_users, name: :groups_users_ids
     rename_table :groups_users, :group_users

--- a/db/migrate/20121004054229_add_wiki_list_attachments.rb
+++ b/db/migrate/20121004054229_add_wiki_list_attachments.rb
@@ -27,11 +27,11 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddWikiListAttachments < ActiveRecord::Migration[4.2]
+class AddWikiListAttachments < ActiveRecord::Migration[5.1]
   # model removed
   class Role < ActiveRecord::Base; end
 
-  class AddViewWikiEditsPermission < ActiveRecord::Migration[4.2]
+  class AddViewWikiEditsPermission < ActiveRecord::Migration[5.1]
     def self.up
       Role.all.each do |r|
         r.add_permission!(:list_attachments) if r.has_permission?(:view_wiki_pages) || r.has_permission?(:view_issues)

--- a/db/migrate/20121030111651_rename_acts_as_journalized_changes_column.rb
+++ b/db/migrate/20121030111651_rename_acts_as_journalized_changes_column.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RenameActsAsJournalizedChangesColumn < ActiveRecord::Migration[4.2]
+class RenameActsAsJournalizedChangesColumn < ActiveRecord::Migration[5.1]
   def self.up
     # This is provided here for migrating up after the JournalDetails has been removed
     unless Object.const_defined?('JournalDetails')

--- a/db/migrate/20121101111303_add_missing_indexes_on_wiki_menu_items.rb
+++ b/db/migrate/20121101111303_add_missing_indexes_on_wiki_menu_items.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddMissingIndexesOnWikiMenuItems < ActiveRecord::Migration[4.2]
+class AddMissingIndexesOnWikiMenuItems < ActiveRecord::Migration[5.1]
   def self.up
     add_index :wiki_menu_items, [:wiki_id, :title]
     add_index :wiki_menu_items, :parent_id

--- a/db/migrate/20121114100641_aggregated_announcements_migrations.rb
+++ b/db/migrate/20121114100641_aggregated_announcements_migrations.rb
@@ -1,7 +1,7 @@
 require Rails.root.join('db', 'migrate', 'migration_utils', 'migration_squasher').to_s
 require 'open_project/plugins/migration_mapping'
 # This migration aggregates the migrations detailed in the MIGRATION_FILES
-class AggregatedAnnouncementsMigrations < ActiveRecord::Migration[4.2]
+class AggregatedAnnouncementsMigrations < ActiveRecord::Migration[5.1]
   MIGRATION_FILES = <<-MIGRATIONS
     001_create_announcements.rb
     20121114100640_index_on_announcements.rb

--- a/db/migrate/20130204140624_add_index_on_identifier_to_projects.rb
+++ b/db/migrate/20130204140624_add_index_on_identifier_to_projects.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddIndexOnIdentifierToProjects < ActiveRecord::Migration[4.2]
+class AddIndexOnIdentifierToProjects < ActiveRecord::Migration[5.1]
   def self.up
     add_index :projects, :identifier
   end

--- a/db/migrate/20130315124655_add_longer_login_to_users.rb
+++ b/db/migrate/20130315124655_add_longer_login_to_users.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddLongerLoginToUsers < ActiveRecord::Migration[4.2]
+class AddLongerLoginToUsers < ActiveRecord::Migration[5.1]
   def self.up
     change_table :users do |t|
       t.change 'login', :string, limit: 256, default: '', null: false

--- a/db/migrate/20130325165622_remove_gantt_related_data_from_database.rb
+++ b/db/migrate/20130325165622_remove_gantt_related_data_from_database.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RemoveGanttRelatedDataFromDatabase < ActiveRecord::Migration[4.2]
+class RemoveGanttRelatedDataFromDatabase < ActiveRecord::Migration[5.1]
   def up
     EnabledModule.where(name: 'gantt').delete_all
   end

--- a/db/migrate/20130409133700_add_timelines_project_type_id_to_projects.rb
+++ b/db/migrate/20130409133700_add_timelines_project_type_id_to_projects.rb
@@ -27,12 +27,10 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddTimelinesProjectTypeIdToProjects < ActiveRecord::Migration[4.2]
+class AddTimelinesProjectTypeIdToProjects < ActiveRecord::Migration[5.1]
   def self.up
     change_table(:projects) do |t|
       t.belongs_to :timelines_project_type
-
-      t.index :timelines_project_type_id
     end
   rescue
     raise "Error: Cannot migrate table 'projects'!"\

--- a/db/migrate/20130409133701_create_timelines_project_types.rb
+++ b/db/migrate/20130409133701_create_timelines_project_types.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimelinesProjectTypes < ActiveRecord::Migration[4.2]
+class CreateTimelinesProjectTypes < ActiveRecord::Migration[5.1]
   def self.up
     create_table(:timelines_project_types) do |t|
       t.column :name,               :string,  default: '',   null: false

--- a/db/migrate/20130409133702_create_timelines_planning_element_types.rb
+++ b/db/migrate/20130409133702_create_timelines_planning_element_types.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimelinesPlanningElementTypes < ActiveRecord::Migration[4.2]
+class CreateTimelinesPlanningElementTypes < ActiveRecord::Migration[5.1]
   def self.up
     create_table(:timelines_planning_element_types) do |t|
       t.column :name,         :string,  null: false
@@ -43,9 +43,6 @@ class CreateTimelinesPlanningElementTypes < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-
-    add_index :timelines_planning_element_types, :color_id
-    add_index :timelines_planning_element_types, :project_type_id
   end
 
   def self.down

--- a/db/migrate/20130409133703_create_timelines_planning_elements.rb
+++ b/db/migrate/20130409133703_create_timelines_planning_elements.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimelinesPlanningElements < ActiveRecord::Migration[4.2]
+class CreateTimelinesPlanningElements < ActiveRecord::Migration[5.1]
   def self.up
     create_table(:timelines_planning_elements) do |t|
       t.column :name,        :string,  null: false
@@ -45,12 +45,6 @@ class CreateTimelinesPlanningElements < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-
-    add_index :timelines_planning_elements, :parent_id
-    add_index :timelines_planning_elements, :project_id
-    add_index :timelines_planning_elements, :responsible_id
-    add_index :timelines_planning_elements, :planning_element_type_id
-    add_index :timelines_planning_elements, :planning_element_status_id
   end
 
   def self.down

--- a/db/migrate/20130409133704_create_timelines_scenarios.rb
+++ b/db/migrate/20130409133704_create_timelines_scenarios.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimelinesScenarios < ActiveRecord::Migration[4.2]
+class CreateTimelinesScenarios < ActiveRecord::Migration[5.1]
   def self.up
     create_table(:timelines_scenarios) do |t|
       t.column :name,        :string, null: false
@@ -37,8 +37,6 @@ class CreateTimelinesScenarios < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-
-    add_index :timelines_scenarios, :project_id
   end
 
   def self.down

--- a/db/migrate/20130409133705_create_timelines_alternate_dates.rb
+++ b/db/migrate/20130409133705_create_timelines_alternate_dates.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimelinesAlternateDates < ActiveRecord::Migration[4.2]
+class CreateTimelinesAlternateDates < ActiveRecord::Migration[5.1]
   def self.up
     create_table(:timelines_alternate_dates) do |t|
       t.column :start_date, :date, null: false
@@ -38,8 +38,6 @@ class CreateTimelinesAlternateDates < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_index :timelines_alternate_dates, :planning_element_id
-    add_index :timelines_alternate_dates, :scenario_id
   end
 
   def self.down

--- a/db/migrate/20130409133706_add_timelines_responsible_id_to_projects.rb
+++ b/db/migrate/20130409133706_add_timelines_responsible_id_to_projects.rb
@@ -27,12 +27,10 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddTimelinesResponsibleIdToProjects < ActiveRecord::Migration[4.2]
+class AddTimelinesResponsibleIdToProjects < ActiveRecord::Migration[5.1]
   def self.up
     change_table(:projects) do |t|
       t.belongs_to :timelines_responsible
-
-      t.index :timelines_responsible_id
     end
   end
 

--- a/db/migrate/20130409133707_create_timelines_colors.rb
+++ b/db/migrate/20130409133707_create_timelines_colors.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimelinesColors < ActiveRecord::Migration[4.2]
+class CreateTimelinesColors < ActiveRecord::Migration[5.1]
   def self.up
     create_table(:timelines_colors) do |t|
       t.column :name,    :string, null: false

--- a/db/migrate/20130409133708_create_timelines_reportings.rb
+++ b/db/migrate/20130409133708_create_timelines_reportings.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimelinesReportings < ActiveRecord::Migration[4.2]
+class CreateTimelinesReportings < ActiveRecord::Migration[5.1]
   def self.up
     create_table(:timelines_reportings) do |t|
       t.column :reported_project_status_comment, :text
@@ -38,9 +38,6 @@ class CreateTimelinesReportings < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_index :timelines_reportings, :project_id
-    add_index :timelines_reportings, :reporting_to_project_id
-    add_index :timelines_reportings, :reported_project_status_id
   end
 
   def self.down

--- a/db/migrate/20130409133709_create_timelines_available_project_statuses.rb
+++ b/db/migrate/20130409133709_create_timelines_available_project_statuses.rb
@@ -27,17 +27,14 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimelinesAvailableProjectStatuses < ActiveRecord::Migration[4.2]
+class CreateTimelinesAvailableProjectStatuses < ActiveRecord::Migration[5.1]
   def self.up
     create_table(:timelines_available_project_statuses) do |t|
       t.belongs_to :project_type
-      t.belongs_to :reported_project_status
+      t.belongs_to :reported_project_status, index: { name: 'index_avail_project_statuses_on_rep_project_status_id' }
 
       t.timestamps
     end
-
-    add_index :timelines_available_project_statuses, :project_type_id
-    add_index :timelines_available_project_statuses, :reported_project_status_id, name: 'index_avail_project_statuses_on_rep_project_status_id'
   end
 
   def self.down

--- a/db/migrate/20130409133710_create_timelines_project_associations.rb
+++ b/db/migrate/20130409133710_create_timelines_project_associations.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimelinesProjectAssociations < ActiveRecord::Migration[4.2]
+class CreateTimelinesProjectAssociations < ActiveRecord::Migration[5.1]
   def self.up
     create_table(:timelines_project_associations) do |t|
       t.belongs_to :project_a
@@ -37,9 +37,6 @@ class CreateTimelinesProjectAssociations < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-
-    add_index :timelines_project_associations, :project_a_id
-    add_index :timelines_project_associations, :project_b_id
   end
 
   def self.down

--- a/db/migrate/20130409133711_create_timelines_enabled_planning_element_types.rb
+++ b/db/migrate/20130409133711_create_timelines_enabled_planning_element_types.rb
@@ -27,17 +27,14 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimelinesEnabledPlanningElementTypes < ActiveRecord::Migration[4.2]
+class CreateTimelinesEnabledPlanningElementTypes < ActiveRecord::Migration[5.1]
   def self.up
     create_table :timelines_enabled_planning_element_types do |t|
       t.belongs_to :project
-      t.belongs_to :planning_element_type
+      t.belongs_to :planning_element_type, index: { name: 'index_enabled_pe_types_on_pe_type_id' }
 
       t.timestamps
     end
-
-    add_index :timelines_enabled_planning_element_types, :project_id
-    add_index :timelines_enabled_planning_element_types, :planning_element_type_id, name: 'index_enabled_pe_types_on_pe_type_id'
   end
 
   def self.down

--- a/db/migrate/20130409133712_create_timelines_default_planning_element_types.rb
+++ b/db/migrate/20130409133712_create_timelines_default_planning_element_types.rb
@@ -27,17 +27,14 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimelinesDefaultPlanningElementTypes < ActiveRecord::Migration[4.2]
+class CreateTimelinesDefaultPlanningElementTypes < ActiveRecord::Migration[5.1]
   def self.up
     create_table :timelines_default_planning_element_types do |t|
-      t.belongs_to :project_type
-      t.belongs_to :planning_element_type
+      t.belongs_to :project_type, index: { name: 'index_default_pe_types_on_project_type_id' }
+      t.belongs_to :planning_element_type, index: { name: 'index_default_pe_types_on_pe_type_id' }
 
       t.timestamps
     end
-
-    add_index :timelines_default_planning_element_types, :project_type_id, name: 'index_default_pe_types_on_project_type_id'
-    add_index :timelines_default_planning_element_types, :planning_element_type_id, name: 'index_default_pe_types_on_pe_type_id'
   end
 
   def self.down

--- a/db/migrate/20130409133713_migrate_planning_element_type_to_project_association.rb
+++ b/db/migrate/20130409133713_migrate_planning_element_type_to_project_association.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class MigratePlanningElementTypeToProjectAssociation < ActiveRecord::Migration[4.2]
+class MigratePlanningElementTypeToProjectAssociation < ActiveRecord::Migration[5.1]
   {
     DefaultPlanningElementType: 'timelines_default_planning_element_types',
     EnabledPlanningElementType: 'timelines_enabled_planning_element_types',

--- a/db/migrate/20130409133714_remove_project_type_id_from_timelines_planning_element_types.rb
+++ b/db/migrate/20130409133714_remove_project_type_id_from_timelines_planning_element_types.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RemoveProjectTypeIdFromTimelinesPlanningElementTypes < ActiveRecord::Migration[4.2]
+class RemoveProjectTypeIdFromTimelinesPlanningElementTypes < ActiveRecord::Migration[5.1]
   def self.up
     change_table(:timelines_planning_element_types) do |t|
       t.remove :project_type_id

--- a/db/migrate/20130409133715_create_timelines_timelines.rb
+++ b/db/migrate/20130409133715_create_timelines_timelines.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimelinesTimelines < ActiveRecord::Migration[4.2]
+class CreateTimelinesTimelines < ActiveRecord::Migration[5.1]
   def self.up
     create_table :timelines_timelines do |t|
       t.column :name,        :string,  null: false
@@ -37,8 +37,6 @@ class CreateTimelinesTimelines < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-
-    add_index :timelines_timelines, :project_id
   end
 
   def self.down

--- a/db/migrate/20130409133717_add_options_to_timelines_timelines.rb
+++ b/db/migrate/20130409133717_add_options_to_timelines_timelines.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddOptionsToTimelinesTimelines < ActiveRecord::Migration[4.2]
+class AddOptionsToTimelinesTimelines < ActiveRecord::Migration[5.1]
   def self.up
     change_table(:timelines_timelines) do |t|
       t.text :options

--- a/db/migrate/20130409133718_remove_content_from_timelines_timelines.rb
+++ b/db/migrate/20130409133718_remove_content_from_timelines_timelines.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RemoveContentFromTimelinesTimelines < ActiveRecord::Migration[4.2]
+class RemoveContentFromTimelinesTimelines < ActiveRecord::Migration[5.1]
   def self.up
     change_table(:timelines_timelines) do |t|
       t.remove :content

--- a/db/migrate/20130409133719_add_indexes_to_timelines_alternate_dates_to_secure_at_scope.rb
+++ b/db/migrate/20130409133719_add_indexes_to_timelines_alternate_dates_to_secure_at_scope.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddIndexesToTimelinesAlternateDatesToSecureAtScope < ActiveRecord::Migration[4.2]
+class AddIndexesToTimelinesAlternateDatesToSecureAtScope < ActiveRecord::Migration[5.1]
   def self.up
     add_index :timelines_alternate_dates,
               [:updated_at, :planning_element_id, :scenario_id],

--- a/db/migrate/20130409133720_add_deleted_at_to_timelines_planning_elements.rb
+++ b/db/migrate/20130409133720_add_deleted_at_to_timelines_planning_elements.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddDeletedAtToTimelinesPlanningElements < ActiveRecord::Migration[4.2]
+class AddDeletedAtToTimelinesPlanningElements < ActiveRecord::Migration[5.1]
   def self.up
     add_column :timelines_planning_elements, :deleted_at, :datetime
   end

--- a/db/migrate/20130409133721_allow_null_position_in_colors.rb
+++ b/db/migrate/20130409133721_allow_null_position_in_colors.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AllowNullPositionInColors < ActiveRecord::Migration[4.2]
+class AllowNullPositionInColors < ActiveRecord::Migration[5.1]
   def self.up
     change_column :timelines_colors, :position, :integer, default: 1, null: true
   end

--- a/db/migrate/20130409133722_allow_null_position_in_planning_element_types.rb
+++ b/db/migrate/20130409133722_allow_null_position_in_planning_element_types.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AllowNullPositionInPlanningElementTypes < ActiveRecord::Migration[4.2]
+class AllowNullPositionInPlanningElementTypes < ActiveRecord::Migration[5.1]
   def self.up
     change_column :timelines_planning_element_types, :position, :integer, default: 1, null: true
   end

--- a/db/migrate/20130409133723_allow_null_position_in_project_types.rb
+++ b/db/migrate/20130409133723_allow_null_position_in_project_types.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AllowNullPositionInProjectTypes < ActiveRecord::Migration[4.2]
+class AllowNullPositionInProjectTypes < ActiveRecord::Migration[5.1]
   def self.up
     change_column :timelines_project_types, :position, :integer, default: 1, null: true
   end

--- a/db/migrate/20130611154020_remove_timelines_namespace.rb
+++ b/db/migrate/20130611154020_remove_timelines_namespace.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RemoveTimelinesNamespace < ActiveRecord::Migration[4.2]
+class RemoveTimelinesNamespace < ActiveRecord::Migration[5.1]
   def self.up
     # rename all tables.
     # this changes everything. again.

--- a/db/migrate/20130612120042_migrate_serialized_yaml_from_syck_to_psych.rb
+++ b/db/migrate/20130612120042_migrate_serialized_yaml_from_syck_to_psych.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/legacy_yamler'
 
-class MigrateSerializedYamlFromSyckToPsych < ActiveRecord::Migration[4.2]
+class MigrateSerializedYamlFromSyckToPsych < ActiveRecord::Migration[5.1]
   include Migration::LegacyYamler
 
   def up

--- a/db/migrate/20130613075253_add_force_password_change_to_user.rb
+++ b/db/migrate/20130613075253_add_force_password_change_to_user.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddForcePasswordChangeToUser < ActiveRecord::Migration[4.2]
+class AddForcePasswordChangeToUser < ActiveRecord::Migration[5.1]
   def change
     add_column :users, :force_password_change, :boolean, default: false
     User.reset_column_information

--- a/db/migrate/20130619081234_create_user_passwords.rb
+++ b/db/migrate/20130619081234_create_user_passwords.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateUserPasswords < ActiveRecord::Migration[4.2]
+class CreateUserPasswords < ActiveRecord::Migration[5.1]
   def initialize(*)
     super
     @former_passwords_table_exists = ActiveRecord::Base.connection.tables.include? 'former_user_passwords'

--- a/db/migrate/20130620082322_create_work_packages.rb
+++ b/db/migrate/20130620082322_create_work_packages.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateWorkPackages < ActiveRecord::Migration[4.2]
+class CreateWorkPackages < ActiveRecord::Migration[5.1]
   def up
     create_table 'work_packages' do |t|
       # Issue
@@ -77,20 +77,11 @@ class CreateWorkPackages < ActiveRecord::Migration[4.2]
       t.change :project_id, :integer, default: 0, null: false
     end
 
-    # Planning Elements
-    add_index :work_packages, :parent_id
-    add_index :work_packages, :project_id
-    add_index :work_packages, :responsible_id
-    add_index :work_packages, :planning_element_type_id
-    add_index :work_packages, :planning_element_status_id
-
     # Nested Set
     add_index :work_packages, [:root_id, :lft, :rgt]
 
     change_table(:projects) do |t|
       t.belongs_to :work_packages_responsible
-
-      t.index :work_packages_responsible_id
     end
 
     # Time Entry

--- a/db/migrate/20130625124242_work_package_custom_field_data_migration.rb
+++ b/db/migrate/20130625124242_work_package_custom_field_data_migration.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class WorkPackageCustomFieldDataMigration < ActiveRecord::Migration[4.2]
+class WorkPackageCustomFieldDataMigration < ActiveRecord::Migration[5.1]
   def self.up
     set_custom_fields_type('IssueCustomField', 'WorkPackageCustomField')
     set_custom_values_type('Issue', 'WorkPackage')

--- a/db/migrate/20130628092725_add_failed_login_count_last_failed_login_on_to_user.rb
+++ b/db/migrate/20130628092725_add_failed_login_count_last_failed_login_on_to_user.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddFailedLoginCountLastFailedLoginOnToUser < ActiveRecord::Migration[4.2]
+class AddFailedLoginCountLastFailedLoginOnToUser < ActiveRecord::Migration[5.1]
   def change
     begin
       add_column :users, :failed_login_count, :integer, default: 0

--- a/db/migrate/20130709084751_rename_end_date_on_alternate_dates.rb
+++ b/db/migrate/20130709084751_rename_end_date_on_alternate_dates.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RenameEndDateOnAlternateDates < ActiveRecord::Migration[4.2]
+class RenameEndDateOnAlternateDates < ActiveRecord::Migration[5.1]
   def change
     rename_column :alternate_dates, :end_date, :due_date
   end

--- a/db/migrate/20130710145350_remove_end_date_from_work_packages.rb
+++ b/db/migrate/20130710145350_remove_end_date_from_work_packages.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RemoveEndDateFromWorkPackages < ActiveRecord::Migration[4.2]
+class RemoveEndDateFromWorkPackages < ActiveRecord::Migration[5.1]
   def up
     # This operation is destructive. The end dates of work packages will
     # be removed, updating due dates to the end date where due dates

--- a/db/migrate/20130717134318_rename_changeset_wp_join_table.rb
+++ b/db/migrate/20130717134318_rename_changeset_wp_join_table.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RenameChangesetWpJoinTable < ActiveRecord::Migration[4.2]
+class RenameChangesetWpJoinTable < ActiveRecord::Migration[5.1]
   def up
     remove_index :changesets_issues, name: :changesets_issues_ids
 

--- a/db/migrate/20130719133922_rename_trackers_to_types.rb
+++ b/db/migrate/20130719133922_rename_trackers_to_types.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RenameTrackersToTypes < ActiveRecord::Migration[4.2]
+class RenameTrackersToTypes < ActiveRecord::Migration[5.1]
   # This migration leaves legacy issues as they are. After this
   # migration, those legacy issues have tracker_id columns as well as
   # having indexes that mention both tracker and issue, since there was

--- a/db/migrate/20130722154555_rename_work_package_sti_column.rb
+++ b/db/migrate/20130722154555_rename_work_package_sti_column.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RenameWorkPackageStiColumn < ActiveRecord::Migration[4.2]
+class RenameWorkPackageStiColumn < ActiveRecord::Migration[5.1]
   def up
     rename_column :work_packages, :type, :sti_type
   end

--- a/db/migrate/20130723092240_add_activity_module.rb
+++ b/db/migrate/20130723092240_add_activity_module.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddActivityModule < ActiveRecord::Migration[4.2]
+class AddActivityModule < ActiveRecord::Migration[5.1]
   def up
     # activate activity module for all projects
     Project.all.each do |project|

--- a/db/migrate/20130723134527_increase_journals_changed_data_limit.rb
+++ b/db/migrate/20130723134527_increase_journals_changed_data_limit.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class IncreaseJournalsChangedDataLimit < ActiveRecord::Migration[4.2]
+class IncreaseJournalsChangedDataLimit < ActiveRecord::Migration[5.1]
   def up
     # fixes the inconsistency introduced in
     # 20091227112908_change_wiki_contents_text_limit.rb, which

--- a/db/migrate/20130724143418_add_planning_element_type_properties_to_type.rb
+++ b/db/migrate/20130724143418_add_planning_element_type_properties_to_type.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddPlanningElementTypePropertiesToType < ActiveRecord::Migration[4.2]
+class AddPlanningElementTypePropertiesToType < ActiveRecord::Migration[5.1]
   def up
     add_column :types, :in_aggregation, :boolean, default: true,  null: false
     add_column :types, :is_milestone,   :boolean, default: false, null: false

--- a/db/migrate/20130729114110_move_planning_element_types_to_legacy_planning_element_types.rb
+++ b/db/migrate/20130729114110_move_planning_element_types_to_legacy_planning_element_types.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class MovePlanningElementTypesToLegacyPlanningElementTypes < ActiveRecord::Migration[4.2]
+class MovePlanningElementTypesToLegacyPlanningElementTypes < ActiveRecord::Migration[5.1]
   def up
     rename_table :default_planning_element_types, :legacy_default_planning_element_types
     rename_table :enabled_planning_element_types, :legacy_enabled_planning_element_types

--- a/db/migrate/20130806075000_add_standard_column_to_type_table.rb
+++ b/db/migrate/20130806075000_add_standard_column_to_type_table.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddStandardColumnToTypeTable < ActiveRecord::Migration[4.2]
+class AddStandardColumnToTypeTable < ActiveRecord::Migration[5.1]
   def change
     add_column :types, :is_standard, :boolean, null: false, default: false
   end

--- a/db/migrate/20130807081927_move_journals_to_legacy_journals.rb
+++ b/db/migrate/20130807081927_move_journals_to_legacy_journals.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class MoveJournalsToLegacyJournals < ActiveRecord::Migration[4.2]
+class MoveJournalsToLegacyJournals < ActiveRecord::Migration[5.1]
   def up
     rename_table :journals, :legacy_journals
   end

--- a/db/migrate/20130807082645_create_normalized_journals.rb
+++ b/db/migrate/20130807082645_create_normalized_journals.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateNormalizedJournals < ActiveRecord::Migration[4.2]
+class CreateNormalizedJournals < ActiveRecord::Migration[5.1]
   def change
     create_table :journals do |t|
       t.references :journable, polymorphic: true

--- a/db/migrate/20130807083715_create_attachment_journals.rb
+++ b/db/migrate/20130807083715_create_attachment_journals.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateAttachmentJournals < ActiveRecord::Migration[4.2]
+class CreateAttachmentJournals < ActiveRecord::Migration[5.1]
   def change
     create_table :attachment_journals do |t|
       t.integer :journal_id,                                   null: false

--- a/db/migrate/20130807083716_change_attachment_journals_description_length.rb
+++ b/db/migrate/20130807083716_change_attachment_journals_description_length.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class ChangeAttachmentJournalsDescriptionLength < ActiveRecord::Migration[4.2]
+class ChangeAttachmentJournalsDescriptionLength < ActiveRecord::Migration[5.1]
   def change
     change_column :attachment_journals,
                   :description,

--- a/db/migrate/20130807084417_create_work_package_journals.rb
+++ b/db/migrate/20130807084417_create_work_package_journals.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateWorkPackageJournals < ActiveRecord::Migration[4.2]
+class CreateWorkPackageJournals < ActiveRecord::Migration[5.1]
   def change
     create_table :work_package_journals do |t|
       t.integer :journal_id,                                      null: false

--- a/db/migrate/20130807084708_create_message_journals.rb
+++ b/db/migrate/20130807084708_create_message_journals.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateMessageJournals < ActiveRecord::Migration[4.2]
+class CreateMessageJournals < ActiveRecord::Migration[5.1]
   def change
     create_table :message_journals do |t|
       t.integer :journal_id,                       null: false

--- a/db/migrate/20130807085108_create_news_journals.rb
+++ b/db/migrate/20130807085108_create_news_journals.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateNewsJournals < ActiveRecord::Migration[4.2]
+class CreateNewsJournals < ActiveRecord::Migration[5.1]
   def change
     create_table :news_journals do |t|
       t.integer :journal_id,                                   null: false

--- a/db/migrate/20130807085245_create_wiki_content_journals.rb
+++ b/db/migrate/20130807085245_create_wiki_content_journals.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateWikiContentJournals < ActiveRecord::Migration[4.2]
+class CreateWikiContentJournals < ActiveRecord::Migration[5.1]
   def change
     create_table :wiki_content_journals do |t|
       t.integer :journal_id,                         null: false

--- a/db/migrate/20130807085430_create_time_entry_journals.rb
+++ b/db/migrate/20130807085430_create_time_entry_journals.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateTimeEntryJournals < ActiveRecord::Migration[4.2]
+class CreateTimeEntryJournals < ActiveRecord::Migration[5.1]
   def change
     create_table :time_entry_journals do |t|
       t.integer :journal_id,      null: false

--- a/db/migrate/20130807085714_create_changeset_journals.rb
+++ b/db/migrate/20130807085714_create_changeset_journals.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CreateChangesetJournals < ActiveRecord::Migration[4.2]
+class CreateChangesetJournals < ActiveRecord::Migration[5.1]
   def change
     create_table :changeset_journals do |t|
       t.integer :journal_id,    null: false

--- a/db/migrate/20130807141542_remove_files_attached_to_projects_and_versions.rb
+++ b/db/migrate/20130807141542_remove_files_attached_to_projects_and_versions.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RemoveFilesAttachedToProjectsAndVersions < ActiveRecord::Migration[4.2]
+class RemoveFilesAttachedToProjectsAndVersions < ActiveRecord::Migration[5.1]
   def up
     if !skip? && Attachment.where(container_type: ['Version', 'Project']).any?
       raise 'Error: There are still attachments attached to Versions or Projects!'\

--- a/db/migrate/20130813062401_add_attachable_journal.rb
+++ b/db/migrate/20130813062401_add_attachable_journal.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddAttachableJournal < ActiveRecord::Migration[4.2]
+class AddAttachableJournal < ActiveRecord::Migration[5.1]
   def change
     create_table :attachable_journals do |t|
       t.integer :journal_id, null: false

--- a/db/migrate/20130813062513_add_customizable_journal.rb
+++ b/db/migrate/20130813062513_add_customizable_journal.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddCustomizableJournal < ActiveRecord::Migration[4.2]
+class AddCustomizableJournal < ActiveRecord::Migration[5.1]
   def change
     create_table :customizable_journals do |t|
       t.integer :journal_id, null: false

--- a/db/migrate/20130813062523_fix_customizable_journal_value_column.rb
+++ b/db/migrate/20130813062523_fix_customizable_journal_value_column.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class FixCustomizableJournalValueColumn < ActiveRecord::Migration[4.2]
+class FixCustomizableJournalValueColumn < ActiveRecord::Migration[5.1]
   def up
     change_column :customizable_journals, :value, :text
   end

--- a/db/migrate/20130814130142_remove_documents.rb
+++ b/db/migrate/20130814130142_remove_documents.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RemoveDocuments < ActiveRecord::Migration[4.2]
+class RemoveDocuments < ActiveRecord::Migration[5.1]
   def up
     unless Redmine::Plugin.registered_plugins.include?(:openproject_documents)
       if  Document.any? || Attachment.where(container_type: ['Document']).any?

--- a/db/migrate/20130828093647_remove_alternate_dates_and_scenarios.rb
+++ b/db/migrate/20130828093647_remove_alternate_dates_and_scenarios.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RemoveAlternateDatesAndScenarios < ActiveRecord::Migration[4.2]
+class RemoveAlternateDatesAndScenarios < ActiveRecord::Migration[5.1]
   def up
     drop_table(:alternate_dates)
     drop_table(:scenarios)

--- a/db/migrate/20130829084747_drop_model_journals_updated_on_column.rb
+++ b/db/migrate/20130829084747_drop_model_journals_updated_on_column.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class DropModelJournalsUpdatedOnColumn < ActiveRecord::Migration[4.2]
+class DropModelJournalsUpdatedOnColumn < ActiveRecord::Migration[5.1]
   def up
     remove_column :work_package_journals, :updated_at
     remove_column :wiki_content_journals, :updated_on

--- a/db/migrate/20130916094339_legacy_issues_to_work_packages.rb
+++ b/db/migrate/20130916094339_legacy_issues_to_work_packages.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/utils'
 
-class LegacyIssuesToWorkPackages < ActiveRecord::Migration[4.2]
+class LegacyIssuesToWorkPackages < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   class ExistingWorkPackagesError < ::StandardError

--- a/db/migrate/20130916123916_planning_element_types_data_to_types.rb
+++ b/db/migrate/20130916123916_planning_element_types_data_to_types.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/utils'
 
-class PlanningElementTypesDataToTypes < ActiveRecord::Migration[4.2]
+class PlanningElementTypesDataToTypes < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   def up

--- a/db/migrate/20130917101922_migrate_query_tracker_references_to_type.rb
+++ b/db/migrate/20130917101922_migrate_query_tracker_references_to_type.rb
@@ -31,7 +31,7 @@ require 'yaml'
 
 require_relative 'migration_utils/queries'
 
-class MigrateQueryTrackerReferencesToType < ActiveRecord::Migration[4.2]
+class MigrateQueryTrackerReferencesToType < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   KEY = { 'tracker_id' => 'type_id', 'tracker' => 'type' }

--- a/db/migrate/20130917122118_remove_is_in_chlog_from_types.rb
+++ b/db/migrate/20130917122118_remove_is_in_chlog_from_types.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RemoveIsInChlogFromTypes < ActiveRecord::Migration[4.2]
+class RemoveIsInChlogFromTypes < ActiveRecord::Migration[5.1]
   def up
     remove_column :types, :is_in_chlog
   end

--- a/db/migrate/20130917131710_planning_element_data_to_work_packages.rb
+++ b/db/migrate/20130917131710_planning_element_data_to_work_packages.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/utils'
 
-class PlanningElementDataToWorkPackages < ActiveRecord::Migration[4.2]
+class PlanningElementDataToWorkPackages < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   def up

--- a/db/migrate/20130918111753_migrate_user_rights.rb
+++ b/db/migrate/20130918111753_migrate_user_rights.rb
@@ -31,7 +31,7 @@ require 'yaml'
 
 require_relative 'migration_utils/utils'
 
-class MigrateUserRights < ActiveRecord::Migration[4.2]
+class MigrateUserRights < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   COLUMN = 'permissions'

--- a/db/migrate/20130919105841_migrate_settings_to_work_package.rb
+++ b/db/migrate/20130919105841_migrate_settings_to_work_package.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/utils'
 
-class MigrateSettingsToWorkPackage < ActiveRecord::Migration[4.2]
+class MigrateSettingsToWorkPackage < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   COLUMN = 'name'

--- a/db/migrate/20130919145142_rename_issue_relations_to_relations.rb
+++ b/db/migrate/20130919145142_rename_issue_relations_to_relations.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RenameIssueRelationsToRelations < ActiveRecord::Migration[4.2]
+class RenameIssueRelationsToRelations < ActiveRecord::Migration[5.1]
   def up
     rename_table :issue_relations, :relations
 

--- a/db/migrate/20130920081120_journal_indices.rb
+++ b/db/migrate/20130920081120_journal_indices.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class JournalIndices < ActiveRecord::Migration[4.2]
+class JournalIndices < ActiveRecord::Migration[5.1]
   def up
     # remove existing indices on legacy_issues, if they still exist to avoid name-clashes with
     # the real(tm) journals-table

--- a/db/migrate/20130920081135_legacy_attachment_journal_data.rb
+++ b/db/migrate/20130920081135_legacy_attachment_journal_data.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/legacy_journal_migrator'
 
-class LegacyAttachmentJournalData < ActiveRecord::Migration[4.2]
+class LegacyAttachmentJournalData < ActiveRecord::Migration[5.1]
   def up
     add_index 'attachment_journals', ['journal_id']
 

--- a/db/migrate/20130920085055_legacy_changeset_journal_data.rb
+++ b/db/migrate/20130920085055_legacy_changeset_journal_data.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/legacy_journal_migrator'
 
-class LegacyChangesetJournalData < ActiveRecord::Migration[4.2]
+class LegacyChangesetJournalData < ActiveRecord::Migration[5.1]
   def up
     add_index 'changeset_journals', ['journal_id']
 

--- a/db/migrate/20130920090201_legacy_news_journal_data.rb
+++ b/db/migrate/20130920090201_legacy_news_journal_data.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/legacy_journal_migrator'
 
-class LegacyNewsJournalData < ActiveRecord::Migration[4.2]
+class LegacyNewsJournalData < ActiveRecord::Migration[5.1]
   def up
     add_index 'news_journals', ['journal_id']
 

--- a/db/migrate/20130920090641_legacy_message_journal_data.rb
+++ b/db/migrate/20130920090641_legacy_message_journal_data.rb
@@ -30,7 +30,7 @@
 require_relative 'migration_utils/legacy_journal_migrator'
 require_relative 'migration_utils/journal_migrator_concerns'
 
-class LegacyMessageJournalData < ActiveRecord::Migration[4.2]
+class LegacyMessageJournalData < ActiveRecord::Migration[5.1]
   def up
     add_index 'message_journals', ['journal_id']
 

--- a/db/migrate/20130920092800_legacy_time_entry_journal_data.rb
+++ b/db/migrate/20130920092800_legacy_time_entry_journal_data.rb
@@ -30,7 +30,7 @@
 require_relative 'migration_utils/legacy_journal_migrator'
 require_relative 'migration_utils/journal_migrator_concerns'
 
-class LegacyTimeEntryJournalData < ActiveRecord::Migration[4.2]
+class LegacyTimeEntryJournalData < ActiveRecord::Migration[5.1]
   def up
     add_index 'time_entry_journals', ['journal_id']
 

--- a/db/migrate/20130920093823_legacy_wiki_content_journal_data.rb
+++ b/db/migrate/20130920093823_legacy_wiki_content_journal_data.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/legacy_journal_migrator'
 
-class LegacyWikiContentJournalData < ActiveRecord::Migration[4.2]
+class LegacyWikiContentJournalData < ActiveRecord::Migration[5.1]
   class UnsupportedWikiContentJournalCompressionError < ::StandardError
   end
 

--- a/db/migrate/20130920094524_legacy_issue_journal_data.rb
+++ b/db/migrate/20130920094524_legacy_issue_journal_data.rb
@@ -31,7 +31,7 @@ require_relative 'migration_utils/utils'
 require_relative 'migration_utils/legacy_journal_migrator'
 require_relative 'migration_utils/journal_migrator_concerns'
 
-class LegacyIssueJournalData < ActiveRecord::Migration[4.2]
+class LegacyIssueJournalData < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   def up

--- a/db/migrate/20130920095747_legacy_planning_element_journal_data.rb
+++ b/db/migrate/20130920095747_legacy_planning_element_journal_data.rb
@@ -30,7 +30,7 @@
 require_relative 'migration_utils/legacy_journal_migrator'
 require_relative 'migration_utils/journal_migrator_concerns'
 
-class LegacyPlanningElementJournalData < ActiveRecord::Migration[4.2]
+class LegacyPlanningElementJournalData < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   class UnknownJournaledError < ::StandardError

--- a/db/migrate/20130920142714_update_attachment_container.rb
+++ b/db/migrate/20130920142714_update_attachment_container.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/utils'
 
-class UpdateAttachmentContainer < ActiveRecord::Migration[4.2]
+class UpdateAttachmentContainer < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   def up

--- a/db/migrate/20130920150143_journal_activities_data.rb
+++ b/db/migrate/20130920150143_journal_activities_data.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/utils'
 
-class JournalActivitiesData < ActiveRecord::Migration[4.2]
+class JournalActivitiesData < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   def up

--- a/db/migrate/20131001075217_rename_issue_category_to_category.rb
+++ b/db/migrate/20131001075217_rename_issue_category_to_category.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RenameIssueCategoryToCategory < ActiveRecord::Migration[4.2]
+class RenameIssueCategoryToCategory < ActiveRecord::Migration[5.1]
   def change
     rename_table :issue_categories, :categories
   end

--- a/db/migrate/20131001105659_rename_issue_statuses_to_statuses.rb
+++ b/db/migrate/20131001105659_rename_issue_statuses_to_statuses.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RenameIssueStatusesToStatuses < ActiveRecord::Migration[4.2]
+class RenameIssueStatusesToStatuses < ActiveRecord::Migration[5.1]
   def change
     rename_table :issue_statuses, :statuses
   end

--- a/db/migrate/20131004141959_generalize_wiki_menu_items.rb
+++ b/db/migrate/20131004141959_generalize_wiki_menu_items.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class GeneralizeWikiMenuItems < ActiveRecord::Migration[4.2]
+class GeneralizeWikiMenuItems < ActiveRecord::Migration[5.1]
   def up
     rename_table :wiki_menu_items, :menu_items
     add_column :menu_items, :type, :string

--- a/db/migrate/20131007062401_migrate_text_references_to_issues_and_planning_elements.rb
+++ b/db/migrate/20131007062401_migrate_text_references_to_issues_and_planning_elements.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/text_references'
 
-class MigrateTextReferencesToIssuesAndPlanningElements < ActiveRecord::Migration[4.2]
+class MigrateTextReferencesToIssuesAndPlanningElements < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   COLUMNS_PER_TABLE = {

--- a/db/migrate/20131009083648_work_package_indices.rb
+++ b/db/migrate/20131009083648_work_package_indices.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class WorkPackageIndices < ActiveRecord::Migration[4.2]
+class WorkPackageIndices < ActiveRecord::Migration[5.1]
   def up
     # drop obsolete fields
     remove_column :work_packages, :planning_element_status_comment

--- a/db/migrate/20131015064141_migrate_timelines_end_date_property_in_options.rb
+++ b/db/migrate/20131015064141_migrate_timelines_end_date_property_in_options.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/timelines'
 
-class MigrateTimelinesEndDatePropertyInOptions < ActiveRecord::Migration[4.2]
+class MigrateTimelinesEndDatePropertyInOptions < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   COLUMN = 'options'

--- a/db/migrate/20131015121430_index_on_users.rb
+++ b/db/migrate/20131015121430_index_on_users.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class IndexOnUsers < ActiveRecord::Migration[4.2]
+class IndexOnUsers < ActiveRecord::Migration[5.1]
   def change
     add_index :users, [:type, :login], length: { type: 255, login: 255 }
     add_index :users, [:type, :status]

--- a/db/migrate/20131016075650_add_queue_to_delayed_jobs.rb
+++ b/db/migrate/20131016075650_add_queue_to_delayed_jobs.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddQueueToDelayedJobs < ActiveRecord::Migration[4.2]
+class AddQueueToDelayedJobs < ActiveRecord::Migration[5.1]
   def self.up
     add_column :delayed_jobs, :queue, :string
   end

--- a/db/migrate/20131017064039_repair_work_packages_initial_attachable_journal.rb
+++ b/db/migrate/20131017064039_repair_work_packages_initial_attachable_journal.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/attachable_utils'
 
-class RepairWorkPackagesInitialAttachableJournal < ActiveRecord::Migration[4.2]
+class RepairWorkPackagesInitialAttachableJournal < ActiveRecord::Migration[5.1]
   include Migration::Utils
   include Migration::Utils::AttachableUtils
 

--- a/db/migrate/20131018134525_repair_messages_initial_attachable_journal.rb
+++ b/db/migrate/20131018134525_repair_messages_initial_attachable_journal.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/attachable_utils'
 
-class RepairMessagesInitialAttachableJournal < ActiveRecord::Migration[4.2]
+class RepairMessagesInitialAttachableJournal < ActiveRecord::Migration[5.1]
   include Migration::Utils
   include Migration::Utils::AttachableUtils
 

--- a/db/migrate/20131018134530_repair_customizable_journals.rb
+++ b/db/migrate/20131018134530_repair_customizable_journals.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/customizable_utils'
 
-class RepairCustomizableJournals < ActiveRecord::Migration[4.2]
+class RepairCustomizableJournals < ActiveRecord::Migration[5.1]
   include Migration::Utils
   include Migration::Utils::CustomizableUtils
 

--- a/db/migrate/20131018134545_add_missing_attachable_journals.rb
+++ b/db/migrate/20131018134545_add_missing_attachable_journals.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/attachable_utils'
 
-class AddMissingAttachableJournals < ActiveRecord::Migration[4.2]
+class AddMissingAttachableJournals < ActiveRecord::Migration[5.1]
   include Migration::Utils
   include Migration::Utils::AttachableUtils
 

--- a/db/migrate/20131018134590_add_missing_customizable_journals.rb
+++ b/db/migrate/20131018134590_add_missing_customizable_journals.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/customizable_utils'
 
-class AddMissingCustomizableJournals < ActiveRecord::Migration[4.2]
+class AddMissingCustomizableJournals < ActiveRecord::Migration[5.1]
   include Migration::Utils
   include Migration::Utils::CustomizableUtils
 

--- a/db/migrate/20131024115743_migrate_remaining_core_settings.rb
+++ b/db/migrate/20131024115743_migrate_remaining_core_settings.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class MigrateRemainingCoreSettings < ActiveRecord::Migration[4.2]
+class MigrateRemainingCoreSettings < ActiveRecord::Migration[5.1]
   REPLACED = {
     'tracker' => 'type',
     'issue_status_updated' => 'status_updated',

--- a/db/migrate/20131024140048_migrate_timelines_options.rb
+++ b/db/migrate/20131024140048_migrate_timelines_options.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/timelines'
 
-class MigrateTimelinesOptions < ActiveRecord::Migration[4.2]
+class MigrateTimelinesOptions < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   COLUMN = 'options'

--- a/db/migrate/20131031170857_fix_watcher_work_package_associations.rb
+++ b/db/migrate/20131031170857_fix_watcher_work_package_associations.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class FixWatcherWorkPackageAssociations < ActiveRecord::Migration[4.2]
+class FixWatcherWorkPackageAssociations < ActiveRecord::Migration[5.1]
   def up
     rename_watchable_type('Issue', 'WorkPackage')
     adapt_planning_element_ids

--- a/db/migrate/20131101125921_migrate_default_values_in_work_package_journals.rb
+++ b/db/migrate/20131101125921_migrate_default_values_in_work_package_journals.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/utils'
 
-class MigrateDefaultValuesInWorkPackageJournals < ActiveRecord::Migration[4.2]
+class MigrateDefaultValuesInWorkPackageJournals < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   def up

--- a/db/migrate/20131108124300_add_index_to_all_the_journals.rb
+++ b/db/migrate/20131108124300_add_index_to_all_the_journals.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddIndexToAllTheJournals < ActiveRecord::Migration[4.2]
+class AddIndexToAllTheJournals < ActiveRecord::Migration[5.1]
   def change
     # This now is only a no op.
     #

--- a/db/migrate/20131114132911_migrate_planning_element_links_in_journal_notes.rb
+++ b/db/migrate/20131114132911_migrate_planning_element_links_in_journal_notes.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/text_references'
 
-class MigratePlanningElementLinksInJournalNotes < ActiveRecord::Migration[4.2]
+class MigratePlanningElementLinksInJournalNotes < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   COLUMNS_PER_TABLE = {

--- a/db/migrate/20131115155147_fix_parent_ids_in_work_package_journals_of_former_planning_elements.rb
+++ b/db/migrate/20131115155147_fix_parent_ids_in_work_package_journals_of_former_planning_elements.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/utils'
 
-class FixParentIdsInWorkPackageJournalsOfFormerPlanningElements < ActiveRecord::Migration[4.2]
+class FixParentIdsInWorkPackageJournalsOfFormerPlanningElements < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   def up

--- a/db/migrate/20131126112911_migrate_update_create_column_reference_in_queries.rb
+++ b/db/migrate/20131126112911_migrate_update_create_column_reference_in_queries.rb
@@ -31,7 +31,7 @@ require 'yaml'
 
 require_relative 'migration_utils/queries'
 
-class MigrateUpdateCreateColumnReferenceInQueries < ActiveRecord::Migration[4.2]
+class MigrateUpdateCreateColumnReferenceInQueries < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   KEY = { 'updated_on' => 'updated_at', 'created_on' => 'created_at' }

--- a/db/migrate/20131202094511_delete_former_deleted_planning_elements.rb
+++ b/db/migrate/20131202094511_delete_former_deleted_planning_elements.rb
@@ -29,7 +29,7 @@
 
 require_relative 'migration_utils/utils'
 
-class DeleteFormerDeletedPlanningElements < ActiveRecord::Migration[4.2]
+class DeleteFormerDeletedPlanningElements < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   def up

--- a/db/migrate/20131210113056_repair_invalid_default_work_package_custom_values.rb
+++ b/db/migrate/20131210113056_repair_invalid_default_work_package_custom_values.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RepairInvalidDefaultWorkPackageCustomValues < ActiveRecord::Migration[4.2]
+class RepairInvalidDefaultWorkPackageCustomValues < ActiveRecord::Migration[5.1]
   class CurrentCustomField < ActiveRecord::Base
     self.table_name = "custom_fields"
 
@@ -39,9 +39,9 @@ class RepairInvalidDefaultWorkPackageCustomValues < ActiveRecord::Migration[4.2]
     translates :name, :default_value, :possible_values
   end
 
-  [
-    :user, :group, :work_package, :project, :version,
-    :time_entry_activity, :time_entry, :issue_priority,
+  %i[
+    user group work_package project version
+    time_entry_activity time_entry issue_priority
   ]
     .each do |name|
       Kernel.const_set(
@@ -55,9 +55,6 @@ class RepairInvalidDefaultWorkPackageCustomValues < ActiveRecord::Migration[4.2]
       create_missing_work_package_custom_values
       create_missing_work_package_customizable_journals
     end
-  end
-
-  def down
   end
 
   private
@@ -88,8 +85,7 @@ class RepairInvalidDefaultWorkPackageCustomValues < ActiveRecord::Migration[4.2]
     end
   end
 
-  def create_missing_custom_value(_table, _customized_id, _custom_field_id)
-  end
+  def create_missing_custom_value(_table, _customized_id, _custom_field_id); end
 
   def missing_custom_values
     @missing_custom_values ||= select_all <<-SQL

--- a/db/migrate/20131216171110_migrate_timelines_enumerations.rb
+++ b/db/migrate/20131216171110_migrate_timelines_enumerations.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class MigrateTimelinesEnumerations < ActiveRecord::Migration[4.2]
+class MigrateTimelinesEnumerations < ActiveRecord::Migration[5.1]
   PROJECT_STATUS_TYPE_NAME = { 'Timelines::ReportedProjectStatus' => 'ReportedProjectStatus' }
 
   def up

--- a/db/migrate/20131219084934_add_enabled_modules_name_index.rb
+++ b/db/migrate/20131219084934_add_enabled_modules_name_index.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddEnabledModulesNameIndex < ActiveRecord::Migration[4.2]
+class AddEnabledModulesNameIndex < ActiveRecord::Migration[5.1]
   def change
     add_index :enabled_modules, :name, length: 8
   end

--- a/db/migrate/20140122161742_remove_journal_columns.rb
+++ b/db/migrate/20140122161742_remove_journal_columns.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RemoveJournalColumns < ActiveRecord::Migration[4.2]
+class RemoveJournalColumns < ActiveRecord::Migration[5.1]
   def up
     change_table :work_package_journals do |t|
       t.remove :lock_version, :created_at, :root_id, :lft, :rgt

--- a/db/migrate/20140127134733_fix_issue_in_notifications.rb
+++ b/db/migrate/20140127134733_fix_issue_in_notifications.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class FixIssueInNotifications < ActiveRecord::Migration[4.2]
+class FixIssueInNotifications < ActiveRecord::Migration[5.1]
   REPLACED = {
     'issue_added' => 'work_package_added',
     'issue_updated' => 'work_package_updated',

--- a/db/migrate/20140203141127_rename_modulename_issue_tracking.rb
+++ b/db/migrate/20140203141127_rename_modulename_issue_tracking.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RenameModulenameIssueTracking < ActiveRecord::Migration[4.2]
+class RenameModulenameIssueTracking < ActiveRecord::Migration[5.1]
   def up
     update <<-SQL
       UPDATE enabled_modules

--- a/db/migrate/20140311120609_add_sticked_on_field_to_messages.rb
+++ b/db/migrate/20140311120609_add_sticked_on_field_to_messages.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddStickedOnFieldToMessages < ActiveRecord::Migration[4.2]
+class AddStickedOnFieldToMessages < ActiveRecord::Migration[5.1]
   def change
     add_column :messages, :sticked_on, :datetime,  default: nil,  null: true
   end

--- a/db/migrate/20140411142338_clear_identity_urls_on_users.rb
+++ b/db/migrate/20140411142338_clear_identity_urls_on_users.rb
@@ -26,7 +26,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class ClearIdentityUrlsOnUsers < ActiveRecord::Migration[4.2]
+class ClearIdentityUrlsOnUsers < ActiveRecord::Migration[5.1]
   def up
     create_table 'legacy_user_identity_urls' do |t|
       t.string 'login', limit: 256, default: '',    null: false

--- a/db/migrate/20140414141459_remove_openid_entirely.rb
+++ b/db/migrate/20140414141459_remove_openid_entirely.rb
@@ -26,7 +26,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class RemoveOpenidEntirely < ActiveRecord::Migration[4.2]
+class RemoveOpenidEntirely < ActiveRecord::Migration[5.1]
   def up
     drop_table 'open_id_authentication_nonces'
     drop_table 'open_id_authentication_associations'

--- a/db/migrate/20140429152018_add_sessions_table.rb
+++ b/db/migrate/20140429152018_add_sessions_table.rb
@@ -26,7 +26,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddSessionsTable < ActiveRecord::Migration[4.2]
+class AddSessionsTable < ActiveRecord::Migration[5.1]
   def change
     create_table :sessions do |t|
       t.string :session_id, null: false

--- a/db/migrate/20140430125956_reset_content_types.rb
+++ b/db/migrate/20140430125956_reset_content_types.rb
@@ -26,7 +26,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class ResetContentTypes < ActiveRecord::Migration[4.2]
+class ResetContentTypes < ActiveRecord::Migration[5.1]
   def up
     Attachment.all.each do |attachment|
       attachment.update_column(:content_type, Attachment.content_type_for(attachment.disk_filename))

--- a/db/migrate/20140602112515_drop_work_packages_priority_not_null_constraint.rb
+++ b/db/migrate/20140602112515_drop_work_packages_priority_not_null_constraint.rb
@@ -26,7 +26,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class DropWorkPackagesPriorityNotNullConstraint < ActiveRecord::Migration[4.2]
+class DropWorkPackagesPriorityNotNullConstraint < ActiveRecord::Migration[5.1]
   def change
     change_column :work_packages, :priority_id, :integer, null: true
   end

--- a/db/migrate/20140610125207_add_updated_at_index_to_work_packages.rb
+++ b/db/migrate/20140610125207_add_updated_at_index_to_work_packages.rb
@@ -26,7 +26,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddUpdatedAtIndexToWorkPackages < ActiveRecord::Migration[4.2]
+class AddUpdatedAtIndexToWorkPackages < ActiveRecord::Migration[5.1]
   def change
     add_index :work_packages, :updated_at
   end

--- a/db/migrate/20141215104802_migrate_attachments_to_carrier_wave.rb
+++ b/db/migrate/20141215104802_migrate_attachments_to_carrier_wave.rb
@@ -28,7 +28,7 @@
 
 require 'tasks/shared/legacy_attachment'
 
-class MigrateAttachmentsToCarrierWave < ActiveRecord::Migration[4.2]
+class MigrateAttachmentsToCarrierWave < ActiveRecord::Migration[5.1]
   def up
     add_column_if_missing :attachments, :file, :string
 

--- a/db/migrate/20150116095004_patch_corrupt_attachments.rb
+++ b/db/migrate/20150116095004_patch_corrupt_attachments.rb
@@ -43,7 +43,7 @@
 #       be displayed, if not downloaded.
 #
 # Important: The migration is irreversible.
-class PatchCorruptAttachments < ActiveRecord::Migration[4.2]
+class PatchCorruptAttachments < ActiveRecord::Migration[5.1]
   def up
     Attachment.all.each do |attachment|
       patch_attachment attachment

--- a/db/migrate/20150623151337_hide_mail_by_default.rb
+++ b/db/migrate/20150623151337_hide_mail_by_default.rb
@@ -26,7 +26,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class HideMailByDefault < ActiveRecord::Migration[4.2]
+class HideMailByDefault < ActiveRecord::Migration[5.1]
   def change
     change_column_default :user_preferences, :hide_mail, true
   end

--- a/db/migrate/20150629075221_add_scm_type_to_repositories.rb
+++ b/db/migrate/20150629075221_add_scm_type_to_repositories.rb
@@ -37,7 +37,7 @@
 # - Repository::*: existing
 # - Repository::Git: local
 #
-class AddScmTypeToRepositories < ActiveRecord::Migration[4.2]
+class AddScmTypeToRepositories < ActiveRecord::Migration[5.1]
   def up
     add_column :repositories, :scm_type, :string, null: true
 

--- a/db/migrate/20150716133712_add_unique_index_on_journals.rb
+++ b/db/migrate/20150716133712_add_unique_index_on_journals.rb
@@ -36,7 +36,7 @@
 # In general we learned that up until now OpenProject was not very good at handling concurrent
 # updates to journables. By adding the index we ensure data consistency, but at the same time
 # provoke errors in those update scenarios.
-class AddUniqueIndexOnJournals < ActiveRecord::Migration[4.2]
+class AddUniqueIndexOnJournals < ActiveRecord::Migration[5.1]
   def up
     cleanup_duplicate_journals
     add_index :journals, [:journable_type, :journable_id, :version], unique: true

--- a/db/migrate/20150716163704_remove_filesystem_repositories.rb
+++ b/db/migrate/20150716163704_remove_filesystem_repositories.rb
@@ -29,7 +29,7 @@
 ##
 # Removes all remaining Repository::Filesystem entries.
 #
-class RemoveFilesystemRepositories < ActiveRecord::Migration[4.2]
+class RemoveFilesystemRepositories < ActiveRecord::Migration[5.1]
   include Migration::Utils
 
   def up

--- a/db/migrate/20150729145732_add_storage_information_to_repository.rb
+++ b/db/migrate/20150729145732_add_storage_information_to_repository.rb
@@ -25,7 +25,7 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
-class AddStorageInformationToRepository < ActiveRecord::Migration[4.2]
+class AddStorageInformationToRepository < ActiveRecord::Migration[5.1]
   def change
     add_column :repositories, :required_storage_bytes, :integer,
                limit: 8, null: false, default: 0

--- a/db/migrate/20150819143300_underscore_scm_settings.rb
+++ b/db/migrate/20150819143300_underscore_scm_settings.rb
@@ -25,7 +25,7 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
-class UnderscoreScmSettings < ActiveRecord::Migration[4.2]
+class UnderscoreScmSettings < ActiveRecord::Migration[5.1]
   def up
     Setting.enabled_scm = Setting.enabled_scm.map(&:underscore)
   end

--- a/db/migrate/20150820133700_denullify_display_sums.rb
+++ b/db/migrate/20150820133700_denullify_display_sums.rb
@@ -25,7 +25,7 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
-class DenullifyDisplaySums < ActiveRecord::Migration[4.2]
+class DenullifyDisplaySums < ActiveRecord::Migration[5.1]
   def change
     change_column_default :queries, :display_sums, false
     change_column_null :queries, :display_sums, false, false

--- a/db/migrate/20150827133700_remove_project_homepage.rb
+++ b/db/migrate/20150827133700_remove_project_homepage.rb
@@ -26,7 +26,7 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
-class RemoveProjectHomepage < ActiveRecord::Migration[4.2]
+class RemoveProjectHomepage < ActiveRecord::Migration[5.1]
   def change
     remove_column :projects, :homepage, :string, default: ''
   end

--- a/db/migrate/20151005113102_remove_summary_from_project.rb
+++ b/db/migrate/20151005113102_remove_summary_from_project.rb
@@ -1,4 +1,4 @@
-class RemoveSummaryFromProject < ActiveRecord::Migration[4.2]
+class RemoveSummaryFromProject < ActiveRecord::Migration[5.1]
   def change
     remove_column :projects, :summary
   end

--- a/db/migrate/20151028063433_boolearlize_bool_custom_values.rb
+++ b/db/migrate/20151028063433_boolearlize_bool_custom_values.rb
@@ -1,4 +1,4 @@
-class BoolearlizeBoolCustomValues < ActiveRecord::Migration[4.2]
+class BoolearlizeBoolCustomValues < ActiveRecord::Migration[5.1]
   def up
     update_custom_values(fake_true, db_true, fake_false, db_false)
     update_queries(fake_true, db_true_unquoted, fake_false, db_false_unquoted)

--- a/db/migrate/20151116110245_fix_customizable_bool_values.rb
+++ b/db/migrate/20151116110245_fix_customizable_bool_values.rb
@@ -1,4 +1,4 @@
-class FixCustomizableBoolValues < ActiveRecord::Migration[4.2]
+class FixCustomizableBoolValues < ActiveRecord::Migration[5.1]
   def up
     update_customizable_values(quoted_true, unquoted_true, quoted_false, unquoted_false)
   end

--- a/db/migrate/20160125143638_index_member_roles_inherited_from.rb
+++ b/db/migrate/20160125143638_index_member_roles_inherited_from.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class IndexMemberRolesInheritedFrom < ActiveRecord::Migration[4.2]
+class IndexMemberRolesInheritedFrom < ActiveRecord::Migration[5.1]
   def change
     # The index is required for member/member_role deletion when a user
     # leaves a group.

--- a/db/migrate/20160419103544_add_attribute_visibility_to_types.rb
+++ b/db/migrate/20160419103544_add_attribute_visibility_to_types.rb
@@ -1,4 +1,4 @@
-class AddAttributeVisibilityToTypes < ActiveRecord::Migration[4.2]
+class AddAttributeVisibilityToTypes < ActiveRecord::Migration[5.1]
   def change
     add_column :types, :attribute_visibility, :text, hash: true
   end

--- a/db/migrate/20160503150449_add_indexes_for_latest_activity.rb
+++ b/db/migrate/20160503150449_add_indexes_for_latest_activity.rb
@@ -1,4 +1,4 @@
-class AddIndexesForLatestActivity < ActiveRecord::Migration[4.2]
+class AddIndexesForLatestActivity < ActiveRecord::Migration[5.1]
   def change
     add_index :work_packages, [:project_id, :updated_at]
     add_index :news, [:project_id, :created_on]

--- a/db/migrate/20160726090624_add_slug_to_wiki_pages.rb
+++ b/db/migrate/20160726090624_add_slug_to_wiki_pages.rb
@@ -1,4 +1,4 @@
-class AddSlugToWikiPages < ActiveRecord::Migration[4.2]
+class AddSlugToWikiPages < ActiveRecord::Migration[5.1]
   def up
     add_column :wiki_pages, :slug, :string
     add_index :wiki_pages, [:wiki_id, :slug], name: 'wiki_pages_wiki_id_slug', unique: true

--- a/db/migrate/20160803094931_wiki_menu_titles_to_slug.rb
+++ b/db/migrate/20160803094931_wiki_menu_titles_to_slug.rb
@@ -1,4 +1,4 @@
-class WikiMenuTitlesToSlug < ActiveRecord::Migration[4.2]
+class WikiMenuTitlesToSlug < ActiveRecord::Migration[5.1]
   def up
     migrate_menu_items
   end

--- a/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/changes.rb
+++ b/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/changes.rb
@@ -119,11 +119,9 @@ module Redmine::Acts::Journalized
       # creation. Incremental changes are reset when the record is saved because they represent
       # a subset of the dirty attribute changes, which are reset upon save.
       def incremental_journal_changes
-        changed.inject({}) { |h, attr|
-          h[attr] = attribute_change(attr) unless !attribute_change(attr).nil? &&
-                                                  attribute_change(attr)[0].blank? && attribute_change(attr)[1].blank?
-          h
-        }.slice(*journaled_columns)
+        saved_changes.reject do |_, change|
+          change[0].blank? && change[1].blank?
+        end.slice(*journaled_columns)
       end
 
       # Simply resets the cumulative changes after journal creation.

--- a/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/creation.rb
+++ b/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/creation.rb
@@ -142,8 +142,10 @@ module Redmine::Acts::Journalized
 
         attributes_setter.call(initial_changes)
 
-        # Call the journal creating method
-        changed_data = fill_object.send(:merge_journal_changes)
+        # Get the changed attributes
+        changed_data = fill_object.changes.reject do |_, change|
+          change[0].blank? && change[1].blank?
+        end.slice(*journaled_columns)
 
         new_journal.version = 1
         new_journal.activity_type = activity_type

--- a/lib/tasks/quote_strings_with_invalid_characters_in_legacy_journals.rake
+++ b/lib/tasks/quote_strings_with_invalid_characters_in_legacy_journals.rake
@@ -40,7 +40,7 @@ namespace :migrations do
 
     private
 
-    class InvalidChangedDataStringQuoter < ActiveRecord::Migration
+    class InvalidChangedDataStringQuoter < ActiveRecord::Migration[5.1]
       include Migration::Utils
 
       def quote_strings_with_invalid_characters

--- a/script/ci_setup.sh
+++ b/script/ci_setup.sh
@@ -69,6 +69,8 @@ else
   run "mkdir -p app/assets/javascripts/bundles"
   run "touch app/assets/javascripts/bundles/openproject-core-app.js"
   run "touch app/assets/javascripts/bundles/openproject-vendors.js"
+  run "mkdir -p app/assets/javascripts/locales"
+  run "touch app/assets/javascripts/locales/en.js"
 
   run "mkdir -p app/assets/stylesheets/bundles"
   run "touch app/assets/javascripts/bundles/openproject-core-app.css"

--- a/spec/controllers/sys_controller_spec.rb
+++ b/spec/controllers/sys_controller_spec.rb
@@ -30,8 +30,7 @@ require 'spec_helper'
 
 describe SysController, type: :controller do
   let(:commit_role) {
-    FactoryGirl.create(:role, permissions: [:commit_access,
-                                            :browse_repository])
+    FactoryGirl.create(:role, permissions: %i[commit_access browse_repository])
   }
   let(:browse_role) { FactoryGirl.create(:role, permissions: [:browse_repository]) }
   let(:guest_role) { FactoryGirl.create(:role, permissions: []) }
@@ -315,13 +314,12 @@ describe SysController, type: :controller do
         end
 
         it 'should respond 403 not allowed for write (push)' do
-          post 'repo_auth',
-               key: api_key,
-               repository: project.identifier,
-               method: 'POST',
-               git_smart_http: '1',
-               uri: "/git/#{project.identifier}/git-receive-pack",
-               location: '/git'
+          post 'repo_auth', params: { key: api_key,
+                                      repository: project.identifier,
+                                      method: 'POST',
+                                      git_smart_http: '1',
+                                      uri: "/git/#{project.identifier}/git-receive-pack",
+                                      location: '/git' }
 
           expect(response.code).to eq('403')
         end

--- a/spec/models/relation/hierarchy_paths_spec.rb
+++ b/spec/models/relation/hierarchy_paths_spec.rb
@@ -226,7 +226,7 @@ describe Relation, 'hierarchy_paths', type: :model do
     let!(:parent_child_relation) { Relation.create relation_type: 'hierarchy', from: parent, to: child }
 
     before do
-      ActiveRecord::Base.connection.select_rows <<-SQL
+      ActiveRecord::Base.connection.execute <<-SQL
         DELETE FROM hierarchy_paths
       SQL
       ActiveRecord::Base.connection.execute <<-SQL

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -448,6 +448,7 @@ describe WorkPackage, type: :model do
         @issue.save!
 
         @issue.description = ''
+        @issue.save!
         expect(@issue.send(:incremental_journal_changes)).to be_empty
       end
     end

--- a/spec/services/authorization/user_allowed_query_spec.rb
+++ b/spec/services/authorization/user_allowed_query_spec.rb
@@ -54,8 +54,8 @@ describe Authorization::UserAllowedQuery do
       non_member_role.save!
     end
 
-    it 'is a user relation' do
-      expect(described_class.query(action, project)).to be_a User::ActiveRecord_Relation
+    it 'is an AR relation' do
+      expect(described_class.query(action, project)).to be_a ActiveRecord::Relation
     end
 
     context 'w/o the project being public

--- a/spec_legacy/functional/timelog_controller_spec.rb
+++ b/spec_legacy/functional/timelog_controller_spec.rb
@@ -148,7 +148,9 @@ describe TimelogController, type: :controller do
     # simulate that this fails (e.g. due to a plugin), see #5700
     TimeEntry.class_eval do
       before_destroy :stop_callback_chain
-      def stop_callback_chain; false; end
+      def stop_callback_chain
+        throw :abort
+      end
     end
 
     session[:user_id] = 2

--- a/spec_legacy/unit/mail_handler_spec.rb
+++ b/spec_legacy/unit/mail_handler_spec.rb
@@ -256,6 +256,7 @@ describe MailHandler, type: :model do
 
   it 'should add work package with localized attributes' do
     User.find_by_mail('jsmith@somenet.foo').update_attribute 'language', 'de'
+
     issue = submit_email('ticket_with_localized_attributes.eml', allow_override: 'type,category,priority')
     assert issue.is_a?(WorkPackage)
     assert !issue.new_record?

--- a/spec_legacy/unit/repository_spec.rb
+++ b/spec_legacy/unit/repository_spec.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -26,7 +27,7 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
-require 'legacy_spec_helper'
+require_relative '../legacy_spec_helper'
 
 describe Repository, type: :model do
   fixtures :all


### PR DESCRIPTION
Initial attempt to bump rails to 5.1 

### TODO
* ~~Squash migrations to be able to remove gems like globalize and syck~~ will be done in different PR
* [x] bump `rails-angular-xss`
* [x] reactivate api reloading (maybe move it from `lib` to `app`)
* [x] fix migrations (can no longer inherit from `ActiveRecord::Migration`)
* [x] Adapt plugins (most of this has been done already by fixing migrations
  * [x] costs
  * [x] reporting_engine
  * [x] two_factor_authentication

https://community.openproject.com/projects/openproject/work_packages/26869