### PR TITLE
[28352][28353] Inline create / No results changes

### DIFF
--- a/frontend/src/app/components/wp-inline-create/wp-inline-create.component.html
+++ b/frontend/src/app/components/wp-inline-create/wp-inline-create.component.html
@@ -6,7 +6,7 @@
       <a class="wp-inline-create--add-link"
               href
               role="link"
-              focus
+              [focus]="focus"
               (accessibleClick)="handleAddRowClick()"
               [attr.disabled]="!isAllowed || undefined"
               [attr.aria-label]="text.create"

--- a/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
@@ -134,11 +134,10 @@ export class WorkPackageInlineCreateComponent implements OnInit, OnChanges, OnDe
       )
       .subscribe((wp:WorkPackageResource) => {
         if (this.currentWorkPackage && this.currentWorkPackage === wp) {
-          // Add next row
-          this.removeWorkPackageRow();
-          this.addWorkPackageRow();
+          // Remove row and focus
+          this.resetRow();
 
-          // Focus on the last inserted id
+          // Split view on the last inserted id if any
           if (!this.table.configuration.isEmbedded) {
             this.wpTableFocus.updateFocus(wp.id);
           }

--- a/frontend/src/app/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/components/wp-table/wp-table.directive.html
@@ -38,7 +38,7 @@
           </th>
         </tr>
       </thead>
-      <tbody class="work-package--empty-tbody" *ngIf="query.hasError || rowcount === 0">
+      <tbody class="work-package--empty-tbody" *ngIf="!isEmbedded && (query.hasError || rowcount === 0)">
       <tr id="empty-row-notification">
         <td [attr.colspan]="columns.length + 1">
           <span *ngIf="!query.hasError">

--- a/frontend/src/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/src/app/components/wp-table/wp-table.directive.ts
@@ -185,6 +185,10 @@ export class WorkPackagesTableController implements OnInit, OnDestroy {
     this.opModalService.show<WpTableConfigurationModalComponent>(WpTableConfigurationModalComponent);
   }
 
+  public get isEmbedded() {
+    return this.configuration.isEmbedded;
+  }
+
   private getTableAndTimelineElement():[HTMLElement, HTMLElement] {
     const $tableSide = this.$element.find('.work-packages-tabletimeline--table-side');
     const $timelineSide = this.$element.find('.work-packages-tabletimeline--timeline-side');

--- a/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
+++ b/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
@@ -53,8 +53,10 @@ describe 'inline create work package', js: true do
         )
 
         # Expect new create row to exist
-        expect(page).to have_selector('.wp--row', count: 3)
-        expect(page).to have_selector('.wp-inline-create-row')
+        expect(page).to have_selector('.wp--row', count: 2)
+        expect(page).to have_selector('.wp-inline-create--add-link')
+
+        wp_table.click_inline_create
 
         subject_field = wp_table.edit_field(nil, :subject)
         subject_field.expect_active!
@@ -73,11 +75,8 @@ describe 'inline create work package', js: true do
           message: 'Successful update. Click here to open this work package in fullscreen view.'
         )
 
-        # Cancel creation
-        expect(page).to have_selector('.wp-inline-create-row')
-        page.find('.wp-table--cancel-create-link').click
+        # Expect no inline create open
         expect(page).to have_no_selector('.wp-inline-create-row')
-        expect(page).to have_selector('.wp-inline-create--add-link')
       end
     end
 

--- a/spec/features/work_packages/table/inline_create/parallel_creation_spec.rb
+++ b/spec/features/work_packages/table/inline_create/parallel_creation_spec.rb
@@ -57,10 +57,9 @@ describe 'Parallel work package creation spec', js: true do
     subject_field = wp_table.edit_field(nil, :subject)
     subject_field.save!
 
-    # Since the WP was started inline, a new row is entered
-    expect(page).to have_selector('.wp-inline-create-row')
-    scroll_to_and_click(page.find('.wp-table--cancel-create-link'))
+    # There should be one row, and no open inline create row
     expect(page).to have_selector('.wp--row', count: 1)
+    expect(page).to have_no_selector('.wp-inline-create-row')
 
     wp_table.expect_notification(
       message: 'Successful creation. Click here to open this work package in fullscreen view.'
@@ -93,12 +92,12 @@ describe 'Parallel work package creation spec', js: true do
     subject_field.expect_value 'New subject'
     subject_field.save!
 
-    expect(page).to have_selector('.wp-inline-create-row')
-    expect(page).to have_selector('.wp--row', count: 3)
     wp_table.expect_notification(
       message: 'Successful creation.'
     )
     wp_table.dismiss_notification!
+    expect(page).to have_selector('.wp--row', count: 2)
+    expect(page).to have_no_selector('.wp-inline-create-row')
 
     # Get the last work package
     wp2 = WorkPackage.last


### PR DESCRIPTION
- Don't show 'No results' in embedded tables
- Don't open another inline create after saving one

https://community.openproject.com/wp/28352
https://community.openproject.com/wp/28353