### PR TITLE
[27606] Allow inline-create in embedded children tables

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_table_embedded.sass
+++ b/app/assets/stylesheets/layout/_work_package_table_embedded.sass
@@ -33,6 +33,7 @@
 
   .work-package-table--container
     contain: initial !important
+    overflow: visible
 
     .generic-table--header,
     .generic-table--sort-header

--- a/app/policies/work_package_policy.rb
+++ b/app/policies/work_package_policy.rb
@@ -102,6 +102,8 @@ class WorkPackagePolicy < BasePolicy
   end
 
   def type_active_in_project?(work_package)
+    return false unless work_package.project
+
     @type_active_cache ||= Hash.new do |hash, project|
       hash[project] = project.types.pluck(:id)
     end

--- a/frontend/app/components/routing/wp-view-base/wp-view-base.controller.ts
+++ b/frontend/app/components/routing/wp-view-base/wp-view-base.controller.ts
@@ -40,6 +40,7 @@ import {WorkPackageTableRefreshService} from '../../wp-table/wp-table-refresh-re
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {ProjectCacheService} from 'core-components/projects/project-cache.service';
 import {OpTitleService} from 'core-components/html/op-title.service';
+import {AuthorisationService} from "core-components/common/model-auth/model-auth.service";
 
 export class WorkPackageViewController implements OnDestroy {
 
@@ -52,6 +53,7 @@ export class WorkPackageViewController implements OnDestroy {
   protected wpEditing:WorkPackageEditingService = this.injector.get(WorkPackageEditingService);
   protected wpTableFocus:WorkPackageTableFocusService = this.injector.get(WorkPackageTableFocusService);
   protected projectCacheService:ProjectCacheService = this.injector.get(ProjectCacheService);
+  protected authorisationService:AuthorisationService = this.injector.get(AuthorisationService);
 
   // Static texts
   public text:any = {};
@@ -108,6 +110,9 @@ export class WorkPackageViewController implements OnDestroy {
       .then(() => {
       this.projectIdentifier = this.workPackage.project.identifier;
     });
+
+    // Set authorisation data
+    this.authorisationService.initModelAuth('work_package', this.workPackage.$links);
 
     // Push the current title
     this.titleService.setFirstPart(this.workPackage.subjectWithType(20));

--- a/frontend/app/components/wp-relations/wp-relation-children/wp-children-query.html
+++ b/frontend/app/components/wp-relations/wp-relation-children/wp-children-query.html
@@ -4,9 +4,10 @@
                    [tableActions]="childrenTableActions"
                    [configuration]="{ actionsColumnEnabled: true,
                                       hierarchyToggleEnabled: false,
-                                      inlineCreateEnabled: false,
+                                      inlineCreateEnabled: true,
                                       columnMenuEnabled: false,
                                       contextMenuEnabled: false,
+                                      projectIdentifier: workPackage.project.idFromLink,
                                       projectContext: false }" >
 </wp-embedded-table>
 

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.template.html
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.template.html
@@ -1,24 +1,24 @@
 <div class="wp-relations-hierarchy-section">
-    <div class="attributes-group--header">
-        <div class="attributes-group--header-container">
-            <h3 class="attributes-group--header-text"
-                [textContent]="text.parentHeadline">
-            </h3>
-        </div>
+  <div class="attributes-group--header">
+    <div class="attributes-group--header-container">
+      <h3 class="attributes-group--header-text"
+          [textContent]="text.parentHeadline">
+      </h3>
     </div>
+  </div>
 
-    <wp-relation-parent [workPackage]="workPackage"></wp-relation-parent>
-
-    <div class="attributes-group--header">
-        <div class="attributes-group--header-container">
-            <h3 class="attributes-group--header-text"
-                [textContent]="text.childrenHeadline">
-            </h3>
-        </div>
+  <wp-relation-parent [workPackage]="workPackage"></wp-relation-parent>
+</div>
+<div class="wp-relations-hierarchy-section wp-relations--children">
+  <div class="attributes-group--header">
+    <div class="attributes-group--header-container">
+      <h3 class="attributes-group--header-text"
+          [textContent]="text.childrenHeadline">
+      </h3>
     </div>
-
-    <wp-children-query
-        [workPackage]="workPackage"
-        [query]="childrenQueryProps">
-    </wp-children-query>
+  </div>
+  <wp-children-query
+      [workPackage]="workPackage"
+      [query]="childrenQueryProps">
+  </wp-children-query>
 </div>

--- a/frontend/app/components/wp-table/embedded/wp-embedded-table.component.ts
+++ b/frontend/app/components/wp-table/embedded/wp-embedded-table.component.ts
@@ -95,6 +95,12 @@ export class WorkPackageEmbeddedTableComponent implements OnInit, AfterViewInit,
     // Load initial query
     this.loadQuery();
 
+    // Reload results on refresh requests
+    this.tableState.refreshRequired
+      .values$()
+      .pipe(untilComponentDestroyed(this))
+      .subscribe(async () => this.refresh());
+
     // Reload results on changes to pagination
     this.tableState.ready.fireOnStateChange(this.wpTablePagination.state,
       'Query loaded').values$().pipe(
@@ -126,6 +132,8 @@ export class WorkPackageEmbeddedTableComponent implements OnInit, AfterViewInit,
 
     if (this.configuration.projectContext) {
       identifier = this.currentProject.identifier;
+    } else {
+      identifier = this.configuration.projectIdentifier;
     }
 
     return identifier || undefined;
@@ -188,5 +196,5 @@ export class WorkPackageEmbeddedTableComponent implements OnInit, AfterViewInit,
 // TODO: remove as this should also work by angular2 only
 opUiComponentsModule.directive(
   'wpEmbeddedTable',
-  downgradeComponent({ component: WorkPackageEmbeddedTableComponent })
+  downgradeComponent({component: WorkPackageEmbeddedTableComponent})
 );

--- a/frontend/app/components/wp-table/wp-table-configuration.ts
+++ b/frontend/app/components/wp-table/wp-table-configuration.ts
@@ -27,7 +27,7 @@
 // ++
 
 
-export type WorkPackageTableConfigurationObject = Partial<{ [field in keyof WorkPackageTableConfiguration]:boolean }>;
+export type WorkPackageTableConfigurationObject = Partial<{ [field in keyof WorkPackageTableConfiguration]:string|boolean }>;
 
 export class WorkPackageTableConfiguration {
   /** Render the table results, set to false when only wanting the table initialization */
@@ -45,6 +45,9 @@ export class WorkPackageTableConfiguration {
   /** Whether the query should be resolved using the current project identifier */
   public projectContext:boolean = true;
 
+  /** Whether the embedded table should live within a specific project context (e.g., given by its parent) */
+  public projectIdentifier:string|null = null;
+
   /** Whether inline create is enabled*/
   public inlineCreateEnabled:boolean = true;
 
@@ -57,7 +60,7 @@ export class WorkPackageTableConfiguration {
   constructor(private providedConfig:WorkPackageTableConfigurationObject) {
     _.each(providedConfig, (value, k) => {
       let key = (k as keyof WorkPackageTableConfiguration);
-      this[key] = !!value;
+      this[key] = value as any;
     });
   }
 }

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -5,7 +5,8 @@ describe 'Work package relations tab', js: true, selenium: true do
 
   let(:user) { FactoryBot.create :admin }
 
-  let(:project) { FactoryBot.create :project }
+
+  let(:project) { FactoryBot.create(:project) }
   let(:work_package) { FactoryBot.create(:work_package, project: project) }
   let(:work_packages_page) { ::Pages::SplitWorkPackage.new(work_package) }
   let(:full_wp) { ::Pages::FullWorkPackage.new(work_package) }
@@ -55,6 +56,24 @@ describe 'Work package relations tab', js: true, selenium: true do
            text: I18n.t('js.relation_buttons.add_existing_child')).click
 
       relations.add_existing_child(child2)
+    end
+
+    describe 'inline create' do
+      let!(:status) { FactoryBot.create(:status, is_default: true) }
+      let!(:priority) { FactoryBot.create(:priority, is_default: true) }
+      let(:type_bug) { FactoryBot.create(:type_bug) }
+      let!(:project) do
+        FactoryBot.create(:project, types: [type_bug])
+      end
+
+      it 'can inline-create children' do
+        relations.inline_create_child 'my new child'
+        table = relations.children_table
+
+        table.expect_work_package_subject 'my new child'
+        work_package.reload
+        expect(work_package.children.count).to eq(1)
+      end
     end
   end
 

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -144,6 +144,15 @@ module Components
         expect(page).to have_no_selector('.relation-row--parent', text: removed_text, wait: 10)
       end
 
+      def inline_create_child(subject_text)
+        container = find('.wp-relations--children')
+        scroll_to_and_click(container.find('.wp-inline-create-button-row .wp-inline-create--add-link'))
+
+        subject = ::WorkPackageField.new(container, 'subject')
+        subject.expect_active!
+        subject.update subject_text
+      end
+
       def add_existing_child(work_package)
         # Locate the create row container
         container = find('.wp-relations--child-form')
@@ -153,6 +162,10 @@ module Components
         select_autocomplete(autocomplete, query: work_package.id, select_text: work_package.subject)
 
         container.find('.wp-create-relation--save').click
+      end
+
+      def children_table
+        ::Pages::EmbeddedWorkPackagesTable.new find('.work-packages-embedded-view--container')
       end
 
       def remove_child(work_package)

--- a/spec/support/pages/work_packages_table.rb
+++ b/spec/support/pages/work_packages_table.rb
@@ -54,6 +54,14 @@ module Pages
       end
     end
 
+    def expect_work_package_subject(subject)
+      within(table_container) do
+        expect(page).to have_selector("td.subject",
+                                      text: subject,
+                                      wait: 20)
+      end
+    end
+
     def expect_work_package_count(n)
       within(table_container) do
         expect(page).to have_selector(".wp--row", count: n, wait: 20)


### PR DESCRIPTION
- Allows inline-create to be enabled in embedded tables
- Adds an override to what projectIdentifier is used to create new work packages (required to create children globally without a project column)
- Add the parent attribute from the embedded filter

https://community.openproject.com/wp/27606