### PR TITLE
handle erroneous embedded queries on form configuration

### DIFF
--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -69,11 +69,12 @@ class TypesController < ApplicationController
     if params[:tab].blank?
       redirect_to tab: :settings
     else
-      @tab = params[:tab]
-      @projects = Project.all
-      @type = ::Type.includes(:projects,
-                              :custom_fields)
-                    .find(params[:id])
+      type = ::Type
+             .includes(:projects,
+                       :custom_fields)
+             .find(params[:id])
+
+      render_edit_tab(type)
     end
   end
 
@@ -89,8 +90,7 @@ class TypesController < ApplicationController
       end
 
       call.on_failure do
-        @projects = Project.all
-        render action: 'edit'
+        render_edit_tab(@type)
       end
     end
   end
@@ -150,6 +150,14 @@ class TypesController < ApplicationController
     else
       ActionController::Base.helpers.link_to(t(:label_work_package_types), types_path)
     end
+  end
+
+  def render_edit_tab(type)
+    @tab = params[:tab]
+    @projects = Project.all
+    @type = type
+
+    render action: 'edit'
   end
 
   def show_local_breadcrumb

--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -192,7 +192,7 @@ module Type::AttributeGroups
     contract = contract_class.new(query, User.current)
 
     unless contract.validate
-      errors.add(:attribute_groups, :query_invalid)
+      errors.add(:attribute_groups, :query_invalid, group: group.key, details: contract.errors.full_messages.join)
     end
   end
 

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -78,23 +78,23 @@ class BaseTypeService
   def parse_attribute_groups_params(params)
     return if params[:attribute_groups].nil?
 
-    transform_query_params_to_query(params[:attribute_groups])
+    transform_params_to_query(params[:attribute_groups])
   end
 
   def after_type_save(_params, _options)
     # noop to be overwritten by subclasses
   end
 
-  def transform_query_params_to_query(groups)
+  def transform_params_to_query(groups)
     groups.each_with_index do |(name, attributes), index|
       next unless attributes.is_a? Hash
       next if attributes.values.compact.empty?
 
-      call = ::API::V3::UpdateQueryFromV3ParamsService
-             .new(Query.new_default(name: "Embedded subelements: #{name}"), user)
-             .call(attributes.with_indifferent_access)
+      query = Query.new_default(name: "Embedded subelements: #{name}")
 
-      query = call.result
+      ::API::V3::UpdateQueryFromV3ParamsService
+        .new(query, user)
+        .call(attributes.with_indifferent_access)
 
       query.show_hierarchies = false
       query.add_filter('parent', '=', ::Queries::Filters::TemplatedValue::KEY)

--- a/app/services/update_type_service.rb
+++ b/app/services/update_type_service.rb
@@ -29,7 +29,7 @@
 
 class UpdateTypeService < BaseTypeService
   def initialize(type, user)
-    super(user: user)
+    super(user)
     self.type = type
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -370,6 +370,7 @@ en:
         spent_on: "Date"
         type: "Type"
       type:
+        attribute_groups: ''
         is_in_roadmap: "In roadmap"
         is_milestone: "Is milestone"
         color: "Color"
@@ -538,9 +539,10 @@ en:
         type:
           attributes:
             attribute_groups:
-              group_without_name: "Unnamed groups are not allowed."
-              duplicate_group: "The group name %{group} is used more than once. Group names must be unique."
               attribute_unknown: "Invalid work package attribute used."
+              duplicate_group: "The group name '%{group}' is used more than once. Group names must be unique."
+              query_invalid: "The embedded query '%{group}' is invalid: %{details}"
+              group_without_name: "Unnamed groups are not allowed."
         user:
           attributes:
             password:


### PR DESCRIPTION
Display an error message:

![image](https://user-images.githubusercontent.com/617519/42885012-2a835d30-8aa0-11e8-9776-d92f4073285c.png)

instead of running into an internal error.

It would be better if the `UpdateQueryFromV3ParamsService` were to return a query even if it is erroneous but changing that interface entails to many changes for now.

https://community.openproject.com/projects/openproject/work_packages/28025