### PR TITLE
[27971] Close active edit fields and datepickers before refreshing

### DIFF
--- a/frontend/src/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
@@ -40,9 +40,9 @@ export class SingleHierarchyRowBuilder extends SingleRowBuilder {
    * Refresh a single row after structural changes.
    * Remembers and re-adds the hierarchy indicator if neccessary.
    */
-  public refreshRow(workPackage:WorkPackageResource, changeset:WorkPackageChangeset, jRow:JQuery):JQuery {
+  public refreshRow(workPackage:WorkPackageResource, jRow:JQuery):JQuery {
     // Remove any old hierarchy
-    const newRow = super.refreshRow(workPackage, changeset, jRow);
+    const newRow = super.refreshRow(workPackage, jRow);
     newRow.find(`.wp-table--hierarchy-span`).remove();
     this.appendHierarchyIndicator(workPackage, newRow);
 

--- a/frontend/src/app/components/wp-fast-table/builders/primary-render-pass.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/primary-render-pass.ts
@@ -95,14 +95,13 @@ export abstract class PrimaryRenderPass {
   public refresh(row:RowRenderInfo, workPackage:WorkPackageResource, body:HTMLElement) {
     let oldRow = jQuery(body).find(`.${row.classIdentifier}`);
     let replacement:JQuery | null = null;
-    let editing = this.wpEditing.changesetFor(workPackage);
 
     switch (row.renderType) {
       case 'primary':
-        replacement = this.rowBuilder.refreshRow(workPackage, editing, oldRow);
+        replacement = this.rowBuilder.refreshRow(workPackage, oldRow);
         break;
       case 'relations':
-        replacement = this.relations.refreshRelationRow(row as RelationRenderInfo, workPackage, editing, oldRow);
+        replacement = this.relations.refreshRelationRow(row as RelationRenderInfo, workPackage, oldRow);
     }
 
     if (replacement !== null && oldRow.length) {

--- a/frontend/src/app/components/wp-fast-table/builders/relations/relations-render-pass.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/relations/relations-render-pass.ts
@@ -105,9 +105,8 @@ export class RelationsRenderPass {
 
   public refreshRelationRow(renderedRow:RelationRenderInfo,
                             workPackage:WorkPackageResource,
-                            changeset:WorkPackageChangeset,
                             oldRow:JQuery) {
-    const newRow = this.relationRowBuilder.refreshRow(workPackage, changeset, oldRow);
+    const newRow = this.relationRowBuilder.refreshRow(workPackage, oldRow);
     this.relationRowBuilder.appendRelationLabel(newRow,
       renderedRow.belongsTo!,
       renderedRow.data.relation,

--- a/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
@@ -112,7 +112,7 @@ export class SingleRowBuilder {
   /**
    * Refresh a row that is currently being edited, that is, some edit fields may be open
    */
-  public refreshRow(workPackage:WorkPackageResource, changeset:WorkPackageChangeset, jRow:JQuery):JQuery {
+  public refreshRow(workPackage:WorkPackageResource, jRow:JQuery):JQuery {
     // Detach all current edit cells
     const cells = jRow.find(`.${wpCellTdClassName}`).detach();
 
@@ -123,7 +123,7 @@ export class SingleRowBuilder {
       const oldTd = cells.filter(`td.${column.id}`);
 
       // Skip the replacement of the column if this is being edited.
-      if (this.isColumnBeingEdited(changeset, column)) {
+      if (this.isColumnBeingEdited(workPackage, column)) {
         newCells.push(oldTd[0]);
         return;
       }
@@ -140,8 +140,14 @@ export class SingleRowBuilder {
     return jRow;
   }
 
-  protected isColumnBeingEdited(changeset:WorkPackageChangeset, column:QueryColumn) {
-    return changeset && changeset.isOverridden(column.id);
+  protected isColumnBeingEdited(workPackage:WorkPackageResource, column:QueryColumn) {
+    const form = this.workPackageTable.editing.forms[workPackage.id];
+    const changeset = this.workPackageTable.editing.changeset(workPackage.id);
+
+    const isOpen = form && form.activeFields[column.id];
+    const isChanged = changeset && changeset.isOverridden(column.id);
+
+    return isOpen || isChanged;
   }
 
   protected buildEmptyRow(workPackage:WorkPackageResource, row:HTMLElement):[HTMLElement, boolean] {

--- a/frontend/src/app/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/src/app/components/wp-fast-table/wp-fast-table.ts
@@ -95,11 +95,7 @@ export class WorkPackageTable {
    * all elements.
    */
   public redrawTableAndTimeline() {
-    const renderPass = this.lastRenderPass = this.rowBuilder.buildRows();
-
-    // Insert table body
-    this.tbody.innerHTML = '';
-    this.tbody.appendChild(renderPass.tableBody);
+    const renderPass = this.performRenderPass();
 
     // Insert timeline body
     this.timelineBody.innerHTML = '';
@@ -112,12 +108,7 @@ export class WorkPackageTable {
    * Redraw all elements in the table section only
    */
   public redrawTable() {
-    this.editing.reset();
-    const renderPass = this.lastRenderPass = this.rowBuilder.buildRows();
-
-    this.tbody.innerHTML = '';
-    this.tbody.appendChild(renderPass.tableBody);
-
+    const renderPass = this.performRenderPass();
     this.tableState.rendered.putValue(renderPass.result);
   }
 
@@ -127,7 +118,7 @@ export class WorkPackageTable {
   public refreshRows(workPackage:WorkPackageResource) {
     const pass = this.lastRenderPass;
     if (!pass) {
-      debugLog('Trying to refresh a singular row without a previus render pass.');
+      debugLog('Trying to refresh a singular row without a previous render pass.');
       return;
     }
 
@@ -138,5 +129,16 @@ export class WorkPackageTable {
         pass.refresh(row, workPackage, this.tbody);
       }
     });
+  }
+
+  private performRenderPass() {
+    this.editing.reset();
+    const renderPass = this.lastRenderPass = this.rowBuilder.buildRows();
+
+    // Insert table body
+    this.tbody.innerHTML = '';
+    this.tbody.appendChild(renderPass.tableBody);
+
+    return renderPass;
   }
 }

--- a/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
@@ -160,9 +160,7 @@ export class WorkPackageInlineCreateComponent implements OnInit, OnChanges, OnDe
       const rowElement = this.$element.find(`.${inlineCreateRowClassName}`);
 
       if (rowElement.length && this.currentWorkPackage) {
-        this.rowBuilder.refreshRow(this.currentWorkPackage,
-          this.workPackageEditForm!.changeset,
-          rowElement);
+        this.rowBuilder.refreshRow(this.currentWorkPackage, rowElement);
       }
     });
 

--- a/frontend/src/app/modules/common/op-date-picker/datepicker.ts
+++ b/frontend/src/app/modules/common/op-date-picker/datepicker.ts
@@ -60,21 +60,26 @@ export class DatePicker {
     this.datepickerInstance = this.datepickerCont.datepicker(mergedOptions);
   }
 
-  private clear() {
+  public clear() {
     this.datepickerInstance.datepicker('setDate', null);
   }
 
-  private hide() {
+  public destroy() {
+    this.hide();
+    this.datepickerInstance.datepicker('destroy');
+  }
+
+  public hide() {
     this.datepickerInstance.datepicker('hide');
     this.datepickerCont.scrollParent().off('scroll');
   }
 
-  private show() {
+  public show() {
     this.datepickerInstance.datepicker('show');
     this.hideDuringScroll();
   }
 
-  private reshow() {
+  public reshow() {
     this.datepickerInstance.datepicker('show');
   }
 

--- a/frontend/src/app/modules/common/op-date-picker/op-date-picker.component.ts
+++ b/frontend/src/app/modules/common/op-date-picker/op-date-picker.component.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, ElementRef, EventEmitter, Inject, Input, OnInit, Output} from '@angular/core';
+import {Component, ElementRef, EventEmitter, Inject, Input, OnDestroy, OnInit, Output} from '@angular/core';
 import {ConfigurationService} from 'core-app/modules/common/config/configuration.service';
 import {DatePicker} from 'core-app/modules/common/op-date-picker/datepicker';
 import {TimezoneService} from 'core-components/datetime/timezone.service';
@@ -35,13 +35,13 @@ import {TimezoneService} from 'core-components/datetime/timezone.service';
   selector: 'op-date-picker',
   templateUrl: './op-date-picker.component.html'
 })
-export class OpDatePickerComponent implements OnInit {
+export class OpDatePickerComponent implements OnInit, OnDestroy {
   @Output() public onChange = new EventEmitter<string>();
   @Output() public onClose = new EventEmitter<string>();
   @Input() public initialDate?:string;
 
   private $element:JQuery;
-  private datePickerInstance:any;
+  private datePickerInstance:DatePicker;
   private input:JQuery;
 
   public constructor(private elementRef:ElementRef,
@@ -58,6 +58,10 @@ export class OpDatePickerComponent implements OnInit {
       this.input = this.$element.find('input');
       this.setup();
     }
+  }
+
+  ngOnDestroy() {
+    this.datePickerInstance && this.datePickerInstance.destroy();
   }
 
   public setup() {


### PR DESCRIPTION
Addresses, but does not fix the underyling issue of
https://community.openproject.com/projects/openproject/work_packages/27971

When refreshing the entire table, all results are destroyed. We can't simply remove that restriction because that would mean addressing it in all mode builders.