### PR TITLE
[27151] Fix label "Crowdin In-Context translation" in language selectors

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -387,21 +387,17 @@ module ApplicationHelper
              []
            end
 
-    mapped_languages = valid_languages.map { |lang|
-      [ll(lang.to_s, :general_lang_name), lang.to_s]
-    }
+    mapped_languages = valid_languages.map { |lang| translate_language(lang) }
 
-    auto + mapped_languages.sort { |x, y| x.last <=> y.last }
+    auto + mapped_languages.sort_by(&:last)
   end
 
   def all_lang_options_for_select(blank = true)
     initial_lang_options = blank ? [['(auto)', '']] : []
 
-    mapped_languages = all_languages.map { |lang|
-      [ll(lang.to_s, :general_lang_name), lang.to_s]
-    }
+    mapped_languages = all_languages.map { |lang| translate_language(lang) }
 
-    initial_lang_options + mapped_languages.sort { |x, y| x.last <=> y.last }
+    initial_lang_options + mapped_languages.sort_by(&:last)
   end
 
   def labelled_tabular_form_for(record, options = {}, &block)
@@ -597,6 +593,16 @@ module ApplicationHelper
   end
 
   private
+
+  def translate_language(lang_code)
+    # rename in-context translation language name for the language select box
+    if lang_code == Redmine::I18n::IN_CONTEXT_TRANSLATION_CODE &&
+       ::I18n.locale != Redmine::I18n::IN_CONTEXT_TRANSLATION_CODE
+      [Redmine::I18n::IN_CONTEXT_TRANSLATION_NAME, lang_code.to_s]
+    else
+      [ll(lang_code.to_s, :general_lang_name), lang_code.to_s]
+    end
+  end
 
   def wiki_helper
     helper = Redmine::WikiFormatting.helper_for(Setting.text_formatting)

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -67,6 +67,13 @@ See docs/COPYRIGHT.rdoc for more details.
         <% end %>
       <% end %>
     <% end %>
+    <% if ::I18n.locale == :lol #the in-context translation pseudo-language %>
+      <script type="text/javascript">
+        var _jipt = [];
+            _jipt.push(['project', 'openproject']);
+      </script>
+      <script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
+    <% end %>
   </head>
   <body class="<%= body_css_classes %>" data-relative_url_root="<%= root_path %>" ng-init="projectIdentifier = '<%= (@project.identifier rescue '') %>'">
     <noscript>

--- a/frontend/app/init-app.ts
+++ b/frontend/app/init-app.ts
@@ -45,7 +45,12 @@ requireGlobals.keys().forEach(requireGlobals);
 
 // load I18n, depending on the html element having a 'lang' attribute
 var documentLang = (angular.element('html').attr('lang') || 'en').toLowerCase();
-require('angular-i18n/angular-locale_' + documentLang + '.js');
+try {
+  require('angular-i18n/angular-locale_' + documentLang + '.js');
+}
+catch(e) {
+  require('angular-i18n/angular-locale_en.js');
+}
 
 import {openprojectModule} from './angular-modules';
 import CacheService = op.CacheService;

--- a/lib/redmine/i18n.rb
+++ b/lib/redmine/i18n.rb
@@ -29,6 +29,9 @@
 
 module Redmine
   module I18n
+    IN_CONTEXT_TRANSLATION_CODE = :lol
+    IN_CONTEXT_TRANSLATION_NAME = 'In-Context Crowdin Translation'.freeze
+
     def self.included(base)
       base.extend Redmine::I18n
     end


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/27151/activity

And load Crowdin’s JS if that language is activate, so that In-Context translation can begin.

!CAUTION WHEN MERGING after the SCP PR!:

- [ ] Check that `https://cdn.crowdin.com` and `https://crowdin.com` are both whitelisted in secure_headers configuration.
- [ ] make the new script tag in base.html.erb be _nonced_