### PR TITLE
[28484] Add some polyfills to make older browsers function just enough

### DIFF
--- a/app/assets/javascripts/specific/main_menu.js.erb
+++ b/app/assets/javascripts/specific/main_menu.js.erb
@@ -107,7 +107,7 @@ jQuery(document).ready(function($) {
     var parentURL = $(child).parents('li').find('.main-item-wrapper > a')[0].href;
     var header = $('<div class="main-menu--children-menu-header"></div>');
     var upLink = $('<a class="main-menu--arrow-left-to-project" href="#"><i class="icon-arrow-left1" aria-hidden="true"></i></a>');
-    var parentLink = $(`<a href="${parentURL}" class="main-menu--parent-node ellipsis">${title}</a>`);
+    var parentLink = $('<a href="' + parentURL + '" class="main-menu--parent-node ellipsis">' + title + '</a>');
     upLink.attr('title', I18n.t('js.label_up'));
     upLink.click(navigateUp);
     header.append(upLink);

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -76,7 +76,6 @@
           "options": {
             "main": "src/test.ts",
             "karmaConfig": "./karma.conf.js",
-            "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.spec.json",
             "scripts": [],
             "styles": [

--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -19,20 +19,20 @@
  */
 
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
-// import 'core-js/es6/symbol';
-// import 'core-js/es6/object';
-// import 'core-js/es6/function';
-// import 'core-js/es6/parse-int';
-// import 'core-js/es6/parse-float';
-// import 'core-js/es6/number';
-// import 'core-js/es6/math';
-// import 'core-js/es6/string';
-// import 'core-js/es6/date';
-// import 'core-js/es6/array';
-// import 'core-js/es6/regexp';
-// import 'core-js/es6/map';
-// import 'core-js/es6/weak-map';
-// import 'core-js/es6/set';
+import 'core-js/es6/symbol';
+import 'core-js/es6/object';
+import 'core-js/es6/function';
+import 'core-js/es6/parse-int';
+import 'core-js/es6/parse-float';
+import 'core-js/es6/number';
+import 'core-js/es6/math';
+import 'core-js/es6/string';
+import 'core-js/es6/date';
+import 'core-js/es6/array';
+import 'core-js/es6/regexp';
+import 'core-js/es6/map';
+import 'core-js/es6/weak-map';
+import 'core-js/es6/set';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.

--- a/frontend/src/test.ts
+++ b/frontend/src/test.ts
@@ -1,6 +1,7 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
 // Require the reflect ES7 polyfill for JIT
+import 'zone.js/dist/zone';  // Included with Angular CLI.
 import 'core-js/es7/reflect';
 
 import 'zone.js/dist/zone-testing';


### PR DESCRIPTION
This enables angular polyfills to ensure that vendors.js can be loaded and processed. This in return achieves that we can use bowser to detect and warn about incompatible browsers.

Also, this might help some older browsers to use OpenProject despite warning.

https://community.openproject.com/wp/28484