### PR TITLE
fix adding notes to work packages

### DIFF
--- a/app/contracts/work_packages/update_contract.rb
+++ b/app/contracts/work_packages/update_contract.rb
@@ -49,6 +49,7 @@ module WorkPackages
       with_unchanged_project_id do
         next if @can.allowed?(model, :edit)
         next user_allowed_to_change_parent if @can.allowed?(model, :manage_subtasks)
+        next if allowed_journal_addition?
 
         errors.add :base, :error_unauthorized
       end
@@ -89,6 +90,10 @@ module WorkPackages
       else
         yield
       end
+    end
+
+    def allowed_journal_addition?
+      model.changes.empty? && model.journal_notes && can.allowed?(model, :comment)
     end
   end
 end


### PR DESCRIPTION
in 395c665627 the too generous interpretation of the :add_work_package_notes, that allowed user having the permission to alter additional attributes was removed.

But after the removal a user having the permission was no longer allowed to add notes at all.