### PR TITLE
 [28499] Don't render empty highlighting dots

### DIFF
--- a/app/controllers/highlighting_controller.rb
+++ b/app/controllers/highlighting_controller.rb
@@ -32,6 +32,9 @@ class HighlightingController < ApplicationController
   skip_before_action :check_if_login_required, only: [:styles]
 
   def styles
+    response.content_type = Mime[:css]
+    request.format = :css
+
     if stale?(last_modified: @last_modified_times.max, etag: cache_key, public: true)
       OpenProject::Cache.fetch(@last_modified_times.max) do
         render template: 'highlighting/styles', formats: [:css]

--- a/app/views/highlighting/styles.css.erb
+++ b/app/views/highlighting/styles.css.erb
@@ -1,6 +1,11 @@
 <%
   colored_resource = Proc.new do |name, scope|
-    scope.where.not(colors: { id: nil }).includes(:color).find_each do |entry|
+    scope.includes(:color).find_each do |entry|
+      if entry.color_id.nil?
+        concat ".__hl_dot_#{name}_#{entry.id}::before { display: none }\n"
+        next
+      end
+
       color = entry.color
       styles = color.color_styles
 


### PR DESCRIPTION
As we know in the backend which status|type|colors have no color assigned, we can hide the `::before` in these cases to avoid colors not being aligned, especially in single view.

For my taste, the invisible dot looked fine in the table though. An alternative solution would be to render a placeholder? (Feedback welcome)

https://community.openproject.com/wp/28499