### PR TITLE
[27780] Assign default status when type changes and old status does not exist

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -51,7 +51,11 @@ class Status < ActiveRecord::Base
 
   # Returns the default status for new issues
   def self.default
-    where(['is_default=?', true]).first
+    where_default.first
+  end
+
+  def self.where_default
+    where(['is_default=?', true])
   end
 
   # Update all the +Issues+ setting their done_ratio to the value of their +Status+

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -97,9 +97,18 @@ class ::Type < ActiveRecord::Base
     ::Type.includes(:projects).where(projects: { id: project })
   end
 
-  def statuses
+  def statuses(include_default: false)
     return [] if new_record?
+
     @statuses ||= ::Type.statuses([id])
+    return @statuses unless include_default
+
+    default = Status.default
+    if default.nil?
+      @statuses
+    else
+      [default] + @statuses
+    end
   end
 
   def enabled_in?(object)

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -98,16 +98,14 @@ class ::Type < ActiveRecord::Base
   end
 
   def statuses(include_default: false)
-    return [] if new_record?
-
-    @statuses ||= ::Type.statuses([id])
-    return @statuses unless include_default
-
-    default = Status.default
-    if default.nil?
-      @statuses
+    if new_record?
+      Status.none
+    elsif include_default
+      ::Type
+        .statuses([id])
+        .or(Status.where_default)
     else
-      [default] + @statuses
+      ::Type.statuses([id])
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -525,6 +525,7 @@ en:
               violates_relationships: "can only be set to %{soonest_start} or later so as not to violate the work package's relationships."
             status_id:
               status_transition_invalid: "is invalid because no valid transition exists from old to new status for the current user's roles."
+              status_invalid_in_type: "is invalid because the current status does not exist in this type."
             priority_id:
               only_active_priorities_allowed: "needs to be active."
             category:

--- a/spec/controllers/work_packages/moves_controller_spec.rb
+++ b/spec/controllers/work_packages/moves_controller_spec.rb
@@ -40,7 +40,7 @@ describe WorkPackages::MovesController, type: :controller do
   end
   let(:type) { FactoryBot.create :type }
   let(:type_2) { FactoryBot.create :type }
-  let(:status) { FactoryBot.create :default_status }
+  let!(:status) { FactoryBot.create :default_status }
   let(:target_status) { FactoryBot.create :status }
   let(:priority) { FactoryBot.create :priority }
   let(:target_priority) { FactoryBot.create :priority }

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -87,6 +87,17 @@ describe Status, type: :model do
     end
   end
 
+  describe 'default status' do
+    context 'when default exists' do
+      let!(:status) { FactoryBot.create(:default_status) }
+
+      it 'returns that one' do
+        expect(Status.default).to eq(status)
+        expect(Status.where_default.pluck(:id)).to eq([status.id])
+      end
+    end
+  end
+
   describe '#cache_key' do
     it 'updates when the updated_at field changes' do
       old_cache_key = stubbed_status.cache_key

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -46,4 +46,52 @@ describe ::Type, type: :model do
       expect(Type.enabled_in(project)).to match_array([type])
     end
   end
+
+  describe '.statuses' do
+    let(:subject) { type.statuses }
+
+    context 'when new' do
+      let(:type) { FactoryBot.build(:type) }
+
+      it 'returns an empty relation' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when existing but no statuses' do
+      let(:type) { FactoryBot.create(:type) }
+
+      it 'returns an empty relation' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when existing with workflow' do
+      let(:role) { FactoryBot.create(:role) }
+      let(:statuses) { (1..2).map { |_i| FactoryBot.create(:status) } }
+
+      let!(:type) { FactoryBot.create(:type) }
+      let!(:workflow_a) do
+        FactoryBot.create(:workflow, role_id: role.id,
+                          type_id: type.id,
+                          old_status_id: statuses[0].id,
+                          new_status_id: statuses[1].id,
+                          author: false,
+                          assignee: false)
+      end
+
+      it 'returns the statuses relation' do
+        expect(subject.pluck(:id)).to contain_exactly(statuses[0].id, statuses[1].id)
+      end
+
+      context 'with default status' do
+        let!(:default_status) { FactoryBot.create(:default_status) }
+        let(:subject) { type.statuses(include_default: true) }
+
+        it 'returns the workflow and the default status' do
+          expect(subject.pluck(:id)).to contain_exactly(default_status.id, statuses[0].id, statuses[1].id)
+        end
+      end
+    end
+  end
 end

--- a/spec_legacy/unit/type_spec.rb
+++ b/spec_legacy/unit/type_spec.rb
@@ -43,19 +43,4 @@ describe ::Type, type: :model do
     target.reload
     assert_equal 89, target.workflows.size
   end
-
-  it 'should statuses' do
-    type = ::Type.find(1)
-    Workflow.delete_all
-    Workflow.create!(role_id: 1, type_id: 1, old_status_id: 2, new_status_id: 3)
-    Workflow.create!(role_id: 2, type_id: 1, old_status_id: 3, new_status_id: 5)
-
-    expect(type.statuses).to all be_kind_of Status
-    assert_equal [2, 3, 5], ::Type.find(1).statuses.map(&:id)
-  end
-
-  it 'should statuses empty' do
-    Workflow.where(type_id: 1).delete_all
-    assert_equal [], ::Type.find(1).statuses
-  end
 end


### PR DESCRIPTION
When switching the type, the status is not validated in the target type,
resulting in a correctly saved work package whose status can no longer
be changed.

https://community.openproject.com/wp/27780


@ulferts This is only half a fix. It will restrict users to move to a type and would potentially allow them to change statuses, but

- again the target type will have no valid transitions and thus the work package cannot be saved.
- its unclear whether (and how) we should check for the validity of the type transition. I believe we should encapsulate this into a separate permission and allow _any_ status transition.

But this has bugged me for a while and I'd like to address at least part of the problem.