### PR TITLE
Fix/speedup wp scheduling

### DIFF
--- a/app/models/work_package/parent.rb
+++ b/app/models/work_package/parent.rb
@@ -101,9 +101,8 @@ module WorkPackage::Parent
 
   def parent_from_id
     if @parent_id
-      @parent_object = WorkPackage.find(@parent_id)
       set_virtual_attribute_was('parent_id', @parent_id)
-      @parent_object
+      @parent_object = WorkPackage.find(@parent_id)
     end
   end
 end

--- a/app/models/work_package/parent.rb
+++ b/app/models/work_package/parent.rb
@@ -95,7 +95,7 @@ module WorkPackage::Parent
   def parent_from_relation
     if parent_relation && ((@parent_id && parent_relation.from.id == @parent_id) || !@parent_id)
       set_virtual_attribute_was('parent_id', parent_relation.from_id)
-      parent_relation.from
+      @parent_object = parent_relation.from
     end
   end
 


### PR DESCRIPTION
By memoizing the parent_object when fetched from the relation, we avoid having to query for it multiple times when building the tree for scheduling a work package.

In setups where 400 work packages make up a single tree, this change saves about 6 seconds (of a total of 10 seconds) when adding yet another work package to the tree. While this is still not perfect, the gains for one change to a single line of code are tremendous.

*Call stack before*
![image](https://user-images.githubusercontent.com/617519/37606599-2158e8a6-2b96-11e8-9771-6e59d9d0df55.png)

*Call stack after*
![image](https://user-images.githubusercontent.com/617519/37606631-3861ef2a-2b96-11e8-9938-2318d6824363.png)
