### PR TITLE
 Improve default titles for wiki pages

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -373,7 +373,8 @@ class WikiController < ApplicationController
 
   def current_menu_item_sym(page)
     if page == :parent_page
-      page = send(:page).parent
+      page = send(:page)
+      page = page.parent if page && page.parent
     else
       page = send(page)
     end

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -72,6 +72,10 @@ class WikiController < ApplicationController
     controller.current_menu_item_sym :related_page
   end
 
+  current_menu_item :new_child do |controller|
+    controller.current_menu_item_sym :parent_page
+  end
+
   current_menu_item do |controller|
     controller.current_menu_item_sym :page
   end
@@ -368,7 +372,12 @@ class WikiController < ApplicationController
   end
 
   def current_menu_item_sym(page)
-    page = send(page)
+    if page == :parent_page
+      page = send(:page).parent
+    else
+      page = send(page)
+    end
+
     menu_item = page.try(:menu_item)
 
     if menu_item.present?
@@ -382,7 +391,7 @@ class WikiController < ApplicationController
   protected
 
   def parse_preview_data
-    page = @wiki.find_page(wiki_page_title)
+    page = @wiki.find_page(wiki_page_title.presence || params[:id])
     # page is nil when previewing a new page
     return render_403 unless page.nil? || editable?(page)
 
@@ -403,7 +412,7 @@ class WikiController < ApplicationController
   private
 
   def wiki_page_title
-    params[:title] || params[:id]
+    params[:title] || action_name == 'new_child' ? '' : params[:id].to_s.capitalize.tr('-', ' ')
   end
 
   def find_wiki
@@ -416,12 +425,12 @@ class WikiController < ApplicationController
 
   # Finds the requested page and returns a 404 error if it doesn't exist
   def find_existing_page
-    @page = @wiki.find_page(wiki_page_title)
+    @page = @wiki.find_page(wiki_page_title.presence || params[:id])
     render_404 if @page.nil?
   end
 
   def build_wiki_page_and_content
-    @page = WikiPage.new wiki: @wiki, title: wiki_page_title.presence || I18n.t(:label_wiki_page)
+    @page = WikiPage.new wiki: @wiki, title: wiki_page_title.presence
     @page.content = WikiContent.new page: @page
 
     @content = @page.content_for_version nil

--- a/app/views/wiki/new.html.erb
+++ b/app/views/wiki/new.html.erb
@@ -44,7 +44,7 @@ See docs/COPYRIGHT.rdoc for more details.
     <div class="form--field -required">
       <%= f.fields_for :page, @page do |page_fields| %>
         <%= page_fields.hidden_field :parent_id %>
-        <%= page_fields.text_field :title, required: true, size: 120 %>
+        <%= page_fields.text_field :title, required: true, size: 120, placeholder: t('label_page_title') %>
       <% end %>
     </div>
     <div class="form--field -required">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1351,6 +1351,7 @@ en:
   label_overall_activity: "Overall activity"
   label_overall_spent_time: "Overall spent time"
   label_overview: "Overview"
+  label_page_title: "Page title"
   label_part_of: "part of"
   label_password_lost: "Forgot your password?"
   label_password_rule_lowercase: "Lowercase"

--- a/spec/features/wiki/wiki_textile_links_spec.rb
+++ b/spec/features/wiki/wiki_textile_links_spec.rb
@@ -70,7 +70,7 @@ describe 'Wiki unicode title spec', type: :feature, js: true do
     find('#content_text').set(wiki_body)
     click_button 'Save'
 
-    expect(page).to have_selector('.title-container h2', text: 'wiki')
+    expect(page).to have_selector('.title-container h2', text: 'Wiki')
   end
 
   it 'renders correct links' do

--- a/spec/features/wiki/wiki_unicode_spec.rb
+++ b/spec/features/wiki/wiki_unicode_spec.rb
@@ -94,7 +94,7 @@ describe 'Wiki unicode title spec', type: :feature, js: true do
     find('#content_text').set(wiki_body)
     click_button 'Save'
 
-    expect(page).to have_selector('.title-container h2', text: 'wiki')
+    expect(page).to have_selector('.title-container h2', text: 'Wiki')
     expect(page).to have_selector('a.wiki-page', count: 5)
   end
 


### PR DESCRIPTION
- When page creation triggered from URL, replace dashes with spaces and capitalize first word. (https://community.openproject.com/wp/27841)
- When created with `../new` do not copy parent’s title into the page title, but have a proper placeholder saying "Page title" instead.
