### PR TITLE
Add check for missing values in resources display field

### DIFF
--- a/frontend/src/app/modules/fields/display/field-types/wp-display-resources-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-display-resources-field.module.ts
@@ -42,8 +42,8 @@ export class ResourcesDisplayField extends DisplayField {
   }
 
   public get value() {
-    if (this.schema) {
-      var cf = this.resource[this.name];
+    let cf = this.resource[this.name];
+    if (this.schema && cf) {
 
       if (cf.elements) {
         return cf.elements.map((e:any) => e.name);
@@ -54,9 +54,9 @@ export class ResourcesDisplayField extends DisplayField {
       } else {
         return ["error: " + JSON.stringify(cf)];
       }
-    } else {
-      return null;
     }
+
+    return [];
   }
 
   public render(element:HTMLElement, displayText:string):void {


### PR DESCRIPTION
When a table is shown with a list CF and a parent is added to the result that does not have this field,
refreshing the table will result in a brief moment where the field is refreshed and trying to access an invalid property.