### PR TITLE
remove bulk boundary more precisely

### DIFF
--- a/lib/open_project/text_formatting/formats/markdown/textile_converter.rb
+++ b/lib/open_project/text_formatting/formats/markdown/textile_converter.rb
@@ -294,7 +294,7 @@ module OpenProject::TextFormatting::Formats
       end
 
       def split_markdown(markdown)
-        markdown.split(DOCUMENT_BOUNDARY).map(&:strip)
+        markdown.split("\n\n#{DOCUMENT_BOUNDARY}\n\n")
       end
 
       def cleanup_before_pandoc(textile)


### PR DESCRIPTION
Before, with strip, it was possible to remove whitespace from the first line of each concatenated text leading to the first line having less indentation which would clash when the first line starts with a list

- first item
  - second item

https://community.openproject.com/projects/openproject/work_packages/28370