### PR TITLE
Bump test-prof to re-use their let_it_be shared_let replacement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -179,7 +179,7 @@ group :test do
 
   # Test prof provides factories from code
   # and other niceties
-  gem 'test-prof'
+  gem 'test-prof', '~> 0.4.0'
 
   gem 'cucumber', '~> 3.0.0'
   gem 'cucumber-rails', '~> 1.5.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -562,7 +562,7 @@ GEM
     syck (1.3.0)
     sys-filesystem (1.1.8)
       ffi
-    test-prof (0.1.0)
+    test-prof (0.4.8)
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -720,7 +720,7 @@ DEPENDENCIES
   svg-graph (~> 2.1.0)
   syck (~> 1.3.0)
   sys-filesystem (~> 1.1.4)
-  test-prof
+  test-prof (~> 0.4.0)
   thin (~> 1.7.2)
   timecop (~> 0.9.0)
   transactional_lock!

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -35,8 +35,8 @@ describe 'API v3 Work package form resource', type: :request do
   include API::V3::Utilities::PathHelper
 
   shared_let(:project) { FactoryGirl.create(:project, is_public: false) }
-  shared_let(:work_package, reload: true) { FactoryGirl.create(:work_package, project: @project) }
-  shared_let(:authorized_user) { FactoryGirl.create(:user, member_in_project: @project) }
+  shared_let(:work_package, reload: true) { FactoryGirl.create(:work_package, project: project) }
+  shared_let(:authorized_user) { FactoryGirl.create(:user, member_in_project: project) }
   shared_let(:unauthorized_user) { FactoryGirl.create(:user) }
 
   describe '#post' do

--- a/spec/support/shared_let.rb
+++ b/spec/support/shared_let.rb
@@ -35,20 +35,11 @@
 # Caveats: Set +reload: true+ if you plan to modify this value, otherwise Rails may still
 # have cached the local value. This will perform a database update, but is much faster
 # than creating new records (especially, work packages).
-def shared_let(key, reload: false, &block)
-  var = "@#{key}"
+#
+# Since test-prof added `let_it_be` this is only a wrapper for it
+require 'test_prof/recipes/rspec/let_it_be'
 
-  before_all do
-    # Use instance_eval so following blocks may reference earlier ones
-    result = instance_eval &block
-    instance_variable_set(var, result)
-  end
-
-  let(key) do
-    value = instance_variable_get(var)
-    value.reload if reload
-
-    value
-  end
+def shared_let(key, reload: false, refind: false, &block)
+  let_it_be(key, reload: reload, refind: refind, &block)
 end
 


### PR DESCRIPTION
When I added test-prof, I added a recipe using before(:all) and based on their https://github.com/palkan/test-prof/blob/master/guides/any_fixture.md `AnyFixture` recipe to remember a let for the entire spec to avoid re-initializing it on every instance.

In the newer version, this is implemented in test-prof itself with `let_it_be`.