### PR TITLE
registration footer override

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -30,8 +30,22 @@ module AccountsHelper
   end
 
   def registration_footer
-    footer = Setting.registration_footer[I18n.locale.to_s].presence
+    footer = registration_footer_for lang: I18n.locale.to_s
 
     Footer.new(footer).to_html if footer
+  end
+
+  ##
+  # Gets the registration footer in the given language.
+  # If registration footers are defined via the OpenProject configuration
+  # then any footers defined via settings will be ignored.
+  #
+  # @param lang [String] ISO 639-1 language code (e.g. 'en', 'de')
+  def registration_footer_for(lang:)
+    if footer = OpenProject::Configuration.registration_footer.presence
+      footer[lang.to_s].presence
+    else
+      Setting.registration_footer[lang.to_s].presence
+    end
   end
 end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -27,6 +27,8 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'permitted_params/allowed_settings'
+
 class PermittedParams
   # This class intends to provide a method for all params hashes coming from the
   # client and that are used for mass assignment.
@@ -192,18 +194,7 @@ class PermittedParams
 
   def settings
     permitted_params = params.require(:settings).permit
-
-    all_setting_keys = Setting.available_settings.keys
-    all_valid_keys = if OpenProject::Configuration.disable_password_login?
-                       all_setting_keys - %w(password_min_length
-                                             password_active_rules
-                                             password_min_adhered_rules
-                                             password_days_valid
-                                             password_count_former_banned
-                                             lost_password)
-                     else
-                       all_setting_keys
-                     end
+    all_valid_keys = AllowedSettings.all
 
     permitted_params.merge(params[:settings].to_unsafe_hash.slice(*all_valid_keys))
   end

--- a/app/models/permitted_params/allowed_settings.rb
+++ b/app/models/permitted_params/allowed_settings.rb
@@ -1,0 +1,65 @@
+class PermittedParams
+  module AllowedSettings
+    class Restriction
+      attr_reader :restricted_keys, :condition
+
+      def initialize(restricted_keys, condition)
+        @restricted_keys = restricted_keys
+        @condition = condition
+      end
+
+      def applicable?
+        if condition.respond_to? :call
+          condition.call
+        else
+          condition
+        end
+      end
+    end
+
+    module_function
+
+    def all
+      keys = Setting.available_settings.keys
+
+      restrictions.select(&:applicable?).each do |restriction|
+        restricted_keys = restriction.restricted_keys
+
+        keys.delete_if { |key| restricted_keys.include? key }
+      end
+
+      keys
+    end
+
+    def add_restriction!(keys:, condition:)
+      restrictions << Restriction.new(keys, condition)
+    end
+
+    def restrictions
+      @restrictions ||= []
+    end
+
+    def init!
+      password_keys = %w(
+        password_min_length
+        password_active_rules
+        password_min_adhered_rules
+        password_days_valid
+        password_count_former_banned
+        lost_password
+      )
+
+      add_restriction!(
+        keys: password_keys,
+        condition: -> { OpenProject::Configuration.disable_password_login? }
+      )
+
+      add_restriction!(
+        keys: %w(registration_footer),
+        condition: -> { OpenProject::Configuration.registration_footer.present? }
+      )
+    end
+
+    init!
+  end
+end

--- a/app/views/settings/_authentication.html.erb
+++ b/app/views/settings/_authentication.html.erb
@@ -46,12 +46,15 @@ See doc/COPYRIGHT.rdoc for more details.
       </div>
     </fieldset>
 
-    <fieldset class="form--fieldset">
-      <fieldset id="registration_footer" class="form--fieldset">
-        <legend class="form--fieldset-legend"><%= I18n.t(:setting_registration_footer) %></legend>
-        <%= cell Settings::TextSettingCell, I18n.locale, name: "registration_footer" %>
+    <%# Footers defined in the OpenProject configuration override and disable those from Settings. %>
+    <% if OpenProject::Configuration.registration_footer.blank? %>
+      <fieldset class="form--fieldset">
+        <fieldset id="registration_footer" class="form--fieldset">
+          <legend class="form--fieldset-legend"><%= I18n.t(:setting_registration_footer) %></legend>
+          <%= cell Settings::TextSettingCell, I18n.locale, name: "registration_footer" %>
+        </fieldset>
       </fieldset>
-    </fieldset>
+    <% end %>
 
     <fieldset class="form--fieldset">
       <legend class="form--fieldset-legend"><%= I18n.t(:passwords, scope: [:settings]) %></legend>

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -112,7 +112,9 @@ module OpenProject
       'health_checks_jobs_never_ran_minutes_ago' => 5,
 
       'after_login_default_redirect_url' => nil,
-      'after_first_login_redirect_url' => nil
+      'after_first_login_redirect_url' => nil,
+
+      'registration_footer' => {}
     }
 
     @config = nil

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -933,6 +933,48 @@ describe PermittedParams, type: :model do
 
       it { expect(subject).to eq(permitted_hash) }
     end
+
+    describe 'with no registration footer configured' do
+      before do
+        allow(OpenProject::Configuration)
+          .to receive(:registration_footer)
+          .and_return({})
+      end
+
+      let(:hash) do
+        {
+          'registration_footer' => {
+            'en' => 'some footer'
+          }
+        }
+      end
+
+      it_behaves_like 'allows params'
+    end
+
+    describe 'with a registration footer configured' do
+      include_context 'prepare params comparison'
+
+      before do
+        allow(OpenProject::Configuration)
+          .to receive(:registration_footer)
+          .and_return("en" => "configured footer")
+      end
+
+      let(:hash) do
+        {
+          'registration_footer' => {
+            'en' => 'some footer'
+          }
+        }
+      end
+
+      let(:permitted_hash) do
+        {}
+      end
+
+      it { expect(subject).to eq(permitted_hash) }
+    end
   end
 
   describe '#enumerations' do

--- a/spec/views/account/register.html.erb_spec.rb
+++ b/spec/views/account/register.html.erb_spec.rb
@@ -94,11 +94,24 @@ describe 'account/register', type: :view do
       allow(Setting).to receive(:registration_footer).and_return("en" => footer)
 
       assign(:user, user)
-      render
     end
 
-    it 'should render the emai footer' do
+    it 'should render the registration footer from the settings' do
+      render
+
       expect(rendered).to include(footer)
+    end
+
+    context 'with a registration footer in the OpenProject configuration' do
+      before do
+        allow(OpenProject::Configuration).to receive(:registration_footer).and_return("en" => footer.reverse)
+      end
+
+      it 'should render the registration footer from the configuration, overriding the settings' do
+        render
+
+        expect(rendered).to include(footer.reverse)
+      end
     end
   end
 end

--- a/spec/views/settings/_authentication.html.erb_spec.rb
+++ b/spec/views/settings/_authentication.html.erb_spec.rb
@@ -58,4 +58,29 @@ describe 'settings/_authentication', type: :view do
       expect(rendered).not_to have_text I18n.t(:brute_force_prevention, scope: [:settings])
     end
   end
+
+  context 'with no registration_footer configured' do
+    before do
+      allow(OpenProject::Configuration).to receive(:registration_footer).and_return({})
+      render
+    end
+
+    it 'shows the registration footer textfield' do
+      expect(rendered).to have_text I18n.t(:setting_registration_footer)
+    end
+  end
+
+  context 'with registration_footer configured' do
+    before do
+      allow(OpenProject::Configuration)
+        .to receive(:registration_footer)
+        .and_return("en" => "You approve.")
+
+      render
+    end
+
+    it 'does not show the registration footer textfield' do
+      expect(rendered).not_to have_text I18n.t(:setting_registration_footer)
+    end
+  end
 end


### PR DESCRIPTION
WP [#27743](https://community.openproject.com/projects/openproject/work_packages/27743/activity?query_id=1249)

Allows defining a registration footer through the environment (configuration) which cannot be changed through settings anymore.