### PR TITLE
[26890] Restore flaot on overridden help menu after dropdown changes

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -66,6 +66,7 @@
     border-top: 0
     position: relative
   li.drop-down,
+  li.help-menu--overridden-link,
   .accessibility-mode & li
     float: left
     list-style-type: none

--- a/lib/redmine/menu_manager/top_menu/help_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/help_menu.rb
@@ -37,6 +37,8 @@ module Redmine::MenuManager::TopMenu::HelpMenu
     Rails.cache.fetch(cache_key) do
       if OpenProject::Static::Links.help_link_overridden?
         render_menu_node(item)
+        caption, url, selected = extract_node_details(item)
+        content_tag('li', render_single_menu_node(item, caption, url, selected), class: 'help-menu--overridden-link')
       else
         render_help_dropdown
       end


### PR DESCRIPTION
https://community.openproject.com/wp/26890