### PR TITLE
[27462] Pass wiki title to new page if it does not exist

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -135,7 +135,7 @@ class WikiController < ApplicationController
     if @page.new_record?
       if User.current.allowed_to?(:edit_wiki_pages, @project) && editable?
         edit
-        render action: 'edit'
+        render action: 'new'
       else
         render_404
       end
@@ -403,7 +403,7 @@ class WikiController < ApplicationController
   private
 
   def wiki_page_title
-    params[:id]
+    params[:title] || params[:id]
   end
 
   def find_wiki

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -283,15 +283,22 @@ module OpenProject
             page = CGI.unescapeHTML(page)
             # check if page exists
             wiki_page = link_project.wiki.find_page(page)
-            wiki_title = wiki_page.nil? ? page : wiki_page.title
+            default_wiki_title = wiki_page.nil? ? page : wiki_page.title
+            wiki_title = title || default_wiki_title
             url = case options[:wiki_links]
                   when :local; "#{title}.html"
                   when :anchor; "##{title}"   # used for single-file wiki export
                   else
                     wiki_page_id = wiki_page.nil? ? page.to_url : wiki_page.slug
-                    url_for(only_path: only_path, controller: '/wiki', action: 'show', project_id: link_project, id: wiki_page_id, anchor: anchor)
+                    url_for(only_path: only_path,
+                            controller: '/wiki',
+                            action: 'show',
+                            project_id: link_project,
+                            id: wiki_page_id,
+                            title: wiki_page.nil? ? wiki_title.strip : nil,
+                            anchor: anchor)
               end
-            link_to(h(title || wiki_title), url, class: ('wiki-page' + (wiki_page ? '' : ' new')))
+            link_to(h(wiki_title), url, class: ('wiki-page' + (wiki_page ? '' : ' new')))
           else
             # project or wiki doesn't exist
             all

--- a/spec/features/security/angular_xss_spec.rb
+++ b/spec/features/security/angular_xss_spec.rb
@@ -116,7 +116,7 @@ describe 'Angular expression escaping', type: :feature do
     let(:content) { find '#content_text' }
     let(:preview) { find '#preview' }
     let(:btn_preview) { find '#wiki_form-preview' }
-    let(:btn_cancel) { find '#wiki_form a.button', text: I18n.t(:button_cancel) }
+    let(:btn_save) { find '.button.-highlight', text: I18n.t(:button_save) }
 
     before do
       login_as(user)
@@ -130,7 +130,7 @@ describe 'Angular expression escaping', type: :feature do
       expect(preview.text).not_to include '{{ $root.DOUBLE_LEFT_CURLY_BRACE }}'
       expect(preview.text).to match /\{\{[\s\w]+\}\}/
 
-      btn_cancel.click
+      btn_save.click
     end
   end
 

--- a/spec/lib/open_project/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting_spec.rb
@@ -440,13 +440,13 @@ describe OpenProject::TextFormatting do
       context 'Wiki link to an unknown page' do
         subject { format_text('[[Unknown page]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page new\" href=\"/projects/#{project.identifier}/wiki/unknown-page\">Unknown page</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page new\" href=\"/projects/#{project.identifier}/wiki/unknown-page?title=Unknown+page\">Unknown page</a></p>") }
       end
 
       context 'Wiki page link to an unknown page' do
         subject { format_text('[[Unknown page|404]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page new\" href=\"/projects/#{project.identifier}/wiki/unknown-page\">404</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page new\" href=\"/projects/#{project.identifier}/wiki/unknown-page?title=404\">404</a></p>") }
       end
 
       context "Link to another project's wiki" do
@@ -476,7 +476,7 @@ describe OpenProject::TextFormatting do
       context 'Link to an unknown wiki page in another project' do
         subject { format_text('[[onlinestore:Unknown page]]') }
 
-        it { is_expected.to be_html_eql("<p><a class=\"wiki-page new\" href=\"/projects/onlinestore/wiki/unknown-page\">Unknown page</a></p>") }
+        it { is_expected.to be_html_eql("<p><a class=\"wiki-page new\" href=\"/projects/onlinestore/wiki/unknown-page?title=Unknown+page\">Unknown page</a></p>") }
       end
 
       context 'Struck through link to wiki page' do

--- a/spec_legacy/functional/wiki_controller_spec.rb
+++ b/spec_legacy/functional/wiki_controller_spec.rb
@@ -91,7 +91,7 @@ describe WikiController, type: :controller do
     session[:user_id] = 2
     get :show, params: { project_id: 1, id: 'Unexistent page' }
     assert_response :success
-    assert_template 'edit'
+    assert_template 'new'
   end
 
   it 'should create page' do

--- a/spec_legacy/unit/helpers/application_helper_spec.rb
+++ b/spec_legacy/unit/helpers/application_helper_spec.rb
@@ -347,7 +347,7 @@ EXPECTED
     FactoryGirl.create :wiki_page_with_content, wiki: @project.wiki, title: 'Last page'
 
     to_test = { "|[[Page|Link title]]|[[Other Page|Other title]]|\n|Cell 21|[[Last page]]|" =>
-                 "<tr><td><a class=\"wiki-page new\" href=\"/projects/#{@project.identifier}/wiki/page\">Link title</a></td>" +
+                 "<tr><td><a class=\"wiki-page new\" href=\"/projects/#{@project.identifier}/wiki/page?title=Link+title\">Link title</a></td>" +
                  "<td><a class=\"wiki-page\" href=\"/projects/#{@project.identifier}/wiki/other-page\">Other title</a></td>" +
                  "</tr><tr><td>Cell 21</td><td><a class=\"wiki-page\" href=\"/projects/#{@project.identifier}/wiki/last-page\">Last page</a></td></tr>"
     }


### PR DESCRIPTION
When creating a wiki page from the text with, e.g., `[[Foo Bar]]`, the user gets redirected to wiki#show for a page `foo-bar` (the slug of the title above).

He thus loses the title attribute he entered previously. Instead we can pass the title to the new wiki page IFF the page does not exist.

https://community.openproject.com/wp/27462