### PR TITLE
[27235] Clear tmp:cache through cronjob

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -26,6 +26,7 @@ crons:
   - packaging/cron/openproject-hourly-tasks
   - packaging/cron/openproject-clear-old-sessions
   - packaging/cron/openproject-clear-uploaded-files
+  - packaging/cron/openproject-clear-tmp-cache
 services:
   - postgres
 installer: https://github.com/pkgr/installer.git

--- a/packaging/cron/openproject-clear-tmp-cache
+++ b/packaging/cron/openproject-clear-tmp-cache
@@ -1,0 +1,3 @@
+APP_NAME="_APP_NAME_"
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+45 2 * * 7 root ${APP_NAME} run rake -s tmp:cache:clear >> /var/log/${APP_NAME}/cron-clear-tmp-files.log 2>&1


### PR DESCRIPTION
The `tmp:cache:clear` does not affect other caches such as memcached, since it's basically `rm -rf tmp/cache/*`

https://github.com/rails/rails/blob/ef5d85709d346e55827e88f53430a2cbe1e5fb9e/railties/lib/rails/tasks/tmp.rake#L25-L30

https://community.openproject.com/wp/27235