### PR TITLE
[27097] Cannot navigate to project on mobile (Safari on iOS) (2)

### DIFF
--- a/frontend/app/components/projects/project-menu-autocomplete/project-menu-autocomplete.component.ts
+++ b/frontend/app/components/projects/project-menu-autocomplete/project-menu-autocomplete.component.ts
@@ -124,6 +124,11 @@ export class ProjectMenuAutocompleteController extends ILazyAutocompleterBridge<
       .text(item.label)
       .appendTo(div);
 
+    // Needed for iOS to ensure that the link is executed on the first click (touch)
+    link.on('touchstart',(evt:JQueryEventObject) => {
+      this.$window.location.href =  this.projectLink(item.object.identifier);
+    });
+
     // When in hierarchy, indent
     if (item.object.level > 0) {
       link


### PR DESCRIPTION
This PR overrides the `touchstart` event to make sure the project selection works on first click.

https://community.openproject.com/projects/openproject/work_packages/27097/activity