### PR TITLE
Improve UX of WP view config modal

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -471,6 +471,9 @@ fieldset.form--fieldset
   &.-no-italic
     font-style: normal
 
+.form--inline-instructions
+  font-style: italic
+
 .form--field-extra-actions
   @extend %form--field-after-container
   @include grid-visible-overflow
@@ -599,6 +602,10 @@ input[readonly].-clickable
     // styles adapted to input fields to align them
     .select2-choice
       height: 2.15rem
+
+.form--inline-select
+  display: inline-block
+  width: initial
 
 .form--text-field,
 .form--select

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -630,6 +630,7 @@ en:
         text_select_hint: "Select boxes should be opened with 'ALT' and arrow keys."
       table_configuration:
         button: 'Configure this work package table'
+        choose_display_mode: 'Display work packages as'
         modal_title: 'Work package table configuration'
         embedded_tab_disabled: "This configuration tab is not available for the embedded view you're editing."
         default: "default"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -632,11 +632,10 @@ en:
         button: 'Configure this work package table'
         modal_title: 'Work package table configuration'
         embedded_tab_disabled: "This configuration tab is not available for the embedded view you're editing."
+        default: "default"
         display_settings: 'Display settings'
-        grouped_mode: "Grouped mode"
-        grouped_hint: "Table results will be grouped by the given attribute."
-        default_mode: "Default mode"
-        hierarchy_mode: "Hierarchy mode"
+        default_mode: "Flat list"
+        hierarchy_mode: "Hierarchy"
         hierarchy_hint: "All filtered table results will be augmented with their ancestors. Hierarchies can be expanded and collapsed."
         display_sums_hint: "Display sums of all summable attributes in a row below the table results."
         show_timeline_hint: "Show an interactive gantt chart on the right side of the table. You can change its width by dragging the divider between table and gantt chart."

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -642,15 +642,12 @@ en:
         show_timeline_hint: "Show an interactive gantt chart on the right side of the table. You can change its width by dragging the divider between table and gantt chart."
         highlighting: 'Highlighting'
         highlighting_mode:
-          description: "Control highlighting of rows through a color defined by a work package attribute, such as priority or status."
-          none: "None"
-          none_text: "Disables highlighted output of attributes in the table altogether."
-          inline: "Inline"
-          inline_text: "No highlighting of work package rows. Display colors of overdue dates, status, and priority attributes in their respective columns."
-          status: "Status"
-          status_text: "Highlight work package rows based on the color of its status."
-          priority: "Priority"
-          priority_text: "Highlight work package rows based on the color of its priority."
+          description: "Highlight with color"
+          none: "No highlighting"
+          inline: 'Overdue dates, "Status", and "Priority" attributes'
+          entire_row_by: 'Entire row by'
+          status: 'Status'
+          priority: 'Priority'
         columns_help_text: "Use the input above to add or remove columns to your table view. You can drag and drop the columns to reorder them."
       tabs:
         overview: Overview

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/columns-tab.component.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/columns-tab.component.html
@@ -7,7 +7,7 @@
   <ng-container *ngIf="!impaired">
     <input #select2Columns
            type="hidden" />
-    <p class="columns-modal--help-text" [textContent]="text.columnsHelp"></p>
+    <p class="form--inline-instructions" [textContent]="text.columnsHelp"></p>
   </ng-container>
   <ng-container *ngIf="impaired">
   <div *ngFor="let column of availableColumns; let first = first;">

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/display-settings-tab.component.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/display-settings-tab.component.html
@@ -1,5 +1,6 @@
 <div>
   <form>
+    <p>Display work packages as</p>
     <div class="form--field -full-width">
       <div class="form--field-container">
         <label class="option-label">
@@ -7,56 +8,56 @@
                  [(ngModel)]="displayMode"
                  value="default"
                  name="display_mode_switch">
+          <op-icon icon-classes="icon-no-hierarchy"
+                   icon-title="{{ text.display_mode.default }}"></op-icon>
           {{ text.display_mode.default }}
+          <span class="form--inline-instructions" [textContent]="text.default"></span>
         </label>
-        <label class="option-label">
-          <input type="radio"
-                 [(ngModel)]="displayMode"
-                 value="grouped"
-                 name="display_mode_switch">
-          {{ text.display_mode.grouped }}
-        </label>
+      </div>
+    </div>
+    <div class="form--field -full-width">
+      <div class="form--field-container">
         <label class="option-label">
           <input type="radio"
                  [(ngModel)]="displayMode"
                  value="hierarchy"
                  name="display_mode_switch">
+          <op-icon icon-classes="icon-hierarchy"
+                   icon-title="{{ text.display_mode.hierarchy }}"></op-icon>
           {{ text.display_mode.hierarchy }}
+          <span *ngIf="displayMode === 'hierarchy'"
+                class="form--inline-instructions"
+                [textContent]="text.display_mode.hierarchy_hint"></span>
         </label>
       </div>
     </div>
-    <div *ngIf="displayMode === 'grouped'">
-      <h4 [textContent]="text.label_group_by"></h4>
-      <p [textContent]="text.display_mode.grouped_hint"></p>
-      <div class="form--field -full-width">
-        <label
-          for="selected_grouping"
-          [textContent]="text.label_group_by"
-          class="form--label hidden-for-sighted">
+    <div class="form--field -full-width">
+      <div class="form--field-container">
+        <label class="option-label">
+          <input type="radio"
+                 [(ngModel)]="displayMode"
+                 value="grouped"
+                 name="display_mode_switch">
+          <op-icon icon-classes="icon-group-by"
+                   icon-title="{{ text.label_group_by }}"></op-icon>
+          {{ text.label_group_by }}
+          <select *ngIf="displayMode === 'grouped'"
+                  (change)="updateGroup($event.target.value)"
+                  id="selected_grouping"
+                  name="selected_grouping"
+                  class="form--select form--inline-select">
+            <option [textContent]="text.please_select"
+                    [selected]="!currentGroup"
+                    disabled
+                    [value]="''"></option>
+            <option *ngFor="let group of availableGroups"
+                    [textContent]="group.name"
+                    [selected]="currentGroup && currentGroup!.href === group.href"
+                    [value]="group.href"></option>
+          </select>
+          <span *ngIf="displayMode !== 'grouped'">...</span>
         </label>
-        <div class="form--field-container">
-          <div class="form--select-container">
-            <select
-              (change)="updateGroup($event.target.value)"
-              id="selected_grouping"
-              name="selected_grouping"
-              class="form--select">
-              <option [textContent]="text.please_select"
-                      [selected]="!currentGroup"
-                      disabled
-                      [value]="''"></option>
-              <option *ngFor="let group of availableGroups"
-                      [textContent]="group.name"
-                      [selected]="currentGroup && currentGroup!.href === group.href"
-                      [value]="group.href"></option>
-            </select>
-          </div>
-        </div>
       </div>
-    </div>
-    <div *ngIf="displayMode === 'hierarchy'">
-      <h4 [textContent]="text.display_mode.hierarchy"></h4>
-      <p [textContent]="text.display_mode.hierarchy_hint"></p>
     </div>
 
     <hr/>
@@ -70,10 +71,11 @@
                    [checked]="displaySums"
                    name="display_sums_switch">
             {{ text.display_sums }}
+            <span class="form--inline-instructions" [textContent]="text.display_sums_hint"></span>
           </label>
         </div>
       </div>
-      <p [textContent]="text.display_sums_hint"></p>
+
     </div>
   </form>
 </div>

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/display-settings-tab.component.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/display-settings-tab.component.html
@@ -38,21 +38,15 @@
                  name="display_mode_switch">
           <op-icon icon-classes="icon-group-by" [attr.icon-title]="text.label_group_by"></op-icon>
           {{ text.label_group_by }}
-          <select *ngIf="displayMode === 'grouped'"
-                  (change)="updateGroup($event.target.value)"
+          <select (change)="updateGroup($event.target.value)"
                   id="selected_grouping"
                   name="selected_grouping"
                   class="form--select form--inline-select">
-            <option [textContent]="text.please_select"
-                    [selected]="!currentGroup"
-                    disabled
-                    [value]="''"></option>
             <option *ngFor="let group of availableGroups"
                     [textContent]="group.name"
                     [selected]="currentGroup && currentGroup!.href === group.href"
                     [value]="group.href"></option>
           </select>
-          <span *ngIf="displayMode !== 'grouped'">...</span>
         </label>
       </div>
     </div>

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/display-settings-tab.component.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/display-settings-tab.component.html
@@ -1,6 +1,6 @@
 <div>
   <form>
-    <p>Display work packages as</p>
+    <p [textContent]="text.choose_mode"></p>
     <div class="form--field -full-width">
       <div class="form--field-container">
         <label class="option-label">
@@ -8,8 +8,7 @@
                  [(ngModel)]="displayMode"
                  value="default"
                  name="display_mode_switch">
-          <op-icon icon-classes="icon-no-hierarchy"
-                   icon-title="{{ text.display_mode.default }}"></op-icon>
+          <op-icon icon-classes="icon-no-hierarchy" [attr.icon-title]="text.display_mode.default"></op-icon>
           {{ text.display_mode.default }}
           <span class="form--inline-instructions" [textContent]="text.default"></span>
         </label>
@@ -22,8 +21,7 @@
                  [(ngModel)]="displayMode"
                  value="hierarchy"
                  name="display_mode_switch">
-          <op-icon icon-classes="icon-hierarchy"
-                   icon-title="{{ text.display_mode.hierarchy }}"></op-icon>
+          <op-icon icon-classes="icon-hierarchy" [attr.icon-title]="text.display_mode.hierarchy"></op-icon>
           {{ text.display_mode.hierarchy }}
           <span *ngIf="displayMode === 'hierarchy'"
                 class="form--inline-instructions"
@@ -38,8 +36,7 @@
                  [(ngModel)]="displayMode"
                  value="grouped"
                  name="display_mode_switch">
-          <op-icon icon-classes="icon-group-by"
-                   icon-title="{{ text.label_group_by }}"></op-icon>
+          <op-icon icon-classes="icon-group-by" [attr.icon-title]="text.label_group_by"></op-icon>
           {{ text.label_group_by }}
           <select *ngIf="displayMode === 'grouped'"
                   (change)="updateGroup($event.target.value)"

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/display-settings-tab.component.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/display-settings-tab.component.ts
@@ -26,14 +26,14 @@ export class WpTableConfigurationDisplaySettingsTab implements TabComponent {
     title: this.I18n.t('js.label_group_by'),
     placeholder: this.I18n.t('js.placeholders.default'),
     please_select: this.I18n.t('js.placeholders.selection'),
+    default: '— ' + this.I18n.t('js.work_packages.table_configuration.default'),
     display_sums: this.I18n.t('js.work_packages.query.display_sums'),
-    display_sums_hint: this.I18n.t('js.work_packages.table_configuration.display_sums_hint'),
+    display_sums_hint: '- ' + this.I18n.t('js.work_packages.table_configuration.display_sums_hint'),
     display_mode: {
       default: this.I18n.t('js.work_packages.table_configuration.default_mode'),
       grouped: this.I18n.t('js.work_packages.table_configuration.grouped_mode'),
-      grouped_hint: this.I18n.t('js.work_packages.table_configuration.grouped_hint'),
       hierarchy: this.I18n.t('js.work_packages.table_configuration.hierarchy_mode'),
-      hierarchy_hint: this.I18n.t('js.work_packages.table_configuration.hierarchy_hint')
+      hierarchy_hint: '— ' + this.I18n.t('js.work_packages.table_configuration.hierarchy_hint')
     }
   };
 

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/display-settings-tab.component.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/display-settings-tab.component.ts
@@ -58,6 +58,7 @@ export class WpTableConfigurationDisplaySettingsTab implements TabComponent {
   }
 
   public updateGroup(href:string) {
+    this.displayMode = 'grouped';
     this.currentGroup = _.find(this.availableGroups, group => group.href === href);
   }
 

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/display-settings-tab.component.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/display-settings-tab.component.ts
@@ -22,13 +22,14 @@ export class WpTableConfigurationDisplaySettingsTab implements TabComponent {
   public displaySums:boolean = false;
 
   public text = {
+    choose_mode: this.I18n.t('js.work_packages.table_configuration.choose_display_mode'),
     label_group_by: this.I18n.t('js.label_group_by'),
     title: this.I18n.t('js.label_group_by'),
     placeholder: this.I18n.t('js.placeholders.default'),
     please_select: this.I18n.t('js.placeholders.selection'),
     default: '— ' + this.I18n.t('js.work_packages.table_configuration.default'),
     display_sums: this.I18n.t('js.work_packages.query.display_sums'),
-    display_sums_hint: '- ' + this.I18n.t('js.work_packages.table_configuration.display_sums_hint'),
+    display_sums_hint: '— ' + this.I18n.t('js.work_packages.table_configuration.display_sums_hint'),
     display_mode: {
       default: this.I18n.t('js.work_packages.table_configuration.default_mode'),
       grouped: this.I18n.t('js.work_packages.table_configuration.grouped_mode'),

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.html
@@ -6,34 +6,47 @@
         <label class="option-label">
           <input type="radio"
                  [(ngModel)]="highlightingMode"
+                 (change)="updateMode($event.target.value)"
                  value="inline"
                  name="highlighting_mode_switch">
           {{ text.highlighting_mode.inline }}
         </label>
+      </div>
+    </div>
+    <div class="form--field -full-width">
+      <div class="form--field-container">
         <label class="option-label">
           <input type="radio"
-                 [(ngModel)]="highlightingMode"
-                 value="status"
-                 name="highlighting_mode_switch">
-          {{ text.highlighting_mode.status }}
+                 [(ngModel)]="entireRowMode"
+                 (change)="updateMode('entire-row')"
+                 [value]="true"
+                 name="entire_row_switch">
+          {{ text.highlighting_mode.entire_row_by }}
+          <select (change)="updateMode($event.target.value)"
+                  id="selected_attribute"
+                  name="selected_attribute"
+                  class="form--select form--inline-select">
+            <option [textContent]="text.highlighting_mode.status"
+                    [selected]="lastEntireRowAttribute === 'status'"
+                    value="status"></option>
+            <option [textContent]="text.highlighting_mode.priority"
+                    [selected]="lastEntireRowAttribute === 'priority'"
+                    value="priority"></option>
+          </select>
         </label>
+      </div>
+    </div>
+    <div class="form--field -full-width">
+      <div class="form--field-container">
         <label class="option-label">
           <input type="radio"
                  [(ngModel)]="highlightingMode"
-                 value="priority"
-                 name="highlighting_mode_switch">
-          {{ text.highlighting_mode.priority }}
-        </label>
-        <label class="option-label">
-          <input type="radio"
-                 [(ngModel)]="highlightingMode"
+                 (change)="updateMode($event.target.value)"
                  value="none"
                  name="highlighting_mode_switch">
           {{ text.highlighting_mode.none }}
         </label>
       </div>
     </div>
-    <p class="form--field-instructions -no-margin"
-       [textContent]="selectedModeDescription"></p>
   </form>
 </div>

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
@@ -12,20 +12,19 @@ import {HighlightingMode} from "core-components/wp-fast-table/builders/highlight
 export class WpTableConfigurationHighlightingTab implements TabComponent {
 
   // Display mode
-  public highlightingMode:HighlightingMode = 'inline';
+  public highlightingMode:HighlightingMode|'entire-row' = 'inline';
+  public entireRowMode:boolean = false;
+  public lastEntireRowAttribute:HighlightingMode = 'status';
 
   public text = {
     title: this.I18n.t('js.work_packages.table_configuration.highlighting'),
     highlighting_mode: {
       description: this.I18n.t('js.work_packages.table_configuration.highlighting_mode.description'),
       none: this.I18n.t('js.work_packages.table_configuration.highlighting_mode.none'),
-      none_text: this.I18n.t('js.work_packages.table_configuration.highlighting_mode.none_text'),
       inline: this.I18n.t('js.work_packages.table_configuration.highlighting_mode.inline'),
-      inline_text: this.I18n.t('js.work_packages.table_configuration.highlighting_mode.inline_text'),
       status: this.I18n.t('js.work_packages.table_configuration.highlighting_mode.status'),
-      status_text: this.I18n.t('js.work_packages.table_configuration.highlighting_mode.status_text'),
       priority: this.I18n.t('js.work_packages.table_configuration.highlighting_mode.priority'),
-      priority_text: this.I18n.t('js.work_packages.table_configuration.highlighting_mode.priority_text')
+      entire_row_by: this.I18n.t('js.work_packages.table_configuration.highlighting_mode.entire_row_by'),
     }
   };
 
@@ -35,14 +34,25 @@ export class WpTableConfigurationHighlightingTab implements TabComponent {
   }
 
   public onSave() {
-    this.wpTableHighlight.update(this.highlightingMode);
+    this.wpTableHighlight.update(this.highlightingMode as HighlightingMode);
   }
 
-  public get selectedModeDescription() {
-    return (this.text.highlighting_mode as any)[`${this.highlightingMode}_text`];
+  public updateMode(mode:HighlightingMode|'entire-row') {
+    if (mode === 'entire-row') {
+      this.highlightingMode = this.lastEntireRowAttribute;
+    } else {
+      this.highlightingMode = mode;
+    }
+
+    if (this.highlightingMode === 'status' || this.highlightingMode === 'priority') {
+      this.lastEntireRowAttribute = this.highlightingMode;
+      this.entireRowMode = true;
+    } else {
+      this.entireRowMode = false;
+    }
   }
 
   ngOnInit() {
-    this.highlightingMode = this.wpTableHighlight.current;
+    this.updateMode(this.wpTableHighlight.current);
   }
 }

--- a/spec/features/work_packages/highlighting_spec.rb
+++ b/spec/features/work_packages/highlighting_spec.rb
@@ -120,8 +120,8 @@ describe 'Work Package highlighting fields', js: true do
     expect(page).to have_no_selector('[class*="__hl_inl_priority"]')
     expect(page).to have_no_selector('[class*="__hl_date"]')
 
-    # Highlight none
-    highlighting.switch_highlight 'None'
+    # No highlighting
+    highlighting.switch_highlight 'No highlighting'
     expect(page).to have_no_selector('[class*="__hl_row"]')
     expect(page).to have_no_selector('[class*="__hl_inl_status"]')
     expect(page).to have_no_selector('[class*="__hl_inl_priority"]')

--- a/spec/support/components/work_packages/table_configuration/highlighting.rb
+++ b/spec/support/components/work_packages/table_configuration/highlighting.rb
@@ -34,17 +34,14 @@ module Components
 
       def initialize; end
 
-      def disable_highlight
-        switch_highlight 'Disabled'
-      end
-
-      def inline_highlight
-        switch_highlight 'Default (inline)'
-      end
-
       def switch_highlight(label)
         modal_open? or open_modal
-        choose label
+        if %w(Status Priority).include? label
+          choose "Entire row by"
+          select label
+        else
+          choose label
+        end
         apply
       end
 


### PR DESCRIPTION
The changes won't win any beautiy price. However, I believe they improve the usability. Please checkout the following tabs (or see the screenshots below):

- Display settings
- Highlighting

I would love to change the tab **Sort by**, too. I dislike the naming of the default sorting **Parent**. Unfortunately I don't have any better suggestion. **All ancestor IDs** does not make it better. Maybe simply say **Default** and leave it as a black box...

Feedback welcome!!

![image](https://user-images.githubusercontent.com/327272/45107328-83f62900-b139-11e8-8928-0ccf4fe3ca81.png)

![image](https://user-images.githubusercontent.com/327272/45107338-8d7f9100-b139-11e8-98c6-ea6276f58394.png)
