### PR TITLE
[27230] Fix restricting the rev only to lowercase tags

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -342,22 +342,22 @@ OpenProject::Application.routes.draw do
 
       get '(/revisions/:rev)/:format/*path', action: :entry,
                                              format: /raw/,
-                                             rev: /[a-z0-9\.\-_]+/
+                                             rev: /[\w0-9\.\-_]+/
 
       %w{diff annotate changes entry browse}.each do |action|
         get "(/revisions/:rev)/#{action}(/*path)", format: false,
                                                    action: action,
-                                                   rev: /[a-z0-9\.\-_]+/,
+                                                   rev: /[\w0-9\.\-_]+/,
                                                    as: "#{action}_revision"
       end
 
-      get '/revision(/:rev)', rev: /[a-z0-9\.\-_]+/,
+      get '/revision(/:rev)', rev: /[\w0-9\.\-_]+/,
                               action: :revision,
                               as: 'show_revision'
 
       get '(/revisions/:rev)(/*path)', action: :show,
                                        format: false,
-                                       rev: /[a-z0-9\.\-_]+/,
+                                       rev: /[\w0-9\.\-_]+/,
                                        as: 'show_revisions_path'
     end
   end

--- a/spec/routing/repositories_routing_spec.rb
+++ b/spec/routing/repositories_routing_spec.rb
@@ -62,6 +62,36 @@ describe RepositoriesController, type: :routing do
     }
   end
 
+  describe 'show with git tags (regression test #27230)' do
+    it {
+      expect(get('/projects/testproject/repository/sub?rev=mytags%2Ffoo&branch=&tag=mytags%2Ffoo'))
+        .to route_to(controller: 'repositories',
+                     action: 'show',
+                     path: 'sub',
+                     branch: '',
+                     rev: 'mytags/foo',
+                     tag: 'mytags/foo',
+                     project_id: 'testproject')
+    }
+    it {
+      expect(get('/projects/testproject/repository?rev=FSubCommit-a&branch=master&tag=FSubCommit-a'))
+        .to route_to(controller: 'repositories',
+                     action: 'show',
+                     branch: 'master',
+                     rev: 'FSubCommit-a',
+                     tag: 'FSubCommit-a',
+                     project_id: 'testproject')
+    }
+    it {
+      expect(get('/projects/testproject/repository/revisions/FSubCommit-a/sub'))
+        .to route_to(controller: 'repositories',
+                     action: 'show',
+                     path: 'sub',
+                     rev: 'FSubCommit-a',
+                     project_id: 'testproject')
+    }
+  end
+
   describe 'edit' do
     it {
       expect(get('/projects/testproject/repository/edit'))


### PR DESCRIPTION
When using mixed-case tags, a part of them is matched if it does not
contain a slash.

https://community.openproject.com/wp/27230