### PR TITLE
[24960] Fix routing to js file in repository results in JS format

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -345,10 +345,11 @@ OpenProject::Application.routes.draw do
                                              rev: /[\w0-9\.\-_]+/
 
       %w{diff annotate changes entry browse}.each do |action|
-        get "(/revisions/:rev)/#{action}(/*path)", format: false,
-                                                   action: action,
-                                                   rev: /[\w0-9\.\-_]+/,
-                                                   as: "#{action}_revision"
+        get "(/revisions/:rev)/#{action}(/*path)",
+            format: 'html',
+            action: action,
+            constraints: { rev: /[\w0-9\.\-_]+/, path: /.*/ },
+            as: "#{action}_revision"
       end
 
       get '/revision(/:rev)', rev: /[\w0-9\.\-_]+/,
@@ -356,8 +357,8 @@ OpenProject::Application.routes.draw do
                               as: 'show_revision'
 
       get '(/revisions/:rev)(/*path)', action: :show,
-                                       format: false,
-                                       rev: /[\w0-9\.\-_]+/,
+                                       format: 'html',
+                                       constraints: { rev: /[\w0-9\.\-_]+/, path: /.*/ },
                                        as: 'show_revisions_path'
     end
   end

--- a/spec/routing/repositories_routing_spec.rb
+++ b/spec/routing/repositories_routing_spec.rb
@@ -34,6 +34,7 @@ describe RepositoriesController, type: :routing do
       expect(get('/projects/testproject/repository'))
         .to route_to(controller: 'repositories',
                      action: 'show',
+                     format: 'html',
                      project_id: 'testproject')
     }
 
@@ -41,6 +42,7 @@ describe RepositoriesController, type: :routing do
       expect(get('/projects/testproject/repository/path/to/file.c'))
         .to route_to(controller: 'repositories',
                      action: 'show',
+                     format: 'html',
                      project_id: 'testproject',
                      path: 'path/to/file.c')
     }
@@ -49,6 +51,7 @@ describe RepositoriesController, type: :routing do
       expect(get('/projects/testproject/repository/folder%20with%20spaces'))
         .to route_to(controller: 'repositories',
                      action: 'show',
+                     format: 'html',
                      project_id: 'testproject',
                      path: 'folder with spaces')
     }
@@ -57,7 +60,20 @@ describe RepositoriesController, type: :routing do
       expect(get('/projects/testproject/repository/revisions/5'))
         .to route_to(controller: 'repositories',
                      action: 'show',
+                     format: 'html',
                      rev: '5',
+                     project_id: 'testproject')
+    }
+  end
+
+  describe 'changes with js file (regression #24960)' do
+    it {
+      expect(get('/projects/testproject/repository/revisions/my-branch/changes/assets/test.js'))
+        .to route_to(controller: 'repositories',
+                     action: 'changes',
+                     path: 'assets/test.js',
+                     rev: 'my-branch',
+                     format: 'html',
                      project_id: 'testproject')
     }
   end
@@ -71,6 +87,7 @@ describe RepositoriesController, type: :routing do
                      branch: '',
                      rev: 'mytags/foo',
                      tag: 'mytags/foo',
+                     format: 'html',
                      project_id: 'testproject')
     }
     it {
@@ -80,6 +97,7 @@ describe RepositoriesController, type: :routing do
                      branch: 'master',
                      rev: 'FSubCommit-a',
                      tag: 'FSubCommit-a',
+                     format: 'html',
                      project_id: 'testproject')
     }
     it {
@@ -88,6 +106,7 @@ describe RepositoriesController, type: :routing do
                      action: 'show',
                      path: 'sub',
                      rev: 'FSubCommit-a',
+                     format: 'html',
                      project_id: 'testproject')
     }
   end
@@ -201,6 +220,7 @@ describe RepositoriesController, type: :routing do
       expect(get('/projects/testproject/repository/browse/path/to/file.c'))
         .to route_to(controller: 'repositories',
                      action: 'browse',
+                     format: 'html',
                      project_id: 'testproject',
                      path: 'path/to/file.c')
     }
@@ -211,6 +231,7 @@ describe RepositoriesController, type: :routing do
       expect(get('/projects/testproject/repository/entry/path/to/file.c'))
         .to route_to(controller: 'repositories',
                      action: 'entry',
+                     format: 'html',
                      project_id: 'testproject',
                      path: 'path/to/file.c')
     }
@@ -219,6 +240,7 @@ describe RepositoriesController, type: :routing do
       expect(get('/projects/testproject/repository/revisions/2/entry/path/to/file.c'))
         .to route_to(controller: 'repositories',
                      action: 'entry',
+                     format: 'html',
                      project_id: 'testproject',
                      path: 'path/to/file.c',
                      rev: '2')
@@ -249,6 +271,7 @@ describe RepositoriesController, type: :routing do
       expect(get('/projects/testproject/repository/annotate/path/to/file.c'))
         .to route_to(controller: 'repositories',
                      action: 'annotate',
+                     format: 'html',
                      project_id: 'testproject',
                      path: 'path/to/file.c')
     }
@@ -256,6 +279,7 @@ describe RepositoriesController, type: :routing do
       expect(get('/projects/testproject/repository/revisions/5/annotate/path/to/file.c'))
         .to route_to(controller: 'repositories',
                      action: 'annotate',
+                     format: 'html',
                      project_id: 'testproject',
                      path: 'path/to/file.c',
                      rev: '5')
@@ -267,6 +291,7 @@ describe RepositoriesController, type: :routing do
       expect(get('/projects/testproject/repository/changes/path/to/file.c'))
         .to route_to(controller: 'repositories',
                      action: 'changes',
+                     format: 'html',
                      project_id: 'testproject',
                      path: 'path/to/file.c')
     }
@@ -275,6 +300,7 @@ describe RepositoriesController, type: :routing do
       expect(get('/projects/testproject/repository/revisions/5/changes/path/to/file.c'))
         .to route_to(controller: 'repositories',
                      action: 'changes',
+                     format: 'html',
                      project_id: 'testproject',
                      path: 'path/to/file.c',
                      rev: '5')


### PR DESCRIPTION
It seems that `format: false` isn't sufficiently working anymore, but
since we force html format anyway, the best way is to set a constraint
for the path to allow extensions, so `foo.js` isnt detected as JS
format.

https://community.openproject.com/wp/24960