### PR TITLE
[28448] Avoid running into nil project on validation check

### DIFF
--- a/app/models/queries/work_packages/filter/subproject_filter.rb
+++ b/app/models/queries/work_packages/filter/subproject_filter.rb
@@ -82,7 +82,7 @@ class Queries::WorkPackages::Filter::SubprojectFilter <
       # include the selected subprojects
       ids += values.each(&:to_i)
     when '*'
-      ids += project.descendants.pluck(:id)
+      ids += visible_subprojects.pluck(:id)
     end
 
     "#{Project.table_name}.id IN (%s)" % ids.join(',')
@@ -91,7 +91,14 @@ class Queries::WorkPackages::Filter::SubprojectFilter <
   private
 
   def visible_subprojects
-    @visible_subprojects ||= project.descendants.visible
+    # This can be accessed even when `available?` is false
+    @visible_subprojects ||= begin
+      if project.nil?
+        Project.none
+      else
+        project.descendants.visible
+      end
+    end
   end
 
   def operator_strategy

--- a/app/models/queries/work_packages/filter/subproject_filter.rb
+++ b/app/models/queries/work_packages/filter/subproject_filter.rb
@@ -32,7 +32,7 @@ class Queries::WorkPackages::Filter::SubprojectFilter <
   Queries::WorkPackages::Filter::WorkPackageFilter
   def allowed_values
     @allowed_values ||= begin
-      visible_subprojects.map { |s| [s.name, s.id.to_s] }
+      visible_subprojects.map { |id, name| [name, id.to_s] }
     end
   end
 
@@ -45,7 +45,7 @@ class Queries::WorkPackages::Filter::SubprojectFilter <
   def available?
     project &&
       !project.leaf? &&
-      visible_subprojects.exists?
+      visible_subprojects.any?
   end
 
   def type
@@ -71,7 +71,7 @@ class Queries::WorkPackages::Filter::SubprojectFilter <
   def value_objects
     value_ints = values.map(&:to_i)
 
-    visible_subprojects.select { |p| value_ints.include?(p.id) }
+    visible_subprojects.select { |id,_| value_ints.include?(id) }
   end
 
   def where
@@ -82,7 +82,7 @@ class Queries::WorkPackages::Filter::SubprojectFilter <
       # include the selected subprojects
       ids += values.each(&:to_i)
     when '*'
-      ids += visible_subprojects.pluck(:id)
+      ids += visible_subprojects.map(&:first)
     end
 
     "#{Project.table_name}.id IN (%s)" % ids.join(',')
@@ -94,9 +94,9 @@ class Queries::WorkPackages::Filter::SubprojectFilter <
     # This can be accessed even when `available?` is false
     @visible_subprojects ||= begin
       if project.nil?
-        Project.none
+        []
       else
-        project.descendants.visible
+        project.descendants.visible.pluck(:id, :name)
       end
     end
   end


### PR DESCRIPTION
The `Subproject` filter controls through `applicable?` that it is not applied to a valid subset when the given project is nil.

However, when testing an existing query where the project is no longer existing (deleted, e.g.,), the filter validation will try to access `values`, which in this case runs into a nil project.

We may want to consider moving this into a higher place, e.g., not running all validations when the filter is not `applicable?`

https://community.openproject.com/wp/28448 