### PR TITLE
[27907] Cannot navigate to project on mobile (Safari on iOS)

### DIFF
--- a/app/assets/stylesheets/content/_autocomplete.sass
+++ b/app/assets/stylesheets/content/_autocomplete.sass
@@ -80,6 +80,9 @@ div.autocomplete
     word-break: break-word
     padding: 10px 5px
 
+    // Necessary for iOS to recognize as clickable
+    cursor: pointer
+
     &.ui-state-active
       border: none
       @include varprop(background, drop-down-selected-bg-color)


### PR DESCRIPTION
In iOS there are a few strange behaviors implemented. 

First events are not passed through. (http://gravitydept.com/blog/js-click-event-bubbling-on-ios) This can be avoided with CSS `cursor: pointer`. This was done in this PR.

Second in iOS a click first reveals a hover effect, a second click then executes the actual function. (https://www.nczonline.net/blog/2012/07/05/ios-has-a-hover-problem/). Thus you have to click twice on the project and take care to hit same element for it work. Since we do not support Safari and the PR at leasts provides a functioning solution I did not tackle this issue.

https://community.openproject.com/projects/openproject/work_packages/27097/activity