### PR TITLE
Check version compatibility before running db:migrate

### DIFF
--- a/lib/open_project/database.rb
+++ b/lib/open_project/database.rb
@@ -34,6 +34,8 @@ module OpenProject
   # syntax differences.
 
   module Database
+    class InsufficientVersionError < StandardError; end
+
     # This method returns a hash which maps the identifier of the supported
     # adapter to a regex matching the adapter_name.
     def self.supported_adapters
@@ -41,6 +43,48 @@ module OpenProject
         mysql: /mysql/i,
         postgresql: /postgres/i
       })
+    end
+
+    ##
+    # Get the database system requirements
+    def self.required_versions
+      {
+        postgresql: {
+          numeric: 90500, # PG_VERSION_NUM
+          string: '9.5.0'
+        },
+        mysql: {
+          string: '5.6.0'
+        }
+      }
+    end
+
+    ##
+    # Check the database version compatibility.
+    # Raises an +InsufficientVersionError+ when the version is incompatible
+    def self.check_version!
+      required = required_versions[name][:string]
+      current = version
+
+      unless version_matches?
+        raise InsufficientVersionError.new(
+          "Database server version mismatch: Required version is #{required}, " \
+          "but current version is #{current}"
+        )
+      end
+    end
+
+    ##
+    # Return +true+ if the required version is matched by the current connection.
+    def self.version_matches?
+      required = required_versions[name]
+
+      case name
+      when :mysql
+        Gem::Version.new(version) >= Gem::Version.new(required[:string])
+      when :postgresql
+        numeric_version >= required[:numeric]
+      end
     end
 
     # Get the raw name of the currently used database adapter.
@@ -75,10 +119,19 @@ module OpenProject
     def self.version(raw = false)
       case name
       when :mysql
-        version = ActiveRecord::Base.connection.select_value('SELECT VERSION()')
+        ActiveRecord::Base.connection.select_value('SELECT VERSION()')
       when :postgresql
         version = ActiveRecord::Base.connection.select_value('SELECT version()')
         raw ? version : version.match(/\APostgreSQL (\S+)/i)[1]
+      end
+    end
+
+    def self.numeric_version
+      case name
+      when :mysql
+        raise ArgumentError, "Can't get numeric version of MySQL"
+      when :postgresql
+        ActiveRecord::Base.connection.select_value('SHOW server_version_num;').to_i
       end
     end
   end

--- a/lib/open_project/database.rb
+++ b/lib/open_project/database.rb
@@ -51,10 +51,12 @@ module OpenProject
       {
         postgresql: {
           numeric: 90500, # PG_VERSION_NUM
-          string: '9.5.0'
+          string: '9.5.0',
+          enforced: true
         },
         mysql: {
-          string: '5.6.0'
+          string: '5.6.0',
+          enforced: false
         }
       }
     end
@@ -63,14 +65,17 @@ module OpenProject
     # Check the database version compatibility.
     # Raises an +InsufficientVersionError+ when the version is incompatible
     def self.check_version!
-      required = required_versions[name][:string]
+      required = required_versions[name]
       current = version
 
-      unless version_matches?
-        raise InsufficientVersionError.new(
-          "Database server version mismatch: Required version is #{required}, " \
-          "but current version is #{current}"
-        )
+      return if version_matches?
+      message = "Database server version mismatch: Required version is #{required[:string]}, " \
+                "but current version is #{current}"
+
+      if required[:enforced]
+        raise InsufficientVersionError.new message
+      else
+        warn "#{message}. Version is not enforced for this database however, so continuing with this version."
       end
     end
 


### PR DESCRIPTION
Enhances the `db:migrate` to check the current database version for compatibility without needing to adapt the installation script.