### PR TITLE
[26737] Journal notification mail changed information not very prominent

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2103,7 +2103,7 @@ en:
   text_work_packages_ref_in_commit_messages: "Referencing and fixing work packages in commit messages"
   text_journal_added: "%{label} %{value} added"
   text_journal_aggregation_time_explanation: "Combine journals for display if their age difference is less than the specified timespan. This will also delay mail notifications by the same amount of time."
-  text_journal_changed: "%{label} changed from %{old} to %{new}"
+  text_journal_changed: "%{label} changed from %{old} </br><strong>to</strong> %{new}"
   text_journal_changed_no_detail: "%{label} updated"
   text_journal_changed_with_diff: "%{label} changed (%{link})"
   text_journal_deleted: "%{label} deleted (%{old})"

--- a/lib/plugins/acts_as_journalized/lib/journal_formatter/base.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_formatter/base.rb
@@ -80,7 +80,7 @@ class JournalFormatter::Base
       if old_value.blank?
         l(:text_journal_set_to, label: label, value: value)
       else
-        l(:text_journal_changed, label: label, old: old_value, new: value)
+        l(:text_journal_changed, label: label, old: old_value, new: value).html_safe
       end
     end
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -226,7 +226,7 @@ describe UserMailer, type: :mailer do
           end
 
           it 'displays changed done ratio' do
-            is_expected.to include('Progress (%) changed from 40 to 100')
+            is_expected.to include('Progress (%) changed from 40 </br><strong>to</strong> 100')
           end
         end
 
@@ -236,7 +236,7 @@ describe UserMailer, type: :mailer do
           end
 
           it 'displays new done ratio' do
-            is_expected.to include('Progress (%) changed from 0 to 100')
+            is_expected.to include('Progress (%) changed from 0 </br><strong>to</strong> 100')
           end
         end
 
@@ -246,7 +246,7 @@ describe UserMailer, type: :mailer do
           end
 
           it 'displays deleted done ratio' do
-            is_expected.to include('Progress (%) changed from 50 to 0')
+            is_expected.to include('Progress (%) changed from 50 </br><strong>to</strong> 0')
           end
         end
       end
@@ -494,7 +494,7 @@ describe UserMailer, type: :mailer do
       end
 
       context 'changed done ratio' do
-        let(:expected) { "#{expected_prefix} changed from <i title=\"40\">40</i> to <i title=\"100\">100</i>" }
+        let(:expected) { "#{expected_prefix} changed from <i title=\"40\">40</i> </br><strong>to</strong> <i title=\"100\">100</i>" }
 
         before do
           allow(journal).to receive(:details).and_return('done_ratio' => [40, 100])
@@ -506,7 +506,7 @@ describe UserMailer, type: :mailer do
       end
 
       context 'new done ratio' do
-        let(:expected) { "#{expected_prefix} changed from <i title=\"0\">0</i> to <i title=\"100\">100</i>" }
+        let(:expected) { "#{expected_prefix} changed from <i title=\"0\">0</i> </br><strong>to</strong> <i title=\"100\">100</i>" }
 
         before do
           allow(journal).to receive(:details).and_return('done_ratio' => [nil, 100])
@@ -518,7 +518,7 @@ describe UserMailer, type: :mailer do
       end
 
       context 'deleted done ratio' do
-        let(:expected) { "#{expected_prefix} changed from <i title=\"50\">50</i> to <i title=\"0\">0</i>" }
+        let(:expected) { "#{expected_prefix} changed from <i title=\"50\">50</i> </br><strong>to</strong> <i title=\"0\">0</i>" }
 
         before do
           allow(journal).to receive(:details).and_return('done_ratio' => [50, nil])

--- a/spec_legacy/unit/repository_spec.rb
+++ b/spec_legacy/unit/repository_spec.rb
@@ -108,7 +108,7 @@ describe Repository, type: :model do
     mail = ActionMailer::Base.deliveries.first
     assert_kind_of Mail::Message, mail
     assert mail.subject.starts_with?("[#{fixed_work_package.project.name} - #{fixed_work_package.type.name} ##{fixed_work_package.id}]")
-    assert mail.body.encoded.include?("Status changed from #{old_status} to #{fixed_work_package.status}")
+    assert mail.body.encoded.include?("Status changed from #{old_status} </br><strong>to</strong> #{fixed_work_package.status}")
 
     # ignoring commits referencing an issue of another project
     assert_equal [], WorkPackage.find(4).changesets


### PR DESCRIPTION
I gave it a try and increase contrast between differences in journal. The additional line break hopefully makes it easier to see the difference. I am aware that it is still not optimal but a start.

https://community.openproject.com/projects/openproject/work_packages/26737/activity