### PR TITLE
Embed work package attachments into PDF list export

### DIFF
--- a/app/models/work_package/pdf_export/attachments.rb
+++ b/app/models/work_package/pdf_export/attachments.rb
@@ -1,0 +1,64 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module WorkPackage::PdfExport::Attachments
+
+  ##
+  # Creates cells for each attachment of the work package
+  #
+  def make_attachments_cells(attachments)
+    # Distribute all attachments on one line, this will work well with up to ~5 attachments.
+    # more than that will be resized further
+    available_width = (pdf.bounds.width / attachments.length) * 0.98
+
+    attachments
+      .map { |attachment| make_attachment_cell attachment, available_width }
+      .compact
+  end
+
+  private
+
+  def make_attachment_cell(attachment, available_width)
+    # We can only include JPG and PNGs, maybe we want to add a text box for other attachments here
+    return nil unless pdf_embeddable?(attachment)
+
+    # Access the local file. For Carrierwave attachments, this will be blocking.
+    file_path = attachment.file.local_file.path
+    # Fit the image roughly in the center of each cell
+    pdf.make_cell(image: file_path, fit: [available_width, 250], position: :center)
+  rescue => e
+    Rails.logger.error { "Failed to attach work package image to PDF: #{e} #{e.message}" }
+    nil
+  end
+
+  def pdf_embeddable?(attachment)
+    %w[image/jpeg image/png].include?(attachment.content_type)
+  end
+end

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -30,6 +30,7 @@
 
 class WorkPackage::PdfExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
   include WorkPackage::PdfExport::Common
+  include WorkPackage::PdfExport::Attachments
 
   attr_accessor :pdf,
                 :options
@@ -54,6 +55,9 @@ class WorkPackage::PdfExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
     success(pdf.render)
   rescue Prawn::Errors::CannotFit
     error(I18n.t(:error_pdf_export_too_many_columns))
+  rescue StandardError => e
+    Rails.logger.error { "Failed to generated PDF export: #{e} #{e.message}." }
+    error(I18n.t(:error_pdf_failed_to_export, error: e.message))
   end
 
   def project
@@ -142,6 +146,14 @@ class WorkPackage::PdfExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
         make_description(work_package.description.to_s).each do |segment|
           result << [segment]
         end
+      end
+
+      if options[:show_attachments] && work_package.attachments.exists?
+        attachments = make_attachments_cells(work_package.attachments)
+
+        result << [
+          { content: pdf.make_table([attachments]), colspan: description_colspan }
+        ]
       end
 
       if query.grouped? && (group = query.group_by_column.value(work_package)) != previous_group

--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -30,6 +30,7 @@
 
 class WorkPackage::PdfExport::WorkPackageToPdf < WorkPackage::Exporter::Base
   include WorkPackage::PdfExport::Common
+  include WorkPackage::PdfExport::Attachments
 
   attr_accessor :pdf
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -929,6 +929,7 @@ en:
   error_invalid_query_column: "Invalid query column: %{value}"
   error_invalid_sort_criterion: "Can't sort by column: %{value}"
   error_pdf_export_too_many_columns: "Too many columns selected for the PDF export. Please reduce the number of columns."
+  error_pdf_failed_to_export: "The PDF export could not be saved: %{error}"
   error_token_authenticity: 'Unable to verify Cross-Site Request Forgery token.'
   error_work_package_done_ratios_not_updated: "Work package done ratios not updated."
   error_work_package_not_found_in_project: "The work package was not found or does not belong to this project"
@@ -971,6 +972,8 @@ en:
       csv: "CSV"
       pdf: "PDF"
       pdf_with_descriptions: "PDF with descriptions"
+      pdf_with_descriptions_and_attachments: "PDF with descriptions and attachments"
+      pdf_with_attachments: "PDF with attachments"
 
   general_csv_decimal_separator: "."
   general_csv_encoding: "UTF-8"

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -194,7 +194,9 @@ module API
         def representation_formats
           formats = [
             representation_format_pdf,
+            representation_format_pdf_attachments,
             representation_format_pdf_description,
+            representation_format_pdf_description_attachments,
             representation_format_csv
           ]
 
@@ -227,12 +229,27 @@ module API
                                 mime_type: 'application/pdf'
         end
 
+        def representation_format_pdf_attachments
+          representation_format 'pdf',
+                                i18n_key: 'pdf_with_attachments',
+                                mime_type: 'application/pdf',
+                                url_query_extras: 'show_attachments=true'
+        end
+
         def representation_format_pdf_description
           representation_format 'pdf-with-descriptions',
                                 format: 'pdf',
                                 i18n_key: 'pdf_with_descriptions',
                                 mime_type: 'application/pdf',
                                 url_query_extras: 'show_descriptions=true'
+        end
+
+        def representation_format_pdf_description_attachments
+          representation_format 'pdf-with-descriptions',
+                                format: 'pdf',
+                                i18n_key: 'pdf_with_descriptions_and_attachments',
+                                mime_type: 'application/pdf',
+                                url_query_extras: 'show_descriptions=true&show_attachments=true'
         end
 
         def representation_format_csv


### PR DESCRIPTION
- [x] Does not support cloud attachments, they would need to be downloaded first
- [x] Check layout for lots of attachments per WP [Works fine](https://github.com/opf/openproject/files/2187947/Demo.project.-.Arbeitspakete.13.pdf)
- [x] Check layout for PDF with descriptions and attachments: [Works fine](https://github.com/opf/openproject/files/2187983/pdf-with-description-and-attachments.pdf)

