### PR TITLE
fix wrong method name for external attachments

### DIFF
--- a/lib/api/v3/attachments/attachment_representer.rb
+++ b/lib/api/v3/attachments/attachment_representer.rb
@@ -72,7 +72,7 @@ module API
 
         link :downloadLocation do
           location = if represented.external_storage?
-                       represented.remote_url
+                       represented.external_url
                      else
                        api_v3_paths.attachment_content(represented.id)
                      end

--- a/spec/lib/api/v3/attachments/attachment_representer_spec.rb
+++ b/spec/lib/api/v3/attachments/attachment_representer_spec.rb
@@ -127,20 +127,20 @@ describe ::API::V3::Attachments::AttachmentRepresenter do
       end
 
       context 'for a remote attachment' do
-        let(:remote_url) { 'https://some.bogus/download/xyz' }
+        let(:external_url) { 'https://some.bogus/download/xyz' }
 
         before do
           allow(attachment)
             .to receive(:external_storage?)
             .and_return(true)
           allow(attachment)
-            .to receive(:remote_url)
-            .and_return(remote_url)
+            .to receive(:external_url)
+            .and_return(external_url)
         end
 
         it_behaves_like 'has an untitled link' do
           let(:link) { 'downloadLocation' }
-          let(:href) { remote_url }
+          let(:href) { external_url }
         end
       end
     end

--- a/spec/requests/api/v3/attachments/attachment_resource_spec.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_spec.rb
@@ -289,21 +289,21 @@ describe 'API v3 Attachment resource', type: :request, content_type: :json do
       end
 
       context 'for a remote file' do
-        let(:remote_url) { 'http://some_service.org/blubs.gif' }
+        let(:external_url) { 'http://some_service.org/blubs.gif' }
         let(:mock_file) { FileHelpers.mock_uploaded_file name: 'foobar.txt' }
         let(:attachment) do
           FactoryBot.create(:attachment, container: container, file: mock_file) do |a|
             # need to mock here to avoid dependency on external service
             allow_any_instance_of(Attachment)
               .to receive(:external_url)
-              .and_return(remote_url)
+              .and_return(external_url)
           end
         end
 
         it 'responds with 302 Redirect' do
           expect(subject.status).to eq 302
           expect(subject.headers['Location'])
-            .to eql remote_url
+            .to eql external_url
         end
       end
     end


### PR DESCRIPTION
The method called did simply not exist. Probably renamed during development.