### PR TITLE
[27233] Edit mode of boolean CF is not cancelable

### DIFF
--- a/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.directive.html
+++ b/frontend/app/components/wp-edit/field-types/wp-edit-boolean-field.directive.html
@@ -6,5 +6,6 @@
        ng-change="vm.handleUserSubmit()"
        ng-focus="vm.handleUserFocus()"
        ng-blur="vm.handleUserBlur()"
+       ng-keydown="vm.handleUserKeydown($event)"
        ng-disabled="vm.field.inFlight"
        ng-attr-id="{{vm.htmlId}}" />


### PR DESCRIPTION
Add keydown event for boolean edit fields. Thus the edit mode is cancelable on Escape.

https://community.openproject.com/projects/openproject/work_packages/27233/activity