### PR TITLE
[27576] Conflict-check only main wiki items from same project

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -256,7 +256,7 @@ class WikiController < ApplicationController
 
   def wiki_root_menu_items
     MenuItems::WikiMenuItem
-      .where(parent_id: nil)
+      .main_items(@wiki.id)
       .map { |it| OpenStruct.new name: it.name, caption: it.title, item: it }
   end
 


### PR DESCRIPTION
The wiki renaming feature includes a check for duplicate menu items
since https://github.com/opf/openproject/pull/4866.

However this check tests for ALL wiki menu items in all projects, while
we only need to check for items in the current project

https://community.openproject.com/wp/27576