### PR TITLE
[27677] Better html titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -322,21 +322,6 @@ module ApplicationHelper
     end
   end
 
-  def html_title(*args)
-    title = []
-
-    if args.empty?
-      title << h(@project.name) if @project
-      title += @html_title if @html_title
-    else
-      @html_title ||= []
-      @html_title += args
-      title += @html_title
-    end
-
-    title.select { |t| !t.blank? }.join(' - ').html_safe
-  end
-
   # Returns the theme, controller name, and action as css classes for the
   # HTML body.
   def body_css_classes

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -1,0 +1,62 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module MetaTagsHelper
+
+  ##
+  # Use meta-tags to output title and site name
+  def output_title_and_meta_tags
+
+    display_meta_tags site: Setting.app_title,
+                      title: html_title_parts,
+                      separator: ' | ', # Update the TitleService when changing this!
+                      reverse: true
+  end
+
+  ##
+  # Writer of html_title as string
+  def html_title(*args)
+    title = []
+
+    raise "Don't use html_title getter" if args.empty?
+
+    @html_title ||= []
+    @html_title += args
+  end
+
+  ##
+  # The html title parts currently defined
+  def html_title_parts
+    [].tap do |parts|
+      parts << h(@project.name) if @project
+      parts.concat @html_title if @html_title
+    end
+  end
+end

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -33,7 +33,6 @@ module MetaTagsHelper
   ##
   # Use meta-tags to output title and site name
   def output_title_and_meta_tags
-
     display_meta_tags site: Setting.app_title,
                       title: html_title_parts,
                       separator: ' | ', # Update the TitleService when changing this!
@@ -56,7 +55,7 @@ module MetaTagsHelper
   def html_title_parts
     [].tap do |parts|
       parts << h(@project.name) if @project
-      parts.concat @html_title if @html_title
+      parts.concat @html_title.map(&:to_s) if @html_title
     end
   end
 end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -31,7 +31,7 @@ See docs/COPYRIGHT.rdoc for more details.
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width">
-    <%= display_meta_tags site: Setting.app_title, title: html_title %>
+    <%= output_title_and_meta_tags %>
 
     <meta name="app_base_path" content="<%= OpenProject::Configuration['rails_relative_url_root'] || '' %>" />
     <% if @project %>

--- a/app/views/layouts/help.html.erb
+++ b/app/views/layouts/help.html.erb
@@ -29,7 +29,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
   <head>
-    <title><%= h html_title %></title>
+    <%= output_title_and_meta_tags %>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <%= nonced_style_tag do %>
       <%= yield(:styles) %>

--- a/app/views/timelog/index.html.erb
+++ b/app/views/timelog/index.html.erb
@@ -60,7 +60,7 @@ See docs/COPYRIGHT.rdoc for more details.
     <% end %>
   <% end %>
 </div>
-<% html_title l(:label_spent_time), l(:label_details) %>
+<% html_title l(:label_spent_time) %>
 <% content_for :header_tags do %>
   <%= auto_discovery_link_tag(:atom, {issue_id: @issue, format: 'atom', key: User.current.rss_key}, title: l(:label_spent_time)) %>
 <% end %>

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -394,7 +394,6 @@ en:
         grouping_other: "Other"
         noneSelection: "(none)"
       name: "Name"
-      new_work_package: "New work package"
       outline: "Reset Outline"
       outlines:
         aggregation: "Show aggregations only"
@@ -486,10 +485,13 @@ en:
       inline_create:
        title: 'Click here to add a new work package to this list'
       create:
+        title: 'New work package'
         header: 'New %{type}'
         header_no_type: 'New work package (Type not yet set)'
         header_with_parent: 'New %{type} (Child of %{parent_type} #%{id})'
         button: 'Create'
+      copy:
+        title: 'Copy work package'
       hierarchy:
         show: "Show hierarchy mode"
         hide: "Hide hierarchy mode"

--- a/frontend/app/angular4-modules.ts
+++ b/frontend/app/angular4-modules.ts
@@ -220,6 +220,7 @@ import {WpDestroyModal} from "core-components/modals/wp-destroy-modal/wp-destroy
 import {FocusWithinDirective} from "core-components/common/focus/focus-within.upgraded.directive";
 import {AccessibleClickDirective} from "core-components/a11y/accessible-click.directive";
 import {WorkPackageChildrenQueryComponent} from 'core-components/wp-relations/wp-relation-children/wp-children-query.component';
+import {OpTitleService} from 'core-components/html/op-title.service';
 
 @NgModule({
   imports: [
@@ -249,6 +250,7 @@ import {WorkPackageChildrenQueryComponent} from 'core-components/wp-relations/wp
     FocusHelperService,
     PathHelperService,
     upgradeServiceWithToken('wpMoreMenuService', wpMoreMenuServiceToken),
+    OpTitleService,
     TimezoneService,
     upgradeService('wpRelations', WorkPackageRelationsService),
     UrlParamsHelperService,

--- a/frontend/app/components/html/op-title.service.ts
+++ b/frontend/app/components/html/op-title.service.ts
@@ -5,7 +5,7 @@ const titlePartsSeparator = ' | ';
 
 @Injectable()
 export class OpTitleService {
-  constructor(readonly titleService:Title) {
+  constructor(private titleService:Title) {
 
   }
 

--- a/frontend/app/components/html/op-title.service.ts
+++ b/frontend/app/components/html/op-title.service.ts
@@ -1,0 +1,27 @@
+import {Title} from "@angular/platform-browser";
+import {Injectable} from "@angular/core";
+
+const titlePartsSeparator = ' | ';
+
+@Injectable()
+export class OpTitleService {
+  constructor(readonly titleService:Title) {
+
+  }
+
+  public get current():string {
+    return this.titleService.getTitle();
+  }
+
+  public get titleParts():string[] {
+    return this.current.split(titlePartsSeparator);
+  }
+
+  public setFirstPart(value:string) {
+    let parts = this.titleParts;
+    parts[0] = value;
+
+    this.titleService.setTitle(parts.join(titlePartsSeparator));
+  }
+
+}

--- a/frontend/app/components/routing/wp-view-base/wp-view-base.controller.ts
+++ b/frontend/app/components/routing/wp-view-base/wp-view-base.controller.ts
@@ -39,6 +39,7 @@ import {KeepTabService} from '../../wp-single-view-tabs/keep-tab/keep-tab.servic
 import {WorkPackageTableRefreshService} from '../../wp-table/wp-table-refresh-request.service';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {ProjectCacheService} from 'core-components/projects/project-cache.service';
+import {OpTitleService} from 'core-components/html/op-title.service';
 
 export class WorkPackageViewController implements OnDestroy {
 
@@ -61,6 +62,8 @@ export class WorkPackageViewController implements OnDestroy {
 
   protected focusAnchorLabel:string;
   public showStaticPagePath:string;
+
+  readonly titleService:OpTitleService = this.injector.get(OpTitleService);
 
   constructor(public injector:Injector, protected workPackageId:string) {
     this.initializeTexts();
@@ -105,6 +108,9 @@ export class WorkPackageViewController implements OnDestroy {
       .then(() => {
       this.projectIdentifier = this.workPackage.project.identifier;
     });
+
+    // Push the current title
+    this.titleService.setFirstPart(this.workPackage.subjectWithType(20));
 
     // Preselect this work package for future list operations
     this.showStaticPagePath = this.PathHelper.workPackagePath(this.workPackageId);

--- a/frontend/app/components/wp-copy/wp-copy.controller.ts
+++ b/frontend/app/components/wp-copy/wp-copy.controller.ts
@@ -45,6 +45,10 @@ export class WorkPackageCopyController extends WorkPackageCreateController {
     });
   }
 
+  protected setTitle() {
+    this.titleService.setFirstPart(this.I18n.t('js.work_packages.copy.title'));
+  }
+
   private async createCopyFrom(wp:WorkPackageResource) {
     const changeset = this.wpEditing.changesetFor(wp);
     return changeset.getForm().then(async (form:any) => {

--- a/frontend/app/components/wp-new/wp-create.controller.ts
+++ b/frontend/app/components/wp-new/wp-create.controller.ts
@@ -43,6 +43,7 @@ import {WorkPackageTableFiltersService} from '../wp-fast-table/state/wp-table-fi
 import {WorkPackageCreateService} from './wp-create.service';
 import {takeUntil} from 'rxjs/operators';
 import {RootDmService} from 'core-app/modules/hal/dm-services/root-dm.service';
+import {OpTitleService} from 'core-components/html/op-title.service';
 
 
 export class WorkPackageCreateController implements OnInit, OnDestroy {
@@ -59,6 +60,7 @@ export class WorkPackageCreateController implements OnInit, OnDestroy {
   constructor(readonly $transition:Transition,
               @Inject($stateToken) readonly $state:StateService,
               @Inject(I18nToken) readonly I18n:op.I18n,
+              readonly titleService:OpTitleService,
               protected wpNotificationsService:WorkPackageNotificationService,
               protected states:States,
               protected wpCreate:WorkPackageCreateService,
@@ -76,6 +78,7 @@ export class WorkPackageCreateController implements OnInit, OnDestroy {
         this.changeset = changeset;
         this.newWorkPackage = changeset.workPackage;
 
+        this.setTitle();
 
         this.wpCacheService.updateWorkPackage(this.newWorkPackage);
         this.wpEditing.updateValue('new', changeset);
@@ -120,6 +123,10 @@ export class WorkPackageCreateController implements OnInit, OnDestroy {
 
   public switchToFullscreen() {
     this.$state.go('work-packages.new', this.$state.params);
+  }
+
+  protected setTitle() {
+    this.titleService.setFirstPart(this.I18n.t('js.work_packages.create.title'));
   }
 
   protected async newWorkPackageFromParams(stateParams:any):Promise<WorkPackageChangeset> {

--- a/frontend/app/components/wp-query-menu/wp-query-menu.ng2.test.ts
+++ b/frontend/app/components/wp-query-menu/wp-query-menu.ng2.test.ts
@@ -34,6 +34,8 @@ import {Component} from '@angular/core';
 import {WorkPackagesListChecksumService} from 'core-components/wp-list/wp-list-checksum.service';
 import {TransitionService} from '@uirouter/core';
 import {$stateToken} from 'core-app/angular4-transition-utils';
+import {I18nToken} from 'core-app/angular4-transition-utils';
+import {OpTitleService} from 'core-components/html/op-title.service';
 
 @Component({
   template: `
@@ -57,6 +59,9 @@ describe('wp-query-menu', () => {
   const $transitionStub = {
     onStart: (criteria:any, callback:(transition:any) => any) => {
       transitionCallback = (id:any) => callback({
+        to: () => {
+          return { name: 'asdf' };
+        },
         params: (val:string) => { return { query_id: id }; }
       } as any);
     }
@@ -70,6 +75,8 @@ describe('wp-query-menu', () => {
         WpQueryMenuTestComponent
       ],
       providers: [
+        { provide: I18nToken, useValue: I18n },
+        { provide: OpTitleService, useValue: { setFirstPart: () => { return; } } },
         { provide: $stateToken, useValue: { params: { query_id: null }, go: (...args:any[]) => undefined } },
         { provide: WorkPackagesListChecksumService, useValue: { clear: () => undefined } },
         { provide: TransitionService, useValue: $transitionStub },

--- a/frontend/app/components/wp-relations/wp-relations-parent/wp-relations-parent.html
+++ b/frontend/app/components/wp-relations/wp-relations-parent/wp-relations-parent.html
@@ -9,7 +9,7 @@
                    class="wp-relations--subject-field"
                    [attr.aria-label]="text.parent"
                    [attr.id]="wp-relations-parent-element"
-                   [textContent]="workPackage.parent.subjectWithType">
+                   [textContent]="workPackage.parent.subjectWithType()">
                 </a>
             </span>
         </div>

--- a/frontend/app/components/wp-relations/wp-single-relation.directive.ts
+++ b/frontend/app/components/wp-relations/wp-single-relation.directive.ts
@@ -44,7 +44,7 @@ export class WorkPackageSingleRelationController {
       return workPackage.subject;
     }
 
-    return workPackage.subjectWithType;
+    return workPackage.subjectWithType();
   }
 }
 

--- a/frontend/app/modules/hal/resources/work-package-resource.ts
+++ b/frontend/app/modules/hal/resources/work-package-resource.ts
@@ -146,12 +146,12 @@ export class WorkPackageResource extends HalResource {
   /**
    * Return "<type name>: <subject>" if the type is known.
    */
-  public get subjectWithType():string {
-    if (this.type) {
-      return `${this.type.name}: ${this.subject}`;
-    } else {
-      return this.subject;
-    }
+  public subjectWithType(truncateSubject:number = 40):string {
+    const type = this.type ? `${this.type.name}: ` : '';
+    const id = this.isNew ? '' : ` (#${this.id})`;
+    const subject = _.truncate(this.subject, { length: truncateSubject });
+
+    return `${type}${subject}${id}`;
   }
 
   public get isNew():boolean {


### PR DESCRIPTION
- [x] Reverse the `html_title` property to make html_titles useful
- [x] extract html_title generation into separate helper
- [x] disallow getter of `html_title` helper.
- [x] Extend frontend titles when changing queries, showing, adding, or copying work packages.

https://community.openproject.com/wp/27677