### PR TITLE
[27684] Embedded tables not aligned with group header

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_table_embedded.sass
+++ b/app/assets/stylesheets/layout/_work_package_table_embedded.sass
@@ -29,6 +29,8 @@
 // Disable CSS containment in the embedded container
 // unless we're setting an external height with overflow, containment will not work.
 .work-packages-embedded-view--container
+  margin-left: -6px
+
   .work-package-table--container
     contain: initial !important
 
@@ -56,3 +58,6 @@
     .wp-table--context-menu-td,
     .wp-table--context-menu-th
       width: 25px
+
+wp-query-group .wp-relations-create-button
+  margin-left: -6px


### PR DESCRIPTION
Move embedded tables to the left to cancel out the padding of the table headers.

https://community.openproject.com/projects/deutsche-bahn/work_packages/27684/activity