### PR TITLE
README updates for new version OpenProject and Postgresql 9.6

### DIFF
--- a/docs/installation/docker/README.md
+++ b/docs/installation/docker/README.md
@@ -35,7 +35,7 @@ the logs to your terminal, which helps with debugging if anything goes wrong.
 For normal usage you probably want to start it in the background, which can be
 achieved with the `-d` flag:
 
-    docker run -d -p 8080:80 -e SECRET_KEY_BASE=secret openproject/community:5.0
+    docker run -d -p 8080:80 -e SECRET_KEY_BASE=secret openproject/community:7
 
 ### Recommended usage
 
@@ -55,7 +55,7 @@ those directories mounted:
     sudo mkdir -p /var/lib/openproject/{pgdata,logs,static}
 
     docker run -d -p 8080:80 --name openproject -e SECRET_KEY_BASE=secret \
-      -v /var/lib/openproject/pgdata:/var/lib/postgresql/9.4/main \
+      -v /var/lib/openproject/pgdata:/var/lib/postgresql/9.6/main \
       -v /var/lib/openproject/logs:/var/log/supervisor \
       -v /var/lib/openproject/static:/var/db/openproject \
       openproject/community:7
@@ -143,7 +143,7 @@ Yes. You can simply pass a custom `DATABASE_URL` environment variable on the
 command-line, which could point to an external database. You can even choose to
 use MySQL instead of PostgreSQL if you wish. Here is how you would do it:
 
-    docker run -d ... -e DATABASE_URL=mysql2://user:pass@host:port/dbname openproject/community:5.0
+    docker run -d ... -e DATABASE_URL=mysql2://user:pass@host:port/dbname openproject/community:7
 
 The container will make sure that the database gets the migrations and demo
 data as well.


### PR DESCRIPTION
The documentation switches between the 7 and 5.0 tag, I'm assuming it should be 7 throughout?

When I set this up I noticed the directory had changed from 9.4 to 9.6.