### PR TITLE
do not throw internal error on invalid custom field

### DIFF
--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -241,7 +241,7 @@ module API
               [value].compact
             end
 
-            represented.custom_field_values = { custom_field.id => values }
+            represented.send(:"custom_field_#{custom_field.id}=", values)
           }
         end
 

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -474,17 +474,17 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
       it 'accepts a valid link' do
         json = { cf_path => { href: (api_v3_paths.user 2) } }.to_json
-        expected = { custom_field.id => ['2'] }
+        expected = ['2']
 
-        expect(represented).to receive(:custom_field_values=).with(expected)
+        expect(represented).to receive(:"custom_field_#{custom_field.id}=").with(expected)
         modified_class.new(represented, current_user: nil).from_json(json)
       end
 
       it 'accepts an empty link' do
         json = { cf_path => { href: nil } }.to_json
-        expected = { custom_field.id => [] }
+        expected = []
 
-        expect(represented).to receive(:custom_field_values=).with(expected)
+        expect(represented).to receive(:"custom_field_#{custom_field.id}=").with(expected)
         modified_class.new(represented, current_user: nil).from_json(json)
       end
     end

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -576,5 +576,21 @@ describe WorkPackages::SetAttributesService, type: :model do
         end
       end
     end
+
+    context 'custom fields' do
+      subject { instance.call(call_attributes) }
+
+      context 'non existing fields' do
+        let(:call_attributes) { { custom_field_891: '1' } }
+
+        before do
+          subject
+        end
+
+        it 'is successful' do
+          expect(subject).to be_success
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Ignore invalid custom fields in `SetAttributesService` to recreate the behaviour before parsing all custom fields in the representer.

https://community.openproject.com/projects/openproject/work_packages/28015