### PR TITLE
[27934] Avoid bulk copying children more than once

### DIFF
--- a/app/assets/stylesheets/content/_contextual.lsg
+++ b/app/assets/stylesheets/content/_contextual.lsg
@@ -1,0 +1,10 @@
+# Contextual text info
+
+Provide some additional information on some content to the left of this span
+
+```
+<p>
+  Some text here
+  <span class="contextual-info -small">(Some contextual information for the text)</span>
+</div>
+```

--- a/app/assets/stylesheets/content/_contextual.sass
+++ b/app/assets/stylesheets/content/_contextual.sass
@@ -1,0 +1,34 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2017 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+//++
+
+span.contextual-info
+  color: #555
+  padding-left: 0.25rem
+
+  &.-small
+    font-size: 0.8rem

--- a/app/assets/stylesheets/content/_index.sass
+++ b/app/assets/stylesheets/content/_index.sass
@@ -67,6 +67,7 @@
 @import content/hide_until_initialized
 @import content/hidden
 @import content/search
+@import content/contextual
 
 @import content/menus/_project_autocompletion
 @import content/editor/index

--- a/app/views/work_packages/moves/new.html.erb
+++ b/app/views/work_packages/moves/new.html.erb
@@ -31,9 +31,20 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <h2><%= @copy ? l(:button_copy) : l(:button_move) %></h2>
 <ul>
+  <% total = 0 %>
   <% @work_packages.each do |work_package| -%>
-    <li><%= link_to_work_package work_package %></li>
+    <% total += 1 %>
+    <li>
+      <%= link_to_work_package work_package %>
+      <% if work_package.children.size > 0 %>
+        <span class="contextual-info -small">(+ <%= t('work_packages.x_children', count: work_package.children.size) %>)</span>
+        <% total += work_package.children.size %>
+      <% end %>
+    </li>
   <% end -%>
+  <p>
+    <%= t(:label_total) %>: <%= total %>
+  </p>
 </ul>
 
 <%= activate_angular_js do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,6 +218,10 @@ en:
       no_results_title_text: There are currently no workflows.
 
   work_packages:
+    x_children:
+      one: 'One child work package'
+      other: '%{count} work package children'
+
     move:
       no_common_statuses_exists: "There is no status available for all selected work packages. Their status cannot be changed."
       unsupported_for_multiple_projects: 'Bulk move/copy is not supported for work packages from multiple projects'


### PR DESCRIPTION
All descendants of work packages are automatically copied by the `MoveService`. We can skip them by checking the ancestors of each work package beforehand.

https://community.openproject.com/wp/27934