### PR TITLE
Fix/parent sorting missing elements

### DIFF
--- a/app/models/queries/columns/base.rb
+++ b/app/models/queries/columns/base.rb
@@ -34,6 +34,7 @@ class Queries::Columns::Base
               :association
 
   attr_accessor :name,
+                :sortable_join,
                 :summable,
                 :default_order
 
@@ -43,6 +44,7 @@ class Queries::Columns::Base
     self.name = name
 
     %i(sortable
+       sortable_join
        groupable
        summable
        association

--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -56,26 +56,34 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
     parent: {
       association: 'ancestors_relations',
       default_order: 'asc',
-      sortable: ["COALESCE(#{Relation.table_name}.from_id, #{WorkPackage.table_name}.id)",
-                 "COALESCE(#{Relation.table_name}.hierarchy, 0)"],
+      sortable: ["COALESCE(depth_relations.from_id, #{WorkPackage.table_name}.id)",
+                 "COALESCE(depth_relations.hierarchy, 0)"],
       sortable_join: <<-SQL
         LEFT OUTER JOIN (
           SELECT
             r1.from_id,
             r1.to_id,
             r1.hierarchy
-        FROM relations r1
-        LEFT OUTER JOIN relations r2
-          ON
-            r1.to_id = r2.to_id
-            AND r1.hierarchy < r2.hierarchy
+          FROM relations r1
+          LEFT OUTER JOIN relations r2
+            ON
+              r1.to_id = r2.to_id
+              AND r1.hierarchy < r2.hierarchy
+              AND r2.relates = 0
+              AND r2.duplicates = 0
+              AND r2.follows = 0
+              AND r2.blocks = 0
+              AND r2.includes = 0
+              AND r2.requires = 0
+          WHERE
+            r2.id IS NULL
             AND r1.relates = 0
             AND r1.duplicates = 0
             AND r1.follows = 0
             AND r1.blocks = 0
             AND r1.includes = 0
             AND r1.requires = 0
-          WHERE r2.id IS NULL) depth_relations
+        ) depth_relations
         ON depth_relations.to_id = work_packages.id
       SQL
     },

--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -57,7 +57,27 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
       association: 'ancestors_relations',
       default_order: 'asc',
       sortable: ["COALESCE(#{Relation.table_name}.from_id, #{WorkPackage.table_name}.id)",
-                 "COALESCE(#{Relation.table_name}.hierarchy, 0)"]
+                 "COALESCE(#{Relation.table_name}.hierarchy, 0)"],
+      sortable_join: <<-SQL
+        LEFT OUTER JOIN (
+          SELECT
+            r1.from_id,
+            r1.to_id,
+            r1.hierarchy
+        FROM relations r1
+        LEFT OUTER JOIN relations r2
+          ON
+            r1.to_id = r2.to_id
+            AND r1.hierarchy < r2.hierarchy
+            AND r1.relates = 0
+            AND r1.duplicates = 0
+            AND r1.follows = 0
+            AND r1.blocks = 0
+            AND r1.includes = 0
+            AND r1.requires = 0
+          WHERE r2.id IS NULL) depth_relations
+        ON depth_relations.to_id = work_packages.id
+      SQL
     },
     status: {
       association: 'status',

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -75,6 +75,7 @@ class ::Query::Results
       .where(query.statement)
       .where(options[:conditions])
       .includes(all_includes)
+      .joins(all_joins)
       .order(order_option)
       .references(:projects)
   end
@@ -141,6 +142,10 @@ class ::Query::Results
     (%i(status project) +
       includes_for_columns(include_columns) +
       (options[:include] || [])).uniq
+  end
+
+  def all_joins
+    query.sort_criteria_columns.map { |column, _direction| column.sortable_join }.compact
   end
 
   def includes_for_columns(column_names)


### PR DESCRIPTION
On sorting by parent, we need to join the query with a subselect that returns only the topmost hierarchy relation (i.e. the relation that has the highest hierarchy value) per work package. Otherwise, if more than one row is returned per wp for the subquery, the work package is also counted multiple times against the provided limit which leads to less work packages being returned than expected.

https://community.openproject.com/projects/openproject/work_packages/26880/activity