### PR TITLE
[28115] MultiCF controls cannot be clicked

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_textareas.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_textareas.sass
@@ -75,6 +75,7 @@
   text-align: center
   // Align controls via flex
   display: flex
+  z-index: 1
 
 // Disabled submit styles when not applicable
 .inplace-edit--control--save[disabled] a,


### PR DESCRIPTION
Lay controls over the application to make them always clickable

https://community.openproject.com/projects/openproject/work_packages/28115/activity