### PR TITLE
Fix: Re-add forms for uploading favicon and touch icon.

### DIFF
--- a/app/views/custom_styles/show.html.erb
+++ b/app/views/custom_styles/show.html.erb
@@ -68,6 +68,74 @@ See docs/COPYRIGHT.rdoc for more details.
   </section>
 <% end %>
 
+<%= form_for @custom_style, url: custom_style_path, html: { multipart: true, class: "form -vertical" } do |f| %>
+  <section class="form--section">
+    <fieldset class="form--fieldset">
+      <legend class="form--fieldset-legend"><%= I18n.t(:label_custom_favicon) %></legend>
+
+      <% if @custom_style.id && @custom_style.favicon.present? %>
+        <div>
+          <%= tag('img', src: custom_style_favicon_path(digest: @custom_style.digest, filename: @custom_style.favicon_identifier), class: 'custom-favicon-preview') %>
+          <%= link_to t(:button_delete),
+                      custom_style_favicon_delete_path,
+                      method: :delete,
+                      class: 'icon icon-delete confirm-form-submit' %>
+        </div>
+      <% end %>
+
+      <div class="grid-block">
+        <div class="form--field -required">
+          <div class="attachment_field form--field-container -vertical -shrink">
+            <div class="form--file-container">
+              <%= f.file_field :favicon, required: true, class: "attachment_choose_file", size: "15" %>
+            </div>
+          </div>
+          <div class="form--field-instructions">
+            <%= t('text_custom_favicon_instructions') %>
+          </div>
+        </div>
+      </div>
+
+      <%= styled_button_tag t(@custom_style.favicon.present? ? :button_replace : :button_upload), class: "button #{@custom_style.favicon.blank? ? '-with-icon icon-add' : ''}" %>
+
+    </fieldset>
+  </section>
+<% end %>
+
+<%= form_for @custom_style, url: custom_style_path, html: { multipart: true, class: "form -vertical" } do |f| %>
+  <section class="form--section">
+    <fieldset class="form--fieldset">
+      <legend class="form--fieldset-legend"><%= I18n.t(:label_custom_touch_icon) %></legend>
+
+      <% if @custom_style.id && @custom_style.touch_icon.present? %>
+        <div>
+          <%= tag('img', src: custom_style_touch_icon_path(digest: @custom_style.digest, filename: @custom_style.touch_icon_identifier), class: 'custom-touch-icon-preview') %>
+          <%= link_to t(:button_delete),
+                      custom_style_touch_icon_delete_path,
+                      method: :delete,
+                      class: 'icon icon-delete confirm-form-submit' %>
+        </div>
+      <% end %>
+
+      <div class="grid-block">
+        <div class="form--field -required">
+          <div class="attachment_field form--field-container -vertical -shrink">
+            <div class="form--file-container">
+              <%= f.file_field :touch_icon, required: true, class: "attachment_choose_file", size: "15" %>
+            </div>
+          </div>
+          <div class="form--field-instructions">
+            <%= t('text_custom_touch_icon_instructions') %>
+          </div>
+        </div>
+      </div>
+
+      <%= styled_button_tag t(@custom_style.touch_icon.present? ? :button_replace : :button_upload), class: "button #{@custom_style.touch_icon.blank? ? '-with-icon icon-add' : ''}" %>
+
+    </fieldset>
+  </section>
+<% end %>
+
 <%= form_tag update_design_colors_path, method: :post, class: "form" do %>
   <section class="form--section">
     <fieldset class="form--fieldset">


### PR DESCRIPTION
Apparently that form got accidentally lost in the commit that removed timelines https://github.com/opf/openproject/commit/a0150fffa005cfa0719803f913c9554597595e9d#diff-cb9916778645badceb0c69d35cd5551a
