### PR TITLE
[28435] Fix custom field with is_for_all eager loading

### DIFF
--- a/lib/api/v3/work_packages/eager_loading/custom_value.rb
+++ b/lib/api/v3/work_packages/eager_loading/custom_value.rb
@@ -153,7 +153,17 @@ module API
           def usage_map
             @usage_map ||= begin
               usages.inject(usage_hash) do |hash, by|
-                hash[by['project_id']][by['type_id']] << custom_field(by['custom_field_id'])
+                cf = custom_field(by['custom_field_id'])
+                target_project_id = by['project_id']
+
+                # If the project_id is NOT nil, and the custom_field is `is_for_all`
+                # Ensure that it gets added to hash[nil] (Regression #28435)
+                if by['project_id'].present? && cf.is_for_all
+                  target_project_id = nil
+                end
+
+                hash[target_project_id][by['type_id']] << cf
+
                 hash
               end
             end


### PR DESCRIPTION
When a custom field is `is_for_all`, and in the join table from custom fields to projects, there exist a value to project A (e.g., before the CF was marked is_for_all in the first place):

Lookups to the work packages in Project B with eager loading will result in this custom field missing, because the `LEFT OUTER JOIN` in usages have already mapped it to Project A.

https://community.openproject.com/wp/28435