### PR TITLE
Fix/highlight color nil exception

### DIFF
--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -61,6 +61,33 @@ module ColorsHelper
     content_tag(:span, color.hexcode, class: 'color--text-preview', style: style)
   end
 
+  def resource_color_css(name, scope)
+    scope.includes(:color).find_each do |entry|
+      color = entry.color
+
+      if color.nil?
+        concat ".__hl_dot_#{name}_#{entry.id}::before { display: none }\n"
+        next
+      end
+
+      styles = color.color_styles
+
+      inline_style = styles.map { |k,v| "#{k}:#{v} !important"}.join(';')
+      row_style = "background-color: #{color.hexcode} !important;"
+
+      border_color = color.bright? ? '#555555' : color.hexcode
+
+      concat ".__hl_inl_#{name}_#{entry.id} { #{inline_style}; }\n"
+      concat ".__hl_dot_#{name}_#{entry.id}::before { #{inline_style}; border-color: #{border_color}; }\n"
+      concat ".__hl_row_#{name}_#{entry.id} { #{row_style}; }\n"
+
+      # Mark color as bright through CSS variable
+      # so it can be used to add a separate -bright class
+      unless color.bright?
+        concat ":root { --hl-#{name}-#{entry.id}-dark: #{styles[:color]} }\n"
+      end
+    end
+  end
 
   def icon_for_color(color, options = {})
     return unless color

--- a/app/views/highlighting/styles.css.erb
+++ b/app/views/highlighting/styles.css.erb
@@ -1,37 +1,7 @@
-<%
-  colored_resource = Proc.new do |name, scope|
-    scope.includes(:color).find_each do |entry|
-      color = entry.color
-
-      if color.nil?
-        concat ".__hl_dot_#{name}_#{entry.id}::before { display: none }\n"
-        next
-      end
-
-      styles = color.color_styles
-
-      inline_style = styles.map{|k,v| "#{k}:#{v} !important"}.join(';')
-      row_style = "background-color: #{color.hexcode} !important;"
-
-      border_color = color.bright? ? '#555555' : color.hexcode
-
-      concat ".__hl_inl_#{name}_#{entry.id} { #{inline_style}; }\n"
-      concat ".__hl_dot_#{name}_#{entry.id}::before { #{inline_style}; border-color: #{border_color}; }\n"
-      concat ".__hl_row_#{name}_#{entry.id} { #{row_style}; }\n"
-
-      # Mark color as bright through CSS variable
-      # so it can be used to add a separate -bright class
-      unless color.bright?
-        concat ":root { --hl-#{name}-#{entry.id}-dark: #{styles[:color]} }\n"
-      end
-    end
-  end
- %>
-
 <%# Highlightable resources %>
-<%= colored_resource.call('status', ::Status) %>
-<%= colored_resource.call('priority', ::IssuePriority) %>
-<%= colored_resource.call('type', ::Type) %>
+<%= resource_color_css('status', ::Status) %>
+<%= resource_color_css('priority', ::IssuePriority) %>
+<%= resource_color_css('type', ::Type) %>
 
 <%# Overdue tasks %>
 .__hl_date_due_today { color: #F76707 !important; }

--- a/app/views/highlighting/styles.css.erb
+++ b/app/views/highlighting/styles.css.erb
@@ -1,12 +1,13 @@
 <%
   colored_resource = Proc.new do |name, scope|
     scope.includes(:color).find_each do |entry|
-      if entry.color_id.nil?
+      color = entry.color
+
+      if color.nil?
         concat ".__hl_dot_#{name}_#{entry.id}::before { display: none }\n"
         next
       end
 
-      color = entry.color
       styles = color.color_styles
 
       inline_style = styles.map{|k,v| "#{k}:#{v} !important"}.join(';')


### PR DESCRIPTION
Fixes

![image](https://user-images.githubusercontent.com/617519/45612798-70fe2580-ba64-11e8-8083-26917430921f.png)

Which is caused by instances having resources evaluated for their color having `color_id = 0` or any other value not pointing to a valid color.