### PR TITLE
[27128] Unnecessary line break for "One-time password" label on mobile

### DIFF
--- a/app/assets/stylesheets/content/_forms_mobile.sass
+++ b/app/assets/stylesheets/content/_forms_mobile.sass
@@ -34,6 +34,8 @@
       .grid-content
         padding: 0
 
+    &.-wide-labels .form--field .form--label,
+    .form--field.-wide-label .form--label,
     .form--label,
     .form--field-container,
     .form--select-container,


### PR DESCRIPTION
Apply mobile rules for `-wide-labels`. 

https://community.openproject.com/projects/openproject/work_packages/27128/activity