### PR TITLE
use absolute URLs for user mentions so they work in emails too

### DIFF
--- a/lib/open_project/object_linking.rb
+++ b/lib/open_project/object_linking.rb
@@ -44,8 +44,12 @@ module OpenProject
     def link_to_user(user, options = {})
       if user.is_a?(User)
         name = user.name
+        only_path = options.delete(:only_path) { false }
+
         if user.active? || user.registered? || user.invited?
-          link_to(name, user, options)
+          href = only_path ? user_path(user) : user_url(user)
+
+          link_to(name, href, options)
         else
           name
         end

--- a/lib/open_project/object_linking.rb
+++ b/lib/open_project/object_linking.rb
@@ -44,7 +44,8 @@ module OpenProject
     def link_to_user(user, options = {})
       if user.is_a?(User)
         name = user.name
-        only_path = options.delete(:only_path) { false }
+        only_path = options.delete(:only_path)
+        only_path = true if only_path.nil?
 
         if user.active? || user.registered? || user.invited?
           href = only_path ? user_path(user) : user_url(user)

--- a/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
@@ -138,7 +138,7 @@ module OpenProject::TextFormatting::Matchers
 
       def render_user
         if (user = User.in_visible_project.find_by(login: oid))
-          link_to_user(user, class: 'user-mention')
+          link_to_user(user, only_path: context[:only_path], class: 'user-mention')
         end
       end
     end

--- a/lib/open_project/text_formatting/matchers/link_handlers/hash_separator.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/hash_separator.rb
@@ -85,7 +85,7 @@ module OpenProject::TextFormatting::Matchers
       def render_user
         user = User.in_visible_project.find_by(id: oid)
         if user
-          link_to_user(user, class: 'user-mention')
+          link_to_user(user, only_path: context[:only_path], class: 'user-mention')
         end
       end
 

--- a/spec/lib/open_project/text_formatting/markdown/markdown_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/markdown_formatting_spec.rb
@@ -67,7 +67,7 @@ describe OpenProject::TextFormatting::Formats::Markdown::Formatter do
     HTML
     assert_html_output({
                          '# 2009\02\09' => html
-                       }, false)
+                       }, expect_paragraph: false)
   end
 
   it 'should double dashes should not strikethrough' do
@@ -96,7 +96,7 @@ describe OpenProject::TextFormatting::Formats::Markdown::Formatter do
       )
     end
 
-    context 'when visible user exists', with_settings: { host_name: "openproject.org" } do
+    context 'when visible user exists' do
       let(:project) { FactoryBot.create :project }
       let(:role) { FactoryBot.create(:role, permissions: %i(view_work_packages)) }
       let(:current_user) do
@@ -118,10 +118,24 @@ describe OpenProject::TextFormatting::Formats::Markdown::Formatter do
         login_as current_user
       end
 
-      it 'outputs the reference' do
-        assert_html_output(
-          'Link to user:"foo@bar.com"' => %(Link to <a class="user-mention" href="http://openproject.org/users/#{user.id}">Foo Barrit</a>)
-        )
+      context 'with path only' do
+        it 'outputs the reference' do
+          assert_html_output(
+            'Link to user:"foo@bar.com"' => %(Link to <a class="user-mention" href="/users/#{user.id}">Foo Barrit</a>)
+          )
+        end
+      end
+
+      context 'with absolute URLs (path_only is false)', with_settings: { host_name: "openproject.org" } do
+        it 'outputs the reference' do
+          assert_html_output(
+            {
+              'Link to user:"foo@bar.com"' =>
+                %(Link to <a class="user-mention" href="http://openproject.org/users/#{user.id}">Foo Barrit</a>)
+            },
+            only_path: false
+          )
+        end
       end
     end
   end
@@ -291,19 +305,22 @@ describe OpenProject::TextFormatting::Formats::Markdown::Formatter do
       <p>Some text after the second h3 heading</p>
     HTML
 
-    assert_html_output({ markdown => html }, false)
+    assert_html_output({ markdown => html }, expect_paragraph: false)
   end
 
   private
 
-  def assert_html_output(to_test, expect_paragraph = true)
+  def assert_html_output(to_test, options = {})
+    options = { expect_paragraph: true }.merge options
+    expect_paragraph = options.delete :expect_paragraph
+
     to_test.each do |text, expected|
       expected = expect_paragraph ? "<p>#{expected}</p>" : expected
-      expect(to_html(text)).to be_html_eql expected
+      expect(to_html(text, options)).to be_html_eql expected
     end
   end
 
-  def to_html(text)
-    described_class.new({}).to_html(text)
+  def to_html(text, options = {})
+    described_class.new(options).to_html(text)
   end
 end

--- a/spec/lib/open_project/text_formatting/markdown/markdown_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/markdown_formatting_spec.rb
@@ -96,7 +96,7 @@ describe OpenProject::TextFormatting::Formats::Markdown::Formatter do
       )
     end
 
-    context 'when visible user exists' do
+    context 'when visible user exists', with_settings: { host_name: "openproject.org" } do
       let(:project) { FactoryBot.create :project }
       let(:role) { FactoryBot.create(:role, permissions: %i(view_work_packages)) }
       let(:current_user) do
@@ -120,7 +120,7 @@ describe OpenProject::TextFormatting::Formats::Markdown::Formatter do
 
       it 'outputs the reference' do
         assert_html_output(
-          'Link to user:"foo@bar.com"' => %(Link to <a class="user-mention" href="/users/#{user.id}">Foo Barrit</a>)
+          'Link to user:"foo@bar.com"' => %(Link to <a class="user-mention" href="http://openproject.org/users/#{user.id}">Foo Barrit</a>)
         )
       end
     end


### PR DESCRIPTION
WP [#28152](https://community.openproject.com/projects/openproject/work_packages/28152/activity?query_id=1283)

This makes it so that absolute URLs are used by default when linking users. This way links to users in emails will work too since they are not just relative paths anymore.