### PR TITLE
Don't enforce utf8mb4 encoding for MySQL 5.7

### DIFF
--- a/config/initializers/check_mysql_encoding.rb
+++ b/config/initializers/check_mysql_encoding.rb
@@ -52,12 +52,18 @@ if OpenProject::Database.mysql?
              #{Rails.env}:
      *         encoding: #{expected}                                         *
 
-     *   in config/database.yml                                              *
+     *   in config/database.yml.                                             *
+         Otherwise, you WILL run into encoding issue when using 4 byte
+     *   UTF-8 characters since utf8 encoding in MySQL does not support them *
+
+     *   If you have been running utf8 in the past, please see this guide    *
+         on how to convert your database:
+     *   https://mathiasbynens.be/notes/mysql-utf8mb4                        *
 
      *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
 
     MESSAGE
 
-    raise message
+    warn message
   end
 end

--- a/config/initializers/check_mysql_encoding.rb
+++ b/config/initializers/check_mysql_encoding.rb
@@ -54,7 +54,7 @@ if OpenProject::Database.mysql?
 
      *   in config/database.yml.                                             *
          Otherwise, you WILL run into encoding issue when using 4 byte
-     *   UTF-8 characters since utf8 encoding in MySQL does not support them *
+     *   UTF-8 characters since utf8 encoding in MySQL doesn't support them. *
 
      *   If you have been running utf8 in the past, please see this guide    *
          on how to convert your database:


### PR DESCRIPTION
If you have been running on utf8@MySQL 5.7, you should not receive an
exception when your encoding is not utf8mb4, since we used utf8 on all
older installations.