### PR TITLE
allow adding attachments to invalid containers

### DIFF
--- a/app/services/add_attachment_service.rb
+++ b/app/services/add_attachment_service.rb
@@ -59,7 +59,11 @@ class AddAttachmentService
         # reload to get the newly added attachment
         container.attachments.reload
         container.add_journal author
-        container.save!
+        # We allow invalid containers to be saved as
+        # adding the attachments does not change the validity of the container
+        # but without that leeway, the user needs to fix the container before
+        # the attachment can be added.
+        container.save!(validate: false)
       end
     end
   end


### PR DESCRIPTION
Adding attachments does not change the validity of the container but we want to save the container to generate a journal when an attachment has been added. We therefore do not expect the user to fix the error on the container before them being able to attach to it again.

https://community.openproject.com/projects/openproject/work_packages/28273