### PR TITLE
remove ruby-progressbar gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,6 @@ gem 'color-tools', '~> 1.3.0', require: 'color'
 
 gem 'addressable', '~> 2.5.2'
 
-gem 'ruby-progressbar'
-
 # Provide timezone info for TZInfo used by AR
 gem 'tzinfo-data', '~> 1.2018.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -713,7 +713,6 @@ DEPENDENCIES
   rspec-retry (~> 0.5.6)
   rubocop
   ruby-duration (~> 3.2.0)
-  ruby-progressbar
   rubytree!
   sanitize (~> 4.6.0)
   sass (= 3.5.1)


### PR DESCRIPTION
Was introduced for a migration that has been squashed