### PR TITLE
[28120] Set location.href when outside wp-base application

### DIFF
--- a/frontend/src/app/components/routing/first-route-service.ts
+++ b/frontend/src/app/components/routing/first-route-service.ts
@@ -36,8 +36,12 @@ export class FirstRouteService {
 
   constructor() {}
 
+  public get isEmpty() {
+    return !this.name;
+  }
+
   public setIfFirst(stateName:string|undefined, params:any) {
-    if (this.name || !stateName) {
+    if (!this.isEmpty || !stateName) {
       return;
     }
 

--- a/frontend/src/app/components/routing/main/work-packages-base.component.ts
+++ b/frontend/src/app/components/routing/main/work-packages-base.component.ts
@@ -29,8 +29,10 @@
 import {Component} from "@angular/core";
 import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
 
+export const wpBaseAppSelector = 'work-packages-base';
+
 @Component({
-  selector: 'work-packages-base',
+  selector: wpBaseAppSelector,
   template: `
     <div class="work-packages-page--ui-view">
       <ui-view></ui-view>
@@ -40,4 +42,4 @@ import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
 export class WorkPackagesBaseComponent {
 }
 
-DynamicBootstrapper.register({ selector: 'work-packages-base', cls: WorkPackagesBaseComponent });
+DynamicBootstrapper.register({ selector: wpBaseAppSelector, cls: WorkPackagesBaseComponent });

--- a/spec/features/wysiwyg/macros/embedded_tables_spec.rb
+++ b/spec/features/wysiwyg/macros/embedded_tables_spec.rb
@@ -100,6 +100,10 @@ describe 'Wysiwyg embedded work package tables',
 
         embedded_table = ::Pages::EmbeddedWorkPackagesTable.new find('.wiki-content')
         embedded_table.expect_work_package_listed work_package
+
+        # Clicking on work package ID redirects
+        full_view = embedded_table.open_full_screen_by_doubleclick work_package
+        full_view.ensure_page_loaded
       end
     end
   end


### PR DESCRIPTION
When we're not within our routed application, state transitions have no effect other than alterting the URL bar.

Instead, move users to the requested page.

https://community.openproject.com/wp/28120