### PR TITLE
Fix/custom action without edit permission

### DIFF
--- a/app/policies/work_package_policy.rb
+++ b/app/policies/work_package_policy.rb
@@ -57,9 +57,7 @@ class WorkPackagePolicy < BasePolicy
 
   def edit_allowed?(work_package)
     @edit_cache ||= Hash.new do |hash, project|
-      hash[project] = work_package.persisted? &&
-                      (user.allowed_to?(:edit_work_packages, project) ||
-                       user.allowed_to?(:add_work_package_notes, project))
+      hash[project] = work_package.persisted? && user.allowed_to?(:edit_work_packages, project)
     end
 
     @edit_cache[work_package.project]

--- a/spec/policies/work_package_policy_spec.rb
+++ b/spec/policies/work_package_policy_spec.rb
@@ -53,10 +53,11 @@ describe WorkPackagePolicy, type: :controller do
         expect(subject).to be_truthy
       end
 
-      it 'is true if the user has the add_work_package_notes permission in the project' do
+      # used to be truthy
+      it 'is false if the user has only the add_work_package_notes permission in the project' do
         allow(user).to receive(:allowed_to?).with(:add_work_package_notes, project)
           .and_return true
-        expect(subject).to be_truthy
+        expect(subject).to be_falsey
       end
 
       it 'is false if the user has the edit_work_package permission in the project' do
@@ -65,7 +66,7 @@ describe WorkPackagePolicy, type: :controller do
         expect(subject).to be_truthy
       end
 
-      it 'is false if the user has the permissions but the work package is unperisted' do
+      it 'is false if the user has the permissions but the work package is unpersisted' do
         allow(user).to receive(:allowed_to?).with(:edit_work_packages, project)
           .and_return true
         allow(user).to receive(:allowed_to?).with(:add_work_package_notes, project)


### PR DESCRIPTION
Restores the changes caused by an action only after the check for whether a subset of actions is possible. Doing that, errors are not hidden which caused: https://community.openproject.com/projects/openproject/work_packages/28277

It additionally removes the permission to allow users only having the `:add_work_package_notes` permission to edit work packages. I couldn't find out why it was added (by me) but it strikes me to be wrong. Users only having that permission can still add notes even though permission has been removed.