### PR TITLE
Scroll to bottom after comment editor activation

### DIFF
--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -88,7 +88,6 @@
 
         .work-packages-full-view--split-right
           width: initial
-          margin-bottom: 55px
           .tabrow
             margin: 0.75rem 0 2.5rem 0
 

--- a/frontend/src/app/components/work-packages/work-package-comment/work-package-comment.component.ts
+++ b/frontend/src/app/components/work-packages/work-package-comment/work-package-comment.component.ts
@@ -136,6 +136,8 @@ export class WorkPackageCommentComponent implements IEditFieldHandler, OnInit, O
     this.editing = true;
 
     this.reset(withText);
+
+    this.scrollToBottom();
   }
 
   public get project() {
@@ -153,7 +155,6 @@ export class WorkPackageCommentComponent implements IEditFieldHandler, OnInit, O
   }
 
   public handleUserSubmit() {
-    this.field.onSubmit();
     if (this.field.isBusy || this.field.isEmpty()) {
       return Promise.resolve();
     }
@@ -200,5 +201,12 @@ export class WorkPackageCommentComponent implements IEditFieldHandler, OnInit, O
 
   stopPropagation(evt:JQueryEventObject):boolean {
     return false;
+  }
+
+  scrollToBottom():void {
+    const scrollableContainer = jQuery(this.elementRef.nativeElement).scrollParent()[0];
+    if (scrollableContainer) {
+      setTimeout(() => { scrollableContainer.scrollTop = scrollableContainer.scrollHeight; }, 400);
+    }
   }
 }

--- a/frontend/src/app/components/wp-activity/user/user-activity.component.ts
+++ b/frontend/src/app/components/wp-activity/user/user-activity.component.ts
@@ -143,7 +143,6 @@ export class UserActivityComponent implements IEditFieldHandler, OnInit, AfterVi
   }
 
   public handleUserSubmit() {
-    this.field.onSubmit();
     if (this.field.isBusy || this.field.isEmpty()) {
       return Promise.resolve();
     }


### PR DESCRIPTION
In a WP's activities or overview tab, after activating the editor for leaving a comment, the actual editor is not completely visible. This PR tries to solve this issue by scrolling the editor into the view port.

@oliverguenther Could you please have a look at this PR? I especially do not like the timeout. I observed a difference between no timeout, timeout of 0sec, 100sec and 1000sec. What I actually want to achieve is to scroll to the bottom by setting the container's scroll position to the new hight that the container has after the editor was rendered. Is there something like a after render callback?