### PR TITLE
stabilize spec by sorting expectations

### DIFF
--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -97,9 +97,9 @@ describe 'API v3 Work package form resource', type: :request do
           it_behaves_like 'API V3 formattable', '_embedded/payload/description' do
             let(:format) { 'textile' }
             let(:raw) { defined?(raw_value) ? raw_value : work_package.description.to_s }
-            let(:html) {
+            let(:html) do
               defined?(html_value) ? html_value : ('<p>' + work_package.description.to_s + '</p>')
-            }
+            end
           end
         end
 
@@ -243,10 +243,10 @@ describe 'API v3 Work package form resource', type: :request do
 
               it_behaves_like 'valid payload' do
                 let(:raw_value) { description }
-                let(:html_value) {
+                let(:html_value) do
                   '<p><strong>Some text</strong> <em>describing</em> ' \
                   '<strong>something</strong>...</p>'
-                }
+                end
               end
 
               it_behaves_like 'having no errors'
@@ -314,13 +314,13 @@ describe 'API v3 Work package form resource', type: :request do
               let(:params) { valid_params.merge(status_parameter) }
 
               context 'valid status' do
-                let!(:workflow) {
+                let!(:workflow) do
                   FactoryBot.create(:workflow,
-                                     type_id: work_package.type.id,
-                                     old_status: work_package.status,
-                                     new_status: target_status,
-                                     role: current_user.memberships[0].roles[0])
-                }
+                                    type_id: work_package.type.id,
+                                    old_status: work_package.status,
+                                    new_status: target_status,
+                                    role: current_user.memberships[0].roles[0])
+                end
 
                 include_context 'post request'
 
@@ -352,9 +352,9 @@ describe 'API v3 Work package form resource', type: :request do
                 end
 
                 context 'status does not exist' do
-                  let(:error_id) {
+                  let(:error_id) do
                     'urn:openproject-org:api:v3:errors:MultipleErrors'.to_json
-                  }
+                  end
                   let(:status_link) { api_v3_paths.status -1 }
 
                   include_context 'post request'
@@ -374,12 +374,12 @@ describe 'API v3 Work package form resource', type: :request do
                   include_context 'post request'
 
                   it_behaves_like 'invalid resource link' do
-                    let(:message) {
+                    let(:message) do
                       I18n.t('api_v3.errors.invalid_resource',
                              property: 'status',
                              expected: '/api/v3/statuses/:id',
                              actual: status_link)
-                    }
+                    end
                   end
                 end
               end
@@ -389,12 +389,12 @@ describe 'API v3 Work package form resource', type: :request do
               shared_context 'setup group membership' do |group_assignment|
                 let(:group) { FactoryBot.create(:group) }
                 let(:role) { FactoryBot.create(:role) }
-                let(:group_member) {
+                let(:group_member) do
                   FactoryBot.create(:member,
-                                     principal: group,
-                                     project: project,
-                                     roles: [role])
-                }
+                                    principal: group,
+                                    project: project,
+                                    roles: [role])
+                end
 
                 before do
                   allow(Setting).to receive(:work_package_group_assignment?)
@@ -406,10 +406,10 @@ describe 'API v3 Work package form resource', type: :request do
 
               shared_examples_for 'handling people' do |property|
                 let(:path) { "_embedded/payload/_links/#{property}/href" }
-                let(:visible_user) {
+                let(:visible_user) do
                   FactoryBot.create(:user,
-                                     member_in_project: project)
-                }
+                                    member_in_project: project)
+                end
                 let(:user_parameter) { { _links: { property => { href: user_link } } } }
                 let(:params) { valid_params.merge(user_parameter) }
 
@@ -470,22 +470,22 @@ describe 'API v3 Work package form resource', type: :request do
                     include_context 'post request'
 
                     it_behaves_like 'invalid resource link' do
-                      let(:message) {
+                      let(:message) do
                         I18n.t('api_v3.errors.invalid_resource',
                                property: property,
                                expected: '/api/v3/users/:id',
                                actual: user_link)
-                      }
+                      end
                     end
                   end
 
                   context 'group assignement disabled' do
                     let(:user_link) { api_v3_paths.user group.id }
                     let(:error_message_path) { "_embedded/validationErrors/#{property}/message" }
-                    let(:error_message) {
+                    let(:error_message) do
                       I18n.t('api_v3.errors.validation.invalid_user_assigned_to_work_package',
                              property: "#{property.capitalize}").to_json
-                    }
+                    end
 
                     include_context 'setup group membership', false
                     include_context 'post request'
@@ -514,7 +514,6 @@ describe 'API v3 Work package form resource', type: :request do
               let(:target_version) { FactoryBot.create(:version, project: project) }
               let(:other_version) { FactoryBot.create(:version, project: project) }
               let(:version_link) { api_v3_paths.version target_version.id }
-              let(:other_version_link) { api_v3_paths.version other_version.id }
               let(:version_parameter) { { _links: { version: { href: version_link } } } }
               let(:params) { valid_params.merge(version_parameter) }
 
@@ -526,10 +525,10 @@ describe 'API v3 Work package form resource', type: :request do
                 include_context 'post request'
 
                 it 'should list all versions available for the project' do
-                  expect(subject.body).to be_json_eql(version_link.to_json)
-                    .at_path('_embedded/schema/version/_links/allowedValues/1/href')
-                  expect(subject.body).to be_json_eql(other_version_link.to_json)
-                    .at_path('_embedded/schema/version/_links/allowedValues/0/href')
+                  [target_version, other_version].sort.each_with_index do |v, i|
+                    expect(subject.body).to be_json_eql(api_v3_paths.version(v.id).to_json)
+                      .at_path("_embedded/schema/version/_links/allowedValues/#{i}/href")
+                  end
                 end
               end
 
@@ -552,7 +551,6 @@ describe 'API v3 Work package form resource', type: :request do
               let(:target_category) { FactoryBot.create(:category, project: project) }
               let(:other_category) { FactoryBot.create(:category, project: project) }
               let(:category_link) { api_v3_paths.category target_category.id }
-              let(:other_category_link) { api_v3_paths.category other_category.id }
               let(:category_parameter) { { _links: { category: { href: category_link } } } }
               let(:params) { valid_params.merge(category_parameter) }
 
@@ -564,10 +562,10 @@ describe 'API v3 Work package form resource', type: :request do
                 include_context 'post request'
 
                 it 'should list the categories' do
-                  expect(subject.body).to be_json_eql(category_link.to_json)
-                    .at_path("#{links_path}/allowedValues/1/href")
-                  expect(subject.body).to be_json_eql(other_category_link.to_json)
-                    .at_path("#{links_path}/allowedValues/0/href")
+                  [target_category, other_category].sort.each_with_index do |c, i|
+                    expect(subject.body).to be_json_eql(api_v3_paths.category(c.id).to_json)
+                      .at_path("#{links_path}/allowedValues/#{i}/href")
+                  end
                 end
               end
 
@@ -667,7 +665,7 @@ describe 'API v3 Work package form resource', type: :request do
             describe 'multiple errors' do
               let(:user_link) { api_v3_paths.user 4200 }
               let(:status_link) { api_v3_paths.status -1 }
-              let(:links) {
+              let(:links) do
                 {
                   _links: {
                     status: { href: status_link },
@@ -675,7 +673,7 @@ describe 'API v3 Work package form resource', type: :request do
                     responsible: { href: user_link }
                   }
                 }
-              }
+              end
               let(:params) { valid_params.merge(subject: nil).merge(links) }
 
               include_context 'post request'


### PR DESCRIPTION
Version and category are sorted lexically and their names include the id. Depending on the categories/versions created in the specs before, the categories/versions in the current spec might have ids passing digit borders (e.g. "Version 9" and "Version 10")

e.g. https://travis-ci.org/opf/openproject/jobs/380194765