### PR TITLE
[27461] Disabled menu items are not disabled for screenreader

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -173,6 +173,7 @@ en:
     label_not_equals: "is not"
     label_on: "on"
     label_open_menu: "Open menu"
+    label_open_context_menu: "Open context menu"
     label_open_work_packages: "open"
     label_password: "Password"
     label_previous: "Previous"

--- a/frontend/app/components/op-context-menu/op-context-menu.html
+++ b/frontend/app/components/op-context-menu/op-context-menu.html
@@ -11,7 +11,7 @@
            tabindex="0"
            [ngClass]="{ 'inactive': item.disabled }"
            [attr.href]="item.href || ''"
-           [attr.disabled]="item.disabled"
+           [attr.aria-disabled]="item.disabled"
            [attr.aria-label]="item.ariaLabel || item.linkText"
            (keydown.enter)="handleClick(item, $event)"
            (click)="handleClick(item, $event)">

--- a/frontend/app/components/wp-table/table-actions/actions/context-menu-table-action.ts
+++ b/frontend/app/components/wp-table/table-actions/actions/context-menu-table-action.ts
@@ -10,10 +10,15 @@ export class OpContextMenuTableAction extends OpTableAction {
 
   public readonly identifier = 'open-context-menu-action';
 
+  private text = {
+    linkTitle: this.I18n.t('js.label_open_context_menu')
+  };
+
   public buildElement() {
     let contextMenu = document.createElement('a');
     contextMenu.href = '#';
     contextMenu.classList.add(contextMenuLinkClassName, contextColumnIcon);
+    contextMenu.title = this.text.linkTitle;
     contextMenu.appendChild(opIconElement('icon', 'icon-show-more-horizontal'));
 
     return contextMenu;


### PR DESCRIPTION
Add labels for screenreader. Next to the disabled links in the more menu, the context menu within the WP table got a link.

https://community.openproject.com/projects/openproject/work_packages/27461/activity