### PR TITLE
[26862] Ensure AWS provider key is uppercase

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -156,7 +156,7 @@ gem 'nokogiri', '~> 1.8.1'
 # fog dependency chain. We only need aws here, so we can avoid it
 # at the cost of referencing carrierwave#master for now.
 gem 'fog-aws'
-gem 'carrierwave', git: 'https://github.com/carrierwaveuploader/carrierwave', branch: 'master'
+gem 'carrierwave', '~> 1.2.2'
 
 gem 'openproject-token', '~> 1.0.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/carrierwaveuploader/carrierwave
-  revision: 5367a636053b85bd639f2d1ee6ab25ef8305aeaf
-  branch: master
-  specs:
-    carrierwave (1.0.0.beta)
-      activemodel (>= 4.0.0)
-      activesupport (>= 4.0.0)
-      mime-types (>= 1.16)
-
-GIT
   remote: https://github.com/dr0verride/RubyTree.git
   revision: 06f53ee78cc2a48377c1bd177d3bc83c1504701c
   ref: 06f53ee
@@ -190,6 +180,10 @@ GEM
     capybara-screenshot (1.0.17)
       capybara (>= 1.0, < 3)
       launchy
+    carrierwave (1.2.2)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      mime-types (>= 1.16)
     cells (4.1.3)
       tilt (>= 1.4, < 3)
       uber (>= 0.0.9)
@@ -632,7 +626,7 @@ DEPENDENCIES
   capybara-ng (~> 0.2.7)
   capybara-screenshot (~> 1.0.14)
   capybara-select2!
-  carrierwave!
+  carrierwave (~> 1.2.2)
   cells-erb (~> 0.0.8)
   cells-rails (~> 0.0.6)
   cocaine (~> 0.5.8)

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -35,9 +35,16 @@ module CarrierWave
     def self.configure_fog!(credentials: OpenProject::Configuration.fog_credentials,
                             directory: OpenProject::Configuration.fog_directory,
                             public: false)
+
+      # Ensure that the provider AWS is uppercased
+      provider = credentials[:provider] || 'AWS'
+      if [:aws, 'aws'].include? provider
+        provider = 'AWS'
+      end
+
       CarrierWave.configure do |config|
         config.fog_provider    = 'fog/aws'
-        config.fog_credentials = { provider: 'AWS' }.merge(credentials)
+        config.fog_credentials = { provider: provider }.merge(credentials)
         config.fog_directory   = directory
         config.fog_public      = public
       end


### PR DESCRIPTION
The fog uploader is not case sensitive, however the storage wrapper in Carrierwave is: https://github.com/carrierwaveuploader/carrierwave/blob/v1.0.0.beta/lib/carrierwave/storage/fog.rb#L186

If the provider is set with a lowercase key, uploading to S3 works, but the remote file will be reported nil.

This also bumps Carrierwave to a non-git version since I've tested against that version.