### PR TITLE
Avoid async ES5 generators all over the place

### DIFF
--- a/frontend/app/components/angular/simple-template-renderer.ts
+++ b/frontend/app/components/angular/simple-template-renderer.ts
@@ -52,7 +52,7 @@ export class SimpleTemplateRenderer {
    *
    * All content of the element is replaced.
    */
-  public async renderIsolated(element:JQuery,
+  public renderIsolated(element:JQuery,
                         scope:ng.IScope,
                         template:string,
                         scopeValues:Object):Promise<ng.IAugmentedJQuery> {

--- a/frontend/app/components/api/api-work-packages/api-work-packages.service.ts
+++ b/frontend/app/components/api/api-work-packages/api-work-packages.service.ts
@@ -49,7 +49,7 @@ export class ApiWorkPackagesService {
    * @param force Bypass any cached value?
    * @returns {IPromise<any>|IPromise<WorkPackageResource>} A promise for the WorkPackage.
    */
-  public async loadWorkPackageById(id:string, force = false) {
+  public loadWorkPackageById(id:string, force = false) {
     const url = this.pathHelper.api.v3.work_packages.id(id).toString();
 
     return this.halResourceService.get<WorkPackageResource>(url).toPromise();
@@ -62,7 +62,7 @@ export class ApiWorkPackagesService {
    * @param ids
    * @return {WorkPackageCollectionResource[]}
    */
-  public async loadWorkPackagesCollectionsFor(ids:string[]):Promise<WorkPackageCollectionResource[]> {
+  public loadWorkPackagesCollectionsFor(ids:string[]):Promise<WorkPackageCollectionResource[]> {
     return this.halResourceService.getAllPaginated(
       this.pathHelper.api.v3.work_packages.toString(),
       ids.length,
@@ -77,7 +77,7 @@ export class ApiWorkPackagesService {
    *
    * @returns An empty work package form resource.
    */
-  public async emptyCreateForm(request:any, projectIdentifier?:string):Promise<HalResource> {
+  public emptyCreateForm(request:any, projectIdentifier?:string):Promise<HalResource> {
     return this.halResourceService
       .post<HalResource>(this.workPackagesFormPath(projectIdentifier), request)
       .toPromise();
@@ -91,7 +91,7 @@ export class ApiWorkPackagesService {
    * @param projectIdentifier: The project to which the work package is initialized
    * @returns An empty work package form resource.
    */
-  public async typedCreateForm(typeId:number, projectIdentifier?:string):Promise<HalResource> {
+  public typedCreateForm(typeId:number, projectIdentifier?:string):Promise<HalResource> {
 
     const typeUrl = this.pathHelper.api.v3.types.id(typeId).toString();
     const request = { _links: { type: { href: typeUrl } } };
@@ -107,7 +107,7 @@ export class ApiWorkPackagesService {
    * @param payload
    * @return {Promise<WorkPackageResource>}
    */
-  public async createWorkPackage(payload:any):Promise<WorkPackageResource> {
+  public createWorkPackage(payload:any):Promise<WorkPackageResource> {
     return this.halResourceService
       .post<WorkPackageResource>(this.pathHelper.api.v3.work_packages.path, payload)
       .toPromise();

--- a/frontend/app/components/common/config/configuration.service.ts
+++ b/frontend/app/components/common/config/configuration.service.ts
@@ -48,11 +48,11 @@ export class ConfigurationService {
 
   }
 
-  public async fetchSettings () {
+  public fetchSettings () {
     return this.http.get<any>(this.path).toPromise();
   }
 
-  public async api() {
+  public api() {
     return new Promise((resolve, reject) => {
       if (this.cache) {
         resolve(this.cache);

--- a/frontend/app/components/common/help-texts/attribute-help-text.component.ts
+++ b/frontend/app/components/common/help-texts/attribute-help-text.component.ts
@@ -83,7 +83,7 @@ export class AttributeHelpTextComponent implements OnInit {
     });
   }
 
-  private async load() {
+  private load() {
     if (this.helpTextId) {
       return this.helpTextDm.load(this.helpTextId);
     } else {

--- a/frontend/app/components/common/help-texts/attribute-help-text.service.ts
+++ b/frontend/app/components/common/help-texts/attribute-help-text.service.ts
@@ -45,8 +45,8 @@ export class AttributeHelpTextsService {
    * @param attribute
    * @param scope
    */
-  public async require(attribute:string, scope:string):Promise<HelpTextResource|undefined> {
-      this.helpTexts.putFromPromiseIfPristine(async () =>
+  public require(attribute:string, scope:string):Promise<HelpTextResource|undefined> {
+      this.helpTexts.putFromPromiseIfPristine(() =>
         this.helpTextDm
           .loadAll()
           .then((resources:CollectionResource<HelpTextResource>) => resources.elements)

--- a/frontend/app/components/modals/confirm-dialog/confirm-dialog.service.ts
+++ b/frontend/app/components/modals/confirm-dialog/confirm-dialog.service.ts
@@ -40,7 +40,7 @@ export class ConfirmDialogService {
   /**
    * Confirm an action with an ng dialog with the given options
    */
-  public async confirm(options:ConfirmDialogOptions):Promise<void> {
+  public confirm(options:ConfirmDialogOptions):Promise<void> {
     return new Promise<void>((resolve, reject) => {
       const confirmModal = this.opModalService.show(ConfirmDialogModal, { options: options });
       confirmModal.closingEvent.subscribe((modal:ConfirmDialogModal) => {

--- a/frontend/app/components/modals/save-modal/save-query.modal.ts
+++ b/frontend/app/components/modals/save-modal/save-query.modal.ts
@@ -93,7 +93,7 @@ export class SaveQueryModal extends OpModalComponent {
 
     this.wpListService
       .create(query, this.queryName)
-      .then(async (savedQuery:QueryResource) => {
+      .then((savedQuery:QueryResource):Promise<any> => {
         if (this.isStarred && !savedQuery.starred) {
           return this.wpListService.toggleStarred(savedQuery).then(() => this.closeMe($event));
         }

--- a/frontend/app/components/projects/project-cache.service.ts
+++ b/frontend/app/components/projects/project-cache.service.ts
@@ -40,13 +40,13 @@ export class ProjectCacheService extends StateCacheService<ProjectResource> {
     super();
   }
 
-  protected async loadAll(ids:string[]):Promise<undefined> {
+  protected loadAll(ids:string[]):Promise<undefined> {
     return Promise
-      .all(ids.map(async id => this.load(id)))
+      .all(ids.map(id => this.load(id)))
       .then(_ => undefined);
   }
 
-  protected async load(id:string):Promise<ProjectResource> {
+  protected load(id:string):Promise<ProjectResource> {
     return this.projectDmService.load(id);
   }
 

--- a/frontend/app/components/routing/wp-list/wp-list.component.ts
+++ b/frontend/app/components/routing/wp-list/wp-list.component.ts
@@ -222,11 +222,11 @@ export class WorkPackagesListComponent implements OnInit, OnDestroy {
     });
   }
 
-  async updateResults() {
+  updateResults() {
     return this.wpListService.reloadCurrentResultsList();
   }
 
-  async updateToFirstResultsPage() {
+  updateToFirstResultsPage() {
     return this.wpListService.loadCurrentResultsListFirstPage();
   }
 

--- a/frontend/app/components/states/state-cache.service.ts
+++ b/frontend/app/components/states/state-cache.service.ts
@@ -72,7 +72,7 @@ export abstract class StateCacheService<T> {
    * @param id The value's identifier.
    * @param force Load the value anyway.
    */
-  public async require(id:string, force:boolean = false):Promise<T> {
+  public require(id:string, force:boolean = false):Promise<T> {
     const state = this.multiState.get(id);
 
     // Refresh when stale or being forced
@@ -90,7 +90,7 @@ export abstract class StateCacheService<T> {
    * @param force Load the values anyway
    * @return {Promise<undefined>} An empty promise to mark when the set of states is filled.
    */
-  public async requireAll(ids:string[], force:boolean = false):Promise<undefined> {
+  public requireAll(ids:string[], force:boolean = false):Promise<undefined> {
     let idsToRequest:string[];
 
     if (force) {

--- a/frontend/app/components/table-pagination/pagination-service.ts
+++ b/frontend/app/components/table-pagination/pagination-service.ts
@@ -112,7 +112,7 @@ export class PaginationService {
     this.paginationOptions.perPageOptions = perPageOptions;
   }
 
-  public async loadPaginationOptions() {
+  public loadPaginationOptions() {
     return this.ConfigurationDm.load().then((configuration:any) => {
       this.setPerPageOptions(configuration.perPageOptions);
       return this.paginationOptions;

--- a/frontend/app/components/user/user-cache.service.ts
+++ b/frontend/app/components/user/user-cache.service.ts
@@ -40,12 +40,12 @@ export class UserCacheService extends StateCacheService<UserResource>  {
     super();
   }
 
-  protected async load(id:number|string):Promise<UserResource> {
+  protected load(id:number|string):Promise<UserResource> {
     return this.userDmService.load(id);
   }
 
-  protected async loadAll(ids:string[]):Promise<undefined> {
-    const promises = ids.map(async id => this.load(id));
+  protected loadAll(ids:string[]):Promise<undefined> {
+    const promises = ids.map(id => this.load(id));
     return Promise.all(promises).then(() => undefined);
   }
 

--- a/frontend/app/components/work-packages/work-package-cache.service.ts
+++ b/frontend/app/components/work-packages/work-package-cache.service.ts
@@ -81,7 +81,7 @@ export class WorkPackageCacheService extends StateCacheService<WorkPackageResour
     }
   }
 
-  async saveWorkPackage(workPackage:WorkPackageResource):Promise<WorkPackageResource | null> {
+  saveWorkPackage(workPackage:WorkPackageResource):Promise<WorkPackageResource | null> {
     if (!(workPackage.dirty || workPackage.isNew)) {
       return Promise.reject<any>(null);
     }
@@ -118,7 +118,7 @@ export class WorkPackageCacheService extends StateCacheService<WorkPackageResour
     return state;
   }
 
-  protected async loadAll(ids:string[]) {
+  protected loadAll(ids:string[]) {
     return new Promise<undefined>((resolve, reject) => {
       this.apiWorkPackages
         .loadWorkPackagesCollectionsFor(_.uniq(ids))
@@ -140,7 +140,7 @@ export class WorkPackageCacheService extends StateCacheService<WorkPackageResour
     });
   }
 
-  protected async load(id:string) {
+  protected load(id:string) {
     return new Promise<WorkPackageResource>((resolve, reject) => {
       this.apiWorkPackages.loadWorkPackageById(id, true)
         .then((workPackage:WorkPackageResource) => {

--- a/frontend/app/components/work-packages/work-package-comment/work-package-comment.directive.ts
+++ b/frontend/app/components/work-packages/work-package-comment/work-package-comment.directive.ts
@@ -152,7 +152,7 @@ export class CommentFieldDirectiveController {
   }
 
   // Ensure the nested ng-include has rendered
-  private async waitForField():Promise<JQuery> {
+  private waitForField():Promise<JQuery> {
     const deferred = this.$q.defer<JQuery>();
 
     const interval = setInterval(() => {

--- a/frontend/app/components/wp-activity/activity-service.ts
+++ b/frontend/app/components/wp-activity/activity-service.ts
@@ -47,7 +47,7 @@ export class ActivityService {
     private $q:ng.IQService) {
     }
 
-  public async createComment(workPackage:WorkPackageResource, comment:string) {
+  public createComment(workPackage:WorkPackageResource, comment:string) {
     return workPackage.addComment(
       { comment: comment},
       { 'Content-Type': 'application/json; charset=UTF-8' }

--- a/frontend/app/components/wp-activity/user/user-activity-directive.ts
+++ b/frontend/app/components/wp-activity/user/user-activity-directive.ts
@@ -147,7 +147,7 @@ export class UserActivityController {
   }
 
   // Ensure the nested ng-include has rendered
-  private async waitForField():Promise<JQuery> {
+  private waitForField():Promise<JQuery> {
     const deferred = this.$q.defer<JQuery>();
 
     const interval = setInterval(() => {

--- a/frontend/app/components/wp-copy/wp-copy.controller.ts
+++ b/frontend/app/components/wp-copy/wp-copy.controller.ts
@@ -32,7 +32,7 @@ import {WorkPackageChangeset} from 'core-components/wp-edit-form/work-package-ch
 import {WorkPackageCreateController} from 'core-components/wp-new/wp-create.controller';
 
 export class WorkPackageCopyController extends WorkPackageCreateController {
-  protected async newWorkPackageFromParams(stateParams:any) {
+  protected newWorkPackageFromParams(stateParams:any) {
     return new Promise<WorkPackageChangeset>((resolve, reject) => {
       this.wpCacheService.loadWorkPackage(stateParams.copiedFromWorkPackageId)
         .values$()
@@ -40,7 +40,7 @@ export class WorkPackageCopyController extends WorkPackageCreateController {
           take(1)
         )
         .subscribe(
-          async (wp:WorkPackageResource) => this.createCopyFrom(wp).then(resolve),
+          (wp:WorkPackageResource) => this.createCopyFrom(wp).then(resolve),
           reject);
     });
   }
@@ -49,9 +49,9 @@ export class WorkPackageCopyController extends WorkPackageCreateController {
     this.titleService.setFirstPart(this.I18n.t('js.work_packages.copy.title'));
   }
 
-  private async createCopyFrom(wp:WorkPackageResource) {
+  private createCopyFrom(wp:WorkPackageResource) {
     const changeset = this.wpEditing.changesetFor(wp);
-    return changeset.getForm().then(async (form:any) => {
+    return changeset.getForm().then((form:any) => {
       return this.wpCreate.copyWorkPackage(form, wp.project.identifier);
     });
   }

--- a/frontend/app/components/wp-edit-form/single-view-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/single-view-edit-context.ts
@@ -118,7 +118,7 @@ export class SingleViewEditContext implements WorkPackageEditContext {
     this.fieldGroup.onSaved(isInitial, savedWorkPackage);
   }
 
-  public async requireVisible(fieldName:string):Promise<void> {
+  public requireVisible(fieldName:string):Promise<void> {
     return new Promise<void>((resolve, ) => {
       const interval = setInterval(() => {
         const field = this.fieldGroup.fields[fieldName];
@@ -135,7 +135,7 @@ export class SingleViewEditContext implements WorkPackageEditContext {
     return 'subject';
   }
 
-  private async fieldCtrl(name:string):Promise<WorkPackageEditFieldComponent> {
+  private fieldCtrl(name:string):Promise<WorkPackageEditFieldComponent> {
     return this.fieldGroup.waitForField(name);
   }
 }

--- a/frontend/app/components/wp-edit-form/table-row-edit-context.ts
+++ b/frontend/app/components/wp-edit-form/table-row-edit-context.ts
@@ -73,7 +73,7 @@ export class TableRowEditContext implements WorkPackageEditContext {
     return this.rowContainer.find(`.${tdClassName}.${fieldName}`).first();
   }
 
-  public async activateField(form:WorkPackageEditForm, field:EditField, fieldName:string, errors:string[]):Promise<WorkPackageEditFieldHandler> {
+  public activateField(form:WorkPackageEditForm, field:EditField, fieldName:string, errors:string[]):Promise<WorkPackageEditFieldHandler> {
     const deferred = this.$q.defer<WorkPackageEditFieldHandler>();
 
     this.waitForContainer(fieldName)
@@ -137,7 +137,7 @@ export class TableRowEditContext implements WorkPackageEditContext {
     }
   }
 
-  public async requireVisible(fieldName:string):Promise<any> {
+  public requireVisible(fieldName:string):Promise<any> {
     this.wpTableColumns.addColumn(fieldName);
     return this.waitForContainer(fieldName);
   }
@@ -152,7 +152,7 @@ export class TableRowEditContext implements WorkPackageEditContext {
 
   // Ensure the given field is visible.
   // We may want to look into MutationObserver if we need this in several places.
-  private async waitForContainer(fieldName:string):Promise<JQuery> {
+  private waitForContainer(fieldName:string):Promise<JQuery> {
     const deferred = this.$q.defer<JQuery>();
 
     const interval = setInterval(() => {

--- a/frontend/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/app/components/wp-edit-form/work-package-changeset.ts
@@ -124,8 +124,8 @@ export class WorkPackageChangeset {
     return this.changes.hasOwnProperty(key);
   }
 
-  public async getForm():Promise<FormResource> {
-    this.wpForm.putFromPromiseIfPristine(async () => {
+  public getForm():Promise<FormResource> {
+    this.wpForm.putFromPromiseIfPristine(() => {
       return this.updateForm();
     });
 
@@ -141,7 +141,7 @@ export class WorkPackageChangeset {
    * Update the form resource from the API.
    * @return {angular.IPromise<any>}
    */
-  public async updateForm():Promise<FormResource> {
+  public updateForm():Promise<FormResource> {
     let payload = this.buildPayloadFromChanges();
 
     return new Promise<FormResource>((resolve, reject) => {
@@ -160,7 +160,7 @@ export class WorkPackageChangeset {
     });
   }
 
-  public async save():Promise<WorkPackageResource> {
+  public save():Promise<WorkPackageResource> {
     this.inFlight = true;
     const wasNew = this.workPackage.isNew;
 

--- a/frontend/app/components/wp-edit-form/work-package-edit-field-handler.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-field-handler.ts
@@ -95,7 +95,7 @@ export class WorkPackageEditFieldHandler {
   /**
    * Handle a user submitting the field (e.g, ng-change)
    */
-  public async handleUserSubmit():Promise<any> {
+  public handleUserSubmit():Promise<any> {
     if (this.field.inFlight || this.form.editMode) {
       return Promise.resolve();
     }

--- a/frontend/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/app/components/wp-edit-form/work-package-edit-form.ts
@@ -114,7 +114,7 @@ export class WorkPackageEditForm {
    * @param fieldName
    * @param noWarnings Ignore warnings if the field cannot be opened
    */
-  public async activate(fieldName:string, noWarnings:boolean = false):Promise<WorkPackageEditFieldHandler> {
+  public activate(fieldName:string, noWarnings:boolean = false):Promise<WorkPackageEditFieldHandler> {
     return new Promise<WorkPackageEditFieldHandler>((resolve, reject) => {
       this.buildField(fieldName)
         .then((field:EditField) => {
@@ -178,7 +178,7 @@ export class WorkPackageEditForm {
    * Save the active changeset.
    * @return {any}
    */
-  public async submit():Promise<WorkPackageResource> {
+  public submit():Promise<WorkPackageResource> {
     if (this.changeset.empty && !this.workPackage.isNew) {
       this.closeEditFields();
       return Promise.resolve(this.workPackage);
@@ -269,7 +269,7 @@ export class WorkPackageEditForm {
 
   private setErrorsForFields(erroneousFields:string[]) {
     // Accumulate errors for the given response
-    let promises:Promise<any>[] = erroneousFields.map(async (fieldName:string) => {
+    let promises:Promise<any>[] = erroneousFields.map((fieldName:string) => {
       return this.editContext.requireVisible(fieldName).then(() => {
         if (this.activeFields[fieldName]) {
           this.activeFields[fieldName].setErrors(this.errorsPerAttribute[fieldName] || []);
@@ -293,7 +293,7 @@ export class WorkPackageEditForm {
       });
   }
 
-  private async buildField(fieldName:string):Promise<EditField> {
+  private buildField(fieldName:string):Promise<EditField> {
     return new Promise<EditField>((resolve, reject) => {
       this.changeset.getForm()
         .then((form:FormResource) => {
@@ -319,7 +319,7 @@ export class WorkPackageEditForm {
     });
   }
 
-  private async renderField(fieldName:string, field:EditField):Promise<WorkPackageEditFieldHandler> {
+  private renderField(fieldName:string, field:EditField):Promise<WorkPackageEditFieldHandler> {
     const promise = this.editContext.activateField(this,
       field,
       fieldName,

--- a/frontend/app/components/wp-edit-form/work-package-editing-service.ts
+++ b/frontend/app/components/wp-edit-form/work-package-editing-service.ts
@@ -116,7 +116,7 @@ export class WorkPackageEditingService extends StateCacheService<WorkPackageChan
     }
   }
 
-  protected async load(id:string) {
+  protected load(id:string) {
     return this.wpCacheService.require(id)
       .then((wp:WorkPackageResource) => {
         return new WorkPackageChangeset(this.injector, wp);
@@ -124,7 +124,7 @@ export class WorkPackageEditingService extends StateCacheService<WorkPackageChan
   }
 
   protected loadAll(ids:string[]) {
-    return Promise.all(ids.map(async id => this.load(id))) as any;
+    return Promise.all(ids.map(id => this.load(id))) as any;
   }
 
   protected get multiState() {

--- a/frontend/app/components/wp-edit-form/work-package-filter-values.ts
+++ b/frontend/app/components/wp-edit-form/work-package-filter-values.ts
@@ -13,8 +13,8 @@ export class WorkPackageFilterValues {
 
   }
 
-  public async applyDefaultsFromFilters() {
-    return this.changeset.getForm().then(async (form) => {
+  public applyDefaultsFromFilters() {
+    return this.changeset.getForm().then((form) => {
       const promises:Promise<any>[] = [];
       angular.forEach(this.filters, filter => {
         // Ignore any filters except =
@@ -42,7 +42,7 @@ export class WorkPackageFilterValues {
     });
   }
 
-  private async setAllowedValueFor(form:FormResource, field:string, value:string|HalResource) {
+  private setAllowedValueFor(form:FormResource, field:string, value:string|HalResource) {
     return this.allowedValuesFor(form, field).then((allowedValues) => {
       let newValue = this.findSpecialValue(value, field) || this.findAllowedValue(value, allowedValues);
 
@@ -77,7 +77,7 @@ export class WorkPackageFilterValues {
     }
   }
 
-  private async allowedValuesFor(form:FormResource, field:string):Promise<HalResource[]> {
+  private allowedValuesFor(form:FormResource, field:string):Promise<HalResource[]> {
     const fieldSchema = form.schema[field];
 
     return new Promise<HalResource[]>(resolve => {

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field-group.directive.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field-group.directive.ts
@@ -152,7 +152,7 @@ export class WorkPackageEditFieldGroupComponent implements OnInit, OnDestroy {
     }
   }
 
-  public async waitForField(name:string):Promise<WorkPackageEditFieldComponent> {
+  public waitForField(name:string):Promise<WorkPackageEditFieldComponent> {
     return this.registeredFields
       .values$()
       .pipe(
@@ -164,14 +164,14 @@ export class WorkPackageEditFieldGroupComponent implements OnInit, OnDestroy {
   }
 
   public start() {
-    _.each(this.fields, async ctrl => this.form.activate(ctrl.fieldName));
+    _.each(this.fields, ctrl => this.form.activate(ctrl.fieldName));
   }
 
   public stop() {
     this.wpEditing.stopEditing(this.workPackage.id);
   }
 
-  public async saveWorkPackage() {
+  public saveWorkPackage() {
     const isInitial = this.workPackage.isNew;
     return this.form
       .submit()

--- a/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.component.ts
+++ b/frontend/app/components/wp-edit/wp-edit-field/wp-edit-field.component.ts
@@ -128,11 +128,11 @@ export class WorkPackageEditFieldComponent implements OnInit {
     return false;
   }
 
-  public async activate(noWarnings:boolean = false):Promise<WorkPackageEditFieldHandler> {
+  public activate(noWarnings:boolean = false):Promise<WorkPackageEditFieldHandler> {
     return this.activateOnForm(this.wpEditFieldGroup.form, noWarnings);
   }
 
-  public async activateOnForm(form:WorkPackageEditForm, noWarnings:boolean = false) {
+  public activateOnForm(form:WorkPackageEditForm, noWarnings:boolean = false) {
     // Activate the field
     const promise = form.activate(this.fieldName, noWarnings);
     promise

--- a/frontend/app/components/wp-fast-table/state/wp-table-additional-elements.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-additional-elements.service.ts
@@ -80,7 +80,7 @@ export class WorkPackageTableAdditionalElementsService {
    * Requires both the relation resource of the given work package ids as well
    * as the `to` work packages returned from the relations
    */
-  private async requireInvolvedRelations(rows:string[]):Promise<string[]> {
+  private requireInvolvedRelations(rows:string[]):Promise<string[]> {
 
     if (!this.wpTableColumns.hasRelationColumns()) {
       return Promise.resolve([]);
@@ -100,7 +100,7 @@ export class WorkPackageTableAdditionalElementsService {
    * @param rows
    * @return {string[]}
    */
-  private async requireHierarchyElements(rows:WorkPackageResource[]):Promise<string[]> {
+  private requireHierarchyElements(rows:WorkPackageResource[]):Promise<string[]> {
     if (!this.wpTableHierarchies.isEnabled) {
       return Promise.resolve([]);
     }

--- a/frontend/app/components/wp-fast-table/state/wp-table-base.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-base.service.ts
@@ -77,7 +77,7 @@ export abstract class WorkPackageTableBaseService<T> {
     return this.state.values$().pipe(takeUntil(unsubscribe));
   }
 
-  public async onReady() {
+  public onReady() {
     return this.state.values$()
       .pipe(
         take(1),

--- a/frontend/app/components/wp-fast-table/state/wp-table-filters.service.ts
+++ b/frontend/app/components/wp-fast-table/state/wp-table-filters.service.ts
@@ -106,12 +106,12 @@ export class WorkPackageTableFiltersService extends WorkPackageTableBaseService<
     this.state.putValue(this.currentState);
   }
 
-  private async loadCurrentFiltersSchemas(filters:QueryFilterInstanceResource[]):Promise<{}> {
+  private loadCurrentFiltersSchemas(filters:QueryFilterInstanceResource[]):Promise<{}> {
     return Promise.all(_.map(filters,
-                       async (filter:QueryFilterInstanceResource) => this.loadFilterSchema(filter)));
+                       (filter:QueryFilterInstanceResource) => this.loadFilterSchema(filter)));
   }
 
-  private async loadFilterSchema(filter:QueryFilterInstanceResource):Promise<{}> {
+  private loadFilterSchema(filter:QueryFilterInstanceResource):Promise<{}> {
     return new Promise((resolve, reject) => {
       filter.schema.$load()
         .catch(reject)

--- a/frontend/app/components/wp-list/wp-list.service.ts
+++ b/frontend/app/components/wp-list/wp-list.service.ts
@@ -74,13 +74,13 @@ export class WorkPackagesListService {
    * Load a query.
    * The query is either a persisted query, identified by the query_id parameter, or the default query. Both will be modified by the parameters in the query_props parameter.
    */
-  public async fromQueryParams(queryParams:any, projectIdentifier ?:string):Promise<QueryResource> {
+  public fromQueryParams(queryParams:any, projectIdentifier ?:string):Promise<QueryResource> {
     const queryData = this.UrlParamsHelper.buildV3GetQueryFromJsonParams(queryParams.query_props);
     const wpListPromise = this.QueryDm.find(queryData, queryParams.query_id, projectIdentifier);
     const promise = this.updateStatesFromQueryOnPromise(wpListPromise);
 
     promise
-      .catch(async (error) => {
+      .catch((error) => {
         const queryProps = this.UrlParamsHelper.buildV3GetQueryFromJsonParams(queryParams.query_props);
 
         return this.handleQueryLoadingError(error, queryProps, queryParams.query_id, projectIdentifier);
@@ -92,14 +92,14 @@ export class WorkPackagesListService {
   /**
    * Load the default query.
    */
-  public async loadDefaultQuery(projectIdentifier ?:string):Promise<QueryResource> {
+  public loadDefaultQuery(projectIdentifier ?:string):Promise<QueryResource> {
     return this.fromQueryParams({}, projectIdentifier);
   }
 
   /**
    * Reloads the current query and set the pagination to the first page.
    */
-  public async reloadQuery(query:QueryResource):Promise<QueryResource> {
+  public reloadQuery(query:QueryResource):Promise<QueryResource> {
     let pagination = this.getPaginationInfo();
     pagination.offset = 1;
 
@@ -108,7 +108,7 @@ export class WorkPackagesListService {
     let promise = this.updateStatesFromQueryOnPromise(wpListPromise);
 
     promise
-      .catch(async (error) => {
+      .catch((error) => {
         let projectIdentifier = query.project && query.project.id;
 
         return this.handleQueryLoadingError(error, {}, query.id, projectIdentifier);
@@ -120,7 +120,7 @@ export class WorkPackagesListService {
   /**
    * Update the list from an existing query object.
    */
-  public async loadResultsList(query:QueryResource, additionalParams:PaginationObject):Promise<WorkPackageCollectionResource> {
+  public loadResultsList(query:QueryResource, additionalParams:PaginationObject):Promise<WorkPackageCollectionResource> {
     let wpListPromise = this.QueryDm.loadResults(query, additionalParams);
 
     return this.updateStatesFromWPListOnPromise(query, wpListPromise);
@@ -130,7 +130,7 @@ export class WorkPackagesListService {
    * Reload the list of work packages for the current query keeping the
    * pagination options.
    */
-  public async reloadCurrentResultsList():Promise<WorkPackageCollectionResource> {
+  public reloadCurrentResultsList():Promise<WorkPackageCollectionResource> {
     let pagination = this.getPaginationInfo();
     let query = this.currentQuery;
 
@@ -140,7 +140,7 @@ export class WorkPackagesListService {
   /**
    * Reload the first page of work packages for the current query
    */
-  public async loadCurrentResultsListFirstPage():Promise<WorkPackageCollectionResource> {
+  public loadCurrentResultsListFirstPage():Promise<WorkPackageCollectionResource> {
     let pagination = this.getPaginationInfo();
     pagination.offset = 1;
     let query = this.currentQuery;
@@ -160,7 +160,7 @@ export class WorkPackagesListService {
       });
   }
 
-  public async loadForm(query:QueryResource):Promise<QueryFormResource> {
+  public loadForm(query:QueryResource):Promise<QueryFormResource> {
     return this.QueryFormDm.load(query).then((form:QueryFormResource) => {
       this.wpStatesInitialization.updateStatesFromForm(query, form);
 
@@ -172,7 +172,7 @@ export class WorkPackagesListService {
    * Persist the current query in the backend.
    * After the update, the new query is reloaded (e.g. for the work packages)
    */
-  public async create(query:QueryResource, name:string):Promise<QueryResource> {
+  public create(query:QueryResource, name:string):Promise<QueryResource> {
     let form = this.states.query.form.value!;
 
     query.name = name;
@@ -192,7 +192,7 @@ export class WorkPackagesListService {
   /**
    * Destroy the current query.
    */
-  public async delete() {
+  public delete() {
     let query = this.currentQuery;
 
     let promise = this.QueryDm.delete(query);
@@ -214,7 +214,7 @@ export class WorkPackagesListService {
     return promise;
   }
 
-  public async save(query?:QueryResource) {
+  public save(query?:QueryResource) {
     query = query || this.currentQuery;
 
     let form = this.states.query.form.value!;
@@ -241,7 +241,7 @@ export class WorkPackagesListService {
     return promise;
   }
 
-  public async toggleStarred(query:QueryResource):Promise<any> {
+  public toggleStarred(query:QueryResource):Promise<any> {
     let promise = this.QueryDm.toggleStarred(query);
 
     promise.then((query:QueryResource) => {
@@ -264,13 +264,13 @@ export class WorkPackagesListService {
     };
   }
 
-  private async conditionallyLoadForm(promise:Promise<QueryResource>):Promise<QueryResource> {
+  private conditionallyLoadForm(promise:Promise<QueryResource>):Promise<QueryResource> {
     promise.then(query => {
 
       let currentForm = this.states.query.form.value;
 
       if (!currentForm || query.$links.update.$href !== currentForm.$href) {
-        setTimeout(async () => this.loadForm(query), 0);
+        setTimeout(() => this.loadForm(query), 0);
       }
 
       return query;
@@ -279,7 +279,7 @@ export class WorkPackagesListService {
     return promise;
   }
 
-  private async updateStatesFromQueryOnPromise(promise:Promise<QueryResource>):Promise<QueryResource> {
+  private updateStatesFromQueryOnPromise(promise:Promise<QueryResource>):Promise<QueryResource> {
     promise
       .then(query => {
         this.tableState.ready.doAndTransition('Query loaded', () => {
@@ -293,7 +293,7 @@ export class WorkPackagesListService {
     return promise;
   }
 
-  private async updateStatesFromWPListOnPromise(query:QueryResource, promise:Promise<WorkPackageCollectionResource>):Promise<WorkPackageCollectionResource> {
+  private updateStatesFromWPListOnPromise(query:QueryResource, promise:Promise<WorkPackageCollectionResource>):Promise<WorkPackageCollectionResource> {
     return promise.then((results) => {
       this.tableState.ready.doAndTransition('Query loaded', () => {
         this.wpStatesInitialization.updateTableState(query, results);
@@ -319,7 +319,7 @@ export class WorkPackagesListService {
     }
   }
 
-  private async handleQueryLoadingError(error:ErrorResource, queryProps:any, queryId:number, projectIdentifier?:string) {
+  private handleQueryLoadingError(error:ErrorResource, queryProps:any, queryId:number, projectIdentifier?:string) {
     this.NotificationsService.addError(this.I18n.t('js.work_packages.faulty_query.description'), error.message);
 
     return new Promise((resolve, reject) => {

--- a/frontend/app/components/wp-new/wp-create.controller.ts
+++ b/frontend/app/components/wp-new/wp-create.controller.ts
@@ -129,7 +129,7 @@ export class WorkPackageCreateController implements OnInit, OnDestroy {
     this.titleService.setFirstPart(this.I18n.t('js.work_packages.create.title'));
   }
 
-  protected async newWorkPackageFromParams(stateParams:any):Promise<WorkPackageChangeset> {
+  protected newWorkPackageFromParams(stateParams:any):Promise<WorkPackageChangeset> {
     const type = parseInt(stateParams.type);
 
     // If there is an open edit for this type, continue it
@@ -146,7 +146,7 @@ export class WorkPackageCreateController implements OnInit, OnDestroy {
       }
     }
 
-    return this.wpCreate.createNewTypedWorkPackage(stateParams.projectPath, type).then(async changeset => {
+    return this.wpCreate.createNewTypedWorkPackage(stateParams.projectPath, type).then(changeset => {
       const filter = new WorkPackageFilterValues(changeset, this.wpTableFilters.current, ['type']);
       return filter.applyDefaultsFromFilters().then(() => changeset);
     });

--- a/frontend/app/components/wp-new/wp-create.service.ts
+++ b/frontend/app/components/wp-new/wp-create.service.ts
@@ -56,13 +56,13 @@ export class WorkPackageCreateService {
     return this.newWorkPackageCreatedSubject.asObservable();
   }
 
-  public async createNewWorkPackage(projectIdentifier:string) {
+  public createNewWorkPackage(projectIdentifier:string) {
     return this.getEmptyForm(projectIdentifier).then(form => {
       return this.fromCreateForm(form);
     });
   }
 
-  public async createNewTypedWorkPackage(projectIdentifier:string, type:number) {
+  public createNewTypedWorkPackage(projectIdentifier:string, type:number) {
     return this.apiWorkPackages.typedCreateForm(type, projectIdentifier).then(form => {
       return this.fromCreateForm(form);
     });
@@ -91,7 +91,7 @@ export class WorkPackageCreateService {
     return new WorkPackageChangeset(this.injector, wp, form);
   }
 
-  public async copyWorkPackage(copyFromForm:any, projectIdentifier?:string) {
+  public copyWorkPackage(copyFromForm:any, projectIdentifier?:string) {
     let request = copyFromForm.payload.$source;
 
     return this.apiWorkPackages.emptyCreateForm(request, projectIdentifier).then(form => {
@@ -99,7 +99,7 @@ export class WorkPackageCreateService {
     });
   }
 
-  public async getEmptyForm(projectIdentifier:string):Promise<HalResource> {
+  public getEmptyForm(projectIdentifier:string):Promise<HalResource> {
     if (!this.form) {
       this.form = this.apiWorkPackages.emptyCreateForm({}, projectIdentifier);
     }

--- a/frontend/app/components/wp-query-menu/wp-query-menu.ng2.test.ts
+++ b/frontend/app/components/wp-query-menu/wp-query-menu.ng2.test.ts
@@ -68,7 +68,7 @@ describe('wp-query-menu', () => {
   };
 
 
-  beforeEach((async () => {
+  beforeEach((() => {
     // noinspection JSIgnoredPromiseFromCall
     return TestBed.configureTestingModule({
       declarations: [

--- a/frontend/app/components/wp-query-select/wp-query-select-dropdown.component.ts
+++ b/frontend/app/components/wp-query-select/wp-query-select-dropdown.component.ts
@@ -84,7 +84,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit {
     });
   }
 
-  private async loadQueries() {
+  private loadQueries() {
     return this.QueryDm.all(this.$state.params['projectPath']);
   }
 

--- a/frontend/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.upgraded.component.ts
+++ b/frontend/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.upgraded.component.ts
@@ -97,7 +97,7 @@ export class WpRelationsAutocompleteComponent implements OnInit {
     }
   }
 
-  private async autocompleteWorkPackages(query:string):Promise<WorkPackageResource[]> {
+  private autocompleteWorkPackages(query:string):Promise<WorkPackageResource[]> {
     this.$element.find('.ui-autocomplete--loading').show();
 
     return this.workPackage.available_relation_candidates.$link.$fetch({

--- a/frontend/app/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
+++ b/frontend/app/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
@@ -50,7 +50,7 @@ export class WorkPackageRelationsCreateComponent {
     this.selectedWpId = workPackageId;
   }
 
-  protected async createCommonRelation() {
+  protected createCommonRelation() {
     return this.wpRelations.addCommonRelation(this.workPackage,
       this.selectedRelationType,
       this.selectedWpId)

--- a/frontend/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
+++ b/frontend/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
@@ -49,7 +49,7 @@ export class WorkPackageRelationsHierarchyService {
 
   }
 
-  public async changeParent(workPackage:WorkPackageResource, parentId:string | null) {
+  public changeParent(workPackage:WorkPackageResource, parentId:string | null) {
     let payload:any = {
       lockVersion: workPackage.lockVersion
     };
@@ -76,21 +76,21 @@ export class WorkPackageRelationsHierarchyService {
         this.wpTableRefresh.request(`Changed parent of ${workPackage.id} to ${parentId}`, true);
         return wp;
       })
-      .catch(async (error) => {
+      .catch((error) => {
         this.wpNotificationsService.handleErrorResponse(error, workPackage);
         return Promise.reject(error);
       });
   }
 
-  public async removeParent(workPackage:WorkPackageResource) {
+  public removeParent(workPackage:WorkPackageResource) {
     return this.changeParent(workPackage, null);
   }
 
-  public async addExistingChildWp(workPackage:WorkPackageResource, childWpId:string):Promise<WorkPackageResource> {
+  public addExistingChildWp(workPackage:WorkPackageResource, childWpId:string):Promise<WorkPackageResource> {
     const state = this.wpCacheService.loadWorkPackage(childWpId);
 
     return new Promise<WorkPackageResource>((resolve, reject) => {
-      state.valuesPromise().then(async (wpToBecomeChild:WorkPackageResource|undefined) => {
+      state.valuesPromise().then((wpToBecomeChild:WorkPackageResource|undefined) => {
         this.wpTableRefresh.request(`Added new child to ${workPackage.id}`, true);
 
         return this.changeParent(wpToBecomeChild!, workPackage.id)
@@ -118,8 +118,8 @@ export class WorkPackageRelationsHierarchyService {
       });
   }
 
-  public async removeChild(childWorkPackage:WorkPackageResource) {
-    return childWorkPackage.$load().then(async () => {
+  public removeChild(childWorkPackage:WorkPackageResource) {
+    return childWorkPackage.$load().then(() => {
       return childWorkPackage.changeParent({
         _links: {
           parent: {
@@ -130,7 +130,7 @@ export class WorkPackageRelationsHierarchyService {
       }).then(wp => {
         this.wpCacheService.updateWorkPackage(wp);
       })
-      .catch(async (error) => {
+      .catch((error) => {
         this.wpNotificationsService.handleErrorResponse(error, childWorkPackage);
         return Promise.reject(error);
       });

--- a/frontend/app/components/wp-relations/wp-relations.service.ts
+++ b/frontend/app/components/wp-relations/wp-relations.service.ts
@@ -42,7 +42,7 @@ export class WorkPackageRelationsService extends StateCacheService<RelationsStat
    * Load a set of work package ids into the states, regardless of them being loaded
    * @param workPackageIds
    */
-  protected async load(id:string):Promise<RelationsStateValue> {
+  protected load(id:string):Promise<RelationsStateValue> {
     return new Promise<RelationsStateValue>((resolve, reject) => {
       this.relationsDm
         .load(id)
@@ -54,7 +54,7 @@ export class WorkPackageRelationsService extends StateCacheService<RelationsStat
     });
   }
 
-  protected async loadAll(ids:string[]) {
+  protected loadAll(ids:string[]) {
     return new Promise<undefined>((resolve, reject) => {
       this.relationsDm
         .loadInvolved(ids)
@@ -70,7 +70,7 @@ export class WorkPackageRelationsService extends StateCacheService<RelationsStat
   /**
    * Remove the given relation.
    */
-  public async removeRelation(relation:RelationResource) {
+  public removeRelation(relation:RelationResource) {
     return relation.delete().then(() => {
       this.removeFromStates(relation);
       this.wpTableRefresh.request(
@@ -83,7 +83,7 @@ export class WorkPackageRelationsService extends StateCacheService<RelationsStat
   /**
    * Update the given relation type, setting new values for from and to
    */
-  public async updateRelationType(from:WorkPackageResource, to:WorkPackageResource, relation:RelationResource, type:string) {
+  public updateRelationType(from:WorkPackageResource, to:WorkPackageResource, relation:RelationResource, type:string) {
     const params = {
       _links: {
         from: {href: from.href},
@@ -95,7 +95,7 @@ export class WorkPackageRelationsService extends StateCacheService<RelationsStat
     return this.updateRelation(relation, params);
   }
 
-  public async updateRelation(relation:RelationResource, params:{[key:string]:any}) {
+  public updateRelation(relation:RelationResource, params:{[key:string]:any}) {
     return relation.updateImmediately(params)
       .then((savedRelation:RelationResource) => {
         this.insertIntoStates(savedRelation);
@@ -107,7 +107,7 @@ export class WorkPackageRelationsService extends StateCacheService<RelationsStat
       });
   }
 
-  public async addCommonRelation(workPackage:WorkPackageResource,
+  public addCommonRelation(workPackage:WorkPackageResource,
                            relationType:string,
                            relatedWpId:string) {
     const params = {

--- a/frontend/app/components/wp-single-view-tabs/activity-panel/wp-activity.service.ts
+++ b/frontend/app/components/wp-single-view-tabs/activity-panel/wp-activity.service.ts
@@ -57,7 +57,7 @@ export class WorkPackagesActivityService extends WorkPackageLinkedResourceCache<
    * Resolves both promises and returns a sorted list of activities
    * whose order depends on the 'commentsSortedInDescendingOrder' property.
    */
-  protected async load(workPackage:WorkPackageResource):Promise<HalResource[]> {
+  protected load(workPackage:WorkPackageResource):Promise<HalResource[]> {
     var aggregated:any[] = [], promises:Promise<any>[] = [];
 
     var add = function (data:any) {

--- a/frontend/app/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
+++ b/frontend/app/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
@@ -178,7 +178,7 @@ export class WorkPackageWatchersTabComponent implements OnInit, OnDestroy {
     return jQuery(li);
   }
 
-  public async autocompleteWatchers(query:string):Promise<any> {
+  public autocompleteWatchers(query:string):Promise<any> {
     let payload:any = {sortBy: JSON.stringify([['name', 'asc']])};
 
     if (query && query.length > 0) {

--- a/frontend/app/components/wp-single-view-tabs/watchers-tab/wp-watchers.service.ts
+++ b/frontend/app/components/wp-single-view-tabs/watchers-tab/wp-watchers.service.ts
@@ -35,7 +35,7 @@ import {WorkPackageLinkedResourceCache} from 'core-components/wp-single-view-tab
 @Injectable()
 export class WorkPackageWatchersService extends WorkPackageLinkedResourceCache<HalResource[]> {
 
-  protected async load(workPackage:WorkPackageResource) {
+  protected load(workPackage:WorkPackageResource) {
     return workPackage.watchers.$update()
       .then((collection:CollectionResource<HalResource>) => {
         return collection.elements;

--- a/frontend/app/components/wp-single-view-tabs/wp-linked-resource-cache.service.ts
+++ b/frontend/app/components/wp-single-view-tabs/wp-linked-resource-cache.service.ts
@@ -50,7 +50,7 @@ export abstract class WorkPackageLinkedResourceCache<T> {
    * @param {WorkPackageResource} workPackage
    * @returns {Promise<T>}
    */
-  public async require(workPackage:WorkPackageResource, force:boolean = false):Promise<T> {
+  public require(workPackage:WorkPackageResource, force:boolean = false):Promise<T> {
     const id = workPackage.id.toString();
     const state = this.cache.state;
 
@@ -66,7 +66,7 @@ export abstract class WorkPackageLinkedResourceCache<T> {
 
     // Ensure value is loaded only once
     this.cache.id = id;
-    this.cache.state.putFromPromiseIfPristine(async () => this.load(workPackage));
+    this.cache.state.putFromPromiseIfPristine(() => this.load(workPackage));
 
     return this.cache.state
       .values$()

--- a/frontend/app/components/wp-table/configuration-modal/wp-table-configuration.modal.ts
+++ b/frontend/app/components/wp-table/configuration-modal/wp-table-configuration.modal.ts
@@ -144,7 +144,7 @@ export class WpTableConfigurationModalComponent extends OpModalComponent impleme
     return this.$element;
   }
 
-  protected async loadForm() {
+  protected loadForm() {
     const query = this.tableState.query.value!;
     return this.queryFormDm
       .load(query)

--- a/frontend/app/components/wp-table/embedded/wp-embedded-table.component.ts
+++ b/frontend/app/components/wp-table/embedded/wp-embedded-table.component.ts
@@ -99,7 +99,7 @@ export class WorkPackageEmbeddedTableComponent implements OnInit, AfterViewInit,
     this.tableState.refreshRequired
       .values$()
       .pipe(untilComponentDestroyed(this))
-      .subscribe(async () => this.refresh());
+      .subscribe(() => this.refresh());
 
     // Reload results on changes to pagination
     this.tableState.ready.fireOnStateChange(this.wpTablePagination.state,
@@ -160,7 +160,7 @@ export class WorkPackageEmbeddedTableComponent implements OnInit, AfterViewInit,
     });
   }
 
-  public async refresh():Promise<any> {
+  public refresh():Promise<any> {
     return this.loadingIndicator = this.loadQuery();
   }
 
@@ -172,7 +172,7 @@ export class WorkPackageEmbeddedTableComponent implements OnInit, AfterViewInit,
     }
   }
 
-  private async loadQuery() {
+  private loadQuery() {
 
     // HACK: Decrease loading time of queries when results are not needed.
     // We should allow the backend to disable results embedding instead.

--- a/frontend/app/components/wp-table/table-pagination/wp-table-pagination.component.ng2.test.ts
+++ b/frontend/app/components/wp-table/table-pagination/wp-table-pagination.component.ng2.test.ts
@@ -42,8 +42,8 @@ import {WorkPackageTablePaginationComponent} from 'core-components/wp-table/tabl
 import {HalResourceService} from 'core-app/modules/hal/services/hal-resource.service';
 import {PathHelperService} from 'core-components/common/path-helper/path-helper.service';
 
-async function setupMocks(paginationService:PaginationService) {
-  sinon.stub(paginationService, 'loadPaginationOptions', async () => {
+function setupMocks(paginationService:PaginationService) {
+  sinon.stub(paginationService, 'loadPaginationOptions', () => {
     const options:IPaginationOptions = {
       perPage: 0,
       perPageOptions: [10, 100, 500, 1000],

--- a/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -239,7 +239,7 @@ export function registerWorkPackageMouseHandler(this:void,
 
   }
 
-  async function saveWorkPackage(changeset:WorkPackageChangeset) {
+  function saveWorkPackage(changeset:WorkPackageChangeset) {
     const queryDm:QueryDmService = injector.get(QueryDmService);
     const states:States = injector.get(States);
 

--- a/frontend/app/modules/hal/dm-services/configuration-dm.service.ts
+++ b/frontend/app/modules/hal/dm-services/configuration-dm.service.ts
@@ -37,7 +37,7 @@ export class ConfigurationDmService {
               protected pathHelper:PathHelperService) {
   }
 
-  public async load():Promise<ConfigurationResource> {
+  public load():Promise<ConfigurationResource> {
     return this.halResourceService.get<ConfigurationResource>(this.pathHelper.api.v3.configuration.toString()).toPromise();
   }
 }

--- a/frontend/app/modules/hal/dm-services/help-text-dm.service.ts
+++ b/frontend/app/modules/hal/dm-services/help-text-dm.service.ts
@@ -38,13 +38,13 @@ export class HelpTextDmService {
               protected pathHelper:PathHelperService) {
   }
 
-  public async loadAll():Promise<CollectionResource<HelpTextResource>> {
+  public loadAll():Promise<CollectionResource<HelpTextResource>> {
     return this.halResourceService
       .get<CollectionResource<HelpTextResource>>(this.pathHelper.api.v3.help_texts.toString())
       .toPromise();
   }
 
-  public async load(helpTextId:string):Promise<HelpTextResource> {
+  public load(helpTextId:string):Promise<HelpTextResource> {
     return this.halResourceService
       .get<HelpTextResource>(this.pathHelper.api.v3.help_texts.id(helpTextId).toString())
       .toPromise();

--- a/frontend/app/modules/hal/dm-services/project-dm.service.ts
+++ b/frontend/app/modules/hal/dm-services/project-dm.service.ts
@@ -37,7 +37,7 @@ export class ProjectDmService {
               protected pathHelper:PathHelperService) {
   }
 
-  public async load(id:string|number):Promise<ProjectResource> {
+  public load(id:string|number):Promise<ProjectResource> {
     return this.halResourceService
       .get<ProjectResource>(this.pathHelper.api.v3.projects.id(id).toString())
       .toPromise();

--- a/frontend/app/modules/hal/dm-services/query-dm.service.ts
+++ b/frontend/app/modules/hal/dm-services/query-dm.service.ts
@@ -50,7 +50,7 @@ export class QueryDmService {
               protected PayloadDm:PayloadDmService) {
   }
 
-  public async find(queryData:Object, queryId?:string, projectIdentifier?:string):Promise<QueryResource> {
+  public find(queryData:Object, queryId?:string, projectIdentifier?:string):Promise<QueryResource> {
     let path:string;
 
     if (queryId) {
@@ -64,11 +64,11 @@ export class QueryDmService {
       .toPromise();
   }
 
-  public async findDefault(queryData:Object, projectIdentifier?:string):Promise<QueryResource> {
+  public findDefault(queryData:Object, projectIdentifier?:string):Promise<QueryResource> {
     return this.find(queryData, undefined, projectIdentifier);
   }
 
-  public async reload(query:QueryResource, pagination:PaginationObject):Promise<QueryResource> {
+  public reload(query:QueryResource, pagination:PaginationObject):Promise<QueryResource> {
     let path = this.pathHelper.api.v3.queries.id(query.id).toString();
 
     return this.halResourceService
@@ -76,7 +76,7 @@ export class QueryDmService {
       .toPromise();
   }
 
-  public async loadResults(query:QueryResource, pagination:PaginationObject):Promise<WorkPackageCollectionResource> {
+  public loadResults(query:QueryResource, pagination:PaginationObject):Promise<WorkPackageCollectionResource> {
     if (!query.results) {
       throw 'No results embedded when expected';
     }
@@ -90,7 +90,7 @@ export class QueryDmService {
       .toPromise();
   }
 
-  public async loadIdsUpdatedSince(ids:any, timestamp:any):Promise<WorkPackageCollectionResource> {
+  public loadIdsUpdatedSince(ids:any, timestamp:any):Promise<WorkPackageCollectionResource> {
     const filters = [
       {
         id: {
@@ -111,7 +111,7 @@ export class QueryDmService {
       .toPromise();
   }
 
-  public async update(query:QueryResource, form:QueryFormResource) {
+  public update(query:QueryResource, form:QueryFormResource) {
     return new Promise<QueryResource>((resolve, reject) => {
       this.extractPayload(query, form)
         .then(payload => {
@@ -125,8 +125,8 @@ export class QueryDmService {
     });
   }
 
-  public async create(query:QueryResource, form:QueryFormResource):Promise<QueryResource> {
-    return this.extractPayload(query, form).then(async payload => {
+  public create(query:QueryResource, form:QueryFormResource):Promise<QueryResource> {
+    return this.extractPayload(query, form).then(payload => {
       let path:string = this.pathHelper.api.v3.queries.toString();
 
       return this.halResourceService
@@ -135,11 +135,11 @@ export class QueryDmService {
     });
   }
 
-  public async delete(query:QueryResource) {
+  public delete(query:QueryResource) {
     return query.delete();
   }
 
-  public async toggleStarred(query:QueryResource) {
+  public toggleStarred(query:QueryResource) {
     if (query.starred) {
       return query.unstar();
     } else {
@@ -147,7 +147,7 @@ export class QueryDmService {
     }
   }
 
-  public async all(projectIdentifier?:string):Promise<CollectionResource> {
+  public all(projectIdentifier?:string):Promise<CollectionResource> {
     let filters = new ApiV3FilterBuilder();
 
     if (projectIdentifier) {
@@ -165,10 +165,10 @@ export class QueryDmService {
       .toPromise();
   }
 
-  private async extractPayload(query:QueryResource, form:QueryFormResource):Promise<QueryResource> {
+  private extractPayload(query:QueryResource, form:QueryFormResource):Promise<QueryResource> {
     // Extracting requires having the filter schemas loaded as the dependencies
     // need to be present. This should be handled within the cached information however, so it is fast.
-    const promises = _.map(query.filters, async filter => filter.schema.$load());
+    const promises = _.map(query.filters, filter => filter.schema.$load());
 
     return Promise
       .all(promises)

--- a/frontend/app/modules/hal/dm-services/query-form-dm.service.ts
+++ b/frontend/app/modules/hal/dm-services/query-form-dm.service.ts
@@ -38,7 +38,7 @@ export class QueryFormDmService {
               protected pathHelper:PathHelperService) {
   }
 
-  public async load(query:QueryResource):Promise<QueryFormResource> {
+  public load(query:QueryResource):Promise<QueryFormResource> {
     // We need a valid payload so that we
     // can check whether form saving is possible.
     // The query needs a name to be valid.
@@ -57,7 +57,7 @@ export class QueryFormDmService {
     return query.$links.update(payload);
   }
 
-  public async loadWithParams(params:{}, queryId?:number, projectIdentifier?:string):Promise<QueryFormResource> {
+  public loadWithParams(params:{}, queryId?:number, projectIdentifier?:string):Promise<QueryFormResource> {
     // We need a valid payload so that we
     // can check whether form saving is possible.
     // The query needs a name to be valid.

--- a/frontend/app/modules/hal/dm-services/relations-dm.service.ts
+++ b/frontend/app/modules/hal/dm-services/relations-dm.service.ts
@@ -43,14 +43,14 @@ export class RelationsDmService {
 
   }
 
-  public async load(workPackageId:string):Promise<RelationResource[]> {
+  public load(workPackageId:string):Promise<RelationResource[]> {
     return this.halResourceService.get<CollectionResource<RelationResource>>(
       this.pathHelper.api.v3.work_packages.id(workPackageId).relations, {})
       .toPromise()
       .then((collection:CollectionResource<RelationResource>) => collection.elements);
   }
 
-  public async loadInvolved(workPackageIds:string[]):Promise<RelationResource[]> {
+  public loadInvolved(workPackageIds:string[]):Promise<RelationResource[]> {
     let validIds = _.filter(workPackageIds, id => /\d+/.test(id));
 
     if (validIds.length === 0) {

--- a/frontend/app/modules/hal/dm-services/root-dm.service.ts
+++ b/frontend/app/modules/hal/dm-services/root-dm.service.ts
@@ -37,7 +37,7 @@ export class RootDmService {
               protected pathHelper:PathHelperService) {
   }
 
-  public async load():Promise<RootResource> {
+  public load():Promise<RootResource> {
     return this.halResourceService
       .get<RootResource>(this.pathHelper.api.v3.root.toString())
       .toPromise();

--- a/frontend/app/modules/hal/dm-services/type-dm.service.ts
+++ b/frontend/app/modules/hal/dm-services/type-dm.service.ts
@@ -41,7 +41,7 @@ export class TypeDmService {
               protected pathHelper:PathHelperService) {
   }
 
-  public async loadAll():Promise<TypeResource[]> {
+  public loadAll():Promise<TypeResource[]> {
     const typeUrl = this.pathHelper.api.v3.types.toString();
 
     return this.halResourceService
@@ -54,7 +54,7 @@ export class TypeDmService {
       });
   }
 
-  public async load():Promise<RootResource> {
+  public load():Promise<RootResource> {
     return this.halResourceService
       .get<RootResource>(this.pathHelper.api.v3.root.toString())
       .toPromise();

--- a/frontend/app/modules/hal/dm-services/user-dm.service.ts
+++ b/frontend/app/modules/hal/dm-services/user-dm.service.ts
@@ -37,7 +37,7 @@ export class UserDmService {
               protected pathHelper:PathHelperService) {
   }
 
-  public async load(id:number|string):Promise<UserResource> {
+  public load(id:number|string):Promise<UserResource> {
     const path = this.pathHelper.api.v3.users.id(id).toString();
 
     return this.halResourceService

--- a/frontend/app/modules/hal/hal-link/hal-link.ts
+++ b/frontend/app/modules/hal/hal-link/hal-link.ts
@@ -62,7 +62,7 @@ export class HalLink implements HalLinkInterface {
    */
   public static fromObject(halResourceService:HalResourceService, link:HalLinkInterface):HalLink {
     return new HalLink(
-  async (method:HTTPSupportedMethods, href:string, data:any, headers:any) =>
+  (method:HTTPSupportedMethods, href:string, data:any, headers:any) =>
         halResourceService.request(method, href, data, headers).toPromise(),
       link.href,
       link.title,
@@ -77,7 +77,7 @@ export class HalLink implements HalLinkInterface {
   /**
    * Fetch the resource.
    */
-  public async $fetch(...params:any[]):Promise<HalResource> {
+  public $fetch(...params:any[]):Promise<HalResource> {
     const [data, headers] = params;
     return this.requestMethod(this.method, this.href as string, data, headers);
   }
@@ -116,7 +116,7 @@ export class HalLink implements HalLinkInterface {
    * @returns {CallableHalLink}
    */
   public $callable():CallableHalLink {
-    const linkFunc:any = async (...params:any[]) => this.$fetch(...params);
+    const linkFunc:any = (...params:any[]) => this.$fetch(...params);
 
     _.extend(linkFunc, {
       $link: this,

--- a/frontend/app/modules/hal/resources/hal-resource.ts
+++ b/frontend/app/modules/hal/resources/hal-resource.ts
@@ -159,7 +159,7 @@ export class HalResource {
     return null;
   }
 
-  public async $load(force = false):Promise<this> {
+  public $load(force = false):Promise<this> {
     if (!this.state) {
       return this.$loadResource(force);
     }
@@ -172,7 +172,7 @@ export class HalResource {
 
     // If nobody has asked yet for the resource to be $loaded, do it ourselves.
     // Otherwise, we risk returning a promise, that will never be resolved.
-    state.putFromPromiseIfPristine(async () => this.$loadResource(force));
+    state.putFromPromiseIfPristine(() => this.$loadResource(force));
 
     return <Promise<this>> state.valuesPromise().then((source:any) => {
       this.$initialize(source);
@@ -181,7 +181,7 @@ export class HalResource {
     });
   }
 
-  protected async $loadResource(force = false):Promise<this> {
+  protected $loadResource(force = false):Promise<this> {
     if (!force) {
       if (this.$loaded) {
         return Promise.resolve(this);
@@ -206,7 +206,7 @@ export class HalResource {
   /**
    * Update the resource ignoring the cache.
    */
-  public async $update() {
+  public $update() {
     return this.$load(true);
   }
 

--- a/frontend/app/modules/hal/resources/relation-resource.ts
+++ b/frontend/app/modules/hal/resources/relation-resource.ts
@@ -123,11 +123,11 @@ export class RelationResource extends HalResource {
     };
   }
 
-  public async updateDescription(description:string) {
+  public updateDescription(description:string) {
     return this.$links.updateImmediately({description: description});
   }
 
-  public async updateType(type:any) {
+  public updateType(type:any) {
     return this.$links.updateImmediately({type: type});
   }
 }

--- a/frontend/app/modules/hal/resources/work-package-resource.ts
+++ b/frontend/app/modules/hal/resources/work-package-resource.ts
@@ -188,7 +188,7 @@ export class WorkPackageResource extends HalResource {
    * Removing it from the elements array assures that the view gets updated immediately.
    * If an error occurs, the user gets notified and the attachment is pushed to the elements.
    */
-  public async removeAttachment(attachment:any):Promise<any> {
+  public removeAttachment(attachment:any):Promise<any> {
     _.pull(this.attachments.elements, attachment);
     _.pull(this.pendingAttachments, attachment);
 
@@ -223,14 +223,14 @@ export class WorkPackageResource extends HalResource {
    * Upload the given attachments, update the resource and notify the user.
    * Return an updated AttachmentCollectionResource.
    */
-  public async uploadAttachments(files:UploadFile[]):Promise<any> {
+  public uploadAttachments(files:UploadFile[]):Promise<any> {
     const { uploads, finished } = this.performUpload(files);
 
     const message = I18n.t('js.label_upload_notification', this);
     const notification = this.NotificationsService.addWorkPackageUpload(message, uploads);
 
     return finished
-      .then(async () => {
+      .then(() => {
         setTimeout(() => this.NotificationsService.remove(notification), 700);
         return this.updateAttachments();
       })
@@ -282,7 +282,7 @@ export class WorkPackageResource extends HalResource {
    * Return a promise that returns the linked resources as properties.
    * Return a rejected promise, if the resource is not a property of the work package.
    */
-  public async updateLinkedResources(...resourceNames:string[]):Promise<any> {
+  public updateLinkedResources(...resourceNames:string[]):Promise<any> {
     const resources:{ [id:string]:Promise<HalResource> } = {};
 
     resourceNames.forEach(name => {
@@ -305,7 +305,7 @@ export class WorkPackageResource extends HalResource {
    * Return a promise that returns the attachments. Reject, if the work package has
    * no attachments.
    */
-  public async updateAttachments():Promise<HalResource> {
+  public updateAttachments():Promise<HalResource> {
     return this
       .updateLinkedResources('activities', 'attachments')
       .then((resources:any) => resources.attachments);
@@ -323,7 +323,7 @@ export class WorkPackageResource extends HalResource {
     // Set update link to form
     this['update'] = this.$links.update = form.$links.self;
     // Use POST /work_packages for saving link
-    this['updateImmediately'] = this.$links.updateImmediately = async (payload) => {
+    this['updateImmediately'] = this.$links.updateImmediately = (payload) => {
       return this.apiWorkPackages.createWorkPackage(payload);
     };
   }

--- a/frontend/tslint_typechecks.json
+++ b/frontend/tslint_typechecks.json
@@ -2,7 +2,7 @@
     "rules": {
         "await-promise": [true, "IPromise"],
         "no-unnecessary-type-assertion": true,
-        "promise-function-async": true,
+        "promise-function-async": false,
         "no-for-in-array": true,
         "no-unbound-method": [true, "ignore-static"],
         "no-unsafe-any": false,


### PR DESCRIPTION
async results in the function being transpiled into an generator by TS for ES5 compability. This is both unwieldy and results in a significant code increase in these files.