### PR TITLE
Fix/manage public queries schmema

### DIFF
--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -142,11 +142,11 @@ Redmine::AccessControl.map do |map|
                    {}
     # Queries
     wpt.permission :manage_public_queries,
-                   { queries: [:star, :unstar] },
+                   {},
                    require: :member
 
     wpt.permission :save_queries,
-                   { queries: [:star, :unstar] },
+                   {},
                    require: :loggedin
     # Watchers
     wpt.permission :view_work_package_watchers,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -487,7 +487,7 @@ en:
             project:
               error_not_found: "not found"
             public:
-              error_unauthorized: "- The user has no permission to create public queries."
+              error_unauthorized: "- The user has no permission to create public views."
           group_by_hierarchies_exclusive: "is mutually exclusive with group by '%{group_by}'. You cannot activate both."
           filters:
             custom_fields:
@@ -1796,7 +1796,7 @@ en:
   permission_manage_members: "Manage members"
   permission_manage_news: "Manage news"
   permission_manage_project_activities: "Manage project activities"
-  permission_manage_public_queries: "Manage public queries"
+  permission_manage_public_queries: "Manage public views"
   permission_manage_repository: "Manage repository"
   permission_manage_subtasks: "Manage subtasks"
   permission_manage_versions: "Manage versions"
@@ -1805,7 +1805,7 @@ en:
   permission_move_work_packages: "Move work packages"
   permission_protect_wiki_pages: "Protect wiki pages"
   permission_rename_wiki_pages: "Rename wiki pages"
-  permission_save_queries: "Save queries"
+  permission_save_queries: "Save views"
   permission_select_project_modules: "Select project modules"
   permission_manage_types: "Select types"
   permission_view_calendar: "View calendar"

--- a/lib/api/v3/queries/schemas/query_project_schema_api.rb
+++ b/lib/api/v3/queries/schemas/query_project_schema_api.rb
@@ -41,6 +41,7 @@ module API
             get do
               representer.new(Query.new(project: @project),
                               api_v3_paths.query_project_schema(@project.id),
+                              current_user: current_user,
                               form_embedded: false)
             end
           end

--- a/lib/api/v3/queries/schemas/query_schema_api.rb
+++ b/lib/api/v3/queries/schemas/query_schema_api.rb
@@ -45,6 +45,7 @@ module API
             get do
               representer.new(Query.new,
                               api_v3_paths.query_schema,
+                              current_user: current_user,
                               form_embedded: false)
             end
           end

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -87,7 +87,11 @@ module API
           schema :public,
                  type: 'Boolean',
                  required: false,
-                 writable: true,
+                 writable: -> do
+                   current_user.allowed_to?(:manage_public_queries,
+                                            represented.project,
+                                            global: represented.project.nil?)
+                 end,
                  has_default: true,
                  visibility: false
 

--- a/spec/requests/api/v3/queries/create_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/create_form_api_spec.rb
@@ -558,7 +558,7 @@ describe "POST /api/v3/queries/form", type: :request do
 
       it "should reject the request" do
         expect(form.dig("_embedded", "validationErrors", "public", "message"))
-          .to eq "Public - The user has no permission to create public queries."
+          .to eq "Public - The user has no permission to create public views."
       end
     end
   end

--- a/spec/requests/api/v3/queries/schemas/query_project_schema_resource_spec.rb
+++ b/spec/requests/api/v3/queries/schemas/query_project_schema_resource_spec.rb
@@ -34,18 +34,15 @@ describe 'API v3 Query Schema resource', type: :request do
   include API::V3::Utilities::PathHelper
 
   let(:project) { FactoryBot.create(:project) }
-  let(:role) { FactoryBot.create(:role, permissions: permissions) }
   let(:permissions) { [:view_work_packages] }
   let(:user) do
     FactoryBot.create(:user,
-                       member_in_project: project,
-                       member_through_role: role)
+                      member_in_project: project,
+                      member_with_permissions: permissions)
   end
 
   before do
-    allow(User)
-      .to receive(:current)
-      .and_return(user)
+    login_as(user)
   end
 
   describe '#get queries/schema' do

--- a/spec/requests/api/v3/queries/update_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/update_form_api_spec.rb
@@ -521,7 +521,7 @@ describe "POST /api/v3/queries/form", type: :request do
 
       it "should reject the request" do
         expect(form.dig("_embedded", "validationErrors", "public", "message"))
-          .to eq "Public - The user has no permission to create public queries."
+          .to eq "Public - The user has no permission to create public views."
       end
     end
   end


### PR DESCRIPTION
Fixes:

* having `writable: true` for the `public` property of a query denoted statically in the schema. By evaluating it dynamically, the permission is enforced in the front end as well which fixes: https://community.openproject.com/projects/openproject/work_packages/28317/activity
* uses `view` instead of `query` for the permissions in the i18n as it seems to be more in line with the work package front end.
