### PR TITLE
[26943] Values in attachments info missing (create form)

### DIFF
--- a/frontend/app/components/wp-attachments/wp-attachment-list/wp-attachment-list-item.html
+++ b/frontend/app/components/wp-attachments/wp-attachment-list/wp-attachment-list-item.html
@@ -10,7 +10,11 @@
             download>
 
           {{ ::attachment.fileName || attachment.customName || attachment.name }}
-          <authoring class="work-package--attachments--info" created-on="attachment.createdAt" author="attachment.author" show-author-as-link="false"></authoring>
+          <authoring class="work-package--attachments--info"
+                     created-on="attachment.createdAt"
+                     author="attachment.author"
+                     show-author-as-link="false"
+                     ng-if="!$ctrl.workPackage.isNew"></authoring>
         </a>
       </span>
       <a


### PR DESCRIPTION
Do not show additional attachments info in create form. They do not provide any additional value since the author is the only one who could have added attachments at this points.

https://community.openproject.com/projects/openproject/work_packages/26943/activity