### PR TITLE
[27948] Workflow table layout broken

### DIFF
--- a/app/assets/stylesheets/content/_headings.sass
+++ b/app/assets/stylesheets/content/_headings.sass
@@ -45,9 +45,6 @@ h3
   padding:            0 0 8px 0
   margin:             0 0 20px 0
 
-h3.-no-border
-  border: none
-
 h4
   color:              $h4-font-color
   font-weight:        normal

--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -58,43 +58,31 @@ table
       font-size: 0.9em
 
   &.workflow-table.generic-table
-    margin-bottom: 16px
-    overflow-x: hidden
+    // Let space for the turned header
+    margin-left: 30px
+    width: calc(100% - 30px)
+
+    .workflow-table--current-status
+      font-weight: bold
+      text-transform: uppercase
+      font-size: 0.875rem
+
     tbody
-      td
-        border-bottom: 1px solid $light-gray
-
-        &.-no-border
-          border-bottom: none
-          border-right: none
-
-        &.-border-right
-          border-right: 1px solid $light-gray
-
-      tr
-        border-bottom: none
-        &:hover
-          background: none
-
-      td.workflow-table--current-status
-        font-weight: bold
-        text-transform: uppercase
-        font-size: 0.875rem
-
-        .icon-context,
-        .icon
-          color: $body-font-color
-
       span.workflow-table--turned-header
         white-space: nowrap
         transform: rotate(270deg)
         position: absolute
         top: 235px
+        left: 0px
         transform-origin: 0 0
         text-transform: uppercase
         font-weight: bold
+        max-width: 220px
+        @include text-shortener
 
     thead
+      th
+        padding: 0 6px
       .workflow-table--header
         text-align: right
         display: flex
@@ -104,17 +92,8 @@ table
         font-size: 12px
         font-style: italic
         text-transform: none
-        a
-          @include varprop(color, content-link-color)
-          &:hover
-            @include varprop(color, content-link-color)
-            text-decoration: underline
-
-      .-border
-        border-bottom: 1px solid $light-gray
-
-    col.hover
-      background: none
+        a:hover
+          text-decoration: underline
 
     .generic-table--sort-header-outer:hover
       background: none

--- a/app/assets/stylesheets/openproject/_generic.sass
+++ b/app/assets/stylesheets/openproject/_generic.sass
@@ -1,5 +1,46 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2017 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+//++
+
 .no-padding-bottom
   padding-bottom: 0 !important
 
 .display-inline
   display: inline !important
+
+.-no-border
+  border: none !important
+
+// Table borders
+.-table-border-top
+  border-top: 1px solid $table-row-border-color
+.-table-border-bottom
+  border-bottom: 1px solid $table-row-border-color
+.-table-border-left
+  border-left: 1px solid $table-row-border-color
+.-table-border-right
+  border-right: 1px solid $table-row-border-color

--- a/app/views/workflows/_form.html.erb
+++ b/app/views/workflows/_form.html.erb
@@ -29,17 +29,11 @@ See docs/COPYRIGHT.rdoc for more details.
 <div id="workflow_form_<%= name %>" class="generic-table--container">
   <div class="generic-table--results-container">
     <table class="generic-table workflow-table transitions-<%= name %>">
-      <colgroup>
-        <col>
-        <col>
-        <col span="<%= @statuses.length%>" highlight-col>
-      </colgroup>
       <thead>
         <tr>
           <th></th>
-          <th><div class="generic-table--empty-header"></div></th>
           <th colspan="<%= @statuses.length%>">
-            <div class="generic-table--sort-header-outer -border">
+            <div class="generic-table--sort-header-outer -no-border">
               <div class="generic-table--sort-header workflow-table--header">
                 <span>
                   <%=l(:label_new_statuses_allowed)%>
@@ -51,29 +45,23 @@ See docs/COPYRIGHT.rdoc for more details.
             </div>
           </th>
         </tr>
-      </thead>
-      <tbody>
         <tr>
-          <td class="-no-border">
-            <span class="workflow-table--turned-header">
-              <%=l(:label_current_status)%>
-            </span>
-          </td>
-          <td class="-border-right"></td>
+          <th class="-table-border-bottom  -table-border-right"></th>
           <% for new_status in @statuses %>
-            <td class="workflow-table--current-status">
-              <%= link_to_function(icon_wrapper('icon-context icon-checkmark',"#{l(:label_check_uncheck_all_in_column)}"), "toggleCheckboxesBySelector('table.transitions-#{name} input.new-status-#{new_status.id}')",
-                               class: 'no-decoration-on-hover',
-                               title: "#{l(:label_check_uncheck_all_in_column)}",
-                               alt: "#{l(:label_check_uncheck_all_in_column)}") %>
-              <%=h new_status.name %>
-            </td>
+              <th class="workflow-table--current-status -table-border-top -table-border-bottom">
+                <%= link_to_function(icon_wrapper('icon-context icon-checkmark',"#{l(:label_check_uncheck_all_in_column)}"), "toggleCheckboxesBySelector('table.transitions-#{name} input.new-status-#{new_status.id}')",
+                                     class: 'no-decoration-on-hover',
+                                     title: "#{l(:label_check_uncheck_all_in_column)}",
+                                     alt: "#{l(:label_check_uncheck_all_in_column)}") %>
+                <%=h new_status.name %>
+              </th>
           <% end %>
         </tr>
+      </thead>
+      <tbody>
         <% for old_status in @statuses %>
-          <tr>
-            <td class="-no-border -border-right"></td>
-            <td class="workflow-table--current-status -border-right">
+          <tr class="-table-border-left">
+            <td class="workflow-table--current-status -table-border-right">
               <%= link_to_function(icon_wrapper('icon-context icon-checkmark',"#{l(:label_check_uncheck_all_in_row)}"), "toggleCheckboxesBySelector('table.transitions-#{name} input.old-status-#{old_status.id}')",
                                          class: 'no-decoration-on-hover',
                                          title: "#{l(:label_check_uncheck_all_in_row)}",
@@ -88,6 +76,13 @@ See docs/COPYRIGHT.rdoc for more details.
             <% end -%>
           </tr>
         <% end %>
+        <tr class="-no-highlighting">
+          <td colspan="<%= @statuses.length + 2 %>">
+                        <span class="workflow-table--turned-header">
+              <%=l(:label_current_status)%>
+            </span>
+          </td>
+        </tr>
       </tbody>
     </table>
     <div class="generic-table--header-background -no-border"></div>


### PR DESCRIPTION
Refactor the workflow table. The html structure of tables is more used. The turned header is now a separate row at the end which is absolutely positioned. 
A lot of unnecessary code was thus deleted.

https://community.openproject.com/projects/openproject/work_packages/27948/activity

#### Before
![image_1_](https://user-images.githubusercontent.com/7457313/42376631-17698c94-8120-11e8-92cc-6e75679d30e1.png)


#### After 
<img width="1179" alt="bildschirmfoto 2018-07-06 um 13 21 04" src="https://user-images.githubusercontent.com/7457313/42376622-104add82-8120-11e8-8516-9bbe8825b2bd.png">