### PR TITLE
[26857] Better display fields titles

### DIFF
--- a/frontend/app/components/wp-display/wp-display-field/wp-display-field.module.ts
+++ b/frontend/app/components/wp-display/wp-display-field/wp-display-field.module.ts
@@ -71,6 +71,17 @@ export class DisplayField extends Field {
     return (this.schema.name || this.name);
   }
 
+  public get title():string|null {
+
+    // Don't return a value for long text fields,
+    // since they shouldn't / won't be truncated.
+    if (this.isFormattable) {
+      return null;
+    }
+
+    return this.valueString;
+  }
+
   protected get $injector():ng.auto.IInjectorService {
     return (this.constructor as typeof DisplayField).$injector;
   }

--- a/frontend/app/components/wp-edit-form/display-field-renderer.ts
+++ b/frontend/app/components/wp-edit-form/display-field-renderer.ts
@@ -55,7 +55,11 @@ export class DisplayFieldRenderer {
 
     const field = this.getField(workPackage, fieldSchema, schemaName, changeset);
     field.render(span, this.getText(field, placeholder));
-    span.setAttribute('title', this.getLabel(field, workPackage));
+
+    const title = field.title;
+    if (title) {
+      span.setAttribute('title', title);
+    }
     span.setAttribute('aria-label', this.getAriaLabel(field, workPackage));
 
     return [field, span];
@@ -115,14 +119,6 @@ export class DisplayFieldRenderer {
       span.setAttribute('role', 'button');
     } else {
       span.classList.add(readOnlyClassName);
-    }
-  }
-
-  private getLabel(field:DisplayField, workPackage:WorkPackageResourceInterface):string {
-    if (field.writable && workPackage.isEditable) {
-      return this.I18n.t('js.inplace.button_edit', { attribute: `${field.displayName}` });
-    } else {
-      return field.displayName;
     }
   }
 


### PR DESCRIPTION
Tested and Jaws and Voiceover, the aria-label is sufficient in the display fields to avoid misusing the title.

Instead, non-formattable will render the display text as its title since its currently the only one that will be truncated.

https://community.openproject.com/wp/26857