### PR TITLE
fix migration for links in parenthesis with a trailing slash

### DIFF
--- a/lib/open_project/text_formatting/formats/markdown/textile_converter.rb
+++ b/lib/open_project/text_formatting/formats/markdown/textile_converter.rb
@@ -357,6 +357,11 @@ module OpenProject::TextFormatting::Formats
         markdown.gsub! /(?<image>\!\[[^\]]*\]\([^\)]+\)):(?<link>https?:\S+)/,
                        '[\k<image>](\k<link>)'
 
+        # remove the escaping from links within parenthesis having a trailing slash
+        # ([description](https://some/url/\))
+        markdown.gsub! /\(\[(?<description>.*?)\]\((?<link>.*?)\\\)\)/,
+                       '([\k<description>](\k<link>))'
+
         convert_macro_syntax(markdown)
 
         markdown


### PR DESCRIPTION
e.g. `([check contrast online here](https://leaverou.github.io/contrast-ratio/\))`

https://community.openproject.com/projects/openproject/work_packages/28404