### PR TITLE
Fix/activity performance

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -36,10 +36,10 @@ class ActivitiesController < ApplicationController
     @days = Setting.activity_days_default.to_i
 
     if params[:from]
-      begin; @date_to = params[:from].to_date + 1; rescue; end
+      begin; @date_to = params[:from].to_date + 1.day; rescue; end
     end
 
-    @date_to ||= User.current.today + 1
+    @date_to ||= User.current.today + 1.day
     @date_from = @date_to - @days
     @with_subprojects = params[:with_subprojects].nil? ? Setting.display_subprojects_work_packages? : (params[:with_subprojects] == '1')
     @author = (params[:user_id].blank? ? nil : User.active.find(params[:user_id]))

--- a/app/models/activity/work_package_activity_provider.rb
+++ b/app/models/activity/work_package_activity_provider.rb
@@ -62,14 +62,7 @@ class Activity::WorkPackageActivityProvider < Activity::BaseActivityProvider
   end
 
   def event_type(event, _activity)
-    state = ''
-    journal = Journal.find(event['event_id'])
-
-    if journal.details.empty? && !journal.initial?
-      state = '-note'
-    else
-      state = ActiveRecord::Type::Boolean.new.cast(event['status_closed']) ? '-closed' : '-edit'
-    end
+    state = ActiveRecord::Type::Boolean.new.cast(event['status_closed']) ? '-closed' : '-edit'
 
     "work_package#{state}"
   end

--- a/lib/plugins/acts_as_activity_provider/lib/acts_as_activity_provider.rb
+++ b/lib/plugins/acts_as_activity_provider/lib/acts_as_activity_provider.rb
@@ -140,8 +140,7 @@ module Redmine
           end
 
           def join_with_projects_table(query, project_ref_table)
-            query = query.join(projects_table).on(projects_table[:id].eq(project_ref_table['project_id']))
-            query
+            query.join(projects_table).on(projects_table[:id].eq(project_ref_table['project_id']))
           end
 
           def restrict_projects_by_selection(options, query)
@@ -177,7 +176,6 @@ module Redmine
             stmt = nil
             perm = Redmine::AccessControl.permission(options[:permission])
             is_member = options[:member]
-            original_query = query.dup
 
             if user.logged?
               allowed_projects = []


### PR DESCRIPTION
Instead of differentiating between the user having added a note and the
user having altered the wp's attributes, we always return the same icon
in the activity.

This allows us to not n+1 fetch the event journal and its predecessor.

https://community.openproject.com/projects/openproject/work_packages/27582