### PR TITLE
Misplaced WP breadcrumb (FF)

### DIFF
--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -105,9 +105,6 @@ ul.breadcrumb
       &:first-child
         &:before
           display: none
-      &.icon-arrow-right5:before
-        padding-right: 8px
-
 
 // This is ugly. However, this way we do not need to touch complicated
 // toolbar-container positioning.

--- a/frontend/app/components/work-packages/wp-breadcrumb/wp-breadcrumb.html
+++ b/frontend/app/components/work-packages/wp-breadcrumb/wp-breadcrumb.html
@@ -2,14 +2,14 @@
      *ngIf="workPackage && workPackage.ancestors.length > 0">
   <ul class="breadcrumb">
     <li *ngFor="let ancestor of workPackage.ancestors"
-        class="icon-context icon-small icon-arrow-right5">
+        class="icon4 icon-small icon-arrow-right5">
       <a [attr.title]="ancestor.name"
          [textContent]="ancestor.name"
          uiSref="work-packages.show.activity"
          [uiParams]="{workPackageId: ancestor.id}"
          class="breadcrumb-project-title nocut"></a>
     </li>
-    <li class="icon-context icon-small icon-arrow-right5"
+    <li class="icon4 icon-small icon-arrow-right5"
         [textContent]="workPackage.name"></li>
   </ul>
 </div>


### PR DESCRIPTION
Similar to https://github.com/opf/openproject/pull/6253 this PR corrects the display of breadcrumb arrows in FF. In the other PR the WP breadcrumb was forgotten.