### PR TITLE
[27949] Wiki history selectbox column too wide

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -220,6 +220,8 @@ html.-supports-sticky-headers
     .generic-table--header,
     .generic-table--sort-header
       visibility: hidden
+      // Matches the min-width of .generic-table--header, .generic-table--sort-header
+      max-width: 40px
 
 .generic-table--empty-header
   padding:       0 6px


### PR DESCRIPTION
Limit width of columns with hidden labels.

https://community.openproject.com/projects/openproject/work_packages/27949/activity


#### Before
![1530284940864-0](https://user-images.githubusercontent.com/7457313/42368917-9b386f62-8108-11e8-9744-a3a01871be31.png)


#### After
<img width="1199" alt="bildschirmfoto 2018-07-06 um 10 36 51" src="https://user-images.githubusercontent.com/7457313/42368896-8ca2fc38-8108-11e8-8049-3016692cc9eb.png">
