### PR TITLE
[28103] Fix reorder my page blocks

### DIFF
--- a/app/assets/javascripts/my_page.js
+++ b/app/assets/javascripts/my_page.js
@@ -111,7 +111,7 @@ jQuery(document).ready(function($) {
   // On 'el' drop, we fire an Ajax request to persist the order chosen by
   // the user. Actual ordering details are handled on the server.
   drake.on('drop', function(el, target, source, sibling){
-    var url = "<%= my_order_blocks_url %>";
+    var url = window.gon.my_order_blocks_url;
 
     // Array of target ordered children after this drop.
     var target_ordered_children = jQuery(target).find('.block-wrapper').map(function(){

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -168,6 +168,9 @@ class MyController < ApplicationController
     @blocks         = get_current_layout
     @block_options  = []
 
+    # Pass block url to frontend
+    gon.my_order_blocks_url = my_order_blocks_url;
+
     # We track blocks that will show up on the page. This is in order to have
     # them disabled in the blocks-to-add-to-page dropdown.
     blocks_on_page = get_current_layout.values.flatten

--- a/app/views/my/page_layout.html.erb
+++ b/app/views/my/page_layout.html.erb
@@ -27,6 +27,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= javascript_include_tag 'my_page' %>
+<%= include_gon(nonce: content_security_policy_nonce(:script)) %>
 
 <%= toolbar title: l(:label_my_page) do %>
   <%= styled_form_tag({ action: "add_block" }, class: 'my-page--block-form') do %>


### PR DESCRIPTION
Got lost in the CSP fixes and the URL is no longer passed to the
frontend. Instead, use gon while we still have my/page blocks.

https://community.openproject.com/wp/28103