### PR TITLE
[28093, 28094] Use macro placeholders on my/page when editing blocks

### DIFF
--- a/app/assets/stylesheets/content/editor/_macros.sass
+++ b/app/assets/stylesheets/content/editor/_macros.sass
@@ -4,21 +4,18 @@ macro.legacy-macro
   border: 2px dashed $nm-color-warning-border
   padding: 10px 5px
 
-// Macro rendering in CKEditor
-.op-ckeditor--wrapper
+.ck-widget.macro
+  border: 2px dashed #ccc
+  min-height: 50px
+  display: flex
+  justify-content: center
+  align-items: center
+  color: #575757
+  background: #f8f8f8
 
-  .ck-widget.macro
-    border: 2px dashed #ccc
-    min-height: 50px
-    display: flex
-    justify-content: center
-    align-items: center
-    color: #575757
-    background: #f8f8f8
-
-    .macro-value
-      font-style: italic
-      color: $gray-dark
+  .macro-value
+    font-style: italic
+    color: $gray-dark
 
 // Unavailable macros
 macro.macro-unavailable

--- a/app/views/my/_block.html.erb
+++ b/app/views/my/_block.html.erb
@@ -41,6 +41,6 @@ See docs/COPYRIGHT.rdoc for more details.
   <% end %>
 
   <div class='handle'>
-    <%= render partial: "my/blocks/#{block_name}", locals: { user: user, block_name: block_name } %>
+    <%= render partial: "my/blocks/#{block_name}", locals: { user: user, edit: true, block_name: block_name } %>
   </div>
 </div>

--- a/app/views/my/_block_container.html.erb
+++ b/app/views/my/_block_container.html.erb
@@ -5,7 +5,7 @@
       <%= render partial: "my/block", locals: { block_name: block_name, user: @user } %>
     <% else %>
       <div class="widget-box">
-        <%= render partial: "my/blocks/#{block_name}", locals: { user: @user } %>
+        <%= render partial: "my/blocks/#{block_name}", locals: { edit: false, user: @user } %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/my/blocks/_embedded_work_package_table.html.erb
+++ b/app/views/my/blocks/_embedded_work_package_table.html.erb
@@ -1,0 +1,7 @@
+<% if edit %>
+  <div class="macro -embedded-table ck-widget">
+    <%= t('js.editor.macro.embedded_table.text') %>
+  </div>
+<% else %>
+  <%= render partial: 'work_packages/me_list_simple', locals: { user_filter: user_filter } %>
+<% end %>

--- a/app/views/my/blocks/_issuesassignedtome.html.erb
+++ b/app/views/my/blocks/_issuesassignedtome.html.erb
@@ -36,8 +36,8 @@ See docs/COPYRIGHT.rdoc for more details.
   <span class="widget-box--header-title"><%=l(:label_assigned_to_me_work_packages)%></span>
 </h3>
 
-<%= render partial: 'work_packages/me_list_simple',
-           locals: { user_filter: :assignee } %>
+<%= render partial: 'my/blocks/embedded_work_package_table',
+    locals: { edit: edit, user_filter: :assignee } %>
 
 <% content_for :header_tags do %>
   <%= auto_discovery_link_tag(:atom,

--- a/app/views/my/blocks/_issuesreportedbyme.html.erb
+++ b/app/views/my/blocks/_issuesreportedbyme.html.erb
@@ -36,8 +36,8 @@ See docs/COPYRIGHT.rdoc for more details.
   <span class="widget-box--header-title"><%=l(:label_reported_work_packages)%></span>
 </h3>
 
-<%= render partial: 'work_packages/me_list_simple',
-           locals: { user_filter: :author } %>
+<%= render partial: 'my/blocks/embedded_work_package_table',
+    locals: { edit: edit, user_filter: :author } %>
 
 <% content_for :header_tags do %>
   <%= auto_discovery_link_tag(:atom,

--- a/app/views/my/blocks/_issueswatched.html.erb
+++ b/app/views/my/blocks/_issueswatched.html.erb
@@ -35,5 +35,5 @@ See docs/COPYRIGHT.rdoc for more details.
   <span class="widget-box--header-title"><%=l(:label_watched_work_packages)%></span>
 </h3>
 
-<%= render partial: 'work_packages/me_list_simple',
-           locals: { user_filter: :watcher } %>
+<%= render partial: 'my/blocks/embedded_work_package_table',
+           locals: { edit: edit, user_filter: :watcher } %>

--- a/app/views/my/blocks/_workpackagesresponsiblefor.html.erb
+++ b/app/views/my/blocks/_workpackagesresponsiblefor.html.erb
@@ -35,8 +35,8 @@ See docs/COPYRIGHT.rdoc for more details.
   <span class="widget-box--header-title"><%=l(:label_responsible_for_work_packages)%></span>
 </h3>
 
-<%= render partial: 'work_packages/me_list_simple',
-           locals: { user_filter: :responsible } %>
+<%= render partial: 'my/blocks/embedded_work_package_table',
+           locals: { edit: edit, user_filter: :responsible } %>
 
 <% content_for :header_tags do %>
   <%= auto_discovery_link_tag(:atom,

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -118,7 +118,7 @@ en:
           with_type: 'Create work package (Type: %{typename})'
         embedded_table:
           button: 'Embed work package table'
-          text: 'Embedded work package table (placeholder)'
+          text: '[Placeholder] Embedded work package table'
 
     error:
       internal: "An internal error has occurred."


### PR DESCRIPTION
- Fixes empty preview when adding new blocks (are not expanded by angular)
(#28049)

- Fixes errors when cancelling editing of multiple widgets

![screenshot from 2018-07-26 14-12-44](https://user-images.githubusercontent.com/459462/43261711-ff1b75ee-90dd-11e8-9291-daf690af545b.png)


https://community.openproject.com/projects/openproject/work_packages/28093
https://community.openproject.com/projects/openproject/work_packages/28094