### PR TITLE
[27427] Breadcrumb missing in Admin/Custom Actions area

### DIFF
--- a/app/controllers/custom_actions_controller.rb
+++ b/app/controllers/custom_actions_controller.rb
@@ -111,4 +111,16 @@ class CustomActionsController < ApplicationController
     params[:custom_action][:conditions] ||= {}
     params[:custom_action][:actions] ||= {}
   end
+
+  def default_breadcrumb
+    if action_name == 'index'
+      t('custom_actions.plural')
+    else
+      ActionController::Base.helpers.link_to(t('custom_actions.plural'), custom_actions_path)
+    end
+  end
+
+  def show_local_breadcrumb
+    true
+  end
 end


### PR DESCRIPTION
Show breadcrumb in Admin --> Custom Actions

https://community.openproject.com/projects/openproject/work_packages/27427/activity