### PR TITLE
[26725] Filter "Assignee's group" contains confusing option <me>

### DIFF
--- a/frontend/app/components/filters/filter-toggled-multiselect-value/filter-toggled-multiselect-value.directive.ts
+++ b/frontend/app/components/filters/filter-toggled-multiselect-value/filter-toggled-multiselect-value.directive.ts
@@ -122,7 +122,7 @@ export class ToggledMultiselectController {
       .then(((resources:Array<HalResource>) => {
         let options = (resources[0] as CollectionResource).elements;
 
-        if (isUserResource) {
+        if (isUserResource && this.filter.filter.id !== 'memberOfGroup') {
           this.addMeValue(options, (resources[1] as RootResource).user);
         }
 


### PR DESCRIPTION
Since "me" does not make sense for a group filter, this MR excludes the mechanism to add it.

https://community.openproject.com/projects/openproject/work_packages/26725/activity