### PR TITLE
Add hourly cron task that doesn't require loading environment

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -21,6 +21,7 @@ targets:
       - sqlite3-devel
 before_precompile: "packaging/setup"
 crons:
+  - packaging/cron/openproject-hourly-tasks
   - packaging/cron/openproject-clear-old-sessions
   - packaging/cron/openproject-clear-uploaded-files
 services:

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -1,0 +1,34 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+namespace 'openproject:cron' do
+  desc 'An hourly cron job hook for plugin functionality'
+  task :hourly do
+    # Does nothing by default
+  end
+end

--- a/packaging/cron/openproject-hourly-tasks
+++ b/packaging/cron/openproject-hourly-tasks
@@ -1,0 +1,3 @@
+APP_NAME="_APP_NAME_"
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+55 * * * * root ${APP_NAME} run rake -s openproject:cron:hourly >> /var/log/${APP_NAME}/cron-hourly.log 2>&1


### PR DESCRIPTION
Only executed with environemnt when a plugin exists that loads it.

Extend by https://github.com/opf/openproject-ldap_groups/commit/c48c5c75d34dce44ad54b46d682f2cccb6bce753