### PR TITLE
[28314] Notify query changes only after query loaded

### DIFF
--- a/frontend/src/app/components/wp-list/wp-list.service.ts
+++ b/frontend/src/app/components/wp-list/wp-list.service.ts
@@ -191,9 +191,11 @@ export class WorkPackagesListService {
     promise
       .then(query => {
         this.NotificationsService.addSuccess(this.I18n.t('js.notice_successful_create'));
-        this.reloadQuery(query);
 
-        this.queryChanges.next(query.name);
+        // Reload the query, and then reload the menu
+        this.reloadQuery(query).then(() => {
+          this.queryChanges.next(query.name);
+        });
 
         return query;
       });


### PR DESCRIPTION
Otherwise selection will be done before UI router has finished loading the query into the params.

https://community.openproject.com/wp/28314