### PR TITLE
[28431] Don't render attachment with downloadLocation

### DIFF
--- a/docs/api/apiv3/endpoints/attachments.apib
+++ b/docs/api/apiv3/endpoints/attachments.apib
@@ -137,8 +137,11 @@ Instead the `fileName` inside the JSON of the metadata part will be used.
                     "author": {
                         "href": "/api/v3/users/1"
                     },
+                    "staticDownloadLocation": {
+                        "href": "/api/v3/attachments/1/download"
+                    }
                     "downloadLocation": {
-                        "href": "/attachments/1/download"
+                        "href": "/some/remote/aws/url/image.png"
                     }
                 },
                 "id": 1,

--- a/frontend/src/app/components/api/op-file-upload/op-file-upload.service.ts
+++ b/frontend/src/app/components/api/op-file-upload/op-file-upload.service.ts
@@ -76,7 +76,7 @@ export class OpenProjectFileUploadService {
     const { uploads, finished } = this.upload(url, files);
     const mapped = finished
       .then((result:HalResource[]) => result.map((el:HalResource) => {
-          return { response: el, uploadUrl: el.downloadLocation.href };
+          return { response: el, uploadUrl: el.staticDownloadLocation.href };
       })) as Promise<{ response:HalResource, uploadUrl:string }[]>;
 
     return { uploads: uploads, finished: mapped } as MappedUploadResult;

--- a/frontend/src/app/modules/hal/resources/mixins/attachable-mixin.ts
+++ b/frontend/src/app/modules/hal/resources/mixins/attachable-mixin.ts
@@ -71,7 +71,7 @@ export function Attachable<TBase extends Constructor<HalResource>>(Base:TBase) {
       }
 
       const match = _.find(this.attachments.elements, (res:HalResource) => res.name === file);
-      return _.get(match, 'downloadLocation.href', null);
+      return _.get(match, 'staticDownloadLocation.href', null);
     }
 
     /**

--- a/lib/api/v3/attachments/attachment_representer.rb
+++ b/lib/api/v3/attachments/attachment_representer.rb
@@ -70,6 +70,12 @@ module API
                             getter: associated_container_getter,
                             link: associated_container_link
 
+        link :staticDownloadLocation do
+          {
+            href: api_v3_paths.attachment_content(represented.id)
+          }
+        end
+
         link :downloadLocation do
           location = if represented.external_storage?
                        represented.external_url

--- a/lib/api/v3/attachments/attachments_api.rb
+++ b/lib/api/v3/attachments/attachments_api.rb
@@ -77,7 +77,7 @@ module API
             namespace :content do
               get do
                 if @attachment.external_storage?
-                  redirect @attachment.external_url
+                  redirect @attachment.external_url.to_s
                 else
                   content_type @attachment.content_type
                   header['Content-Disposition'] = "attachment; filename=#{@attachment.filename}"

--- a/spec/lib/api/v3/attachments/attachment_representer_spec.rb
+++ b/spec/lib/api/v3/attachments/attachment_representer_spec.rb
@@ -142,6 +142,11 @@ describe ::API::V3::Attachments::AttachmentRepresenter do
           let(:link) { 'downloadLocation' }
           let(:href) { external_url }
         end
+
+        it_behaves_like 'has an untitled link' do
+          let(:link) { 'staticDownloadLocation' }
+          let(:href) { api_v3_paths.attachment_content(attachment.id) }
+        end
       end
     end
 


### PR DESCRIPTION
The downloadLocation may contain a temporary URL as it is with the case of AWS.

https://community.openproject.com/wp/28431