### PR TITLE
Fix breadcrumb alignment && add spaces in WP info row

### DIFF
--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -93,7 +93,6 @@ ul.breadcrumb
 
 .wp-breadcrumb
   margin-top: 10px
-  margin-left: -10px
   height: initial
   ul.breadcrumb
     height: initial

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
@@ -19,9 +19,13 @@
          *ngIf="!workPackage.isNew">
       <span [textContent]="idLabel"></span>:
       <span [textContent]="text.infoRow.createdBy"></span>
+      <!-- The space has to be in an extra span
+      because otherwise the browser would add a second space after it -->
+      <span>&nbsp;</span>
       <user-link class="user-link"
                  [user]="workPackage.author"></user-link>.
       <span [textContent]="text.infoRow.lastUpdatedOn"></span>
+      <span>&nbsp;</span>
       <op-date-time [dateTimeValue]="workPackage.updatedAt"></op-date-time>.
      </div>
 

--- a/frontend/src/app/modules/common/date/op-date-time.component.ts
+++ b/frontend/src/app/modules/common/date/op-date-time.component.ts
@@ -35,7 +35,7 @@ import {TimezoneService} from 'core-components/datetime/timezone.service';
     <span title="{{date}} {{ time }}">
       <span [textContent]="date"></span>
       <span [textContent]="time"></span>
-    </span>'
+    </span>
   `
 })
 export class OpDateTimeComponent {


### PR DESCRIPTION
This aligns the WP breadcrumb correctly and adds spaces in the WP info row.

https://community.openproject.com/projects/openproject/work_packages/27937/activity
https://community.openproject.com/projects/openproject/work_packages/27938/activity