### PR TITLE
[27915] Fix initial saving of query with is_public

### DIFF
--- a/frontend/src/app/components/modals/save-modal/save-query.modal.html
+++ b/frontend/src/app/components/modals/save-modal/save-query.modal.html
@@ -12,8 +12,9 @@
       </a>
     </div>
 
+    <h3 [textContent]="text.save_as"></h3>
+
     <form name="modalSaveForm" class="form">
-      <h3 [textContent]="text.save_as"></h3>
       <div class="form--field -required">
         <label class="form--label" for="save-query-name" [textContent]="text.label_name"></label>
         <div class="form--field-container">

--- a/frontend/src/app/components/modals/share-modal/query-sharing-form.component.ts
+++ b/frontend/src/app/components/modals/share-modal/query-sharing-form.component.ts
@@ -37,7 +37,7 @@ export class QuerySharingForm {
   public get canPublish() {
     const form = this.states.query.form.value!;
 
-    return this.authorisationService.can('query', 'saveImmediately')
+    return this.authorisationService.can('query', 'updateImmediately')
       && form.schema.public.writable;
   }
 

--- a/spec/features/work_packages/table/queries/query_menu_spec.rb
+++ b/spec/features/work_packages/table/queries/query_menu_spec.rb
@@ -50,6 +50,23 @@ describe 'Query menu item', js: true do
       wp_table.visit!
     end
 
+    it 'allows to save query as name with sharing options (Regression #27915)' do
+      # Publish query
+      wp_table.click_setting_item 'Save as'
+
+      fill_in 'save-query-name', with: 'Some query name'
+      find('#show-in-menu').set true
+      find('#show-public').set true
+
+      find('.button', text: 'Save').click
+
+      wp_table.expect_notification message: 'Successful creation.'
+      expect(page).to have_selector('.query-menu-item', text: 'Some query name')
+
+      last_query = Query.last
+      expect(last_query.is_public).to be_truthy
+    end
+
     it 'allows filtering, saving, retrieving and altering the saved filter (Regression #25372)' do
       filters.open
       filters.add_filter_by('Version', 'is', version.name)


### PR DESCRIPTION
Fixes:

- Overlapped close icon due to misplaced `<h3>` 
- Disabled 'Show query in menu' item on initial save

https://community.openproject.com/wp/27915