### PR TITLE
Fix/invalid activation tokens

### DIFF
--- a/app/cells/rails_cell.rb
+++ b/app/cells/rails_cell.rb
@@ -9,10 +9,24 @@ class RailsCell < Cell::ViewModel
   # this would override Cell's own render method and
   # subsequently break everything.
 
+  ##
+  # Defines options for this cell which can be used within the cell's template.
+  # Options are passed to the cell during the render call.
+  #
+  # @param names [Array<String> | Hash<String, Any>] Either a list of names for options whose
+  #                                                  default value is empty or a hash mapping
+  #                                                  option names to default values.
   def self.options(*names)
+    default_values = {}
+
+    if names.size == 1 && names.first.is_a?(Hash)
+      default_values = names.first
+      names = default_values.keys
+    end
+
     names.each do |name|
       define_method(name) do
-        options[name]
+        options[name] || default_values[name]
       end
     end
   end

--- a/app/cells/settings/numeric_setting_cell.rb
+++ b/app/cells/settings/numeric_setting_cell.rb
@@ -1,0 +1,14 @@
+module Settings
+  ##
+  # A text field to enter numeric values.
+  class NumericSettingCell < ::RailsCell
+    include SettingsHelper
+
+    options :unit, :title
+    options size: 3
+
+    def name # name of setting and tag
+      model
+    end
+  end
+end

--- a/app/cells/views/settings/numeric_setting/show.erb
+++ b/app/cells/views/settings/numeric_setting/show.erb
@@ -1,0 +1,11 @@
+<div class="form--field">
+  <%=
+    setting_text_field(
+      name,
+      size: size,
+      unit: t("label_#{unit.singularize}_plural"),
+      container_class: '-xslim',
+      title: title
+    )
+  %>
+</div>

--- a/app/models/token/expirable_token.rb
+++ b/app/models/token/expirable_token.rb
@@ -33,7 +33,7 @@ module Token
       end
 
       def expired?
-        Time.now > (created_on + validity_time)
+        expires_on && Time.now > expires_on
       end
 
       def validity_time
@@ -48,9 +48,7 @@ module Token
 
       # Delete all expired tokens
       def delete_expired_tokens
-        if validity_time
-          self.class.where(["expires_on < ?", Time.now]).delete_all
-        end
+        self.class.where(["expires_on < ?", Time.now]).delete_all
       end
     end
   end

--- a/app/models/token/invitation.rb
+++ b/app/models/token/invitation.rb
@@ -37,7 +37,17 @@ module Token
     ##
     # Invitation tokens are valid for one day.
     def self.validity_time
-      1.day
+      Setting.invitation_expiration_days
+    end
+
+    ##
+    # Don't delete expired invitation tokens. Each user can have at most one anyway
+    # and we don't want that one to be deleted. Instead when the user tries to activate
+    # their account using the expired token the activation will fail due to it being
+    # expired. A new invitation token will be generated which deletes the expired one
+    # implicitly.
+    def delete_expired_tokens
+
     end
   end
 end

--- a/app/views/settings/_authentication.html.erb
+++ b/app/views/settings/_authentication.html.erb
@@ -46,6 +46,8 @@ See docs/COPYRIGHT.rdoc for more details.
       </div>
     </fieldset>
 
+    <%= cell Settings::NumericSettingCell, "invitation_expiration_days", unit: "days" %>
+
     <fieldset class="form--fieldset">
       <fieldset id="registration_footer" class="form--fieldset">
         <legend class="form--fieldset-legend"><%= I18n.t(:setting_registration_footer) %></legend>

--- a/config/locales/crowdin/de.yml
+++ b/config/locales/crowdin/de.yml
@@ -2596,6 +2596,8 @@ de:
   note_password_login_disabled: Der Passwort-Login wurde per %{configuration} deaktiviert.
   warning: Warnung
   warning_attachments_not_saved: "%{count} Datei(en) konnten nicht gespeichert werden."
+  warning_registration_token_expired: |
+    Die Aktivierungs-Email ist abgelaufen. Wir haben eine neue geschickt an: %{email}
   menu_item: Menüpunkt
   menu_item_setting: Sichtbarkeit
   wiki_menu_item_for: Menüpunkt für die Wikiseite "%{title}"

--- a/config/locales/crowdin/de.yml
+++ b/config/locales/crowdin/de.yml
@@ -2084,6 +2084,7 @@ de:
   setting_feeds_limit: Max. Anzahl Einträge pro Atom-Feed
   setting_file_max_size_displayed: Maximale Größe inline angezeigter Textdateien
   setting_host_name: Hostname
+  setting_invitation_expiration_days: Gültigkeit von Aktivierungs-Emails
   setting_work_package_done_ratio: Berechne den Arbeitspaket-Fortschritt mittels
   setting_work_package_done_ratio_field: Arbeitspaket-Feld %-erledigt
   setting_work_package_done_ratio_status: Arbeitspaket-Status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1945,6 +1945,7 @@ en:
   setting_feeds_limit: "Feed content limit"
   setting_file_max_size_displayed: "Max size of text files displayed inline"
   setting_host_name: "Host name"
+  setting_invitation_expiration_days: "Activation E-Mail expires after"
   setting_work_package_done_ratio: "Calculate the work package done ratio with"
   setting_work_package_done_ratio_field: "Use the work package field"
   setting_work_package_done_ratio_status: "Use the work package status"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2388,6 +2388,9 @@ en:
   note_password_login_disabled: "Password login has been disabled by %{configuration}."
   warning: Warning
   warning_attachments_not_saved: "%{count} file(s) could not be saved."
+  warning_registration_token_expired: |
+    The activation email has expired. We sent you a new one to %{email}.
+    Please click the link inside of it to activate your account.
 
   menu_item: "Menu item"
   menu_item_setting: "Visibility"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -309,6 +309,9 @@ users_deletable_by_admins:
   default: 0
 users_deletable_by_self:
   default: 0
+invitation_expiration_days:
+  default: 7
+  format: int
 journal_aggregation_time_minutes:
   default: 5
   format: int


### PR DESCRIPTION
WP [#26320](https://community.openproject.com/projects/openproject/work_packages/26320)

Changes:

* makes invitation/activation token expiration time a setting (default 7 days)
* invitation tokens may expire but are not deleted (before:)
* activation with an expired token generates a new token and sends out a new activation email

<img width="626" alt="expired" src="https://user-images.githubusercontent.com/158871/36254136-cd5f596e-1241-11e8-8a3a-2376a5038ce8.png">
