### PR TITLE
[28095] Add inline attachments parsing to backend commonmark parser

### DIFF
--- a/lib/open_project/text_formatting/filters/attachment_filter.rb
+++ b/lib/open_project/text_formatting/filters/attachment_filter.rb
@@ -1,0 +1,74 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject::TextFormatting
+  module Filters
+    class AttachmentFilter < HTML::Pipeline::Filter
+      include OpenProject::StaticRouting::UrlHelpers
+
+      def matched_filenames_regex
+        /(bmp|gif|jpe?g|png|svg)\z/
+      end
+
+      def call
+        attachments = get_attachments
+        return doc if attachments.nil?
+
+        doc.css('img[src]').each do |node|
+          # We allow linking to filenames that are replaced with their attachment URL
+          filename = node['src'].downcase
+
+          # We only match a specific set of attributes as before
+          next unless filename =~ matched_filenames_regex
+
+          # Try to find the attachment
+          if found = attachments.detect { |att| att.filename.downcase == filename }
+            node['src'] = url_for only_path: context[:only_path],
+                                  controller: '/attachments',
+                                  action: 'download',
+                                  id: found
+
+            # Replace alt text with description, unless it has one already
+            node['alt'] = node['alt'].presence || found.description
+          end
+        end
+
+        doc
+      end
+
+      def get_attachments
+        attachments = context[:attachments] || context[:object].try(:attachments)
+        if attachments
+          attachments.sort_by(&:created_at).reverse
+        end
+      end
+    end
+  end
+end

--- a/lib/open_project/text_formatting/formats/markdown/formatter.rb
+++ b/lib/open_project/text_formatting/formats/markdown/formatter.rb
@@ -57,6 +57,7 @@ module OpenProject::TextFormatting::Formats::Markdown
         :macro,
         :pattern_matcher,
         :syntax_highlight,
+        :attachment,
         :autolink
       ]
     end

--- a/spec/factories/attachment_factory.rb
+++ b/spec/factories/attachment_factory.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
   factory :attachment do
     container factory: :work_package
     author factory: :user
+    description nil
 
     transient do
       filename nil

--- a/spec/lib/open_project/text_formatting/markdown/markdown_inline_attachments_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/markdown_inline_attachments_spec.rb
@@ -1,0 +1,78 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe OpenProject::TextFormatting::Formats::Markdown::Formatter do
+  let(:context) { {} }
+  let(:subject) { described_class.new(context).to_html(text) }
+
+  describe 'work package with attachments' do
+    let!(:work_package) { FactoryBot.create :work_package }
+    let!(:inlinable) {
+      FactoryBot.create(:attached_picture, filename: 'my-image.jpg', description: '"foobar"', container: work_package)
+    }
+    let(:context) { { object: work_package, only_path: true } }
+
+    let!(:non_inlinable) {
+      FactoryBot.create(:attachment, filename: 'whatever.pdf', container: work_package)
+    }
+
+    it 'should inline the inlineable attachment, not the others' do
+      work_package.attachments.reload
+      assert_html_output(
+        '![](my-image.jpg)'                => %(<img src="/attachments/#{inlinable.id}" alt='"foobar"'>),
+        '![alt-text](my-image.jpg)'        => %(<img src="/attachments/#{inlinable.id}" alt="alt-text">),
+        '![foo](does-not-exist.jpg)'       => %(<img src="does-not-exist.jpg" alt="foo">),
+        '![](whatever.pdf)'                => %(<img src="whatever.pdf" alt="">),
+        '![](some/path/to/my-image.jpg)'   => %(<img src="some/path/to/my-image.jpg" alt="">)
+      )
+    end
+
+    context 'with only_path=false' do
+      let(:context) { { object: work_package, only_path: false } }
+
+      it 'should inline the inlineable attachment, not the others' do
+        work_package.attachments.reload
+        assert_html_output(
+          '![](my-image.jpg)' => %(<img src="http://localhost:3000/attachments/#{inlinable.id}" alt='"foobar"'>),
+          )
+      end
+    end
+  end
+
+  private
+
+  def assert_html_output(to_test)
+    instance = described_class.new(context)
+    to_test.each do |text, expected|
+      expect(instance.to_html(text)).to be_html_eql "<p>#{expected}</p>"
+    end
+  end
+end


### PR DESCRIPTION
This solves the backend part of https://community.openproject.com/wp/28095

  - This does not address the frontend part. Drag&Drop of images still result in images, and typing `![](image.jpg)` manually is escaped by CKE.
  - Since `!foo.jpg!` is standard textile, nothing needs to be done for the pandoc migration.