### PR TITLE
Fix/speedup wp scheduling 7.4

### DIFF
--- a/app/models/work_package/parent.rb
+++ b/app/models/work_package/parent.rb
@@ -116,7 +116,7 @@ module WorkPackage::Parent
 
   def parent_from_relation
     if parent_relation && ((@parent_id && parent_relation.from.id == @parent_id) || !@parent_id)
-      parent_relation.from
+      @parent_object = parent_relation.from
     end
   end
 


### PR DESCRIPTION
We do memoize the object when fetching it via the id so we should also do this here.

On setup, where 400 work packages are part of a tree, this saves about 6 seconds when adding another work package to the tree.