### PR TITLE
gsub multitude of empty textile paragraphs

### DIFF
--- a/lib/open_project/text_formatting/formats/markdown/textile_converter.rb
+++ b/lib/open_project/text_formatting/formats/markdown/textile_converter.rb
@@ -74,7 +74,6 @@ module OpenProject::TextFormatting::Formats
       def run!
         puts 'Starting conversion of Textile fields to CommonMark+GFM.'
 
-
         puts 'Checking compatibility of your installed pandoc version.'
         pandoc.check_arguments!
 
@@ -415,7 +414,7 @@ module OpenProject::TextFormatting::Formats
 
       # Remove empty paragraph blocks which trip up pandoc
       def remove_empty_paragraphs(textile)
-        textile.gsub!(/\np\.\n/, '')
+        textile.gsub!(/\np(=|>)?\.[\s\.]*\n/, '')
       end
 
       # Replace numbered headings as they are not supported in commonmark/gfm


### PR DESCRIPTION
gsubs
```
p.

p.[and now some spaces]

p>.

p=.

p. .
```
and combinations of those that trip up pandoc.