### PR TITLE
bump rack-protection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -412,7 +412,7 @@ GEM
       rack (>= 0.4)
     rack-attack (5.0.1)
       rack
-    rack-protection (2.0.0)
+    rack-protection (2.0.1)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)


### PR DESCRIPTION
For those brave enough to try running openproject on windows (CVE-2018-7212)

![image](https://user-images.githubusercontent.com/617519/36981608-eaacd302-208d-11e8-805a-94b4089c154c.png)
