### PR TITLE
avoid wrapping on wp payload

### DIFF
--- a/lib/api/v3/work_packages/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/work_package_payload_representer.rb
@@ -36,14 +36,12 @@ module API
 
         cached_representer disabled: true
 
-        def initialize(model, current_user:, embed_links: false)
-          model = ::API::V3::WorkPackages::EagerLoading::NeutralWrapper.wrap_one(model, current_user)
-
-          super
-        end
-
         def writeable_attributes
           super + ["date"]
+        end
+
+        def load_complete_model(model)
+          model
         end
       end
     end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -40,12 +40,7 @@ module API
                            disabled: false
 
         def initialize(model, current_user:, embed_links: false)
-          # Define all accessors on the customizable as they
-          # will be used afterwards anyway. Otherwise, we will have to
-          # go through method_missing which will take more time.
-          model.define_all_custom_field_accessors
-
-          model = ::API::V3::WorkPackages::WorkPackageEagerLoadingWrapper.wrap_one(model, current_user)
+          model = load_complete_model(model)
 
           super
         end
@@ -532,6 +527,15 @@ module API
           'WorkPackage'
         end
 
+        def to_hash(*args)
+          # Define all accessors on the customizable as they
+          # will be used afterwards anyway. Otherwise, we will have to
+          # go through method_missing which will take more time.
+          represented.define_all_custom_field_accessors
+
+          super
+        end
+
         def watchers
           # TODO/LEGACY: why do we need to ensure a specific order here?
           watchers = represented.watcher_users.order(User::USER_FORMATS_STRUCTURE[Setting.user_format])
@@ -638,6 +642,10 @@ module API
 
         def view_time_entries_allowed?
           current_user_allowed_to(:view_time_entries, context: represented.project)
+        end
+
+        def load_complete_model(model)
+          ::API::V3::WorkPackages::WorkPackageEagerLoadingWrapper.wrap_one(model, current_user)
         end
       end
     end


### PR DESCRIPTION
Wrapping can interfere with a couple of method e.g. setting the errors.

Fixes:

* rspec ./spec/requests/api/v3/work_packages/dependent_errors_spec.rb:186
* rspec ./spec/requests/api/v3/work_packages/dependent_errors_spec.rb:184