### PR TITLE
Fix/parent depth first sorting

### DIFF
--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -56,35 +56,12 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
     parent: {
       association: 'ancestors_relations',
       default_order: 'asc',
-      sortable: ["COALESCE(depth_relations.from_id, #{WorkPackage.table_name}.id)",
-                 "COALESCE(depth_relations.hierarchy, 0)"],
+      sortable: ["CONCAT_WS(',', hierarchy_paths.path, work_packages.id)"],
       sortable_join: <<-SQL
-        LEFT OUTER JOIN (
-          SELECT
-            r1.from_id,
-            r1.to_id,
-            r1.hierarchy
-          FROM relations r1
-          LEFT OUTER JOIN relations r2
-            ON
-              r1.to_id = r2.to_id
-              AND r1.hierarchy < r2.hierarchy
-              AND r2.relates = 0
-              AND r2.duplicates = 0
-              AND r2.follows = 0
-              AND r2.blocks = 0
-              AND r2.includes = 0
-              AND r2.requires = 0
-          WHERE
-            r2.id IS NULL
-            AND r1.relates = 0
-            AND r1.duplicates = 0
-            AND r1.follows = 0
-            AND r1.blocks = 0
-            AND r1.includes = 0
-            AND r1.requires = 0
-        ) depth_relations
-        ON depth_relations.to_id = work_packages.id
+        LEFT OUTER JOIN
+          hierarchy_paths
+        ON
+          hierarchy_paths.work_package_id = work_packages.id
       SQL
     },
     status: {

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -93,7 +93,7 @@ class Query < ActiveRecord::Base
   def set_default_sort
     return if sort_criteria.any?
 
-    self.sort_criteria = [['parent', 'asc'], ['id', 'asc']]
+    self.sort_criteria = [['parent', 'asc']]
   end
 
   def context

--- a/app/models/relation/hierarchy_paths.rb
+++ b/app/models/relation/hierarchy_paths.rb
@@ -1,0 +1,149 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module Relation::HierarchyPaths
+  extend ActiveSupport::Concern
+
+  included do
+    after_create :add_hierarchy_path
+    after_destroy :remove_hierarchy_path
+    after_update :update_hierarchy_path
+
+    def self.rebuild_hierarchy_paths!
+      execute_sql remove_hierarchy_path_sql
+      execute_sql add_hierarchy_path_sql
+    end
+
+    def self.execute_sql(sql)
+      ActiveRecord::Base.connection.execute sql
+    end
+
+    private
+
+    def add_hierarchy_path
+      return unless hierarchy?
+
+      self.class.execute_sql self.class.add_hierarchy_path_sql(to_id)
+    end
+
+    def remove_hierarchy_path
+      self.class.execute_sql self.class.remove_hierarchy_path_sql(to_id)
+      self.class.execute_sql self.class.add_hierarchy_path_sql(to_id)
+    end
+
+    def update_hierarchy_path
+      if was_hierarchy_relation?
+        remove_hierarchy_path
+      elsif now_hierarchy_relation_or_former_id_changed?
+        add_hierarchy_path
+      elsif hierarchy_relatin_and_to_id_changed?
+        alter_hierarchy_path
+      end
+    end
+
+    def was_hierarchy_relation?
+      relation_type_changed? && relation_type_was == Relation::TYPE_HIERARCHY
+    end
+
+    def now_hierarchy_relation_or_former_id_changed?
+      (relation_type_changed? || from_id_changed?) && hierarchy?
+    end
+
+    def hierarchy_relatin_and_to_id_changed?
+      hierarchy? && to_id_changed?
+    end
+
+    def alter_hierarchy_path
+      self.class.execute_sql self.class.remove_hierarchy_path_sql(to_id_was)
+      self.class.execute_sql self.class.add_hierarchy_path_sql(to_id)
+    end
+
+    def self.add_hierarchy_path_sql(id = nil)
+      <<-SQL
+        INSERT INTO
+          #{hierarchy_table_name}
+          (work_package_id, path)
+        SELECT
+          to_id, #{add_hierarchy_agg_function} AS path
+          FROM
+          (SELECT to_id, from_id, hierarchy
+          FROM relations
+          WHERE hierarchy > 0 AND relates = 0 AND blocks = 0 AND duplicates = 0 AND includes = 0 AND requires = 0 AND follows = 0
+          #{add_hierarchy_id_constraint(id)}
+          ) ordered_by_hierarchy
+          GROUP BY to_id
+        #{add_hierarchy_conflict_statement}
+      SQL
+    end
+
+    def self.remove_hierarchy_path_sql(id = nil)
+      id_constraint = if id
+                        "WHERE work_package_id = #{id}"
+                      end
+
+      <<-SQL
+        DELETE FROM
+        #{hierarchy_table_name}
+        #{id_constraint}
+      SQL
+    end
+
+    def self.add_hierarchy_id_constraint(id)
+      if id
+        <<-SQL
+          AND (to_id = #{id}
+               OR to_id IN (#{Relation.hierarchy.where(from_id: id).select(:to_id).to_sql}))
+        SQL
+      end
+    end
+
+    def self.add_hierarchy_conflict_statement
+      if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+        "ON DUPLICATE KEY
+         UPDATE #{hierarchy_table_name}.path = VALUES(path)"
+      else
+        "ON CONFLICT (work_package_id)
+         DO UPDATE SET path = EXCLUDED.path"
+      end
+    end
+
+    def self.add_hierarchy_agg_function
+      if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+        "GROUP_CONCAT(from_id ORDER BY hierarchy DESC SEPARATOR ',')"
+      else
+        "string_agg(from_id::TEXT, ',' ORDER BY hierarchy DESC)"
+      end
+    end
+
+    def self.hierarchy_table_name
+      'hierarchy_paths'
+    end
+  end
+end

--- a/db/migrate/20180116065518_add_hierarchy_paths.rb
+++ b/db/migrate/20180116065518_add_hierarchy_paths.rb
@@ -1,0 +1,45 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+class AddHierarchyPaths < ActiveRecord::Migration[5.0]
+  def change
+    create_table :hierarchy_paths do |t|
+      t.belongs_to :work_package, index: { unique: true }
+      # (255 * 3) = ca 767 bytes is the max length for an index in mysql 5.6 InnoDB
+      t.string :path, null: false, limit: 255
+
+      t.index :path
+    end
+
+    reversible do |dir|
+      dir.up { Relation.rebuild_hierarchy_paths! }
+    end
+  end
+end

--- a/spec/features/work_packages/table_sorting_spec.rb
+++ b/spec/features/work_packages/table_sorting_spec.rb
@@ -113,44 +113,46 @@ describe 'Select work package row', type: :feature, js: true do
     let(:child1) do
       FactoryGirl.create :work_package,
                          project: project,
-                         parent: parent,
-                         start_date: Date.today,
-                         due_date: (Date.today + 2.days)
+                         parent: parent
     end
     let(:child2) do
       FactoryGirl.create :work_package,
                          project: project,
-                         parent: parent,
-                         start_date: (Date.today + 1.days),
-                         due_date: (Date.today + 4.days)
+                         parent: parent
     end
-    let(:child3) do
+    let(:grand_child1) do
       FactoryGirl.create :work_package,
                          project: project,
-                         parent: parent,
-                         start_date: (Date.today + 2.days),
-                         due_date: (Date.today + 5.days)
+                         parent: child1
+    end
+    let(:grand_child2) do
+      FactoryGirl.create :work_package,
+                         project: project,
+                         parent: child2
+    end
+    let(:grand_child3) do
+      FactoryGirl.create :work_package,
+                         project: project,
+                         parent: child1
     end
 
     before do
+      allow(Setting).to receive(:per_page_options).and_return '4'
+
       parent
       child1
+      grand_child1
       child2
-      child3
+      grand_child2
+      grand_child3
 
       login_as user
       wp_table.visit!
     end
 
-    it 'provides the default sortation and allows second criterion after parent' do
-      wp_table.expect_work_package_listed parent, child1, child2, child3
-      wp_table.expect_work_package_order parent.id, child1.id, child2.id, child3.id
-
-      sort_by.expect_criteria(['Parent', 'asc'], ['ID', 'asc'])
-      sort_by.update_criteria(['Parent', 'asc'], ['Start date', 'desc'])
-
-      wp_table.expect_work_package_listed parent, child1, child2, child3
-      wp_table.expect_work_package_order parent.id, child3.id, child2.id, child1.id
+    it 'default sortation (parent) orders depth first' do
+      wp_table.expect_work_package_listed parent, child1, grand_child1, grand_child3
+      wp_table.expect_work_package_order parent.id, child1.id, grand_child1.id, grand_child3.id
     end
   end
 end

--- a/spec/features/work_packages/table_sorting_spec.rb
+++ b/spec/features/work_packages/table_sorting_spec.rb
@@ -89,17 +89,17 @@ describe 'Select work package row', type: :feature, js: true do
       wp_table.visit!
     end
 
-    it 'provides the default sortation and allows second criterion after parent (Regression WP#26792)' do
+    it 'provides the default sortation and allows using the value at another level (Regression WP#26792)' do
       # Expect current criteria
-      sort_by.expect_criteria(['Parent', 'asc'], ['ID', 'asc'])
+      sort_by.expect_criteria(['Parent', 'asc'])
 
       # Expect we can change the criteria and reuse that value
       sort_by.open_modal
-      sort_by.update_nth_criteria(1, 'Type')
       sort_by.update_nth_criteria(0, 'ID', descending: true)
+      sort_by.update_nth_criteria(1, 'Parent')
 
       sort_by.apply_changes
-      sort_by.expect_criteria(['ID', 'desc'], ['Type', 'asc'])
+      sort_by.expect_criteria(['ID', 'desc'], ['Parent', 'asc'])
     end
   end
 

--- a/spec/models/query/results_spec.rb
+++ b/spec/models/query/results_spec.rb
@@ -397,8 +397,8 @@ describe ::Query::Results, type: :model do
       let(:work_package8) { FactoryGirl.create(:work_package, project: project_1, subject: '8') }
       let(:work_package9) { FactoryGirl.create(:work_package, project: project_1, parent: work_package8, subject: '9') }
 
-      # have to sort by a second criteria as the order within each level (except for the first)
-      # is undefined without
+      # While we set a second sort criteria, it will be ignored as the sorting works solely on the id of the ancestors and
+      # the work package itself
       let(:sort_by) { [['parent', 'asc'], ['subject', 'asc']] }
 
       before do
@@ -416,30 +416,24 @@ describe ::Query::Results, type: :model do
         work_package7
       end
 
-      it 'sorts breadth first by parent where each level, except for the first, is orderd by the second criteria' do
+      it 'sorts depth first by parent (id) where the second criteria is unfortunately ignored' do
+        expected_order = [work_package8,
+                          work_package9,
+                          work_package1,
+                          work_package4,
+                          work_package5,
+                          work_package6,
+                          work_package2,
+                          work_package3,
+                          work_package7]
+
         expect(query_results.sorted_work_packages)
-          .to match [work_package8,
-                     work_package9,
-                     work_package1,
-                     work_package2,
-                     work_package4,
-                     work_package3,
-                     work_package5,
-                     work_package6,
-                     work_package7]
+          .to match expected_order
 
         query.sort_criteria = [['parent', 'desc'], ['subject', 'asc']]
 
         expect(query_results.sorted_work_packages)
-          .to match [work_package7,
-                     work_package3,
-                     work_package5,
-                     work_package6,
-                     work_package2,
-                     work_package4,
-                     work_package1,
-                     work_package9,
-                     work_package8]
+          .to match expected_order.reverse
       end
     end
 

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -45,7 +45,7 @@ describe Query, type: :model do
       query = Query.new_default
 
       expect(query.sort_criteria)
-        .to match_array([['parent', 'asc'], ['id', 'asc']])
+        .to match_array([['parent', 'asc']])
     end
 
     it 'does not use the default sortation if an order is provided' do

--- a/spec/models/relation/hierarchy_paths_spec.rb
+++ b/spec/models/relation/hierarchy_paths_spec.rb
@@ -1,0 +1,251 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+require 'spec_helper'
+
+describe Relation, 'hierarchy_paths', type: :model do
+  let(:parent) { FactoryGirl.create(:work_package) }
+  let(:child) { FactoryGirl.create(:work_package) }
+  let(:grand_parent) do
+    wp = FactoryGirl.create(:work_package)
+    parent.parent = wp
+    parent.save!
+    wp
+  end
+  let(:grand_child) { FactoryGirl.create(:work_package, parent: child) }
+
+  def record_for(id)
+    ActiveRecord::Base.connection.select_rows <<-SQL
+      SELECT work_package_id, path from hierarchy_paths WHERE work_package_id = #{id}
+    SQL
+  end
+
+  def path_for(id)
+    record_for(id)[0][1]
+  end
+
+  context 'on creation' do
+    context 'with a relation between two work packages' do
+      before do
+        Relation.create relation_type: 'hierarchy', from: parent, to: child
+      end
+
+      it 'adds a hierarchy path for the child' do
+        expect(record_for(child.id)).not_to be_empty
+      end
+
+      it 'has the parent_id in the path' do
+        expect(path_for(child.id)).to eql parent.id.to_s
+      end
+
+      it 'has no hierarchy path for the parent' do
+        expect(record_for(parent.id)).to be_empty
+      end
+    end
+
+    context 'with a non hierarchy relation between two work packages' do
+      before do
+        Relation.create relation_type: Relation::TYPE_BLOCKS, from: parent, to: child
+      end
+
+      it 'has no hierarchy path for the child' do
+        expect(record_for(child.id)).to be_empty
+      end
+
+      it 'has no hierarchy path for the parent' do
+        expect(record_for(parent.id)).to be_empty
+      end
+    end
+
+    context 'with a relation connecting two already existing hierarchies' do
+      before do
+        grand_parent
+        grand_child
+        Relation.create relation_type: 'hierarchy', from: parent, to: child
+      end
+
+      it 'adds a hierarchy path for the child' do
+        expect(record_for(child.id)).not_to be_empty
+      end
+
+      it 'has the grand parent and the parent in the path for the child' do
+        expect(path_for(child.id)).to eql "#{grand_parent.id},#{parent.id}"
+      end
+
+      it 'has grand parent, parent and child in the path for the grand_child' do
+        expect(path_for(grand_child.id)).to eql "#{grand_parent.id},#{parent.id},#{child.id}"
+      end
+    end
+  end
+
+  context 'on deletion' do
+    context 'with a simple parent-child relationship' do
+      before do
+        relation = Relation.create relation_type: 'hierarchy', from: parent, to: child
+        relation.destroy
+      end
+
+      it 'removes the hierarchy path for the child' do
+        expect(record_for(child.id)).to be_empty
+      end
+    end
+
+    context 'with a relation spanning several hops' do
+      before do
+        grand_parent
+        grand_child
+        relation = Relation.create relation_type: 'hierarchy', from: parent, to: child
+
+        relation.destroy
+      end
+
+      it 'removes the hierarchy path for the child' do
+        expect(record_for(child.id)).to be_empty
+      end
+
+      it 'has the grand parent in the path for the parent' do
+        expect(path_for(parent.id)).to eql grand_parent.id.to_s
+      end
+
+      it 'child in the path for the grand_child' do
+        expect(path_for(grand_child.id)).to eql child.id.to_s
+      end
+    end
+
+    context 'with a non hierarchy relation connecting hierarchies' do
+      before do
+        grand_parent
+        grand_child
+        relation = Relation.create relation_type: Relation::TYPE_RELATES, from: parent, to: child
+
+        relation.destroy
+      end
+
+      it 'removes the hierarchy path for the child' do
+        expect(record_for(child.id)).to be_empty
+      end
+
+      it 'has the grand parent in the path for the parent' do
+        expect(path_for(parent.id)).to eql grand_parent.id.to_s
+      end
+
+      it 'child in the path for the grand_child' do
+        expect(path_for(grand_child.id)).to eql child.id.to_s
+      end
+    end
+  end
+
+  context 'on update' do
+    let(:parent_child_relation) { Relation.create relation_type: 'hierarchy', from: parent, to: child }
+    let(:follows_relation) { Relation.create relation_type: 'follows', from: parent, to: child }
+    let(:other_wp) { FactoryGirl.create :work_package }
+
+    context 'on switching the type to non hierarchy' do
+      before do
+        parent_child_relation.relation_type = Relation::TYPE_FOLLOWS
+        parent_child_relation.save
+      end
+
+      it 'removes the hierarchy_path' do
+        expect(record_for(child.id)).to be_empty
+      end
+    end
+
+    context 'on switching from_id' do
+      before do
+        parent_child_relation.from_id = other_wp.id
+        parent_child_relation.save!
+      end
+
+      it 'updates the path' do
+        expect(path_for(child.id)).to eql other_wp.id.to_s
+      end
+    end
+
+    context 'on switching to_id' do
+      before do
+        grand_child
+        grand_parent
+        relation = Relation.create to_id: other_wp.id, from_id: parent.id, relation_type: Relation::TYPE_HIERARCHY
+        relation.to_id = child.id
+        relation.save!
+      end
+
+      it 'adds a path for the new child' do
+        expect(path_for(child.id)).to eql "#{grand_parent.id},#{parent.id}"
+      end
+
+      it 'removes the path for the former child' do
+        expect(record_for(other_wp.id)).to be_empty
+      end
+
+      it 'updates the path to the children of the new child' do
+        expect(path_for(grand_child.id)).to eql "#{grand_parent.id},#{parent.id},#{child.id}"
+      end
+    end
+
+    context 'on switching the type to hierarchy' do
+      before do
+        follows_relation.relation_type = Relation::TYPE_HIERARCHY
+        follows_relation.save
+      end
+
+      it 'adds the hierarchy_path' do
+        expect(record_for(child.id)).not_to be_empty
+      end
+    end
+  end
+
+  describe '#rebuild_hierarchy_paths!' do
+    let!(:parent_child_relation) { Relation.create relation_type: 'hierarchy', from: parent, to: child }
+
+    before do
+      ActiveRecord::Base.connection.select_rows <<-SQL
+        DELETE FROM hierarchy_paths
+      SQL
+      ActiveRecord::Base.connection.execute <<-SQL
+        INSERT INTO hierarchy_paths (work_package_id, path) VALUES (#{parent.id}, '123')
+      SQL
+
+      Relation.rebuild_hierarchy_paths!
+    end
+
+    it 'adds a hierarchy path for the child' do
+      expect(record_for(child.id)).not_to be_empty
+    end
+
+    it 'has the parent_id in the path' do
+      expect(path_for(child.id)).to eql parent.id.to_s
+    end
+
+    it 'has no hierarchy path for the parent' do
+      expect(record_for(parent.id)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Instead of sorting breadth-first, the wp query results are now filtered depth-first which prevents cutting work packages of same level in two which happened when the ids where not consecutive.

https://community.openproject.com/projects/openproject/work_packages/26880/activity

Because calculating the tree for depth-first sorting on the fly is too expensive, the `hierarchy_paths` table is introduced. It is updated whenever a hierarchy relation is added/removed or altered.

:warning: Requires Postgresql >= 9.5 :warning:
And as such should be merged after #6100 