### PR TITLE
[27746] When validating the contract, ignore the old parent

### DIFF
--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -1119,4 +1119,27 @@ describe WorkPackages::UpdateService, 'integration tests', type: :model do
       end
     end
   end
+
+  ##
+  # Regression test for #27746
+  # - Parent: A
+  # - Child1: B
+  # - Child2: C
+  #
+  # Trying to set parent of C to B failed because parent relation is requested before change is saved.
+  describe 'Changing parent to a new one that has the same parent as the current element (Regression #27746)' do
+    let(:project) { FactoryGirl.create :project }
+    let!(:wp_a) { FactoryGirl.create :work_package }
+    let!(:wp_b) { FactoryGirl.create :work_package, parent: wp_a }
+    let!(:wp_c) { FactoryGirl.create :work_package, parent: wp_a }
+
+    let(:user) { FactoryGirl.create :admin }
+    let(:work_package) { wp_c }
+
+    let(:attributes) { { parent: wp_b } }
+
+    it 'allows changing the parent' do
+      expect(subject).to be_success
+    end
+  end
 end


### PR DESCRIPTION
The old parent is still there because we're only validating the contract.

https://community.openproject.com/wp/27746