### PR TITLE
[26955] Improved distribution of available width for column width distribution

### DIFF
--- a/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
+++ b/frontend/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
@@ -97,18 +97,21 @@ export class SingleHierarchyRowBuilder extends SingleRowBuilder {
    * @param level
    */
   private appendHierarchyIndicator(workPackage:WorkPackageResourceInterface, jRow:JQuery, level?:number):void {
-    const hierarchyElement = this.buildHierarchyIndicator(workPackage, jRow, level);
+    const hierarchyLevel = level === undefined || null ? workPackage.ancestors.length : level;
+    const hierarchyElement = this.buildHierarchyIndicator(workPackage, jRow, hierarchyLevel);
 
     jRow.find('td.subject')
       .addClass('-with-hierarchy')
       .prepend(hierarchyElement);
+
+    // Assure that the content is still visble when the hierarchy indentation is very large
+    jRow.find('td.subject')[0].style.minWidth =  125 + (20 * hierarchyLevel) + 'px';
   }
 
   /**
    * Build the hierarchy indicator at the given indentation level.
    */
-  private buildHierarchyIndicator(workPackage:WorkPackageResourceInterface, jRow:JQuery | null, index:number | null = null):HTMLElement {
-    const level = index === null ? workPackage.ancestors.length : index;
+  private buildHierarchyIndicator(workPackage:WorkPackageResourceInterface, jRow:JQuery | null, level:number):HTMLElement {
     const hierarchyIndicator = document.createElement('span');
     const collapsed = this.wpTableHierarchies.collapsed(workPackage.id);
     const indicatorWidth = 25 + (20 * level) + 'px';


### PR DESCRIPTION
At the moment we have a problem when there is a large hierarchy level to show within the WP table. The subject of the lowest WP is in certain circumstances not shown (see ticket).

Normally the browser takes care of the optimal width distribution. However in this case the browser cannot know that the actual content only begins after x pixels. This results in white cells. Therefore this PR sets a min-width to the cells depending on the hierarchy indentation. Thus the user can at least see 100px of the title. 

https://community.openproject.com/projects/openproject/work_packages/26955/activity