### PR TITLE
[28471] Don't escape truncate in output for title

### DIFF
--- a/lib/open_project/text_formatting/matchers/link_handlers/work_packages.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/work_packages.rb
@@ -75,7 +75,7 @@ module OpenProject::TextFormatting::Matchers
           link_to("#{matcher.sep}#{work_package.id}",
                   work_package_path_or_url(id: work_package.id, only_path: context[:only_path]),
                   class: work_package_css_classes(work_package),
-                  title: "#{truncate(work_package.subject, length: 100)} (#{work_package.status.try(:name)})")
+                  title: "#{truncate(work_package.subject, escape: false, length: 100)} (#{work_package.status.try(:name)})")
         end
       end
 

--- a/spec/lib/open_project/text_formatting/markdown/markdown_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/markdown_spec.rb
@@ -249,6 +249,22 @@ describe OpenProject::TextFormatting,
         it { is_expected.to be_html_eql("<p>##{issue.id}</p>") }
       end
 
+      context 'WP subject with escapable chars' do
+        let(:work_package) do
+          FactoryBot.create :work_package, subject: "Title with \"quote\" and 'sòme 'chárs."
+        end
+
+        let(:issue_link) do
+          link_to("##{issue.id}",
+                  work_package_path(issue),
+                  class: 'issue work_package status-3 priority-1 created-by-me',
+                  title: "#{issue.subject} (#{issue.status})")
+        end
+
+        subject { format_text("##{issue.id}") }
+        it { is_expected.to be_html_eql("<p>#{issue_link}</p>") }
+      end
+
       context 'Cyclic Description Links' do
         let(:issue2) do
           FactoryBot.create :work_package,


### PR DESCRIPTION
Otherwise, this leads to double encoding entities for the title attribute

https://community.openproject.com/wp/28471