### PR TITLE
Add `Gantt` as extra `Work package` child item and to modules menu

### DIFF
--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -77,8 +77,12 @@ class WorkPackagesController < ApplicationController
     end
   end
 
-  current_menu_item :index do
-    :all_open_wps
+  current_menu_item :index do |controller|
+    if controller.params[:query_props] == OpenProject::DefaultWpQueries::GANTT
+      :gantt
+    else
+      :all_open_wps
+    end
   end
 
   protected

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -41,6 +41,14 @@ Redmine::MenuManager.map :top_menu do |menu|
               (User.current.logged? || !Setting.login_required?) &&
                 User.current.allowed_to?(:view_work_packages, nil, global: true)
             }
+
+  menu.push :gantt,
+            { controller: '/work_packages',
+              action: 'index',
+              query_props: OpenProject::DefaultWpQueries::GANTT },
+            param: :project_id,
+            caption: :label_gantt
+
   menu.push :news,
             { controller: '/news', project_id: nil, action: 'index' },
             context: :modules,
@@ -240,7 +248,7 @@ Redmine::MenuManager.map :project_menu do |menu|
             { controller: '/work_packages', action: 'index' },
             param: :project_id,
             caption: :label_work_package_plural,
-            icon: 'icon2 icon-work-packages',
+            icon: 'icon2 icon-view-timeline',
             html: {
               id: 'main-menu-work-packages',
               :'wp-query-menu' => 'wp-query-menu'
@@ -250,6 +258,14 @@ Redmine::MenuManager.map :project_menu do |menu|
             { controller: '/work_packages', action: 'index' },
             param: :project_id,
             caption: :label_all_open_wps,
+            parent: :work_packages
+
+  menu.push :gantt,
+            { controller: '/work_packages',
+              action: 'index',
+              query_props: OpenProject::DefaultWpQueries::GANTT },
+            param: :project_id,
+            caption: :label_gantt,
             parent: :work_packages
 
   menu.push :summary_field,

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -47,7 +47,7 @@ Redmine::MenuManager.map :top_menu do |menu|
               action: 'index',
               query_props: OpenProject::DefaultWpQueries::GANTT },
             param: :project_id,
-            caption: :label_gantt,
+            caption: :label_gantt_chart,
             if: Proc.new {
               (User.current.logged? || !Setting.login_required?) &&
                 User.current.allowed_to?(:view_work_packages, nil, global: true)
@@ -269,7 +269,8 @@ Redmine::MenuManager.map :project_menu do |menu|
               action: 'index',
               query_props: OpenProject::DefaultWpQueries::GANTT },
             param: :project_id,
-            caption: :label_gantt,
+            caption: :label_gantt_chart,
+            icon_after: 'icon2 icon-view-timeline',
             parent: :work_packages
 
   menu.push :summary_field,

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -47,7 +47,11 @@ Redmine::MenuManager.map :top_menu do |menu|
               action: 'index',
               query_props: OpenProject::DefaultWpQueries::GANTT },
             param: :project_id,
-            caption: :label_gantt
+            caption: :label_gantt,
+            if: Proc.new {
+              (User.current.logged? || !Setting.login_required?) &&
+                User.current.allowed_to?(:view_work_packages, nil, global: true)
+            }
 
   menu.push :news,
             { controller: '/news', project_id: nil, action: 'index' },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1228,6 +1228,7 @@ en:
   label_force_user_language_to_default: "Set language of users having a non allowed language to default"
   label_form_configuration: "Form configuration"
   label_gantt: "Gantt"
+  label_gantt_chart: "Gantt chart"
   label_general: "General"
   label_generate_key: "Generate a key"
   label_git_path: "Path to .git directory"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1226,7 +1226,8 @@ en:
   label_folder: "Folder"
   label_follows: "follows"
   label_force_user_language_to_default: "Set language of users having a non allowed language to default"
-  label_form_configuration: Form configuration
+  label_form_configuration: "Form configuration"
+  label_gantt: "Gantt"
   label_general: "General"
   label_generate_key: "Generate a key"
   label_git_path: "Path to .git directory"

--- a/lib/open_project/default_wp_queries.rb
+++ b/lib/open_project/default_wp_queries.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -29,6 +30,6 @@
 
 module OpenProject
   module DefaultWpQueries
-    GANTT = '{"tv":true}'
+    GANTT = '{"tv":true}'.freeze
   end
 end

--- a/lib/open_project/default_wp_queries.rb
+++ b/lib/open_project/default_wp_queries.rb
@@ -1,0 +1,34 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject
+  module DefaultWpQueries
+    GANTT = '{"tv":true}'
+  end
+end

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -206,6 +206,7 @@ module Redmine::MenuManager::MenuHelper
     link_text << op_icon(item.icon) if item.icon.present?
     link_text << you_are_here_info(selected)
     link_text << content_tag(:span, caption, class: 'menu-item--title ellipsis', lang: menu_item_locale(item))
+    link_text << ' '.html_safe + op_icon(item.icon_after) if item.icon_after.present?
     html_options = item.html_options(selected: selected)
     html_options[:title] ||= selected ? t(:description_current_position) + caption : caption
     link_to link_text, url, html_options

--- a/lib/redmine/menu_manager/menu_item.rb
+++ b/lib/redmine/menu_manager/menu_item.rb
@@ -29,7 +29,7 @@
 
 class Redmine::MenuManager::MenuItem < Redmine::MenuManager::TreeNode
   include Redmine::I18n
-  attr_reader :name, :url, :param, :icon, :context, :condition, :parent, :child_menus, :last, :partial
+  attr_reader :name, :url, :param, :icon, :icon_after, :context, :condition, :parent, :child_menus, :last, :partial
 
   def initialize(name, url, options)
     raise ArgumentError, "Invalid option :if for menu item '#{name}'" if options[:if] && !options[:if].respond_to?(:call)
@@ -41,6 +41,7 @@ class Redmine::MenuManager::MenuItem < Redmine::MenuManager::TreeNode
     @condition = options[:if]
     @param = options[:param] || :id
     @icon = options[:icon]
+    @icon_after = options[:icon_after]
     @caption = options[:caption]
     @context = options[:context]
     @html_options = options[:html].nil? ? {} : options[:html].dup

--- a/spec/models/work_package/work_package_notifications_spec.rb
+++ b/spec/models/work_package/work_package_notifications_spec.rb
@@ -1,5 +1,4 @@
 #-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)


### PR DESCRIPTION
This is a tiny PR that basically adds a child menu item **Gantt** to main menu item **Work packages** and to the "global" modules menu

Pro:
- Improves discoverability of the **Gantt** feature at almost no costs.

Contra:
- We might want to discuss a "bigger" solution first.
- I have the impression that we are not all on one page if we want to call it "Gantt" or "Timelines".
