### PR TITLE
Convert buttons to add a file into tiny buttons instead of links

### DIFF
--- a/app/assets/stylesheets/content/_forms.lsg
+++ b/app/assets/stylesheets/content/_forms.lsg
@@ -933,7 +933,7 @@ The modifier classes **-middle**, **-wide**, ... can be applied to the form-[inp
           </div>
         </div>
       </div></div>
-    <span class="add_another_file">
+    <span class="add-another-file">
       <a href="#">Add another file</a>
       (Maximum size: 5 MB)
     </span>

--- a/app/assets/stylesheets/content/work_packages/single_view/_attachments.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_attachments.sass
@@ -79,3 +79,7 @@
     margin: 0 0 0 10px
     text-align: left
 
+
+.add-another-file
+  .button
+    margin-bottom: 0

--- a/app/assets/stylesheets/openproject/_legacy.sass
+++ b/app/assets/stylesheets/openproject/_legacy.sass
@@ -244,6 +244,7 @@ textarea#custom_field_possible_values
 
 div.attachments
   margin-top: 12px
+  margin-bottom: 12px
   p
     margin: 4px 0 2px 0
   img

--- a/app/views/attachments/_form.html.erb
+++ b/app/views/attachments/_form.html.erb
@@ -50,8 +50,8 @@ See docs/COPYRIGHT.rdoc for more details.
       </div>
     </div>
   </div>
-  <span class="add_another_file">
-    <%= link_to_function t(:label_add_another_file), 'addFileField()' %>
+  <span class="add-another-file">
+    <%= link_to_function t(:label_add_another_file), 'addFileField()', class: 'button -with-icon -tiny icon-attachment' %>
     (<%= l(:label_max_size) %>: <%= number_to_human_size(Setting.attachment_max_size.to_i.kilobytes, precision: 3) %>)
   </span>
 </fieldset>

--- a/app/views/attachments/_nested_form.html.erb
+++ b/app/views/attachments/_nested_form.html.erb
@@ -71,8 +71,8 @@ an attachments_attributes= and not every model supports this we build a nested f
         </div>
       </div>
     </div>
-    <span class="add_another_file">
-      <%= link_to_function t(:label_add_another_file), 'addFileField()' %>
+    <span class="add-another-file">
+      <%= link_to_function t(:label_add_another_file), 'addFileField()', class: 'button -with-icon -tiny icon-attachment'  %>
       (<%= l(:label_max_size) %>: <%= number_to_human_size(Setting.attachment_max_size.to_i.kilobytes, precision: 3) %>)
     </span>
   </div>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -123,7 +123,8 @@ See docs/COPYRIGHT.rdoc for more details.
                              jQuery(this).hide();
                              jQuery('#add_attachment_form')[0].scrollIntoView();
                            },
-                           id: 'attach_files_link' %>
+                           id: 'attach_files_link',
+                           class: 'button -with-icon -tiny icon-attachment' %>
     </p>
     <%= form_tag({ controller: '/wiki', action: 'add_attachment', project_id: @project, id: @page }, multipart: true, id: "add_attachment_form", style: "display:none;") do %>
       <div class="box">


### PR DESCRIPTION
**Before:**
<img width="701" alt="bildschirmfoto 2018-07-02 um 14 14 06" src="https://user-images.githubusercontent.com/327272/42163329-54aa5866-7e02-11e8-9576-a730ea2de6c7.png">

**After:**
<img width="690" alt="bildschirmfoto 2018-07-02 um 14 13 40" src="https://user-images.githubusercontent.com/327272/42163361-787be430-7e02-11e8-9c96-98228744a475.png">
