### PR TITLE
Fix/color id 0 breaks highlighting

### DIFF
--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -29,7 +29,7 @@
 #++
 
 module ColorsHelper
-  def options_for_colors(colored_thing, default_label: I18n.t('colors.label_no_color'), default_color: nil)
+  def options_for_colors(colored_thing, default_label: I18n.t('colors.label_no_color'), default_color: '')
     s = content_tag(:option, default_label, value: default_color)
     Color.find_each do |c|
       options = {}

--- a/app/views/highlighting/styles.css.erb
+++ b/app/views/highlighting/styles.css.erb
@@ -1,6 +1,6 @@
 <%
   colored_resource = Proc.new do |name, scope|
-    scope.where.not(color_id: nil).includes(:color).find_each do |entry|
+    scope.where.not(colors: { id: nil }).includes(:color).find_each do |entry|
       color = entry.color
       styles = color.color_styles
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,7 +215,7 @@ en:
       edit_query: "Edit embedded query"
       reset: "Reset to defaults"
       type_color_text: |
-        Click to assign or change the color of this type. The selected color will is used to distinguish work packages
+        Click to assign or change the color of this type. The selected color distinguishes work packages
         in Gantt charts.
 
   versions:


### PR DESCRIPTION
As the `options_for_colors` method leads to writing 0 into the color_id column when the default option is selected, the `WHERE color_id IS NOT NULL` queried with when rendering the styles yields a result for a color having selected the default option. 

But as no color with an id of 0 exists, the code in the rendering block runs into null pointer exceptions.