### PR TITLE
[28155] Replace calendar_for with global augmented datepickers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -421,40 +421,6 @@ module ApplicationHelper
     end
   end
 
-  def calendar_for(field_id)
-    # Ensure global AV context exists (when, e.g., called from widget)
-    @_request ||= request
-    include_calendar_headers_tags
-    nonced_javascript_tag <<-EOS
-      jQuery(function() { jQuery('##{field_id}').attr('autocomplete', 'off').datepicker(); });
-    EOS
-  end
-
-  def include_calendar_headers_tags
-    unless @calendar_headers_tags_included
-      @calendar_headers_tags_included = true
-      content_for :header_tags do
-        start_of_week = case Setting.start_of_week.to_i
-                        when 1
-                          '1' # Monday
-                        when 7
-                          '0' # Sunday
-                        when 6
-                          '6' # Saturday
-                        else
-                          # use language (pass a blank string into the JSON object,
-                          # as the datepicker implementation checks for numbers in
-                          # /frontend/app/misc/datepicker-defaults.js:34)
-                          '""'
-        end
-        # FIXME: Get rid of this abomination
-        nonced_javascript_tag do
-          "var CS = { lang: '#{current_language.to_s.downcase}', firstDay: #{start_of_week} };".html_safe
-        end.html_safe
-      end
-    end
-  end
-
   # Returns the javascript tags that are included in the html layout head
   def user_specific_javascript_includes
     tags = ''
@@ -467,10 +433,32 @@ module ApplicationHelper
       });
       I18n.defaultLocale = "#{I18n.default_locale}";
       I18n.locale = "#{I18n.locale}";
+      I18n.firstDayOfWeek = "#{locale_first_day_of_week}"
+
       }.html_safe
     end
 
     tags.html_safe
+  end
+
+  def calendar_for(*args)
+    ActiveSupport::Deprecation.warn "calendar_for has been removed. Please add the class '-augmented-datepicker' instead.", caller
+  end
+
+  def locale_first_day_of_week
+    case Setting.start_of_week.to_i
+    when 1
+      '1' # Monday
+    when 7
+      '0' # Sunday
+    when 6
+      '6' # Saturday
+    else
+      # use language (pass a blank string into the JSON object,
+      # as the datepicker implementation checks for numbers in
+      # /frontend/app/misc/datepicker-defaults.js:34)
+      ''
+    end
   end
 
   # To avoid the menu flickering, disable it

--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -52,8 +52,7 @@ module CustomFieldsHelper
 
     tag = case field_format.try(:edit_as)
           when 'date'
-            styled_text_field_tag(field_name, custom_value.value, id: field_id, size: 10) +
-            calendar_for(field_id)
+            styled_text_field_tag(field_name, custom_value.value, id: field_id, class: '-augmented-datepicker', size: 10)
           when 'text'
             styled_text_area_tag(field_name, custom_value.value, id: field_id, rows: 3)
           when 'bool'
@@ -118,8 +117,7 @@ module CustomFieldsHelper
     field_format = OpenProject::CustomFieldFormat.find_by_name(custom_field.field_format)
     case field_format.try(:edit_as)
     when 'date'
-      styled_text_field_tag(field_name, '', id: field_id, size: 10) +
-        calendar_for(field_id)
+      styled_text_field_tag(field_name, '', id: field_id, size: 10, class: '-augmented-datepicker')
     when 'text'
       styled_text_area_tag(field_name, '', id: field_id, rows: 3, with_text_formatting: true)
     when 'bool'

--- a/app/views/announcements/edit.html.erb
+++ b/app/views/announcements/edit.html.erb
@@ -11,8 +11,7 @@
     <%= f.text_area :text, :cols => 80, :rows => 5, label: t(:label_text), container_class: '-wide' %>
   </div>
   <div class="form--field">
-    <%= f.text_field :show_until, label: t('announcements.show_until'), container_class: '-xslim' %>
-    <%= calendar_for("announcement_show_until") %>
+    <%= f.text_field :show_until, label: t('announcements.show_until'), container_class: '-xslim', class: '-augmented-datepicker' %>
   </div>
   <div class="form--field">
     <%= f.check_box :active, label: t(:label_active) %>

--- a/app/views/custom_actions/_form.html.erb
+++ b/app/views/custom_actions/_form.html.erb
@@ -59,12 +59,11 @@
               </autocomplete-select-decoration>
             </div>
           <% elsif %i(date_property).include?(action.type) %>
-            <op-date-picker>
-              <%= styled_text_field_tag input_name,
-                                        action.values,
-                                        container_class: '-slim',
-                                        size: '10' %>
-            </op-date-picker>
+            <%= styled_text_field_tag input_name,
+                                      action.values,
+                                      container_class: '-slim',
+                                      class: '-augmented-datepicker',
+                                      size: '10' %>
           <% elsif %i(string_property text_property).include?(action.type) %>
             <%= styled_text_field_tag input_name,
                                       action.values,

--- a/app/views/projects/filters/date/_between_dates.html.erb
+++ b/app/views/projects/filters/date/_between_dates.html.erb
@@ -1,8 +1,6 @@
 <div class="between-dates">
   <span><%= t(:label_date_from) %>:</span>
-  <%= text_field_tag :from_value, from_value, id: "between-dates-from-value-#{filter.name}", class: 'advanced-filters--text-field -slim', size: '10' %>
-  <%= calendar_for("between-dates-from-value-#{filter.name}") %>
+  <%= text_field_tag :from_value, from_value, id: "between-dates-from-value-#{filter.name}", class: 'advanced-filters--text-field -augmented-datepicker -slim', size: '10' %>
   <span><%= t(:label_date_to) %>:</span>
-  <%= text_field_tag :to_value, to_value, id: "between-dates-to-value-#{filter.name}", class: 'advanced-filters--text-field -slim', size: '10' %>
-  <%= calendar_for("between-dates-to-value-#{filter.name}") %>
+  <%= text_field_tag :to_value, to_value, id: "between-dates-to-value-#{filter.name}", class: 'advanced-filters--text-field -augmented-datepicker -slim', size: '10' %>
 </div>

--- a/app/views/projects/filters/date/_on_date.html.erb
+++ b/app/views/projects/filters/date/_on_date.html.erb
@@ -1,8 +1,7 @@
 <div class="on-date">
   <div class="form--field-container">
     <div class="form--text-field-container -slim">
-      <%= text_field_tag :value, value, id: "on-date-value-#{filter.name}", class: 'advanced-filters--text-field -slim', size: '10' %>
-      <%= calendar_for("on-date-value-#{filter.name}") %>
+      <%= text_field_tag :value, value, id: "on-date-value-#{filter.name}", class: 'advanced-filters--text-field -slim -augmented-datepicker', size: '10' %>
     </div>
   </div>
 </div>

--- a/app/views/timelog/_date_range.html.erb
+++ b/app/views/timelog/_date_range.html.erb
@@ -45,13 +45,11 @@ See docs/COPYRIGHT.rdoc for more details.
       <%= styled_radio_button_tag 'period_type', '2', @free_period, id: "period_type_interval" %>
       <%= styled_label_tag("from", l(:label_date_from), class: 'simple-filters--filter-name') %>
       <div class="simple-filters--filter-value">
-        <%= styled_text_field_tag('from', @from, size: 10) %>
-        <%= calendar_for('from') %>
+        <%= styled_text_field_tag('from', @from, class: '-augmented-datepicker', size: 10) %>
       </div>
       <%= styled_label_tag("to", l(:label_date_to), class: 'simple-filters--filter-name') %>
       <div class="simple-filters--filter-value">
-        <%= styled_text_field_tag('to', @to, size: 10) %>
-        <%= calendar_for('to') %>
+        <%= styled_text_field_tag('to', @to, class: '-augmented-datepicker', size: 10) %>
       </div>
     </li>
     <li class="simple-filters--controls">

--- a/app/views/timelog/edit.html.erb
+++ b/app/views/timelog/edit.html.erb
@@ -40,12 +40,11 @@ See docs/COPYRIGHT.rdoc for more details.
   </div>
 
   <div class="form--field -required">
-    <%= f.text_field :spent_on, size: 10, required: true, container_class: '-xslim' %>
-    <%= calendar_for('time_entry_spent_on') %>
+    <%= f.text_field :spent_on, size: 10, required: true, container_class: '-xslim', class: '-augmented-datepicker' %>
   </div>
 
   <div class="form--field -required">
-    <%= f.text_field :hours, size: 6, required: true, container_class: '-xslim' %>
+    <%= f.text_field :hours, size: 6, required: true, container_class: '-xslim', class: '-augmented-datepicker' %>
   </div>
 
   <div class="form--field">

--- a/app/views/versions/_form.html.erb
+++ b/app/views/versions/_form.html.erb
@@ -58,13 +58,11 @@ See docs/COPYRIGHT.rdoc for more details.
 </div>
 
 <div class="form--field">
-  <%= f.text_field :start_date, container_class: '-xslim' %>
-  <%= calendar_for('version_start_date') %>
+  <%= f.text_field :start_date, container_class: '-xslim', class: '-augmented-datepicker' %>
 </div>
 
 <div class="form--field">
-  <%= f.text_field :effective_date, container_class: '-xslim'%>
-  <%= calendar_for('version_effective_date') %>
+  <%= f.text_field :effective_date, container_class: '-xslim', class: '-augmented-datepicker' %>
 </div>
 
 <div class="form--field">

--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -126,13 +126,13 @@ See docs/COPYRIGHT.rdoc for more details.
           <div class="form--field">
             <label class="form--label" for='work_package_start_date'><%= WorkPackage.human_attribute_name(:start_date) %></label>
             <div class="form--field-container">
-              <%= styled_text_field_tag 'work_package[start_date]', '', size: 10 %><%= calendar_for('work_package_start_date') %>
+              <%= styled_text_field_tag 'work_package[start_date]', '', size: 10, class: '-augmented-datepicker' %>
             </div>
           </div>
           <div class="form--field">
             <label class="form--label" for='work_package_due_date'><%= WorkPackage.human_attribute_name(:due_date) %></label>
             <div class="form--field-container">
-              <%= styled_text_field_tag 'work_package[due_date]', '', size: 10 %><%= calendar_for('work_package_due_date') %>
+              <%= styled_text_field_tag 'work_package[due_date]', '', size: 10, class: '-augmented-datepicker' %>
             </div>
           </div>
           <% if WorkPackage.use_field_for_done_ratio? %>

--- a/app/views/work_packages/moves/new.html.erb
+++ b/app/views/work_packages/moves/new.html.erb
@@ -116,13 +116,13 @@ See docs/COPYRIGHT.rdoc for more details.
             <div class="form--field">
               <label class="form--label" for='start_date'><%= WorkPackage.human_attribute_name(:start_date) %></label>
               <div class="form--field-container">
-                <%= styled_text_field_tag 'start_date', '', size: 10 %><%= calendar_for('start_date') %>
+                <%= styled_text_field_tag 'start_date', '', size: 10, class: '-augmented-datepicker' %>
               </div>
             </div>
             <div class="form--field">
               <label class="form--label" for='due_date'><%= WorkPackage.human_attribute_name(:due_date) %></label>
               <div class="form--field-container">
-                <%= styled_text_field_tag 'due_date', '', size: 10 %><%= calendar_for('due_date') %>
+                <%= styled_text_field_tag 'due_date', '', size: 10, class: '-augmented-datepicker' %>
               </div>
             </div>
           </div>

--- a/frontend/src/app/globals/global-listeners.ts
+++ b/frontend/src/app/globals/global-listeners.ts
@@ -26,48 +26,26 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
+import {performAnchorHijacking} from "./global-listeners/link-hijacking";
+import {augmentedDatePicker} from "./global-listeners/augmented-date-picker";
+
 /**
  * A set of listeners that are relevant on every page to set sensible defaults
  */
 (function($:JQueryStatic) {
 
-  // Our application is still a hybrid one, meaning most routes are still
-  // handled by Rails. As such, we disable the default link-hijacking that
-  // Angular's HTML5-mode turns on.
+
   $(function() {
     $(document.documentElement)
-      // Prevent angular handling clicks on href="#..." links from other libraries
-      // (especially jquery-ui and its datepicker) from routing to <base url>/#
       .on('click', (evt) => {
         const target = jQuery(evt.target);
 
-        // Avoid defaulting clicks on elements already removed from DOM
-        if (!document.contains(evt.target)) {
-          evt.preventDefault();
-        }
+        // Create datepickers dynamically for Rails-based views
+        augmentedDatePicker(evt, target);
 
-        // Avoid handling clicks on anything other than a
-        const linkElement = target.closest('a');
-        if (linkElement.length === 0) {
-          return true;
-        }
-
-        const link = linkElement.attr('href') || '';
-        const hashPos = link.indexOf('#');
-
-        // If link is neither empty nor starts with hash, ignore it
-        if (link !== '' && hashPos === -1) {
-          return true;
-        }
-
-        // Set the location to the hash if there is any
-        // Since with the base tag, links like href="#whatever" otherwise target to <base>/#whatever
-        if (hashPos !== -1 && link !== '#') {
-          window.location.hash = link;
-        }
-
-        evt.preventDefault();
-        return false;
+        // Prevent angular handling clicks on href="#..." links from other libraries
+        // (especially jquery-ui and its datepicker) from routing to <base url>/#
+        return performAnchorHijacking(evt, target);
       });
 
     // Disable global drag & drop handling, which results in the browser loading the image and losing the page

--- a/frontend/src/app/globals/global-listeners/augmented-date-picker.ts
+++ b/frontend/src/app/globals/global-listeners/augmented-date-picker.ts
@@ -1,0 +1,15 @@
+/**
+ * Our application is still a hybrid one, meaning most routes are still
+ * handled by Rails. As such, we disable the default link-hijacking that
+ * Angular's HTML5-mode with <base href="/"> results in
+ * @param evt
+ * @param target
+ */
+export function augmentedDatePicker(evt:JQueryEventObject, target:JQuery) {
+  if (target.hasClass('-augmented-datepicker')) {
+    target
+      .attr('autocomplete', 'off') // Disable autocomplete for those fields
+      .datepicker() // Create datepicker with defaults
+      .datepicker('show'); // And show immediately since the click is not yet wired to the datepicker instance
+  }
+}

--- a/frontend/src/app/globals/global-listeners/link-hijacking.ts
+++ b/frontend/src/app/globals/global-listeners/link-hijacking.ts
@@ -1,0 +1,36 @@
+/**
+ * Our application is still a hybrid one, meaning most routes are still
+ * handled by Rails. As such, we disable the default link-hijacking that
+ * Angular's HTML5-mode with <base href="/"> results in
+ * @param evt
+ * @param target
+ */
+export function performAnchorHijacking(evt:JQueryEventObject, target:JQuery):boolean {
+  // Avoid defaulting clicks on elements already removed from DOM
+  if (!document.contains(evt.target)) {
+    evt.preventDefault();
+  }
+
+  // Avoid handling clicks on anything other than a
+  const linkElement = target.closest('a');
+  if (linkElement.length === 0) {
+    return true;
+  }
+
+  const link = linkElement.attr('href') || '';
+  const hashPos = link.indexOf('#');
+
+  // If link is neither empty nor starts with hash, ignore it
+  if (link !== '' && hashPos === -1) {
+    return true;
+  }
+
+  // Set the location to the hash if there is any
+  // Since with the base tag, links like href="#whatever" otherwise target to <base>/#whatever
+  if (hashPos !== -1 && link !== '#') {
+    window.location.hash = link;
+  }
+
+  evt.preventDefault();
+  return false;
+}

--- a/frontend/src/app/misc/datepicker-defaults.js
+++ b/frontend/src/app/misc/datepicker-defaults.js
@@ -30,9 +30,8 @@ jQuery(function($) {
   var regional = regions[I18n.locale] || regions[''];
 
   // see ./app/helpers/application_helper.rb:508
-  var CS = window.CS || {};
-  if (typeof CS.firstDay === 'number') {
-    regional.firstDay = CS.firstDay;
+  if (typeof I18n.firstDayOfWeek === 'number') {
+    regional.firstDay = I18n.firstDayOfWeek;
   }
 
   $.datepicker.setDefaults(regional);

--- a/lib/custom_field_form_builder.rb
+++ b/lib/custom_field_form_builder.rb
@@ -64,8 +64,8 @@ class CustomFieldFormBuilder < TabularFormBuilder
 
     case field_format.try(:edit_as)
     when 'date'
-      text_field(field, input_options) +
-        template.calendar_for(custom_field_field_id)
+      input_options[:class] = (input_options[:class] || '') << ' -augmented-datepicker'
+      text_field(field, input_options)
     when 'text'
       text_area(field, input_options.merge(rows: 3))
     when 'bool'

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -72,10 +72,6 @@ describe CustomFieldFormBuilder do
 
     context 'for a date custom field' do
       before do
-        expect(helper)
-          .to receive(:calendar_for)
-          .with("user#{resource.custom_field_id}")
-
         resource.custom_field.field_format = 'date'
       end
 
@@ -85,7 +81,7 @@ describe CustomFieldFormBuilder do
 
       it 'should output element' do
         expect(output).to be_html_eql(%{
-          <input class="custom-class form--text-field"
+          <input class="custom-class -augmented-datepicker form--text-field"
                  id="user#{resource.custom_field_id}"
                  name="user[#{resource.custom_field_id}]"
                  type="text" />


### PR DESCRIPTION
Allow to create and reuse datepicker fields through a global event
listener instead of calling `calendar_for` in Rails.

This allows us to use a datepicker even in the legacy app.

https://community.openproject.com/wp/28155