### PR TITLE
Fix/back url when already logged in

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -48,7 +48,7 @@ class AccountController < ApplicationController
     user = User.current
 
     if user.logged?
-      redirect_to home_url
+      redirect_after_login(user)
     elsif omniauth_direct_login?
       direct_login(user)
     elsif request.post?

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -87,36 +87,33 @@ class AccountController < ApplicationController
         end
       end
       render template: 'account/password_recovery'
-      return
-    else
-      if request.post?
-        mail = params[:mail]
-        user = User.find_by_mail(mail)
+    elsif request.post?
+      mail = params[:mail]
+      user = User.find_by_mail(mail)
 
-        # Ensure the same request is sent regardless of which email is entered
-        # to avoid detecability of mails
+      # Ensure the same request is sent regardless of which email is entered
+      # to avoid detecability of mails
+      flash[:notice] = l(:notice_account_lost_email_sent)
+
+      unless user
+        # user not found in db
+        Rails.logger.error "Lost password unknown email input: #{mail}"
+        return
+      end
+
+      unless user.change_password_allowed?
+        # user uses an external authentification
+        Rails.logger.error "Password cannot be changed for user: #{mail}"
+        return
+      end
+
+      # create a new token for password recovery
+      token = Token::Recovery.new(user_id: user.id)
+      if token.save
+        UserMailer.password_lost(token).deliver_now
         flash[:notice] = l(:notice_account_lost_email_sent)
-
-        unless user
-          # user not found in db
-          Rails.logger.error "Lost password unknown email input: #{mail}"
-          return
-        end
-
-        unless user.change_password_allowed?
-          # user uses an external authentification
-          Rails.logger.error "Password cannot be changed for user: #{mail}"
-          return
-        end
-
-        # create a new token for password recovery
-        token = Token::Recovery.new(user_id: user.id)
-        if token.save
-          UserMailer.password_lost(token).deliver_now
-          flash[:notice] = l(:notice_account_lost_email_sent)
-          redirect_to action: 'login', back_url: home_url
-          return
-        end
+        redirect_to action: 'login', back_url: home_url
+        return
       end
     end
   end
@@ -622,38 +619,42 @@ class AccountController < ApplicationController
 
   # Log an attempt to log in to an account in "registered" state and show a flash message.
   def account_not_activated(flash_now: true)
-    flash_hash = flash_now ? flash.now : flash
-
-    logger.warn "Failed login for '#{params[:username]}' from #{request.remote_ip}" \
-                " at #{Time.now.utc} (NOT ACTIVATED)"
-
-    if Setting.self_registration == '1'
-      flash_hash[:error] = I18n.t('account.error_inactive_activation_by_mail')
-    else
-      flash_hash[:error] = I18n.t('account.error_inactive_manual_activation')
+    flash_error_message(log_reason: 'NOT ACTIVATED', flash_now: flash_now) do
+      if Setting.self_registration == '1'
+        'account.error_inactive_activation_by_mail'
+      else
+        'account.error_inactive_manual_activation'
+      end
     end
   end
 
   def invited_account_not_activated(user)
-    logger.warn "Failed login for '#{params[:username]}' from #{request.remote_ip}" \
-                " at #{Time.now.utc} (invited, NOT ACTIVATED)"
-
-    flash[:error] = I18n.t('account.error_inactive_activation_by_mail')
+    flash_error_message(log_reason: 'invited, NOT ACTIVATED', flash_now: false) do
+      'account.error_inactive_activation_by_mail'
+    end
   end
 
   # Log an attempt to log in to a locked account or with invalid credentials
   # and show a flash message.
   def invalid_credentials(flash_now: true)
+    flash_error_message(log_reason: 'invalid credentials', flash_now: flash_now) do
+      if Setting.brute_force_block_after_failed_logins?
+        :notice_account_invalid_credentials_or_blocked
+      else
+        :notice_account_invalid_credentials
+      end
+    end
+  end
+
+  def flash_error_message(log_reason: '', flash_now: true)
     flash_hash = flash_now ? flash.now : flash
 
     logger.warn "Failed login for '#{params[:username]}' from #{request.remote_ip}" \
-                " at #{Time.now.utc}"
+                " at #{Time.now.utc}: #{log_reason}"
 
-    if Setting.brute_force_block_after_failed_logins.to_i == 0
-      flash_hash[:error] = I18n.t(:notice_account_invalid_credentials)
-    else
-      flash_hash[:error] = I18n.t(:notice_account_invalid_credentials_or_blocked)
-    end
+    flash_message = yield
+
+    flash_hash[:error] = I18n.t(flash_message)
   end
 
   def account_pending

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -444,7 +444,7 @@ class ApplicationController < ActionController::Base
       params[:back_url],
       hostname: request.host,
       default: default,
-      return_escaped: use_escaped,
+      return_escaped: use_escaped
     )
 
     redirect_to policy.redirect_url

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -29,18 +29,53 @@
 require 'spec_helper'
 
 describe AccountController, type: :controller do
-  render_views
-
   after do
     User.delete_all
     User.current = nil
   end
+  let(:user) { FactoryGirl.build_stubbed(:user) }
 
   context 'GET #login' do
+    let(:setup) {}
+    let(:params) { {} }
+
+    before do
+      setup
+
+      get :login, params: params
+    end
+
     it 'renders the view' do
-      get :login
       expect(response).to render_template 'login'
       expect(response).to be_success
+    end
+
+    context 'user already logged in' do
+      let(:setup) { login_as user }
+
+      it 'redirects to home' do
+        expect(response)
+          .to redirect_to my_page_path
+      end
+    end
+
+    context 'user already logged in and back url present' do
+      let(:setup) { login_as user }
+      let(:params) { { back_url: "/projects" } }
+
+      it 'redirects to back_url value' do
+        expect(response)
+          .to redirect_to projects_path
+      end
+    end
+
+    context 'user already logged in and invalid back url present' do
+      let(:setup) { login_as user }
+      let(:params) { { back_url: 'http://test.foo/work_packages/show/1' } }
+
+      it 'redirects to home' do
+        expect(response).to redirect_to my_page_path
+      end
     end
   end
 
@@ -608,6 +643,8 @@ describe AccountController, type: :controller do
   end
 
   describe 'GET #auth_source_sso_failed (/sso)' do
+   render_views
+
     let(:failure) do
       {
         user: user,

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -437,7 +437,7 @@ describe AccountController, type: :controller do
       end
 
       context 'with a locked account',
-              with_settings: { brute_force_block_after_failed_logins: 0 } do
+              with_settings: { brute_force_block_after_failed_logins?: false } do
         before do
           user.lock
           user.save!


### PR DESCRIPTION
But check the validity of the back_url to not be used maliciously to redirect users to pages outside our host. This is the same check we employ throughout the rest of the login process.

It additionally reduced duplication on three messages and some other minor coding style improvements.

https://community.openproject.com/projects/openproject/work_packages/27119