### PR TITLE
[26466] Don't set timelog timeframe condition to today if none exist

### DIFF
--- a/app/controllers/timelog_controller.rb
+++ b/app/controllers/timelog_controller.rb
@@ -65,8 +65,10 @@ class TimelogController < ApplicationController
       cond << @project.project_condition(Setting.display_subprojects_work_packages?)
     end
 
-    retrieve_date_range
-    cond << ['spent_on BETWEEN ? AND ?', @from, @to]
+    retrieve_date_range allow_nil: true
+    if @from && @to
+      cond << ['spent_on BETWEEN ? AND ?', @from, @to]
+    end
 
     respond_to do |format|
       format.html do

--- a/app/helpers/timelog_helper.rb
+++ b/app/helpers/timelog_helper.rb
@@ -199,7 +199,7 @@ module TimelogHelper
   end
 
   # Retrieves the date range based on predefined ranges or specific from/to param dates
-  def retrieve_date_range
+  def retrieve_date_range(allow_nil: false)
     @free_period = false
     @from = nil
     @to = nil
@@ -240,8 +240,11 @@ module TimelogHelper
     end
 
     @from, @to = @to, @from if @from && @to && @from > @to
-    @from ||= (TimeEntry.earliest_date_for_project(@project) || Date.today)
-    @to ||= (TimeEntry.latest_date_for_project(@project) || Date.today)
+
+    unless allow_nil
+      @from ||= (TimeEntry.earliest_date_for_project(@project) || Date.today)
+      @to ||= (TimeEntry.latest_date_for_project(@project) || Date.today)
+    end
   end
 
   def find_optional_project

--- a/spec_legacy/functional/timelog_controller_spec.rb
+++ b/spec_legacy/functional/timelog_controller_spec.rb
@@ -184,8 +184,8 @@ describe TimelogController, type: :controller do
     refute_nil assigns(:total_hours)
     assert_equal '162.90', '%.2f' % assigns(:total_hours)
     # display all time by default
-    assert_equal '2007-03-12'.to_date, assigns(:from)
-    assert_equal '2007-04-22'.to_date, assigns(:to)
+    assert_equal nil, assigns(:from)
+    assert_equal nil, assigns(:to)
     assert_select 'form',
                attributes: { action: '/projects/ecookbook/time_entries', id: 'query_form' }
   end
@@ -235,8 +235,8 @@ describe TimelogController, type: :controller do
     refute_nil assigns(:total_hours)
     assert_equal 154.25, assigns(:total_hours)
     # display all time based on what's been logged
-    assert_equal '2007-03-12'.to_date, assigns(:from)
-    assert_equal '2007-04-22'.to_date, assigns(:to)
+    assert_equal nil, assigns(:from)
+    assert_equal nil, assigns(:to)
     assert_select 'form',
                attributes: { action: work_package_time_entries_path(1), id: 'query_form' }
   end


### PR DESCRIPTION
When no date condition is set, it is set to the earliest date **in the
current project** which in case of #26466 is empty.

https://community.openproject.com/wp/26466