### PR TITLE
Skip before action in highlighting controller

### DIFF
--- a/app/controllers/highlighting_controller.rb
+++ b/app/controllers/highlighting_controller.rb
@@ -29,6 +29,7 @@
 
 class HighlightingController < ApplicationController
   before_action :determine_freshness
+  skip_before_action :check_if_login_required, only: [:styles]
 
   def styles
     if stale?(last_modified: @last_modified_times.max, etag: cache_key, public: true)


### PR DESCRIPTION
This is what trips up cloudfront. https://rpm.newrelic.com/accounts/228346/applications/10504765/traced_errors/0e8a7de9-b5a2-11e8-8176-0242ac110006_21239_34495