### PR TITLE
FEATURE: 'Blocked by predecessors' field in work packages

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -53,6 +53,9 @@ module WorkPackages
     attribute :lock_version
     attribute :project_id
 
+    attribute :blocked_by_predecessors,
+              writable: false
+
     attribute :done_ratio,
               writeable: ->(*) {
                 model.leaf? && Setting.work_package_done_ratio == 'field'

--- a/app/models/queries/work_packages.rb
+++ b/app/models/queries/work_packages.rb
@@ -51,6 +51,7 @@ module Queries::WorkPackages
   register.filter Query, filters_module::RoleFilter
   register.filter Query, filters_module::StartDateFilter
   register.filter Query, filters_module::StatusFilter
+  register.filter Query, filters_module::BlockedByPredecessorsFilter
   register.filter Query, filters_module::SubjectFilter
   register.filter Query, filters_module::SubprojectFilter
   register.filter Query, filters_module::TypeFilter

--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -141,6 +141,12 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
     created_at: {
       sortable: "#{WorkPackage.table_name}.created_at",
       default_order: 'desc'
+    },
+    blocked_by_predecessors: {
+      association: 'blocked_by_predecessors',
+      sortable: "#{WorkPackage.table_name}.blocked_by_predecessors",
+      default_order: 'asc',
+      groupable: true
     }
   }
 

--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -48,7 +48,8 @@ module Type::AttributeGroups
         responsible: :people,
         estimated_time: :estimates_and_time,
         spent_time: :estimates_and_time,
-        priority: :details
+        priority: :details,
+        blocked_by_predecessors: :details
       }
     end
 

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -186,6 +186,20 @@ class WorkPackage < ActiveRecord::Base
       .exists?
   end
 
+  def has_open_predecessors?
+    follows
+      .with_status_open
+      .exists?
+  end
+
+  def blocked_by_predecessors
+    read_attribute :blocked_by_predecessors
+  end
+
+  def blocked_by_predecessors=(v)
+    write_attribute :blocked_by_predecessors, v
+  end
+
   def relations
     Relation.of_work_package(self)
   end

--- a/app/services/relations/base_service.rb
+++ b/app/services/relations/base_service.rb
@@ -41,8 +41,7 @@ class Relations::BaseService
   private
 
   def update_relation(relation, attributes)
-
-    # NOTE: in the current implementation of frontend, the used cannot change
+    # NOTE: in the current implementation of frontend, the user cannot change
     #       the type of the relation. So we do *not* handle that case here!
 
     relation.attributes = relation.attributes.merge attributes

--- a/app/services/relations/destroy_service.rb
+++ b/app/services/relations/destroy_service.rb
@@ -47,9 +47,10 @@ class Relations::DestroyService < Relations::BaseService
       if !predecessor.closed?
         follower = WorkPackage.find(relation.from_id)
 
-        has_open_predecessors = follower.follows.includes(:status)
-          .where(statuses: { is_closed: false})
-          .where.not(id: predecessor.id).exists?
+        has_open_predecessors =
+          follower.follows.includes(:status)
+                  .where(statuses: { is_closed: false })
+                  .where.not(id: predecessor.id).exists?
 
         if follower.blocked_by_predecessors != has_open_predecessors
           follower.blocked_by_predecessors = has_open_predecessors

--- a/app/services/work_packages/create_service.rb
+++ b/app/services/work_packages/create_service.rb
@@ -30,6 +30,7 @@
 
 class WorkPackages::CreateService
   include ::WorkPackages::Shared::UpdateAncestors
+  include ::WorkPackages::Shared::UpdateFollowers
   include ::Shared::ServiceContext
 
   attr_accessor :user,
@@ -67,6 +68,11 @@ class WorkPackages::CreateService
       update_ancestors_all_attributes(result.all_results).each do |ancestor_result|
         result.merge!(ancestor_result)
       end
+
+      update_followers_all_attributes(result.all_results).each do |followers_result|
+        result.merge!(followers_result)
+      end
+
     else
       result.success = false
     end

--- a/app/services/work_packages/destroy_service.rb
+++ b/app/services/work_packages/destroy_service.rb
@@ -52,7 +52,6 @@ class WorkPackages::DestroyService
     result = ServiceResult.new success: true,
                                result: work_package
 
-    # TODO: special case for delete!
     # BUG: There is a bug right now: when deleting a WP, the progress
     #      of ancestors packages doesn't change
 

--- a/app/services/work_packages/shared/update_followers.rb
+++ b/app/services/work_packages/shared/update_followers.rb
@@ -1,0 +1,81 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module WorkPackages
+  module Shared
+    module UpdateFollowers
+      def update_followers(changed_work_packages)
+        changes = changed_work_packages
+                  .map { |wp| wp.previous_changes.keys }
+                  .flatten
+                  .uniq
+                  .map(&:to_sym)
+
+        update_each_follower(changed_work_packages, changes)
+      end
+
+      def update_followers_all_attributes(work_packages)
+        changes = work_packages
+                  .first
+                  .attributes
+                  .keys
+                  .uniq
+                  .map(&:to_sym)
+
+        update_each_follower(work_packages, changes)
+      end
+
+      def update_followers_after_delete(work_packages)
+        changes = work_packages
+                  .first
+                  .attributes
+                  .keys
+                  .uniq
+                  .map(&:to_sym)
+
+        update_each_follower(work_packages, changes, true)
+      end
+
+      def update_each_follower(work_packages, changes, is_deleted = false)
+        work_packages.map do |wp|
+          update_one_follower(wp, changes, is_deleted)
+        end
+      end
+
+      def update_one_follower(wp, changes, is_deleted)
+        WorkPackages::UpdateFollowersService
+          .new(user: user,
+               work_package: wp,
+               is_deleted: is_deleted)
+          .call(changes)
+      end
+    end
+  end
+end

--- a/app/services/work_packages/update_followers_service.rb
+++ b/app/services/work_packages/update_followers_service.rb
@@ -1,0 +1,95 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+class WorkPackages::UpdateFollowersService
+  attr_accessor :user,
+                :work_package,
+                :is_deleted
+
+  def initialize(user:, work_package:, is_deleted: false)
+    self.user = user
+    self.work_package = work_package
+    self.is_deleted = is_deleted
+  end
+
+  def call(attributes)
+    operation_success = true
+
+    if is_deleted || attributes.include?(:status_id)
+      modified = update_followers(is_deleted || work_package.closed?)
+
+      set_journal_note(modified, is_deleted || work_package.closed?)
+
+      operation_success = modified.all? { |wp| wp.save(validate: false) }
+    end
+
+    result = ServiceResult.new(success: operation_success,
+                               result: work_package)
+
+    unless modified.nil?
+      modified.each do |wp|
+        result.add_dependent!(ServiceResult.new(success: !wp.changed?, result: wp))
+      end
+    end
+
+    result
+  end
+
+  private
+
+  def update_followers(work_package_closed)
+    work_package.precedes.includes(:status).select do |follower|
+
+      if !work_package_closed && !follower.blocked_by_predecessors
+        follower.blocked_by_predecessors = true
+      elsif work_package_closed && follower.blocked_by_predecessors
+
+        has_open_predecessors = follower.follows.includes(:status)
+          .where(statuses: { is_closed: false})
+          .where.not(id: work_package.id).exists?
+
+        follower.blocked_by_predecessors = has_open_predecessors
+
+      end
+
+      follower.changed?
+    end
+  end
+
+  def set_journal_note(work_packages, work_package_closed)
+    work_packages.each do |wp|
+      if work_package_closed
+        wp.journal_notes = I18n.t('work_package.unblocked_by_predecessor_status_changes', predecessor: "##{work_package.id}")
+      else
+        wp.journal_notes = I18n.t('work_package.blocked_by_predecessor_status_changes', predecessor: "##{work_package.id}")
+      end
+    end
+  end
+end

--- a/app/services/work_packages/update_followers_service.rb
+++ b/app/services/work_packages/update_followers_service.rb
@@ -66,17 +66,14 @@ class WorkPackages::UpdateFollowersService
 
   def update_followers(work_package_closed)
     work_package.precedes.includes(:status).select do |follower|
-
       if !work_package_closed && !follower.blocked_by_predecessors
         follower.blocked_by_predecessors = true
       elsif work_package_closed && follower.blocked_by_predecessors
-
-        has_open_predecessors = follower.follows.includes(:status)
-          .where(statuses: { is_closed: false})
-          .where.not(id: work_package.id).exists?
-
+        has_open_predecessors =
+          follower.follows.includes(:status)
+                  .where(statuses: { is_closed: false })
+                  .where.not(id: work_package.id).exists?
         follower.blocked_by_predecessors = has_open_predecessors
-
       end
 
       follower.changed?

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -30,6 +30,7 @@
 
 class WorkPackages::UpdateService
   include ::WorkPackages::Shared::UpdateAncestors
+  include ::WorkPackages::Shared::UpdateFollowers
   include ::Shared::ServiceContext
 
   attr_accessor :user,
@@ -61,6 +62,12 @@ class WorkPackages::UpdateService
     if save_if_valid(result)
       update_ancestors([work_package]).each do |ancestor_result|
         result.merge!(ancestor_result)
+      end
+    end
+
+    if result.success?
+      update_followers([work_package]).each do |follower_result|
+        result.merge!(follower_result)
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -610,6 +610,7 @@ en:
     author: "Author"
     base: "General Error:"
     blocks_ids: "IDs of blocked work packages"
+    blocked_by_predecessors: "Blocked by predecessors"
     category: "Category"
     comment: "Comment"
     comments: "Comment"
@@ -2461,6 +2462,10 @@ en:
   work_package:
     updated_automatically_by_child_changes: |
         _Updated automatically by changing values within child work package %{child}_
+    blocked_by_predecessor_status_changes: |
+        _Blocked automatically by changing status of preceding work package %{predecessor}_
+    unblocked_by_predecessor_status_changes: |
+        _Unblocked automatically by changing status of preceding work package %{predecessor}_
     destroy:
       info: "Deleting the work package is an irreversible action."
       title: "Delete the work package"

--- a/db/migrate/20180617125428_add_blocked_by_predecessors.rb
+++ b/db/migrate/20180617125428_add_blocked_by_predecessors.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -28,27 +26,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-require_relative 'base'
 
-module Queries::Filters::Shared
-  module CustomFields
-    class Bool < Base
-      def allowed_values
-        [
-          [I18n.t(:general_text_yes), OpenProject::Database::DB_VALUE_TRUE],
-          [I18n.t(:general_text_no), OpenProject::Database::DB_VALUE_FALSE]
-        ]
-      end
-
-      def type
-        :boolean
-      end
-
-      protected
-
-      def type_strategy_class
-        ::Queries::Filters::Strategies::BooleanList
-      end
-    end
+class AddBlockedByPredecessors < ActiveRecord::Migration[5.0]
+  def change
+    add_column :work_packages, :blocked_by_predecessors, :boolean
   end
 end

--- a/db/migrate/20180617125428_add_blocked_by_predecessors.rb
+++ b/db/migrate/20180617125428_add_blocked_by_predecessors.rb
@@ -26,7 +26,6 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-
 class AddBlockedByPredecessors < ActiveRecord::Migration[5.0]
   def change
     add_column :work_packages, :blocked_by_predecessors, :boolean

--- a/lib/api/v3/queries/filters/query_filter_instance_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_instance_representer.rb
@@ -109,8 +109,7 @@ module API
                       end
                     },
                     getter: ->(*) {
-                      if represented.respond_to?(:custom_field) &&
-                         represented.custom_field.field_format == 'bool'
+                      if represented.type == :boolean
                         represented.values.map do |value|
                           value == OpenProject::Database::DB_VALUE_TRUE
                         end
@@ -140,8 +139,7 @@ module API
           end
 
           def set_property_values(vals)
-            represented.values = if represented.respond_to?(:custom_field) &&
-                                    represented.custom_field.field_format == 'bool'
+            represented.values = if represented.type == :boolean
                                    vals.map do |value|
                                      if value
                                        OpenProject::Database::DB_VALUE_TRUE

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -31,6 +31,7 @@ require 'api/v3/relations/relation_collection_representer'
 
 require 'relations/create_service'
 require 'relations/update_service'
+require 'relations/destroy_service'
 
 module API
   module V3
@@ -83,8 +84,15 @@ module API
 
               authorize :manage_work_package_relations, context: project
 
-              Relation.destroy params[:id]
-              status 204
+              relation = Relation.find params[:id]
+              service = ::Relations::DestroyService.new user: current_user
+              call = service.call relation, send_notifications: (params[:notify] != 'false')
+
+              if call.success?
+                status 204
+              else
+                fail ::API::Errors::ErrorBase.create_and_merge_errors(call.errors)
+              end
             end
           end
         end

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -150,6 +150,12 @@ module API
                  show_if: ->(*) { Setting.work_package_done_ratio != 'disabled' },
                  required: false
 
+          schema :blocked_by_predecessors,
+                 type: 'Boolean',
+                 name_source: :blocked_by_predecessors,
+                 required: false,
+                 writable: false
+
           schema :created_at,
                  type: 'DateTime'
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -396,6 +396,8 @@ module API
                  },
                  uncacheable: true
 
+        property :blocked_by_predecessors
+
         property :done_ratio,
                  as: :percentageDone,
                  render_nil: true,


### PR DESCRIPTION
Usecase: let the user search for the packages that has no
         incomplete predecessors. It allows pipelining the work
         performed by different people. Assignees can see only
         the packages that has been "released" by previous stages
         (including many-to-one dependencies)

This patch implements the following requirements:

1) Adds 'blocked_by_predecessors' field to the database table of
   work packages

2) If a package has any non-closed 'precedes' relations, then this
   field is set to 'true'. All CRUD actions with Work Packages and
   Relations keep this field in consistent state (the same way as
   done_ratio is calculated)

3) The user can see this field in the Work Package editor, can filter
   them using queries, and can save these queries.

4) The user can also show this field in query column. This column is
   sortable and groupable