### PR TITLE
[28355] Always redraw on changed columns

### DIFF
--- a/frontend/src/app/components/wp-fast-table/handlers/state/columns-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/columns-transformer.ts
@@ -16,7 +16,6 @@ export class ColumnsTransformer {
     this.tableState.updates.columnsUpdates
       .values$('Refreshing columns on user request')
       .pipe(
-        filter(() => !this.wpTableColumns.hasRelationColumns()),
         takeUntil(this.tableState.stopAllSubscriptions)
       )
       .subscribe(() => {


### PR DESCRIPTION
This line of code is no longer valid now that we're not always reloading
the table with relation columns active (only when new ones are added).

https://community.openproject.com/wp/28355