### PR TITLE
fix textile to markdown converter

### DIFF
--- a/lib/open_project/text_formatting/formatters/markdown/textile_converter.rb
+++ b/lib/open_project/text_formatting/formatters/markdown/textile_converter.rb
@@ -1,5 +1,34 @@
-# Textile to Markdown converter
-# Based on redmine_convert_textile_to_markown
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+# This file is derived from the 'Redmine converter from Textile to Markown'
 # https://github.com/Ecodev/redmine_convert_textile_to_markown
 #
 # Original license:
@@ -28,19 +57,17 @@ require 'open3'
 module OpenProject::TextFormatting::Formatters
   module Markdown
     class TextileConverter
-      attr_reader :src, :dst
-
-      def initialize
-      end
-
+      TAG_CODE = 'pandoc-unescaped-single-backtick'.freeze
+      TAG_FENCED_CODE_BLOCK = 'force-pandoc-to-ouput-fenced-code-block'.freeze
+      DOCUMENT_BOUNDARY = "TextileConverterDocumentBoundary09339cab-f4f4-4739-85b0-d02ba1f342e6".freeze
+      BLOCKQUOTE_START = "TextileConverterBlockquoteStart09339cab-f4f4-4739-85b0-d02ba1f342e6".freeze
+      BLOCKQUOTE_END = "TextileConverterBlockquoteEnd09339cab-f4f4-4739-85b0-d02ba1f342e6".freeze
 
       def run!
         puts 'Starting conversion of Textile fields to CommonMark+GFM.'
 
         ActiveRecord::Base.transaction do
-          converters.each do |handler|
-            handler.call
-          end
+          converters.each(&:call)
         end
 
         puts "\n-- Completed --"
@@ -72,20 +99,18 @@ module OpenProject::TextFormatting::Formatters
       ##
       # Converting model attributes as defined in +models_to_convert+.
       def convert_models
-        models_to_convert.each do |the_class, attributes|
-          print "#{the_class.name} "
+        models_to_convert.each do |klass, attributes|
+          print "#{klass.name} "
 
           # Iterate in batches to avoid plucking too much
-          the_class.in_batches(of: 200) do |relation|
-            relation.pluck(:id, *attributes).each do |values|
-              # Zip converted texts into
-              # { attr_a: textile, ... }
-              converted = values.drop(1).map(&method(:convert_textile_to_markdown))
-              update_hash = Hash[attributes.zip(converted)]
-              the_class.where(id: values.first).update_all(update_hash)
+          with_original_values_in_batches(klass, attributes) do |orig_values|
+            markdowns_in_groups = bulk_convert_textile_with_fallback(orig_values, attributes)
 
-              print '.'
-            end
+            new_values = new_values_for(attributes, orig_values, markdowns_in_groups)
+
+            next if new_values.empty?
+
+            ActiveRecord::Base.connection.execute(batch_update_statement(klass, attributes, new_values))
           end
           puts 'done'
         end
@@ -102,55 +127,178 @@ module OpenProject::TextFormatting::Formatters
         end
 
         puts 'done'
-    end
+      end
+
+      # Iterate in batches to avoid plucking too much
+      def with_original_values_in_batches(klass, attributes)
+        batches_of_objects_to_convert(klass, attributes) do |relation|
+          orig_values = relation.pluck(:id, *attributes)
+
+          yield orig_values
+        end
+      end
+
+      def bulk_convert_textile_with_fallback(orig_values, attributes)
+        old_values = orig_values.inject([]) do |former_values, values|
+          former_values + values.drop(1)
+        end
+
+        joined_textile = concatenate_textile(old_values)
+
+        markdown = convert_textile_to_markdown(joined_textile)
+
+        markdowns_in_groups = []
+
+        begin
+          markdowns_in_groups = split_markdown(markdown).each_slice(attributes.length).to_a
+        rescue StandardError
+          # Don't do anything. Let the subsequent code try to handle it again
+        end
+
+        if markdowns_in_groups.length != orig_values.length
+          # Error handling: Some textile seems to be misformed e.g. <pre>something</pre (without closing >).
+          # In such cases, handle texts individually to avoid the error affecting other texts
+          markdowns = old_values.map do |old_value|
+            convert_textile_to_markdown(old_value)
+          end
+
+          markdowns_in_groups = markdowns.each_slice(attributes.length).to_a
+        end
+
+        markdowns_in_groups
+      end
+
+      def new_values_for(attributes, orig_values, markdowns_in_groups)
+        new_values = []
+        orig_values.each_with_index do |values, index|
+          new_values << { id: values[0] }.merge(attributes.zip(markdowns_in_groups[index]).to_h)
+
+          print '.'
+        end
+
+        new_values
+      end
 
       def convert_textile_to_markdown(textile)
         return '' unless textile.present?
 
-        # Redmine support @ inside inline code marked with @ (such as "@git@github.com@"), but not pandoc.
-        # So we inject a placeholder that will be replaced later on with a real backtick.
-        tag_code = 'pandoc-unescaped-single-backtick'
-        textile.gsub!(/@([\S]+@[\S]+)@/, tag_code + '\\1' + tag_code)
-
-        # Drop table colspan/rowspan notation ("|\2." or "|/2.") because pandoc does not support it
-        # See https://github.com/jgm/pandoc/issues/22
-        textile.gsub!(/\|[\/\\]\d\. /, '| ')
-
-        # Drop table alignement notation ("|>." or "|<." or "|=.") because pandoc does not support it
-        # See https://github.com/jgm/pandoc/issues/22
-        textile.gsub!(/\|[<>=]\. /, '| ')
-
-        # Move the class from <code> to <pre> so pandoc can generate a code block with correct language
-        textile.gsub!(/(<pre)(><code)( class="[^"]*")(>)/, '\\1\\3\\2\\4')
-
-        # Remove the <code> directly inside <pre>, because pandoc would incorrectly preserve it
-        textile.gsub!(/(<pre[^>]*>)<code>/, '\\1')
-        textile.gsub!(/<\/code>(<\/pre>)/, '\\1')
-
-        # Inject a class in all <pre> that do not have a blank line before them
-        # This is to force pandoc to use fenced code block (```) otherwise it would
-        # use indented code block and would very likely need to insert an empty HTML
-        # comment "<!-- -->" (see http://pandoc.org/README.html#ending-a-list)
-        # which are unfortunately not supported by Redmine (see http://www.redmine.org/issues/20497)
-        tag_fenced_code_block = 'force-pandoc-to-ouput-fenced-code-block'
-        textile.gsub!(/([^\n]<pre)(>)/, "\\1 class=\"#{tag_fenced_code_block}\"\\2")
-
-        # Force <pre> to have a blank line before them
-        # Without this fix, a list of items containing <pre> would not be interpreted as a list at all.
-        textile.gsub!(/([^\n])(<pre)/, "\\1\n\n\\2")
-
-        # Some malformed textile content make pandoc run extremely slow,
-        # so we convert it to proper textile before hitting pandoc
-        # see https://github.com/jgm/pandoc/issues/3020
-        textile.gsub!(/-          # (\d+)/, "* \\1")
+        cleanup_before_pandoc(textile)
 
         # TODO pandoc recommends format 'gfm' but that isnt available in current LTS
         # markdown_github, which is deprecated, is however available.
-        command = %w(pandoc --wrap=preserve -f textile -t markdown_github)
-        markdown, stderr_str, status = Open3.capture3(*command, stdin_data: textile)
+        # --wrap=preserve will keep the wrapping the same
+        # --atx-headers will lead to headers like `### Some header` and '## Another header'
+        command = %w(pandoc --wrap=preserve --atx-headers -f textile -t markdown_github)
+        markdown, stderr_str, status = begin
+          Open3.capture3(*command, stdin_data: textile)
+        rescue StandardError
+          raise "Pandoc failed with unspecific error"
+        end
 
         raise "Pandoc failed: #{stderr_str}" unless status.success?
 
+        cleanup_after_pandoc(markdown)
+      end
+
+      def models_to_convert
+        {
+          ::Announcement => [:text],
+          ::AttributeHelpText => [:help_text],
+          ::Comment => [:comments],
+          ::WikiContent => [:text],
+          ::WorkPackage =>  [:description],
+          ::Message => [:content],
+          ::News => [:description],
+          ::Board => [:description],
+          ::Project => [:description],
+          ::Journal => [:notes],
+          ::Journal::MessageJournal => [:content],
+          ::Journal::WikiContentJournal => [:text],
+          ::Journal::WorkPackageJournal => [:description]
+        }
+      end
+
+      def batches_of_objects_to_convert(klass, attributes)
+        scopes = attributes.map { |attribute| klass.where.not(attribute => nil).where.not(attribute => '') }
+
+        scope = scopes.shift
+        scopes.each do |attribute_scope|
+          scope = scope.or(attribute_scope)
+        end
+
+        # Iterate in batches to avoid plucking too much
+        scope.in_batches(of: 50) do |relation|
+          yield relation
+        end
+      end
+
+      def batch_update_statement(klass, attributes, values)
+        if OpenProject::Database.mysql?
+          batch_update_statement_mysql(klass, attributes, values)
+        else
+          batch_update_statement_postgresql(klass, attributes, values)
+        end
+      end
+
+      def batch_update_statement_postgresql(klass, attributes, values)
+        table_name = klass.table_name
+        sets = attributes.map { |a| "#{a} = new_values.#{a}" }.join(', ')
+        new_values = values.map do |value_hash|
+          text_values = value_hash.except(:id).map { |_, v| ActiveRecord::Base.connection.quote(v) }.join(', ')
+          "(#{value_hash[:id]}, #{text_values})"
+        end
+
+        <<-SQL
+          UPDATE #{table_name}
+          SET
+            #{sets}
+          FROM (
+            VALUES
+             #{new_values.join(', ')}
+          ) AS new_values (id, #{attributes.join(', ')})
+          WHERE #{table_name}.id = new_values.id
+        SQL
+      end
+
+      def batch_update_statement_mysql(klass, attributes, values)
+        table_name = klass.table_name
+        sets = attributes.map { |a| "#{table_name}.#{a} = new_values.#{a}" }.join(', ')
+        new_values_union = values.map do |value_hash|
+          text_values = value_hash.except(:id).map { |k, v| "#{ActiveRecord::Base.connection.quote(v)} AS #{k}" }.join(', ')
+          "SELECT #{value_hash[:id]} AS id, #{text_values}"
+        end.join(' UNION ')
+
+        <<-SQL
+          UPDATE #{table_name}, (#{new_values_union}) AS new_values
+          SET
+            #{sets}
+          WHERE #{table_name}.id = new_values.id
+        SQL
+      end
+
+      def concatenate_textile(textiles)
+        textiles.join("\n\n#{DOCUMENT_BOUNDARY}\n\n")
+      end
+
+      def split_markdown(markdown)
+        markdown.split(DOCUMENT_BOUNDARY).map(&:strip)
+      end
+
+      def cleanup_before_pandoc(textile)
+        placeholder_for_inline_code_at(textile)
+        drop_table_colspan_notation(textile)
+        drop_table_alignment_notation(textile)
+        move_class_from_code_to_pre(textile)
+        remove_code_inside_pre(textile)
+        convert_malformed_textile(textile)
+        remove_empty_paragraphs(textile)
+        replace_numbered_headings(textile)
+        add_newline_to_avoid_lazy_blocks(textile)
+        remove_spaces_before_table(textile)
+        wrap_blockquotes(textile)
+      end
+
+      def cleanup_after_pandoc(markdown)
         # Remove the \ pandoc puts before * and > at begining of lines
         markdown.gsub!(/^((\\[*>])+)/) { $1.gsub("\\", "") }
 
@@ -158,41 +306,93 @@ module OpenProject::TextFormatting::Formatters
         markdown.gsub!(/^([^*].*)\n\*/, "\\1\n\n*")
 
         # Remove the injected tag
-        markdown.gsub!(' ' + tag_fenced_code_block, '')
+        markdown.gsub!(' ' + TAG_FENCED_CODE_BLOCK, '')
 
         # Replace placeholder with real backtick
-        markdown.gsub!(tag_code, '`')
+        markdown.gsub!(TAG_CODE, '`')
 
         # Un-escape Redmine link syntax to wiki pages
         markdown.gsub!('\[\[', '[[')
         markdown.gsub!('\]\]', ']]')
 
-        # Un-escape Redmine quotation mark "> " that pandoc is not aware of
-        markdown.gsub!(/(^|\n)&gt; /, "\n> ")
+        # replace filtered out span with ins
+        markdown.gsub!(/<span class="underline">(.+)<\/span>/, '<ins>\1</ins>')
 
-        return markdown
+        markdown.gsub!(/#{BLOCKQUOTE_START}\n(.+?)\n\n#{BLOCKQUOTE_END}/m) do
+          $1.gsub(/([\n])([^\n]*)/, '\1> \2')
+        end
+
+        markdown
       end
 
-      def models_to_convert
-        {
-          ::Announcement => [:text],
-          ::AttributeHelpText => [:help_text],
-          ::Comment => [:text],
-          ::WikiContent => [:text],
-          ::WorkPackage =>  [:description],
-          ::Message => [:content],
-          ::News => [:description],
-          ::Project => [:description],
-          ::Journal => [:notes],
-          ::Journal::AttachmentJournal => [:description],
-          ::Journal::MessageJournal => [:content],
-          ::Journal::WikiContentJournal => [:text],
-          ::Journal::WorkPackageJournal => [:description],
-          ## TODO
-          # Documents
-          # ::Document => [:description],
-          # Meetings
-        }
+      # OpenProject support @ inside inline code marked with @ (such as "@git@github.com@"), but not pandoc.
+      # So we inject a placeholder that will be replaced later on with a real backtick.
+      def placeholder_for_inline_code_at(textile)
+        textile.gsub!(/@([\S]+@[\S]+)@/, TAG_CODE + '\\1' + TAG_CODE)
+      end
+
+      # Drop table colspan/rowspan notation ("|\2." or "|/2.") because pandoc does not support it
+      # See https://github.com/jgm/pandoc/issues/22
+      def drop_table_colspan_notation(textile)
+        textile.gsub!(/\|[\/\\]\d\. /, '| ')
+      end
+
+      # Drop table alignment notation ("|>." or "|<." or "|=.") because pandoc does not support it
+      # See https://github.com/jgm/pandoc/issues/22
+      def drop_table_alignment_notation(textile)
+        textile.gsub!(/\|[<>=]\. /, '| ')
+      end
+
+      # Move the class from <code> to <pre> so pandoc can generate a code block with correct language
+      def move_class_from_code_to_pre(textile)
+        textile.gsub!(/(<pre)(><code)( class="[^"]*")(>)/, '\\1\\3\\2\\4')
+      end
+
+      # Remove the <code> directly inside <pre>, because pandoc would incorrectly preserve it
+      def remove_code_inside_pre(textile)
+        textile.gsub!(/(<pre[^>]*>)<code>/, '\\1')
+        textile.gsub!(/<\/code>(<\/pre>)/, '\\1')
+      end
+
+      # Some malformed textile content make pandoc run extremely slow,
+      # so we convert it to proper textile before hitting pandoc
+      # see https://github.com/jgm/pandoc/issues/3020
+      def convert_malformed_textile(textile)
+        textile.gsub!(/-          # (\d+)/, "* \\1")
+      end
+
+      # Remove empty paragraph blocks which trip up pandoc
+      def remove_empty_paragraphs(textile)
+        textile.gsub!(/\np\.\n/, '')
+      end
+
+      # Replace numbered headings as they are not supported in commonmark/gfm
+      def replace_numbered_headings(textile)
+        textile.gsub!(/h(\d+)#./, 'h\\1.')
+      end
+
+      # Add an additional newline before:
+      # * every pre block prefixed by only one newline
+      #   as indented code blocks do not interrupt a paragraph and also do not have precedence
+      #   compared to a list which might also be indented.
+      # * every table prefixed by only one newline (if the line before isn't a table already)
+      # * every blockquote prefixed by one newline (if the line before isn't a blockquote)
+      def add_newline_to_avoid_lazy_blocks(textile)
+        textile.gsub!(/(\n[^>|]+)\r?\n(\s*)(<pre>|\||>)/, "\\1\n\n\\2\\3")
+      end
+
+      # Remove spaces before a table as that would lead to the table
+      # not being identified
+      def remove_spaces_before_table(textile)
+        textile.gsub!(/(^|\n)\s+(\|.+\|)\s*/, "\n\n\\2\n")
+      end
+
+      # Wrap all blockquote blocks into boundaries as `>` is not valid blockquote syntax and would thus be
+      # escaped
+      def wrap_blockquotes(textile)
+        textile.gsub!(/(([\n]>[^\n]*)+)/m) do
+          "\n#{BLOCKQUOTE_START}\n" + $1.gsub(/([\n])> *([^\n]*)/, '\1\2') + "\n\n#{BLOCKQUOTE_END}\n"
+        end
       end
     end
   end


### PR DESCRIPTION
* Attachment Journals do not have textile
* Comments have a comment field, not a text field
* Performance:
  * only fetch records, wo actually have values to convert
  * write changes in batches

### TODO

* ~~Tables with block text in first row do nevertheless receive an additional header row~~ We either have this or we might falsely use the first line of a table as the header.
* [x] Numbered headings (`h1#.`) are not replaced
* [x] Board description is not converted
* [x] empty paragraphs (`\np.\n`) trip up conversion
* ~~macros like `include`, `timeline`, `toc` ...~~ should not longer be a problem with the recent limitation to the handlebars being evaluated
* ~~textile extensions like `##`, `###` are excaped to `\#\#`, `\#\#\#` (example: https://community.openproject.com/projects/openproject-foundation/wiki/js-library-spike-for-timelines/edit)~~ but this does not interfere with the macro
* [x] pre blocks lost (example from https://community.openproject.com/projects/openproject-foundation/wiki/how-to-plugin-migration/edit)
Before:
``` 
* Checkout the current OpenProject core in the feature/rails3 branch
<pre>git clone git@github.com:opf/openproject.git</pre>
* Setup OpenProject
```
After:
```
-   Checkout the current OpenProject core in the feature/rails3 branch
        git clone git@github.com:opf/openproject.git

-   Setup OpenProject
```

* [x] Table not converted (example from https://community.openproject.com/projects/openproject-foundation/wiki/sprint-capacity)

Before:
```
Estimations are done using an unit called point. A point represent 4 hours. The total points available within a sprint is the total capacity. This total capacity is used as following:
|*Activity*|*Percent*|*Description*|
|Buffer|20| Meetings, unforeseen problems|
|Live Issues| 0 | Buffer for Live issues|
|Sprint Capacity|80|Sprint Work|

For 10 days sprint with 2 developers, the sprint capacity would be:
```
After:
```
Estimations are done using an unit called point. A point represent 4 hours. The total points available within a sprint is the total capacity. This total capacity is used as following:  
\|**Activity**\|**Percent**\|**Description**\|  
\|Buffer\|20\| Meetings, unforeseen problems\|  
\|Live Issues\| 0 \| Buffer for Live issues\|  
\|Sprint Capacity\|80\|Sprint Work\|

For 10 days sprint with 2 developers, the sprint capacity would be:  
```
* [x] underlining of text is simply removed (example from https://community.openproject.com/projects/openproject-foundation/wiki/changes-in-settings-in-openproject-30/edit)
Before 
```
h2. Settings +do not+ change
```
After 
```
Settings which <span class="underline">do not</span> change
-----------------------------------------------------------
```
With the `<span>` being removed when rendering. Instead of replacing the `+` with a `<span>`, replacing it with `<ins>` would be valid.

* [x] Quotation blocks `>` without a newline after a list are replaced by `&gt;` (example from: https://community.openproject.com/projects/openproject-foundation/wiki/bug-reports)
Before:
```
* *Example:*
> * _In Roadmap status below version is missing translations:_ 
> ** _translation missing: en.label_x_closed_issues_abbr_ (Language setting: English)_
> ** _translation missing: de.label_x_closed_issues_abbr_ (Language setting: German)_
````

After
```
-   **Example:**  
    &gt; \* *In Roadmap status below version is missing translations:*  
    &gt; *translation missing: en.label\_x\_closed\_issues\_abbr* (Language setting: English)\_  
    &gt; *translation missing: de.label\_x\_closed\_issues\_abbr* (Language setting: German)\_
```

* [x] List within quotation are not converted (example from: https://community.openproject.com/projects/openproject-foundation/wiki/bug-reports/edit)

Before
```
>
> *Steps to reproduce*
> # Assign work package to version
> # Click on Roadmap in left navigation
> # (translation missing is displayed below progress bar of version)
>
````
After
```
>  
> **Steps to reproduce**  
> \# Assign work package to version  
> \# Click on Roadmap in left navigation  
> \# (translation missing is displayed below progress bar of version)  
>  
```

* [x] Tables with images *or* tables with a single column and only two rows *or* tables not starting at the beginning of the line are not replaced (example from: https://community.openproject.com/projects/openproject-foundation/wiki/rails3-dev-report/edit)

Before
```

   |!http://eyweb-images.s3.amazonaws.com/blog_crossimp.jpg!|
   |*Ruby* performance: version 1.8.7 (blue) compared to 1.9.2 (green)|

```

After
```

\|![](http://eyweb-images.s3.amazonaws.com/blog_19big.jpg)\|  
\|**Rails** performance: version 3.x (blue) compared to version 2.x (green)\|

```

* ~~Invalid textile tables (forgetting the closing `|` in a line busts the layout (e.g. https://community.openproject.com/projects/gmbh/wiki/release-and-deployment-process/edit)~~ cannot automatically fix this

### Out of scope

* `<pre><code>jsdlfjdkflj</code></pre>` blocks are displayed incorrectly:
![image](https://user-images.githubusercontent.com/617519/41025022-1c071a12-6971-11e8-89dd-55e13bcbb46d.png)
instead of 
![image](https://user-images.githubusercontent.com/617519/41025054-2c2e3e20-6971-11e8-84f6-18ceb4ec07d9.png)

* `<pre>` and fenced code blocks e.g. 
~~~
```
jskdfjkldsfj
```
~~~
get stripped out when entering edit mode persumably by the ckeditor

