### PR TITLE
Create linked image tag in Markdown from textile syntax

### DIFF
--- a/lib/open_project/text_formatting/formats/markdown/textile_converter.rb
+++ b/lib/open_project/text_formatting/formats/markdown/textile_converter.rb
@@ -335,6 +335,11 @@ module OpenProject::TextFormatting::Formats
           $1.gsub(/([\n])([^\n]*)/, '\1> \2')
         end
 
+        # Create markdown links from !image!:link syntax
+        # ![alt](image])
+        markdown.gsub! /(?<image>\!\[[^\]]*\]\([^\)]+\)):(?<link>https?:\S+)/,
+                       '[\k<image>](\k<link>)'
+
         convert_macro_syntax(markdown)
 
         markdown


### PR DESCRIPTION
Fixes "!imagelink!:http://foobar links in textile in Markdown

https://community.openproject.com/wp/28374