### PR TITLE
Fix inline JS for wiki history view

### DIFF
--- a/app/views/wiki/history.html.erb
+++ b/app/views/wiki/history.html.erb
@@ -124,7 +124,7 @@ See docs/COPYRIGHT.rdoc for more details.
                                        (line_num==1),
                                        id: "cb-#{line_num}" %>
                 <% end %>
-                <% csp_onclick("jQuery(#'cbto-#{line_num+1}').attr('checked', true);", "#cb-#{line_num}}") %>
+                <% csp_onclick("jQuery('#cbto-#{line_num+1}').attr('checked', true);", "#cb-#{line_num}") %>
               </td>
               <td class="checkbox">
                 <% if show_diff && (line_num > 1) %>


### PR DESCRIPTION
just have look at the one commit. Nothing complicated.

BTW: The layout issue, of too wide columns for the radio-buttons will already be addressed by @HDinger here https://community.openproject.com/projects/openproject/work_packages/details/27949/overview