### PR TITLE
remove members restriction from view_members

### DIFF
--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -59,8 +59,7 @@ Redmine::AccessControl.map do |map|
                  require: :member
 
   map.permission :view_members,
-                 { members: [:index] },
-                 require: :member
+                 { members: [:index] }
 
   map.permission :manage_versions,
                  { project_settings: [:show],


### PR DESCRIPTION
That way, an admin can decide to allow users having the non members or anonymous role to see members in a project.

https://community.openproject.com/projects/openproject/work_packages/27492