### PR TITLE
[26942] Dropdowns are too big in accessibility mode

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -67,7 +67,7 @@
     position: relative
   li.drop-down,
   li.help-menu--overridden-link,
-  .accessibility-mode & li
+  .accessibility-mode & #account-nav-left li
     float: left
     list-style-type: none
     white-space: nowrap


### PR DESCRIPTION
This limits an accessibility styling rule so that it is only applied on the left top menu where it is needed. Thus the dropdowns now look normal again.


https://community.openproject.com/projects/openproject/work_packages/26942/activity