### PR TITLE
[28088] Line shown next to embedded tables

### DIFF
--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -27,6 +27,8 @@
 //++
 
 div.wiki
+  // ------------------- FONT -------------------
+
   font-size: $wiki-default-font-size
   $wiki-max-heading-font-size: $wiki-default-font-size * 1.5
 
@@ -52,6 +54,8 @@ div.wiki
     text-transform: none
     border-bottom: 1px dotted #bbbbbb
 
+
+  // ------------------- TABLES -------------------
   table
     border: 1px solid #505050
     border-collapse: collapse
@@ -61,9 +65,30 @@ div.wiki
     border: 1px solid #bbb
     padding: 4px
 
-  .external.icon-context:before
-    padding: 4px 4px 0 0
+  .-compact-tables
+    // In FF there is bug (https://bugzilla.mozilla.org/show_bug.cgi?id=688556) which causes
+    // the border of tables to vanish once the background of table cells is set.
+    // Therefor we need to disable the automatic table border rendering with border-collapse: collapse and
+    // add the borders manually.
+    .work-package-table
+      border-collapse: separate
+      border: none
+      padding: 0
 
+      .wp-table--table-header:not(:last-of-type)
+        border-right: 0px solid #bbb
+        &:first-of-type
+          border-left: 1px solid #bbb
+
+      .wp-table--cell-td:not(:last-of-type)
+        border-right: 0px solid #bbb
+        &:first-of-type
+          border-left: 1px solid #bbb
+      .wp-table--row:not(:last-of-type)
+        .wp-table--cell-td
+          border-bottom: 0px solid #bbb
+
+  // ------------------- LISTINGS -------------------
   ul.toc
     margin-bottom: 12px
     margin-right: 12px
@@ -108,6 +133,12 @@ div.wiki
 
   li li
     margin-left: 1.5em
+
+
+  // ------------------- GENERAL -------------------
+  .external.icon-context:before
+    padding: 4px 4px 0 0
+
   fieldset.collapsible legend
     font-weight: bold
     font-size: $wiki-toc-header-font-size

--- a/app/assets/stylesheets/layout/_work_package_table_embedded.sass
+++ b/app/assets/stylesheets/layout/_work_package_table_embedded.sass
@@ -56,29 +56,6 @@ $table-timeline--compact-row-height: 28px
       &:hover
         @include varprop(background-color, table-row-highlighting-color)
 
-    // In FF there is bug (https://bugzilla.mozilla.org/show_bug.cgi?id=688556) which causes
-    // the border of tables to vanish once the background of table cells is set.
-    // Therefor we need to disable the automatic table border rendering with border-collapse: collapse and
-    // add the borders manually.
-    .work-package-table
-      border-collapse: separate
-      border: none
-      padding: 0
-
-      .wp-table--table-header:not(:last-of-type)
-        border-right: 0px solid #bbb
-        &:first-of-type
-          border-left: 1px solid #bbb
-
-      .wp-table--cell-td:not(:last-of-type)
-        border-right: 0px solid #bbb
-        &:first-of-type
-          border-left: 1px solid #bbb
-      .wp-table--row:not(:last-of-type)
-        .wp-table--cell-td
-          border-bottom: 0px solid #bbb
-
-
     thead,
     .generic-table--sort-header-outer
       line-height: $table-timeline--compact-row-height

--- a/app/assets/stylesheets/openproject/_legacy.sass
+++ b/app/assets/stylesheets/openproject/_legacy.sass
@@ -359,10 +359,6 @@ div.issue hr
 .question .wiki
   margin: 0
 
-.wiki
-  ol, ul
-    margin-bottom: 6px
-
 // The min-height takes care that menus within the toolbar can be seen.
 // On the full screen view the min-height crashes the complete view
 // when anchors in the url were used on small sreens, because there the body is not scrollable.


### PR DESCRIPTION
In the wiki we want tables to have a border. Therefore we introduced in https://github.com/opf/openproject/pull/6444 styling rules. However currently these rules apply to all compact tables which results in strange behavior on the WP page. That is why this PR limits these rules to the wiki tables.

https://community.openproject.com/projects/deutsche-bahn/work_packages/28088/activity