### PR TITLE
[Mobile] Unhide my menu entries that used to be hidden.

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -70,15 +70,12 @@ end
 Redmine::MenuManager.map :account_menu do |menu|
   menu.push :my_page,
             { controller: '/my', action: 'page' },
-            html: { class: 'hidden-for-mobile' },
             if: Proc.new { User.current.logged? }
   menu.push :my_account,
             { controller: '/my', action: 'account' },
-            html: { class: 'hidden-for-mobile' },
             if: Proc.new { User.current.logged? }
   menu.push :administration,
             { controller: '/users', action: 'index' },
-            html: { class: 'hidden-for-mobile' },
             if: Proc.new { User.current.admin? }
   menu.push :logout, :signout_path,
             if: Proc.new { User.current.logged? }


### PR DESCRIPTION
I personally missed my menu entries on my mobile, especially 'My page'. I believe that we have a good reason why all the other menu items should be visible on mobile, too.

@lindenthal has already agreed on this. Any opposste opinions? @ulferts @oliverguenther @machisuji @HDinger?