### PR TITLE
[25029] Menu entries are not visible with dark background

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -271,7 +271,7 @@ fieldset.form--fieldset
       padding:   0.625rem 0.25rem 0 0.25rem
 
 #sidebar .form--fieldset-legend
-  color: $main-menu-sidebar-font-color
+  @include varprop(color, main-menu-sidebar-font-color)
 
 .form--fieldset-control
   float:          right

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -180,7 +180,7 @@ $toggler-width: 40px
     display: block
     position: relative
     height: $main-menu-item-height
-    color: $main-menu-font-color
+    @include varprop(color, main-menu-font-color)
     font-family: $body-font-family
     font-weight: normal
     font-size: $main-menu-font-size
@@ -255,7 +255,7 @@ $toggler-width: 40px
   margin: 30px 0 0 0
   padding: 0 17px 0 17px
   width: auto
-  color: $main-menu-sidebar-font-color
+  @include varprop(color, main-menu-sidebar-font-color)
   font-family: $body-font-family
   font-style: normal
   overflow: hidden
@@ -265,7 +265,7 @@ $toggler-width: 40px
   h3
     display: block
     border: none
-    color: $main-menu-sidebar-h3-color
+    @include varprop(color, main-menu-sidebar-h3-color)
     font-weight: normal
     font-size: $main-menu-sidebar-h3-font-size
     margin: 30px 0 8px 0
@@ -277,7 +277,7 @@ $toggler-width: 40px
     margin-top: 0
 
   a, a:link
-    color: $main-menu-sidebar-link-color
+    @include varprop(color, main-menu-sidebar-link-color)
     display: inline
     position: static
     text-decoration: underline
@@ -286,7 +286,7 @@ $toggler-width: 40px
     text-decoration: underline
 
   label
-    color: $main-menu-sidebar-font-color
+    @include varprop(color, main-menu-sidebar-font-color)
     max-width: 80%
     vertical-align: top
 

--- a/lib/open_project/design.rb
+++ b/lib/open_project/design.rb
@@ -113,9 +113,9 @@ module OpenProject
       'main-menu-child-font-size'                            => "12px",
       'main-menu-child-hover-font-color'                     => "$main-menu-hover-font-color",
       'main-menu-child-selected-font-color'                  => "$main-menu-selected-font-color",
-      'main-menu-sidebar-font-color'                         => "#333333",
-      'main-menu-sidebar-h3-color'                           => "#333333",
-      'main-menu-sidebar-link-color'                         => "#333333",
+      'main-menu-sidebar-font-color'                         => "$main-menu-font-color",
+      'main-menu-sidebar-h3-color'                           => "$main-menu-font-color",
+      'main-menu-sidebar-link-color'                         => "$main-menu-font-color",
       'main-menu-sidebar-h3-border-top-color'                => "#1F4654",
       'main-menu-sidebar-h3-font-size'                       => "15px",
       'toolbar-title-color'                                  => "#5F5F5F",
@@ -279,7 +279,8 @@ module OpenProject
           header-item-bg-hover-color
           header-border-bottom-color
           content-link-color
-          main-menu-bg-color )
+          main-menu-bg-color
+          main-menu-font-color )
     end
   end
 end


### PR DESCRIPTION
This adds a customizable font color for the main menu. Since the main menu is customizable it is necessary that the font is changeable too. Otherwise the user had no chance to see the menu entries.

https://community.openproject.com/projects/openproject/work_packages/25029/activity