### PR TITLE
Right side top menu on next line (mobile)

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -99,12 +99,13 @@
     #projects-menu
       font-size: 15px
       .button--dropdown-text
-        // Viewport minus #account-nav-right when logged out minus padding
-        // (french: Connexion).
-        max-width: calc(100vW - 150px - 49px)
+        // Viewport minus #account-nav-right when logged out
+        // Long login translation: "Connexion" (French) to test
+        max-width: calc(100vW - 165px - 49px)
     .drop-down
-      // Viewport minus #account-nav-right when logged out (french: Connexion)
-      max-width: calc(100vW - 150px)
+      // Viewport minus #account-nav-right when logged out
+      // Long login translation: "Connexion" (French) to test
+      max-width: calc(100vW - 165px)
       ul
         width: 100vw !important
         border: none


### PR DESCRIPTION
On mobile screens the projects title has to be limited to have enough space for the right handed menu. 
With german language the design broke because there was not enough space.

![bildschirmfoto 2018-01-12 um 10 19 09](https://user-images.githubusercontent.com/7457313/34867874-12222f48-f782-11e7-96de-1b005606921e.png)
