### PR TITLE
Hide attachment list when attachments are empty

### DIFF
--- a/frontend/src/app/components/attachments/attachments.component.ts
+++ b/frontend/src/app/components/attachments/attachments.component.ts
@@ -110,6 +110,12 @@ export class AttachmentsComponent implements OnInit, OnDestroy {
     this.$formElement.off('submit.attachment-component');
   }
 
+  // Only show attachment list when allow uploading is set
+  // or when at least one attachment exists
+  public showAttachments() {
+    return this.allowUploading || _.get(this.resource, 'attachments.count', 0) > 0;
+  }
+
   private destroyRemovedAttachments() {
     let missingAttachments = _.differenceBy(this.initialAttachments,
       this.resource.attachments.elements,

--- a/frontend/src/app/components/attachments/attachments.html
+++ b/frontend/src/app/components/attachments/attachments.html
@@ -1,4 +1,4 @@
-<fieldset class="form--fieldset">
+<fieldset class="form--fieldset" *ngIf="showAttachments()">
   <legend class="form--fieldset-legend">
     {{ text.attachments }}
   </legend>

--- a/frontend/src/app/modules/hal/resources/mixins/attachable-mixin.ts
+++ b/frontend/src/app/modules/hal/resources/mixins/attachable-mixin.ts
@@ -81,6 +81,8 @@ export function Attachable<TBase extends Constructor<HalResource>>(Base:TBase) {
           .then(() => {
             if (!!this.attachmentsBackend) {
               this.updateAttachments();
+            } else {
+              this.attachments.count = Math.max(this.attachments.count - 1, 0);
             }
           })
           .catch((error:any) => {
@@ -108,6 +110,7 @@ export function Attachable<TBase extends Constructor<HalResource>>(Base:TBase) {
           if (!!this.attachmentsBackend && !this.isNew) {
             this.updateAttachments();
           } else {
+            this.attachments.count += result.length;
             result.forEach(r => {
               this.attachments.elements.push(r.response);
             });


### PR DESCRIPTION
When attachment uploading is forbidden and attachments are empty, currently there is an empty 'Files' legend that may be surprising.

We can hide it by deciding whether we should show it when:

- Uploading is allowed
- At least one attachment exists