### PR TITLE
[27939] Re-add select2 for column selection

### DIFF
--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -125,7 +125,7 @@ $ng-modal-image-width: $ng-modal-image-height
     @include varprop(color, header-item-font-color)
 
 // Specific styles for columns-modal
-.columns-modal-content
+.columns-modal--content
   margin-bottom: 15px
   label
     display: inline

--- a/app/assets/stylesheets/vendor/_select2.scss
+++ b/app/assets/stylesheets/vendor/_select2.scss
@@ -84,15 +84,6 @@
   text-overflow: ellipsis;
 }
 
-.controller-work_packages.action-index .select2-drop:not(.project-search-results) .select2-results .select2-result-selectable {
-  color: #000;
-}
-
-.controller-work_packages.action-index .select2-drop:not(.project-search-results) .select2-results .select2-result-selectable.select2-highlighted {
-  color: #fff;
-  font-weight: bold;
-}
-
 .select2-drop {
   z-index: 30001;
 }

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -583,6 +583,7 @@ en:
         hierarchy_hint: "All filtered table results will be augmented with their ancestors. Hierarchies can be expanded and collapsed."
         display_sums_hint: "Display sums of all summable attributes in a row below the table results."
         show_timeline_hint: "Show an interactive gantt chart on the right side of the table. You can change its width by dragging the divider between table and gantt chart."
+        columns_help_text: "Use the input above to add or remove columns to your table view. You can drag and drop the columns to reorder them."
       tabs:
         overview: Overview
         activity: Activity

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-columns.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-columns.service.ts
@@ -150,6 +150,11 @@ export class WorkPackageTableColumnsService extends WorkPackageTableBaseService<
     this.state.putValue(currentState);
   }
 
+  public setColumnsById(columnIds:string[]) {
+    const mapped = columnIds.map(id => _.find(this.all, c => c.id === id));
+    this.setColumns(_.compact(mapped));
+  }
+
   /**
    * Move the column at index {fromIndex} to {toIndex}.
    * - If toIndex is larger than all columns, insert at the end.

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/columns-tab.component.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/columns-tab.component.html
@@ -1,9 +1,15 @@
-<div class="columns-modal-content select2-modal-content">
+<div class="columns-modal--content select2-modal-content">
   <label
     [textContent]="text.selectedColumns"
     class="hidden-for-sighted">
   </label>
 
+  <ng-container *ngIf="!impaired">
+    <input #select2Columns
+           type="hidden" />
+    <p class="columns-modal--help-text" [textContent]="text.columnsHelp"></p>
+  </ng-container>
+  <ng-container *ngIf="impaired">
   <div *ngFor="let column of availableColumns; let first = first;">
     <label class="form--label-with-check-box" for="column-{{column.id}}">
       <div class="form--check-box-container">
@@ -17,6 +23,7 @@
       {{column.name}}
     </label>
   </div>
+  </ng-container>
 </div>
 <div *ngIf="eeShowBanners" class="ee-relation-columns-upsale">
   {{text.upsaleRelationColumns}}

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/columns-tab.component.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/columns-tab.component.ts
@@ -1,25 +1,30 @@
-import {Component, Inject, Injector} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, Injector, OnDestroy, ViewChild} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {QueryColumn} from 'core-components/wp-query/query-column';
 import {ConfigurationService} from 'core-app/modules/common/config/configuration.service';
 import {WorkPackageTableColumnsService} from 'core-components/wp-fast-table/state/wp-table-columns.service';
 import {TabComponent} from 'core-components/wp-table/configuration-modal/tab-portal-outlet';
-import {cloneHalResourceCollection} from 'core-app/modules/hal/helpers/hal-resource-builder';
+
+interface ColumnLike {
+  text:string;
+  id:string;
+}
 
 @Component({
   templateUrl: './columns-tab.component.html'
 })
-export class WpTableConfigurationColumnsTab implements TabComponent {
+export class WpTableConfigurationColumnsTab implements TabComponent, AfterViewInit, OnDestroy {
 
   public availableColumns = this.wpTableColumns.all;
-  public unusedColumns = this.wpTableColumns.unused;
-  public selectedColumns = cloneHalResourceCollection<QueryColumn>(this.wpTableColumns.getColumns());
+  public availableColumnsMap:{[id:string]: QueryColumn} = _.keyBy(this.availableColumns, c => c.id);
+  public selectedColumns:ColumnLike[] = this.wpTableColumns.getColumns().map(c => this.column2Like(c));
 
   public impaired = this.ConfigurationService.accessibilityModeEnabled();
   public selectedColumnMap:{ [id:string]:boolean } = {};
   public eeShowBanners:boolean = false;
   public text = {
 
+    columnsHelp: this.I18n.t('js.work_packages.table_configuration.columns_help_text'),
     columnsLabel: this.I18n.t('js.label_columns'),
     selectedColumns: this.I18n.t('js.description_selected_columns'),
     multiSelectLabel: this.I18n.t('js.work_packages.label_column_multiselect'),
@@ -28,6 +33,9 @@ export class WpTableConfigurationColumnsTab implements TabComponent {
     upsaleRelationColumnsLink: this.I18n.t('js.modals.upsale_relation_columns_link')
   };
 
+  // In non-impaired mode, we use select2 for usability
+  @ViewChild('select2Columns') select2Columns:ElementRef;
+
   constructor(readonly injector:Injector,
               readonly I18n:I18nService,
               readonly wpTableColumns:WorkPackageTableColumnsService,
@@ -35,22 +43,83 @@ export class WpTableConfigurationColumnsTab implements TabComponent {
   }
 
   public onSave() {
-    this.wpTableColumns.setColumns(this.selectedColumns);
+    this.wpTableColumns.setColumnsById(this.selectedColumns.map(c => c.id));
   }
 
-  public setSelectedColumn(column:QueryColumn) {
+  public setSelectedColumn(column:ColumnLike) {
     if (this.selectedColumnMap[column.id]) {
       this.selectedColumns.push(column);
     }
     else {
-      _.remove(this.selectedColumns, (c:QueryColumn) => c.id === column.id);
+      _.remove(this.selectedColumns, (c:ColumnLike) => c.id === column.id);
     }
+  }
+
+  public updateSelect2Columns(event:any) {
+    const current:string[] = event.val;
+
+    this.selectedColumnMap = {};
+    this.selectedColumns = current.map(id => {
+      this.selectedColumnMap[id] = true;
+      return this.column2Like(this.availableColumnsMap[id]!)
+    });
   }
 
   ngOnInit() {
     this.eeShowBanners = jQuery('body').hasClass('ee-banners-visible');
-    this.selectedColumns.forEach((column:QueryColumn) => {
-      this.selectedColumnMap[column.id] = true;
+    this.selectedColumns.forEach((c:ColumnLike) => {
+      this.selectedColumnMap[c.id] = true;
     });
+  }
+
+  ngAfterViewInit() {
+    if (!this.impaired) {
+      this.setupSelect2();
+    }
+  }
+
+  ngOnDestroy() {
+    if (!this.impaired) {
+      const input = jQuery(this.select2Columns.nativeElement);
+      input.select2('close');
+    }
+  }
+
+  setupSelect2() {
+    const input = jQuery(this.select2Columns.nativeElement);
+
+    input
+      .on('change', this.updateSelect2Columns.bind(this))
+      .select2({
+        multiple: true,
+        tags: false,
+        initSelection: (_:any, callback:(data:any) => any) => callback(this.selectedColumns),
+        query: (query:any) => {
+          let results:ColumnLike[] = [];
+
+          this.availableColumns.forEach(c => {
+            if (query.term.length === 0 || c.name.toUpperCase().indexOf(query.term.toUpperCase()) >= 0) {
+              results.push({id: c.id, text: c.name });
+            }
+          });
+          query.callback({ results: results, more: false });
+        }
+      })
+      // Need to initialize with some empty value in order to hit initSelection
+      .select2('val', []);
+
+    // Make it sortable
+    input
+      .select2("container")
+      .find("ul.select2-choices")
+      .sortable({
+        containment: 'parent',
+        start: function() { input.select2("onSortStart"); },
+        update: function() { input.select2("onSortEnd"); }
+      });
+  }
+
+  private column2Like(c:QueryColumn):ColumnLike {
+    return { id: c.id, text: c.name };
   }
 }

--- a/frontend/src/typings/shims.d.ts
+++ b/frontend/src/typings/shims.d.ts
@@ -51,6 +51,7 @@ declare global {
     topShelf:any;
     atwho:any;
     mark:any;
+    select2:any;
   }
 }
 

--- a/frontend/vendor/select2/select2.css
+++ b/frontend/vendor/select2/select2.css
@@ -141,7 +141,7 @@ html[dir="rtl"] .select2-container .select2-choice > .select2-chosen {
     width: 100%;
     margin-top: -1px;
     position: absolute;
-    z-index: 9999;
+    z-index: 20000;
     top: 100%;
 
     background: #fff;
@@ -606,7 +606,7 @@ html[dir="rtl"] .select2-container-multi .select2-choices .select2-search-choice
     height: 13px;
     position: absolute;
     right: 3px;
-    top: 4px;
+    top: 2px;
 
     font-size: 1px;
     outline: none;

--- a/spec/features/work_packages/table/configuration_modal/column_spec.rb
+++ b/spec/features/work_packages/table/configuration_modal/column_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+describe 'Work Package table configuration modal columns spec', js: true do
+  let(:user) { FactoryBot.create :admin }
+
+  let(:project) { FactoryBot.create(:project) }
+  let!(:wp_1) { FactoryBot.create(:work_package, project: project) }
+
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  let(:columns) { ::Components::WorkPackages::Columns.new impaired: user.impaired }
+  let!(:work_package) { FactoryBot.create :work_package, project: project }
+
+  let!(:query) do
+    query = FactoryBot.build(:query, user: user, project: project)
+    query.column_names = %w[id subject]
+
+    query.save!
+    query
+  end
+
+  before do
+    login_as(user)
+    wp_table.visit_query query
+    wp_table.expect_work_package_listed work_package
+    expect(page).to have_selector('.wp-table--table-header', text: 'ID')
+    expect(page).to have_selector('.wp-table--table-header', text: 'SUBJECT')
+  end
+
+  shared_examples 'add and remove columns' do
+    it do
+      columns.open_modal
+      columns.expect_checked 'ID'
+      columns.expect_checked 'Subject'
+
+      columns.remove 'Subject', save_changes: false
+      columns.add 'Project', save_changes: true
+      columns.expect_column_available 'Subject'
+      columns.expect_column_not_selectable 'Project'
+
+      expect(page).to have_selector('.wp-table--table-header', text: 'ID')
+      expect(page).to have_selector('.wp-table--table-header', text: 'PROJECT')
+      expect(page).to have_no_selector('.wp-table--table-header', text: 'SUBJECT')
+    end
+  end
+
+  context 'when impaired' do
+    let(:user) {
+      user = FactoryBot.create :admin
+      user.impaired = true
+
+      user
+    }
+
+    it_behaves_like 'add and remove columns'
+  end
+
+  context 'when not impaired' do
+    it_behaves_like 'add and remove columns'
+
+
+    context 'with three columns' do
+      let!(:query) do
+        query = FactoryBot.build(:query, user: user, project: project)
+        query.column_names = %w[id project subject]
+
+        query.save!
+        query
+      end
+
+      it 'can reorder columns' do
+        columns.open_modal
+        columns.expect_checked 'ID'
+        columns.expect_checked 'Project'
+        columns.expect_checked 'Subject'
+
+        # Drag subject left of project
+        subject = find('.select2-search-choice', text: 'Subject')
+        page
+          .driver
+          .browser
+          .action
+          .move_to(subject.native)
+          .drag_and_drop_by(subject.native, -100, 0)
+          .perform
+
+        columns.apply
+        expect(page).to have_selector('.wp-table--table-header', text: 'ID')
+        expect(page).to have_selector('.wp-table--table-header', text: 'PROJECT')
+        expect(page).to have_selector('.wp-table--table-header', text: 'SUBJECT')
+
+        names = all('.wp-table--table-header').map(&:text)
+        expect(names).to eq(%w[ID SUBJECT PROJECT])
+      end
+    end
+  end
+end

--- a/spec/features/work_packages/table_sorting_spec.rb
+++ b/spec/features/work_packages/table_sorting_spec.rb
@@ -73,8 +73,6 @@ describe 'Select work package row', type: :feature, js: true do
       end
 
       it 'sorts by version although version is not selected as a column' do
-        columns.remove 'Version'
-
         sort_by.open_modal
         sort_by.update_nth_criteria(0, 'Version')
         expect_work_packages_to_be_in_order([work_package_1, work_package_2])


### PR DESCRIPTION
It got removed when converting screens to Angular, but we still use select2 in the members view and its trivial to re-add

https://community.openproject.com/wp/27939
