### PR TITLE
[27088] Pagination is broken in some edge cases

### DIFF
--- a/frontend/app/components/table-pagination/table-pagination.component.ts
+++ b/frontend/app/components/table-pagination/table-pagination.component.ts
@@ -124,18 +124,19 @@ export class TablePaginationComponent implements OnInit {
     var pageNumbers = [];
 
     const perPage = this.pagination.perPage;
+    const currentPage = this.pagination.page;
     if (perPage) {
       for (var i = 1; i <= Math.ceil(this.pagination.total / perPage); i++) {
         pageNumbers.push(i);
       }
 
       // This avoids a truncation when there are not enough elements to truncate for the first elements
-      var startingDiff = perPage - 2 * truncSize;
+      var startingDiff = currentPage - 2 * truncSize;
       if ( 0 <= startingDiff && startingDiff <= 1 ) {
         this.postPageNumbers = this.truncatePageNums(pageNumbers, pageNumbers.length >= maxVisible + (truncSize * 2), maxVisible + truncSize, pageNumbers.length, 0);
       }
       else {
-        this.prePageNumbers = this.truncatePageNums(pageNumbers, perPage >= maxVisible, 0, Math.min(perPage - Math.ceil(maxVisible / 2), pageNumbers.length - maxVisible), truncSize);
+        this.prePageNumbers = this.truncatePageNums(pageNumbers, currentPage >= maxVisible, 0, Math.min(currentPage - Math.ceil(maxVisible / 2), pageNumbers.length - maxVisible), truncSize);
         this.postPageNumbers = this.truncatePageNums(pageNumbers, pageNumbers.length >= maxVisible + (truncSize * 2), maxVisible, pageNumbers.length, 0);
       }
     }


### PR DESCRIPTION
In the scope of the WP table refactoring the pagination got broken (https://github.com/opf/openproject/commit/4eea96fa9e4b7a89351b66430b4ed6edfc5a5063#diff-8e33d47b019a1cb320e66d52f9975134L84). I assume it was a copy/paste error. This PR fixes this.

https://community.openproject.com/projects/openproject/work_packages/27088/activity