### PR TITLE
[27425] Breadcrumb misplaced in FF

### DIFF
--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -88,7 +88,7 @@ ul.breadcrumb
 .wp-breadcrumb
   ul.breadcrumb li
     float: left
-    margin: 0 0 0 10px
+    margin: 0 5px 0 0
     padding: 0
 
 .wp-breadcrumb

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -50,7 +50,7 @@ module BreadcrumbHelper
                     end
         content_tag(:li,
                     h(element.to_s),
-                    class: "#{css_class} icon-context icon-small icon-arrow-right5")
+                    class: "#{css_class} icon4 icon-small icon-arrow-right5")
       end
     }
 


### PR DESCRIPTION
Avoid misalignment in FF

https://community.openproject.com/projects/openproject/work_packages/27425/activity

#### Before
![bildschirmfoto 2018-04-06 um 13 57 21](https://user-images.githubusercontent.com/7457313/38423414-25dd2948-39ae-11e8-9633-7dc57f93db96.png)

#### After
<img width="231" alt="bildschirmfoto 2018-04-06 um 14 01 19" src="https://user-images.githubusercontent.com/7457313/38423429-310d6f30-39ae-11e8-8278-23f789409dfa.png">
