### PR TITLE
Add spec for category mail_handler

### DIFF
--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -301,14 +301,16 @@ class MailHandler < ActionMailer::Base
   # Returns a Hash of issue attributes extracted from keywords in the email body
   def issue_attributes_from_keywords(issue)
     assigned_to = (k = get_keyword(:assigned_to, override: true)) && find_assignee_from_keyword(k, issue)
+    project = issue.project
 
     attrs = {
-      'type_id' => (k = get_keyword(:type)) && issue.project.types.find_by(name: k).try(:id),
+      'type_id' => (k = get_keyword(:type)) && project.types.find_by(name: k).try(:id),
       'status_id' =>  (k = get_keyword(:status)) && Status.find_by(name: k).try(:id),
+      'parent_id' => (k = get_keyword(:parent)),
       'priority_id' => (k = get_keyword(:priority)) && IssuePriority.find_by(name: k).try(:id),
-      'category_id' => (k = get_keyword(:category)) && issue.project.categories.find_by(name: k).try(:id),
+      'category_id' => (k = get_keyword(:category)) && project.categories.find_by(name: k).try(:id),
       'assigned_to_id' => assigned_to.try(:id),
-      'fixed_version_id' => (k = get_keyword(:fixed_version)) && issue.project.shared_versions.find_by(name: k).try(:id),
+      'fixed_version_id' => (k = get_keyword(:fixed_version)) && project.shared_versions.find_by(name: k).try(:id),
       'start_date' => get_keyword(:start_date, override: true, format: '\d{4}-\d{2}-\d{2}'),
       'due_date' => get_keyword(:due_date, override: true, format: '\d{4}-\d{2}-\d{2}'),
       'estimated_hours' => get_keyword(:estimated_hours, override: true),

--- a/spec/fixtures/mail_handler/ticket_with_category.eml
+++ b/spec/fixtures/mail_handler/ticket_with_category.eml
@@ -1,0 +1,18 @@
+Return-Path: <john.doe@somenet.foo>
+Received: from osiris ([127.0.0.1])
+	by OSIRIS
+	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
+Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
+From: "John Doe" <john.doe@somenet.foo>
+To: <redmine@somenet.foo>
+Subject: Ticket by unknown user
+Date: Sun, 22 Jun 2008 12:28:07 +0200
+MIME-Version: 1.0
+Content-Type: text/plain;
+	format=flowed;
+	charset="iso-8859-1";
+	reply-type=original
+Content-Transfer-Encoding: 7bit
+
+This is a ticket submitted with a category
+category:Foobar

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -73,6 +73,23 @@ describe MailHandler, type: :model do
     }.to change(User, :count).by(1)
   end
 
+  describe '#category' do
+    let!(:category) { FactoryBot.create :category, project: project, name: 'Foobar' }
+
+    it 'should add a work_package with category' do
+      allow(Setting).to receive(:default_language).and_return('en')
+      Role.non_member.update_attribute :permissions, [:add_work_packages]
+      project.update_attribute :is_public, true
+
+      work_package = submit_email 'ticket_with_category.eml',
+                                  issue: { project: 'onlinestore' },
+                                  allow_override: ['category'],
+                                  unknown_user: 'create'
+      work_package_created(work_package)
+      expect(work_package.category).to eq(category)
+    end
+  end
+
   describe '#cleanup_body' do
     let(:input) { "Subject:foo\nDescription:bar\n" \
                   ">>> myserver.example.org 2016-01-27 15:56 >>>\n... (Email-Body) ..." }


### PR DESCRIPTION
A user suspected that category in incoming mails was broken. It turned out to be an issue with `allow_override`, but since there is no spec for it I decided to add one.