### PR TITLE
support plugins in the docker container

### DIFF
--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -18,8 +18,37 @@ pwfile=$(mktemp)
 chown postgres $pwfile
 echo "$PGPASSWORD" > $pwfile
 
+PLUGIN_GEMFILE_TMP=$(mktemp)
+PLUGIN_GEMFILE=/usr/src/app/Gemfile.local
+
+if [ "$PLUGIN_GEMFILE_URL" != "" ]; then
+	echo "Fetching custom gemfile from ${PLUGIN_GEMFILE_URL}..."
+	curl -L -o "$PLUGIN_GEMFILE_TMP" "$PLUGIN_GEMFILE_URL"
+
+	# set custom plugin gemfile if file is readable and non-empty
+	if [ -s "$PLUGIN_GEMFILE_TMP" ]; then
+		mv "$PLUGIN_GEMFILE_TMP" "$PLUGIN_GEMFILE"
+		chown app.app "$PLUGIN_GEMFILE"
+	fi
+fi
+
 indent() {
 	sed -u 's/^/       /'
+}
+
+install_plugins() {
+	pushd /usr/src/app
+
+	if [ -s "$PLUGIN_GEMFILE" ]; then
+		echo "Installing plugins..."
+		bundle install
+		echo "Precompiling new assets..."
+		bundle exec rake assets:precompile
+
+		echo "Plugins installed"
+	fi
+
+	popd
 }
 
 migrate() {
@@ -36,7 +65,7 @@ if [ "$dbhost" = "127.0.0.1" ]; then
 	if [ -f "$PGDATA/PG_VERSION" ]; then
 		echo "-----> Database cluster already exists, not modifying."
 		/etc/init.d/postgresql start | indent
-		migrate | indent
+		(install_plugins && migrate) | indent
 		/etc/init.d/postgresql stop | indent
 	else
 		echo "-----> Database cluster not found. Creating a new one in $PGDATA..."
@@ -46,7 +75,7 @@ if [ "$dbhost" = "127.0.0.1" ]; then
 		/etc/init.d/postgresql start | indent
 		su postgres -c "$PGBIN/psql --command \"CREATE USER openproject WITH SUPERUSER PASSWORD 'openproject';\"" | indent
 		su postgres -c "$PGBIN/createdb -O openproject openproject" | indent
-		migrate | indent
+		(install_plugins && migrate) | indent
 		/etc/init.d/postgresql stop | indent
 	fi
 else


### PR DESCRIPTION
Proof:

![custom-plugins](https://user-images.githubusercontent.com/158871/42313132-e8c8fe9c-8039-11e8-843b-54d5edfa2f86.png)

Tested by copying the new `entrypoint` into `openproject-ce` and:

```
sudo docker build -t openproject-ce -f Dockerfile.public .
sudo docker run -P -e PLUGIN_GEMFILE_URL="$CUSTOM_PLUGIN_GEMFILE_URL" openproject-ce:latest
```

Where `PLUGIN_GEMFILE_URL` pointed to an URL with the following contents:

```
group :opf_plugins do
  gem "openproject-proto_plugin", git: "https://github.com/opf/openproject-proto_plugin.git", branch: "dev"
end
```