### PR TITLE
[Wiki] Reuse form for creating and updating a wiki page

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -177,30 +177,22 @@ class WikiController < ApplicationController
 
   # Creates a new page or updates an existing one
   def update
-    @page = @wiki.find_or_new_page(wiki_page_title)
-    unless editable?
-      flash[:error] = l(:error_unable_update_wiki)
-      return render_403
-    end
+    @page = @wiki.find_page(params[:id])
+    render_404 if @page.nil?
+    @content = @page.content
+    return if locked?
 
-    @page.content = WikiContent.new(page: @page) if @page.new_record?
-
-    @content = @page.content_for_version(params[:version])
-    # don't keep previous comment
-    @content.comments = nil
     @page.attach_files(permitted_params.attachments.to_h)
 
-    if !@page.new_record? && params[:content].present? && @content.text == params[:content][:text]
-      render_attachment_warning_if_needed(@page)
-      # don't save if text wasn't changed
-      redirect_to_show
-      return
-    end
+    return if nothing_to_update?
+
+    @page.title = permitted_params.wiki_page[:title]
+    @page.parent_id = permitted_params.wiki_page[:parent_id].to_i
     @content.attributes = permitted_params.wiki_content
     @content.author = User.current
     @content.add_journal User.current, params['content']['comments']
-    # if page is new @page.save will also save content, but not if page isn't a new record
-    if @page.new_record? ? @page.save : @content.save
+
+    if @page.save_with_content
       render_attachment_warning_if_needed(@page)
       call_hook(:controller_wiki_edit_after_save, params: params, page: @page)
       flash[:notice] = l(:notice_successful_update)
@@ -384,6 +376,30 @@ class WikiController < ApplicationController
   end
 
   private
+
+  def nothing_to_update?
+    return false if @page.new_record?
+    if anything_to_update?
+      render_attachment_warning_if_needed(@page)
+      # don't save if text wasn't changed
+      redirect_to_show
+      true
+    end
+  end
+
+  def anything_to_update?
+    params[:content].present? &&
+      @content.text == permitted_params.wiki_content[:text] &&
+      @page.parent_id == permitted_params.wiki_page[:parent_id].to_i
+  end
+
+  def locked?
+    return false if editable?
+
+    flash[:error] = l(:error_unable_update_wiki)
+    render_403
+    true
+  end
 
   def page_for_menu_item(page)
     if page == :parent_page

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -239,6 +239,16 @@ class WikiPage < ActiveRecord::Base
     slug || title.to_url
   end
 
+  def save_with_content
+    if valid? && content.valid?
+      ActiveRecord::Base.transaction do
+        save!
+        content.save!
+      end
+      true
+    end
+  end
+
   def is_only_wiki_page?
     wiki.pages == [self]
   end

--- a/app/views/wiki/_page_form.html.erb
+++ b/app/views/wiki/_page_form.html.erb
@@ -1,0 +1,38 @@
+<%= error_messages_for 'page' %>
+
+<div class="form--field -required">
+  <%= f.fields_for :page, @page do |page_fields| %>
+    <%= page_fields.hidden_field :parent_id %>
+    <%= page_fields.text_field :title, required: true, size: 120, placeholder: t('label_page_title') %>
+  <% end %>
+</div>
+<div class="form--field -required">
+  <%= f.fields_for :page, @page do |page_fields| %>
+    <%= page_fields.select :parent_id,
+                           wiki_page_options_for_select(@wiki.pages),
+                           { label: WikiPage.human_attribute_name(:parent_title), include_blank: false },
+                           { class: "parent-select form--select" } %>
+  <% end%>
+</div>
+<div class="attributes-group">
+  <div class="attributes-group--header">
+    <div class="attributes-group--header-container">
+      <h3 class="attributes-group--header-text"><%= WikiPage.human_attribute_name(:text) %></h3>
+    </div>
+  </div>
+  <%= f.text_area :text,
+                  cols: 100,
+                  rows: 25,
+                  class: 'wiki-edit op-auto-complete',
+                  accesskey: accesskey(:edit),
+                  with_text_formatting: true %>
+</div>
+
+<div class="form--field">
+  <%= f.text_field :comments, size: 120 %>
+</div>
+
+<%= render partial: 'attachments/form', f: f %>
+
+<hr class="form--separator" />
+<%= f.button t(:button_save), class: 'button -highlight -with-icon icon-checkmark' %>

--- a/app/views/wiki/edit.html.erb
+++ b/app/views/wiki/edit.html.erb
@@ -28,32 +28,16 @@ See docs/COPYRIGHT.rdoc for more details.
 ++#%>
 <%= toolbar title: @page.title %>
 <% html_title t(:label_edit), @page.title %>
-<%= labelled_tabular_form_for @content, as: :content, url: {action: 'update', id: @page}, html: {method: :put, multipart: true, id: 'wiki_form'} do |f| %>
+<%= labelled_tabular_form_for @content,
+                              as: :content,
+                              url: {action: 'update', id: @page},
+                              html: {method: :put, multipart: true, id: 'wiki_form'} do |f| %>
   <%= f.hidden_field :lock_version %>
-  <%= error_messages_for 'content' %>
 
-  <div class="attributes-group">
-    <%= f.text_area :text,
-                    cols: 100,
-                    rows: 25,
-                    class: 'wiki-edit',
-                    accesskey:  accesskey(:edit),
-                    with_text_formatting: true,
-                    preview_context: preview_context(@page) %>
-  </div>
+  <%= render partial: 'wiki/page_form', locals: {f: f}  %>
 
-  <div class="form--field">
-    <%= f.text_field :comments, size: 120 %>
-  </div>
-
-  <%= render partial: 'attachments/form' %>
-
-  <hr class="form--separator" />
-  <%= f.button t(:button_save), class: 'button -highlight -with-icon icon-checkmark' %>
-  <%= link_to t(:button_cancel),
-      { controller: '/wiki', action: 'show', project_id: @project, id: @page },
-      class: 'button' %>
 <% end %>
+
 <div id="preview"></div>
 <% content_for :header_tags do %>
   <%= robot_exclusion_tag %>

--- a/app/views/wiki/new.html.erb
+++ b/app/views/wiki/new.html.erb
@@ -38,45 +38,13 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <% html_title t("create_new_page") %>
 
-<%= labelled_tabular_form_for @content, as: :content, url: create_project_wiki_index_path(project_id: @project), html: { method: :post, multipart: true, id: 'wiki_form' } do |f| %>
-  <%= error_messages_for 'page' %>
+<%= labelled_tabular_form_for @content,
+                              as: :content,
+                              url: create_project_wiki_index_path(project_id: @project),
+                              html: { method: :post, multipart: true, id: 'wiki_form' } do |f| %>
 
-    <div class="form--field -required">
-      <%= f.fields_for :page, @page do |page_fields| %>
-        <%= page_fields.hidden_field :parent_id %>
-        <%= page_fields.text_field :title, required: true, size: 120, placeholder: t('label_page_title') %>
-      <% end %>
-    </div>
-    <div class="form--field -required">
-      <%= f.fields_for :page, @page do |page_fields| %>
-        <%= page_fields.select :parent_id,
-                               wiki_page_options_for_select(@wiki.pages),
-                               { label: WikiPage.human_attribute_name(:parent_title), include_blank: false },
-                               { class: "parent-select form--select" } %>
-      <% end%>
-    </div>
-    <div class="attributes-group">
-      <div class="attributes-group--header">
-        <div class="attributes-group--header-container">
-          <h3 class="attributes-group--header-text"><%= WikiPage.human_attribute_name(:text) %></h3>
-         </div>
-       </div>
-      <%= f.text_area :text,
-                      cols: 100,
-                      rows: 25,
-                      class: 'wiki-edit',
-                      accesskey: accesskey(:edit),
-                      with_text_formatting: true %>
-    </div>
+  <%= render partial: 'page_form', locals: {f: f}  %>
 
-    <div class="form--field">
-      <%= f.text_field :comments, size: 120 %>
-    </div>
-
-    <%= render partial: 'attachments/form', f: f %>
-
-  <hr class="form--separator" />
-  <%= f.button t(:button_save), class: 'button -highlight -with-icon icon-checkmark' %>
 <% end %>
 
 <div id="preview"></div>


### PR DESCRIPTION
When updating a page,
- allow updating the title
- allow changing the parent page

The `WikiController` is an ugly piece of software and would benefit from some serious code refactoring. However, I stopped here, as other tasks are more pressing.