### PR TITLE
[28004][28430] Custom Actions: Implement current user assignee and improve performance

### DIFF
--- a/app/models/custom_actions/actions/assigned_to.rb
+++ b/app/models/custom_actions/actions/assigned_to.rb
@@ -31,7 +31,27 @@
 class CustomActions::Actions::AssignedTo < CustomActions::Actions::Base
   include CustomActions::Actions::Strategies::Associated
 
+  def self.key
+    :assigned_to
+  end
+
   def associated
+    [[current_user_value_key, I18n.t('custom_actions.actions.assigned_to.executing_user_value')]] + available_principles
+  end
+
+  def values=(values)
+    values = Array(values).map do |v|
+      if v == current_user_value_key
+        v
+      else
+        to_integer_or_nil(v)
+      end
+    end
+
+    @values = values.uniq
+  end
+
+  def available_principles
     principal_class
       .active_or_registered
       .select(:id, :firstname, :lastname, :type)
@@ -39,15 +59,42 @@ class CustomActions::Actions::AssignedTo < CustomActions::Actions::Base
       .map { |u| [u.id, u.name] }
   end
 
-  def required?
-    false
+  def apply(work_package)
+    work_package.assigned_to_id = transformed_value(values.first)
   end
 
-  def self.key
-    :assigned_to
+  ##
+  # Returns the me value if the user is logged
+  def transformed_value(val)
+    return val unless has_me_value?
+
+    if User.current.logged?
+      User.current.id
+    end
+  end
+
+  def current_user_value_key
+    'current_user'.freeze
+  end
+
+  def has_me_value?
+    values.first == current_user_value_key
+  end
+
+  def validate(errors)
+    super
+    validate_me_value(errors)
   end
 
   private
+
+  def validate_me_value(errors)
+    if has_me_value? && !User.current.logged?
+      errors.add :actions,
+                 I18n.t(:'activerecord.errors.models.custom_actions.not_logged_in', name: human_name),
+                 error_symbol: :not_logged_in
+    end
+  end
 
   def principal_class
     if Setting.work_package_group_assignment?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,8 @@ en:
     actions:
       name: 'Actions'
       add: 'Add action'
+      assigned_to:
+        executing_user_value: '(Assign to executing user)'
     conditions: 'Conditions'
     plural: 'Custom actions'
     new: 'New custom action'
@@ -473,6 +475,7 @@ en:
           only_one_allowed: "(%{name}) only one value is allowed."
           empty: "(%{name}) value can't be empty."
           inclusion: "(%{name}) value is not set to one of the allowed values."
+          not_logged_in: "(%{name}) value cannot be set because you are not logged in."
           not_an_integer: "(%{name}) is not an integer."
           smaller_than_or_equal_to: "(%{name}) must be smaller than or equal to %{count}."
           greater_than_or_equal_to: "(%{name}) must be greater than or equal to %{count}."

--- a/frontend/legacy/app/components/autocomplete-select-decoration/autocomplete-select-decoration.component.ts
+++ b/frontend/legacy/app/components/autocomplete-select-decoration/autocomplete-select-decoration.component.ts
@@ -126,7 +126,7 @@ export class AutocompleteSelectDecorationComponent {
 
   private setupAutocompleter() {
     let autocompleteOptions = {
-      delay: 100,
+      delay: 250,
       minLength: 0,
       position: { my: 'left top', at: 'left bottom', collision: 'flip' },
       classes: {
@@ -134,11 +134,16 @@ export class AutocompleteSelectDecorationComponent {
       },
       source: (request:{ term:string }, response:Function) => {
         let available = _.difference(this.allItems, this.selectedItems);
-        let withTerm = _.filter(available, (item) =>
-          item.value.toLowerCase().indexOf(request.term.toLowerCase()) !== -1
-        );
+        let matches = available;
 
-        response(withTerm);
+        // Filter only for non-empty terms
+        if (request.term !== '') {
+          matches = available.filter((item) =>
+            item.value.toLowerCase().indexOf(request.term.toLowerCase()) !== -1
+          );
+        }
+
+        return response(_.take(matches, 100));
       },
       select: (evt:JQueryEventObject, ui:any) => {
         this.setValue(ui.item);


### PR DESCRIPTION
Resolves performance for large number of users when opening autocompleter by reducing default set of values until filtered. 

With this, performance is bearable on community.

This implements the `current_user` value replacement similar to the `AssignedToFilter`. If the user is not logged in, the value is not applied.

https://community.openproject.com/wp/28004
https://community.openproject.com/wp/28430