### PR TITLE
[27284 ] Allow :none authentication as empty smtp_authentication setting

### DIFF
--- a/app/assets/javascripts/settings.js.erb
+++ b/app/assets/javascripts/settings.js.erb
@@ -72,6 +72,13 @@ See doc/COPYRIGHT.rdoc for more details.
       $("#email_delivery_method_" + delivery_method).show();
     }).trigger("change");
 
+    $('#settings_smtp_authentication').on('change', function() {
+      var isNone = $(this).val() === 'none';
+      $('#settings_smtp_user_name,#settings_smtp_password')
+          .closest('.form--field')
+          .toggle(!isNone);
+    });
+
     /** Toggle repository checkout fieldsets required when option is disabled */
     $('.settings-repositories--checkout-toggle').change(function() {
       var wasChecked = this.checked,

--- a/app/views/settings/_notifications.html.erb
+++ b/app/views/settings/_notifications.html.erb
@@ -56,7 +56,7 @@ See doc/COPYRIGHT.rdoc for more details.
         <div class="form--field"><%= setting_text_field :smtp_address, container_class: '-middle' %></div>
         <div class="form--field"><%= setting_text_field :smtp_port, size: 6, container_class: '-xslim' %></div>
         <div class="form--field"><%= setting_text_field :smtp_domain, container_class: '-middle' %></div>
-        <div class="form--field"><%= setting_select(:smtp_authentication, [:plain, :login, :cram_md5], container_class: '-slim') %></div>
+        <div class="form--field"><%= setting_select(:smtp_authentication, [:none, :plain, :login, :cram_md5], container_class: '-slim') %></div>
         <div class="form--field"><%= setting_text_field :smtp_user_name, container_class: '-middle' %></div>
         <div class="form--field"><%= setting_password :smtp_password, container_class: '-middle' %></div>
         <div class="form--field"><%= setting_check_box :smtp_enable_starttls_auto %></div>

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -285,13 +285,8 @@ module OpenProject
           when :smtp
             ActionMailer::Base.perform_deliveries = true
             ActionMailer::Base.delivery_method = Setting.email_delivery_method
-            %w{address port domain authentication user_name password}.each do |setting|
-              value = Setting["smtp_#{setting}".to_sym]
-              if value.present?
-                ActionMailer::Base.smtp_settings[setting.to_sym] = value
-              end
-            end
-            ActionMailer::Base.smtp_settings[:enable_starttls_auto] = Setting.smtp_enable_starttls_auto?
+
+            reload_smtp_settings!
           when :sendmail
             ActionMailer::Base.perform_deliveries = true
             ActionMailer::Base.delivery_method = Setting.email_delivery_method
@@ -322,6 +317,33 @@ module OpenProject
       end
 
       private
+
+      def reload_smtp_settings!
+        # Correct smtp settings when using authentication :none
+        authentication = Setting.smtp_authentication.try(:to_sym)
+        keys = %i[address port domain authentication user_name password]
+        if authentication == :none
+          # Rails Mailer will croak if passing :none as the authentication.
+          # Instead, it requires to be removed from its settings
+          ActionMailer::Base.smtp_settings.delete :user_name
+          ActionMailer::Base.smtp_settings.delete :password
+          ActionMailer::Base.smtp_settings.delete :authentication
+
+          keys = %i[address port domain]
+        end
+
+        keys.each do |setting|
+          value = Setting["smtp_#{setting}"]
+          if value.present?
+            ActionMailer::Base.smtp_settings[setting] = value
+          else
+            ActionMailer::Base.smtp_settings.delete setting
+          end
+        end
+
+        ActionMailer::Base.smtp_settings[:enable_starttls_auto] = Setting.smtp_enable_starttls_auto?
+      end
+
 
       ##
       # The default source for overriding configuration values

--- a/spec/lib/open_project/configuration_spec.rb
+++ b/spec/lib/open_project/configuration_spec.rb
@@ -300,6 +300,26 @@ describe OpenProject::Configuration do
       OpenProject::Configuration.reload_mailer_configuration!
     end
 
+    it 'allows settings smtp_authentication to none' do
+      Setting.email_delivery_method = :smtp
+      Setting.smtp_authentication = :none
+      Setting.smtp_password = 'old'
+      Setting.smtp_address = 'smtp.example.com'
+      Setting.smtp_domain = 'example.com'
+      Setting.smtp_port = 25
+      Setting.smtp_user_name = 'username'
+      Setting.smtp_enable_starttls_auto = 1
+
+      expect(action_mailer).to receive(:perform_deliveries=).with(true)
+      expect(action_mailer).to receive(:delivery_method=).with(:smtp)
+      OpenProject::Configuration.reload_mailer_configuration!
+      expect(action_mailer.smtp_settings[:smtp_authentication]).to be_nil
+      expect(action_mailer.smtp_settings).to eq(address: 'smtp.example.com',
+                                                port: 25,
+                                                domain: 'example.com',
+                                                enable_starttls_auto: true)
+    end
+
     it 'correctly sets the action mailer configuration based on the settings' do
       Setting.email_delivery_method = :smtp
       Setting.smtp_password = 'p4ssw0rd'


### PR DESCRIPTION
We have users that need SMTP without authentication present, e.g., in an internal network. When passing `:none` to the smtp settings, this results in an authentication error since it tries to use that authentication method.

The correct way is to remove the authentication setting in order to use none. https://stackoverflow.com/a/26093613

https://community.openproject.com/wp/27284