### PR TITLE
Avoid running into 422 loop due to null session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,7 +68,6 @@ class ApplicationController < ActionController::Base
   # Thus, we show an error message unless the request probably is an API
   # request.
   def handle_unverified_request
-    super
     cookies.delete(OpenProject::Configuration['autologin_cookie_name'])
     self.logged_user = nil
 


### PR DESCRIPTION
The default for generated Rails 5 controllers is `protect_from_forgery with: :exception` - resulting throwing an exception when a CSRF violation occurs. Since we override `handle_unverified_request` for detecting API requests, the super behavior is the default handling - a null session handler (http://marcgg.com/blog/2016/08/22/csrf-rails/) would be to override the current session with a null session object

This results in no session cookie being created for the anonymous user and subsequent POST requests being impossible.

For example, this will happen when you invalidated your cookies while on the login page and try to log in. You will remain in a 422 loop because there is no valid CSRF token.

If we instead use `reset_session` only, a new session is generated, the user is logged out and reset, but the following request may issue new data into the session.

https://community.openproject.com/wp/28072