### PR TITLE
Extract upsale into a common template

### DIFF
--- a/app/assets/stylesheets/content/_enterprise.sass
+++ b/app/assets/stylesheets/content/_enterprise.sass
@@ -8,6 +8,9 @@
     float: right
     margin-top: -20px
 
+  .upsale--feature-reference
+    padding-bottom: 2rem
+
 .token-form textarea
   font-family: "Lucida Console", Monaco, monospace
   max-width: 560px

--- a/app/controllers/custom_actions_controller.rb
+++ b/app/controllers/custom_actions_controller.rb
@@ -89,7 +89,12 @@ class CustomActionsController < ApplicationController
     return if EnterpriseToken.allows_to?(:custom_actions)
 
     if request.get?
-      render :enterprise_token
+      render template: 'common/upsale',
+             locals: {
+                 feature_title: I18n.t('custom_actions.upsale.title'),
+                 feature_description: I18n.t('custom_actions.upsale.description'),
+                 feature_reference: 'custom_actions_admin'
+             }
     else
       render_403
     end

--- a/app/views/common/upsale.html.erb
+++ b/app/views/common/upsale.html.erb
@@ -1,0 +1,34 @@
+<div class="notification-box upsale-notification">
+  <div class="notification-box--content">
+    <h3><%= t('admin.enterprise.upgrade_to_ee') %></h3>
+    <%= image_tag "enterprise_edition.png", class: "widget-box--teaser-image" %>
+
+
+    <p class="upsale--feature-reference">
+      <strong><%= feature_title %></strong>
+      <br/>
+      <%= feature_description %>
+    </p>
+
+    <p><%= t('homescreen.blocks.upsale.description') %></p>
+
+    <ul class="">
+      <li>
+        <%= t('homescreen.blocks.upsale.additional_features') %>
+      </li>
+      <li>
+        <%= t('homescreen.blocks.upsale.professional_support') %>
+      </li>
+    </ul>
+    <p>
+      <b><%= t('homescreen.blocks.upsale.become_hero') %></b> <%= t('homescreen.blocks.upsale.you_contribute') %>
+    </p>
+    <%= link_to( "#{OpenProject::Static::Links.links[:upsale][:href]}/?utm_source=unknown&utm_medium=community-edition&utm_campaign=#{feature_reference}",
+                 { class: 'button -alt-highlight',
+                   aria: {label: t('admin.enterprise.order')},
+                   title: t('admin.enterprise.order')}) do %>
+      <%= op_icon('button--icon icon-add') %>
+      <span class="button--text"><%= t('admin.enterprise.order') %></span>
+    <% end %>
+  </div>
+</div>

--- a/app/views/custom_actions/enterprise_token.html.erb
+++ b/app/views/custom_actions/enterprise_token.html.erb
@@ -1,1 +1,0 @@
-<%= raw I18n.t('custom_actions.enterprise_edition') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,15 +90,9 @@ en:
     plural: 'Custom actions'
     new: 'New custom action'
     edit: 'Edit custom action %{name}'
-    enterprise_edition: '<h2>Custom actions is an enterprise edition feature</h2>
-                         <p>
-                         Custom actions streamline everyday work by combining a set of individual steps into one button.
-                         </p>
-                         <p>
-                         Apart from custom actions, purchase of the enterprise edition offers
-                         <a href="https://www.openproject.org/enterprise-edition">a set of premium features, support and additional benefits</a>.
-                         </p>'
-
+    upsale:
+      title: 'Custom actions is an Enterprise Edition feature'
+      description: 'Custom actions streamline everyday work by combining a set of individual steps into one button.'
   custom_fields:
     text_add_new_custom_field: >
       To add new custom fields to a project you first need to create them before

--- a/spec/controllers/custom_actions_controller_spec.rb
+++ b/spec/controllers/custom_actions_controller_spec.rb
@@ -56,7 +56,7 @@ describe CustomActionsController, type: :controller do
 
       it 'renders enterprise_token' do
         expect(response)
-          .to render_template :enterprise_token
+          .to render_template 'common/upsale'
       end
     end
   end


### PR DESCRIPTION
This allows us to re-use it in custom actions, as well as other plugins that previously copied the partial.