### PR TITLE
return proper WWW Authenticate header on missing credentials

### DIFF
--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -9,10 +9,11 @@ require 'open_project/authentication/strategies/warden/session'
 WS = OpenProject::Authentication::Strategies::Warden
 
 strategies = [
-  [:basic_auth_failure, WS::BasicAuthFailure, 'Basic'],
-  [:global_basic_auth,  WS::GlobalBasicAuth,  'Basic'],
-  [:user_basic_auth,    WS::UserBasicAuth,    'Basic'],
-  [:session,            WS::Session,          'Session']
+  [:basic_auth_failure, WS::BasicAuthFailure,  'Basic'],
+  [:global_basic_auth,  WS::GlobalBasicAuth,   'Basic'],
+  [:user_basic_auth,    WS::UserBasicAuth,     'Basic'],
+  [:anonymous_fallback, WS::AnonymousFallback, 'Basic'],
+  [:session,            WS::Session,           'Session']
 ]
 
 strategies.each do |name, clazz, auth_scheme|
@@ -25,5 +26,5 @@ api_v3_options = {
   store: false
 }
 OpenProject::Authentication.update_strategies(API_V3, api_v3_options) do |_strategies|
-  [:global_basic_auth, :user_basic_auth, :basic_auth_failure, :session]
+  %i[global_basic_auth user_basic_auth basic_auth_failure session anonymous_fallback]
 end

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -108,8 +108,6 @@ module API
         content_type = request.content_type
         error!('Missing content-type header', 406) unless content_type.present?
 
-
-
         # Allow JSON and JSON+HAL per default
         # and anything that each endpoint may optionally add to that
         if content_type.present?

--- a/lib/open_project/authentication/strategies/warden/anonymous_fallback.rb
+++ b/lib/open_project/authentication/strategies/warden/anonymous_fallback.rb
@@ -1,0 +1,45 @@
+require 'warden/basic_auth'
+
+module OpenProject
+  module Authentication
+    module Strategies
+      module Warden
+        # Intended to be used as the last strategy in warden so that the
+        # anonymous user is returned if no other strategy applies
+        class AnonymousFallback < ::Warden::Strategies::BasicAuth
+          def self.configuration
+            @configuration ||= {}
+          end
+
+          def self.user
+            User.anonymous
+          end
+
+          def username
+            nil
+          end
+
+          def password
+            nil
+          end
+
+          ##
+          # Always valid unless session based. We are using it as a fallback after all.
+          def valid?
+            !session
+          end
+
+          def authenticate_user(_username, _password)
+            self.class.user
+          end
+
+          private
+
+          def session
+            env['rack.session']
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
An anonymous_fallback is introduced and registered to be the last
strategy for warden. That strategy will always apply (unless the authorization is session based)
 and it will always return the anonymous user.

The better way would be to only apply the strategy if login is not
required. That way we would still be able to return a 403 when
credentials are missing but would no longer need to have 401 handlers
outside of warden. That duplicity caused the missing header in the first
place.

It would however require us to handle the realm in the strategy and by
that increase the coupling between the strategy and the application.

https://community.openproject.com/projects/openproject/work_packages/26983