### PR TITLE
[27460] WP context menu misplaced when opened via keyboard

### DIFF
--- a/frontend/app/components/op-context-menu/op-context-menu-handler.ts
+++ b/frontend/app/components/op-context-menu/op-context-menu-handler.ts
@@ -32,7 +32,7 @@ export abstract class OpContextMenuHandler {
     return {
       my: 'left top',
       at: 'right bottom',
-      of: openerEvent
+      of: this.$element
     };
   }
 


### PR DESCRIPTION
Render menu in correct place even on enter

https://community.openproject.com/projects/openproject/work_packages/27460/activity