### PR TITLE
Enable ubuntu 18.04 on packager.io

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/pkgr/pkgr-buildpack-imagemagick.git
 https://github.com/heroku/heroku-buildpack-nodejs.git#v106
-https://github.com/opf/heroku-buildpack-ruby.git#7fbc10bd8046e0cbb6af6667de68a2b90c83e1a6
+https://github.com/pkgr/heroku-buildpack-ruby.git#v183-1

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -10,6 +10,8 @@ targets:
     <<: *debian8
   ubuntu-16.04:
     <<: *debian8
+  ubuntu-18.04:
+    <<: *debian8
   centos-7:
    dependencies:
       - epel-release


### PR DESCRIPTION
Tested with a build at https://packager.io/gh/crohr/openproject/builds/410/install/ubuntu-18.04, and it works fine.