### PR TITLE
[28163] Show an error when WP page can be accessed, but WP not loaded

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,6 +109,8 @@
     "style-loader": "^0.8.3",
     "ticky": "^1.0.1",
     "ts-loader": "^4.3.1",
+    "node-sass": "^4.9.0",
+    "sass-loader": "^7.1.0",
     "typescript": "2.7.2",
     "ui-select": "~0.19.6",
     "url-loader": "^1.0.1",

--- a/frontend/src/app/components/work-packages/work-package-cache.service.ts
+++ b/frontend/src/app/components/work-packages/work-package-cache.service.ts
@@ -140,13 +140,19 @@ export class WorkPackageCacheService extends StateCacheService<WorkPackageResour
 
   protected load(id:string) {
     return new Promise<WorkPackageResource>((resolve, reject) => {
+
+      const errorAndReject = (error:any) => {
+        this.wpNotificationsService.handleErrorResponse(error);
+        reject(error);
+      };
+
       this.apiWorkPackages.loadWorkPackageById(id, true)
         .then((workPackage:WorkPackageResource) => {
           this.schemaCacheService.ensureLoaded(workPackage).then(() => {
             this.multiState.get(id).putValue(workPackage);
             resolve(workPackage);
-          }, reject);
-        }, reject);
+          }, errorAndReject);
+        }, errorAndReject);
     });
   }
 


### PR DESCRIPTION
When acessing a private subproject's WP with the URL of the public
parent, there was no error message  shown when the user was unable to
view the work package.

https://community.openproject.com/wp/28163