### PR TITLE
[27947] Filter by commit date for changeset activity provider

### DIFF
--- a/app/models/activity/base_activity_provider.rb
+++ b/app/models/activity/base_activity_provider.rb
@@ -73,6 +73,18 @@ class Activity::BaseActivityProvider
     activity_journals_table(activity)
   end
 
+  def filter_for_event_datetime(query, journals_table, typed_journals_table, from, to)
+    if from
+      query = query.where(journals_table[:created_at].gteq(from))
+    end
+
+    if to
+      query = query.where(journals_table[:created_at].lteq(to))
+    end
+
+    query
+  end
+
   def activity_journals_table(_activity)
     @activity_journals_table ||= JournalManager.journal_class(activitied_type).arel_table
   end

--- a/app/models/activity/changeset_activity_provider.rb
+++ b/app/models/activity/changeset_activity_provider.rb
@@ -49,6 +49,21 @@ class Activity::ChangesetActivityProvider < Activity::BaseActivityProvider
     repositories_table
   end
 
+  ##
+  # Override this method if not the journal created_at datetime, but another column
+  # value is the actual relevant time event. (e..g., commit date)
+  def filter_for_event_datetime(query, journals_table, typed_journals_table, from, to)
+    if from
+      query = query.where(typed_journals_table[:committed_on].gteq(from))
+    end
+
+    if to
+      query = query.where(typed_journals_table[:committed_on].lteq(to))
+    end
+
+    query
+  end
+
   protected
 
   def event_type(_event, _activity)

--- a/lib/plugins/acts_as_activity_provider/lib/acts_as_activity_provider.rb
+++ b/lib/plugins/acts_as_activity_provider/lib/acts_as_activity_provider.rb
@@ -109,8 +109,7 @@ module Redmine
             query = journals_table.join(activity_journals_table).on(journals_table[:id].eq(activity_journals_table[:journal_id]))
             query = query.where(journals_table[:journable_type].eq(provider.activitied_type(activity).name))
 
-            query = query.where(journals_table[:created_at].gteq(from)) if from
-            query = query.where(journals_table[:created_at].lteq(to)) if to
+            provider.filter_for_event_datetime query, journals_table, activity_journals_table, from, to
 
             query = query.where(journals_table[:user_id].eq(options[:author].id)) if options[:author]
 


### PR DESCRIPTION
Currently, changesets are filtered for to/from values by their
created_at date. That however is the time of the import to the database,
not the actual commit data.

Instead, we should filter for the commit date to get proper responses.

https://community.openproject.com/wp/27947