### PR TITLE
Feature/default auto hide notifications

### DIFF
--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -69,7 +69,7 @@ class UserPreference < ActiveRecord::Base
   end
 
   def auto_hide_popups?
-    others[:auto_hide_popups] || false
+    others.fetch(:auto_hide_popups) { Setting.default_auto_hide_popups? }
   end
 
   def warn_on_leaving_unsaved?

--- a/app/views/settings/_display.html.erb
+++ b/app/views/settings/_display.html.erb
@@ -34,8 +34,6 @@ See docs/COPYRIGHT.rdoc for more details.
 
     <div class="form--field" id="setting_available_languages"><%= setting_multiselect :available_languages, all_lang_options_for_select(false) %></div>
 
-    <div class="form--field" id="setting_default_language"><%= setting_select :default_language, all_lang_options_for_select(false), container_class: '-slim' %></div>
-
     <div class="form--field"><%= setting_select :start_of_week, [[day_name(1),'1'], [day_name(6),'6'], [day_name(7),'7']], blank: :label_language_based, container_class: '-slim' %></div>
 
     <div class="form--field"><%= setting_select :date_format, Setting::DATE_FORMATS.collect {|f| [Date.today.strftime(f), f]}, blank: :label_language_based, container_class: '-slim' %></div>
@@ -43,15 +41,6 @@ See docs/COPYRIGHT.rdoc for more details.
     <div class="form--field"><%= setting_select :time_format, Setting::TIME_FORMATS.collect {|f| [Time.now.strftime(f), f]}, blank: :label_language_based, container_class: '-slim' %></div>
 
     <div class="form--field"><%= setting_select :user_format, @options[:user_format], container_class: '-slim' %></div>
-
-    <%=
-      cell(
-        Settings::TimeZoneSettingCell,
-        "user_default_timezone",
-        container_class: "-slim",
-        title: I18n.t("tooltip_user_default_timezone")
-      )
-    %>
 
     <div class="form--field"><%= setting_text_field :journal_aggregation_time_minutes, unit: t(:label_minute_plural), container_class: '-xslim' %>
       <span class="form--field-instructions">

--- a/app/views/settings/_users.html.erb
+++ b/app/views/settings/_users.html.erb
@@ -29,7 +29,17 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <%= styled_form_tag({ action: 'edit', tab: 'users' }, class: 'admin-settings--form') do %>
 
-  <div class ="form--section">
+  <div class="form--fieldset">
+    <legend class="form--fieldset-legend"><%= t(:'settings.user.default_preferences')%></legend>
+
+    <div class="form--field">
+      <%= setting_check_box :default_auto_hide_popups, label: 'activerecord.attributes.user_preference.auto_hide_popups' %>
+    </div>
+
+  </div>
+
+  <div class="form--fieldset">
+    <legend class="form--fieldset-legend"><%= t(:'settings.user.deletion')%></legend>
     <div class="form--field">
       <%= setting_check_box :users_deletable_by_admins %>
     </div>
@@ -39,42 +49,40 @@ See docs/COPYRIGHT.rdoc for more details.
     </div>
   </div>
 
-  <fieldset class="form--fieldset">
-    <fieldset id="consent_settings" class="form--fieldset">
-      <legend class="form--fieldset-legend"><%= I18n.t(:label_consent_settings) %></legend>
+  <fieldset id="consent_settings" class="form--fieldset">
+    <legend class="form--fieldset-legend"><%= I18n.t(:label_consent_settings) %></legend>
 
-      <div class="form--field">
-        <%= setting_check_box :consent_required %>
-      </div>
+    <div class="form--field">
+      <%= setting_check_box :consent_required %>
+    </div>
 
-      <%= cell Settings::TextSettingCell, I18n.locale, name: "consent_info" %>
+    <%= cell Settings::TextSettingCell, I18n.locale, name: "consent_info" %>
 
-      <div class="form--field">
-        <%= setting_block("consent_time") do %>
-          <span class="form--check-box-field-container -slim">
-            <input type="hidden" name="settings[consent_time]" disabled id="settings_consent_time">
-            <%= check_box_tag 'toggle_consent_time',
-                              '1',
-                              !Setting.consent_time.present?,
-                              id: 'toggle_consent_time' %>
-          </span>
-        <% end %>
-        <div class="form--field-instructions">
-          <%= I18n.t('consent.text_update_consent_time') %>
-          <br/>
-          <strong>
-            <%= I18n.t('consent.update_consent_last_time',
-                       update_time: Setting.consent_time.present? ? format_time(Setting.consent_time) : t(:label_never)) %>
-          </strong>
-        </div>
-      </div>
-      <div class="form--field">
-        <%= setting_text_field :consent_decline_mail, size: 6, container_class: '-middle' %>
-        <span class="form--field-instructions">
-          <%= t('consent.contact_mail_instructions') %>
+    <div class="form--field">
+      <%= setting_block("consent_time") do %>
+        <span class="form--check-box-field-container -slim">
+          <input type="hidden" name="settings[consent_time]" disabled id="settings_consent_time">
+          <%= check_box_tag 'toggle_consent_time',
+                            '1',
+                            !Setting.consent_time.present?,
+                            id: 'toggle_consent_time' %>
         </span>
+      <% end %>
+      <div class="form--field-instructions">
+        <%= I18n.t('consent.text_update_consent_time') %>
+        <br/>
+        <strong>
+          <%= I18n.t('consent.update_consent_last_time',
+                     update_time: Setting.consent_time.present? ? format_time(Setting.consent_time) : t(:label_never)) %>
+        </strong>
       </div>
-    </fieldset>
+    </div>
+    <div class="form--field">
+      <%= setting_text_field :consent_decline_mail, size: 6, container_class: '-middle' %>
+      <span class="form--field-instructions">
+        <%= t('consent.contact_mail_instructions') %>
+      </span>
+    </div>
   </fieldset>
   <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
 <% end %>

--- a/app/views/settings/_users.html.erb
+++ b/app/views/settings/_users.html.erb
@@ -29,16 +29,28 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <%= styled_form_tag({ action: 'edit', tab: 'users' }, class: 'admin-settings--form') do %>
 
-  <div class="form--fieldset">
+  <fieldset class="form--fieldset">
     <legend class="form--fieldset-legend"><%= t(:'settings.user.default_preferences')%></legend>
+
+    <div class="form--field" id="setting_default_language">
+      <%= setting_select :default_language, all_lang_options_for_select(false), container_class: '-slim' %>
+    </div>
+
+    <%=
+      cell(
+          Settings::TimeZoneSettingCell,
+          "user_default_timezone",
+          container_class: "-slim",
+          title: I18n.t("tooltip_user_default_timezone")
+      )
+    %>
 
     <div class="form--field">
       <%= setting_check_box :default_auto_hide_popups, label: 'activerecord.attributes.user_preference.auto_hide_popups' %>
     </div>
+  </fieldset>
 
-  </div>
-
-  <div class="form--fieldset">
+  <fieldset class="form--fieldset">
     <legend class="form--fieldset-legend"><%= t(:'settings.user.deletion')%></legend>
     <div class="form--field">
       <%= setting_check_box :users_deletable_by_admins %>
@@ -47,7 +59,7 @@ See docs/COPYRIGHT.rdoc for more details.
     <div class="form--field">
       <%= setting_check_box :users_deletable_by_self %>
     </div>
-  </div>
+  </fieldset>
 
   <fieldset id="consent_settings" class="form--fieldset">
     <legend class="form--fieldset-legend"><%= I18n.t(:label_consent_settings) %></legend>
@@ -82,6 +94,14 @@ See docs/COPYRIGHT.rdoc for more details.
       <span class="form--field-instructions">
         <%= t('consent.contact_mail_instructions') %>
       </span>
+    </div>
+  </fieldset>
+
+  <fieldset class="form--fieldset">
+    <legend class="form--fieldset-legend"><%= t(:label_accessibility)%></legend>
+
+    <div class="form--field">
+      <%= setting_check_box :accessibility_mode_for_anonymous %>
     </div>
   </fieldset>
   <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2067,6 +2067,9 @@ en:
     passwords: "Passwords"
     session: "Session"
     brute_force_prevention: "Automated user blocking"
+    user:
+      default_preferences: "Default preferences"
+      deletion: "Deletion"
 
   text_formatting:
     textile: 'Textile'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -167,6 +167,9 @@ available_languages:
   - ru
 default_language:
   default: en
+default_auto_hide_popups:
+  default: 1
+  format: boolean
 email_login: # use email address as login, hide login in registration form
   default: 0
 host_name:

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -45,8 +45,16 @@ describe UserPreference do
       expect(subject.others[:no_self_notified]).to be_truthy
     end
 
-    it 'disables auto hide popups' do
-      expect(subject.auto_hide_popups).to eql(false)
+    context 'with default setting auto_hide_popups to false', with_settings: { default_auto_hide_popups: false } do
+      it 'disables auto hide popups' do
+        expect(subject.auto_hide_popups).to be_falsey
+      end
+    end
+
+    context 'with default setting auto_hide_popups to true', with_settings: { default_auto_hide_popups: true } do
+      it 'disables auto hide popups' do
+        expect(subject.auto_hide_popups).to be_truthy
+      end
     end
   end
 

--- a/spec/support/shared/with_settings.rb
+++ b/spec/support/shared/with_settings.rb
@@ -46,7 +46,20 @@ RSpec.configure do |config|
       settings = aggregate_mocked_settings(example, settings)
 
       settings.each do |k, v|
-        allow(Setting).to receive(k).and_return(v)
+        bare, questionmarked = if k.to_s.ends_with?('?')
+                                 [k.to_s[0..-2].to_sym, k]
+                               else
+                                 [k, "#{k}?".to_sym]
+                               end
+
+        raise "#{k} is not a valid setting" unless Setting.available_settings[bare.to_s]
+
+        if Setting.available_settings[bare.to_s]['format'] == 'boolean'
+          allow(Setting).to receive(bare).and_return(v)
+          allow(Setting).to receive(questionmarked).and_return(v)
+        else
+          allow(Setting).to receive(k).and_return(v)
+        end
       end
     end
   end

--- a/spec/support/shared/with_settings.rb
+++ b/spec/support/shared/with_settings.rb
@@ -52,9 +52,9 @@ RSpec.configure do |config|
                                  [k, "#{k}?".to_sym]
                                end
 
-        raise "#{k} is not a valid setting" unless Setting.available_settings[bare.to_s]
+        raise "#{k} is not a valid setting" unless Setting.respond_to?(bare)
 
-        if Setting.available_settings[bare.to_s]['format'] == 'boolean'
+        if Setting.available_settings[bare.to_s] && Setting.available_settings[bare.to_s]['format'] == 'boolean'
           allow(Setting).to receive(bare).and_return(v)
           allow(Setting).to receive(questionmarked).and_return(v)
         else


### PR DESCRIPTION
Introduces a setting that serves as a default value for the auto hide notifications behaviour: https://community.openproject.com/projects/openproject/work_packages/26925/activity

Also bundles all global default settings for user preferences in one place.