### PR TITLE
Styling of custom action buttons

### DIFF
--- a/app/assets/stylesheets/content/_custom_actions.sass
+++ b/app/assets/stylesheets/content/_custom_actions.sass
@@ -30,17 +30,19 @@
   display: flex
   flex-wrap: wrap
   justify-content: flex-end
+  flex-grow: 1
+  // Cancel out the margin of the last button
+  margin-right: -10px
 
   .custom-action
     display: flex
     justify-content: flex-end
-    flex: 1 1 10px
+    flex: 1 1 auto
     margin-bottom: 0.5rem
     @include text-shortener
 
     .button
       @include text-shortener
       width: 100%
-
-    &:not(:last-of-type)
-      margin-right: 0.625em
+      // The margin is necessary for all buttons so that the alignment is correct on small screens
+      margin-right: 10px

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -272,7 +272,7 @@ i
     .icon:before
       padding: 0
   .work-packages--info-row
-    flex-grow: 1
+    flex-grow: 2
     margin-right: 5px
 
   &.-wrapped
@@ -282,12 +282,15 @@ i
       flex-basis: 100%
       margin-bottom: 0.5rem
 
-    .wp-status-button
-      flex-grow: 1
+    wp-status-button
       margin-bottom: 0.5rem
+      // In case that there is no attribute help text, the status button needs to increase.
+      // This is a heuristic based on the current DOM structure.
+      &:nth-last-child(3)
+        flex-grow: 2
     attribute-help-text
       // Take care that the help text is next to the button and the action buttons are still at the right side
-      flex-grow: 100
+      flex-grow: 2
       margin-bottom: 0.5rem
     wp-custom-action
       margin-bottom: 0.5rem

--- a/frontend/src/app/components/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/components/resizer/wp-resizer.component.ts
@@ -193,6 +193,6 @@ export class WpResizerDirective implements OnInit, OnDestroy {
   }
 
   private applyInfoRowLayout() {
-    jQuery('.wp-info-wrapper').toggleClass('-wrapped', jQuery('.wp-info-wrapper').width() - jQuery('wp-custom-actions').width() - jQuery('wp-status-button').width() < 430);
+    jQuery('.wp-info-wrapper').toggleClass('-wrapped', jQuery('.wp-info-wrapper').width() - jQuery('wp-custom-actions').width() - jQuery('wp-status-button .button').width() < 475);
   }
 }

--- a/frontend/src/app/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.html
+++ b/frontend/src/app/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.html
@@ -1,6 +1,6 @@
 <button
     (click)="update()"
     class="custom-action--button button -narrow"
-    title="{{action.description}}" >
+    title="{{action.description ? action.description : action.name}}" >
   {{action.name}}
 </button>


### PR DESCRIPTION
This fixes multiple styling issues with the custom action buttons.

* The width of the buttons is more flexible so that no content is truncated. 
* It is working in FF, Safari, Chrome and MS Edge
* On small screens or a small left side of the WP page the paddings are correct.
* The styling is also correct w/o an attribute help text next to the status button.


https://community.openproject.com/projects/openproject/work_packages/28336/activity
https://community.openproject.com/projects/openproject/work_packages/28328/activity
https://community.openproject.com/projects/openproject/work_packages/28359/activity