### PR TITLE
Remove "Parent" form Sort by modal tab

### DIFF
--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/sort-by-tab.component.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/sort-by-tab.component.ts
@@ -65,7 +65,11 @@ export class WpTableConfigurationSortByTab implements TabComponent {
       .pipe(take(1))
       .toPromise()
       .then(() => {
-        let allColumns:SortColumn[] = this.wpTableSortBy.available.map(
+        let allColumns:SortColumn[] = this.wpTableSortBy.available.filter(
+          (sort:QuerySortByResource) => {
+            return !sort.column.$href!.endsWith('/parent');
+          }
+        ).map(
           (sort:QuerySortByResource) => {
             return {name: sort.column.name, href: sort.column.$href};
           }
@@ -76,10 +80,12 @@ export class WpTableConfigurationSortByTab implements TabComponent {
         this.allColumns = _.uniqBy(allColumns, 'href');
 
         _.each(this.wpTableSortBy.currentSortBys, sort => {
-          this.sortationObjects.push(
-            new SortModalObject({name: sort.column.name, href: sort.column.$href},
-              sort.direction.$href!)
-          );
+          if (!sort.column.$href!.endsWith('/parent')) {
+            this.sortationObjects.push(
+              new SortModalObject({name: sort.column.name, href: sort.column.$href},
+                sort.direction.$href!)
+            );
+          }
         });
 
         this.updateUsedColumns();

--- a/spec/features/work_packages/table_sorting_spec.rb
+++ b/spec/features/work_packages/table_sorting_spec.rb
@@ -90,15 +90,16 @@ describe 'Select work package row', type: :feature, js: true do
 
     it 'provides the default sortation and allows using the value at another level (Regression WP#26792)' do
       # Expect current criteria
-      sort_by.expect_criteria(['Parent', 'asc'])
+      sort_by.expect_criteria(['-', 'asc'])
 
       # Expect we can change the criteria and reuse that value
       sort_by.open_modal
+      sort_by.update_nth_criteria(0, 'Type', descending: true)
       sort_by.update_nth_criteria(0, 'ID', descending: true)
-      sort_by.update_nth_criteria(1, 'Parent')
+      sort_by.update_nth_criteria(1, 'Type')
 
       sort_by.apply_changes
-      sort_by.expect_criteria(['ID', 'desc'], ['Parent', 'asc'])
+      sort_by.expect_criteria(['ID', 'desc'], ['Type', 'asc'])
     end
   end
 


### PR DESCRIPTION
As the default sorting is always by Parent ASC we can remove it from the table configuration tab and reduce confusion/explanation.