### PR TITLE
[27262] Disable distinct on attributes only from leaves query for aggregated values

### DIFF
--- a/app/services/work_packages/update_ancestors_service.rb
+++ b/app/services/work_packages/update_ancestors_service.rb
@@ -76,7 +76,11 @@ class WorkPackages::UpdateAncestorsService
   def inherit_attributes(ancestor, attributes)
     return unless attributes_justify_inheritance?(attributes)
 
-    leaves = ancestor.leaves.select(selected_leaf_attributes).includes(:status).to_a
+    leaves = ancestor
+      .leaves
+      .select(selected_leaf_attributes)
+      .distinct(true) # Be explicit that this is a distinct (wrt ID) query
+      .includes(:status).to_a
 
     inherit_done_ratio(ancestor, leaves)
 
@@ -170,6 +174,6 @@ class WorkPackages::UpdateAncestorsService
   end
 
   def selected_leaf_attributes
-    %i(done_ratio estimated_hours status_id)
+    %i(id done_ratio estimated_hours status_id)
   end
 end

--- a/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -116,6 +116,16 @@ describe WorkPackages::UpdateAncestorsService, type: :model do
       end
     end
 
+    context 'with some values same for done ratio' do
+      it_behaves_like 'attributes of parent having children' do
+        let(:done_ratios) { [20, 20, 50] }
+        let(:estimated_hours) { [nil, nil, nil] }
+
+        let(:aggregate_done_ratio) { 30 }
+        let(:aggregate_estimated_hours) { nil }
+      end
+    end
+
     context 'with no estimated hours and 1.5 of the tasks done' do
       it_behaves_like 'attributes of parent having children' do
         let(:done_ratios) { [0, 50, 100] }


### PR DESCRIPTION
`ancestor.leaves` is a distinct query on work packages, which the `select` reduces to a set of relevant attributes. Duplicate attribute values are ignored in this fashion. We can either disable the distinct, or ensure a unique property is added.

https://community.openproject.com/wp/27262