### PR TITLE
Add separate script 'npm run serve-public' for developing cross device.

### DIFF
--- a/docs/development/running-tests.md
+++ b/docs/development/running-tests.md
@@ -266,7 +266,7 @@ you can access both from inside a VM with nat/bridged networking as follows:
 
 ```bash
 # Start ng serve middleware binding to all interfaces
-ng serve --host 0.0.0.0
+npm run serve-public
 
 # Start your openproject server with the CLI proxy configuration set
 OPENPROJECT_CLI_PROXY='<your local ip>:4200' ./bin/rails s -b 0.0.0.0 -p 3000

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "cd frontend && npm test && cd ..",
     "tslint_typechecks": "cd frontend && npm run tslint_typechecks && cd ..",
     "serve": "cd frontend && npm run serve",
+    "serve-public": "cd frontend && ./node_modules/.bin/ng serve --host 0.0.0.0",
     "legacy-webpack": "cd frontend && npm run legacy-webpack && cd ..",
     "legacy-webpack-watch": "cd frontend && npm run legacy-webpack-watch"
   },


### PR DESCRIPTION
Script calls relative path to `ng` as many people seem to have issues to have `ng` within their load path (See: https://github.com/angular/angular-cli/issues/503).
Documentation updated to use that script.