### PR TITLE
Enforce mutual exclusiveness of hierarchies and sort by

### DIFF
--- a/frontend/src/app/components/wp-fast-table/state/wp-table-hierarchy.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-hierarchy.service.ts
@@ -42,11 +42,16 @@ export class WorkPackageTableHierarchiesService extends WorkPackageTableBaseServ
     state.current = active;
     state.last = null;
 
-    // hierarchies and group by are mutually exclusive
     if (active) {
+      // hierarchies and group by are mutually exclusive
       var groupBy = this.tableState.groupBy.value!;
       groupBy.current = undefined;
       this.tableState.groupBy.putValue(groupBy);
+
+      // hierarchies and sort by are mutually exclusive
+      var sortBy = this.tableState.sortBy.value!;
+      sortBy.current = [];
+      this.tableState.sortBy.putValue(sortBy);
     }
 
     this.state.putValue(state);

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-sort-by.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-sort-by.service.ts
@@ -77,6 +77,14 @@ export class WorkPackageTableSortByService extends WorkPackageTableBaseService<W
   }
 
   public applyToQuery(query:QueryResource) {
+    if (this.current.current.length > 0) {
+      // hierarchies and sort by are mutually exclusive
+      var hierarchies = this.tableState.hierarchies.value!;
+      hierarchies.current = false;
+      hierarchies.last = null;
+      this.tableState.hierarchies.putValue(hierarchies);
+      query.hierarchies = hierarchies.current;
+    }
     query.sortBy = cloneHalResourceCollection<QuerySortByResource>(this.current.current);
     return true;
   }


### PR DESCRIPTION
The goal is to ensure that you cannot have both hierarchies mode and a sort by set. The user does not get any special feedback about that yet. However, I believe that this is much butter than letting the user configure stuff that does not make any sense.

Please review carefully. I don't really know, what I am doing when I am fiddeling around with query and stat ;-)