### PR TITLE
[27253] Custom actions: Design buttons in WP full and split view

### DIFF
--- a/app/assets/stylesheets/content/_custom_actions.sass
+++ b/app/assets/stylesheets/content/_custom_actions.sass
@@ -28,8 +28,19 @@
 
 .custom-actions
   display: flex
-  flex-grow: 2
+  flex-wrap: wrap
   justify-content: flex-end
 
-.custom-action
-  margin-left: 0.625em
+  .custom-action
+    display: flex
+    justify-content: flex-end
+    flex: 1 1 10px
+    margin-bottom: 0.5rem
+    @include text-shortener
+
+    .button
+      @include text-shortener
+      width: 100%
+
+    &:not(:last-of-type)
+      margin-right: 0.625em

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -270,6 +270,26 @@ i
     margin: 0 10px 0 -10px
     .icon:before
       padding: 0
+  .work-packages--info-row
+    flex-grow: 1
+    margin-right: 5px
+
+  &.-wrapped
+    flex-wrap: wrap
+    .work-packages--info-row
+      order: -1
+      flex-basis: 100%
+      margin-bottom: 0.5rem
+
+    .wp-status-button
+      flex-grow: 1
+      margin-bottom: 0.5rem
+    attribute-help-text
+      // Take care that the help text is next to the button and the action buttons are still at the right side
+      flex-grow: 100
+      margin-bottom: 0.5rem
+    wp-custom-action
+      margin-bottom: 0.5rem
 
 .work-packages--new .wp-status-button
   padding: 3px

--- a/frontend/src/app/components/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/components/resizer/wp-resizer.component.ts
@@ -73,6 +73,7 @@ export class WpResizerDirective implements OnInit, OnDestroy {
     // Otherwise function will be executed with empty list
     jQuery(document).ready(() => {
       this.applyColumnLayout(this.resizingElement, this.elementFlex);
+      this.applyInfoRowLayout();
     });
 
     // Add event listener
@@ -87,8 +88,10 @@ export class WpResizerDirective implements OnInit, OnDestroy {
       .subscribe( changeData => {
         jQuery('.-can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left').width() > 750);
       });
+    let that = this;
     jQuery(window).resize(function() {
       jQuery('.-can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left').width() > 750);
+      that.applyInfoRowLayout();
     });
   }
 
@@ -171,6 +174,9 @@ export class WpResizerDirective implements OnInit, OnDestroy {
     // Apply two column layout
     this.applyColumnLayout(element, newValue);
 
+    // Apply info row Layout
+    this.applyInfoRowLayout();
+
     // Set new width
     element.style.flexBasis = newValue + 'px';
   }
@@ -184,5 +190,9 @@ export class WpResizerDirective implements OnInit, OnDestroy {
     else {
       element.classList.toggle('-columns-2', newWidth > 700);
     }
+  }
+
+  private applyInfoRowLayout() {
+    jQuery('.wp-info-wrapper').toggleClass('-wrapped', jQuery('.wp-info-wrapper').width() - jQuery('wp-custom-actions').width() - jQuery('wp-status-button').width() < 430);
   }
 }


### PR DESCRIPTION
This deal with Custom Action Buttons in the info row.

The behavior differs (because of the DOM structure) a bit from the one described in the ticket. Now it is a follows:

1. The info row moves at the top. This is based on an approximation. Since most of its content is fixed, I guess it is good enough.
2. The CustomAction buttons vary in their size. There is a maximum and minimum. However the buttons move to a new row before they shrink. I could not find any way around this because of the nested ActionButton structure. 

https://community.openproject.com/projects/openproject/work_packages/27253/activity