### PR TITLE
[26881] Fix sass deprecations

### DIFF
--- a/app/assets/stylesheets/content/_advanced_filters.sass
+++ b/app/assets/stylesheets/content/_advanced_filters.sass
@@ -75,18 +75,22 @@
 // The type="text" is required to be more specific
 .advanced-filters--text-field[type="text"],
 .advanced-filters--date-field[type="text"]
-  @extend .form--text-field, .form--text-field.-small
+  @extend .form--text-field
+  @include form--input-field-mixin--small
 
   &:required
     box-shadow: none
 
 .advanced-filters--select
-  @extend .form--select, .form--select.-small, .form--select.-narrow
+  @extend .form--select
+  @include form--input-field-mixin--small
+  @include form--input-field-mixin--narrow
   margin-bottom: 0
 
 // The type="number" is required to be more specific
 .advanced-filters--number-field[type="number"]
-  @extend .form--text-field, .form--text-field.-small
+  @extend .form--text-field
+  @include form--input-field-mixin--small
 
 .advanced-filters--filter-name
   @include grid-content(2)
@@ -111,7 +115,8 @@
     flex: 1
 
 .advanced-filters--affix
-  @extend .form--field-affix, .form--field-affix.-transparent
+  @extend .form--field-affix
+  @include form--field-affix-mixin--transparent
   font-size: 0.9rem
 
 .advanced-filters--tooltip-trigger[data-tooltip]

--- a/app/assets/stylesheets/content/_collapsible_section.sass
+++ b/app/assets/stylesheets/content/_collapsible_section.sass
@@ -4,12 +4,12 @@
 .collapsible-section--legend
   &:before
     @include icon-common
-    @extend .icon-arrow-down1:before
+    @include icon-mixin-arrow-down1
     font-size: 0.75rem
     padding:   0.625rem 0.25rem 0 0.25rem
 
     .collapsible-section.-expanded &
-      @extend .icon-arrow-up1:before
+      @include icon-mixin-arrow-up1
 
 .collapsible-section--toggle-link
   @include without-link-styling

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -262,12 +262,12 @@ fieldset.form--fieldset
     font-size: 0.75rem
 
     .form--fieldset.-collapsible > &
-      @extend .icon-arrow-up1:before
+      @include icon-mixin-arrow-up1
       padding:   0.625rem 0.25rem 0 0.25rem
 
     .form--fieldset.-collapsible.-collapsed > &,
     .form--fieldset.-collapsible.collapsed  > &
-      @extend .icon-arrow-down1:before
+      @include icon-mixin-arrow-down1
       padding:   0.625rem 0.25rem 0 0.25rem
 
 #sidebar .form--fieldset-legend
@@ -566,17 +566,16 @@ input[readonly].-clickable
 .form--text-field,
 .form--select
   &.-tiny
-    font-size: 0.7rem
+    @include form--input-field-mixin--tiny
 
   &.-small
-    font-size: 0.8rem
+    @include form--input-field-mixin--small
 
   &.-large
-    font-size: 1.3rem
+    @include form--input-field-mixin--large
 
   &.-narrow
-    width: auto
-    max-width: 100%
+    @include form--input-field-mixin--narrow
 
   .form &
     margin-bottom: 0rem
@@ -729,8 +728,7 @@ input[readonly].-clickable
     border-left:  0
 
   &.-transparent
-    background: none
-    border: none
+    @include form--field-affix-mixin--transparent
 
 .form--tooltip-container
   flex: 0 0 auto

--- a/app/assets/stylesheets/content/_links.sass
+++ b/app/assets/stylesheets/content/_links.sass
@@ -46,14 +46,14 @@ a
     background-repeat: no-repeat
     &.asc:after
       @include icon-font-common
-      @extend .icon-sort-ascending:before
+      @include icon-mixin-sort-ascending
       margin-left: 5px
       font-size: 1.2em
       vertical-align: text-bottom
 
     &.desc:after
       @include icon-font-common
-      @extend .icon-sort-descending:before
+      @include icon-mixin-sort-descending
       margin-left: 5px
       font-size: 1.2em
       vertical-align: text-bottom

--- a/app/assets/stylesheets/content/_notifications.sass
+++ b/app/assets/stylesheets/content/_notifications.sass
@@ -67,19 +67,19 @@ $nm-upload-file-status-icon-size: rem-calc(12)
 $nm-upload-box-padding: rem-calc(15) rem-calc(25)
 
 %nm-icon-error
-  @extend .icon-error:before
+  @include icon-mixin-error
   color: $nm-color-error-icon
 
 %nm-icon-success
-  @extend .icon-checkmark:before
+  @include icon-mixin-checkmark
   color: $nm-color-success-icon
 
 %nm-icon-warning
-  @extend .icon-attention:before
+  @include icon-mixin-attention
   color: $nm-color-warning-icon
 
 %nm-icon-info
-  @extend .icon-info1:before
+  @include icon-mixin-info1
   color: $nm-color-info-icon
 
 %error-placeholder

--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -107,14 +107,14 @@ table.generic-table
     .sort
       &.asc:after
         @include icon-font-common
-        @extend .icon-sort-ascending:before
+        @include icon-mixin-sort-ascending
         margin-left: 5px
         font-size: 1.2em
         vertical-align: text-bottom
 
       &.desc:after
         @include icon-font-common
-        @extend .icon-sort-descending:before
+        @include icon-mixin-sort-descending
         margin-left: 5px
         font-size: 1.2em
         vertical-align: text-bottom

--- a/app/assets/stylesheets/content/_widget_box.sass
+++ b/app/assets/stylesheets/content/_widget_box.sass
@@ -100,7 +100,7 @@ $widget-box--enumeration-width: 20px
       li:before
         @include icon-font-common
         @extend .icon-context
-        @extend .icon-arrow-right2:before
+        @include icon-mixin-arrow-right2
         display: inline-block
         font-size: 0.6rem
         color: $content-icon-link-color
@@ -130,8 +130,8 @@ $widget-box--enumeration-width: 20px
 
       li:before
         @include icon-common
-        @extend .icon-notice
-        @extend .icon-notice:before
+        @extend .icon-yes
+        @include icon-mixin-yes
         display: inline-block
         font-size: 0.6rem
         color: $alternative-color

--- a/app/assets/stylesheets/layout/_drop_down.sass
+++ b/app/assets/stylesheets/layout/_drop_down.sass
@@ -158,9 +158,9 @@
 .drop-down .button--dropdown-indicator
   &:before
     @include icon-font-common
+    @include icon-mixin-pulldown
     font-size: 10px
     padding: 0 0 0 9px
-    @extend .icon-pulldown:before
 
 .drop-down .menu-drop-down-container
   right: 0

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -115,10 +115,9 @@ $toggler-width: 40px
           a:not(:only-child):first-of-type
             @extend .small-10
 
-
         .open .toggler
           .icon-toggler:before
-            @extend .icon-arrow-up1:before
+            @include icon-mixin-arrow-up1
 
         // padding for placeholder for highlighted left-item-border
         a
@@ -211,7 +210,7 @@ $toggler-width: 40px
         height: 100%
         padding: 0 10px 0 0
         i:before
-          @extend .icon-double-arrow-right:before
+          @include icon-mixin-double-arrow-right
     a.navigation-toggler
       @include default-transition
       position: relative

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -56,7 +56,7 @@
 
   ::-webkit-input-placeholder
     color: $header-search-field-font-color
-  :-moz-placeholder
+  ::-moz-placeholder
     color: $header-search-field-font-color
   .menu_root
     margin: 0
@@ -117,7 +117,7 @@
 
       .button--dropdown-indicator
         &:before
-          @extend .icon-pulldown-up:before
+          @include icon-mixin-pulldown-up
 
     li
       > a

--- a/app/assets/stylesheets/openproject/_mixins.sass
+++ b/app/assets/stylesheets/openproject/_mixins.sass
@@ -91,3 +91,24 @@
   background: $widget-box-block-bg-color
   border: 1px solid $widget-box-block-border-color
   margin: 10px
+
+
+// These mixins are necessary so that other classes can inherit     the styles.
+// In future Sass versions a doubled inheritance like @extend classA.classB will not work any more.
+// See https://github.com/sass/sass/issues/1599
+@mixin form--input-field-mixin--tiny
+  font-size: 0.7rem
+
+@mixin form--input-field-mixin--small
+  font-size: 0.8rem
+
+@mixin form--input-field-mixin--narrow
+  width: auto
+  max-width: 100%
+
+@mixin form--input-field-mixin--large
+  font-size: 1.3rem
+
+@mixin form--field-affix-mixin--transparent
+  background: none
+  border: none

--- a/app/assets/stylesheets/openproject/_scm.sass
+++ b/app/assets/stylesheets/openproject/_scm.sass
@@ -210,18 +210,18 @@ tr.dir
       @include icon-common
       cursor: pointer
       &:before
-        @extend .icon-plus:before
+        @include icon-mixin-plus
         margin-left: 5px
         padding: 0
   &.loading
     .dir-expander i:before
-      @extend .icon-loading1:before
+      @include icon-mixin-loading1
   &.collapsed
     .dir-expander i:before
-      @extend .icon-plus:before
+      @include icon-mixin-plus
   &.open
     .dir-expander i:before
-      @extend .icon-minus1:before
+      @include icon-mixin-minus1
 
 tr
   &.entry

--- a/app/assets/stylesheets/vendor/_ng_dialog.sass
+++ b/app/assets/stylesheets/vendor/_ng_dialog.sass
@@ -68,4 +68,4 @@
     &:before
       @include icon-font-common
       @extend .icon-context
-      @extend .icon-close:before
+      @include icon-mixin-close

--- a/app/assets/stylesheets/vendor/_select2.scss
+++ b/app/assets/stylesheets/vendor/_select2.scss
@@ -204,7 +204,7 @@ $se2-width: 100%;
 .select2-drop {
   .select2-search {
     &:before {
-      @extend .icon-search:before;
+      @include icon-mixin-search;
       font-family: "openproject-icon-font";
       color: #E0E0E0;
       position: absolute;

--- a/app/views/members/_common_notice.html.erb
+++ b/app/views/members/_common_notice.html.erb
@@ -27,7 +27,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<div class="flash notice icon icon-notice <%= User.current.pref.auto_hide_popups? ? 'autohide-notification' : '' %>"
+<div class="flash notice icon icon-yes <%= User.current.pref.auto_hide_popups? ? 'autohide-notification' : '' %>"
      role="alert">
   <%= h message %>
   <span class="close-handler" role="button" tabindex="0" aria-label="{{ ::I18n.t('js.close_popup_title') }}">


### PR DESCRIPTION
This removes sass deprecation warnings (mostly compound selectors). The problem with compound selectors is described here: https://github.com/sass/sass/issues/1599 . Therefore a doubled inheritance (e.g. `@extend icon-class:before`) is replaced by a belonging mixin (e.g. `@include icon-mixin-class`). 

https://community.openproject.com/projects/openproject/work_packages/26881/activity
