### PR TITLE
[25135] Warn on leaving unsafed outside edit mode

### DIFF
--- a/frontend/src/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-edit-form.ts
@@ -91,6 +91,13 @@ export class WorkPackageEditForm {
   }
 
   /**
+   * Return whether this form has any active fields
+   */
+  public hasActiveFields():boolean {
+    return !_.isEmpty(this.activeFields);
+  }
+
+  /**
    * Return the current or a new changeset for the given work package.
    * This will always return a valid (potentially empty) changeset.
    *

--- a/frontend/src/app/components/wp-form-group/wp-attribute-group.component.ts
+++ b/frontend/src/app/components/wp-form-group/wp-attribute-group.component.ts
@@ -64,6 +64,6 @@ export class WorkPackageFormAttributeGroupComponent {
    */
   public shouldHideField(descriptor:FieldDescriptor) {
     const field = descriptor.field || descriptor.fields![0];
-    return this.wpEditFieldGroup.inEditMode && !field.writable;
+    return this.wpEditFieldGroup.editMode && !field.writable;
   }
 }

--- a/frontend/src/app/modules/common/edit-actions-bar/wp-edit-actions-bar.component.ts
+++ b/frontend/src/app/modules/common/edit-actions-bar/wp-edit-actions-bar.component.ts
@@ -66,7 +66,7 @@ export class WorkPackageEditActionsBarComponent {
   }
 
   public cancel():void {
-    this.wpEditFieldGroup.inEditMode = false;
+    this.wpEditFieldGroup.stop();
     this.onCancel.emit();
   }
 }

--- a/spec/features/work_packages/cancel_editing_spec.rb
+++ b/spec/features/work_packages/cancel_editing_spec.rb
@@ -96,6 +96,29 @@ describe 'Cancel editing work package', js: true do
     expect(wp_page).not_to have_alert_dialog
   end
 
+  it 'shows an alert when moving to other states while editing a single attribute (Regression #25135)' do
+    wp_table.visit!
+    wp_table.expect_work_package_listed(work_package, work_package2)
+
+    # Edit subject in split page
+    split_page = wp_table.open_split_view(work_package)
+    subject = split_page.edit_field :subject
+    subject.activate!
+
+    # Decline move, expect field still active
+    wp_table.open_split_view(work_package2)
+    page.driver.browser.switch_to.alert.dismiss
+    subject.expect_active!
+
+    sleep 1
+
+    # Now accept to move to the second page
+    split_page = wp_table.open_split_view(work_package2)
+    page.driver.browser.switch_to.alert.accept
+    subject = split_page.edit_field :subject
+    subject.expect_inactive!
+  end
+
   it 'cancels the editing when clicking the button' do
     paths.each do |path|
       expect_active_edit(path)


### PR DESCRIPTION
This adds/fixes the warning when leaving a work package with an active
edit field outside edit mode.

https://community.openproject.com/wp/25135