### PR TITLE
Avoid require memory leak with pathnames in load path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -102,8 +102,8 @@ module OpenProject
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
     config.enable_dependency_loading = true
-    config.autoload_paths << Rails.root.join('lib')
-    config.autoload_paths << Rails.root.join('lib/constraints')
+    config.autoload_paths << Rails.root.join('lib').to_s
+    config.autoload_paths << Rails.root.join('lib/constraints').to_s
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.


### PR DESCRIPTION
Any ruby requires that occur in your application will leak with
Pathnames in the $LOAD_PATH in ruby 2.3/2.4. Beyond that, it's faster
to use strings in the load path. Please join this bug and add your
support for a fix:

https://bugs.ruby-lang.org/issues/14372

Same problem found here: https://github.com/lobsters/lobsters/pull/449