### PR TITLE
use integer for primary key columns

### DIFF
--- a/db/migrate/000_aggregated_migrations.rb
+++ b/db/migrate/000_aggregated_migrations.rb
@@ -278,7 +278,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
   private
 
   def run_aggregated_migrations
-    create_table 'attachments', force: true do |t|
+    create_table 'attachments', force: true, id: :integer do |t|
       t.integer 'container_id',                 default: 0,  null: false
       t.string 'container_type', limit: 30, default: '', null: false
       t.string 'filename',                     default: '', null: false
@@ -296,7 +296,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'attachments', ['container_id', 'container_type'], name: 'index_attachments_on_container_id_and_container_type'
     add_index 'attachments', ['created_on'], name: 'index_attachments_on_created_on'
 
-    create_table 'auth_sources', force: true do |t|
+    create_table 'auth_sources', force: true, id: :integer do |t|
       t.string 'type',              limit: 30, default: '',    null: false
       t.string 'name',              limit: 60, default: '',    null: false
       t.string 'host',              limit: 60
@@ -314,7 +314,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
 
     add_index 'auth_sources', ['id', 'type'], name: 'index_auth_sources_on_id_and_type'
 
-    create_table 'boards', force: true do |t|
+    create_table 'boards', force: true, id: :integer do |t|
       t.integer 'project_id',                      null: false
       t.string 'name',            default: '', null: false
       t.string 'description'
@@ -327,7 +327,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'boards', ['last_message_id'], name: 'index_boards_on_last_message_id'
     add_index 'boards', ['project_id'], name: 'boards_project_id'
 
-    create_table 'changes', force: true do |t|
+    create_table 'changes', force: true, id: :integer do |t|
       t.integer 'changeset_id',                               null: false
       t.string 'action',        limit: 1, default: '', null: false
       t.text 'path',                                       null: false
@@ -339,7 +339,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
 
     add_index 'changes', ['changeset_id'], name: 'changesets_changeset_id'
 
-    create_table 'changesets', force: true do |t|
+    create_table 'changesets', force: true, id: :integer do |t|
       t.integer 'repository_id', null: false
       t.string 'revision',      null: false
       t.string 'committer'
@@ -363,7 +363,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
 
     add_index 'changesets_issues', ['changeset_id', 'issue_id'], name: 'changesets_issues_ids', unique: true
 
-    create_table 'comments', force: true do |t|
+    create_table 'comments', force: true, id: :integer do |t|
       t.string 'commented_type', limit: 30, default: '', null: false
       t.integer 'commented_id',                 default: 0,  null: false
       t.integer 'author_id',                    default: 0,  null: false
@@ -375,7 +375,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'comments', ['author_id'], name: 'index_comments_on_author_id'
     add_index 'comments', ['commented_id', 'commented_type'], name: 'index_comments_on_commented_id_and_commented_type'
 
-    create_table 'custom_fields', force: true do |t|
+    create_table 'custom_fields', force: true, id: :integer do |t|
       t.string 'type',            limit: 30, default: '',    null: false
       t.string 'name',            limit: 30, default: '',    null: false
       t.string 'field_format',    limit: 30, default: '',    null: false
@@ -409,7 +409,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
 
     add_index 'custom_fields_trackers', ['custom_field_id', 'tracker_id'], name: 'index_custom_fields_trackers_on_custom_field_id_and_tracker_id'
 
-    create_table 'custom_values', force: true do |t|
+    create_table 'custom_values', force: true, id: :integer do |t|
       t.string 'customized_type', limit: 30, default: '', null: false
       t.integer 'customized_id',                 default: 0,  null: false
       t.integer 'custom_field_id',               default: 0,  null: false
@@ -419,7 +419,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'custom_values', ['custom_field_id'], name: 'index_custom_values_on_custom_field_id'
     add_index 'custom_values', ['customized_type', 'customized_id'], name: 'custom_values_customized'
 
-    create_table 'documents', force: true do |t|
+    create_table 'documents', force: true, id: :integer do |t|
       t.integer 'project_id',                default: 0,  null: false
       t.integer 'category_id',               default: 0,  null: false
       t.string 'title',       limit: 60, default: '', null: false
@@ -431,14 +431,14 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'documents', ['created_on'], name: 'index_documents_on_created_on'
     add_index 'documents', ['project_id'], name: 'documents_project_id'
 
-    create_table 'enabled_modules', force: true do |t|
+    create_table 'enabled_modules', force: true, id: :integer do |t|
       t.integer 'project_id'
       t.string 'name',       null: false
     end
 
     add_index 'enabled_modules', ['project_id'], name: 'enabled_modules_project_id'
 
-    create_table 'enumerations', force: true do |t|
+    create_table 'enumerations', force: true, id: :integer do |t|
       t.string 'name',       limit: 30, default: '',    null: false
       t.integer 'position',                 default: 1
       t.boolean 'is_default',               default: false, null: false
@@ -458,7 +458,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
 
     add_index 'groups_users', ['group_id', 'user_id'], name: 'groups_users_ids', unique: true
 
-    create_table 'issue_categories', force: true do |t|
+    create_table 'issue_categories', force: true, id: :integer do |t|
       t.integer 'project_id',                   default: 0,  null: false
       t.string 'name',           limit: 30, default: '', null: false
       t.integer 'assigned_to_id'
@@ -467,7 +467,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'issue_categories', ['assigned_to_id'], name: 'index_issue_categories_on_assigned_to_id'
     add_index 'issue_categories', ['project_id'], name: 'issue_categories_project_id'
 
-    create_table 'issue_relations', force: true do |t|
+    create_table 'issue_relations', force: true, id: :integer do |t|
       t.integer 'issue_from_id',                 null: false
       t.integer 'issue_to_id',                   null: false
       t.string 'relation_type', default: '', null: false
@@ -477,7 +477,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'issue_relations', ['issue_from_id'], name: 'index_issue_relations_on_issue_from_id'
     add_index 'issue_relations', ['issue_to_id'], name: 'index_issue_relations_on_issue_to_id'
 
-    create_table 'issue_statuses', force: true do |t|
+    create_table 'issue_statuses', force: true, id: :integer do |t|
       t.string 'name',               limit: 30, default: '',    null: false
       t.boolean 'is_closed',                        default: false, null: false
       t.boolean 'is_default',                       default: false, null: false
@@ -489,7 +489,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'issue_statuses', ['is_default'], name: 'index_issue_statuses_on_is_default'
     add_index 'issue_statuses', ['position'], name: 'index_issue_statuses_on_position'
 
-    create_table 'issues', force: true do |t|
+    create_table 'issues', force: true, id: :integer do |t|
       t.integer 'tracker_id',       default: 0,  null: false
       t.integer 'project_id',       default: 0,  null: false
       t.string 'subject',          default: '', null: false
@@ -524,7 +524,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'issues', ['status_id'], name: 'index_issues_on_status_id'
     add_index 'issues', ['tracker_id'], name: 'index_issues_on_tracker_id'
 
-    create_table 'journal_details', force: true do |t|
+    create_table 'journal_details', force: true, id: :integer do |t|
       t.integer 'journal_id',               default: 0,  null: false
       t.string 'property',   limit: 30, default: '', null: false
       t.string 'prop_key',   limit: 30, default: '', null: false
@@ -534,7 +534,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
 
     add_index 'journal_details', ['journal_id'], name: 'journal_details_journal_id'
 
-    create_table 'journals', force: true do |t|
+    create_table 'journals', force: true, id: :integer do |t|
       t.integer 'journaled_id',  default: 0, null: false
       t.integer 'user_id',       default: 0, null: false
       t.text 'notes'
@@ -553,7 +553,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'journals', ['type'], name: 'index_journals_on_type'
     add_index 'journals', ['user_id'], name: 'index_journals_on_user_id'
 
-    create_table 'member_roles', force: true do |t|
+    create_table 'member_roles', force: true, id: :integer do |t|
       t.integer 'member_id',      null: false
       t.integer 'role_id',        null: false
       t.integer 'inherited_from'
@@ -562,7 +562,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'member_roles', ['member_id'], name: 'index_member_roles_on_member_id'
     add_index 'member_roles', ['role_id'], name: 'index_member_roles_on_role_id'
 
-    create_table 'members', force: true do |t|
+    create_table 'members', force: true, id: :integer do |t|
       t.integer 'user_id',           default: 0,     null: false
       t.integer 'project_id',        default: 0,     null: false
       t.datetime 'created_on'
@@ -573,7 +573,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'members', ['user_id', 'project_id'], name: 'index_members_on_user_id_and_project_id', unique: true
     add_index 'members', ['user_id'], name: 'index_members_on_user_id'
 
-    create_table 'messages', force: true do |t|
+    create_table 'messages', force: true, id: :integer do |t|
       t.integer 'board_id',                         null: false
       t.integer 'parent_id'
       t.string 'subject',       default: '',    null: false
@@ -593,7 +593,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'messages', ['last_reply_id'], name: 'index_messages_on_last_reply_id'
     add_index 'messages', ['parent_id'], name: 'messages_parent_id'
 
-    create_table 'news', force: true do |t|
+    create_table 'news', force: true, id: :integer do |t|
       t.integer 'project_id'
       t.string 'title',          limit: 60, default: '', null: false
       t.string 'summary',                      default: ''
@@ -607,7 +607,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'news', ['created_on'], name: 'index_news_on_created_on'
     add_index 'news', ['project_id'], name: 'news_project_id'
 
-    create_table 'open_id_authentication_associations', force: true do |t|
+    create_table 'open_id_authentication_associations', force: true, id: :integer do |t|
       t.integer 'issued'
       t.integer 'lifetime'
       t.string 'handle'
@@ -616,13 +616,13 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
       t.binary 'secret'
     end
 
-    create_table 'open_id_authentication_nonces', force: true do |t|
+    create_table 'open_id_authentication_nonces', force: true, id: :integer do |t|
       t.integer 'timestamp',  null: false
       t.string 'server_url'
       t.string 'salt',       null: false
     end
 
-    create_table 'projects', force: true do |t|
+    create_table 'projects', force: true, id: :integer do |t|
       t.string 'name',        default: '',   null: false
       t.text 'description'
       t.string 'homepage',    default: ''
@@ -647,7 +647,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'projects_trackers', ['project_id', 'tracker_id'], name: 'projects_trackers_unique', unique: true
     add_index 'projects_trackers', ['project_id'], name: 'projects_trackers_project_id'
 
-    create_table 'queries', force: true do |t|
+    create_table 'queries', force: true, id: :integer do |t|
       t.integer 'project_id'
       t.string 'name',          default: '',    null: false
       t.text 'filters'
@@ -661,7 +661,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'queries', ['project_id'], name: 'index_queries_on_project_id'
     add_index 'queries', ['user_id'], name: 'index_queries_on_user_id'
 
-    create_table 'repositories', force: true do |t|
+    create_table 'repositories', force: true, id: :integer do |t|
       t.integer 'project_id',                  default: 0,  null: false
       t.string 'url',                         default: '', null: false
       t.string 'login',         limit: 60, default: ''
@@ -674,7 +674,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
 
     add_index 'repositories', ['project_id'], name: 'index_repositories_on_project_id'
 
-    create_table 'roles', force: true do |t|
+    create_table 'roles', force: true, id: :integer do |t|
       t.string 'name',        limit: 30, default: '',   null: false
       t.integer 'position',                  default: 1
       t.boolean 'assignable',                default: true
@@ -682,7 +682,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
       t.text 'permissions'
     end
 
-    create_table 'settings', force: true do |t|
+    create_table 'settings', force: true, id: :integer do |t|
       t.string 'name',       default: '', null: false
       t.text 'value'
       t.datetime 'updated_on'
@@ -690,7 +690,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
 
     add_index 'settings', ['name'], name: 'index_settings_on_name'
 
-    create_table 'time_entries', force: true do |t|
+    create_table 'time_entries', force: true, id: :integer do |t|
       t.integer 'project_id',  null: false
       t.integer 'user_id',     null: false
       t.integer 'issue_id'
@@ -711,7 +711,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'time_entries', ['project_id'], name: 'time_entries_project_id'
     add_index 'time_entries', ['user_id'], name: 'index_time_entries_on_user_id'
 
-    create_table 'tokens', force: true do |t|
+    create_table 'tokens', force: true, id: :integer do |t|
       t.integer 'user_id',                  default: 0,  null: false
       t.string 'action',     limit: 30, default: '', null: false
       t.string 'value',      limit: 40, default: '', null: false
@@ -720,14 +720,14 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
 
     add_index 'tokens', ['user_id'], name: 'index_tokens_on_user_id'
 
-    create_table 'trackers', force: true do |t|
+    create_table 'trackers', force: true, id: :integer do |t|
       t.string 'name',          limit: 30, default: '',    null: false
       t.boolean 'is_in_chlog',                 default: false, null: false
       t.integer 'position',                    default: 1
       t.boolean 'is_in_roadmap',               default: true,  null: false
     end
 
-    create_table 'user_preferences', force: true do |t|
+    create_table 'user_preferences', force: true, id: :integer do |t|
       t.integer 'user_id',   default: 0,     null: false
       t.text 'others'
       t.boolean 'hide_mail', default: false
@@ -736,7 +736,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
 
     add_index 'user_preferences', ['user_id'], name: 'index_user_preferences_on_user_id'
 
-    create_table 'users', force: true do |t|
+    create_table 'users', force: true, id: :integer do |t|
       t.string 'login',             limit: 30, default: '',    null: false
       t.string 'hashed_password',   limit: 40, default: '',    null: false
       t.string 'firstname',         limit: 30, default: '',    null: false
@@ -759,7 +759,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'users', ['id', 'type'], name: 'index_users_on_id_and_type'
     add_index 'users', ['type'], name: 'index_users_on_type'
 
-    create_table 'versions', force: true do |t|
+    create_table 'versions', force: true, id: :integer do |t|
       t.integer 'project_id',      default: 0,      null: false
       t.string 'name',            default: '',     null: false
       t.string 'description',     default: ''
@@ -775,7 +775,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'versions', ['project_id'], name: 'versions_project_id'
     add_index 'versions', ['sharing'], name: 'index_versions_on_sharing'
 
-    create_table 'watchers', force: true do |t|
+    create_table 'watchers', force: true, id: :integer do |t|
       t.string 'watchable_type', default: '', null: false
       t.integer 'watchable_id',   default: 0,  null: false
       t.integer 'user_id'
@@ -785,7 +785,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'watchers', ['user_id'], name: 'index_watchers_on_user_id'
     add_index 'watchers', ['watchable_id', 'watchable_type'], name: 'index_watchers_on_watchable_id_and_watchable_type'
 
-    create_table 'wiki_content_versions', force: true do |t|
+    create_table 'wiki_content_versions', force: true, id: :integer do |t|
       t.integer 'wiki_content_id',                                        null: false
       t.integer 'page_id',                                                null: false
       t.integer 'author_id'
@@ -799,7 +799,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'wiki_content_versions', ['updated_on'], name: 'index_wiki_content_versions_on_updated_on'
     add_index 'wiki_content_versions', ['wiki_content_id'], name: 'wiki_content_versions_wcid'
 
-    create_table 'wiki_contents', force: true do |t|
+    create_table 'wiki_contents', force: true, id: :integer do |t|
       t.integer 'page_id',                              null: false
       t.integer 'author_id'
       t.text 'text',         limit: 16.megabytes
@@ -810,7 +810,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'wiki_contents', ['author_id'], name: 'index_wiki_contents_on_author_id'
     add_index 'wiki_contents', ['page_id'], name: 'wiki_contents_page_id'
 
-    create_table 'wiki_pages', force: true do |t|
+    create_table 'wiki_pages', force: true, id: :integer do |t|
       t.integer 'wiki_id',                       null: false
       t.string 'title',                         null: false
       t.datetime 'created_on',                    null: false
@@ -822,7 +822,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'wiki_pages', ['wiki_id', 'title'], name: 'wiki_pages_wiki_id_title'
     add_index 'wiki_pages', ['wiki_id'], name: 'index_wiki_pages_on_wiki_id'
 
-    create_table 'wiki_redirects', force: true do |t|
+    create_table 'wiki_redirects', force: true, id: :integer do |t|
       t.integer 'wiki_id',      null: false
       t.string 'title'
       t.string 'redirects_to'
@@ -832,7 +832,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
     add_index 'wiki_redirects', ['wiki_id', 'title'], name: 'wiki_redirects_wiki_id_title'
     add_index 'wiki_redirects', ['wiki_id'], name: 'index_wiki_redirects_on_wiki_id'
 
-    create_table 'wikis', force: true do |t|
+    create_table 'wikis', force: true, id: :integer do |t|
       t.integer 'project_id',                null: false
       t.string 'start_page',                null: false
       t.integer 'status',     default: 1, null: false
@@ -840,7 +840,7 @@ class AggregatedMigrations < ActiveRecord::Migration[5.1]
 
     add_index 'wikis', ['project_id'], name: 'wikis_project_id'
 
-    create_table 'workflows', force: true do |t|
+    create_table 'workflows', force: true, id: :integer do |t|
       t.integer 'tracker_id',    default: 0,     null: false
       t.integer 'old_status_id', default: 0,     null: false
       t.integer 'new_status_id', default: 0,     null: false

--- a/db/migrate/20120529090411_create_delayed_jobs.rb
+++ b/db/migrate/20120529090411_create_delayed_jobs.rb
@@ -29,7 +29,7 @@
 
 class CreateDelayedJobs < ActiveRecord::Migration[5.1]
   def self.up
-    create_table :delayed_jobs, force: true do |table|
+    create_table :delayed_jobs, force: true, id: :integer do |table|
       table.integer :priority, default: 0      # Allows some jobs to jump to the front of the queue
       table.integer :attempts, default: 0      # Provides for retries, but still fail eventually.
       table.text :handler                      # YAML-encoded string of the object that will do work

--- a/db/migrate/20120731135140_create_wiki_menu_items.rb
+++ b/db/migrate/20120731135140_create_wiki_menu_items.rb
@@ -29,7 +29,7 @@
 
 class CreateWikiMenuItems < ActiveRecord::Migration[5.1]
   def self.up
-    create_table :wiki_menu_items do |t|
+    create_table :wiki_menu_items, id: :integer do |t|
       t.column :name, :string
       t.column :title, :string
       t.column :parent_id, :integer

--- a/db/migrate/20121114100641_aggregated_announcements_migrations.rb
+++ b/db/migrate/20121114100641_aggregated_announcements_migrations.rb
@@ -12,7 +12,7 @@ class AggregatedAnnouncementsMigrations < ActiveRecord::Migration[5.1]
   def up
     migration_names = OpenProject::Plugins::MigrationMapping.migration_files_to_migration_names(MIGRATION_FILES, OLD_PLUGIN_NAME)
     Migration::MigrationSquasher.squash(migration_names) do
-      create_table :announcements do |t|
+      create_table :announcements, id: :integer do |t|
         t.text :text
         t.date :show_until
         t.boolean :active, default: false

--- a/db/migrate/20130409133701_create_timelines_project_types.rb
+++ b/db/migrate/20130409133701_create_timelines_project_types.rb
@@ -29,7 +29,7 @@
 
 class CreateTimelinesProjectTypes < ActiveRecord::Migration[5.1]
   def self.up
-    create_table(:timelines_project_types) do |t|
+    create_table(:timelines_project_types, id: :integer) do |t|
       t.column :name,               :string,  default: '',   null: false
       t.column :allows_association, :boolean, default: true, null: false
       t.column :position,           :integer, default: 1,    null: false

--- a/db/migrate/20130409133702_create_timelines_planning_element_types.rb
+++ b/db/migrate/20130409133702_create_timelines_planning_element_types.rb
@@ -29,7 +29,7 @@
 
 class CreateTimelinesPlanningElementTypes < ActiveRecord::Migration[5.1]
   def self.up
-    create_table(:timelines_planning_element_types) do |t|
+    create_table(:timelines_planning_element_types, id: :integer) do |t|
       t.column :name,         :string,  null: false
 
       t.column :in_aggregation, :boolean, default: true,  null: false

--- a/db/migrate/20130409133703_create_timelines_planning_elements.rb
+++ b/db/migrate/20130409133703_create_timelines_planning_elements.rb
@@ -29,7 +29,7 @@
 
 class CreateTimelinesPlanningElements < ActiveRecord::Migration[5.1]
   def self.up
-    create_table(:timelines_planning_elements) do |t|
+    create_table(:timelines_planning_elements, id: :integer) do |t|
       t.column :name,        :string,  null: false
       t.column :description, :text
       t.column :planning_element_status_comment, :text

--- a/db/migrate/20130409133704_create_timelines_scenarios.rb
+++ b/db/migrate/20130409133704_create_timelines_scenarios.rb
@@ -29,7 +29,7 @@
 
 class CreateTimelinesScenarios < ActiveRecord::Migration[5.1]
   def self.up
-    create_table(:timelines_scenarios) do |t|
+    create_table(:timelines_scenarios, id: :integer) do |t|
       t.column :name,        :string, null: false
       t.column :description, :text
 

--- a/db/migrate/20130409133705_create_timelines_alternate_dates.rb
+++ b/db/migrate/20130409133705_create_timelines_alternate_dates.rb
@@ -29,7 +29,7 @@
 
 class CreateTimelinesAlternateDates < ActiveRecord::Migration[5.1]
   def self.up
-    create_table(:timelines_alternate_dates) do |t|
+    create_table(:timelines_alternate_dates, id: :integer) do |t|
       t.column :start_date, :date, null: false
       t.column :end_date,   :date, null: false
 

--- a/db/migrate/20130409133707_create_timelines_colors.rb
+++ b/db/migrate/20130409133707_create_timelines_colors.rb
@@ -29,7 +29,7 @@
 
 class CreateTimelinesColors < ActiveRecord::Migration[5.1]
   def self.up
-    create_table(:timelines_colors) do |t|
+    create_table(:timelines_colors, id: :integer) do |t|
       t.column :name,    :string, null: false
       t.column :hexcode, :string, null: false, length: 7
 

--- a/db/migrate/20130409133708_create_timelines_reportings.rb
+++ b/db/migrate/20130409133708_create_timelines_reportings.rb
@@ -29,7 +29,7 @@
 
 class CreateTimelinesReportings < ActiveRecord::Migration[5.1]
   def self.up
-    create_table(:timelines_reportings) do |t|
+    create_table(:timelines_reportings, id: :integer) do |t|
       t.column :reported_project_status_comment, :text
 
       t.belongs_to :project

--- a/db/migrate/20130409133709_create_timelines_available_project_statuses.rb
+++ b/db/migrate/20130409133709_create_timelines_available_project_statuses.rb
@@ -29,7 +29,7 @@
 
 class CreateTimelinesAvailableProjectStatuses < ActiveRecord::Migration[5.1]
   def self.up
-    create_table(:timelines_available_project_statuses) do |t|
+    create_table(:timelines_available_project_statuses, id: :integer) do |t|
       t.belongs_to :project_type
       t.belongs_to :reported_project_status, index: { name: 'index_avail_project_statuses_on_rep_project_status_id' }
 

--- a/db/migrate/20130409133710_create_timelines_project_associations.rb
+++ b/db/migrate/20130409133710_create_timelines_project_associations.rb
@@ -29,7 +29,7 @@
 
 class CreateTimelinesProjectAssociations < ActiveRecord::Migration[5.1]
   def self.up
-    create_table(:timelines_project_associations) do |t|
+    create_table(:timelines_project_associations, id: :integer) do |t|
       t.belongs_to :project_a
       t.belongs_to :project_b
 

--- a/db/migrate/20130409133711_create_timelines_enabled_planning_element_types.rb
+++ b/db/migrate/20130409133711_create_timelines_enabled_planning_element_types.rb
@@ -29,7 +29,7 @@
 
 class CreateTimelinesEnabledPlanningElementTypes < ActiveRecord::Migration[5.1]
   def self.up
-    create_table :timelines_enabled_planning_element_types do |t|
+    create_table :timelines_enabled_planning_element_types, id: :integer do |t|
       t.belongs_to :project
       t.belongs_to :planning_element_type, index: { name: 'index_enabled_pe_types_on_pe_type_id' }
 

--- a/db/migrate/20130409133712_create_timelines_default_planning_element_types.rb
+++ b/db/migrate/20130409133712_create_timelines_default_planning_element_types.rb
@@ -29,7 +29,7 @@
 
 class CreateTimelinesDefaultPlanningElementTypes < ActiveRecord::Migration[5.1]
   def self.up
-    create_table :timelines_default_planning_element_types do |t|
+    create_table :timelines_default_planning_element_types, id: :integer do |t|
       t.belongs_to :project_type, index: { name: 'index_default_pe_types_on_project_type_id' }
       t.belongs_to :planning_element_type, index: { name: 'index_default_pe_types_on_pe_type_id' }
 

--- a/db/migrate/20130409133715_create_timelines_timelines.rb
+++ b/db/migrate/20130409133715_create_timelines_timelines.rb
@@ -29,7 +29,7 @@
 
 class CreateTimelinesTimelines < ActiveRecord::Migration[5.1]
   def self.up
-    create_table :timelines_timelines do |t|
+    create_table :timelines_timelines, id: :integer do |t|
       t.column :name,        :string,  null: false
       t.column :content,     :text
 

--- a/db/migrate/20130619081234_create_user_passwords.rb
+++ b/db/migrate/20130619081234_create_user_passwords.rb
@@ -34,7 +34,7 @@ class CreateUserPasswords < ActiveRecord::Migration[5.1]
   end
 
   def up
-    create_table :user_passwords do |t|
+    create_table :user_passwords, id: :integer do |t|
       t.integer :user_id, null: false
       t.string :hashed_password, limit: 40
       t.string :salt, limit: 64

--- a/db/migrate/20130620082322_create_work_packages.rb
+++ b/db/migrate/20130620082322_create_work_packages.rb
@@ -29,7 +29,7 @@
 
 class CreateWorkPackages < ActiveRecord::Migration[5.1]
   def up
-    create_table 'work_packages' do |t|
+    create_table 'work_packages', id: :integer do |t|
       # Issue
       t.column :tracker_id, :integer, default: 0, null: false
       t.column :project_id, :integer

--- a/db/migrate/20130807082645_create_normalized_journals.rb
+++ b/db/migrate/20130807082645_create_normalized_journals.rb
@@ -29,7 +29,7 @@
 
 class CreateNormalizedJournals < ActiveRecord::Migration[5.1]
   def change
-    create_table :journals do |t|
+    create_table :journals, id: :integer do |t|
       t.references :journable, polymorphic: true
       t.references :journable_data, polymorphic: true
       t.integer :user_id, default: 0, null: false

--- a/db/migrate/20130807083715_create_attachment_journals.rb
+++ b/db/migrate/20130807083715_create_attachment_journals.rb
@@ -29,7 +29,7 @@
 
 class CreateAttachmentJournals < ActiveRecord::Migration[5.1]
   def change
-    create_table :attachment_journals do |t|
+    create_table :attachment_journals, id: :integer do |t|
       t.integer :journal_id,                                   null: false
       t.integer :container_id,                 default: 0,  null: false
       t.string :container_type, limit: 30, default: '', null: false

--- a/db/migrate/20130807084417_create_work_package_journals.rb
+++ b/db/migrate/20130807084417_create_work_package_journals.rb
@@ -29,7 +29,7 @@
 
 class CreateWorkPackageJournals < ActiveRecord::Migration[5.1]
   def change
-    create_table :work_package_journals do |t|
+    create_table :work_package_journals, id: :integer do |t|
       t.integer :journal_id,                                      null: false
       t.integer :type_id,                         default: 0,  null: false
       t.integer :project_id,                      default: 0,  null: false

--- a/db/migrate/20130807084708_create_message_journals.rb
+++ b/db/migrate/20130807084708_create_message_journals.rb
@@ -29,7 +29,7 @@
 
 class CreateMessageJournals < ActiveRecord::Migration[5.1]
   def change
-    create_table :message_journals do |t|
+    create_table :message_journals, id: :integer do |t|
       t.integer :journal_id,                       null: false
       t.integer :board_id,                         null: false
       t.integer :parent_id

--- a/db/migrate/20130807085108_create_news_journals.rb
+++ b/db/migrate/20130807085108_create_news_journals.rb
@@ -29,7 +29,7 @@
 
 class CreateNewsJournals < ActiveRecord::Migration[5.1]
   def change
-    create_table :news_journals do |t|
+    create_table :news_journals, id: :integer do |t|
       t.integer :journal_id,                                   null: false
       t.integer :project_id
       t.string :title,          limit: 60, default: '', null: false

--- a/db/migrate/20130807085245_create_wiki_content_journals.rb
+++ b/db/migrate/20130807085245_create_wiki_content_journals.rb
@@ -29,7 +29,7 @@
 
 class CreateWikiContentJournals < ActiveRecord::Migration[5.1]
   def change
-    create_table :wiki_content_journals do |t|
+    create_table :wiki_content_journals, id: :integer do |t|
       t.integer :journal_id,                         null: false
       t.integer :page_id,                            null: false
       t.integer :author_id

--- a/db/migrate/20130807085430_create_time_entry_journals.rb
+++ b/db/migrate/20130807085430_create_time_entry_journals.rb
@@ -29,7 +29,7 @@
 
 class CreateTimeEntryJournals < ActiveRecord::Migration[5.1]
   def change
-    create_table :time_entry_journals do |t|
+    create_table :time_entry_journals, id: :integer do |t|
       t.integer :journal_id,      null: false
       t.integer :project_id,      null: false
       t.integer :user_id,         null: false

--- a/db/migrate/20130807085714_create_changeset_journals.rb
+++ b/db/migrate/20130807085714_create_changeset_journals.rb
@@ -29,7 +29,7 @@
 
 class CreateChangesetJournals < ActiveRecord::Migration[5.1]
   def change
-    create_table :changeset_journals do |t|
+    create_table :changeset_journals, id: :integer do |t|
       t.integer :journal_id,    null: false
       t.integer :repository_id, null: false
       t.string :revision,      null: false

--- a/db/migrate/20130813062401_add_attachable_journal.rb
+++ b/db/migrate/20130813062401_add_attachable_journal.rb
@@ -29,7 +29,7 @@
 
 class AddAttachableJournal < ActiveRecord::Migration[5.1]
   def change
-    create_table :attachable_journals do |t|
+    create_table :attachable_journals, id: :integer do |t|
       t.integer :journal_id, null: false
       t.integer :attachment_id, null: false
       t.string :filename, default: '', null: false

--- a/db/migrate/20130813062513_add_customizable_journal.rb
+++ b/db/migrate/20130813062513_add_customizable_journal.rb
@@ -29,7 +29,7 @@
 
 class AddCustomizableJournal < ActiveRecord::Migration[5.1]
   def change
-    create_table :customizable_journals do |t|
+    create_table :customizable_journals, id: :integer do |t|
       t.integer :journal_id, null: false
       t.integer :custom_field_id, null: false
       t.string :value, :default_value

--- a/db/migrate/20130814130142_remove_documents.rb
+++ b/db/migrate/20130814130142_remove_documents.rb
@@ -51,7 +51,7 @@ class RemoveDocuments < ActiveRecord::Migration[5.1]
 
   def down
     unless ActiveRecord::Base.connection.table_exists? 'Documents'
-      create_table 'documents', force: true do |t|
+      create_table 'documents', force: true, id: :integer do |t|
         t.integer 'project_id',                default: 0,  null: false
         t.integer 'category_id',               default: 0,  null: false
         t.string 'title',       limit: 60, default: '', null: false

--- a/db/migrate/20130828093647_remove_alternate_dates_and_scenarios.rb
+++ b/db/migrate/20130828093647_remove_alternate_dates_and_scenarios.rb
@@ -34,7 +34,7 @@ class RemoveAlternateDatesAndScenarios < ActiveRecord::Migration[5.1]
   end
 
   def down
-    create_table(:scenarios) do |t|
+    create_table(:scenarios, id: :integer) do |t|
       t.column :name,        :string, null: false
       t.column :description, :text
 
@@ -45,7 +45,7 @@ class RemoveAlternateDatesAndScenarios < ActiveRecord::Migration[5.1]
 
     add_index :scenarios, :project_id
 
-    create_table(:alternate_dates) do |t|
+    create_table(:alternate_dates, id: :integer) do |t|
       t.column :start_date, :date, null: false
       t.column :due_date,   :date, null: false
 

--- a/db/migrate/20140122161742_remove_journal_columns.rb
+++ b/db/migrate/20140122161742_remove_journal_columns.rb
@@ -101,7 +101,7 @@ class RemoveJournalColumns < ActiveRecord::Migration[5.1]
       t.string :default_value
     end
 
-    create_table :journal_details do |t|
+    create_table :journal_details, id: :integer do |t|
       t.integer :journal_id,               default: 0,  null: false
       t.string :property,   limit: 30, default: '', null: false
       t.string :prop_key,   limit: 30, default: '', null: false

--- a/db/migrate/20140411142338_clear_identity_urls_on_users.rb
+++ b/db/migrate/20140411142338_clear_identity_urls_on_users.rb
@@ -28,7 +28,7 @@
 
 class ClearIdentityUrlsOnUsers < ActiveRecord::Migration[5.1]
   def up
-    create_table 'legacy_user_identity_urls' do |t|
+    create_table 'legacy_user_identity_urls', id: :integer do |t|
       t.string 'login', limit: 256, default: '',    null: false
       t.string 'identity_url'
     end

--- a/db/migrate/20140414141459_remove_openid_entirely.rb
+++ b/db/migrate/20140414141459_remove_openid_entirely.rb
@@ -33,7 +33,7 @@ class RemoveOpenidEntirely < ActiveRecord::Migration[5.1]
   end
 
   def down
-    create_table 'open_id_authentication_associations', force: true do |t|
+    create_table 'open_id_authentication_associations', force: true, id: :integer do |t|
       t.integer 'issued'
       t.integer 'lifetime'
       t.string 'handle'
@@ -42,7 +42,7 @@ class RemoveOpenidEntirely < ActiveRecord::Migration[5.1]
       t.binary 'secret'
     end
 
-    create_table 'open_id_authentication_nonces', force: true do |t|
+    create_table 'open_id_authentication_nonces', force: true, id: :integer do |t|
       t.integer 'timestamp',  null: false
       t.string 'server_url'
       t.string 'salt',       null: false

--- a/db/migrate/20140429152018_add_sessions_table.rb
+++ b/db/migrate/20140429152018_add_sessions_table.rb
@@ -28,7 +28,7 @@
 
 class AddSessionsTable < ActiveRecord::Migration[5.1]
   def change
-    create_table :sessions do |t|
+    create_table :sessions, id: :integer do |t|
       t.string :session_id, null: false
       t.text :data
       t.timestamps

--- a/db/migrate/20160907113604_normalize_permissions.rb
+++ b/db/migrate/20160907113604_normalize_permissions.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class NormalizePermissions < ActiveRecord::Migration[5.0]
+class NormalizePermissions < ActiveRecord::Migration[5.1]
   class Role < ActiveRecord::Base
     self.table_name = :roles
 
@@ -41,7 +41,7 @@ class NormalizePermissions < ActiveRecord::Migration[5.0]
   end
 
   def up
-    create_table :role_permissions do |p|
+    create_table :role_permissions, id: :integer do |p|
       p.string :permission
       p.integer :role_id
 

--- a/db/migrate/20161102160032_create_enterprise_token.rb
+++ b/db/migrate/20161102160032_create_enterprise_token.rb
@@ -1,6 +1,6 @@
-class CreateEnterpriseToken < ActiveRecord::Migration[5.0]
+class CreateEnterpriseToken < ActiveRecord::Migration[5.1]
   def change
-    create_table :enterprise_tokens do |t|
+    create_table :enterprise_tokens, id: :integer do |t|
       t.text :encoded_token
 
       t.timestamps

--- a/db/migrate/20161116130657_create_custom_styles.rb
+++ b/db/migrate/20161116130657_create_custom_styles.rb
@@ -1,6 +1,6 @@
-class CreateCustomStyles < ActiveRecord::Migration[5.0]
+class CreateCustomStyles < ActiveRecord::Migration[5.1]
   def change
-    create_table :custom_styles do |t|
+    create_table :custom_styles, id: :integer do |t|
       t.string :logo
 
       t.timestamps

--- a/db/migrate/20170116105342_add_custom_options.rb
+++ b/db/migrate/20170116105342_add_custom_options.rb
@@ -32,7 +32,7 @@
 # If a custom field has no possible values then arbitrary values
 # are allowed which may be further restriced by other means other than
 # specific values.
-class AddCustomOptions < ActiveRecord::Migration[5.0]
+class AddCustomOptions < ActiveRecord::Migration[5.1]
   require 'globalize'
 
   class OldCustomField < ActiveRecord::Base
@@ -51,7 +51,7 @@ class AddCustomOptions < ActiveRecord::Migration[5.0]
   end
 
   def up
-    create_table table_name do |t|
+    create_table table_name, id: :integer do |t|
       t.integer :custom_field_id
       t.integer :position
       t.boolean :default_value

--- a/db/migrate/20170117112648_create_design_colors.rb
+++ b/db/migrate/20170117112648_create_design_colors.rb
@@ -1,6 +1,6 @@
-class CreateDesignColors < ActiveRecord::Migration[5.0]
+class CreateDesignColors < ActiveRecord::Migration[5.1]
   def change
-    create_table :design_colors do |t|
+    create_table :design_colors, id: :integer do |t|
       t.string :variable
       t.string :hexcode
 

--- a/db/migrate/20170703075208_add_attribute_help_texts.rb
+++ b/db/migrate/20170703075208_add_attribute_help_texts.rb
@@ -1,6 +1,6 @@
-class AddAttributeHelpTexts < ActiveRecord::Migration[5.0]
+class AddAttributeHelpTexts < ActiveRecord::Migration[5.1]
   def change
-    create_table :attribute_help_texts do |t|
+    create_table :attribute_help_texts, id: :integer do |t|
       t.text :help_text, null: false
       t.string :type, null: false
       t.string :attribute_name, null: false

--- a/db/migrate/20171106074835_move_hashed_token_to_core.rb
+++ b/db/migrate/20171106074835_move_hashed_token_to_core.rb
@@ -1,4 +1,4 @@
-class MoveHashedTokenToCore < ActiveRecord::Migration[5.0]
+class MoveHashedTokenToCore < ActiveRecord::Migration[5.1]
   class OldToken < ActiveRecord::Base
     self.table_name = :plaintext_tokens
   end
@@ -17,7 +17,7 @@ class MoveHashedTokenToCore < ActiveRecord::Migration[5.0]
   private
 
   def create_tokens_table
-    create_table :tokens do |t|
+    create_table :tokens, id: :integer do |t|
       t.references :user, index: true
       t.string :type
       t.string :value, default: "", null: false, limit: 128

--- a/db/migrate/20180116065518_add_hierarchy_paths.rb
+++ b/db/migrate/20180116065518_add_hierarchy_paths.rb
@@ -28,9 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddHierarchyPaths < ActiveRecord::Migration[5.0]
+class AddHierarchyPaths < ActiveRecord::Migration[5.1]
   def change
-    create_table :hierarchy_paths do |t|
+    create_table :hierarchy_paths, id: :integer do |t|
       t.belongs_to :work_package, index: { unique: true }
       # (255 * 3) = ca 767 bytes is the max length for an index in mysql 5.6 InnoDB
       t.string :path, null: false, limit: 255

--- a/db/migrate/20180117065255_remove_timelines_and_reportings.rb
+++ b/db/migrate/20180117065255_remove_timelines_and_reportings.rb
@@ -49,7 +49,7 @@ class RemoveTimelinesAndReportings < ActiveRecord::Migration[5.0]
   private
 
   def create_reportings
-    create_table(:reportings) do |t|
+    create_table(:reportings, id: :integer) do |t|
       t.column :reported_project_status_comment, :text
 
       t.belongs_to :project
@@ -61,7 +61,7 @@ class RemoveTimelinesAndReportings < ActiveRecord::Migration[5.0]
   end
 
   def create_timelines
-    create_table :timelines do |t|
+    create_table :timelines, id: :integer do |t|
       t.column :name, :string, null: false
       t.column :options, :text
 
@@ -72,7 +72,7 @@ class RemoveTimelinesAndReportings < ActiveRecord::Migration[5.0]
   end
 
   def create_available_project_statuses
-    create_table(:available_project_statuses) do |t|
+    create_table(:available_project_statuses, id: :integer) do |t|
       t.belongs_to :project_type
       t.belongs_to :reported_project_status, index: { name: 'index_avail_project_statuses_on_rep_project_status_id' }
 

--- a/db/migrate/20180123092002_add_custom_actions.rb
+++ b/db/migrate/20180123092002_add_custom_actions.rb
@@ -1,26 +1,26 @@
-class AddCustomActions < ActiveRecord::Migration[5.0]
+class AddCustomActions < ActiveRecord::Migration[5.1]
   def change
-    create_table :custom_actions do |t|
+    create_table :custom_actions, id: :integer do |t|
       t.string :name
       t.text :actions
     end
 
-    create_table :custom_actions_statuses do |t|
+    create_table :custom_actions_statuses, id: :integer do |t|
       t.belongs_to :status
       t.belongs_to :custom_action
     end
 
-    create_table :custom_actions_roles do |t|
+    create_table :custom_actions_roles, id: :integer do |t|
       t.belongs_to :role
       t.belongs_to :custom_action
     end
 
-    create_table :custom_actions_types do |t|
+    create_table :custom_actions_types, id: :integer do |t|
       t.belongs_to :type
       t.belongs_to :custom_action
     end
 
-    create_table :custom_actions_projects do |t|
+    create_table :custom_actions_projects, id: :integer do |t|
       t.belongs_to :project
       t.belongs_to :custom_action
     end


### PR DESCRIPTION
Rails 5.1 uses bigint(20) as the default for primary key columns (id typically) when it used to be int(11) up until Rails 5.0. While it might make sense to change to bigint in the long run, we can not do this by altering the old migrations as existing installations would not profit from the change.

We therefore force using int(11) for all old, and potentially already executed, migrations.