### PR TITLE
[22316] Feature: Adjustable width of tabs section in wp fullscreen view

### DIFF
--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -95,6 +95,9 @@
           .work-packages--panel-inner
             padding-left: 0
 
+        .work-packages-full-view--resizer
+          display: none
+
 @include breakpoint(1248px down)
   body.controller-work_packages
     // --------------- ALL WP VIEWS ---------------

--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -93,7 +93,7 @@
             margin: 0.75rem 0 2.5rem 0
 
           .work-packages--panel-inner
-            padding-left: 0
+            padding-right: 0
 
         .work-packages-full-view--resizer
           display: none

--- a/app/assets/stylesheets/layout/_work_package_table_embedded.sass
+++ b/app/assets/stylesheets/layout/_work_package_table_embedded.sass
@@ -42,7 +42,8 @@
 
   .work-package-table--container
     contain: initial !important
-    overflow: visible
+    overflow-y: visible
+    overflow-x: auto
 
     .generic-table--header,
     .generic-table--sort-header

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -116,7 +116,7 @@ body.controller-work_packages.full-create
   .work-packages--panel-inner
     padding: 5px 15px 20px 0px
     width: 100%
-    
+
     // These styles were taken over from the details tab styling.
     // Thus the header and the details tab can be aligned on the same line.
     .attributes-group:first-of-type
@@ -127,10 +127,7 @@ body.controller-work_packages.full-create
 
         h3.attributes-group--header-text
           line-height: $work-package-details--tab-height - 10px
-
-.work-packages-full-view--resizer
-  position: relative
-
+  
 .work-packages-full-view--split-right
   //min-width: 420px
   min-width: 60px

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -103,7 +103,7 @@ body.controller-work_packages.full-create
 .work-packages-full-view--split-left
   border-right: 1px solid #ccc
   overflow-y: auto
-  overflow-x: auto
+  overflow-x: hidden
   flex: 2
   position: relative
   min-width: 360px

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -104,12 +104,7 @@ body.controller-work_packages.full-create
   border-right: 1px solid #ccc
   overflow-y: auto
   overflow-x: auto
-  //width: calc(100vw - 480px)
   flex: 2
-  flex-grow: 2
-  flex-shrink: 1
-  flex-basis: 0%
-  display: flex
   position: relative
   min-width: 360px
 
@@ -127,14 +122,12 @@ body.controller-work_packages.full-create
 
         h3.attributes-group--header-text
           line-height: $work-package-details--tab-height - 10px
-  
+
 .work-packages-full-view--split-right
-  //min-width: 420px
-  min-width: 60px
+  min-width: 480px
   overflow-y: auto
   overflow-x: auto
   position: relative
-  //width: calc(40% + 15px)
 
   .work-packages--panel-inner
     padding: 15px 15px 0px 15px
@@ -148,6 +141,13 @@ body.controller-work_packages.full-create
   .button.icon-edit.ng-hide
     display: block !important
     visibility: hidden
+
+.work-packages-full-view--resizer
+  .work-packages--resizer
+    width: 18px
+    left: 0
+    &::before
+      left: 0
 
 .nosidebar
   ul.subject-header

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -147,7 +147,7 @@ body.controller-work_packages.full-create
     width: 18px
     left: 0
     &::before
-      left: 0
+      left: -2px
 
 .nosidebar
   ul.subject-header
@@ -162,6 +162,8 @@ body.controller-work_packages.full-create
     @at-root
       .detailsViewMenuItem
         display: block
+  .work-packages-full-view--resizer
+    display: none
 
 @media only screen and (max-width: 78rem)
   .work-packages--show-view

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -144,9 +144,11 @@ body.controller-work_packages.full-create
 
 .work-packages-full-view--resizer
   .work-packages--resizer
+    height: 100vh
     width: 18px
-    left: 0
+    left: -2px
     &::before
+      position: sticky
       left: -2px
 
 .nosidebar

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -166,8 +166,6 @@ body.controller-work_packages.full-create
     @at-root
       .detailsViewMenuItem
         display: block
-  .work-packages-full-view--resizer
-    display: none
 
 @media only screen and (max-width: 78rem)
   .work-packages--show-view

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -104,11 +104,19 @@ body.controller-work_packages.full-create
   border-right: 1px solid #ccc
   overflow-y: auto
   overflow-x: auto
-  width: 60%
+  //width: calc(100vw - 480px)
+  flex: 2
+  flex-grow: 2
+  flex-shrink: 1
+  flex-basis: 0%
+  display: flex
+  position: relative
+  min-width: 360px
 
   .work-packages--panel-inner
     padding: 5px 15px 20px 0px
-
+    width: 100%
+    
     // These styles were taken over from the details tab styling.
     // Thus the header and the details tab can be aligned on the same line.
     .attributes-group:first-of-type
@@ -120,12 +128,16 @@ body.controller-work_packages.full-create
         h3.attributes-group--header-text
           line-height: $work-package-details--tab-height - 10px
 
+.work-packages-full-view--resizer
+  position: relative
+
 .work-packages-full-view--split-right
-  min-width: 420px
+  //min-width: 420px
+  min-width: 60px
   overflow-y: auto
   overflow-x: auto
-  width: calc(40% + 15px)
-  margin-right: -15px
+  position: relative
+  //width: calc(40% + 15px)
 
   .work-packages--panel-inner
     padding: 15px 15px 0px 15px

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -143,13 +143,15 @@ body.controller-work_packages.full-create
     visibility: hidden
 
 .work-packages-full-view--resizer
+  position: fixed
   .work-packages--resizer
     height: 100vh
     width: 18px
     left: -2px
     &::before
-      position: sticky
-      left: -2px
+      left: 0
+      // 130px is the size of header (55px) and toolbar with padding (75px)
+      top: calc((100vh - 130px)/2)
 
 .nosidebar
   ul.subject-header

--- a/app/assets/stylesheets/layout/_work_packages_full_view.sass
+++ b/app/assets/stylesheets/layout/_work_packages_full_view.sass
@@ -130,7 +130,10 @@ body.controller-work_packages.full-create
   position: relative
 
   .work-packages--panel-inner
-    padding: 15px 15px 0px 15px
+    position: absolute
+    display: inline-block
+    padding: 15px 15px 0px 0px
+    width: calc(100% - 18px)
 
   .work-package-details-activities-activity-contents ul
     padding-left: 2em
@@ -143,15 +146,17 @@ body.controller-work_packages.full-create
     visibility: hidden
 
 .work-packages-full-view--resizer
-  position: fixed
+  position: sticky
+  top: 0
+  bottom: 0
+  height: 100%
+  width: 18px
+  display: inline-block
   .work-packages--resizer
-    height: 100vh
-    width: 18px
     left: -2px
+    width: 18px
     &::before
       left: 0
-      // 130px is the size of header (55px) and toolbar with padding (75px)
-      top: calc((100vh - 130px)/2)
 
 .nosidebar
   ul.subject-header

--- a/frontend/src/app/components/resizer/main-menu-resizer.component.ts
+++ b/frontend/src/app/components/resizer/main-menu-resizer.component.ts
@@ -67,7 +67,7 @@ export class MainMenuResizerComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.subscription = this.toggleService.allData$
+    this.subscription = this.toggleService.titleData$
       .pipe(
         distinctUntilChanged(),
         untilComponentDestroyed(this)
@@ -152,4 +152,3 @@ export class MainMenuResizerComponent implements OnInit, OnDestroy {
     this.toggleService.setWidth(this.elementWidth);
   }
 }
-

--- a/frontend/src/app/components/resizer/main-menu-toggle.component.ts
+++ b/frontend/src/app/components/resizer/main-menu-toggle.component.ts
@@ -65,7 +65,7 @@ export class MainMenuToggleComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.toggleService.initializeMenu();
 
-    this.toggleService.allData$
+    this.toggleService.titleData$
       .pipe(
         distinctUntilChanged(),
         untilComponentDestroyed(this)

--- a/frontend/src/app/components/resizer/main-menu-toggle.service.ts
+++ b/frontend/src/app/components/resizer/main-menu-toggle.service.ts
@@ -43,8 +43,13 @@ export class MainMenuToggleService {
   private mainMenu = jQuery('#main-menu')[0];  // main menu, containing sidebar and resizer
   private hideElements = jQuery('.can-hide-navigation');
 
-  private allData = new BehaviorSubject<string>('');
-  public allData$ = this.allData.asObservable();
+  // Title needs to be sync in main-menu-toggle.component.ts and main-menu-resizer.component.ts
+  private titleData = new BehaviorSubject<string>('');
+  public titleData$ = this.titleData.asObservable();
+
+  // Notes all changes of the menu size (currently needed in wp-resizer.component.ts)
+  private changeData = new BehaviorSubject<any>({});
+  public changeData$ = this.changeData.asObservable();
 
   constructor(protected I18n:I18nService) {
   }
@@ -108,7 +113,7 @@ export class MainMenuToggleService {
     } else {
       this.toggleTitle = this.I18n.t('js.label_expand_project_menu');
     }
-    this.allData.next(this.toggleTitle);
+    this.titleData.next(this.toggleTitle);
   }
 
   private addRemoveClassHidden() : void {
@@ -119,6 +124,12 @@ export class MainMenuToggleService {
     this.setWidth(width);
     window.OpenProject.guardedLocalStorage(this.localStorageKey, String(this.elementWidth));
     this.setToggleTitle();
+    // Send change event when size of menu is changing (menu toggled or resized)
+    // Event should only be fired, when transition is finished
+    let changeEvent = jQuery.Event("change");
+    jQuery('#content-wrapper').on('transitionend webkitTransitionEnd oTransitionEnd otransitionend MSTransitionEnd', () => {
+      this.changeData.next(changeEvent);
+    });
   }
 
   public setWidth(width?:any) : void {

--- a/frontend/src/app/components/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/components/resizer/wp-resizer.component.ts
@@ -67,13 +67,20 @@ export class WpResizerDirective implements OnInit, OnDestroy {
 
     // Wait until dom content is loaded and initialize column layout
     // Otherwise function will be executed with empty list
-    var that = this;
-    jQuery(document).ready(function () {
-      that.applyColumnLayout(that.resizingElement, that.elementFlex);
+    jQuery(document).ready(() => {
+      this.applyColumnLayout(this.resizingElement, this.elementFlex);
     });
 
     // Add event listener
     this.element = this.elementRef.nativeElement;
+
+    // Add event listener on hamburger menu and toggle column layout, if necessary
+    // The timeout is currently needed, because the sidebar is sliding in
+    jQuery('#main-menu-toggle')[0].addEventListener('click', () => {
+      setTimeout(function(){
+        jQuery('.can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left')[0].offsetWidth > 750);
+      }, 150);
+    });
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/components/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/components/resizer/wp-resizer.component.ts
@@ -85,10 +85,10 @@ export class WpResizerDirective implements OnInit, OnDestroy {
         untilComponentDestroyed(this)
       )
       .subscribe( changeData => {
-        jQuery('.can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left').width() > 750);
+        jQuery('.-can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left').width() > 750);
       });
     jQuery(window).resize(function() {
-      jQuery('.can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left').width() > 750);
+      jQuery('.-can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left').width() > 750);
     });
   }
 
@@ -178,7 +178,7 @@ export class WpResizerDirective implements OnInit, OnDestroy {
   private applyColumnLayout(element:HTMLElement, newWidth:number) {
     // Apply two column layout in fullscreen view of a workpackage
     if (element === jQuery('.work-packages-full-view--split-right')[0]) {
-      jQuery('.can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left').width() > 750);
+      jQuery('.-can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left').width() > 750);
     }
     // Apply two column layout when details view of wp is open
     else {

--- a/frontend/src/app/components/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/components/resizer/wp-resizer.component.ts
@@ -65,8 +65,12 @@ export class WpResizerDirective implements OnInit, OnDestroy {
     }
     this.resizingElement.style.flexBasis = this.elementFlex + 'px';
 
-    // Apply two column layout
-    this.resizingElement.classList.toggle('-columns-2', this.elementFlex > 700);
+    // Wait until dom content is loaded and initialize column layout
+    // Otherwise function will be executed with empty list
+    var that = this;
+    jQuery(document).ready(function () {
+      that.applyColumnLayout(that.resizingElement, that.elementFlex);
+    });
 
     // Add event listener
     this.element = this.elementRef.nativeElement;
@@ -149,9 +153,21 @@ export class WpResizerDirective implements OnInit, OnDestroy {
     window.OpenProject.guardedLocalStorage(this.localStorageKey, String(newValue));
 
     // Apply two column layout
-    element.classList.toggle('-columns-2', newValue > 700);
+    this.applyColumnLayout(element, newValue);
 
     // Set new width
     element.style.flexBasis = newValue + 'px';
+  }
+
+  private applyColumnLayout(element:HTMLElement, newWidth:number) {
+    // Apply two column layout in fullscreen view of a workpackage
+    if (element === jQuery('.work-packages-full-view--split-right')[0]) {
+      let widthLeftCol = jQuery('.work-packages-full-view--split-left')[0].offsetWidth;
+      jQuery('.can-have-columns').toggleClass('-columns-2', widthLeftCol > 750);
+    }
+    // Apply two column layout when details view of wp is open
+    else {
+      element.classList.toggle('-columns-2', newWidth > 700);
+    }
   }
 }

--- a/frontend/src/app/components/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/components/resizer/wp-resizer.component.ts
@@ -90,6 +90,9 @@ export class WpResizerDirective implements OnInit, OnDestroy {
       .subscribe( changeData => {
         jQuery('.can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left')[0].offsetWidth > 750);
       });
+    jQuery(window).resize(function() {
+      jQuery('.can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left')[0].offsetWidth > 750);
+    });
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/components/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/components/resizer/wp-resizer.component.ts
@@ -28,7 +28,6 @@
 
 import {ChangeDetectorRef, Component, ElementRef, HostListener, Injector, Input, OnDestroy, OnInit} from '@angular/core';
 import {distinctUntilChanged} from 'rxjs/operators';
-import {Subscription} from 'rxjs/Subscription';
 import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {MainMenuToggleService} from "core-components/resizer/main-menu-toggle.service";
 
@@ -49,8 +48,6 @@ export class WpResizerDirective implements OnInit, OnDestroy {
   private element:HTMLElement;
 
   public moving:boolean = false;
-
-  private subscription:Subscription;
 
   constructor(readonly toggleService:MainMenuToggleService,
               private elementRef:ElementRef) {
@@ -88,17 +85,16 @@ export class WpResizerDirective implements OnInit, OnDestroy {
         untilComponentDestroyed(this)
       )
       .subscribe( changeData => {
-        jQuery('.can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left')[0].offsetWidth > 750);
+        jQuery('.can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left').width() > 750);
       });
     jQuery(window).resize(function() {
-      jQuery('.can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left')[0].offsetWidth > 750);
+      jQuery('.can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left').width() > 750);
     });
   }
 
   ngOnDestroy() {
     // Reset the style when killing this directive, otherwise the style remains
     this.resizingElement.style.flexBasis = null;
-    this.subscription.unsubscribe();
   }
 
   @HostListener('mousedown', ['$event'])
@@ -182,8 +178,7 @@ export class WpResizerDirective implements OnInit, OnDestroy {
   private applyColumnLayout(element:HTMLElement, newWidth:number) {
     // Apply two column layout in fullscreen view of a workpackage
     if (element === jQuery('.work-packages-full-view--split-right')[0]) {
-      let widthLeftCol = jQuery('.work-packages-full-view--split-left')[0].offsetWidth;
-      jQuery('.can-have-columns').toggleClass('-columns-2', widthLeftCol > 750);
+      jQuery('.can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left').width() > 750);
     }
     // Apply two column layout when details view of wp is open
     else {

--- a/frontend/src/app/components/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/components/routing/wp-full-view/wp-full-view.html
@@ -56,11 +56,11 @@
           <wp-single-view [workPackage]="workPackage"></wp-single-view>
         </div>
       </div>
-      <div class="work-packages-full-view--resizer hidden-for-mobile hide-when-print">
-        <wp-resizer [elementClass]="'work-packages-full-view--split-right'"
-                  [localStorageKey]="'openProject-fullViewFlexBasis'"></wp-resizer>
-      </div>
       <div class="work-packages-full-view--split-right">
+        <div class="work-packages-full-view--resizer hidden-for-mobile hide-when-print">
+          <wp-resizer [elementClass]="'work-packages-full-view--split-right'"
+                    [localStorageKey]="'openProject-fullViewFlexBasis'"></wp-resizer>
+        </div>
         <div class="work-packages--panel-inner">
           <span class="hidden-for-sighted" tabindex="-1" focus [textContent]="focusAnchorLabel"></span>
           <div id="tabs">

--- a/frontend/src/app/components/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/components/routing/wp-full-view/wp-full-view.html
@@ -56,6 +56,10 @@
           <wp-single-view [workPackage]="workPackage"></wp-single-view>
         </div>
       </div>
+      <div class="work-packages-full-view--resizer hidden-for-mobile hide-when-print">
+        <wp-resizer [elementClass]="'work-packages-full-view--split-right'"
+                  [localStorageKey]="'openProject-fullViewFlexBasis'"></wp-resizer>
+      </div>
       <div class="work-packages-full-view--split-right">
         <div class="work-packages--panel-inner">
           <span class="hidden-for-sighted" tabindex="-1" focus [textContent]="focusAnchorLabel"></span>

--- a/frontend/src/app/components/wp-form-group/wp-attribute-group.template.html
+++ b/frontend/src/app/components/wp-form-group/wp-attribute-group.template.html
@@ -1,4 +1,4 @@
-<div class="can-have-columns -columns-2">
+<div class="-can-have-columns -columns-2">
   <div class="attributes-key-value"
        [ngClass]="{'-span-all-columns': descriptor.spanAll }"
        *ngFor="let descriptor of group.members; trackBy:trackByName">

--- a/frontend/src/app/components/wp-form-group/wp-attribute-group.template.html
+++ b/frontend/src/app/components/wp-form-group/wp-attribute-group.template.html
@@ -1,4 +1,4 @@
-<div class="-columns-2">
+<div class="can-have-columns -columns-2">
   <div class="attributes-key-value"
        [ngClass]="{'-span-all-columns': descriptor.spanAll }"
        *ngFor="let descriptor of group.members; trackBy:trackByName">


### PR DESCRIPTION
New Feature: Width of the sections in a work package fullscreen view is now adjustable
- Fullscreen view is now using the wp-resizer.component.ts
- Both sections have a minimum width (you can not hide one side completely)
- If width of left side is too small for a layout with two columns, it will switch to one column

**ToDo's**
- [x] Column layout needs to change, if hamburger menu is expanded and size of left section is then too small (currently the element is just reacting on a resize event)
- [ ] Possible extension of the feature: Right side can be completely collapsed (similar to hamburger menu)

https://community.openproject.com/projects/openproject/work_packages/22316/activity
