### PR TITLE
[28331] Don't show local user breadcrumb as non-admin

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -343,6 +343,6 @@ class UsersController < ApplicationController
   end
 
   def show_local_breadcrumb
-    true
+    current_user.admin?
   end
 end


### PR DESCRIPTION
https://community.openproject.com/wp/28331