### PR TITLE
[27873] Overlapping menus in mobile view

### DIFF
--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -234,6 +234,8 @@
 
     registerEventHandlers: function () {
       var self = this;
+      var toggler = $("#main-menu-toggle");
+
       this.menu_container.on("closeDropDown", function (event) {
         self.close($(event.target));
       }).on("openDropDown", function (event) {
@@ -243,6 +245,10 @@
       }).on("openMenu", function () {
         self.open(self.dropdowns().first());
         self.opening();
+      });
+
+      toggler.on("click", function() {  // click on hamburger icon is closing other menu
+        self.closing();
       });
     }
   });

--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -39,12 +39,12 @@
   #content-wrapper
     padding-bottom: 0 !important
     position: relative !important
-    top: 0 !important
     min-height: calc(100vH - #{$header-height-mobile})
 
   #main
     height: initial !important
     overflow: auto !important
+    top: 55px !important
 
   #header
     min-width: 0 !important
@@ -57,6 +57,7 @@
     margin: 0 !important
     padding: 20px !important
     width: 100% !important
+    top: 0 !important
   #main-menu ~ #content-wrapper
     padding: 5px 15px 0 15px !important
 

--- a/app/assets/stylesheets/layout/_main_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_main_menu_mobile.sass
@@ -35,6 +35,7 @@
     border-bottom: 1px solid $main-menu-border-color
     width: 100vw !important
     border: none
+    box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.15)
 
     %absolute-layout-mode &
       height: auto
@@ -47,3 +48,6 @@
 
   .main-menu--resizer
     display: none
+
+  #wrapper:not(.hidden-navigation) #main-menu-toggle i:before
+    @include icon-mixin-close

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -296,29 +296,3 @@
 .toolbar
   *
     outline: none
-
-@include breakpoint(680px down)
-  .toolbar-container .toolbar-items
-    background: #fff
-    display: flex
-    width: calc(100% + 5px)
-
-    &:not(:empty)
-      margin-bottom: 20px
-    > li
-      -webkit-flex: 1 0 0
-      flex: 1 0 0
-
-      &:first-child
-        -webkit-flex: 3 0 0
-        flex: 3 0 0
-
-      .button
-        width: 100%
-        white-space: nowrap
-
-      .button,
-      input,
-      label,
-      div
-        margin-top: 0

--- a/app/assets/stylesheets/layout/_toolbar_mobile.sass
+++ b/app/assets/stylesheets/layout/_toolbar_mobile.sass
@@ -30,19 +30,34 @@
   .toolbar-container
     margin-bottom: 0px
 
-  .toolbar-items
-    background: #fff
-    display: flex
-    margin-bottom: 20px
-    width: calc(100% + 5px)
+    .toolbar-items
+      background: #fff
+      display: flex
+      width: calc(100% + 5px)
+      margin-bottom: 20px
 
-    > li
-      -webkit-flex: 1 0 0
-      flex: 1 0 0
+      &:not(:empty)
+        margin-bottom: 20px
+      > li
+        -webkit-flex: 1 0 0
+        flex: 1 0 0
 
-      &:first-child
-        -webkit-flex: 3 0 0
-        flex: 3 0 0
+        // Add left margin for all visible toolbar elements except the first one
+        &:not(.hidden-for-mobile)
+          margin: 0px
+        &:not(.hidden-for-mobile) + :not(.hidden-for-mobile)
+          margin-left: 10px
 
-      button
-        width: 100%
+        &:first-child
+          -webkit-flex: 3 0 0
+          flex: 3 0 0
+
+        .button
+          width: 100%
+          white-space: nowrap
+
+        .button,
+        input,
+        label,
+        div
+          margin-top: 0

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -33,8 +33,10 @@
     background-color: transparent
 
   #top-menu
-    position: relative !important
+    position: fixed !important
     height: $header-height-mobile
+    top: 0px
+    left: 0px
 
     #nav-login-content
       float: none

--- a/app/assets/stylesheets/layout/_work_package_mobile.sass
+++ b/app/assets/stylesheets/layout/_work_package_mobile.sass
@@ -106,6 +106,7 @@
 
     .toolbar-container
       min-height: 36px
+      padding-right: 0
 
     .attributes-key-value--key,
     .attributes-key-value--value-container


### PR DESCRIPTION
This MR takes care of several mobile issues:

* Close other menus when opening the main menu
* Make the top menu fixed on mobile
* Add shadow to main menu
* Take care of toolbar paddings/margins
* Show close icon on mobile when the main menu is opened

https://community.openproject.com/projects/openproject/work_packages/27873/activity