### PR TITLE
[28105] Fix click on button in formattable not going through

### DIFF
--- a/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field.component.ts
+++ b/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field.component.ts
@@ -123,11 +123,18 @@ export class WorkPackageEditFieldComponent implements OnInit {
       return true;
     }
 
+    // Skip activation if the user clicked on a link
+    const target = jQuery(event.target);
+    if (target.closest('a', this.displayContainer.nativeElement).length > 0) {
+      return true;
+    }
+
     if (this.isEditable) {
       this.handleUserActivate(event);
     }
 
     this.opContextMenu.close();
+    event.preventDefault();
     event.stopImmediatePropagation();
 
     return false;
@@ -145,13 +152,6 @@ export class WorkPackageEditFieldComponent implements OnInit {
     let positionOffset = 0;
 
     if (evt) {
-      // Skip activation if the user clicked on a link
-      const target = jQuery(evt.target);
-
-      if (target.closest('a', this.displayContainer.nativeElement).length > 0) {
-        return true;
-      }
-
       // Get the position where the user clicked.
       positionOffset = ClickPositionMapper.getPosition(evt);
     }

--- a/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field.html
+++ b/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field.html
@@ -10,6 +10,7 @@
   </div>
 
   <div (accessibleClick)="activateIfEditable($event)"
+       [accessibleClickStopEvent]="false"
        [hidden]="active"
        tabindex="-1"
        #displayContainer></div>


### PR DESCRIPTION
This is due to accessibleClick stopping all event propagation by
default.

https://community.openproject.com/wp/28105