### PR TITLE
[26883] New autocompleter does not grow in size with the dropdown

### DIFF
--- a/app/assets/stylesheets/content/menus/_project_autocompletion.sass
+++ b/app/assets/stylesheets/content/menus/_project_autocompletion.sass
@@ -5,7 +5,7 @@
 .project-search-results
   position: absolute
   left: -1px
-  width: 400px !important
+  width: 400px
   background: white
 
   @include default-font($header-drop-down-projects-search-font-color, 13px)

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -95,7 +95,7 @@
       li
         float: none
     > ul.drop-down--projects
-      min-width: 400px
+      width: 400px
       left: 0
       box-shadow: none
 

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -58,7 +58,8 @@
       font-size: 1.25rem !important
       vertical-align: text-bottom
     li > ul.drop-down--projects
-      min-width: 0
+      width: 100vw
+      border-right: none
 
   #account-nav-right
     > li
@@ -105,7 +106,7 @@
       // Viewport minus #account-nav-right when logged out (french: Connexion)
       max-width: calc(100vW - 150px)
       ul
-        width: 100vw
+        width: 100vw !important
         border: none
         top: $header-height-mobile
 
@@ -113,5 +114,9 @@
     width: 100vw !important
     left: 0 !important
     border-right: 0
-    .select2-search:before
-      right: 44px
+
+    .project-menu-autocomplete--input-container
+      border-right: none !important
+    .project-menu-autocomplete--results
+      border-bottom: 2px solid $header-drop-down-border-color !important
+


### PR DESCRIPTION
This limit the projects dropdown width to fit the new autocompleter. On mobile the whole screen is used. Thus the same behavior is achieved as before the dropdown and autocompleter refactorings.

https://community.openproject.com/projects/openproject/work_packages/26883/activity