### PR TITLE
Fix/ignore inactive stages

### DIFF
--- a/app/controllers/concerns/authentication_stages.rb
+++ b/app/controllers/concerns/authentication_stages.rb
@@ -51,22 +51,30 @@ module Concerns
     end
 
     def init_authentication_stages(after_activation:)
-      stages = OpenProject::Authentication::Stage
-               .stages
-               .select(&:active?)
-               .select { |s| s.run_after_activation? || !after_activation }
+      stages = active_stages
 
       session[:authentication_stages] = stages.map(&:identifier)
-      session[:stage_secrets] = session[:authentication_stages]
-                                .map { |ident| [ident, stage_secret(ident)] }
-                                .to_h
+      session[:stage_secrets] = new_stage_secrets
       session[:back_url] = back_url
 
       stages
     end
 
+    def active_stages
+      OpenProject::Authentication::Stage
+        .stages
+        .select(&:active?)
+        .select { |s| s.run_after_activation? || !after_activation }
+    end
+
     def stage_secrets
       Hash(session[:stage_secrets])
+    end
+
+    def new_stage_secrets
+      session[:authentication_stages]
+        .map { |ident| [ident, stage_secret(ident)] }
+        .to_h
     end
 
     def stage_secret(ident)

--- a/app/controllers/concerns/authentication_stages.rb
+++ b/app/controllers/concerns/authentication_stages.rb
@@ -33,7 +33,7 @@ module Concerns
     private
 
     def authentication_stages(after_activation: false, reset: true)
-      if !OpenProject::Authentication::Stage.stages.empty?
+      if OpenProject::Authentication::Stage.stages.select(&:active?).any?
         session.delete [:authentication_stages, :stage_secrets, :back_url] if reset
 
         if session.include?(:authentication_stages)

--- a/app/controllers/concerns/authentication_stages.rb
+++ b/app/controllers/concerns/authentication_stages.rb
@@ -52,14 +52,14 @@ module Concerns
 
     def init_authentication_stages(after_activation:)
       stages = OpenProject::Authentication::Stage
-        .stages
-        .select { |s| s.active? }
-        .select { |s| s.run_after_activation? || !after_activation }
+               .stages
+               .select(&:active?)
+               .select { |s| s.run_after_activation? || !after_activation }
 
       session[:authentication_stages] = stages.map(&:identifier)
       session[:stage_secrets] = session[:authentication_stages]
-        .map { |ident| [ident, stage_secret(ident)] }
-        .to_h
+                                .map { |ident| [ident, stage_secret(ident)] }
+                                .to_h
       session[:back_url] = back_url
 
       stages

--- a/app/controllers/concerns/authentication_stages.rb
+++ b/app/controllers/concerns/authentication_stages.rb
@@ -51,7 +51,7 @@ module Concerns
     end
 
     def init_authentication_stages(after_activation:)
-      stages = active_stages
+      stages = active_stages after_activation
 
       session[:authentication_stages] = stages.map(&:identifier)
       session[:stage_secrets] = new_stage_secrets
@@ -60,7 +60,7 @@ module Concerns
       stages
     end
 
-    def active_stages
+    def active_stages(after_activation)
       OpenProject::Authentication::Stage
         .stages
         .select(&:active?)


### PR DESCRIPTION
Otherwise the back_url is reset once a stage is defined (e.g by a plugin) regardless of whether the stage is active or not.