### PR TITLE
Buy now Teaser and scrolling in the Main menu

### DIFF
--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -53,6 +53,7 @@ $menu-item-line-height: 30px
     position: relative
 
     // Fixed heights to allow inner scrolling
+    .menu_root.closed,
     .menu_root > li.open,
     .main-menu--children > li.partial,
     wp-query-select,
@@ -317,10 +318,14 @@ a.main-menu--parent-node
     display: none
 
 .menu-wiki-pages-tree
+  height: 100%
+  overflow: auto
   border-top: $main-menu-border-width solid $main-menu-border-color
   padding-top: 7px
   padding-left: 7px
   padding-right: 7px
+
+  @include styled-scroll-bar
 
 .main-menu--segment-header
   @include varprop(color, main-menu-fieldset-header-color)

--- a/app/assets/stylesheets/layout/work_packages/_query_menu.sass
+++ b/app/assets/stylesheets/layout/work_packages/_query_menu.sass
@@ -15,19 +15,7 @@ $wp-query-menu-search-container-height: 35px
     background: none
     z-index: 0 // Prevent overlapping with project select dropdown (https://community.openproject.com/wp/28175)
 
-    &::-webkit-scrollbar
-      width: 8px
-      height: 12px
-
-    &::-webkit-scrollbar-track
-      background: transparent
-
-    &::-webkit-scrollbar-thumb
-      background: #ddd
-      visibility:hidden
-
-    &:hover::-webkit-scrollbar-thumb
-      visibility:visible
+    @include styled-scroll-bar
 
 
   .wp-query-menu--results-container

--- a/app/assets/stylesheets/openproject/_mixins.sass
+++ b/app/assets/stylesheets/openproject/_mixins.sass
@@ -112,3 +112,18 @@
 @mixin form--field-affix-mixin--transparent
   background: none
   border: none
+
+@mixin styled-scroll-bar
+  &::-webkit-scrollbar
+    width: 8px
+    height: 12px
+
+  &::-webkit-scrollbar-track
+    background: transparent
+
+  &::-webkit-scrollbar-thumb
+    background: #ddd
+    visibility: hidden
+
+  &:hover::-webkit-scrollbar-thumb
+    visibility: visible


### PR DESCRIPTION
This fixes some issues with the scrolling of the sidebar (e.g. in https://github.com/opf/openproject/pull/6620 I was too courageous with removing code).  It is quite complex to catch all cases (all sub menus, w/o teaser, different starting points). The different starting points are quite a problem, because the sidebar looks different depending on which page you started. I will open a separate ticket to unify this. For now it should at least look good enough on all pages and menu parts (independent from where you came from) although there are differences. 


https://community.openproject.com/projects/saas/work_packages/28379/activity