### PR TITLE
Rework helper to auto-include wysiwig in tab builder when requested

### DIFF
--- a/app/cells/views/settings/text_setting/show.erb
+++ b/app/cells/views/settings/text_setting/show.erb
@@ -33,7 +33,6 @@
             container_class: '-wide'
           )
         %>
-        <%= wikitoolbar_for "settings-#{name}-#{lang}" %>
       </div>
     </div>
   </div>

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -436,8 +436,7 @@ class WikiController < ApplicationController
   # Returns the default content of a new wiki page
   def initial_page_content(page)
     helper = OpenProject::TextFormatting::Formatters.helper_for(Setting.text_formatting)
-    extend helper unless self.instance_of?(helper)
-    helper.instance_method(:initial_page_content).bind(self).call(page)
+    helper.initial_page_content page
   end
 
   def load_pages_for_index

--- a/app/helpers/text_formatting_helper.rb
+++ b/app/helpers/text_formatting_helper.rb
@@ -32,6 +32,7 @@ module TextFormattingHelper
   def_delegators :current_formatting_helper,
                  :text_formatting_has_preview?,
                  :text_formatting_js_includes,
+                 :initial_page_content,
                  :wikitoolbar_for,
                  :heads_for_wiki_formatter
 
@@ -55,8 +56,7 @@ module TextFormattingHelper
   private
 
   def current_formatting_helper
-    helper = OpenProject::TextFormatting::Formatters.helper_for(Setting.text_formatting)
-    extend helper
-    self
+    helper_class = OpenProject::TextFormatting::Formatters.helper_for(Setting.text_formatting)
+    helper_class.new(self)
   end
 end

--- a/app/views/projects/form/attributes/_description.html.erb
+++ b/app/views/projects/form/attributes/_description.html.erb
@@ -29,8 +29,9 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <div class="form--field">
   <%= form.text_area :description,
+                     id: :project_description,
+                     with_text_formatting: true,
                      rows: 5,
                      class: 'wiki-edit',
                      container_class: '-wide' %>
 </div>
-<%= wikitoolbar_for 'project_description' %>

--- a/app/views/settings/_general.html.erb
+++ b/app/views/settings/_general.html.erb
@@ -63,8 +63,13 @@ See docs/COPYRIGHT.rdoc for more details.
       <legend class="form--fieldset-legend"><%= t(:setting_welcome_text) %></legend>
       <div class="form--field"><%= setting_text_field :welcome_title, size: 30, container_class: '-wide' %></div>
       <div class="form--field">
-        <%= setting_text_area :welcome_text, cols: 60, rows: 5, class: 'wiki-edit', container_class: '-wide' %>
-        <%= wikitoolbar_for 'settings_welcome_text' %>
+        <%= setting_text_area :welcome_text,
+                              cols: 60,
+                              rows: 5,
+                              class: 'wiki-edit',
+                              id: 'settings_welcome_text',
+                              with_text_formatting: true,
+                              container_class: '-wide' %>
       </div>
       <div class="form--field"><%= setting_check_box :welcome_on_homescreen %></div>
       <div class="form--field"><%= setting_check_box :welcome_on_projects_page %></div>

--- a/lib/open_project/form_tag_helper.rb
+++ b/lib/open_project/form_tag_helper.rb
@@ -73,8 +73,24 @@ module OpenProject
     def styled_text_area_tag(name, content = nil, options = {})
       apply_css_class_to_options(options, 'form--text-area')
       wrap_field 'text-area', options do
-        text_area_tag(name, content, options)
+        output = text_area_tag(name, content, options)
+
+        if options[:with_text_formatting]
+          output << text_formatting_wrapper(options[:id])
+        end
+
+        output
       end
+    end
+
+    ##
+    # Create a wrapper for the text formatting toolbar for this field
+    def text_formatting_wrapper(target_id)
+      return ''.html_safe unless target_id.present?
+
+      format = Setting.text_formatting
+      helper = ::OpenProject::TextFormatting::Formatters.helper_for(format).new(self)
+      helper.wikitoolbar_for target_id
     end
 
     def styled_check_box_tag(name, value = '1', checked = false, options = {})

--- a/lib/open_project/text_formatting/formatters/markdown/helper.rb
+++ b/lib/open_project/text_formatting/formatters/markdown/helper.rb
@@ -29,9 +29,16 @@
 
 module OpenProject::TextFormatting::Formatters
   module Markdown
-    module Helper
+    class Helper
+      attr_reader :view_context
+
+      def initialize(view_context)
+        @view_context = view_context
+      end
+
+
       def text_formatting_js_includes
-        javascript_include_tag 'vendor/ckeditor/ckeditor.js'
+        view_context.javascript_include_tag 'vendor/ckeditor/ckeditor.js'
       end
 
       def text_formatting_has_preview?
@@ -39,11 +46,11 @@ module OpenProject::TextFormatting::Formatters
       end
 
       def wikitoolbar_for(field_id)
-        content_tag 'op-ckeditor-form', '', 'textarea-selector': "##{field_id}"
+        view_context.content_tag 'op-ckeditor-form', '', 'textarea-selector': "##{field_id}"
       end
 
-      def initial_page_content(_page)
-        "h1. #{@page.title}"
+      def self.initial_page_content(page)
+        "# #{page.title}"
       end
     end
   end

--- a/lib/open_project/text_formatting/formatters/plain/helper.rb
+++ b/lib/open_project/text_formatting/formatters/plain/helper.rb
@@ -29,8 +29,9 @@
 
 module OpenProject::TextFormatting::Formatters
   module Plain
-    module Helper
+    class Helper
       def wikitoolbar_for(_field_id)
+        ''.html_safe
       end
 
       def text_formatting_has_preview?
@@ -40,10 +41,7 @@ module OpenProject::TextFormatting::Formatters
       def text_formatting_js_includes
       end
 
-      def heads_for_wiki_formatter
-      end
-
-      def initial_page_content(page)
+      def self.initial_page_content(page)
         page.title.to_s
       end
     end

--- a/lib/open_project/text_formatting/formatters/textile/helper.rb
+++ b/lib/open_project/text_formatting/formatters/textile/helper.rb
@@ -29,7 +29,14 @@
 
 module OpenProject::TextFormatting::Formatters
   module Textile
-    module Helper
+    class Helper
+
+      attr_reader :view_context
+
+      def initialize(view_context)
+        @view_context = view_context
+      end
+
       def text_formatting_js_includes
         # TODO Nothing to do here yet, since the js_toolbar is still part of application
       end
@@ -39,31 +46,30 @@ module OpenProject::TextFormatting::Formatters
       end
 
       def wikitoolbar_for(field_id)
-        heads_for_wiki_formatter
-        help_button = content_tag :button,
-                                  '',
-                                  type: 'button',
-                                  class: 'jstb_help formatting-help-link-button',
-                                  :'aria-label' => ::I18n.t('js.inplace.link_formatting_help'),
-                                  title: ::I18n.t('js.inplace.link_formatting_help')
+        help_button = view_context.content_tag(
+          :button,
+          '',
+          type: 'button',
+          class: 'jstb_help formatting-help-link-button',
+          :'aria-label' => ::I18n.t('js.inplace.link_formatting_help'),
+          title: ::I18n.t('js.inplace.link_formatting_help')
+        )
 
-        nonced_javascript_tag(<<-EOF)
-              // initialSetup the toolbar later, so that i18n-js has a chance to set the translations
-              // for the wiki-buttons first.
-              jQuery(document).ready(function(){
-                var wikiToolbar = new jsToolBar(document.getElementById('#{field_id}'));
 
-                wikiToolbar.setHelpLink(jQuery('#{escape_javascript help_button}')[0]);
-                wikiToolbar.draw();
-              });
-        EOF
+        view_context.content_for(:additional_js_dom_ready) do
+          %(
+              var wikiToolbar = new jsToolBar(document.getElementById('#{field_id}'));
+
+              wikiToolbar.setHelpLink(jQuery('#{view_context.escape_javascript help_button}')[0]);
+              wikiToolbar.draw();
+            ).html_safe
+        end
+
+        ''.html_safe
       end
 
-      def initial_page_content(_page)
-        "h1. #{@page.title}"
-      end
-
-      def heads_for_wiki_formatter
+      def self.initial_page_content(page)
+        "h1. #{page.title}"
       end
     end
   end

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -45,6 +45,10 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
       label = label_for_field(field, label_options)
       input = super(field, input_options, *args)
 
+      if options[:with_text_formatting]
+        input.concat text_formatting_wrapper options[:id]
+      end
+
       (label + container_wrap_field(input, selector, options))
     end
   end
@@ -168,6 +172,16 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     classes.strip
   end
 
+  ##
+  # Create a wrapper for the text formatting toolbar for this field
+  def text_formatting_wrapper(target_id)
+    return ''.html_safe unless target_id.present?
+
+    format = Setting.text_formatting
+    helper = ::OpenProject::TextFormatting::Formatters.helper_for(format).new(@template)
+    helper.wikitoolbar_for target_id
+  end
+
   def field_css_class(selector)
     if TEXT_LIKE_FIELDS.include?(selector)
       "form--text-field -#{selector.to_s.gsub(/_field$/, '')}"
@@ -196,7 +210,9 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
     label_for_field_prefix(content, options)
 
     label_options[:lang] = options[:lang]
-    label_options.reject! do |_k, v| v.nil? end
+    label_options.reject! do |_k, v|
+      v.nil?
+    end
 
     @template.label(@object_name, field, content, label_options)
   end

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -187,6 +187,26 @@ describe TabularFormBuilder do
 JJ Abrams</textarea>
       }).at_path('textarea')
     end
+
+    context 'when requesting a text formatting wrapper', with_settings: { text_formatting: :markdown } do
+      let(:options) { { title: 'Name', class: 'custom-class', with_text_formatting: true } }
+
+      context 'an id is missing' do
+        it 'does not output the wrapper' do
+          expect(output).to have_selector 'textarea'
+          expect(output).to have_no_selector 'op-ckeditor-form'
+        end
+      end
+
+      context 'with id present' do
+        let(:options) { { id: 'my-id', title: 'Name', class: 'custom-class', with_text_formatting: true } }
+
+        it 'outputs the wysiwyg wrapper' do
+          expect(output).to have_selector 'textarea'
+          expect(output).to have_selector 'op-ckeditor-form'
+        end
+      end
+    end
   end
 
   describe '#select' do


### PR DESCRIPTION
This fixes the position of the wysiwig editor when used in combination with the tab builder