### PR TITLE
Avoid bundler 1.16.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,8 @@ before_install:
   - "nvm install --lts"
   # work around https://github.com/travis-ci/travis-ci/issues/8969
   - travis_retry gem update --system
-  - gem install bundler
+  # Don't install 1.16.3
+  - gem install bundler -v 1.16.2
 
 
 bundler_args: --binstubs --without development production docker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -739,4 +739,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
Cucumber builds started to break this morning, this seems to be connected to the release of 1.16.3. It only fails in a nested bundle context in combination with `parallel_testing`, thus other jobs are not affected.