### PR TITLE
Disable unsafe-eval now that we're on AOT

### DIFF
--- a/app/helpers/angular_helper.rb
+++ b/app/helpers/angular_helper.rb
@@ -41,9 +41,10 @@ module AngularHelper
     end
 
     if block_given?
-      content_tag(type, options.merge('ng-app': 'OpenProjectLegacy'), &block)
+      merged_options = options.merge('ng-app': 'OpenProjectLegacy', 'ng-csp': '')
+      content_tag(type, merged_options, &block)
     else
-      'ng-app="OpenProjectLegacy"'.html_safe
+      'ng-app="OpenProjectLegacy" ng-csp'.html_safe
     end
   end
 end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -47,11 +47,12 @@ SecureHeaders::Configuration.default do |config|
     frame_ancestors: %w('self'),
     # Allow images from anywhere
     img_src: %w(* data:),
-    # Allow scripts from self (not inline, but)
-    # for now require unsafe-eval for Angular JIT
-    script_src: assets_src + %w('unsafe-eval'),
+    # Allow scripts from self
+    script_src: assets_src,
     # Allow unsafe-inline styles
     style_src: assets_src + %w('unsafe-inline'),
+    # disallow all object-src
+    object_src: %w('none'),
 
     # Connect sources for CLI in dev mode
     connect_src: connect_src

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -13,6 +13,7 @@
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
             "outputPath": "../public/assets/frontend/",
+            "aot": true,
             "index": "src/index2.html",
             "main": "src/main.ts",
             "tsConfig": "src/tsconfig.app.json",
@@ -34,7 +35,7 @@
               "sourceMap": false,
               "extractCss": true,
               "namedChunks": false,
-              "aot": false, // TODO broken https://github.com/opf/openproject/pull/6346#issue-190950635
+              "aot": true,
               "extractLicenses": true,
               "vendorChunk": true,
               "buildOptimizer": false,
@@ -50,7 +51,9 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "OpenProject:build"
+            "browserTarget": "OpenProject:build",
+            "proxyConfig": "cli_to_rails_proxy.js",
+            "aot": true
           },
           "configurations": {
             "production": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -118,7 +118,7 @@
     "zone.js": "^0.8.26"
   },
   "scripts": {
-    "serve": "ng serve --proxy-config cli_to_rails_proxy.js",
+    "serve": "ng serve",
     "test": "ng test",
     "tslint_typechecks": "tslint -p . -c tslint_typechecks.json",
     "posttest": "npm run tslint_typechecks",


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/27321

In development mode, this results in the CSP policy

```
default-src 'self';
base-uri 'self';
child-src 'self' https://player.vimeo.com;
connect-src 'self' ws://localhost:4200 http://localhost:4200;
font-src 'self' ws://localhost:4200 http://localhost:4200 data:;
form-action 'self';
frame-ancestors 'self';
img-src * data:;
object-src 'none';
script-src 'self' ws://localhost:4200 http://localhost:4200 'nonce-kBoSYEcbLxwoFyOpZ/NbeVhbAna71K4vLHm4rZ1srtg=';
style-src 'self' ws://localhost:4200 http://localhost:4200 'unsafe-inline';
``` 

You can validate this config with https://csp-evaluator.withgoogle.com/, which only croaks about:

- Non https access (does not apply in production)
- strict-dynamic mode with nonces. We can look into that, but would need to find a way to work around it at e.g., cloudfront. It's not supported by all browsers we need though.