### PR TITLE
[26833] Allow view_members to be public permission

### DIFF
--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -59,7 +59,8 @@ Redmine::AccessControl.map do |map|
                  require: :member
 
   map.permission :view_members,
-                 { members: [:index] }
+                 { members: [:index] },
+                 public: true
 
   map.permission :manage_versions,
                  { project_settings: [:show],

--- a/spec/permissions/view_members_spec.rb
+++ b/spec/permissions/view_members_spec.rb
@@ -1,0 +1,36 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require File.expand_path('../../support/permission_specs', __FILE__)
+
+describe MembersController, 'view_members permission', type: :controller do
+  include PermissionSpecs
+
+  check_permission_required_for('members#index', :view_members, publishable_permission: true)
+end


### PR DESCRIPTION
When a project is a public, a non-member user should be able to:

- View members
- Also in the my_project page (controlled by :view_members)

https://community.openproject.com/wp/26833