### PR TITLE
[28498] Too much padding on homescreen on mobile

### DIFF
--- a/app/assets/stylesheets/openproject/_homescreen.sass
+++ b/app/assets/stylesheets/openproject/_homescreen.sass
@@ -73,3 +73,9 @@
       flex: auto
       margin: 20px 0
       width: 50%
+
+  .controller-homescreen
+    .widget-boxes--screen-header
+      margin-left: 0px
+    .widget-boxes .widget-box
+      margin: 10px 0px


### PR DESCRIPTION
Since the home screen widgets span the entire width on mobile there is no additional margin needed to separate them.

https://community.openproject.com/projects/openproject/work_packages/28498/activity