### PR TITLE
[27789] "Configure form" menu item is missing in work package more menu

### DIFF
--- a/frontend/app/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
+++ b/frontend/app/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
@@ -92,6 +92,8 @@ export class WorkPackageSingleContextMenuDirective extends OpContextMenuTrigger 
   }
 
   protected buildItems(permittedActions:WorkPackageAction[]) {
+    const configureFormLink = this.workPackage.configureForm;
+
     this.items = permittedActions.map((action:WorkPackageAction) => {
       const key = action.key;
       return {
@@ -109,5 +111,18 @@ export class WorkPackageSingleContextMenuDirective extends OpContextMenuTrigger 
         }
       };
     });
+
+    if (configureFormLink) {
+      this.items.push(
+        {
+          href:configureFormLink.href,
+          icon: 'icon-settings3',
+          linkText: configureFormLink.name,
+          onClick: () => false
+        }
+      );
+    }
+
+    return this.items;
   }
 }


### PR DESCRIPTION
Add configure Form menu entry in WP context menu

https://community.openproject.com/projects/openproject/work_packages/27789/activity