### PR TITLE
Feature/notify custom action

### DIFF
--- a/app/assets/stylesheets/content/_index.sass
+++ b/app/assets/stylesheets/content/_index.sass
@@ -62,5 +62,6 @@
 @import content/help_texts
 @import content/on_off_status
 @import content/custom_actions
+@import content/user_mention
 
 @import content/menus/_project_autocompletion

--- a/app/assets/stylesheets/content/_links.sass
+++ b/app/assets/stylesheets/content/_links.sass
@@ -77,10 +77,6 @@ a.icon, a.icon-context
 a.icon:hover, a.icon-context:hover
   text-decoration: none
 
-a.user-mention:before
-  content: '@'
-  color: $gray-dark
-
 a.-inactive
   pointer-events: none
   cursor: default

--- a/app/assets/stylesheets/content/_user_mention.sass
+++ b/app/assets/stylesheets/content/_user_mention.sass
@@ -26,10 +26,6 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-angular.module('openproject.helpers')
-  .constant('CUSTOM_FIELD_PREFIX', 'cf_')
-  .service('CustomFieldHelper', ['CUSTOM_FIELD_PREFIX', 'I18n', require(
-    './custom-field-helper')])
-  .factory('SvgHelper', require('./svg-helper'))
-  .service('WorkPackageLoadingHelper', ['$timeout', require(
-    './work-package-loading-helper')]);
+.user-mention:before
+  content: '@'
+  color: $gray-dark

--- a/app/models/custom_action.rb
+++ b/app/models/custom_action.rb
@@ -128,6 +128,7 @@ CustomActions::Register.action(CustomActions::Actions::Priority)
 CustomActions::Register.action(CustomActions::Actions::CustomField)
 CustomActions::Register.action(CustomActions::Actions::Type)
 CustomActions::Register.action(CustomActions::Actions::Project)
+CustomActions::Register.action(CustomActions::Actions::Notify)
 
 CustomActions::Register.condition(CustomActions::Conditions::Status)
 CustomActions::Register.condition(CustomActions::Conditions::Role)

--- a/app/models/custom_actions/actions/notify.rb
+++ b/app/models/custom_actions/actions/notify.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
@@ -25,32 +27,29 @@
 #
 # See doc/COPYRIGHT.rdoc for more details.
 #++
-require 'spec_helper'
-require_relative '../shared_expectations'
 
-describe CustomActions::Actions::Type, type: :model do
-  let(:key) { :type }
-  let(:priority) { 20 }
-  let(:allowed_values) do
-    types = [FactoryGirl.build_stubbed(:type),
-             FactoryGirl.build_stubbed(:type)]
-    allow(Type)
-      .to receive_message_chain(:select, :order)
-            .and_return(types)
+class CustomActions::Actions::Notify < CustomActions::Actions::Base
+  include CustomActions::Actions::Strategies::Associated
 
-    [{ value: types.first.id, label: types.first.name },
-     { value: types.last.id, label: types.last.name }]
+  def apply(work_package)
+    comment = values.map { |id| "user##{id}" }.join(', ')
+
+    work_package.journal_notes = comment
   end
 
-  it_behaves_like 'base custom action'
-  it_behaves_like 'associated custom action' do
-    describe '#allowed_values' do
-      it 'is the list of all type' do
-        allowed_values
+  def associated
+    Principal
+      .active_or_registered
+      .select(:id, :firstname, :lastname, :type)
+      .order_by_name
+      .map { |u| [u.id, u.name] }
+  end
 
-        expect(instance.allowed_values)
-          .to eql(allowed_values)
-      end
-    end
+  def self.key
+    :notify
+  end
+
+  def multi_value?
+    true
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,14 +36,14 @@ class User < Principal
     lastname_firstname:       [:lastname, :firstname],
     lastname_coma_firstname:  [:lastname, :firstname],
     username:                 [:login]
-  }
+  }.freeze
 
-  USER_MAIL_OPTION_ALL            = ['all', :label_user_mail_option_all]
-  USER_MAIL_OPTION_SELECTED       = ['selected', :label_user_mail_option_selected]
-  USER_MAIL_OPTION_ONLY_MY_EVENTS = ['only_my_events', :label_user_mail_option_only_my_events]
-  USER_MAIL_OPTION_ONLY_ASSIGNED  = ['only_assigned', :label_user_mail_option_only_assigned]
-  USER_MAIL_OPTION_ONLY_OWNER     = ['only_owner', :label_user_mail_option_only_owner]
-  USER_MAIL_OPTION_NON            = ['none', :label_user_mail_option_none]
+  USER_MAIL_OPTION_ALL            = ['all', :label_user_mail_option_all].freeze
+  USER_MAIL_OPTION_SELECTED       = ['selected', :label_user_mail_option_selected].freeze
+  USER_MAIL_OPTION_ONLY_MY_EVENTS = ['only_my_events', :label_user_mail_option_only_my_events].freeze
+  USER_MAIL_OPTION_ONLY_ASSIGNED  = ['only_assigned', :label_user_mail_option_only_assigned].freeze
+  USER_MAIL_OPTION_ONLY_OWNER     = ['only_owner', :label_user_mail_option_only_owner].freeze
+  USER_MAIL_OPTION_NON            = ['none', :label_user_mail_option_none].freeze
 
   MAIL_NOTIFICATION_OPTIONS = [
     USER_MAIL_OPTION_ALL,
@@ -52,7 +52,7 @@ class User < Principal
     USER_MAIL_OPTION_ONLY_ASSIGNED,
     USER_MAIL_OPTION_ONLY_OWNER,
     USER_MAIL_OPTION_NON
-  ]
+  ].freeze
 
   has_and_belongs_to_many :groups,
                           join_table:   "#{table_name_prefix}group_users#{table_name_suffix}",
@@ -131,11 +131,11 @@ class User < Principal
   before_destroy :delete_associated_private_queries
   before_destroy :reassign_associated
 
-  scope :in_group, -> (group) {
+  scope :in_group, ->(group) {
     group_id = group.is_a?(Group) ? group.id : group.to_i
     where(["#{User.table_name}.id IN (SELECT gu.user_id FROM #{table_name_prefix}group_users#{table_name_suffix} gu WHERE gu.group_id = ?)", group_id])
   }
-  scope :not_in_group, -> (group) {
+  scope :not_in_group, ->(group) {
     group_id = group.is_a?(Group) ? group.id : group.to_i
     where(["#{User.table_name}.id NOT IN (SELECT gu.user_id FROM #{table_name_prefix}group_users#{table_name_suffix} gu WHERE gu.group_id = ?)", group_id])
   }

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -64,6 +64,14 @@ class UserPreference < ActiveRecord::Base
     others[:no_self_notified] = !value
   end
 
+  def auto_hide_popups=(value)
+    others[:auto_hide_popups] = to_boolean(value)
+  end
+
+  def auto_hide_popups?
+    others[:auto_hide_popups] || false
+  end
+
   def warn_on_leaving_unsaved?
     # Need to cast here as previous values were '0' / '1'
     to_boolean(others.fetch(:warn_on_leaving_unsaved) { true })
@@ -71,14 +79,6 @@ class UserPreference < ActiveRecord::Base
 
   def warn_on_leaving_unsaved=(value)
     others[:warn_on_leaving_unsaved] = to_boolean(value)
-  end
-
-  def auto_hide_popups=(value)
-    others[:auto_hide_popups] = to_boolean(value)
-  end
-
-  def auto_hide_popups?
-    others[:auto_hide_popups] || false
   end
 
   # Provide an alias to form builders
@@ -101,19 +101,6 @@ class UserPreference < ActiveRecord::Base
 
   def impaired?
     !!impaired
-  end
-
-  def warn_on_leaving_unsaved?
-    # Need to cast here as previous values were '0' / '1'
-    to_boolean(others.fetch(:warn_on_leaving_unsaved) { true })
-  end
-
-  def warn_on_leaving_unsaved
-    warn_on_leaving_unsaved?
-  end
-
-  def warn_on_leaving_unsaved=(value)
-    others[:warn_on_leaving_unsaved] = to_boolean(value)
   end
 
   private

--- a/frontend/app/components/common/autocomplete/auto-complete-helper.service.ts
+++ b/frontend/app/components/common/autocomplete/auto-complete-helper.service.ts
@@ -36,8 +36,8 @@ export class AutoCompleteHelperService {
       at: at,
       startWithSpace: true,
       searchKey: 'id_principal',
-      displayTpl: '<li data-value="user#${id}">${name}</li>',
-      insertTpl: "user#${id}",
+      displayTpl: '<li data-value="#{subtype}#${id}">${name}</li>',
+      insertTpl: "${typePrefix}#${id}",
       limit: 10,
       highlightFirst: true,
       suffix: '',
@@ -55,6 +55,7 @@ export class AutoCompleteHelperService {
                 const principals = data["_embedded"]["elements"];
                 for (let i = principals.length - 1; i >= 0; i--) {
                   principals[i]['id_principal'] = principals[i]['id'].toString() + ' ' + principals[i]['name'];
+                  principals[i]['typePrefix'] = principals[i]['subtype'].toLowerCase();
                 }
 
                 if (angular.element(textarea).is(':visible')) {

--- a/frontend/app/components/common/hide-section/add-section-dropdown/add-section-dropdown.component.ts
+++ b/frontend/app/components/common/hide-section/add-section-dropdown/add-section-dropdown.component.ts
@@ -61,7 +61,7 @@ export class AddSectionDropdownComponent implements OnInit, OnDestroy {
                                      .subscribe(([all, displayed]) => {
       this.selectable = _.filter(all, all_candidate =>
         !_.some(displayed, displayed_candidate => all_candidate.key === displayed_candidate.key)
-      );
+      ).sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase()));
     });
   }
 

--- a/frontend/app/components/common/path-helper/path-helper.service.test.ts
+++ b/frontend/app/components/common/path-helper/path-helper.service.test.ts
@@ -50,12 +50,12 @@ describe('PathHelper', function() {
     });
 
     it('should provide a path to the project\'s mentionable principals', function() {
-      var projectId = "1";
-      var term = "Maria";
+      var projectId = '1';
+      var term = 'Maria';
 
       expect(
         PathHelper.apiv3MentionablePrincipalsPath(projectId, term)
-      ).to.equal('/api/v3/principals?filters=' +  encodeURI('[{"status":{"operator":"!","values":["0","3"]}},{"member":{"operator":"=","values":["1"]}},{"type":{"operator":"=","values":["User"]}},{"id":{"operator":"!","values":["me"]}},{"name":{"operator":"~","values":["Maria"]}}]&sortBy=[["name","asc"]]&offset=1&pageSize=10'));
+      ).to.equal('/api/v3/principals?filters=' +  encodeURI('[{"status":{"operator":"!","values":["0","3"]}},{"member":{"operator":"=","values":["1"]}},{"type":{"operator":"=","values":["User","Group"]}},{"id":{"operator":"!","values":["me"]}},{"name":{"operator":"~","values":["Maria"]}}]&sortBy=[["name","asc"]]&offset=1&pageSize=10'));
     });
   });
 });

--- a/frontend/app/components/common/path-helper/path-helper.service.ts
+++ b/frontend/app/components/common/path-helper/path-helper.service.ts
@@ -198,7 +198,7 @@ export class PathHelperService {
     // that are members of that project:
     filters.add('member', '=', [projectId.toString()]);
     // That are users:
-    filters.add('type', '=', ['User']);
+    filters.add('type', '=', ['User', 'Group']);
     // That are not the current user:
     filters.add('id', '!', ['me']);
 

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -335,7 +335,7 @@ module OpenProject
     #     identifier:version:1.0.0
     #     identifier:source:some/file
     def parse_redmine_links(text, project, obj, attr, only_path, options)
-      text.gsub!(%r{([\s\(,\-\[\>]|^)(!)?(([a-z0-9\-_]+):)?(attachment|version|commit|source|export|message|project|user)?((#+|r)(\d+)|(:)([^"\s<>][^\s<>]*?|"[^"]+?"))(?=(?=[[:punct:]]\W)|,|\s|\]|<|$)}) do |_m|
+      text.gsub!(%r{([\s\(,\-\[\>]|^)(!)?(([a-z0-9\-_]+):)?(attachment|version|commit|source|export|message|project|user|group)?((#+|r)(\d+)|(:)([^"\s<>][^\s<>]*?|"[^"]+?"))(?=(?=[[:punct:]]\W)|,|\s|\]|<|$)}) do |_m|
         leading = $1
         esc = $2
         project_prefix = $3
@@ -384,6 +384,10 @@ module OpenProject
             when 'user'
               if user = User.in_visible_project.find_by(id: oid)
                 link = link_to_user(user, class: 'user-mention')
+              end
+            when 'group'
+              if group = Group.find_by(id: oid)
+                link = content_tag(:span, group.name, class: 'user-mention')
               end
             end
           elsif sep == '##'

--- a/spec/features/work_packages/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions_spec.rb
@@ -49,6 +49,13 @@ describe 'Custom actions', type: :feature, js: true do
                        user: user)
     user
   end
+  let!(:other_member_user) do
+    FactoryGirl.create(:user,
+                       firstname: 'Other member',
+                       lastname: 'User',
+                       member_in_project: project,
+                       member_through_role: role)
+  end
   let(:project) { FactoryGirl.create(:project) }
   let(:other_project) { FactoryGirl.create(:project) }
   let!(:work_package) do
@@ -159,6 +166,7 @@ describe 'Custom actions', type: :feature, js: true do
     new_ca_page = index_ca_page.new
     new_ca_page.set_name('Escalate')
     new_ca_page.add_action('Priority', immediate_priority.name)
+    new_ca_page.add_action('Notify', other_member_user.name)
     new_ca_page.add_action(list_custom_field.name, selected_list_custom_field_options.map(&:name))
     new_ca_page.create
 
@@ -249,6 +257,9 @@ describe 'Custom actions', type: :feature, js: true do
                               status: default_status.name,
                               assignee: '-',
                               "customField#{list_custom_field.id}" => selected_list_custom_field_options.map(&:name).join(' ')
+
+    expect(page)
+      .to have_selector('.work-package-details-activities-activity-contents a.user-mention', text: other_member_user.name)
     wp_page.expect_notification message: 'Successful update'
     wp_page.dismiss_notification!
 

--- a/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/description_editor_spec.rb
@@ -1,3 +1,31 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
 require 'spec_helper'
 require 'features/work_packages/details/inplace_editor/shared_examples'
 require 'features/work_packages/shared_contexts'

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -46,8 +46,9 @@ describe OpenProject::TextFormatting do
       FactoryGirl.create :user,
                          member_in_project: project,
                          member_through_role: FactoryGirl.create(:role,
-                                                                 permissions: [:view_work_packages, :edit_work_packages,
-                                                                               :browse_repository, :view_changesets, :view_wiki_pages])
+                                                                 permissions: %i[view_work_packages edit_work_packages
+                                                                                 browse_repository view_changesets
+                                                                                 view_wiki_pages])
     end
     let(:issue) do
       FactoryGirl.create :work_package,
@@ -292,8 +293,8 @@ describe OpenProject::TextFormatting do
     context 'User links' do
       let(:role) do
         FactoryGirl.create :role,
-                           permissions: [:view_work_packages, :edit_work_packages,
-                                         :browse_repository, :view_changesets, :view_wiki_pages]
+                           permissions: %i[view_work_packages edit_work_packages
+                                           browse_repository view_changesets view_wiki_pages]
       end
 
       let(:linked_project_member) do
@@ -320,7 +321,6 @@ describe OpenProject::TextFormatting do
             is_expected.to be_html_eql("<p>user##{linked_project_member.id}</p>")
           }
         end
-
       end
 
       context 'User link via login name' do
@@ -352,6 +352,38 @@ describe OpenProject::TextFormatting do
           it {
             is_expected.to be_html_eql("<p>user:\"#{linked_project_member.login}\"</p>")
           }
+        end
+      end
+    end
+
+    context 'Group reference' do
+      let(:role) do
+        FactoryGirl.create :role,
+                           permissions: []
+      end
+
+      let(:linked_project_member_group) do
+        FactoryGirl.create(:group).tap do |group|
+          FactoryGirl.create(:member,
+                             principal: group,
+                             project: project,
+                             roles: [role])
+        end
+      end
+
+      context 'group exists' do
+        subject { format_text("group##{linked_project_member_group.id}") }
+
+        it 'produces the expected html' do
+          is_expected.to be_html_eql("<p><span class='user-mention'>#{linked_project_member_group.name}</span></p>")
+        end
+      end
+
+      context 'group does not exist' do
+        subject { format_text("group#000000") }
+
+        it 'leaves the text unchangd' do
+          is_expected.to be_html_eql("<p>group#000000</p>")
         end
       end
     end

--- a/spec/models/custom_actions/actions/assigned_to_spec.rb
+++ b/spec/models/custom_actions/actions/assigned_to_spec.rb
@@ -29,30 +29,30 @@ require 'spec_helper'
 require_relative '../shared_expectations'
 
 describe CustomActions::Actions::AssignedTo, type: :model do
-  it_behaves_like 'associated custom action' do
-    let(:key) { :assigned_to }
-    let(:allowed_values) do
-      users = []
+  let(:key) { :assigned_to }
+  let(:allowed_values) do
+    users = []
 
-      if !Setting.work_package_group_assignment?
-        users = [FactoryGirl.build_stubbed(:user),
-                 FactoryGirl.build_stubbed(:user)]
-        allow(User)
-          .to receive_message_chain(:active_or_registered, :select, :order_by_name)
-          .and_return(users)
-      else
-        users = [FactoryGirl.build_stubbed(:user),
-                 FactoryGirl.build_stubbed(:group)]
-        allow(Principal)
-          .to receive_message_chain(:active_or_registered, :select, :order_by_name)
-          .and_return(users)
-      end
-
-      [{ value: nil, label: '-' },
-       { value: users.first.id, label: users.first.name },
-       { value: users.last.id, label: users.last.name }]
+    if !Setting.work_package_group_assignment?
+      users = [FactoryGirl.build_stubbed(:user),
+               FactoryGirl.build_stubbed(:user)]
+      allow(User)
+        .to receive_message_chain(:active_or_registered, :select, :order_by_name)
+              .and_return(users)
+    else
+      users = [FactoryGirl.build_stubbed(:user),
+               FactoryGirl.build_stubbed(:group)]
+      allow(Principal)
+        .to receive_message_chain(:active_or_registered, :select, :order_by_name)
+              .and_return(users)
     end
 
+    [{ value: nil, label: '-' },
+     { value: users.first.id, label: users.first.name },
+     { value: users.last.id, label: users.last.name }]
+  end
+  it_behaves_like 'base custom action'
+  it_behaves_like 'associated custom action' do
     describe '#allowed_values' do
       context 'group assignment disabled', with_settings: { work_package_group_assignment?: false } do
         it 'is the list of all users' do

--- a/spec/models/custom_actions/actions/custom_field_spec.rb
+++ b/spec/models/custom_actions/actions/custom_field_spec.rb
@@ -194,7 +194,7 @@ describe CustomActions::Actions::CustomField, type: :model do
     context 'for a list custom field allowing multiple values' do
       let(:custom_field) { list_multi_custom_field }
 
-      it 'is :associated_property_multi' do
+      it 'is :associated_property' do
         expect(instance.type)
           .to eql(:associated_property)
       end

--- a/spec/models/custom_actions/actions/notify_spec.rb
+++ b/spec/models/custom_actions/actions/notify_spec.rb
@@ -58,12 +58,20 @@ describe CustomActions::Actions::Notify, type: :model do
     describe '#apply' do
       let(:work_package) { FactoryGirl.build_stubbed(:stubbed_work_package) }
 
-      it 'adds a note with all values' do
-        instance.values = [1, 2, 3]
+      it 'adds a note with all values distinguised by type' do
+        principals = [FactoryGirl.build_stubbed(:user),
+                      FactoryGirl.build_stubbed(:group),
+                      FactoryGirl.build_stubbed(:user)]
+
+        allow(Principal)
+          .to receive_message_chain(:active_or_registered, :select, :order_by_name, :where)
+          .and_return(principals)
+
+        instance.values = principals.map(&:id)
 
         expect(work_package)
           .to receive(:journal_notes=)
-          .with('user#1, user#2, user#3')
+          .with("user##{principals[0].id}, group##{principals[1].id}, user##{principals[2].id}")
 
         instance.apply(work_package)
       end

--- a/spec/models/custom_actions/actions/priority_spec.rb
+++ b/spec/models/custom_actions/actions/priority_spec.rb
@@ -29,19 +29,20 @@ require 'spec_helper'
 require_relative '../shared_expectations'
 
 describe CustomActions::Actions::Priority, type: :model do
+  let(:key) { :priority }
+  let(:allowed_values) do
+    priorities = [FactoryGirl.build_stubbed(:issue_priority),
+                  FactoryGirl.build_stubbed(:issue_priority)]
+    allow(IssuePriority)
+      .to receive_message_chain(:select, :order)
+            .and_return(priorities)
+
+    [{ value: priorities.first.id, label: priorities.first.name },
+     { value: priorities.last.id, label: priorities.last.name }]
+  end
+
+  it_behaves_like 'base custom action'
   it_behaves_like 'associated custom action' do
-    let(:key) { :priority }
-    let(:allowed_values) do
-      priorities = [FactoryGirl.build_stubbed(:issue_priority),
-                    FactoryGirl.build_stubbed(:issue_priority)]
-      allow(IssuePriority)
-        .to receive_message_chain(:select, :order)
-        .and_return(priorities)
-
-      [{ value: priorities.first.id, label: priorities.first.name },
-       { value: priorities.last.id, label: priorities.last.name }]
-    end
-
     describe '#allowed_values' do
       it 'is the list of all priorities' do
         allowed_values

--- a/spec/models/custom_actions/actions/project_spec.rb
+++ b/spec/models/custom_actions/actions/project_spec.rb
@@ -29,21 +29,22 @@ require 'spec_helper'
 require_relative '../shared_expectations'
 
 describe CustomActions::Actions::Project, type: :model do
+  let(:key) { :project }
+  let(:priority) { 10 }
+
+  let(:allowed_values) do
+    projects = [FactoryGirl.build_stubbed(:project),
+                FactoryGirl.build_stubbed(:project)]
+    allow(Project)
+      .to receive_message_chain(:select, :order)
+            .and_return(projects)
+
+    [{ value: projects.first.id, label: projects.first.name },
+     { value: projects.last.id, label: projects.last.name }]
+  end
+
+  it_behaves_like 'base custom action'
   it_behaves_like 'associated custom action' do
-    let(:key) { :project }
-    let(:priority) { 10 }
-
-    let(:allowed_values) do
-      projects = [FactoryGirl.build_stubbed(:project),
-                  FactoryGirl.build_stubbed(:project)]
-      allow(Project)
-        .to receive_message_chain(:select, :order)
-        .and_return(projects)
-
-      [{ value: projects.first.id, label: projects.first.name },
-       { value: projects.last.id, label: projects.last.name }]
-    end
-
     describe '#allowed_values' do
       it 'is the list of all project' do
         allowed_values

--- a/spec/models/custom_actions/actions/responsible_spec.rb
+++ b/spec/models/custom_actions/actions/responsible_spec.rb
@@ -29,21 +29,22 @@ require 'spec_helper'
 require_relative '../shared_expectations'
 
 describe CustomActions::Actions::Responsible, type: :model do
+  let(:key) { :responsible }
+  let(:allowed_values) do
+    users = [FactoryGirl.build_stubbed(:user),
+             FactoryGirl.build_stubbed(:user)]
+
+    allow(User)
+      .to receive_message_chain(:active_or_registered, :select, :order_by_name)
+            .and_return(users)
+
+    [{ value: nil, label: '-' },
+     { value: users.first.id, label: users.first.name },
+     { value: users.last.id, label: users.last.name }]
+  end
+
+  it_behaves_like 'base custom action'
   it_behaves_like 'associated custom action' do
-    let(:key) { :responsible }
-    let(:allowed_values) do
-      users = [FactoryGirl.build_stubbed(:user),
-               FactoryGirl.build_stubbed(:user)]
-
-      allow(User)
-        .to receive_message_chain(:active_or_registered, :select, :order_by_name)
-        .and_return(users)
-
-      [{ value: nil, label: '-' },
-       { value: users.first.id, label: users.first.name },
-       { value: users.last.id, label: users.last.name }]
-    end
-
     describe '#allowed_values' do
       context 'group assignment disabled', with_settings: { work_package_group_assignment?: false } do
         it 'is the list of all users' do

--- a/spec/models/custom_actions/actions/status_spec.rb
+++ b/spec/models/custom_actions/actions/status_spec.rb
@@ -29,19 +29,20 @@ require 'spec_helper'
 require_relative '../shared_expectations'
 
 describe CustomActions::Actions::Status, type: :model do
+  let(:key) { :status }
+  let(:allowed_values) do
+    statuses = [FactoryGirl.build_stubbed(:status),
+                FactoryGirl.build_stubbed(:status)]
+    allow(Status)
+      .to receive_message_chain(:select, :order)
+            .and_return(statuses)
+
+    [{ value: statuses.first.id, label: statuses.first.name },
+     { value: statuses.last.id, label: statuses.last.name }]
+  end
+
+  it_behaves_like 'base custom action'
   it_behaves_like 'associated custom action' do
-    let(:key) { :status }
-    let(:allowed_values) do
-      statuses = [FactoryGirl.build_stubbed(:status),
-                  FactoryGirl.build_stubbed(:status)]
-      allow(Status)
-        .to receive_message_chain(:select, :order)
-        .and_return(statuses)
-
-      [{ value: statuses.first.id, label: statuses.first.name },
-       { value: statuses.last.id, label: statuses.last.name }]
-    end
-
     describe '#allowed_values' do
       it 'is the list of all status' do
         allowed_values

--- a/spec/models/custom_actions/shared_expectations.rb
+++ b/spec/models/custom_actions/shared_expectations.rb
@@ -26,7 +26,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-shared_examples_for 'associated custom action' do
+shared_context 'custom actions action' do
   let(:instance) do
     described_class.new
   end
@@ -37,6 +37,10 @@ shared_examples_for 'associated custom action' do
       raise ":key needs to be defined"
     end
   end
+end
+
+shared_examples_for 'base custom action' do
+  include_context 'custom actions action'
   let(:expected_priority) do
     if defined?(priority)
       priority
@@ -96,28 +100,32 @@ shared_examples_for 'associated custom action' do
     end
   end
 
-  describe '#apply' do
-    let(:work_package) { FactoryGirl.build_stubbed(:stubbed_work_package) }
-
-    it 'sets the associated_id in the work package to the action\'s value' do
-      expect(work_package)
-        .to receive(:"#{key}_id=")
-        .with(42)
-
-      instance.values = 42
-
-      instance.apply(work_package)
-    end
-  end
-
   describe '#priority' do
     it 'is the expected level' do
       expect(instance.priority)
         .to eql(expected_priority)
     end
   end
+end
 
-  it_behaves_like 'associated custom action validations'
+shared_examples_for 'associated custom action' do
+  include_context 'custom actions action' do
+    describe '#apply' do
+      let(:work_package) { FactoryGirl.build_stubbed(:stubbed_work_package) }
+
+      it 'sets the associated_id in the work package to the action\'s value' do
+        expect(work_package)
+          .to receive(:"#{key}_id=")
+          .with(42)
+
+        instance.values = 42
+
+        instance.apply(work_package)
+      end
+    end
+
+    it_behaves_like 'associated custom action validations'
+  end
 end
 
 shared_examples_for 'associated custom action validations' do


### PR DESCRIPTION
Adds the "notify" action to custom actions:

![image](https://user-images.githubusercontent.com/617519/36106849-b5a6cab2-1018-11e8-97f4-88646860614d.png)

Can either be a group or a user. 

This action employs the "mentions"-feature to actually send out the notifications. The users selected as values for the action are written into the journal_notes which will trigger sending the email in turn.

To support groups, the mentions functionality is extended. Now, groups can also be selected for custom actions but also for the manual mentions functionality. This does not look perfect right now as groups do not have a page to link to.