### PR TITLE
[28287] Implement all UserMailer actions as delayed jobs

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -114,7 +114,7 @@ class AccountController < ApplicationController
       # create a new token for password recovery
       token = Token::Recovery.new(user_id: user.id)
       if token.save
-        UserMailer.password_lost(token).deliver_now
+        UserMailer.password_lost(token)
         flash[:notice] = l(:notice_account_lost_email_sent)
         redirect_to action: 'login', back_url: home_url
         return
@@ -493,7 +493,7 @@ class AccountController < ApplicationController
   end
 
   def send_activation_email!(token)
-    UserMailer.user_signed_up(token).deliver_now
+    UserMailer.user_signed_up(token)
   end
 
   def pending_auth_source_registration?
@@ -632,7 +632,7 @@ class AccountController < ApplicationController
       # Sends an email to the administrators
       admins = User.admin.active
       admins.each do |admin|
-        UserMailer.account_activation_requested(admin, user).deliver_now
+        UserMailer.account_activation_requested(admin, user)
       end
       account_pending
     else

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -52,7 +52,7 @@ class AdminController < ApplicationController
     # Force ActionMailer to raise delivery errors so we can catch it
     ActionMailer::Base.raise_delivery_errors = true
     begin
-      @test = UserMailer.test_mail(User.current).deliver_now
+      @test = UserMailer.deliver_immediately!(:test_mail, User.current)
       flash[:notice] = I18n.t(:notice_email_sent, value: User.current.mail)
     rescue => e
       flash[:error] = I18n.t(:notice_email_error, value: Redmine::CodesetUtil.replace_invalid_utf8(e.message.dup))

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -176,7 +176,7 @@ class UsersController < ApplicationController
         end
 
         if @user.active? && send_information
-          UserMailer.account_information(@user, @user.password).deliver_now
+          UserMailer.account_information(@user, @user.password)
         end
       end
 
@@ -240,7 +240,7 @@ class UsersController < ApplicationController
     elsif @user.save
       flash[:notice] = I18n.t(:notice_successful_update)
       if was_activated
-        UserMailer.account_activated(@user).deliver_now
+        UserMailer.account_activated(@user)
       end
     else
       flash[:error] = I18n.t(:error_status_change_failed,

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -52,7 +52,7 @@ class Comment < ActiveRecord::Base
 
     recipients = commented.recipients + commented.watcher_recipients
     recipients.uniq.each do |user|
-      UserMailer.news_comment_added(user, self, User.current).deliver_now
+      UserMailer.news_comment_added(user, self, User.current)
     end
   end
 end

--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -100,7 +100,7 @@ class MailHandler < ActionMailer::Base
         @user = MailHandler.create_user_from_email(email)
         if @user
           log "[#{@user.login}] account created"
-          UserMailer.account_information(@user, @user.password).deliver_now
+          UserMailer.account_information(@user, @user.password)
         else
           log "could not create account for [#{sender_email}]", :error
           return false

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -151,9 +151,8 @@ class Message < ActiveRecord::Base
     to_mail = recipients +
               root.watcher_recipients +
               board.watcher_recipients
-
     to_mail.uniq.each do |user|
-      UserMailer.message_posted(user, self, User.current).deliver_now
+      UserMailer.message_posted(user, self, User.current)
     end
   end
 end

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -105,7 +105,7 @@ class News < ActiveRecord::Base
   def send_news_added_mail
     if Setting.notified_events.include?('news_added')
       recipients.uniq.each do |user|
-        UserMailer.news_added(user, self, User.current).deliver_now
+        UserMailer.news_added(user, self, User.current)
       end
     end
   end

--- a/app/models/wiki_content.rb
+++ b/app/models/wiki_content.rb
@@ -92,7 +92,7 @@ class WikiContent < ActiveRecord::Base
     return unless Setting.notified_events.include?('wiki_content_added')
 
     create_recipients.uniq.each do |user|
-      UserMailer.wiki_content_added(user, self, User.current).deliver_now
+      UserMailer.wiki_content_added(user, self, User.current)
     end
   end
 
@@ -100,7 +100,7 @@ class WikiContent < ActiveRecord::Base
     return unless Setting.notified_events.include?('wiki_content_updated')
 
     update_recipients.uniq.each do |user|
-      UserMailer.wiki_content_updated(user, self, User.current).deliver_now
+      UserMailer.wiki_content_updated(user, self, User.current)
     end
   end
 

--- a/app/views/settings/_notifications.html.erb
+++ b/app/views/settings/_notifications.html.erb
@@ -31,7 +31,6 @@ See docs/COPYRIGHT.rdoc for more details.
     <section class="form--section">
       <div class="form--field"><%= setting_text_field :mail_from, size: 60, container_class: '-middle' %></div>
       <div class="form--field"><%= setting_check_box :bcc_recipients %></div>
-      <div class="form--field"><%= setting_check_box :plain_text_mail %></div>
       <div class="form--field"><%= setting_select(:default_notification_option, User.valid_notification_options.collect {|o| [t(o.last), o.first.to_s]}, container_class: '-middle') %></div>
     </section>
     <fieldset id="notified_events" class="form--fieldset"><legend class="form--fieldset-legend"><%=t(:text_select_mail_notifications)%></legend>

--- a/app/workers/copy_project_job.rb
+++ b/app/workers/copy_project_job.rb
@@ -56,11 +56,11 @@ class CopyProjectJob < ApplicationJob
     }
 
     if target_project
-      UserMailer.copy_project_succeeded(user, source_project, target_project, errors).deliver_now
+      UserMailer.copy_project_succeeded(user, source_project, target_project, errors)
     else
       target_project_name = target_project_params['name']
 
-      UserMailer.copy_project_failed(user, source_project, target_project_name, errors).deliver_now
+      UserMailer.copy_project_failed(user, source_project, target_project_name, errors)
     end
   end
 

--- a/app/workers/deliver_invitation_job.rb
+++ b/app/workers/deliver_invitation_job.rb
@@ -36,7 +36,7 @@ class DeliverInvitationJob < ApplicationJob
 
   def perform
     if token
-      UserMailer.user_signed_up(token).deliver_now
+      UserMailer.user_signed_up(token)
     else
       Rails.logger.warn "Can't deliver invitation. The token is missing: #{token_id}"
     end

--- a/app/workers/deliver_notification_job.rb
+++ b/app/workers/deliver_notification_job.rb
@@ -38,6 +38,7 @@ class DeliverNotificationJob < ApplicationJob
     return unless recipient
 
     mail = User.execute_as(recipient) { build_mail }
+
     if mail
       mail.deliver_now
     end
@@ -55,7 +56,7 @@ class DeliverNotificationJob < ApplicationJob
   def build_mail
     render_mail(recipient: recipient, sender: sender)
   rescue StandardError => e
-    Rails.logger.error "#{self.class.name}: Unexpected error rendering a mail: #{e}"
+    Rails.logger.error "#{self.class.name}: Unexpected error while generating a mail: #{e} #{e.message}"
     # not raising, to avoid re-schedule of DelayedJob; don't expect render errors to fix themselves
     # by retrying
     nil

--- a/app/workers/deliver_watcher_notification_job.rb
+++ b/app/workers/deliver_watcher_notification_job.rb
@@ -38,7 +38,7 @@ class DeliverWatcherNotificationJob < DeliverNotificationJob
   def render_mail(recipient:, sender:)
     return nil unless watcher
 
-    UserMailer.work_package_watcher_added(watcher.watchable, recipient, sender)
+    UserMailer.work_package_watcher_added! watcher.watchable, recipient, sender
   end
 
   private

--- a/app/workers/deliver_work_package_notification_job.rb
+++ b/app/workers/deliver_work_package_notification_job.rb
@@ -43,9 +43,9 @@ class DeliverWorkPackageNotificationJob < DeliverNotificationJob
     raise 'aggregated journal got outdated' unless journal
 
     if journal.initial?
-      UserMailer.work_package_added(recipient, journal, sender)
+      UserMailer.work_package_added! recipient, journal, sender
     else
-      UserMailer.work_package_updated(recipient, journal, sender)
+      UserMailer.work_package_updated! recipient, journal, sender
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2042,7 +2042,6 @@ en:
   setting_password_min_length: "Minimum length"
   setting_password_min_adhered_rules: "Minimum number of required classes"
   setting_per_page_options: "Objects per page options"
-  setting_plain_text_mail: "Plain text mail (no HTML)"
   setting_protocol: "Protocol"
   setting_registration_footer: "Registration footer"
   setting_repositories_automatic_managed_vendor: "Automatic repository vendor type"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -139,8 +139,6 @@ mail_from:
   default: openproject@example.net
 bcc_recipients:
   default: 1
-plain_text_mail:
-  default: 0
 cache_formatted_text:
   default: 0
 wiki_compression:

--- a/lib/open_project/enterprise.rb
+++ b/lib/open_project/enterprise.rb
@@ -73,7 +73,7 @@ module OpenProject
       # the user limit having been reached.
       def send_activation_limit_notification_about(user)
         User.active.admin.each do |admin|
-          MailUserJob.activation_limit_reached(user.mail, admin)
+          UserMailer.activation_limit_reached(user.mail, admin)
         end
       end
 

--- a/lib/plugins/acts_as_journalized/lib/journal_changes.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_changes.rb
@@ -34,7 +34,7 @@ module JournalChanges
 
     @changes = HashWithIndifferentAccess.new
 
-    if predecessor.nil?
+    if predecessor.nil? || predecessor.data.nil?
       @changes = data.journaled_attributes
                  .reject { |_, new_value| new_value.nil? }
                  .inject({}) { |result, (attribute, new_value)|

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -193,7 +193,7 @@ END_DESC
       ActionMailer::Base.raise_delivery_errors = true
 
       begin
-        UserMailer.test_mail(user).deliver_now
+        UserMailer.deliver_immediately!(:test_mail, user)
         puts I18n.t(:notice_email_sent, value: user.mail)
       rescue => e
         abort I18n.t(:notice_email_error, e.message)

--- a/spec/controllers/copy_projects_controller_spec.rb
+++ b/spec/controllers/copy_projects_controller_spec.rb
@@ -143,15 +143,9 @@ describe CopyProjectsController, type: :controller do
   end
 
   describe 'copy sends eMail' do
-    let(:maildouble) { double('Mail::Message', deliver: true) }
-
-    before do
-      allow(maildouble).to receive(:deliver_now).and_return nil
-    end
-
     context 'on success' do
       it 'user receives success mail' do
-        expect(UserMailer).to receive(:copy_project_succeeded).and_return(maildouble)
+        expect(UserMailer).to receive(:copy_project_succeeded)
 
         copy_project(project)
       end
@@ -163,7 +157,7 @@ describe CopyProjectsController, type: :controller do
       end
 
       it 'user receives success mail' do
-        expect(UserMailer).to receive(:copy_project_failed).and_return(maildouble)
+        expect(UserMailer).to receive(:copy_project_failed)
 
         copy_project(project)
       end

--- a/spec/features/admin/test_mail_notification_spec.rb
+++ b/spec/features/admin/test_mail_notification_spec.rb
@@ -40,7 +40,7 @@ describe 'Test mail notification', type: :feature do
 
   it 'shows the correct message on errors in test notification (Regression #28226)' do
     error_message = '"error" with <strong>Markup?</strong>'
-    expect(UserMailer).to receive(:test_mail).with(admin)
+    expect(UserMailer).to receive(:test_mail!).with(admin)
       .and_raise error_message
 
     click_link 'Send a test email'

--- a/spec/models/copy_project_job_spec.rb
+++ b/spec/models/copy_project_job_spec.rb
@@ -33,11 +33,6 @@ describe CopyProjectJob, type: :model do
   let(:user) { FactoryBot.create(:user) }
   let(:role) { FactoryBot.create(:role, permissions: [:copy_projects]) }
   let(:params) { { name: 'Copy', identifier: 'copy' } }
-  let(:maildouble) { double('Mail::Message', deliver: true) }
-
-  before do
-    allow(maildouble).to receive(:deliver_now).and_return nil
-  end
 
   describe 'copy localizes error message' do
     let(:user_de) { FactoryBot.create(:admin, language: :de) }
@@ -56,7 +51,7 @@ describe CopyProjectJob, type: :model do
       # (see https://github.com/collectiveidea/delayed_job#rails-3-mailers).
       # Thus, we need to return a message object here, otherwise 'Delayed Job'
       # will complain about an object without a method #deliver.
-      allow(UserMailer).to receive(:copy_project_failed).and_return(maildouble)
+      allow(UserMailer).to receive(:copy_project_failed)
     end
 
     it 'sets locale correctly' do
@@ -96,12 +91,6 @@ describe CopyProjectJob, type: :model do
 
       allow(User).to receive(:current).and_return(admin)
 
-      # 'Delayed Job' uses a work around to get Rails 3 mailers working with it
-      # (see https://github.com/collectiveidea/delayed_job#rails-3-mailers).
-      # Thus, we need to return a message object here, otherwise 'Delayed Job'
-      # will complain about an object without a method #deliver.
-      allow(UserMailer).to receive(:copy_project_succeeded).and_return(maildouble)
-
       @copied_project, @errors = copy_job.send(:create_project_copy,
                                                source_project,
                                                params,
@@ -139,7 +128,7 @@ describe CopyProjectJob, type: :model do
       let(:subproject) { FactoryBot.create(:project, parent: project) }
 
       describe 'invalid parent' do
-        before do expect(UserMailer).to receive(:copy_project_failed).and_return(maildouble) end
+        before do expect(UserMailer).to receive(:copy_project_failed) end
 
         include_context 'copy project' do
           let(:project_to_copy) { subproject }
@@ -158,7 +147,7 @@ describe CopyProjectJob, type: :model do
         }
 
         before do
-          expect(UserMailer).to receive(:copy_project_succeeded).and_return(maildouble)
+          expect(UserMailer).to receive(:copy_project_succeeded)
 
           member_add_subproject
         end

--- a/spec/workers/mail_notification_jobs/deliver_watcher_notification_job_spec.rb
+++ b/spec/workers/mail_notification_jobs/deliver_watcher_notification_job_spec.rb
@@ -43,12 +43,11 @@ describe DeliverWatcherNotificationJob, type: :model do
 
   before do
     # make sure no actual calls make it into the UserMailer
-    allow(UserMailer).to receive(:work_package_watcher_added)
-      .and_return(double('mail', deliver_now: nil))
+    allow(UserMailer).to receive(:work_package_watcher_added!)
   end
 
   it 'sends a mail' do
-    expect(UserMailer).to receive(:work_package_watcher_added).with(work_package,
+    expect(UserMailer).to receive(:work_package_watcher_added!).with(work_package,
                                                                     watcher_user,
                                                                     watcher_setter)
     subject.perform
@@ -57,13 +56,11 @@ describe DeliverWatcherNotificationJob, type: :model do
   describe 'exceptions' do
     describe 'exceptions should be raised' do
       before do
-        mail = double('mail')
-        allow(mail).to receive(:deliver_now).and_raise(SocketError)
-        expect(UserMailer).to receive(:work_package_watcher_added).and_return(mail)
+        expect(UserMailer).to receive(:work_package_watcher_added!).and_raise(SocketError)
       end
 
-      it 'raises the error' do
-        expect { subject.perform }.to raise_error(SocketError)
+      it 'does not raise outside the job' do
+        expect { subject.perform }.not_to raise_error(SocketError)
       end
     end
   end

--- a/spec_legacy/functional/user_mailer_spec.rb
+++ b/spec_legacy/functional/user_mailer_spec.rb
@@ -35,7 +35,6 @@ describe UserMailer, type: :mailer do
     Setting.mail_from = 'john@doe.com'
     Setting.host_name = 'mydomain.foo'
     Setting.protocol = 'http'
-    Setting.plain_text_mail = '0'
     Setting.default_language = 'en'
 
     User.delete_all
@@ -49,8 +48,9 @@ describe UserMailer, type: :mailer do
 
     FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
 
-    mail = UserMailer.test_mail(user)
-    assert mail.deliver_now
+    assert UserMailer.deliver_immediately!(:test_mail, user)
+    assert last_email
+    mail = last_email
 
     assert_equal 1, ActionMailer::Base.deliveries.size
 
@@ -67,7 +67,7 @@ describe UserMailer, type: :mailer do
 
     project, user, related_issue, issue, changeset, attachment, journal = setup_complex_issue_update
 
-    assert UserMailer.work_package_updated(user, journal).deliver_now
+    assert UserMailer.deliver_immediately!(:work_package_updated, user, journal)
     assert last_email
 
     assert_select_email do
@@ -110,7 +110,7 @@ describe UserMailer, type: :mailer do
 
       project, user, related_issue, issue, changeset, attachment, journal = setup_complex_issue_update
 
-      assert UserMailer.work_package_updated(user, journal).deliver_now
+      assert UserMailer.deliver_immediately!(:work_package_updated, user, journal)
       assert last_email
 
       assert_select_email do
@@ -148,33 +148,24 @@ describe UserMailer, type: :mailer do
   end
 
   it 'should email headers' do
-    user  = FactoryBot.create(:user)
+    user = FactoryBot.create(:user)
+    # notify him
+    user.pref[:no_self_notified] = false
+    user.pref.save
+
     issue = FactoryBot.create(:work_package)
-    mail = UserMailer.work_package_added(user, issue.journals.first, user)
-    assert mail.deliver_now
+    assert UserMailer.deliver_immediately!(:work_package_added, user, issue.journals.first, user)
+    mail = last_email
     refute_nil mail
     assert_equal 'bulk', mail.header['Precedence'].to_s
     assert_equal 'auto-generated', mail.header['Auto-Submitted'].to_s
   end
 
-  it 'sends plain text mail' do
-    Setting.plain_text_mail = 1
-    user = FactoryBot.create(:user)
-    FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
-    issue = FactoryBot.create(:work_package)
-    UserMailer.work_package_added(user, issue.journals.first, user).deliver_now
-    mail = ActionMailer::Base.deliveries.last
-    assert_match /text\/plain/, mail.content_type
-    assert_equal 0, mail.parts.size
-    assert !mail.encoded.include?('href')
-  end
-
   it 'sends html mail' do
-    Setting.plain_text_mail = 0
     user = FactoryBot.create(:user)
     FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
     issue = FactoryBot.create(:work_package)
-    UserMailer.work_package_added(user, issue.journals.first, user).deliver_now
+    UserMailer.deliver_immediately!(:work_package_added, user, issue.journals.first, user)
     mail = ActionMailer::Base.deliveries.last
     assert_match /multipart\/alternative/, mail.content_type
     assert_equal 2, mail.parts.size
@@ -185,7 +176,7 @@ describe UserMailer, type: :mailer do
     it 'should mail from with phrase' do
       user = FactoryBot.create(:user)
       FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
-      UserMailer.test_mail(user).deliver_now
+      UserMailer.deliver_immediately!(:test_mail, user)
       mail = ActionMailer::Base.deliveries.last
       refute_nil mail
       assert_equal 'Redmine app <redmine@example.net>', mail.header['From'].to_s
@@ -200,22 +191,26 @@ describe UserMailer, type: :mailer do
     user.pref[:no_self_notified] = false
     user.pref.save
     ActionMailer::Base.deliveries.clear
-    UserMailer.news_added(user, news, user).deliver_now
+    UserMailer.deliver_immediately!(:news_added, user, news, user)
     assert_equal 1, last_email.to.size
 
     # nobody to notify
     user.pref[:no_self_notified] = true
     user.pref.save
     ActionMailer::Base.deliveries.clear
-    UserMailer.news_added(user, news, user).deliver_now
+    UserMailer.deliver_immediately!(:news_added, user, news, user)
     assert ActionMailer::Base.deliveries.empty?
   end
 
   it 'should issue add message id' do
     user  = FactoryBot.create(:user)
+    # notify him
+    user.pref[:no_self_notified] = false
+    user.pref.save
+
     issue = FactoryBot.create(:work_package)
-    mail = UserMailer.work_package_added(user, issue.journals.first, user)
-    mail.deliver_now
+    UserMailer.deliver_immediately!(:work_package_added, user, issue.journals.first, user)
+    mail = ActionMailer::Base.deliveries.last
     refute_nil mail
     assert_equal UserMailer.generate_message_id(issue, user), mail.message_id
     assert_nil mail.references
@@ -225,7 +220,7 @@ describe UserMailer, type: :mailer do
     user  = FactoryBot.create(:user)
     issue = FactoryBot.create(:work_package)
     journal = issue.journals.first
-    UserMailer.work_package_updated(user, journal).deliver_now
+    UserMailer.deliver_immediately!(:work_package_updated, user, journal)
     mail = ActionMailer::Base.deliveries.last
     refute_nil mail
     assert_equal UserMailer.generate_message_id(journal, user), mail.message_id
@@ -236,7 +231,7 @@ describe UserMailer, type: :mailer do
     user    = FactoryBot.create(:user)
     FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
     message = FactoryBot.create(:message)
-    UserMailer.message_posted(user, message, user).deliver_now
+    UserMailer.deliver_immediately!(:message_posted, user, message, user)
     mail = ActionMailer::Base.deliveries.last
     refute_nil mail
     assert_equal UserMailer.generate_message_id(message, user), mail.message_id
@@ -252,7 +247,7 @@ describe UserMailer, type: :mailer do
     FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
     parent  = FactoryBot.create(:message)
     message = FactoryBot.create(:message, parent: parent)
-    UserMailer.message_posted(user, message, user).deliver_now
+    UserMailer.deliver_immediately!(:message_posted, user, message, user)
     mail = ActionMailer::Base.deliveries.last
     refute_nil mail
     assert_equal UserMailer.generate_message_id(message, user), mail.message_id
@@ -271,7 +266,7 @@ describe UserMailer, type: :mailer do
       FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
 
       I18n.locale = 'en'
-      assert UserMailer.work_package_added(user, issue.journals.first, user).deliver_now
+      assert UserMailer.deliver_immediately!(:work_package_added, user, issue.journals.first, user)
       assert_equal 1, ActionMailer::Base.deliveries.size
       mail = last_email
       assert_equal ['foo@bar.de'], mail.to
@@ -289,7 +284,7 @@ describe UserMailer, type: :mailer do
       FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
 
       I18n.locale = 'de'
-      assert UserMailer.work_package_added(user, issue.journals.first, user).deliver_now
+      assert UserMailer.deliver_immediately!(:work_package_added, user, issue.journals.first, user)
       assert_equal 1, ActionMailer::Base.deliveries.size
       mail = last_email
       assert_equal ['foo@bar.de'], mail.to
@@ -302,31 +297,31 @@ describe UserMailer, type: :mailer do
   it 'should news added' do
     user = FactoryBot.create(:user)
     news = FactoryBot.create(:news)
-    assert UserMailer.news_added(user, news, user).deliver_now
+    assert UserMailer.deliver_immediately!(:news_added, user, news, user)
   end
 
   it 'should news comment added' do
     user    = FactoryBot.create(:user)
     news    = FactoryBot.create(:news)
     comment = FactoryBot.create(:comment, commented: news)
-    assert UserMailer.news_comment_added(user, comment, user).deliver_now
+    assert UserMailer.deliver_immediately!(:news_comment_added, user, comment, user)
   end
 
   it 'should message posted' do
     user    = FactoryBot.create(:user)
     message = FactoryBot.create(:message)
-    assert UserMailer.message_posted(user, message, user).deliver_now
+    assert UserMailer.deliver_immediately!(:message_posted, user, message, user)
   end
 
   it 'should account information' do
     user = FactoryBot.create(:user)
-    assert UserMailer.account_information(user, 'pAsswORd').deliver_now
+    assert UserMailer.deliver_immediately!(:account_information, user, 'pAsswORd')
   end
 
   it 'should lost password' do
     user  = FactoryBot.create(:user)
     token = FactoryBot.create(:recovery_token, user: user)
-    assert UserMailer.password_lost(token).deliver_now
+    assert UserMailer.deliver_immediately!(:password_lost, token)
   end
 
   it 'should register' do
@@ -335,8 +330,8 @@ describe UserMailer, type: :mailer do
     Setting.host_name = 'redmine.foo'
     Setting.protocol = 'https'
 
-    mail = UserMailer.user_signed_up(token)
-    assert mail.deliver_now
+    UserMailer.deliver_immediately!(:user_signed_up, token)
+    mail = last_email
     assert mail.body.encoded.include?("https://redmine.foo/account/activate?token=#{token.value}")
   end
 
@@ -376,7 +371,7 @@ describe UserMailer, type: :mailer do
       I18n.locale = :en
       # Send an email to a german user
       user = FactoryBot.create(:user, language: 'de')
-      UserMailer.account_activated(user).deliver_now
+      UserMailer.deliver_immediately!(:account_activated, user)
       mail = ActionMailer::Base.deliveries.last
       assert mail.body.encoded.include?('aktiviert')
       assert_equal :en, I18n.locale
@@ -386,7 +381,7 @@ describe UserMailer, type: :mailer do
   it 'should with deliveries off' do
     user = FactoryBot.create(:user)
     UserMailer.with_deliveries(false) do
-      UserMailer.test_mail(user).deliver_now
+      UserMailer.deliver_immediately!(:test_mail, user)
     end
     assert ActionMailer::Base.deliveries.empty?
     # should restore perform_deliveries
@@ -400,7 +395,7 @@ describe UserMailer, type: :mailer do
           } do
     it 'should include the emails_header depeding on the locale' do
       user = FactoryBot.create(:user, language: :de)
-      assert UserMailer.test_mail(user).deliver_now
+      assert UserMailer.deliver_immediately!(:test_mail, user)
       mail = ActionMailer::Base.deliveries.last
       assert mail.body.encoded.include?('deutscher header')
     end

--- a/spec_legacy/unit/lib/redmine/hook_spec.rb
+++ b/spec_legacy/unit/lib/redmine/hook_spec.rb
@@ -158,14 +158,14 @@ describe 'Redmine::Hook::Manager' do # FIXME: naming (RSpec-port)
     user = User.find(1)
     issue = FactoryBot.create(:work_package)
 
-    UserMailer.work_package_added(user, issue.journals.first, user).deliver_now
+    UserMailer.deliver_immediately!(:work_package_added, user, issue.journals.first, user)
     mail = ActionMailer::Base.deliveries.last
 
     @hook_module.add_listener(TestLinkToHook)
     hook_helper.call_hook(:view_layouts_base_html_head)
 
     ActionMailer::Base.deliveries.clear
-    UserMailer.work_package_added(user, issue.journals.first, user).deliver_now
+    UserMailer.deliver_immediately!(:work_package_added, user, issue.journals.first, user)
     mail2 = ActionMailer::Base.deliveries.last
 
     assert_equal mail.text_part.body.encoded, mail2.text_part.body.encoded


### PR DESCRIPTION
This will:

1. Make all `UserMailer.action(args)` delayed by default

2. Allows to explicitly send immediate mails by `UserMailer.deliver_immediately!(:action, *args)` if you _really_ want to.

https://community.openproject.com/wp/28287