### PR TITLE
[27951][27952] Convert macro syntax and show warning for legacy macro

### DIFF
--- a/app/assets/stylesheets/content/editor/_ckeditor.sass
+++ b/app/assets/stylesheets/content/editor/_ckeditor.sass
@@ -1,3 +1,5 @@
+@import './macros'
+
 // Wrapper for inline text editor
 .op-ckeditor-element
   min-height: 50px
@@ -17,12 +19,3 @@
   // Min height for the editable section
   .ck-editor__editable
     min-height: 20vh
-
-  .ck-widget.macro
-    border: 2px dashed #ccc
-    min-height: 50px
-    display: flex
-    justify-content: center
-    align-items: center
-    color: #575757
-    background: #f8f8f8

--- a/app/assets/stylesheets/content/editor/_macros.sass
+++ b/app/assets/stylesheets/content/editor/_macros.sass
@@ -1,0 +1,17 @@
+// Legacy macro rendering
+macro.legacy-macro
+  background: $nm-color-warning-background
+  border: 2px dashed $nm-color-warning-border
+  padding: 10px 5px
+
+// Macro rendering in CKEditor
+.op-ckeditor--wrapper
+
+  .ck-widget.macro
+    border: 2px dashed #ccc
+    min-height: 50px
+    display: flex
+    justify-content: center
+    align-items: center
+    color: #575757
+    background: #f8f8f8

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1619,6 +1619,8 @@ en:
   macro_execution_error: "Error executing the macro %{macro_name}"
   macro_unavailable: "Macro %{macro_name} cannot be displayed."
   macros:
+    legacy_warning:
+      timeline: 'This legacy timeline macro has been removed and is no longer available. You can replace the functionality with an embedded table macro.'
     create_work_package_link:
       errors:
         no_project_context: 'Calling create_work_package_link macro from outside project context.'


### PR DESCRIPTION
Replaces 

```
h1. test

some *textile* _code_


--- Timeline

{{timeline(36)}}


--- hello_world

{{hello_world}}


--- Include

{{include(ckeditor-test)}}

--- Child pages 

{{child_pages}}
```

with

```
<h1>
  <a id="test" class="anchor" href="#test" aria-hidden="true">
    <span aria-hidden="true" class="octicon octicon-link"></span>
  </a>test</h1>
<p>some
  <strong>textile</strong>
  <em>code</em>
</p>
<p>--- Timeline</p>
<p>
  <macro class="legacy-macro -macro-unavailable">
    This legacy timeline macro has been removed and is no longer available. You can replace the functionality with an embedded table macro.
  </macro>
</p>
<p>--- hello_world</p>
<p>--- Include</p>
<p>
  <macro class="include"></macro>
</p>
<p>--- Child pages</p>
<p>
  <macro class="child_pages"></macro>
</p>
```

Legacy macro prints like this:

![screenshot from 2018-07-04 08-46-12](https://user-images.githubusercontent.com/459462/42260978-cda33b7e-7f66-11e8-9671-d1bc478698ca.png)


https://community.openproject.com/wp/27951
https://community.openproject.com/wp/27952