### PR TITLE
Feature/cached representers

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -122,6 +122,10 @@ class Attachment < ActiveRecord::Base
     file.readable?
   end
 
+  def cache_key
+    "#{super}-#{created_on.to_i}"
+  end
+
   # Bulk attaches a set of files to an object
   #
   # Returns a Hash of the results:

--- a/app/models/issue_priority.rb
+++ b/app/models/issue_priority.rb
@@ -41,6 +41,6 @@ class IssuePriority < Enumeration
   end
 
   def transfer_relations(to)
-    work_packages.update_all("priority_id = #{to.id}")
+    work_packages.update_all(priority_id: to.id)
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -47,6 +47,10 @@ class Member < ActiveRecord::Base
   after_save :save_notification
   after_destroy :destroy_notification
 
+  scope :of, ->(project) {
+    where(project_id: project)
+  }
+
   def self.visible(user)
     where(project_id: Project.visible_by(user))
   end

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -66,16 +66,11 @@ class Principal < ActiveRecord::Base
   scope :active_or_registered_like, ->(query) { active_or_registered.like(query) }
 
   scope :in_project, ->(project) {
-    projects = Array(project)
-    subquery = "SELECT DISTINCT user_id FROM members WHERE project_id IN (?)"
-    condition = ["#{Principal.table_name}.id IN (#{subquery})",
-                 projects.map(&:id)]
-
-    where(condition)
+    where(id: Member.of(project).select(:user_id))
   }
 
   scope :not_in_project, ->(project) {
-    where("id NOT IN (select m.user_id FROM members as m where m.project_id = #{project.id})")
+    where.not(id: Member.of(project).select(:user_id))
   }
 
   # Active non-anonymous principals scope

--- a/app/models/queries/principals/orders/name_order.rb
+++ b/app/models/queries/principals/orders/name_order.rb
@@ -1,3 +1,33 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
 class Queries::Principals::Orders::NameOrder < Queries::BaseOrder
   self.model = Principal
 

--- a/db/migrate/20180419061910_timestamp_for_caching.rb
+++ b/db/migrate/20180419061910_timestamp_for_caching.rb
@@ -1,7 +1,6 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -24,25 +23,26 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# See docs/COPYRIGHT.rdoc for more details.
+# See doc/COPYRIGHT.rdoc for more details.
 #++
-require 'legacy_spec_helper'
 
-describe IssuePriority do
-  fixtures :all
-
-  it 'should be an enumeration' do
-    assert IssuePriority.ancestors.include?(Enumeration)
+class TimestampForCaching < ActiveRecord::Migration[5.1]
+  def change
+    [Enumeration, Status, Category, AuthSource].each do |model|
+      add_timestamps(model)
+    end
   end
 
-  it 'should objects_count' do
-    # low priority
-    assert_equal 6, IssuePriority.find(4).objects_count
-    # urgent
-    assert_equal 0, IssuePriority.find(7).objects_count
-  end
+  def add_timestamps(model)
+    table = model.table_name
 
-  it 'should option_name' do
-    assert_equal :enumeration_work_package_priorities, IssuePriority.new.option_name
+    change_table table do |t|
+      t.timestamps null: true
+    end
+
+    model.update_all(updated_at: Time.now, created_at: Time.now)
+
+    change_column_null table, :created_at, false
+    change_column_null table, :updated_at, false
   end
 end

--- a/docs/api/apiv3-documentation.apib
+++ b/docs/api/apiv3-documentation.apib
@@ -13,6 +13,7 @@ FORMAT: 1A
 <!-- include(apiv3/endpoints/custom-actions.apib) -->
 <!-- include(apiv3/endpoints/custom-options.apib) -->
 <!-- include(apiv3/endpoints/forms.apib) -->
+<!-- include(apiv3/endpoints/groups.apib) -->
 <!-- include(apiv3/endpoints/help_texts.apib) -->
 <!-- include(apiv3/endpoints/principals.apib) -->
 <!-- include(apiv3/endpoints/priorities.apib) -->

--- a/docs/api/apiv3/endpoints/groups.apib
+++ b/docs/api/apiv3/endpoints/groups.apib
@@ -1,0 +1,66 @@
+# Group Groups
+
+Groups are collections of users. They support assigning/unassigning multiple users to/from a project in one operation.
+
+This resource is currently a stub.
+
+## Actions
+
+None
+
+## Linked Properties
+|  Link       | Description                                                   | Type          | Constraints           | Supported operations | Condition                                 |
+|:-----------:|-------------------------------------------------------------- | ------------- | --------------------- | -------------------- | ----------------------------------------- |
+| self        | This group                                                    | Group         | not null              | READ                 |                                           |
+
+## Local Properties
+| Property     | Description                                                | Type     | Constraints                                          | Supported operations | Condition                                                                           |
+| :----------: | ---------------------------------------------------------  | -------- | ---------------------------------------------------- | -------------------- | -----------------------------------------------------------                         |
+| id           | Group's id                                                 | Integer  | x > 0                                                | READ                 |                                                                                     |
+| name         | Group's full name, formatting depends on instance settings | String   |                                                      | READ                 |                                                                                     |
+| createdAt    | Time of creation                                           | DateTime |                                                      | READ                 |                                                                                     |
+| updatedAt    | Time of the most recent change to the user                 | DateTime |                                                      | READ                 |                                                                                     |
+
+## Group [/api/v3/groups/{id}]
+
++ Model
+    + Body
+
+            {
+                "_type": "Group",
+                "id": 9,
+                "name": "The group",
+                "createdAt": "2015-09-23T11:06:36Z",
+                "updatedAt": "2015-09-23T11:06:36Z",
+                "_links": {
+                    "self": {
+                        "href": "/api/v3/groups/9",
+                        "title": "The group"
+                    }
+                }
+            }
+
+## View group [GET]
+
++ Parameters
+    + id (required, integer, `1`) ... Group id.
+
++ Response 200 (application/hal+json)
+
+    [Group][]
+
++ Response 404 (application/hal+json)
+
+    Returned if the group does not exist or if the API user does not have permission to view them.
+
+    **Required permission** If the user has the *manage members* permission in at least one project the user will be able to query all groups. If not, the user
+    will be able to query all groups which are members in projects, he has the *view members* permission in.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The requested resource could not be found."
+            }
+

--- a/docs/api/apiv3/endpoints/principals.apib
+++ b/docs/api/apiv3/endpoints/principals.apib
@@ -2,15 +2,13 @@
 
 Principals are the superclass of groups and users.
 
-Currently, OpenProject represents groups the same way it represents users. This is subject to change.
-
 ## Linked Properties
 
-See [user](#users)
+See [user](#users) and [group](#groups)
 
 ## Local Properties
 
-See [user](#users)
+See [user](#users) and [group](#groups)
 
 ## Principals [/api/v3/principals{?filters}]
 
@@ -28,7 +26,6 @@ See [user](#users)
                     "id": 4,
                     "login": "Eliza92778",
                     "admin": false,
-                    "subtype": "User",
                     "firstName": "Danika",
                     "lastName": "O'Keefe",
                     "name": "Danika O'Keefe",
@@ -69,7 +66,6 @@ See [user](#users)
                     "id": 2,
                     "login": "Sebastian9686",
                     "admin": false,
-                    "subtype": "User",
                     "firstName": "Peggie",
                     "lastName": "Feeney",
                     "name": "Peggie Feeney",
@@ -106,39 +102,17 @@ See [user](#users)
                     }
                   },
                   {
-                    "_type": "User",
-                    "id": 9,
-                    "login": "",
-                    "admin": false,
-                    "subtype": "Group",
-                    "firstName": "",
-                    "lastName": "Group 1",
-                    "name": "Group 1",
-                    "email": null,
-                    "avatar": "",
-                    "createdAt": "2015-09-23T11:06:36Z",
-                    "updatedAt": "2015-09-23T11:06:36Z",
-                    "status": "active",
-                    "_links": {
-                      "self": {
-                        "href": "/api/v3/users/9",
-                        "title": "Group 1"
-                      },
-                      "showUser": {
-                        "href": "/users/9",
-                        "type": "text/html"
-                      },
-                      "updateImmediately": {
-                        "href": "/api/v3/users/9",
-                        "title": "Update ",
-                        "method": "patch"
-                      },
-                      "delete": {
-                        "href": "/api/v3/users/9",
-                        "title": "Delete ",
-                        "method": "delete"
+                      "_type": "Group",
+                      "id": 9,
+                      "name": "The group",
+                      "createdAt": "2015-09-23T11:06:36Z",
+                      "updatedAt": "2015-09-23T11:06:36Z",
+                      "_links": {
+                          "self": {
+                              "href": "/api/v3/groups/9",
+                              "title": "The group"
+                          }
                       }
-                    }
                   }
                 ]
               },

--- a/docs/api/apiv3/endpoints/users.apib
+++ b/docs/api/apiv3/endpoints/users.apib
@@ -110,7 +110,7 @@ Please note that custom fields are not yet supported by the api although the bac
 
     Returned if the user does not exist or if the API user does not have permission to view them.
 
-    **Required permission** The user needs to be locked in if the installation is configured to pervent anonymous access
+    **Required permission** The user needs to be locked in if the installation is configured to prevent anonymous access
 
     + Body
 

--- a/frontend/app/components/common/autocomplete/auto-complete-helper.service.ts
+++ b/frontend/app/components/common/autocomplete/auto-complete-helper.service.ts
@@ -36,7 +36,7 @@ export class AutoCompleteHelperService {
       at: at,
       startWithSpace: true,
       searchKey: 'id_principal',
-      displayTpl: '<li data-value="#{subtype}#${id}">${name}</li>',
+      displayTpl: '<li data-value="#{_type}#${id}">${name}</li>',
       insertTpl: "${typePrefix}#${id}",
       limit: 10,
       highlightFirst: true,
@@ -55,7 +55,7 @@ export class AutoCompleteHelperService {
                 const principals = data["_embedded"]["elements"];
                 for (let i = principals.length - 1; i >= 0; i--) {
                   principals[i]['id_principal'] = principals[i]['id'].toString() + ' ' + principals[i]['name'];
-                  principals[i]['typePrefix'] = principals[i]['subtype'].toLowerCase();
+                  principals[i]['typePrefix'] = principals[i]['_type'].toLowerCase();
                 }
 
                 if (angular.element(textarea).is(':visible')) {

--- a/frontend/app/templates/components/user_field.html
+++ b/frontend/app/templates/components/user_field.html
@@ -4,9 +4,9 @@
        ng-src="{{user.avatar}}" alt="Avatar" title="{{userName}}" />
   <span class="user-avatar--user-with-role">
     <span class="user-avatar--user" ng-if="userName">
-      <a ng-if="user.subtype !== 'Group'" ng-href="{{ userPath(user.id) }}" ng-bind="user.name"
+      <a ng-if="user.type !== 'Group'" ng-href="{{ userPath(user.id) }}" ng-bind="user.name"
          class="user-field-user-link"/>
-      <span ng-if="user.subtype == 'Group'" ng-bind="user.name" class="user-field-user-link"/>
+      <span ng-if="user.type == 'Group'" ng-bind="user.name" class="user-field-user-link"/>
     </span>
     <span class="user-avatar--user" ng-if="!userName"> - </span>
     <span class="user-avatar--role" ng-if="user.role" ng-bind="user.role"/>

--- a/lib/api/caching/cached_representer.rb
+++ b/lib/api/caching/cached_representer.rb
@@ -1,0 +1,212 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module Caching
+    module CachedRepresenter
+      extend ::ActiveSupport::Concern
+
+      DEFAULT_CONFIGURATION = { disabled: false, key_parts: [] }.freeze
+
+      included do
+        def to_json(*args)
+          return super if no_caching?
+
+          cached_json_rep = OpenProject::Cache.fetch(json_cache_key) do
+            with_caching_state :cacheable do
+              super
+            end
+          end
+
+          uncached_json_rep = with_caching_state :uncacheable do
+            super
+          end
+
+          cached_hash_rep = ::JSON::parse(cached_json_rep)
+
+          apply_link_cache_ifs(cached_hash_rep)
+          apply_property_cache_ifs(cached_hash_rep)
+
+          add_uncacheable_links(cached_hash_rep)
+
+          uncached_hash_rep = ::JSON::parse(uncached_json_rep)
+          hash_rep = uncached_hash_rep.deep_merge(cached_hash_rep)
+
+          ::JSON::dump(hash_rep)
+        end
+
+        def json_cache_key
+          self.class.name.to_s.split('::') + [
+            'json',
+            I18n.locale,
+            json_key_model_parts
+          ]
+        end
+
+        protected
+
+        attr_accessor :caching_state
+        class_attribute :_cached_representer_config
+
+        private
+
+        def apply_link_cache_ifs(hash_rep)
+          link_conditions = representable_attrs['links']
+                            .link_configs
+                            .select { |config, _block| config[:cache_if] }
+
+          link_conditions.each do |(config, _block)|
+            condition = config[:cache_if]
+            next if instance_exec(&condition)
+
+            name = config[:rel]
+
+            delete_from_hash(hash_rep, '_links', name)
+          end
+        end
+
+        def apply_property_cache_ifs(hash_rep)
+          attrs = representable_attrs
+                  .select { |_name, config| config[:cache_if] }
+
+          attrs.each do |name, config|
+            condition = config[:cache_if]
+            next if instance_exec(&condition)
+
+            hash_name = (config[:as] && instance_exec(&config[:as])) || name
+
+            delete_from_hash(hash_rep, config[:embedded] ? '_embedded' : nil, hash_name)
+          end
+        end
+
+        def add_uncacheable_links(hash_rep)
+          link_conditions = representable_attrs['links']
+                            .link_configs
+                            .select { |config, _block| config[:uncacheable] }
+
+          link_conditions.each do |config, block|
+            name = config[:rel]
+            block_result = instance_exec(&block)
+
+            if block_result
+              hash_rep['_links'][name] = block_result
+            else
+              hash_rep['_links'].delete(name)
+            end
+          end
+        end
+
+        # Overriding Roar::Hypermedia#perpare_link_for
+        # to remove the cache_if option which would otherwise
+        # be visible in the output
+        def prepare_link_for(href, options)
+          super(href, options.except(:cache_if))
+        end
+
+        # Overriding Roar::Hypbermedia#combile_links_for
+        # to remove all uncacheable links if the caching_state is set to :cacheable
+        def compile_links_for(configs, *args)
+          current_configs = case caching_state
+                            when :cacheable
+                              configs.reject { |c| c.first[:uncacheable] }
+                            when :uncacheable
+                              configs.select { |c| c.first[:uncacheable] }
+                            else
+                              configs
+                            end
+
+          super(current_configs, *args)
+        end
+
+        def delete_from_hash(hash, path, key)
+          pathed_hash = path ? hash[path] : hash
+
+          pathed_hash.delete(key.to_s) if pathed_hash
+        end
+
+        def representable_map(*)
+          ret = super
+
+          current_map = case caching_state
+                        when :cacheable
+                          ret.reject { |b| b[:uncacheable] }
+                        when :uncacheable
+                          ret.select { |b| b[:uncacheable] }
+                        else
+                          ret
+                        end
+
+          Representable::Binding::Map.new(current_map)
+        end
+
+        def with_caching_state(state)
+          self.caching_state = state
+          ret = yield
+          self.caching_state = nil
+          ret
+        end
+
+        def json_key_model_parts
+          models = [represented]
+
+          self.class.cached_representer_configuration[:key_parts].each do |association|
+            models << represented.send(association)
+          end
+
+          OpenProject::Cache::CacheKey.expand(models)
+        end
+
+        def no_caching?
+          self.class.cached_representer_configuration[:disabled]
+        end
+      end
+
+      class_methods do
+        def cached_representer_configuration
+          self._cached_representer_config ||= DEFAULT_CONFIGURATION
+        end
+
+        def cached_representer(config)
+          self._cached_representer_config = DEFAULT_CONFIGURATION.merge(config)
+        end
+
+        def link(name, options = {}, &block)
+          rel_hash = name.is_a?(Hash) ? name : { rel: name }
+          super(rel_hash.merge(options), &block)
+        end
+
+        def links(name, options = {}, &block)
+          rel_hash = name.is_a?(Hash) ? name : { rel: name }
+          super(rel_hash.merge(options), &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/attachments/attachment_representer.rb
+++ b/lib/api/v3/attachments/attachment_representer.rb
@@ -36,6 +36,7 @@ module API
     module Attachments
       class AttachmentRepresenter < ::API::Decorators::Single
         include API::Decorators::LinkedResource
+        include API::Caching::CachedRepresenter
 
         self_link title_getter: ->(*) { represented.filename }
 
@@ -56,8 +57,8 @@ module API
         end
 
         # visibility of this link is also work_package specific!
-        link :delete do
-          next unless current_user_allowed_to(:edit_work_packages, context: represented.container.project)
+        link :delete,
+             cache_if: -> { current_user_allowed_to(:edit_work_packages, context: represented.container.project) } do
           {
             href: api_v3_paths.attachment(represented.id),
             method: :delete

--- a/lib/api/v3/categories/category_representer.rb
+++ b/lib/api/v3/categories/category_representer.rb
@@ -34,10 +34,14 @@ module API
   module V3
     module Categories
       class CategoryRepresenter < ::API::Decorators::Single
+        include ::API::Caching::CachedRepresenter
+
+        cached_representer key_parts: %i(assigned_to project)
+
         link :self do
           {
             href: api_v3_paths.category(represented.id),
-            title: "#{represented.name}"
+            title: represented.name
           }
         end
 
@@ -49,10 +53,12 @@ module API
         end
 
         link :defaultAssignee do
+          next unless represented.assigned_to
+
           {
             href: api_v3_paths.user(represented.assigned_to.id),
             title: represented.assigned_to.name
-          } if represented.assigned_to
+          }
         end
 
         property :id, render_nil: true

--- a/lib/api/v3/groups/group_representer.rb
+++ b/lib/api/v3/groups/group_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -29,9 +30,11 @@
 
 module API
   module V3
-    module Users
-      class UserCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        include API::V3::Principals::GroupOrUserElements
+    module Groups
+      class GroupRepresenter < ::API::V3::Principals::PrincipalRepresenter
+        def _type
+          'Group'
+        end
       end
     end
   end

--- a/lib/api/v3/groups/groups_api.rb
+++ b/lib/api/v3/groups/groups_api.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -29,9 +28,36 @@
 
 module API
   module V3
-    module Users
-      class UserCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        include API::V3::Principals::GroupOrUserElements
+    module Groups
+      class GroupsAPI < ::API::OpenProjectAPI
+        helpers ::API::Utilities::ParamsHelper
+
+        resources :groups do
+          params do
+            requires :id, desc: 'Group\'s id'
+          end
+          route_param :id do
+            helpers do
+              def group_scope
+                if current_user.allowed_to_globally?(:manage_members)
+                  Group.all
+                else
+                  Group
+                    .in_project(Project.allowed_to(current_user, :view_members))
+                end
+              end
+
+              def requested_user
+                group_scope.find(params[:id])
+              end
+            end
+
+            get do
+              GroupRepresenter
+                .new(requested_user, current_user: current_user)
+            end
+          end
+        end
       end
     end
   end

--- a/lib/api/v3/principals/associated_subclass_lambda.rb
+++ b/lib/api/v3/principals/associated_subclass_lambda.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -29,9 +30,24 @@
 
 module API
   module V3
-    module Users
-      class UserCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        include API::V3::Principals::GroupOrUserElements
+    module Principals
+      module AssociatedSubclassLambda
+        def self.getter(name)
+          ->(*) {
+            instance = represented.send(name)
+
+            case instance
+            when User
+              ::API::V3::Users::UserRepresenter.new(represented.send(name), current_user: current_user)
+            when Group
+              ::API::V3::Groups::GroupRepresenter.new(represented.send(name), current_user: current_user)
+            when NilClass
+              nil
+            else
+              raise "undefined subclass for #{instance}"
+            end
+          }
+        end
       end
     end
   end

--- a/lib/api/v3/principals/group_or_user_elements.rb
+++ b/lib/api/v3/principals/group_or_user_elements.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -29,9 +30,29 @@
 
 module API
   module V3
-    module Users
-      class UserCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        include API::V3::Principals::GroupOrUserElements
+    module Principals
+      module GroupOrUserElements
+        extend ::ActiveSupport::Concern
+
+        included do
+          collection :elements,
+                     getter: ->(*) {
+                       represented.map do |model|
+                         representer_class = case model
+                                             when User
+                                               ::API::V3::Users::UserRepresenter
+                                             when Group
+                                               ::API::V3::Groups::GroupRepresenter
+                                             else
+                                               raise "unsupported type"
+                                             end
+
+                         representer_class.new(model, current_user: current_user)
+                       end
+                     },
+                     exec_context: :decorator,
+                     embedded: true
+        end
       end
     end
   end

--- a/lib/api/v3/principals/principal_representer.rb
+++ b/lib/api/v3/principals/principal_representer.rb
@@ -1,0 +1,81 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'roar/decorator'
+require 'roar/json/hal'
+
+module API
+  module V3
+    module Principals
+      class PrincipalRepresenter < ::API::Decorators::Single
+        include AvatarHelper
+        include ::API::Caching::CachedRepresenter
+
+        def self.create(user, current_user:)
+          new(user, current_user: current_user)
+        end
+
+        def initialize(user, current_user:)
+          super(user, current_user: current_user)
+        end
+
+        self_link
+
+        property :id,
+                 render_nil: true
+
+        property :name,
+                 render_nil: true
+
+        property :created_on,
+                 exec_context: :decorator,
+                 as: 'createdAt',
+                 getter: ->(*) { datetime_formatter.format_datetime(represented.created_on) },
+                 render_nil: false,
+                 cache_if: -> { current_user_is_admin_or_self }
+
+        property :updated_on,
+                 exec_context: :decorator,
+                 as: 'updatedAt',
+                 getter: ->(*) { datetime_formatter.format_datetime(represented.updated_on) },
+                 render_nil: false,
+                 cache_if: -> { current_user_is_admin_or_self }
+
+        def current_user_is_admin_or_self
+          current_user_is_admin || represented.id == current_user.id
+        end
+
+        def current_user_is_admin
+          current_user.admin?
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/principals/principals_api.rb
+++ b/lib/api/v3/principals/principals_api.rb
@@ -37,14 +37,13 @@ module API
             query = ParamsToQueryService.new(Principal, current_user).call(params)
 
             if query.valid?
-              users = query
-                      .results
-                      .where(id: Principal.in_visible_project(current_user)
-                                          .or(Principal.me))
-                      .includes(:preference)
+              principals = query
+                           .results
+                           .where(id: Principal.in_visible_project_or_me(current_user))
+                           .includes(:preference)
 
-              ::API::V3::Users::PaginatedUserCollectionRepresenter.new(users,
-                                                                       api_v3_paths.users,
+              ::API::V3::Users::PaginatedUserCollectionRepresenter.new(principals,
+                                                                       api_v3_paths.principals,
                                                                        page: to_i_or_nil(params[:offset]),
                                                                        per_page: resolve_page_size(params[:pageSize]),
                                                                        current_user: current_user)

--- a/lib/api/v3/priorities/priority_representer.rb
+++ b/lib/api/v3/priorities/priority_representer.rb
@@ -34,6 +34,8 @@ module API
   module V3
     module Priorities
       class PriorityRepresenter < ::API::Decorators::Single
+        include API::Caching::CachedRepresenter
+
         self_link
 
         property :id, render_nil: true

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -34,7 +34,7 @@ module API
       class ProjectsAPI < ::API::OpenProjectAPI
         resources :projects do
           get do
-            ::API::V3::Utilities::ParamsToQuery.collection_response(Project.visible(current_user),
+            ::API::V3::Utilities::ParamsToQuery.collection_response(Project.visible(current_user).includes(:enabled_modules),
                                                                     current_user,
                                                                     params)
           end

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -56,6 +56,7 @@ module API
       mount ::API::V3::Types::TypesAPI
       mount ::API::V3::Users::UsersAPI
       mount ::API::V3::UserPreferences::UserPreferencesAPI
+      mount ::API::V3::Groups::GroupsAPI
       mount ::API::V3::Versions::VersionsAPI
       mount ::API::V3::WorkPackages::WorkPackagesAPI
 

--- a/lib/api/v3/statuses/status_representer.rb
+++ b/lib/api/v3/statuses/status_representer.rb
@@ -31,6 +31,8 @@ module API
   module V3
     module Statuses
       class StatusRepresenter < ::API::Decorators::Single
+        include API::Caching::CachedRepresenter
+
         self_link
 
         property :id, render_nil: true

--- a/lib/api/v3/types/type_representer.rb
+++ b/lib/api/v3/types/type_representer.rb
@@ -31,6 +31,8 @@ module API
   module V3
     module Types
       class TypeRepresenter < ::API::Decorators::Single
+        include ::API::Caching::CachedRepresenter
+
         self_link
 
         property :id

--- a/lib/api/v3/users/paginated_user_collection_representer.rb
+++ b/lib/api/v3/users/paginated_user_collection_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -37,7 +38,7 @@ module API
   module V3
     module Users
       class PaginatedUserCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
-        element_decorator ::API::V3::Users::UserRepresenter
+        include API::V3::Principals::GroupOrUserElements
       end
     end
   end

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -321,11 +321,14 @@ module API
 
           class << self
             alias :groups :users
-            alias :group :user
           end
 
           def self.user_lock(id)
             "#{user(id)}/lock"
+          end
+
+          def self.group(id)
+            "#{root}/groups/#{id}"
           end
 
           def self.version(version_id)

--- a/lib/api/v3/versions/version_representer.rb
+++ b/lib/api/v3/versions/version_representer.rb
@@ -36,6 +36,9 @@ module API
     module Versions
       class VersionRepresenter < ::API::Decorators::Single
         include API::Decorators::LinkedResource
+        include ::API::Caching::CachedRepresenter
+
+        cached_representer key_parts: %i(project)
 
         self_link
 

--- a/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
@@ -72,6 +72,10 @@ module API
             end
           end
 
+          def no_caching?
+            true
+          end
+
           private
 
           def contract

--- a/lib/api/v3/work_packages/schema/typed_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/typed_work_package_schema.rb
@@ -48,6 +48,10 @@ module API
             project.all_work_package_custom_fields.to_a & type.custom_fields.to_a
           end
 
+          def no_caching?
+            false
+          end
+
           private
 
           def contract

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -35,6 +35,8 @@ module API
     module WorkPackages
       module Schema
         class WorkPackageSchemaRepresenter < ::API::Decorators::SchemaRepresenter
+          include API::Caching::CachedRepresenter
+
           class << self
             def represented_class
               WorkPackage
@@ -88,14 +90,15 @@ module API
             super(schema, self_link, context)
           end
 
-          def cache_key
-            custom_fields = represented.project.all_work_package_custom_fields
+          def json_cache_key
+            parts = ['api/v3/work_packages/schemas',
+                     project_type_cache_key,
+                     I18n.locale,
+                     project_cache_key,
+                     type_cache_key,
+                     custom_field_cache_key]
 
-            OpenProject::Cache::CacheKey.key('api/v3/work_packages/schemas',
-                                             "#{represented.project.id}-#{represented.type.id}",
-                                             I18n.locale,
-                                             represented.type.updated_at,
-                                             OpenProject::Cache::CacheKey.expand(custom_fields))
+            OpenProject::Cache::CacheKey.key(parts)
           end
 
           link :baseSchema do
@@ -145,7 +148,8 @@ module API
 
           schema :spent_time,
                  type: 'Duration',
-                 required: false
+                 required: false,
+                 show_if: ->(*) { represented.project && represented.project.module_enabled?('time_tracking') }
 
           schema :percentage_done,
                  type: 'Integer',
@@ -275,6 +279,32 @@ module API
             end
 
             @attribute_group_map[key]
+          end
+
+          private
+
+          def custom_field_cache_key
+            custom_fields = represented.project ? represented.project.all_work_package_custom_fields : []
+            OpenProject::Cache::CacheKey.expand(custom_fields)
+          end
+
+          def project_type_cache_key
+            project_cache_key = represented.project ? represented.project.id : nil
+            type_cache_key = represented.type ? represented.type.id : nil
+
+            "#{project_cache_key}-#{type_cache_key}"
+          end
+
+          def type_cache_key
+            represented.type.try(:updated_at)
+          end
+
+          def project_cache_key
+            represented.project.updated_on
+          end
+
+          def no_caching?
+            represented.no_caching?
           end
         end
       end

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -116,11 +116,9 @@ module API
                                                                          self_link,
                                                                          current_user: nil)
 
-                with_etag! represented_schema.cache_key
+                with_etag! represented_schema.json_cache_key
 
-                cache(represented_schema.cache_key) do
-                  represented_schema
-                end
+                represented_schema
               end
             end
 

--- a/lib/api/v3/work_packages/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/work_package_payload_representer.rb
@@ -34,6 +34,8 @@ module API
       class WorkPackagePayloadRepresenter < WorkPackageRepresenter
         include ::API::Utilities::PayloadRepresenter
 
+        cached_representer disabled: true
+
         def writeable_attributes
           super + ["date"]
         end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -33,6 +33,10 @@ module API
     module WorkPackages
       class WorkPackageRepresenter < ::API::Decorators::Single
         include API::Decorators::LinkedResource
+        include API::Caching::CachedRepresenter
+
+        cached_representer key_parts: %i(type project status priority category author responsible assigned_to),
+                           disabled: false
 
         class << self
           def create_class(work_package)
@@ -60,8 +64,8 @@ module API
 
         self_link title_getter: ->(*) { represented.subject }
 
-        link :update do
-          next unless current_user_allowed_to(:edit_work_packages, context: represented.project)
+        link :update,
+             cache_if: -> { current_user_allowed_to(:edit_work_packages, context: represented.project) } do
           {
             href: api_v3_paths.work_package_form(represented.id),
             method: :post
@@ -74,25 +78,26 @@ module API
           }
         end
 
-        link :updateImmediately do
-          next unless current_user_allowed_to(:edit_work_packages, context: represented.project)
+        link :updateImmediately,
+             cache_if: -> { current_user_allowed_to(:edit_work_packages, context: represented.project) } do
           {
             href: api_v3_paths.work_package(represented.id),
             method: :patch
           }
         end
 
-        link :delete do
-          next unless current_user_allowed_to(:delete_work_packages, context: represented.project)
+        link :delete,
+             cache_if: -> { current_user_allowed_to(:delete_work_packages, context: represented.project) } do
           {
             href: api_v3_paths.work_package(represented.id),
             method: :delete
           }
         end
 
-        link :logTime do
-          next unless current_user_allowed_to(:log_time, context: represented.project) &&
-                      represented.id
+        link :logTime,
+             cache_if: -> { current_user_allowed_to(:log_time, context: represented.project) } do
+          next if represented.new_record?
+
           {
             href: new_work_package_time_entry_path(represented),
             type: 'text/html',
@@ -100,9 +105,9 @@ module API
           }
         end
 
-        link :move do
-          next unless current_user_allowed_to(:move_work_packages, context: represented.project) &&
-                      represented.id
+        link :move,
+             cache_if: -> { current_user_allowed_to(:move_work_packages, context: represented.project) } do
+          next if represented.new_record?
 
           {
             href: new_work_package_move_path(represented),
@@ -111,9 +116,10 @@ module API
           }
         end
 
-        link :copy do
-          next unless current_user_allowed_to(:move_work_packages, context: represented.project) &&
-                      represented.id
+        link :copy,
+             cache_if: -> { current_user_allowed_to(:move_work_packages, context: represented.project) } do
+          next if represented.new_record?
+
           {
             href: new_work_package_move_path(represented, copy: true, ids: [represented.id]),
             type: 'text/html',
@@ -121,9 +127,9 @@ module API
           }
         end
 
-        link :pdf do
-          next unless current_user_allowed_to(:export_work_packages, context: represented.project) &&
-                      represented.id
+        link :pdf,
+             cache_if: -> { current_user_allowed_to(:export_work_packages, context: represented.project) } do
+          next if represented.new_record?
 
           {
             href: work_package_path(id: represented.id, format: :pdf),
@@ -132,10 +138,10 @@ module API
           }
         end
 
-        link :atom do
-          next unless Setting.feeds_enabled? &&
-                      current_user_allowed_to(:export_work_packages, context: represented.project) &&
-                      represented.id
+        link :atom,
+             cache_if: -> { current_user_allowed_to(:export_work_packages, context: represented.project) } do
+          next if represented.new_record? || !Setting.feeds_enabled?
+
           {
             href: work_package_path(id: represented.id, format: :atom),
             type: 'application/rss+xml',
@@ -144,7 +150,7 @@ module API
         end
 
         link :available_relation_candidates do
-          next unless represented.id
+          next if represented.new_record?
 
           {
             href: "/api/v3/work_packages/#{represented.id}/available_relation_candidates",
@@ -152,8 +158,9 @@ module API
           }
         end
 
-        link :customFields do
-          next unless current_user_allowed_to(:edit_project, context: represented.project)
+        link :customFields,
+             cache_if: -> { current_user_allowed_to(:edit_project, context: represented.project) } do
+          next if represented.project.nil?
           {
             href: settings_project_path(represented.project.identifier, tab: 'custom_fields'),
             type: 'text/html',
@@ -161,8 +168,9 @@ module API
           }
         end
 
-        link :configureForm do
-          next unless current_user.admin? && represented.type_id
+        link :configureForm,
+             cache_if: -> { current_user.admin? } do
+          next unless represented.type_id
           {
             href: edit_type_path(represented.type_id, tab: 'form_configuration'),
             type: 'text/html',
@@ -182,17 +190,19 @@ module API
           }
         end
 
-        link :addAttachment do
-          next unless current_user_allowed_to(:edit_work_packages, context: represented.project) ||
-                      current_user_allowed_to(:add_work_packages, context: represented.project)
+        link :addAttachment,
+             cache_if: -> do
+               current_user_allowed_to(:edit_work_packages, context: represented.project) ||
+                 current_user_allowed_to(:add_work_packages, context: represented.project)
+             end do
           {
             href: api_v3_paths.attachments_by_work_package(represented.id),
             method: :post
           }
         end
 
-        link :availableWatchers do
-          next unless current_user_allowed_to(:add_work_package_watchers, context: represented.project)
+        link :availableWatchers,
+             cache_if: -> { current_user_allowed_to(:add_work_package_watchers, context: represented.project) } do
           {
             href: api_v3_paths.available_watchers(represented.id)
           }
@@ -210,8 +220,10 @@ module API
           }
         end
 
-        link :watch do
+        link :watch,
+             uncacheable: true do
           next if current_user.anonymous? || represented.watcher_users.include?(current_user)
+
           {
             href: api_v3_paths.work_package_watchers(represented.id),
             method: :post,
@@ -219,7 +231,8 @@ module API
           }
         end
 
-        link :unwatch do
+        link :unwatch,
+             uncacheable: true do
           next unless represented.watcher_users.include?(current_user)
           {
             href: api_v3_paths.watcher(current_user.id, represented.id),
@@ -227,15 +240,15 @@ module API
           }
         end
 
-        link :watchers do
-          next unless  current_user_allowed_to(:view_work_package_watchers, context: represented.project)
+        link :watchers,
+             cache_if: -> { current_user_allowed_to(:view_work_package_watchers, context: represented.project) } do
           {
             href: api_v3_paths.work_package_watchers(represented.id)
           }
         end
 
-        link :addWatcher do
-          next unless current_user_allowed_to(:add_work_package_watchers, context: represented.project)
+        link :addWatcher,
+             cache_if: -> { current_user_allowed_to(:add_work_package_watchers, context: represented.project) } do
           {
             href: api_v3_paths.work_package_watchers(represented.id),
             method: :post,
@@ -244,8 +257,8 @@ module API
           }
         end
 
-        link :removeWatcher do
-          next unless current_user_allowed_to(:delete_work_package_watchers, context: represented.project)
+        link :removeWatcher,
+             cache_if: -> { current_user_allowed_to(:delete_work_package_watchers, context: represented.project) } do
           {
             href: api_v3_paths.watcher('{user_id}', represented.id),
             method: :delete,
@@ -253,9 +266,8 @@ module API
           }
         end
 
-        link :addRelation do
-          next unless current_user_allowed_to(:manage_work_package_relations,
-                                              context: represented.project)
+        link :addRelation,
+             cache_if: -> { current_user_allowed_to(:manage_work_package_relations, context: represented.project) } do
           {
             href: api_v3_paths.work_package_relations(represented.id),
             method: :post,
@@ -263,8 +275,9 @@ module API
           }
         end
 
-        link :addChild do
-          next unless current_user_allowed_to(:add_work_packages, context: represented.project)
+        link :addChild,
+             cache_if: -> { current_user_allowed_to(:add_work_packages, context: represented.project) } do
+          next if represented.new_record?
           {
             href: api_v3_paths.work_packages_by_project(represented.project.identifier),
             method: :post,
@@ -272,8 +285,8 @@ module API
           }
         end
 
-        link :changeParent do
-          next unless current_user_allowed_to(:manage_subtasks, context: represented.project)
+        link :changeParent,
+             cache_if: -> { current_user_allowed_to(:manage_subtasks, context: represented.project) } do
           {
             href: api_v3_paths.work_package(represented.id),
             method: :patch,
@@ -281,8 +294,8 @@ module API
           }
         end
 
-        link :addComment do
-          next unless current_user_allowed_to(:add_work_package_notes, context: represented.project)
+        link :addComment,
+             cache_if: -> { current_user_allowed_to(:add_work_package_notes, context: represented.project) } do
           {
             href: api_v3_paths.work_package_activities(represented.id),
             method: :post,
@@ -297,9 +310,9 @@ module API
           }
         end
 
-        link :timeEntries do
-          next unless current_user_allowed_to(:view_time_entries, context: represented.project) &&
-                      represented.id
+        link :timeEntries,
+             cache_if: -> { view_time_entries_allowed? } do
+          next if represented.new_record?
           {
             href: work_package_time_entries_path(represented.id),
             type: 'text/html',
@@ -307,7 +320,8 @@ module API
           }
         end
 
-        links :children do
+        links :children,
+              uncacheable: true do
           next if visible_children.empty?
 
           visible_children.map do |child|
@@ -318,7 +332,8 @@ module API
           end
         end
 
-        links :ancestors do
+        links :ancestors,
+              uncacheable: true do
           represented.visible_ancestors(current_user).map do |ancestor|
             {
               href: api_v3_paths.work_package(ancestor.id),
@@ -347,6 +362,7 @@ module API
                  setter: ->(fragment:, **) {
                    represented.description = fragment['raw']
                  },
+                 uncacheable: true,
                  render_nil: true
 
         property :start_date,
@@ -392,9 +408,10 @@ module API
                  getter: ->(*) do
                    datetime_formatter.format_duration_from_hours(represented.spent_hours)
                  end,
-                 if: ->(_) {
-                   current_user_allowed_to(:view_time_entries, context: represented.project)
-                 }
+                 if: ->(*) {
+                   view_time_entries_allowed?
+                 },
+                 uncacheable: true
 
         property :done_ratio,
                  as: :percentageDone,
@@ -418,6 +435,7 @@ module API
         property :watchers,
                  embedded: true,
                  exec_context: :decorator,
+                 uncacheable: true,
                  if: ->(*) {
                    current_user_allowed_to(:view_work_package_watchers,
                                            context: represented.project) &&
@@ -427,12 +445,14 @@ module API
         property :attachments,
                  embedded: true,
                  exec_context: :decorator,
-                 if: ->(*) { embed_links }
+                 if: ->(*) { embed_links },
+                 uncacheable: true
 
         property :relations,
                  embedded: true,
                  exec_context: :decorator,
-                 if: ->(*) { embed_links }
+                 if: ->(*) { embed_links },
+                 uncacheable: true
 
         associated_resource :category
 
@@ -467,10 +487,9 @@ module API
                             representer: ::API::V3::WorkPackages::WorkPackageRepresenter,
                             skip_render: ->(*) { represented.parent && !represented.parent.visible? },
                             link_title_attribute: :subject,
+                            uncacheable_link: true,
                             link: ->(*) {
-                              next if represented.parent && !represented.parent.visible?
-
-                              if represented.parent
+                              if represented.parent && represented.parent.visible?
                                 {
                                   href: api_v3_paths.work_package(represented.parent.id),
                                   title: represented.parent.subject
@@ -502,6 +521,7 @@ module API
                             end
 
         resources :customActions,
+                  uncacheable_link: true,
                   link: ->(*) {
                     ordered_custom_actions.map do |action|
                       {
@@ -515,7 +535,7 @@ module API
                       ::API::V3::CustomActions::CustomActionRepresenter.new(action, current_user: current_user)
                     end
                   },
-                  setter: ->(_fragment:, **) do
+                  setter: ->(*) do
                     # noop
                   end
 
@@ -615,6 +635,22 @@ module API
                               :watcher_users,
                               :category,
                               :attachments]
+
+        # The dynamic class generation introduced because of the custom fields interferes with
+        # the class naming as well as prevents calls to super
+        def json_cache_key
+          self.class.superclass.name.to_s.split('::') + [
+            'json',
+            I18n.locale,
+            json_key_model_parts,
+            Setting.work_package_done_ratio,
+            Setting.feeds_enabled?
+          ]
+        end
+
+        def view_time_entries_allowed?
+          current_user_allowed_to(:view_time_entries, context: represented.project)
+        end
       end
     end
   end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -470,12 +470,12 @@ module API
 
         associated_resource :responsible,
                             v3_path: :user,
-                            representer: ::API::V3::Users::UserRepresenter
+                            getter: ::API::V3::Principals::AssociatedSubclassLambda.getter(:responsible)
 
         associated_resource :assigned_to,
                             as: :assignee,
                             v3_path: :user,
-                            representer: ::API::V3::Users::UserRepresenter
+                            getter: ::API::V3::Principals::AssociatedSubclassLambda.getter(:assigned_to)
 
         associated_resource :fixed_version,
                             as: :version,

--- a/lib/open_project/cache.rb
+++ b/lib/open_project/cache.rb
@@ -29,7 +29,7 @@
 module OpenProject
   module Cache
     def self.fetch(*parts, &block)
-      Rails.cache.fetch(CacheKey.key(parts), &block)
+      Rails.cache.fetch(CacheKey.key(*parts), &block)
     end
 
     def self.clear

--- a/lib/open_project/cache/cache_key.rb
+++ b/lib/open_project/cache/cache_key.rb
@@ -31,7 +31,7 @@ module OpenProject
     module CacheKey
       def self.key(*parts)
         ['openproject',
-         OpenProject::VERSION] + parts
+         OpenProject::VERSION] + parts.flatten
       end
 
       def self.expand(ar_models)

--- a/lib/open_project/cache/cache_key.rb
+++ b/lib/open_project/cache/cache_key.rb
@@ -31,7 +31,7 @@ module OpenProject
     module CacheKey
       def self.key(*parts)
         ['openproject',
-         OpenProject::VERSION] + parts.flatten
+         OpenProject::VERSION] + parts.flatten(1)
       end
 
       def self.expand(ar_models)

--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -253,7 +253,7 @@ module OpenProject::Plugins
       def add_api_representer_cache_key(*path,
                                         &keys)
         mod = Module.new
-        mod.send :define_method, :cache_key do
+        mod.send :define_method, :json_cache_key do
           if defined?(super)
             existing = super()
 

--- a/spec/factories/group_factory.rb
+++ b/spec/factories/group_factory.rb
@@ -27,7 +27,7 @@
 #++
 
 FactoryGirl.define do
-  factory :group do
+  factory :group, parent: :principal, class: Group do
     # groups have lastnames? hmm...
     sequence(:lastname) { |g| "Group #{g}" }
   end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -39,8 +39,8 @@ FactoryGirl.define do
     sequence(:mail) do |n| "bob#{n}.bobbit@bob.com" end
     password 'adminADMIN!'
     password_confirmation 'adminADMIN!'
-    created_on Time.now
-    updated_on Time.now
+    created_on { Time.now }
+    updated_on { Time.now }
 
     mail_notification(OpenProject::VERSION::MAJOR > 0 ? 'all' : true)
 

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -27,20 +27,13 @@
 #++
 
 FactoryGirl.define do
-  factory :user do
-    transient do
-      member_in_project nil
-      member_in_projects nil
-      member_through_role nil
-    end
+  factory :user, parent: :principal, class: User do
     firstname 'Bob'
     lastname 'Bobbit'
     sequence(:login) do |n| "bob#{n}" end
     sequence(:mail) do |n| "bob#{n}.bobbit@bob.com" end
     password 'adminADMIN!'
     password_confirmation 'adminADMIN!'
-    created_on { Time.now }
-    updated_on { Time.now }
 
     mail_notification(OpenProject::VERSION::MAJOR > 0 ? 'all' : true)
 
@@ -48,17 +41,6 @@ FactoryGirl.define do
     status User::STATUSES[:active]
     admin false
     first_login false if User.table_exists? and User.columns.map(&:name).include? 'first_login'
-
-    callback(:after_build) do |user, evaluator| # this is also done after :create
-      (projects = evaluator.member_in_projects || [])
-      projects << evaluator.member_in_project if evaluator.member_in_project
-      if !projects.empty?
-        role = evaluator.member_through_role || FactoryGirl.build(:role, permissions: [:view_work_packages, :edit_work_packages])
-        projects.each do |project|
-          project.add_member! user, role if project
-        end
-      end
-    end
 
     factory :admin do
       firstname 'OpenProject'
@@ -87,6 +69,7 @@ FactoryGirl.define do
       status User::STATUSES[:invited]
     end
   end
+
   factory :anonymous, class: AnonymousUser do
     status User::STATUSES[:builtin]
     initialize_with { User.anonymous }

--- a/spec/features/users/create_spec.rb
+++ b/spec/features/users/create_spec.rb
@@ -45,7 +45,7 @@ describe 'create users', type: :feature, selenium: true do
     it 'creates the user' do
       expect(page).to have_selector('.flash', text: 'Successful creation.')
 
-      new_user = User.order('created_on DESC').first
+      new_user = User.order('id DESC').first
 
       expect(current_path).to eql(edit_user_path(new_user.id))
     end

--- a/spec/features/work_packages/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions_spec.rb
@@ -246,12 +246,13 @@ describe 'Custom actions', type: :feature, js: true do
     wp_page.dismiss_notification!
 
     ## Bump the lockVersion and by that force a conflict.
-    WorkPackage.where(id: work_package.id).update_all(lock_version: 10)
+    WorkPackage.where(id: work_package.id).update_all(lock_version: 10, updated_at: Time.now)
 
     wp_page.click_custom_action('Escalate')
 
     wp_page.expect_notification type: :error, message: I18n.t('api_v3.errors.code_409')
 
+    visit "/"
     wp_page.visit!
 
     wp_page.click_custom_action('Escalate')

--- a/spec/lib/api/v3/attachments/attachment_representer_spec.rb
+++ b/spec/lib/api/v3/attachments/attachment_representer_spec.rb
@@ -31,20 +31,33 @@ require 'spec_helper'
 describe ::API::V3::Attachments::AttachmentRepresenter do
   include API::V3::Utilities::PathHelper
 
-  let(:current_user) {
-    FactoryGirl.create(:user, member_in_project: project, member_through_role: role)
-  }
-  let(:project) { FactoryGirl.create(:project) }
-  let(:role) { FactoryGirl.create(:role, permissions: permissions) }
-  let(:all_permissions) { [:view_work_packages, :edit_work_packages] }
+  let(:current_user) do
+    FactoryGirl.build_stubbed(:user)
+  end
+  let(:all_permissions) { %i[view_work_packages edit_work_packages] }
   let(:permissions) { all_permissions }
 
-  let(:container) { FactoryGirl.create(:work_package, project: project) }
-
-  let(:attachment) { FactoryGirl.create(:attachment, container: container) }
-  let(:representer) {
+  let(:container) { FactoryGirl.build_stubbed(:stubbed_work_package) }
+  let(:attachment) do
+    FactoryGirl.build_stubbed(:attachment,
+                              container: container,
+                              created_on: DateTime.now) do |attachment|
+      allow(attachment)
+       .to receive(:filename)
+       .and_return('some_file_of_mine.txt')
+    end
+  end
+  
+  let(:representer) do
     ::API::V3::Attachments::AttachmentRepresenter.new(attachment, current_user: current_user)
-  }
+  end
+
+  before do
+    allow(current_user)
+      .to receive(:allowed_to?) do |permission|
+      permissions.include? permission
+    end
+  end
 
   subject { representer.to_json }
 
@@ -105,6 +118,42 @@ describe ::API::V3::Attachments::AttachmentRepresenter do
         it_behaves_like 'has no link' do
           let(:link) { 'delete' }
         end
+      end
+    end
+  end
+
+  describe 'caching' do
+    it 'is based on the representer\'s cache_key' do
+      expect(OpenProject::Cache)
+        .to receive(:fetch)
+        .with(representer.json_cache_key)
+        .and_call_original
+
+      representer.to_json
+    end
+
+    describe '#json_cache_key' do
+      let!(:former_cache_key) { representer.json_cache_key }
+
+      it 'includes the name of the representer class' do
+        expect(representer.json_cache_key)
+          .to include('API', 'V3', 'Attachments', 'AttachmentRepresenter')
+      end
+
+      it 'changes when the locale changes' do
+        I18n.with_locale(:fr) do
+          expect(representer.json_cache_key)
+            .not_to eql former_cache_key
+        end
+      end
+
+      it 'changes when the attachment is changed (has no update)' do
+        allow(attachment)
+          .to receive(:cache_key)
+          .and_return('blubs')
+
+        expect(representer.json_cache_key)
+          .not_to eql former_cache_key
       end
     end
   end

--- a/spec/lib/api/v3/groups/group_representer_spec.rb
+++ b/spec/lib/api/v3/groups/group_representer_spec.rb
@@ -1,0 +1,140 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Groups::GroupRepresenter do
+  let(:group) { FactoryGirl.build_stubbed(:group) }
+  let(:current_user) { FactoryGirl.build_stubbed(:user) }
+  let(:representer) { described_class.new(group, current_user: current_user) }
+
+  context 'generation' do
+    subject(:generated) { representer.to_json }
+
+    it do is_expected.to include_json('Group'.to_json).at_path('_type') end
+
+    context 'as regular user' do
+      it 'has an id property' do
+        is_expected
+          .to be_json_eql(group.id.to_json)
+          .at_path('id')
+      end
+
+      it 'has a name property' do
+        is_expected
+          .to be_json_eql(group.name.to_json)
+          .at_path('name')
+      end
+
+      it 'hides the updatedAt property' do
+        is_expected.not_to have_json_path('updatedAt')
+      end
+
+      it 'hides the createdAt property' do
+        is_expected.not_to have_json_path('createdAt')
+      end
+    end
+
+    context 'as admin' do
+      let(:current_user) { FactoryGirl.build_stubbed(:admin) }
+
+      it 'has an id property' do
+        is_expected
+          .to be_json_eql(group.id.to_json)
+          .at_path('id')
+      end
+
+      it 'has a name property' do
+        is_expected
+          .to be_json_eql(group.name.to_json)
+          .at_path('name')
+      end
+
+      it_behaves_like 'has UTC ISO 8601 date and time' do
+        let(:date) { group.created_on }
+        let(:json_path) { 'createdAt' }
+      end
+
+      it_behaves_like 'has UTC ISO 8601 date and time' do
+        let(:date) { group.updated_on }
+        let(:json_path) { 'updatedAt' }
+      end
+    end
+
+    describe '_links' do
+      it 'should link to self' do
+        expect(subject).to have_json_path('_links/self/href')
+      end
+    end
+
+    describe 'caching' do
+      it 'is based on the representer\'s cache_key' do
+        expect(OpenProject::Cache)
+          .to receive(:fetch)
+          .with(representer.json_cache_key)
+          .and_call_original
+
+        representer.to_json
+      end
+
+      describe 'caching' do
+        it 'is based on the representer\'s cache_key' do
+          expect(OpenProject::Cache)
+            .to receive(:fetch)
+            .with(representer.json_cache_key)
+            .and_call_original
+
+          representer.to_json
+        end
+
+        describe '#json_cache_key' do
+          let!(:former_cache_key) { representer.json_cache_key }
+
+          it 'includes the name of the representer class' do
+            expect(representer.json_cache_key)
+              .to include('API', 'V3', 'Groups', 'GroupRepresenter')
+          end
+
+          it 'changes when the locale changes' do
+            I18n.with_locale(:fr) do
+              expect(representer.json_cache_key)
+                .not_to eql former_cache_key
+            end
+          end
+
+          it 'changes when the group is updated' do
+            group.updated_on = Time.now + 20.seconds
+
+            expect(representer.json_cache_key)
+              .not_to eql former_cache_key
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/api/v3/priorities/priority_representer_spec.rb
+++ b/spec/lib/api/v3/priorities/priority_representer_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 
 describe ::API::V3::Priorities::PriorityRepresenter do
-  let(:priority) { FactoryGirl.build(:priority) }
+  let(:priority) { FactoryGirl.build_stubbed(:priority) }
   let(:representer) { described_class.new(priority, current_user: double('current_user')) }
 
   include API::V3::Utilities::PathHelper
@@ -68,6 +68,40 @@ describe ::API::V3::Priorities::PriorityRepresenter do
       end
       it 'should have an active flag' do
         is_expected.to be_json_eql(priority.active.to_json).at_path('isActive')
+      end
+    end
+
+    describe 'caching' do
+      it 'is based on the representer\'s cache_key' do
+        expect(OpenProject::Cache)
+          .to receive(:fetch)
+          .with(representer.json_cache_key)
+          .and_call_original
+
+        representer.to_json
+      end
+
+      describe '#json_cache_key' do
+        let!(:former_cache_key) { representer.json_cache_key }
+
+        it 'includes the name of the representer class' do
+          expect(representer.json_cache_key)
+            .to include('API', 'V3', 'Priorities', 'PriorityRepresenter')
+        end
+
+        it 'changes when the locale changes' do
+          I18n.with_locale(:fr) do
+            expect(representer.json_cache_key)
+              .not_to eql former_cache_key
+          end
+        end
+
+        it 'changes when the priority is updated' do
+          priority.updated_at = Time.now + 20.seconds
+
+          expect(representer.json_cache_key)
+            .not_to eql former_cache_key
+        end
       end
     end
   end

--- a/spec/lib/api/v3/types/type_representer_spec.rb
+++ b/spec/lib/api/v3/types/type_representer_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 
 describe ::API::V3::Types::TypeRepresenter do
-  let(:type) { FactoryGirl.build_stubbed(:type, color: FactoryGirl.build(:color)) }
+  let(:type) { FactoryGirl.build_stubbed(:type, color: FactoryGirl.build_stubbed(:color)) }
   let(:representer) { described_class.new(type, current_user: double('current_user')) }
 
   include API::V3::Utilities::PathHelper
@@ -58,7 +58,7 @@ describe ::API::V3::Types::TypeRepresenter do
     end
 
     context 'no color set' do
-      let(:type) { FactoryGirl.build(:type, color: nil) }
+      let(:type) { FactoryGirl.build_stubbed(:type, color: nil) }
 
       it 'indicates a missing color' do
         is_expected.to be_json_eql(nil.to_json).at_path('color')
@@ -74,7 +74,7 @@ describe ::API::V3::Types::TypeRepresenter do
     end
 
     context 'as default type' do
-      let(:type) { FactoryGirl.build(:type, is_default: true) }
+      let(:type) { FactoryGirl.build_stubbed(:type, is_default: true) }
 
       it 'indicates that it is the default type' do
         is_expected.to be_json_eql(true.to_json).at_path('isDefault')
@@ -86,7 +86,7 @@ describe ::API::V3::Types::TypeRepresenter do
     end
 
     context 'as milestone' do
-      let(:type) { FactoryGirl.build(:type, is_milestone: true) }
+      let(:type) { FactoryGirl.build_stubbed(:type, is_milestone: true) }
 
       it 'indicates that it is a milestone' do
         is_expected.to be_json_eql(true.to_json).at_path('isMilestone')

--- a/spec/lib/api/v3/users/user_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_representer_spec.rb
@@ -91,9 +91,10 @@ describe ::API::V3::Users::UserRepresenter do
     end
 
     describe 'email' do
+      let(:user) { FactoryGirl.build_stubbed(:user, status: 1, preference: preference) }
+
       context 'user shows his E-Mail address' do
         let(:preference) { FactoryGirl.build(:user_preference, hide_mail: false) }
-        let(:user) { FactoryGirl.build_stubbed(:user, status: 1, preference: preference) }
 
         it 'shows the users E-Mail address' do
           is_expected.to be_json_eql(user.mail.to_json).at_path('email')
@@ -102,7 +103,6 @@ describe ::API::V3::Users::UserRepresenter do
 
       context 'user hides his E-Mail address' do
         let(:preference) { FactoryGirl.build(:user_preference, hide_mail: true) }
-        let(:user) { FactoryGirl.build_stubbed(:user, status: 1, preference: preference) }
 
         it 'does not render the users E-Mail address' do
           is_expected.to be_json_eql(nil.to_json).at_path('email')

--- a/spec/lib/api/v3/users/user_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_representer_spec.rb
@@ -38,7 +38,6 @@ describe ::API::V3::Users::UserRepresenter do
 
     it do is_expected.to include_json('User'.to_json).at_path('_type') end
 
-
     context 'as regular user' do
       it 'hides as much information as possible' do
         is_expected.to have_json_path('id')
@@ -73,11 +72,11 @@ describe ::API::V3::Users::UserRepresenter do
       let(:current_user) { FactoryGirl.build_stubbed(:admin) }
 
       it 'shows everything' do
-       is_expected.to have_json_path('id')
-       is_expected.to have_json_path('login')
-       is_expected.to have_json_path('firstName')
-       is_expected.to have_json_path('lastName')
-       is_expected.to have_json_path('name')
+        is_expected.to have_json_path('id')
+        is_expected.to have_json_path('login')
+        is_expected.to have_json_path('firstName')
+        is_expected.to have_json_path('lastName')
+        is_expected.to have_json_path('name')
       end
 
       it_behaves_like 'has UTC ISO 8601 date and time' do
@@ -172,6 +171,63 @@ describe ::API::V3::Users::UserRepresenter do
 
         it 'should not link to delete' do
           expect(subject).not_to have_json_path('_links/delete/href')
+        end
+      end
+    end
+
+    describe 'caching' do
+      it 'is based on the representer\'s cache_key' do
+        expect(OpenProject::Cache)
+          .to receive(:fetch)
+                .with(representer.json_cache_key)
+                .and_call_original
+
+        representer.to_json
+      end
+
+      describe 'caching' do
+        it 'is based on the representer\'s cache_key' do
+          expect(OpenProject::Cache)
+            .to receive(:fetch)
+            .with(representer.json_cache_key)
+            .and_call_original
+
+          representer.to_json
+        end
+
+        describe '#json_cache_key' do
+          let(:auth_source) { FactoryGirl.build_stubbed(:auth_source) }
+
+          before do
+            user.auth_source = auth_source
+          end
+          let!(:former_cache_key) { representer.json_cache_key }
+
+          it 'includes the name of the representer class' do
+            expect(representer.json_cache_key)
+              .to include('API', 'V3', 'Users', 'UserRepresenter')
+          end
+
+          it 'changes when the locale changes' do
+            I18n.with_locale(:fr) do
+              expect(representer.json_cache_key)
+                .not_to eql former_cache_key
+            end
+          end
+
+          it 'changes when the user is updated' do
+            user.updated_on = Time.now + 20.seconds
+
+            expect(representer.json_cache_key)
+              .not_to eql former_cache_key
+          end
+
+          it 'changes when the user\'s auth_source is updated' do
+            user.auth_source.updated_at = Time.now + 20.seconds
+
+            expect(representer.json_cache_key)
+              .not_to eql former_cache_key
+          end
         end
       end
     end

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -522,6 +522,14 @@ describe ::API::V3::Utilities::PathHelper do
     end
   end
 
+  describe 'group paths' do
+    describe '#group' do
+      subject { helper.group 1 }
+
+      it_behaves_like 'api v3 path', '/groups/1'
+    end
+  end
+
   describe '#version' do
     subject { helper.version 42 }
 

--- a/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
@@ -406,6 +406,15 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
         representer.to_json
       end
     end
+
+    describe 'caching' do
+      it 'does not cache' do
+        expect(Rails.cache)
+          .not_to receive(:fetch)
+
+        representer.to_json
+      end
+    end
   end
 
   describe 'parsing' do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -41,6 +41,14 @@ describe Attachment, type: :model do
       content_type: nil, # so that it is detected
       file:         file)
   end
+  let(:stubbed_attachment) do
+    FactoryGirl.build_stubbed(
+      :attachment,
+      author:       author,
+      container:    work_package,
+      content_type: nil, # so that it is detected
+      file:         file)
+  end
 
   describe 'create' do
     context 'save' do
@@ -113,6 +121,20 @@ describe Attachment, type: :model do
 
     it "deletes the attachment's file" do
       expect(File.exists?(attachment.file.path)).to eq false
+    end
+  end
+
+  # Made necessary as attachments only have the created_on field which is not factored
+  # into the cache_key. While it shouldn't be a problem in production, as attachments cannot be
+  # altered, it is a problem in the tests.
+  describe '#cache_key' do
+    before do
+      stubbed_attachment.created_on = Time.now
+    end
+
+    it 'factors in id and created_on' do
+      expect(stubbed_attachment.cache_key)
+        .to eql("attachments/#{stubbed_attachment.id}-#{stubbed_attachment.created_on.to_i}")
     end
   end
 end

--- a/spec/models/issue_priority_spec.rb
+++ b/spec/models/issue_priority_spec.rb
@@ -1,0 +1,94 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+require 'spec_helper'
+
+describe IssuePriority, type: :model do
+  let(:stubbed_priority) { FactoryGirl.build_stubbed(:priority) }
+  let(:priority) { FactoryGirl.create(:priority) }
+
+  describe '.ancestors' do
+    it 'is an enumeration' do
+      expect(IssuePriority.ancestors)
+        .to include(Enumeration)
+    end
+  end
+
+  describe '#objects_count' do
+    let(:work_package1) { FactoryGirl.create(:work_package, priority: priority) }
+    let(:work_package2) { FactoryGirl.create(:work_package) }
+
+    it 'counts the work packages having the priority' do
+      expect(priority.objects_count)
+        .to eql 0
+
+      work_package1
+      work_package2
+
+      # will not count the other work package
+      expect(priority.objects_count)
+        .to eql 1
+    end
+  end
+
+  describe '#option_name' do
+    it 'is a symbol' do
+      expect(stubbed_priority.option_name)
+        .to eql :enumeration_work_package_priorities
+    end
+  end
+
+  describe '#cache_key' do
+    it 'updates when the updated_at field changes' do
+      old_cache_key = stubbed_priority.cache_key
+
+      stubbed_priority.updated_at = Time.now
+
+      expect(stubbed_priority.cache_key)
+        .not_to eql old_cache_key
+    end
+  end
+
+  describe '#transer_to' do
+    let(:new_priority) { FactoryGirl.create(:priority) }
+    let(:work_package1) { FactoryGirl.create(:work_package, priority: priority) }
+    let(:work_package2) { FactoryGirl.create(:work_package) }
+    let(:work_package3) { FactoryGirl.create(:work_package, priority: new_priority) }
+
+    it 'moves all work_packages to the designated priority' do
+      work_package1
+      work_package2
+      work_package3
+
+      priority.transfer_relations(new_priority)
+
+      expect(new_priority.work_packages.reload)
+        .to match_array [work_package3, work_package1]
+    end
+  end
+end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -29,6 +29,8 @@
 require 'spec_helper'
 
 describe Status, type: :model do
+  let(:stubbed_status) { FactoryGirl.build_stubbed(:status) }
+
   describe '.new_statuses_allowed' do
     let(:role) { FactoryGirl.create(:role) }
     let(:type) { FactoryGirl.create(:type) }
@@ -82,6 +84,17 @@ describe Status, type: :model do
     it 'should respect workflows w/ author and w/ assignee' do
       expect(Status.new_statuses_allowed(status, [role], type, true, true))
         .to match_array([statuses[1], statuses[2], statuses[3]])
+    end
+  end
+
+  describe '#cache_key' do
+    it 'updates when the updated_at field changes' do
+      old_cache_key = stubbed_status.cache_key
+
+      stubbed_status.updated_at = Time.now
+
+      expect(stubbed_status.cache_key)
+        .not_to eql old_cache_key
     end
   end
 end

--- a/spec/requests/api/v3/groups/group_resource_spec.rb
+++ b/spec/requests/api/v3/groups/group_resource_spec.rb
@@ -1,0 +1,102 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 Group resource', type: :request, content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:project) { FactoryGirl.create(:project) }
+  let(:group) do
+    FactoryGirl.create(:group,
+                       member_in_project: project,
+                       member_through_role: role)
+  end
+  let(:group_project) { project }
+  let(:role) { FactoryGirl.create(:role, permissions: permissions) }
+  let(:permissions) { [:view_members] }
+  let(:current_user) do
+    FactoryGirl.create(:user,
+                       member_in_project: project,
+                       member_through_role: role)
+  end
+
+  subject(:response) { last_response }
+
+  before do
+    login_as(current_user)
+  end
+
+  describe '#get' do
+    before do
+      get get_path
+    end
+
+    context 'having the necessary permission' do
+      let(:get_path) { api_v3_paths.group group.id }
+
+      it 'responds with 200 OK' do
+        expect(subject.status)
+          .to eq(200)
+      end
+
+      it 'responds with a group resource' do
+        expect(subject.body)
+          .to be_json_eql('Group'.to_json)
+          .at_path('_type')
+      end
+
+      it 'responds with the correct group' do
+        expect(subject.body)
+          .to be_json_eql(group.name.to_json)
+          .at_path('name')
+      end
+    end
+
+    context 'requesting nonexistent user' do
+      let(:get_path) { api_v3_paths.group 9999 }
+
+      it_behaves_like 'not found' do
+        let(:id) { 9999 }
+        let(:type) { 'Group' }
+      end
+    end
+
+    context 'not having the necessary permission' do
+      let(:permissions) { [] }
+      let(:get_path) { api_v3_paths.group group.id }
+
+      it_behaves_like 'not found' do
+        let(:id) { group.id }
+        let(:type) { 'Group' }
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/principals/principals_resource_spec.rb
+++ b/spec/requests/api/v3/principals/principals_resource_spec.rb
@@ -34,7 +34,23 @@ describe 'API v3 Principals resource', type: :request do
   include API::V3::Utilities::PathHelper
 
   describe '#get principals' do
-    let(:path) { api_v3_paths.principals }
+    let(:path) do
+      path = api_v3_paths.principals
+
+      query_props = []
+
+      if order
+        query_props << "sortBy=#{JSON.dump(order.map { |(k, v)| [k, v] })}"
+      end
+
+      if filter
+        query_props << "filters=#{CGI.escape(JSON.dump(filter))}"
+      end
+
+      "#{path}?#{query_props.join('&')}"
+    end
+    let(:order) { { name: :desc } }
+    let(:filter) { nil }
     let(:project) { FactoryGirl.create(:project) }
     let(:other_project) { FactoryGirl.create(:project) }
     let(:non_member_project) { FactoryGirl.create(:project) }
@@ -43,7 +59,8 @@ describe 'API v3 Principals resource', type: :request do
     let(:user) do
       user = FactoryGirl.create(:user,
                                 member_in_project: project,
-                                member_through_role: role)
+                                member_through_role: role,
+                                lastname: 'aaaa')
 
       other_project.add_member! user, role
 
@@ -52,15 +69,18 @@ describe 'API v3 Principals resource', type: :request do
     let(:other_user) do
       FactoryGirl.create(:user,
                          member_in_project: other_project,
-                         member_through_role: role)
+                         member_through_role: role,
+                         lastname: 'bbbb')
     end
     let(:user_in_non_member_project) do
       FactoryGirl.create(:user,
                          member_in_project: non_member_project,
-                         member_through_role: role)
+                         member_through_role: role,
+                         lastname: 'cccc')
     end
     let(:group) do
-      group = FactoryGirl.create(:group)
+      group = FactoryGirl.create(:group,
+                                 lastname: 'gggg')
 
       project.add_member! group, role
 
@@ -86,15 +106,17 @@ describe 'API v3 Principals resource', type: :request do
 
     it_behaves_like 'API V3 collection response', 3, 3, 'User' do
       let(:response) { last_response }
+
+      it 'has the group as the last element' do
+        is_expected
+          .to be_json_eql('Group'.to_json)
+          .at_path('_embedded/elements/2/_type')
+      end
     end
 
     context 'provide filter for project the user is member in' do
       let(:filter) do
         [{ member: { operator: '=', values: [project.id.to_s] } }]
-      end
-
-      let(:path) do
-        "#{api_v3_paths.principals}?filters=#{CGI.escape(JSON.dump(filter))}"
       end
 
       it_behaves_like 'API V3 collection response', 2, 2, 'User' do
@@ -107,10 +129,6 @@ describe 'API v3 Principals resource', type: :request do
         [{ type: { operator: '=', values: ['User'] } }]
       end
 
-      let(:path) do
-        "#{api_v3_paths.principals}?filters=#{CGI.escape(JSON.dump(filter))}"
-      end
-
       it_behaves_like 'API V3 collection response', 2, 2, 'User' do
         let(:response) { last_response }
       end
@@ -121,11 +139,7 @@ describe 'API v3 Principals resource', type: :request do
         [{ type: { operator: '=', values: ['Group'] } }]
       end
 
-      let(:path) do
-        "#{api_v3_paths.principals}?filters=#{CGI.escape(JSON.dump(filter))}"
-      end
-
-      it_behaves_like 'API V3 collection response', 1, 1, 'User' do
+      it_behaves_like 'API V3 collection response', 1, 1, 'Group' do
         let(:response) { last_response }
       end
     end

--- a/spec/requests/api/v3/user/user_resource_spec.rb
+++ b/spec/requests/api/v3/user/user_resource_spec.rb
@@ -35,8 +35,6 @@ describe 'API v3 User resource', type: :request, content_type: :json do
 
   let(:current_user) { FactoryGirl.create(:user) }
   let(:user) { FactoryGirl.create(:user) }
-  let(:model) { ::API::V3::Users::UserModel.new(user) }
-  let(:representer) { ::API::V3::Users::UserRepresenter.new(model) }
 
   subject(:response) { last_response }
 

--- a/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
@@ -130,18 +130,6 @@ describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI, type: :request do
   describe 'GET /api/v3/work_packages/schemas/:id' do
     let(:schema_path) { api_v3_paths.work_package_schema project.id, type.id }
 
-    def cache_key
-      # Compare with ETag composed of project and customizations
-      # to avoid evaluating the server request
-      custom_fields = project.all_work_package_custom_fields
-
-      custom_fields_key = ActiveSupport::Cache.expand_cache_key custom_fields
-
-      ["api/v3/work_packages/schema/#{project.id}-#{type.id}",
-       type.updated_at,
-       Digest::SHA2.hexdigest(custom_fields_key)]
-    end
-
     context 'logged in' do
       before do
         allow(User).to receive(:current).and_return(current_user)
@@ -168,7 +156,7 @@ describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI, type: :request do
                                                         self_link,
                                                         current_user: nil)
 
-          expect(Rails.cache.fetch(represented_schema.cache_key)).to_not be_nil
+          expect(OpenProject::Cache.fetch(represented_schema.json_cache_key)).to_not be_nil
         end
       end
 

--- a/spec/support/api/v3/shared_available_principals_examples.rb
+++ b/spec/support/api/v3/shared_available_principals_examples.rb
@@ -55,17 +55,17 @@ shared_examples_for 'available principals' do |principals|
   end
 
   describe 'response' do
-    shared_examples_for "returns available #{principals}" do |total, count|
+    shared_examples_for "returns available #{principals}" do |total, count, klass|
       include_context "request available #{principals}"
 
-      it_behaves_like 'API V3 collection response', total, count, 'User'
+      it_behaves_like 'API V3 collection response', total, count, klass
     end
 
     describe 'users' do
       context 'single user' do
         # The current user
 
-        it_behaves_like "returns available #{principals}", 1, 1
+        it_behaves_like "returns available #{principals}", 1, 1, 'User'
       end
 
       context 'multiple users' do
@@ -74,7 +74,7 @@ shared_examples_for 'available principals' do |principals|
           # and the current user
         end
 
-        it_behaves_like "returns available #{principals}", 2, 2
+        it_behaves_like "returns available #{principals}", 2, 2, 'User'
       end
     end
 
@@ -87,7 +87,7 @@ shared_examples_for 'available principals' do |principals|
         end
 
         # current user and group
-        it_behaves_like "returns available #{principals}", 2, 2
+        it_behaves_like "returns available #{principals}", 2, 2, 'Group'
       end
 
       context 'without work_package_group_assignment' do
@@ -96,7 +96,7 @@ shared_examples_for 'available principals' do |principals|
         end
 
         # Only the current user
-        it_behaves_like "returns available #{principals}", 1, 1
+        it_behaves_like "returns available #{principals}", 1, 1, 'User'
       end
     end
   end

--- a/spec_legacy/unit/enumeration_spec.rb
+++ b/spec_legacy/unit/enumeration_spec.rb
@@ -36,11 +36,6 @@ describe Enumeration, type: :model do
     @default_enumeration = FactoryGirl.create :default_enumeration
   end
 
-  it 'should objects count' do
-    assert_equal @issues.size, @low_priority.objects_count
-    assert_equal 0, FactoryGirl.create(:priority).objects_count
-  end
-
   it 'should in use' do
     assert @low_priority.in_use?
     assert !FactoryGirl.create(:priority).in_use?


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/27541

### TODO

- [x] project representer
- [x] user representer
- [x] priority representer 
- [x] status representer 
- [x] attachments representer 
- [x] version representer
- [x] type representer  
- [x] category representer 
- [x] work_package schema representer 
- [x] work package representer
- ~~work package eager loading~~ will be extracted to a separate PR
- [x] adapt plugins modifying representers
  - [x] costs (https://github.com/finnlabs/openproject-costs/pull/307)
  - [x] backlogs (https://github.com/finnlabs/openproject-backlogs/pull/265)
- [x] remove `subtype` dependencies in the front end as there is now a `Group` resource

### Preliminary results

Setting: 
* OpenProject Core only

#### Without caching:
```
> ab -n 300 -H "Authorization: Basic YXBpa2V5OjVlZTM2ZjdlNzNmOTFkYjcyOWNkOWNhZWYwYTRhMjEyMGNlYzg2NGM4YjI5YTNlZGZjZGVjMzk0NDhiZTcxYTQ=" http://localhost:3000/api/v3/work_packages?pageSize=50&offset=1
[1] 7143
This is ApacheBench, Version 2.3 <$Revision: 1807734 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Finished 300 requests


Server Software:        thin
Server Hostname:        localhost
Server Port:            3000

Document Path:          /api/v3/work_packages?pageSize=50
Document Length:        325220 bytes

Concurrency Level:      1
Time taken for tests:   533.943 seconds
Complete requests:      300
Failed requests:        0
Total transferred:      97800600 bytes
HTML transferred:       97566000 bytes
Requests per second:    0.56 [#/sec] (mean)
Time per request:       1779.812 [ms] (mean)
Time per request:       1779.812 [ms] (mean, across all concurrent requests)
Transfer rate:          178.87 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:  1529 1780 294.7   1706    5005
Waiting:     1529 1779 294.7   1706    5005
Total:       1529 1780 294.7   1706    5006

Percentage of the requests served within a certain time (ms)
  50%   1706
  66%   1769
  75%   1835
  80%   1884
  90%   2002
  95%   2255
  98%   2523
  99%   3247
 100%   5006 (longest request)
```

#### With caching:
```
> ab -n 300 -H "Authorization: Basic YXBpa2V5OjVlZTM2ZjdlNzNmOTFkYjcyOWNkOWNhZWYwYTRhMjEyMGNlYzg2NGM4YjI5YTNlZGZjZGVjMzk0NDhiZTcxYTQ=" http://localhost:3000/api/v3/work_packages?pageSize=50&offset=1
[1] 6194
This is ApacheBench, Version 2.3 <$Revision: 1807734 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
  Licensed to The Apache Software Foundation, http://www.apache.org/

  Benchmarking localhost (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Finished 300 requests


Server Software:        thin
Server Hostname:        localhost
Server Port:            3000

Document Path:          /api/v3/work_packages?pageSize=50
Document Length:        325220 bytes

Concurrency Level:      1
Time taken for tests:   291.349 seconds
Complete requests:      300
Failed requests:        0
Total transferred:      97800600 bytes
HTML transferred:       97566000 bytes
Requests per second:    1.03 [#/sec] (mean)
Time per request:       971.165 [ms] (mean)
Time per request:       971.165 [ms] (mean, across all concurrent requests)
Transfer rate:          327.81 [Kbytes/sec] received

Connection Times (ms)
min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   859  971  75.9    933    1179
Waiting:      858  971  75.9    933    1178
Total:        859  971  75.9    934    1179

Percentage of the requests served within a certain time (ms)
  50%    934
  66%   1018
  75%   1058
  80%   1065
  90%   1078
  95%   1092
  98%   1108
  99%   1124
 100%   1179 (longest request)
```

#### Analysis
Although eager loading has not yet been implemented, caching the representers shows a significant improvement in speed. Response time drops to about 60% with a lower standard deviation. 

### Background

Improves on the [first POC of caching API representers](https://github.com/opf/openproject/pull/5086).

As of now, the improvements in response time need to be taken with a grain of salt but the preliminary measurements indicate a reduction of the response time for `api/v3/work_packages` to about 50 - 33%. E.g. a request for 50 work packages takes about 1s on my machine. With the changes of this PR applied, the response is served in about 350ms. For 100 work package the response time drops from 1.5 seconds to 400ms.

The first POC's approach was to distinguish the representer into layers of concerns which where individually cached. Upon a request, the cache key, mainly derived from the user's permissions would determine the separate layers that where then combined into the final response body.

This PR takes the opposite approach. The representer is rendered without any consideration for the current user's permission which results in a representation fit for responding to an admin's request. For non admins, that cached representation is stripped of those parts not fit for the requesting user's permissions. As an example, the project representer has the `createWorkPackages` link:

```
{
    "_type": "Project",
    ...
    "_links": {
        "self": {
            "href": "/api/v3/projects/1",
            "title": "Seeded Project"
        },
        "createWorkPackage": {
            "href": "/api/v3/projects/1/work_packages/form",
            "method": "post"
        },
        ...
    }
}
```

The cached representation will contain that link and thus be able to satisfy the complete permissions an admin has. But when a user lacking the `add_work_packages` permission requests that same project, the same representation will be the used as the foundation for the response, but before returning the response the application removes the `createWorkPackage` link.

Compared to the first POC this approach has a couple of advantages:
* High probability of a cache hit as the same result can be used as the base for all users' requests. In effect, that should mean to only need to do the heavy lifting of determining the response once for every saved state of a resource. E.g. the project's representation can be reused for all users' requests until the project is saved again.
* Simple to implement (see commits)

However, rending the representer is only responsible for the lesser part of time spent when responding to `/api/v3/work_packages/` (with our without project scope). That type of request is responsible for over 30% of computational resources spent on SaaS.  

![image](https://user-images.githubusercontent.com/617519/36245673-74448e72-122c-11e8-9070-73a236e8cb10.png)

The bulk of time is spent on instantiating the AR models after fetching them from the DB.
 
![image](https://user-images.githubusercontent.com/617519/36245746-d80b3262-122c-11e8-8d85-3128a9de38b1.png)

 In the past, we optimized the response time by eager loading all of the models before rendering. But as the work package representer contains information from a lot of different models (`WorkPackage`, `User` (3 times), `Status`, ...), that approach has lead to the application having to instantiating a lot of models which is quite costly. 

To maximize the gains received from caching, we also need to reduce the amount of models instantiated. But as the cached representation needs to be invalidated once any of the models change (e.g. when the status is renamed, the cached work package representation is no longer valid). 

Invalidation should happen by changing the cache key. The cache key will typically consist of a class, the id and a timestamp. For our purposes, we need to extend that to also include the timestamps of all the rendered models. As Rails' eager loading mechanism is not able to select only a few fields we need to write custom queries of the form:
```
WorkPackages.joins(:author).select('work_packages.*, users.updated_on)
```

This approach to caching has only one drawback, which is that if a lot of resources in a collection are uncached, that response is going to take a lot more time as the models are than fetched with N+1 queries. This effect can be avoided in part by preemptively loading a large set of representations into the cache by e.g. a rake task.