### PR TITLE
[28099] Close active edited resource when changing type

### DIFF
--- a/frontend/src/app/modules/fields/edit/edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/edit-field.component.ts
@@ -58,7 +58,13 @@ export class EditFieldComponent implements OnDestroy {
       )
       .subscribe((changeset) => {
         if (!this.changeset.empty && this.changeset.wpForm.hasValue()) {
-          this.field.schema = changeset.wpForm.value!.schema[this.field.name];
+          const fieldSchema = changeset.wpForm.value!.schema[this.field.name];
+
+          if (!fieldSchema) {
+            return handler.deactivate(false);
+          }
+
+          this.field.schema = fieldSchema;
           this.field.resource = changeset.workPackage;
           this.initialize();
           this.cdRef.markForCheck();


### PR DESCRIPTION
When the table has a required CF for the current type A, and the required CF is open,
and you switch to a type B where this required CF does not exist, the field does not close, but remains open, trying to access its field schema. This field schema does no longer exist (no schema entry for this
CF).

https://community.openproject.com/wp/28099