### PR TITLE
added wp list highlighting mode setting

### DIFF
--- a/app/models/query/highlighting.rb
+++ b/app/models/query/highlighting.rb
@@ -41,9 +41,26 @@ module Query::Highlighting
       return :none unless EnterpriseToken.allows_to?(:conditional_highlighting)
 
       val = super
+
       if val.present?
         val.to_sym
+      else
+        highlighting_mode_from_setting
       end
+    end
+
+    def highlighting_mode_from_setting
+      value = Setting.work_package_list_default_highlighting_mode.to_sym
+
+      if QUERY_HIGHLIGHTING_MODES.include? value
+        value
+      else
+        default_highlighting_mode
+      end
+    end
+
+    def default_highlighting_mode
+      QUERY_HIGHLIGHTING_MODES.first
     end
   end
 end

--- a/app/views/settings/_work_packages.html.erb
+++ b/app/views/settings/_work_packages.html.erb
@@ -34,6 +34,14 @@ See docs/COPYRIGHT.rdoc for more details.
     <div class="form--field"><%= setting_check_box :work_package_startdate_is_adddate %></div>
     <div class="form--field"><%= setting_select :work_package_done_ratio, WorkPackage::DONE_RATIO_OPTIONS.collect {|i| [t("setting_work_package_done_ratio_#{i}"), i]}, container_class: '-middle' %></div>
     <div class="form--field"><%= setting_text_field :work_packages_export_limit, size: 6, container_class: '-xslim' %></div>
+    <div class="form--field">
+      <%= setting_select :work_package_list_default_highlighting_mode,
+                         Query::Highlighting::QUERY_HIGHLIGHTING_MODES.map { |mode|
+                           [t("js.work_packages.table_configuration.highlighting_mode.#{mode}"), mode]
+                         },
+                         container_class: '-middle'
+      %>
+    </div>
   </section>
   <fieldset class="form--fieldset"><legend class="form--fieldset-legend"><%= t(:setting_column_options) %></legend>
     <%

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2102,6 +2102,7 @@ en:
   setting_welcome_on_homescreen: "Display welcome block on homescreen"
   setting_wiki_compression: "Wiki history compression"
   setting_work_package_group_assignment: "Allow assignment to groups"
+  setting_work_package_list_default_highlighting_mode: "Default work package highlighting mode"
 
   settings:
     general: "General"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -259,6 +259,8 @@ work_package_list_default_columns:
   - status
   - assigned_to
   - updated_on
+work_package_list_default_highlighting_mode:
+  default: 'inline'
 work_package_list_summable_columns:
   serialized: true
   default:

--- a/spec/lib/api/v3/queries/query_representer_generation_spec.rb
+++ b/spec/lib/api/v3/queries/query_representer_generation_spec.rb
@@ -515,10 +515,10 @@ describe ::API::V3::Queries::QueryRepresenter do
             is_expected.to be_json_eql('status'.to_json).at_path('highlightingMode')
           end
 
-          it 'does not render nil' do
+          it 'renders the default' do
             query.highlighting_mode = nil
 
-            is_expected.not_to have_json_path('highlightingMode')
+            is_expected.to be_json_eql('inline'.to_json).at_path('highlightingMode')
           end
         end
 
@@ -529,7 +529,7 @@ describe ::API::V3::Queries::QueryRepresenter do
             is_expected.to be_json_eql('none'.to_json).at_path('highlightingMode')
           end
 
-          it 'does not render nil' do
+          it 'renders none when not set' do
             query.highlighting_mode = nil
 
             is_expected.to be_json_eql('none'.to_json).at_path('highlightingMode')

--- a/spec/models/query/default_query_spec.rb
+++ b/spec/models/query/default_query_spec.rb
@@ -1,0 +1,73 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe "default query", type: :model do
+  let(:query) { Query.new_default }
+
+  describe "highlighting mode" do
+    context " with highlighting mode setting" do
+      describe "not set" do
+        it "is inline" do
+          expect(query.highlighting_mode).to eq :inline
+        end
+      end
+
+      describe "set to inline", with_settings: { work_package_list_default_highlighting_mode: "inline" } do
+        it "is inline" do
+          expect(query.highlighting_mode).to eq :inline
+        end
+      end
+
+      describe "set to none", with_settings: { work_package_list_default_highlighting_mode: "none" } do
+        it "is none" do
+          expect(query.highlighting_mode).to eq :none
+        end
+      end
+
+      describe "set to status", with_settings: { work_package_list_default_highlighting_mode: "status" } do
+        it "is status" do
+          expect(query.highlighting_mode).to eq :status
+        end
+      end
+
+      describe "set to priority", with_settings: { work_package_list_default_highlighting_mode: "priority" } do
+        it "is priority" do
+          expect(query.highlighting_mode).to eq :priority
+        end
+      end
+
+      describe "set to invalid value", with_settings: { work_package_list_default_highlighting_mode: "fubar" } do
+        it "is inline" do
+          expect(query.highlighting_mode).to eq :inline
+        end
+      end
+    end
+  end
+end

--- a/spec/models/query/default_query_spec.rb
+++ b/spec/models/query/default_query_spec.rb
@@ -32,7 +32,7 @@ describe "default query", type: :model do
   let(:query) { Query.new_default }
 
   describe "highlighting mode" do
-    context " with highlighting mode setting" do
+    context " with highlighting mode setting", with_ee: %i[conditional_highlighting] do
       describe "not set" do
         it "is inline" do
           expect(query.highlighting_mode).to eq :inline


### PR DESCRIPTION
Allows users to change the default highlighting mode in case they don't like it.