### PR TITLE
Escape row cell when not AS::SafeBuffer

### DIFF
--- a/app/cells/row_cell.rb
+++ b/app/cells/row_cell.rb
@@ -12,7 +12,12 @@ class RowCell < RailsCell
   end
 
   def column_value(column)
-    send column
+    value = send column
+    if value.html_safe?
+      value
+    else
+      h(value)
+    end
   end
 
   def row_css_id


### PR DESCRIPTION
We don't use this in the core, but when a plugin defines a new table, it must otherwise manually escape its cell values.