### PR TITLE
[28378][28379] Misplaced "Buy Now" Teaser (Core)

### DIFF
--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -53,7 +53,6 @@ $menu-item-line-height: 30px
     position: relative
 
     // Fixed heights to allow inner scrolling
-    .menu_root,
     .menu_root > li.open,
     .main-menu--children > li.partial,
     wp-query-select,


### PR DESCRIPTION
Remove height from menu to position the buy now teaser correctly. This belongs to: 
https://github.com/finnlabs/openproject-zacero/pull/98