### PR TITLE
register project description toggle click handler only once

### DIFF
--- a/app/assets/javascripts/project/description_handling.js
+++ b/app/assets/javascripts/project/description_handling.js
@@ -26,21 +26,29 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-function toggleDescription(el) {
-  let $el = jQuery(el);
-  let otherTrigger = $el.siblings('.projects-table--description-toggle')
-  let clickedRow = $el.closest('.project');
-  let descriptionRow = clickedRow.next();
+(function($) {
+  function toggleDescription() {
+    let $el = $(this);
+    let otherTrigger = $el.siblings('.projects-table--description-toggle');
+    let clickedRow = $el.closest('.project');
+    let descriptionRow = clickedRow.next();
 
-  clickedRow.toggleClass('-no-highlighting');
-  clickedRow.toggleClass('-expanded');
-  descriptionRow.toggleClass('-expanded');
+    clickedRow.toggleClass('-no-highlighting');
+    clickedRow.toggleClass('-expanded');
+    descriptionRow.toggleClass('-expanded');
 
-  if (descriptionRow.hasClass('-expanded')) {
-    jQuery(descriptionRow).attr('aria-live', 'polite');
-  } else {
-    jQuery(descriptionRow).removeAttr('aria-live');
+    if (descriptionRow.hasClass('-expanded')) {
+      $(descriptionRow).attr('aria-live', 'polite');
+    } else {
+      $(descriptionRow).removeAttr('aria-live');
+    }
+
+    otherTrigger.focus();
+
+    return false;
   }
 
-  otherTrigger.focus();
-}
+  $('document').ready(function() {
+    $('.projects-table--description-toggle').click(toggleDescription);
+  });
+})(jQuery);

--- a/app/helpers/removed_js_helpers_helper.rb
+++ b/app/helpers/removed_js_helpers_helper.rb
@@ -34,7 +34,6 @@
 module RemovedJsHelpersHelper
   # removed in rails 4.1
   def link_to_function(content, function, html_options = {})
-
     id = html_options.delete(:id) { "link-to-function-#{SecureRandom.uuid}" }
     csp_onclick(function, "##{id}")
 

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -138,7 +138,6 @@ See docs/COPYRIGHT.rdoc for more details.
                 <% unless project.description.blank? %>
                   <a class="icon collapse icon-arrow-up1 projects-table--description-toggle" href title="<%= t('label_project_hide_details') %>"></a>
                   <a class="icon expand icon-arrow-down1 projects-table--description-toggle" href title="<%= t('label_project_show_details') %>"></a>
-                  <% csp_onclick('toggleDescription(this)', '.projects-table--description-toggle') %>
                 <% end %>
               </td>
             </tr>


### PR DESCRIPTION
using the `csp_onclick` helper lead to having a click handler registered once for every project having a description. With an even number of projects on the page having a description, this would lead to the handler's effects canceling each other out:

![image](https://user-images.githubusercontent.com/617519/44842272-b12c6e00-ac45-11e8-830f-ed4d156d489e.png)

https://community.openproject.com/projects/openproject/work_packages/28406