### PR TITLE
[28065] Avoid firefox CSP warning by setting ng-csp globally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ env:
     - RAILS_ENV=test
 
   matrix:
-    - "TEST_SUITE=npm"
+    - "TEST_SUITE=npm DB=none"
 
 
     - "TEST_SUITE=spec_legacy       DB=mysql     GROUP_SIZE=1 GROUP=1"
@@ -102,10 +102,10 @@ before_install:
 bundler_args: --binstubs --without development production docker
 
 before_script:
-  - sh script/ci_setup.sh $TEST_SUITE $DB
+  - bash script/ci_setup.sh $TEST_SUITE $DB
 
 script:
-  - sh script/ci_runner.sh
+  - bash script/ci_runner.sh
 
 
 addons:

--- a/app/helpers/angular_helper.rb
+++ b/app/helpers/angular_helper.rb
@@ -41,10 +41,10 @@ module AngularHelper
     end
 
     if block_given?
-      merged_options = options.merge('ng-app': 'OpenProjectLegacy', 'ng-csp': '')
+      merged_options = options.merge('ng-app': 'OpenProjectLegacy')
       content_tag(type, merged_options, &block)
     else
-      'ng-app="OpenProjectLegacy" ng-csp'.html_safe
+      'ng-app="OpenProjectLegacy"'.html_safe
     end
   end
 end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -27,7 +27,11 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%><!DOCTYPE html>
 <% show_decoration = params["layout"].nil? %>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="<%= I18n.locale.to_s %>" xml:lang="<%= I18n.locale.to_s %>" class="<%= 'in_modal' unless show_decoration %>">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      lang="<%= I18n.locale.to_s %>"
+      xml:lang="<%= I18n.locale.to_s %>"
+      ng-csp="no-unsafe-eval"
+      class="<%= 'in_modal' unless show_decoration %>">
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
   <meta name="viewport" content="width=device-width">

--- a/app/views/queries/_filters.html.erb
+++ b/app/views/queries/_filters.html.erb
@@ -124,8 +124,13 @@ See docs/COPYRIGHT.rdoc for more details.
                          options_for_select(operators_for_select(filter),
                                             query.filter_for(field).try(:operator)),
                          id:       "operators_#{field}",
-                         onchange: "toggle_operator('#{field}');",
                          class:    "advanced-filters--select" %>
+
+          <%=
+            content_for(:additional_js_dom_ready) do
+              "jQuery('#operators_#{field}').change(toggle_operator('#{field}'));".html_safe
+            end
+          %>
 
         </div>
         <div id="div_values_<%= field %>" style="display:none;" class="advanced-filters--filter-value">
@@ -181,9 +186,14 @@ See docs/COPYRIGHT.rdoc for more details.
     <div class="advanced-filters--add-filter-value">
       <%= select_tag 'add_filter_select',
                      options_for_select(entries_for_filter_select_sorted(query)),
-                     onchange: "add_filter();",
                      class:    "advanced-filters--select",
                      name:     nil %>
+
+      <%=
+        content_for(:additional_js_dom_ready) do
+          "jQuery('.advanced-filters--select').change(add_filter);".html_safe
+        end
+      %>
     </div>
   </li>
 </ul>

--- a/app/views/repositories/diff.html.erb
+++ b/app/views/repositories/diff.html.erb
@@ -32,8 +32,14 @@ See docs/COPYRIGHT.rdoc for more details.
     <%= form_tag({path: to_path_param(@path)}, method: :get) do %>
       <%= hidden_field_tag('rev', params[:rev]) if params[:rev] %>
       <%= hidden_field_tag('rev_to', params[:rev_to]) if params[:rev_to] %>
-      <%= styled_select_tag 'type', options_for_select([[l(:label_diff_inline), "inline"], [l(:label_diff_side_by_side), "sbs"]], @diff_type), onchange: "if (this.value != '') {this.form.submit()}" %>
-    <% end %>
+      <%= styled_select_tag 'type', options_for_select([[l(:label_diff_inline), "inline"], [l(:label_diff_side_by_side), "sbs"]], @diff_type), id: "repository-diff-type-select" %>
+      <%=
+        content_for(:additional_js_dom_ready) do
+          "jQuery('#repository-diff-type-select').change(function() {
+             if (this.value != '') { this.form.submit() }
+          });".html_safe
+        end
+      %>
   </li>
 <% end %>
 

--- a/app/views/repositories/diff.html.erb
+++ b/app/views/repositories/diff.html.erb
@@ -33,6 +33,7 @@ See docs/COPYRIGHT.rdoc for more details.
       <%= hidden_field_tag('rev', params[:rev]) if params[:rev] %>
       <%= hidden_field_tag('rev_to', params[:rev_to]) if params[:rev_to] %>
       <%= styled_select_tag 'type', options_for_select([[l(:label_diff_inline), "inline"], [l(:label_diff_side_by_side), "sbs"]], @diff_type), id: "repository-diff-type-select" %>
+    <% end %>
       <%=
         content_for(:additional_js_dom_ready) do
           "jQuery('#repository-diff-type-select').change(function() {

--- a/app/views/repositories/settings/subversion/_existing.html.erb
+++ b/app/views/repositories/settings/subversion/_existing.html.erb
@@ -57,9 +57,16 @@ See docs/COPYRIGHT.rdoc for more details.
                           size: 30,
                           label: t('repositories.subversion.password'),
                           name: 'ignore',
+                          id: 'repository-password-placeholder',
                           value: ((repository.new_record? || repository.password.blank?) ? '' : ('x' * 15)),
-                          onfocus: "this.value=''; this.name='repository[password]';",
-                          onchange: "this.name='repository[password]';",
                           container_class: '-middle')
+  %>
+  <%=
+    content_for(:additional_js_dom_ready) do
+      "jQuery('#repository-password-placeholder')
+        .change(function() { this.name = 'repository[password]'; })
+        .focus(function() { this.value = ''; this.name = 'repository[password]'; });
+        ".html_safe
+    end
   %>
 </div>

--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -13789,7 +13789,8 @@
     },
     "stringstream": {
       "version": "0.0.5",
-      "resolved": ""
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -126,7 +126,7 @@
     "pretest": "./scripts/link_plugin_placeholder.js",
     "test": "ng test",
     "posttest": "npm run tslint_typechecks",
-    "tslint_typechecks": "tslint -p . -c tslint_typechecks.json",
+    "tslint_typechecks": "./node_modules/.bin/tslint -p . -c tslint_typechecks.json",
     "generate-typings": "tsc -d -p src/tsconfig.app.json",
     "legacy-webpack": "./node_modules/.bin/webpack --colors --config legacy/webpack.config.js",
     "legacy-webpack-watch": "RAILS_ENV=development ./node_modules/.bin/webpack --config legacy/webpack.config.js --display-error-details --watch --colors --cache --debug"

--- a/script/ci_setup.sh
+++ b/script/ci_setup.sh
@@ -45,7 +45,6 @@ if [ $2 = "mysql" ]; then
   run "mysql -u root -e \"CREATE DATABASE IF NOT EXISTS travis_ci_test DEFAULT CHARACTER SET = 'utf8' DEFAULT COLLATE 'utf8_general_ci';\""
   run "mysql -u root -e \"GRANT ALL ON travis_ci_test.* TO 'travis'@'localhost';\""
   run "cp script/templates/database.travis.mysql.yml config/database.yml"
-
 elif [ $2 = "postgres" ]; then
   run "psql -c 'create database travis_ci_test;' -U postgres"
   run "cp script/templates/database.travis.postgres.yml config/database.yml"
@@ -58,7 +57,9 @@ fi
 
 run "for i in {1..3}; do npm install && break || sleep 15; done"
 
-if [ $1 != 'specs' ] && [ $1 != 'spec_legacy' ]; then
+if [ $1 = 'npm' ]; then
+  echo "No asset compilation required"
+elif [ $1 != 'specs' ] && [ $1 != 'spec_legacy' ]; then
   run "bundle exec rails assets:precompile"
 else
   # fake result of npm/asset run

--- a/spec/features/repositories/repository_settings_spec.rb
+++ b/spec/features/repositories/repository_settings_spec.rb
@@ -180,7 +180,7 @@ describe 'Repository Settings', type: :feature, js: true do
 
     it 'can set login and password' do
       fill_in('repository[login]', with: 'foobar')
-      fill_in('repository_password', with: 'password')
+      fill_in('repository-password-placeholder', with: 'password')
 
       click_button(I18n.t(:button_save))
       expect(page).to have_selector('[name="repository[login]"][value="foobar"]')


### PR DESCRIPTION
AngularJS will try to autodetect CSP in a setting where the ng-csp selector is not globally available before onLoad (which is not always the case in our legacy app usage).

This will result in a CSP warning in Firefox. This is cosmetic only.

https://community.openproject.com/projects/openproject/work_packages/28065