### PR TITLE
[27812] Embedded tables do not align with section header

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_table_embedded.sass
+++ b/app/assets/stylesheets/layout/_work_package_table_embedded.sass
@@ -29,8 +29,12 @@
 // Disable CSS containment in the embedded container
 // unless we're setting an external height with overflow, containment will not work.
 .work-packages-embedded-view--container
-  .generic-table--sort-header-outer
-    padding: 0 12px 0 0px
+
+  // Align with section header
+  .wp-table--table-header:first-child .generic-table--sort-header-outer,
+  .wp-table--cell-td:first-child .wp-edit-field--display-field,
+  .wp-inline-create--add-link i:before
+    padding-left: 0
 
   .work-package-table--container
     contain: initial !important


### PR DESCRIPTION
Remove padding from first column to align with section headers.

#### Before
<img width="447" alt="bildschirmfoto 2018-05-25 um 16 33 17" src="https://user-images.githubusercontent.com/7457313/40550068-6b6049d0-6039-11e8-9874-2ddf1beee3b1.png">

#### After
<img width="454" alt="bildschirmfoto 2018-05-25 um 16 32 36" src="https://user-images.githubusercontent.com/7457313/40550072-6f0a5dfa-6039-11e8-84af-bcf7ee0b0e59.png">


https://community.openproject.com/projects/deutsche-bahn/work_packages/27812/activity