### PR TITLE
eager load attachments to avoid n+1 query

### DIFF
--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -592,9 +592,11 @@ module API
           represented.custom_actions(current_user).to_a.sort_by(&:position)
         end
 
+        # Attachments need to be eager loaded for the description
         self.to_eager_load = %i[parent
                                 type
-                                watchers]
+                                watchers
+                                attachments]
 
         # The dynamic class generation introduced because of the custom fields interferes with
         # the class naming as well as prevents calls to super


### PR DESCRIPTION
The attachments are needed for rendering the work package description where attached images are rendered inline.

Removes:
![image](https://user-images.githubusercontent.com/617519/45284553-2d923d00-b4e1-11e8-997c-f7d361e59ffd.png)

And by that saves about 300 ms (1200ms vs 1700ms)