### PR TITLE
[27763] Ensure session cookie receives secure flag in https

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -258,4 +258,7 @@ class Setting < ActiveRecord::Base
 
   require_dependency 'setting/callbacks'
   extend Callbacks
+
+  require_dependency 'setting/aliases'
+  extend Aliases
 end

--- a/app/models/setting/aliases.rb
+++ b/app/models/setting/aliases.rb
@@ -27,23 +27,17 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-# Be sure to restart your server when you modify this file.
+class Setting
 
-config = OpenProject::Configuration
+  ##
+  # Shorthand to common setting aliases to avoid checking values
+  module Aliases
 
-session_store     = config['session_store'].to_sym
-relative_url_root = config['rails_relative_url_root'].presence
-
-session_options = {
-  key:    config['session_cookie_name'],
-  httponly: true,
-  secure: Setting.https?,
-  path:   relative_url_root
-}
-
-OpenProject::Application.config.session_store session_store, session_options
-
-##
-# We use our own decorated session model to note the user_id
-# for each session.
-ActionDispatch::Session::ActiveRecordStore.session_class = ::UserSession
+    ##
+    # Whether the application is configured to use or force SSL output
+    # for cookie storage et al.
+    def https?
+      Setting.protocol == 'https' || Rails.configuration.force_ssl
+    end
+  end
+end

--- a/lib/tasks/packager.rake
+++ b/lib/tasks/packager.rake
@@ -71,6 +71,11 @@ namespace :packager do
         ENV.fetch('SERVER_PROTOCOL', Setting.protocol)
       end
 
+    # Set https configured, set Rails force_ssl to true
+    if Setting.https?
+      shell_setup(['config:set', "OPENPROJECT_RAILS__FORCE__SSL=true"])
+    end
+
     # Run customization step, if it is defined.
     # Use to define custom postinstall steps required after each configure,
     # or to configure products.


### PR DESCRIPTION
When users enable https in their instance, the session cookie should be `secure` by default.
It currently is only when the configuration `rails_force_ssl` is set.

https://community.openproject.com/wp/27763