### PR TITLE
Feature/28438/beatify inline highlighting

### DIFF
--- a/app/assets/stylesheets/content/_colors.sass
+++ b/app/assets/stylesheets/content/_colors.sass
@@ -84,3 +84,14 @@
 
   a.-dark
     color: white
+
+span[class^='__hl_inl_'],
+span[class*=' __hl_inl_']
+  &::before
+    content: ''
+    display: inline-block
+    width: 12px
+    height: 12px
+    vertical-align: -1px
+    margin-right: 4px
+    border-radius: 50%

--- a/app/assets/stylesheets/content/_colors.sass
+++ b/app/assets/stylesheets/content/_colors.sass
@@ -85,8 +85,8 @@
   a.-dark
     color: white
 
-span[class^='__hl_inl_'],
-span[class*=' __hl_inl_']
+[class^='__hl_dot_'],
+[class*=' __hl_dot_']
   &::before
     content: ''
     display: inline-block

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -53,9 +53,9 @@ class Color < ActiveRecord::Base
   end
 
   ##
-  # Get the fill style for this color
-  # If the color is bright, use itself for filling
-  # Otherwise, use a transparent background with the color itself
+  # Get the fill style for this color.
+  # If the color is light, use a dark font.
+  # Otherwise, use a white font.
   def color_styles(light_color: '#FFFFFF', dark_color: '#333333')
     if bright?
       { color: dark_color, 'background-color': hexcode }

--- a/app/views/colors/_color_autocomplete_field.html.erb
+++ b/app/views/colors/_color_autocomplete_field.html.erb
@@ -1,11 +1,12 @@
-<div class="form--field">
-    <%= form.select :color_id,
-                    options_for_colors(object),
-                    {},
-                    container_class: '-middle',
-                    class: 'colors-autocomplete' %>
+<% form_field_class = form_field_class || '' %>
+<% container_class  = container_class  || '' %>
+<div class="form--field <%= form_field_class %>">
+  <%= form.select :color_id,
+                  options_for_colors(object),
+                  {},
+                  container_class: container_class.present? ? container_class : '-middle',
+                  class: 'colors-autocomplete' %>
 
-    <div class="form--field-instructions"><%= label %></div>
-    <colors-autocompleter></colors-autocompleter>
-  </div>
+  <div class="form--field-instructions"><%= label %></div>
+  <colors-autocompleter></colors-autocompleter>
 </div>

--- a/app/views/highlighting/styles.css.erb
+++ b/app/views/highlighting/styles.css.erb
@@ -7,7 +7,7 @@
       inline_style = styles.map{|k,v| "#{k}:#{v} !important"}.join(';')
       row_style = "background-color: #{color.hexcode} !important;"
 
-      concat ".__hl_inl_#{name}_#{entry.id}::before { #{inline_style} }\n"
+      concat ".__hl_inl_#{name}_#{entry.id}, .__hl_dot_#{name}_#{entry.id}::before { #{inline_style} }\n"
       concat ".__hl_row_#{name}_#{entry.id} { #{row_style} }\n"
 
       # Mark color as bright through CSS variable

--- a/app/views/highlighting/styles.css.erb
+++ b/app/views/highlighting/styles.css.erb
@@ -7,7 +7,7 @@
       inline_style = styles.map{|k,v| "#{k}:#{v} !important"}.join(';')
       row_style = "background-color: #{color.hexcode} !important;"
 
-      concat ".__hl_inl_#{name}_#{entry.id} { #{inline_style} }\n"
+      concat ".__hl_inl_#{name}_#{entry.id}::before { #{inline_style} }\n"
       concat ".__hl_row_#{name}_#{entry.id} { #{row_style} }\n"
 
       # Mark color as bright through CSS variable

--- a/app/views/types/form/_settings.html.erb
+++ b/app/views/types/form/_settings.html.erb
@@ -32,7 +32,14 @@ See docs/COPYRIGHT.rdoc for more details.
     <!--[form:type]-->
     <div class="form--field -wide-label"><%= f.text_field :name, required: true, disabled: @type.is_standard?, container_class: '-middle' %></div>
     <div class="form--field -wide-label"><%= f.check_box :is_in_roadmap %></div>
-    <div class="form--field -wide-label"><%= f.select :color_id, options_for_colors(@type), container_class: '-slim' %></div>
+    <%= render partial: '/colors/color_autocomplete_field',
+               locals: {
+                   form: f,
+                   object: @type,
+                   label: t('types.edit.type_color_text'),
+                   form_field_class: '-wide-label',
+                   container_class: '-slim'
+               } %>
     <div class="form--field -wide-label"><%= f.check_box :is_default %></div>
     <div class="form--field -wide-label"><%= f.check_box :is_milestone %></div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,6 +212,9 @@ en:
       add_subelements: "Add subelements group"
       edit_query: "Edit embedded query"
       reset: "Reset to defaults"
+      type_color_text: |
+        Click to assign or change the color of this type. The selected color will is used to distinguish work packages
+        in Gantt charts.
 
   versions:
     overview:

--- a/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
@@ -95,14 +95,14 @@ export class WorkPackageStatusDropdownDirective extends OpContextMenuTrigger {
         this.wpTableRefresh.request('Altered work package status via button');
       });
     }
-  };
+  }
 
   private buildItems(statuses:CollectionResource<HalResource>) {
     this.items = statuses.map((status:HalResource) => {
       return {
         disabled: false,
         linkText: status.name,
-        class: Highlighting.dotClass('status', status.getId());
+        class: Highlighting.dotClass('status', status.getId()),
         onClick: () => {
           this.updateStatus(status);
           return true;

--- a/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
@@ -37,6 +37,7 @@ import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-r
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
 import {CollectionResource} from 'core-app/modules/hal/resources/collection-resource';
 import {IWorkPackageEditingServiceToken} from "../../wp-edit-form/work-package-editing.service.interface";
+import {Highlighting} from "core-components/wp-fast-table/builders/highlighting/highlighting.functions";
 
 @Directive({
   selector: '[wpStatusDropdown]'
@@ -101,6 +102,7 @@ export class WorkPackageStatusDropdownDirective extends OpContextMenuTrigger {
       return {
         disabled: false,
         linkText: status.name,
+        class: Highlighting.dotClass('status', status.getId());
         onClick: () => {
           this.updateStatus(status);
           return true;

--- a/frontend/src/app/components/wp-fast-table/builders/highlighting/highlighting.functions.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/highlighting/highlighting.functions.ts
@@ -7,6 +7,10 @@ export namespace Highlighting {
     return `__hl_inl_${property}_${id}`;
   }
 
+  export function dotClass(property:string, id:string|number) {
+    return `__hl_dot_${property}_${id}`;
+  }
+
   /**
    * Given the difference from today (negative = n days in the past),
    * output the fixed overdue classes

--- a/frontend/src/app/modules/fields/display/field-types/wp-display-highlighted-resource-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-display-highlighted-resource-field.module.ts
@@ -51,7 +51,7 @@ export class HighlightedResourceDisplayField extends HighlightableDisplayField {
 
   private addHighlight(element:HTMLElement):void {
     if (this.attribute instanceof HalResource) {
-      const hlClass = Highlighting.inlineClass(this.name, this.attribute.getId());
+      const hlClass = Highlighting.dotClass(this.name, this.attribute.getId());
       element.classList.add(hlClass);
     }
   }

--- a/spec/features/work_packages/highlighting_spec.rb
+++ b/spec/features/work_packages/highlighting_spec.rb
@@ -56,17 +56,24 @@ describe 'Work Package highlighting fields', js: true do
     wp2_row = wp_table.row(wp_2)
 
     ## Status
-    status1_field = wp1_row.find(".__hl_inl_status_#{status1.id}")
-    expect(status1_field.native.css_value('background-color')).to eq('rgba(255, 0, 0, 1)')
-    status2_field = wp2_row.find(".__hl_inl_status_#{status2.id}")
-    expect(status2_field.native.css_value('background-color')).to eq('rgba(240, 240, 240, 1)')
+    expect(SelectorHelpers.get_pseudo_class_property(page,
+                                                     wp1_row.find('[class^="__hl_dot_status_"]'),
+                                                     ':before',
+                                                     "background-color")).to eq('rgb(255, 0, 0)')
+    expect(SelectorHelpers.get_pseudo_class_property(page,
+                                                     wp2_row.find('[class^="__hl_dot_status_"]'),
+                                                     ':before',
+                                                     "background-color")).to eq('rgb(240, 240, 240)')
 
     ## Priority
-    prio1_field = wp1_row.find(".__hl_inl_priority_#{priority1.id}")
-    expect(prio1_field.native.css_value('background-color')).to eq('rgba(18, 52, 86, 1)')
-    ## Priority has no color assigned
-    prio2_field = wp2_row.find(".__hl_inl_priority_#{priority_no_color.id}")
-    expect(prio2_field.native.css_value('background-color')).to eq('rgba(0, 0, 0, 0)')
+    expect(SelectorHelpers.get_pseudo_class_property(page,
+                                                     wp1_row.find('[class^="__hl_dot_priority_"]'),
+                                                     ':before',
+                                                     "background-color")).to eq('rgb(18, 52, 86)')
+    expect(SelectorHelpers.get_pseudo_class_property(page,
+                                                     wp2_row.find('[class^="__hl_dot_priority_"]'),
+                                                     ':before',
+                                                     "background-color")).to eq('rgba(0, 0, 0, 0)')
 
     ## Overdue
     expect(wp1_row).to have_selector('.__hl_date_overdue')
@@ -129,6 +136,6 @@ describe 'Work Package highlighting fields', js: true do
     # Expect highlighted fields in single view even when table disabled
     wp_table.open_full_screen_by_doubleclick wp_1
     expect(page).to have_selector(".wp-status-button .__hl_inl_status_#{status1.id}")
-    expect(page).to have_selector(".__hl_inl_priority_#{priority1.id}")
+    expect(page).to have_selector(".__hl_dot_priority_#{priority1.id}")
   end
 end

--- a/spec/support/selector_helpers.rb
+++ b/spec/support/selector_helpers.rb
@@ -1,0 +1,42 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+
+module SelectorHelpers
+  module_function
+
+  def get_pseudo_class_property(page, node, pseudo_class, property)
+    page.evaluate_script('window.getComputedStyle(' + element_by_node(node) + ', "' +
+                                                  pseudo_class +
+                         '").getPropertyValue("' + property + '")')
+  end
+
+  def element_by_node(node)
+    'document.evaluate("' + node.path + '", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue'
+  end
+end


### PR DESCRIPTION
- Prepend big colored dots before the attribute to highlight it.
- Add extra class for dot coloring and apply it to status selector options.
- Reuse color selector for editing types.

https://community.openproject.com/wp/28438
https://community.openproject.com/wp/28437