### PR TITLE
Move crowdin CSP into separate helper to override CSP at runtime

### DIFF
--- a/app/helpers/crowdin_helper.rb
+++ b/app/helpers/crowdin_helper.rb
@@ -1,0 +1,25 @@
+module CrowdinHelper
+  def crowdin_in_context_translation
+    return unless OpenProject::Configuration.crowdin_in_context_translations?
+    return unless ::I18n.locale == :lol
+
+    # Enable CSP to load the following script by whitelisting for this request.
+    # This will be slower than manually adding it to the initializer, but we wouldn't want to
+    # allow cdn.crowdin.com for users without in context translations.
+    controller.append_content_security_policy_directives(
+      # initial script and setup API calls
+      script_src: %w(cdn.crowdin.com crowdin.com),
+      # Form action to crowdin, github etc.
+      form_action: %w(https:),
+      # Iframe
+      frame_src: %w(crowdin.com),
+      # CSS loaded from cdn
+      style_src: %w(cdn.crowdin.com)
+    )
+
+    concat(nonced_javascript_tag do
+      "var _jipt = []; _jipt.push(['project', 'openproject']);".html_safe
+    end)
+    concat javascript_include_tag 'https://cdn.crowdin.com/jipt/jipt.js'
+  end
+end

--- a/app/helpers/crowdin_helper.rb
+++ b/app/helpers/crowdin_helper.rb
@@ -10,7 +10,11 @@ module CrowdinHelper
       # initial script and setup API calls
       script_src: %w(cdn.crowdin.com crowdin.com),
       # Form action to crowdin, github etc.
-      form_action: %w(https:),
+      form_action: %w[https://crowdin.com
+                      https://accounts.google.com
+                      https://api.twitter.com
+                      https://github.com
+                      https://gitlab.com],
       # Iframe
       frame_src: %w(crowdin.com),
       # CSS loaded from cdn

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -67,13 +67,7 @@ See docs/COPYRIGHT.rdoc for more details.
         <% end %>
       <% end %>
     <% end %>
-    <% if OpenProject::Configuration.crowdin_in_context_translations? && ::I18n.locale == :lol #the in-context translation pseudo-language %>
-      <%= nonced_javascript_tag do %>
-        var _jipt = [];
-            _jipt.push(['project', 'openproject']);
-      <% end %>
-      <script type="text/javascript" src="https://cdn.crowdin.com/jipt/jipt.js"></script>
-    <% end %>
+    <%= crowdin_in_context_translation %>
   </head>
   <body class="<%= body_css_classes %>" data-relative_url_root="<%= root_path %>" ng-init="projectIdentifier = '<%= (@project.identifier rescue '') %>'">
     <noscript>

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -23,7 +23,7 @@ SecureHeaders::Configuration.default do |config|
     preserve_schemes: true,
 
     # Fallback when no value is defined
-    default_src: %w(https: 'self'),
+    default_src: %w('self'),
     # Allowed uri in <base> tag
     base_uri: %w('self'),
 

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -19,12 +19,6 @@ SecureHeaders::Configuration.default do |config|
   # Valid for iframes
   frame_src = ["'self'"]
 
-  # Allow in-context translations iframe and sources if enabled
-  if OpenProject::Configuration.crowdin_in_context_translations?
-    assets_src += %w[https://cdn.crowdin.com https://crowdin.com]
-    frame_src << 'https://crowdin.com'
-  end
-
   config.csp = {
     preserve_schemes: true,
 


### PR DESCRIPTION
Crowdin requires a lot more additions to the CSP whitelist when its activated. This PR thus avoids having cdn.crowdin.com allowed in the script-src even if the user doesnt use in-context translations. 

Note: Activating the in context translations yields a console error due to zone.js. This seems to originate from an asset loaded in the crowdin iframe that sets `window.Zone`. I couldn't find any issue however, so I chose to ignore it:

```
application.js:1565 Uncaught Error: Zone already loaded.
    at VM2665 application.js:1565
    at VM2665 application.js:1565
    at VM2665 application.js:1537
...
```