### PR TITLE
[28286] Wrong layout for attribute help texts

### DIFF
--- a/frontend/src/app/modules/common/help-texts/attribute-help-text.modal.ts
+++ b/frontend/src/app/modules/common/help-texts/attribute-help-text.modal.ts
@@ -39,7 +39,7 @@ import {OpModalLocalsToken} from "core-components/op-modals/op-modal.service";
 export class AttributeHelpTextModal extends OpModalComponent {
 
   /* Close on escape? */
-  public closeOnEscape = false;
+  public closeOnEscape = true;
 
   /* Close on outside click */
   public closeOnOutsideClick = false;

--- a/frontend/src/app/modules/common/help-texts/help-text.modal.html
+++ b/frontend/src/app/modules/common/help-texts/help-text.modal.html
@@ -2,10 +2,10 @@
      data-indicator-name="modal">
   <div class="op-modal--modal-container attribute-help-text--modal" tabindex="0">
     <div class="op-modal--modal-header">
-      <a>
+      <a class="op-modal--modal-close-button">
         <i
           class="icon-close"
-          (click)="closeMe($event)"
+          (accessibleClick)="closeMe($event)"
           [attr.title]="text.close">
         </i>
       </a>


### PR DESCRIPTION
Apply correct styling and allow close on escape for attribute help text modal

https://community.openproject.com/projects/openproject/work_packages/28286/activity