### PR TITLE
After initializing query menu one element needs focus

### DIFF
--- a/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
+++ b/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
@@ -99,6 +99,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
   private reportsBodySelector = '.controller-work_packages\\/reports';
 
   private queryResultsContainer:JQuery;
+  private buttonArrowLeft:JQuery;
 
   private searchInput:IQueryAutocompleteJQuery;
 
@@ -159,7 +160,9 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
     }
 
     this.searchInput = jQuery(this._wpQueryMenuSearchInput.nativeElement) as any;
+    this.buttonArrowLeft = jQuery('.main-menu--arrow-left-to-project', jQuery('#main-menu-work-packages-wrapper').parent()) as any;
     this.initialized = true;
+    this.buttonArrowLeft.focus();
     this.setupAutoCompletion(this.searchInput);
     this.updateMenuOnChanges(this.searchInput);
   }


### PR DESCRIPTION
https://community.openproject.com/wp/28214

On mobile, when opening the wp query menu for the first time, coming from somewhere else, the check that the focus is still within menu is negative unless we set a focus. So I added a focus on the left arrow button. This comes handy as that button is already there before the query menu component gets initialized.