### PR TITLE
Set query id on initialisation.

### DIFF
--- a/frontend/app/components/wp-query-menu/wp-query-menu.ng2.test.ts
+++ b/frontend/app/components/wp-query-menu/wp-query-menu.ng2.test.ts
@@ -70,7 +70,7 @@ describe('wp-query-menu', () => {
         WpQueryMenuTestComponent
       ],
       providers: [
-        { provide: $stateToken, useValue: { go: (...args:any[]) => undefined } },
+        { provide: $stateToken, useValue: { params: { query_id: null }, go: (...args:any[]) => undefined } },
         { provide: WorkPackagesListChecksumService, useValue: { clear: () => undefined } },
         { provide: TransitionService, useValue: $transitionStub },
         QueryMenuService,

--- a/frontend/app/components/wp-query-menu/wp-query-menu.service.ts
+++ b/frontend/app/components/wp-query-menu/wp-query-menu.service.ts
@@ -73,6 +73,7 @@ export class QueryMenuService {
 
   public initialize() {
     this.container = jQuery('#main-menu-work-packages').parent().find('ul.menu-children');
+    this.onQueryIdChanged(this.$state.params['query_id']);
   }
 
   /**


### PR DESCRIPTION
After moving the menu item directive(?) to a service the initial selection of WP queries was broken. This fixes this by setting it during initialisation 