### PR TITLE
improve performance of relation query

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -144,8 +144,12 @@ class Relation < ActiveRecord::Base
   end
 
   def self.from_work_package_or_ancestors(work_package)
-    where(from_id: work_package.ancestors_relations.select(:from_id))
-      .or(where(from_id: work_package.id))
+    ancestor_or_self_ids = work_package
+                           .ancestors_relations
+                           .or(where(from_id: work_package.id))
+                           .select(:from_id)
+
+    where(from_id: ancestor_or_self_ids)
   end
 
   def self.from_parent_to_self_and_descendants(work_package)


### PR DESCRIPTION
By restructuring the `or` to be within the subselect, the query engine is able to filter down on the relations way more efficient than before.

As this query is used within WP scheduling, changes to the dates are more performant now. On my setup with about 500k relations on MySql, the change saved about 500ms