### PR TITLE
Fix #28356 – Mobile:  WP queries, click on queries shall close menu

### DIFF
--- a/app/assets/stylesheets/layout/work_packages/_query_menu.sass
+++ b/app/assets/stylesheets/layout/work_packages/_query_menu.sass
@@ -63,7 +63,7 @@ $wp-query-menu-search-container-height: 35px
 
     .ui-autocomplete--category
       width: 100%
-      padding-left: 25px
+      padding-left: 33px
       line-height: $menu-item-line-height
       height: $menu-item-line-height
       font-weight: normal
@@ -91,7 +91,7 @@ $wp-query-menu-search-container-height: 35px
     font-size: 0.6rem
     line-height: $menu-item-line-height
     height: $menu-item-line-height
-    margin: 0px 8px
+    margin: 0px 12px
     position: absolute
     color: $main-menu-fieldset-header-color
     z-index: 1
@@ -110,7 +110,6 @@ $wp-query-menu-search-container-height: 35px
   .wp-query-menu--item
     display: block !important
     height: 30px !important
-    margin-left: 18px !important
     border-radius: 3px
 
     &.-hidden
@@ -128,13 +127,14 @@ $wp-query-menu-search-container-height: 35px
   .wp-query-menu--item-link
     @include text-shortener
     @include varprop(color, main-menu-font-color)
-    padding: 0px 2px 0px 5px !important
+    padding: 0px 2px 0px 33px !important
     margin: 0
     line-height: 30px
     height: 30px !important
 
     &:hover, &:focus, &:active
       @include varprop(background, main-menu-bg-hover-background)
+      @include varprop(color, main-menu-hover-font-color)
 
   // Rule complexed for specificity issues
   input[type="text"].wp-query-menu--search-input

--- a/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
+++ b/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
@@ -440,7 +440,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
 
     // On mobile, close the main menu after selecting a view.
     if (window.innerWidth < 680) {
-      this.toggleService.toggleNavigation()
+      this.toggleService.toggleNavigation();
     }
   }
 

--- a/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
+++ b/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
@@ -44,6 +44,7 @@ import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
 import {LinkHandling} from "core-app/modules/common/link-handling/link-handling";
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {keyCodes} from "../../../../legacy/app/components/keyCodes.enum";
+import {MainMenuToggleService} from "core-components/resizer/main-menu-toggle.service";
 
 export type QueryCategory = 'starred' | 'public' | 'private' | 'default';
 
@@ -117,7 +118,8 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
               readonly wpListChecksumService:WorkPackagesListChecksumService,
               readonly loadingIndicator:LoadingIndicatorService,
               readonly pathHelper:PathHelperService,
-              readonly wpStaticQueries:WorkPackageStaticQueriesService) {
+              readonly wpStaticQueries:WorkPackageStaticQueriesService,
+              readonly toggleService:MainMenuToggleService) {
   }
 
   public ngOnInit() {
@@ -435,6 +437,11 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
       params,
       opts
     );
+
+    // On mobile, close the main menu after selecting a view.
+    if (window.innerWidth < 680) {
+      this.toggleService.toggleNavigation()
+    }
   }
 
   private getQueryParams(item:IAutocompleteItem) {


### PR DESCRIPTION
https://community.openproject.com/wp/28356

.... and some layouting/typography of query menu, too