### PR TITLE
Feature: user limits

### DIFF
--- a/app/assets/javascripts/members_form.js
+++ b/app/assets/javascripts/members_form.js
@@ -76,6 +76,16 @@ function showAddMemberForm() {
   jQuery('#filter-member-button').removeClass('-active');
   localStorage.setItem("showFilter", 'false');
   jQuery('#add-member-button').prop('disabled', true);
+
+  jQuery("input#member_user_ids").on("change", function() {
+    var values = jQuery("input#member_user_ids").val();
+
+    if (values.indexOf("@") != -1) {
+      jQuery("#member-user-limit-warning").css("display", "block");
+    } else {
+      jQuery("#member-user-limit-warning").css("display", "none");
+    }
+  });
 }
 
 function hideAddMemberForm() {

--- a/app/assets/stylesheets/openproject/_generic.sass
+++ b/app/assets/stylesheets/openproject/_generic.sass
@@ -1,0 +1,5 @@
+.no-padding-bottom
+  padding-bottom: 0 !important
+
+.display-inline
+  display: inline !important

--- a/app/assets/stylesheets/openproject/_index.sass
+++ b/app/assets/stylesheets/openproject/_index.sass
@@ -7,6 +7,8 @@
 // Legacy styles, remove if possible
 @import openproject/legacy
 
+@import openproject/generic
+
 @import openproject/mixins
 @import openproject/onboarding
 @import openproject/scm

--- a/app/controllers/concerns/user_limits.rb
+++ b/app/controllers/concerns/user_limits.rb
@@ -1,0 +1,84 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+##
+# Intended to be used by the UsersController to enforce the user limit.
+module Concerns::UserLimits
+  def enforce_user_limit(redirect_to: users_path, hard: OpenProject::Enterprise.fail_fast?)
+    if user_limit_reached?
+      if hard
+        show_user_limit_error!
+
+        redirect_back fallback_location: redirect_to
+      else
+        show_user_limit_warning!
+      end
+
+      true
+    else
+      false
+    end
+  end
+
+  def enforce_activation_user_limit(redirect_to: signin_path)
+    if user_limit_reached?
+      show_user_limit_activation_error!
+
+      redirect_back fallback_location: redirect_to
+
+      true
+    else
+      false
+    end
+  end
+
+  def show_user_limit_activation_error!
+    flash[:error] = I18n.t(:error_enterprise_activation_user_limit)
+  end
+
+  def show_user_limit_warning!
+    flash[:warning] = user_limit_warning
+  end
+
+  def show_user_limit_error!
+    flash[:error] = user_limit_warning
+  end
+
+  def user_limit_warning
+    warning = I18n.t(
+      :warning_user_limit_reached,
+      upgrade_url: OpenProject::Enterprise.upgrade_path
+    )
+
+    warning.html_safe
+  end
+
+  def user_limit_reached?
+    OpenProject::Enterprise.user_limit_reached?
+  end
+end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -235,7 +235,7 @@ class MembersController < ApplicationController
     user_ids.map do |id|
       if id.to_i == 0 && id.present? # we've got an email - invite that user
         # only admins can invite new users
-        if current_user.admin?
+        if current_user.admin? && (!OpenProject::Enterprise.user_limit_reached? && OpenProject::Enterprise.fail_fast?)
           # The invitation can pretty much only fail due to the user already
           # having been invited. So look them up if it does.
           user = UserInvitation.invite_new_user(email: id) ||

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -235,7 +235,7 @@ class MembersController < ApplicationController
     user_ids.map do |id|
       if id.to_i == 0 && id.present? # we've got an email - invite that user
         # only admins can invite new users
-        if current_user.admin? && (!OpenProject::Enterprise.user_limit_reached? && OpenProject::Enterprise.fail_fast?)
+        if current_user.admin? && enterprise_allow_new_users?
           # The invitation can pretty much only fail due to the user already
           # having been invited. So look them up if it does.
           user = UserInvitation.invite_new_user(email: id) ||
@@ -247,6 +247,10 @@ class MembersController < ApplicationController
         id
       end
     end.compact
+  end
+
+  def enterprise_allow_new_users?
+    !OpenProject::Enterprise.user_limit_reached? || !OpenProject::Enterprise.fail_fast?
   end
 
   def each_comma_seperated(array, &block)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,6 +50,9 @@ class UsersController < ApplicationController
   include Concerns::PasswordConfirmation
   before_action :check_password_confirmation, only: [:destroy]
 
+  include Concerns::UserLimits
+  before_action :enforce_user_limit, only: [:new, :create]
+
   accept_key_auth :index, :show, :create, :update, :destroy
 
   include SortHelper
@@ -159,7 +162,13 @@ class UsersController < ApplicationController
 
         if @user.invited?
           # setting a password for an invited user activates them implicitly
-          @user.activate!
+          if OpenProject::Enterprise.user_limit_reached?
+            @user.register!
+            show_user_limit_warning!
+          else
+            @user.activate!
+          end
+
           send_information = true
         end
 
@@ -202,6 +211,13 @@ class UsersController < ApplicationController
       redirect_back_or_default(action: 'edit', id: @user)
       return
     end
+
+    if (params[:unlock] || params[:activate]) && user_limit_reached?
+      show_user_limit_error!
+
+      return redirect_back_or_default(action: 'edit', id: @user)
+    end
+
     if params[:unlock]
       @user.failed_login_count = 0
       @user.activate

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -2,11 +2,11 @@ module ToolbarHelper
   include ERB::Util
   include ActionView::Helpers::OutputSafetyHelper
 
-  def toolbar(title:, subtitle: '', link_to: nil, html: {})
+  def toolbar(title:, title_extra: nil, title_class: nil, subtitle: '', link_to: nil, html: {})
     classes = ['toolbar-container', html[:class]].compact.join(' ')
     content_tag :div, class: classes do
       toolbar = content_tag :div, class: 'toolbar' do
-        dom_title(title, link_to) + dom_toolbar {
+        dom_title(title, link_to, title_class: title_class, title_extra: title_extra) + dom_toolbar {
           yield if block_given?
         }
       end
@@ -21,7 +21,7 @@ module ToolbarHelper
 
   protected
 
-  def dom_title(raw_title, link_to = nil)
+  def dom_title(raw_title, link_to = nil, title_class: nil, title_extra: nil)
     title = ''.html_safe
     title << raw_title
 
@@ -31,7 +31,9 @@ module ToolbarHelper
     end
 
     content_tag :div, class: 'title-container' do
-      content_tag(:h2, title)
+      content_tag(:h2, title, class: String(title_class)) + (
+        title_extra.present? ? title_extra : ''
+      )
     end
   end
 

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -31,7 +31,11 @@ module ToolbarHelper
     end
 
     content_tag :div, class: 'title-container' do
-      content_tag(:h2, title, class: String(title_class)) + (
+      opts = {}
+
+      opts[:class] = title_class if title_class.present?
+
+      content_tag(:h2, title, opts) + (
         title_extra.present? ? title_extra : ''
       )
     end

--- a/app/views/enterprises/_current.html.erb
+++ b/app/views/enterprises/_current.html.erb
@@ -13,6 +13,14 @@
           <span><%= @current_token.mail %></span>
         </div>
       </div>
+      <% Hash(@current_token.restrictions).each do |key, value| %>
+      <div class="attributes-key-value--key"><%= EnterpriseToken.human_attribute_name("#{key}_restriction") %></div>
+      <div class="attributes-key-value--value-container">
+        <div class="attributes-key-value--value -text">
+          <span><%= value %></span>
+        </div>
+      </div>
+      <% end %>
       <div class="attributes-key-value--key"><%= EnterpriseToken.human_attribute_name(:starts_at) %></div>
       <div class="attributes-key-value--value-container">
         <div class="attributes-key-value--value -text">

--- a/app/views/members/_member_form_non_impaired.html.erb
+++ b/app/views/members/_member_form_non_impaired.html.erb
@@ -80,4 +80,11 @@ See doc/COPYRIGHT.rdoc for more details.
       </div>
     </div>
   </div>
+  <% if OpenProject::Enterprise.user_limit_reached? %>
+    <div class="notification-box -warning icon-warning" id="member-user-limit-warning" style="display: none;">
+      <div class="notification-box--content">
+        <p><%= I18n.t(:warning_user_limit_reached, upgrade_url: OpenProject::Enterprise.upgrade_path).html_safe %></p>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -26,8 +26,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<% html_title l(:label_administration), l(:label_user_plural) -%>
-<%= toolbar title: l(:label_user_plural) do %>
+<% html_title t(:label_administration), t(:label_user_plural) -%>
+<% users_info = OpenProject::Enterprise.token && content_tag(:div) do %>
+  <% token = OpenProject::Enterprise.token %>
+
+  <%= t(:label_enterprise_active_users, current: User.active.count, limit: token.restrictions[:active_user_count]) %>
+  &nbsp;
+  <a href="<%= OpenProject::Enterprise.upgrade_path %>" class="display-inline button -tiny -highlight" title="<%= t(:title_enterprise_upgrade) %>"><%= t(:button_upgrade) %></a>
+<% end %>
+<%= toolbar title: t(:label_user_plural), title_class: 'no-padding-bottom', title_extra: users_info do %>
   <li class="toolbar-item">
     <%= link_to new_user_path,
         { class: 'button -alt-highlight',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -314,6 +314,7 @@ en:
         expires_at: "Expires at"
         subscriber: "Subscriber"
         encoded_token: "Enterprise support token"
+        active_user_count_restriction: "Maximum active users"
       relation:
         delay: "Delay"
         from: "Work package"
@@ -703,6 +704,7 @@ en:
   button_unlock: "Unlock"
   button_unwatch: "Unwatch"
   button_update: "Update"
+  button_upgrade: "Upgrade"
   button_upload: "Upload"
   button_view: "View"
   button_watch: "Watch"
@@ -921,6 +923,7 @@ en:
   error_cookie_missing: 'The OpenProject cookie is missing. Please ensure that cookies are enabled, as this application will not properly function without.'
   error_custom_option_not_found: "Option does not exist."
   error_dependent_work_package: "Error in dependent work package #%{related_id} %{related_subject}: %{error}"
+  error_enterprise_activation_user_limit: "Your account could not be activated (user limit reached). Please contact your administrator to gain access."
   error_failed_to_delete_entry: 'Failed to delete this entry.'
   error_invalid_group_by: "Can't group by: %{value}"
   error_invalid_query_column: "Invalid query column: %{value}"
@@ -1178,6 +1181,7 @@ en:
   label_enumerations: "Enumerations"
   label_enterprise: "Enterprise"
   label_enterprise_edition: "Enterprise Edition"
+  label_enterprise_active_users: "%{current}/%{limit} booked active users"
   label_environment: "Environment"
   label_estimates_and_time: "Estimates and time"
   label_equals: "is"
@@ -2354,6 +2358,7 @@ en:
       years: "Years"
 
   title_remove_and_delete_user: Remove the invited user from the project and delete him/her.
+  title_enterprise_upgrade: "Upgrade to unlock more users."
 
   tooltip_resend_invitation: >
     Sends another invitation email with a fresh token in
@@ -2420,6 +2425,7 @@ en:
   note_password_login_disabled: "Password login has been disabled by %{configuration}."
   warning: Warning
   warning_attachments_not_saved: "%{count} file(s) could not be saved."
+  warning_user_limit_reached: "User limit reached. Please <a href=\"%{upgrade_url}\">upgrade</a> to allow for additional users."
 
   menu_item: "Menu item"
   menu_item_setting: "Visibility"

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -64,6 +64,7 @@ storage config above like this:
 * [`blacklisted_routes`](#blacklisted-routes) (default: [])
 * [`global_basic_auth`](#global-basic-auth)
 * [`apiv3_enable_basic_auth`](#apiv3_enable_basic_auth)
+* [`enterprise_limits`](#enterprise-limits)
 
 ## Setting session options
 
@@ -338,3 +339,29 @@ default:
 ## Onboarding variables:
 
 * 'onboarding_video_url': An URL for the video displayed on the onboarding modal. This is only shown when the user logs in for the first time.
+
+### Enterprise Limits
+
+If using an Enterprise token there are certain limits that apply.
+You can configure how these limits are enforced.
+
+#### `fail_fast`
+
+*default: false*
+
+If you set `fail_fast` to true, new users cannot be invited or registered if the user limit has been reached.
+If it is false then you can still invite and register new users but their activation will fail until the
+user limit has been increased (or the number of active users decreased).
+
+Configured in the `configuration.yml` like this:
+
+```
+enterprise:
+  fail_fast: true
+```
+
+Or through the environment like this:
+
+```
+OPENPROJECT_ENTERPRISE_FAIL__FAST=true
+```

--- a/lib/open_project/enterprise.rb
+++ b/lib/open_project/enterprise.rb
@@ -1,0 +1,63 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject
+  module Enterprise
+    class << self
+      def token
+        EnterpriseToken.current.presence
+      end
+
+      def upgrade_path
+        url_helpers.enterprise_path
+      end
+
+      def user_limit
+        Hash(token.restrictions)[:active_user_count]
+      end
+
+      def active_user_count
+        User.active.count
+      end
+
+      def user_limit_reached?
+        active_user_count >= user_limit if user_limit
+      end
+
+      def fail_fast?
+        Hash(OpenProject::Configuration["enterprise"])["fail_fast"]
+      end
+
+      private
+
+      def url_helpers
+        @url_helpers ||= OpenProject::StaticRouting::StaticUrlHelpers.new
+      end
+    end
+  end
+end

--- a/lib/open_project/enterprise.rb
+++ b/lib/open_project/enterprise.rb
@@ -38,7 +38,7 @@ module OpenProject
       end
 
       def user_limit
-        Hash(token.restrictions)[:active_user_count]
+        Hash(token.restrictions)[:active_user_count] if token
       end
 
       def active_user_count

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -445,6 +445,30 @@ describe AccountController, type: :controller do
             expect(user.status).to eq(User::STATUSES[:active])
           end
         end
+
+        context "with user limit reached" do
+          before do
+            allow(OpenProject::Enterprise).to receive(:user_limit_reached?).and_return(true)
+          end
+
+          it "fails" do
+            post :register,
+                 params: {
+                   user: {
+                     login: 'register',
+                     password: 'adminADMIN!',
+                     password_confirmation: 'adminADMIN!',
+                     firstname: 'John',
+                     lastname: 'Doe',
+                     mail: 'register@example.com'
+                   }
+                 }
+
+            is_expected.to redirect_to(signin_path)
+
+            expect(flash[:error]).to match /user limit reached/
+          end
+        end
       end
 
       context 'with password login disabled' do

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -666,6 +666,42 @@ describe AccountController, type: :controller do
     end
   end
 
+  context 'POST activate' do
+    let(:user) { FactoryGirl.create :user, status: status }
+    let(:status) { -1 }
+
+    let(:token) { Token::Invitation.create!(user_id: user.id) }
+
+    before do
+      allow(OpenProject::Enterprise).to receive(:user_limit_reached?).and_return(true)
+
+      post :activate, params: { token: token.value }
+    end
+
+    shared_examples "activation is blocked due to user limit" do
+      it "does not activate the user" do
+        expect(user.reload).not_to be_active
+      end
+
+      it "redirects back to the login page and shows the user limit error" do
+        expect(response).to redirect_to(signin_path)
+        expect(flash[:error]).to match /user limit reached.*contact.*admin/i
+      end
+    end
+
+    context 'registered user' do
+      let(:status) { User::STATUSES[:registered] }
+
+      it_behaves_like "activation is blocked due to user limit"
+    end
+
+    context 'invited user' do
+      let(:status) { User::STATUSES[:invited] }
+
+      it_behaves_like "activation is blocked due to user limit"
+    end
+  end
+
   describe 'GET #auth_source_sso_failed (/sso)' do
    render_views
 

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -1,0 +1,73 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'users/index', type: :view do
+  let!(:admin) { FactoryGirl.create :admin }
+  let!(:user) { FactoryGirl.create :user, firstname: "Scarlet", lastname: "Scallywag" }
+
+  before do
+    assign(:users, [admin, user])
+    assign(:status, "all")
+    assign(:groups, Group.all)
+
+    allow(view).to receive(:current_user).and_return(admin)
+
+    allow_any_instance_of(TableCell).to receive(:controller_name).and_return("users")
+    allow_any_instance_of(TableCell).to receive(:action_name).and_return("index")
+  end
+
+  it 'renders the user table' do
+    render
+
+    expect(rendered).to have_text(admin.name)
+    expect(rendered).to have_text("Scarlet Scallywag")
+  end
+
+  context "with an Enterprise token" do
+    before do
+      allow(OpenProject::Enterprise).to receive(:token).and_return(Struct.new(:restrictions).new({active_user_count: 5}))
+    end
+
+    it "shows the current number of active and allowed users" do
+      render
+
+      # expected active users: admin and user from above
+      expect(rendered).to have_text("2/5 booked active users")
+    end
+  end
+
+  context "without an Enterprise token" do
+    it "does not show the current number of active and allowed users" do
+      render
+
+      expect(rendered).not_to have_text("booked active users")
+    end
+  end
+end


### PR DESCRIPTION
WP [#27301](https://community.openproject.com/projects/openproject/work_packages/27301/activity?query_id=1315)

Enforces user limits in various places. Supports hard and soft limits. The difference being:

* hard - once the user limit is reached, no new users can be invited or registered
* soft  (default) - New users can still be invited and registered, but can't be activated. Admins will be warned of this when inviting new users.