### PR TITLE
[28556] Correctly check for the index during migrating

### DIFF
--- a/db/migrate/20180510184732_rename_planning_elemnt_type_colors_to_colors.rb
+++ b/db/migrate/20180510184732_rename_planning_elemnt_type_colors_to_colors.rb
@@ -1,9 +1,9 @@
 class RenamePlanningElemntTypeColorsToColors < ActiveRecord::Migration[5.1]
   def up
-
     # Fix existing indexes due to old migration away from timeline_colors
-    if table_exists? :timelines_colors_pkey
-      rename_table :timelines_colors_pkey, :planning_element_type_colors_pkey
+    # This hasn't happened automatically in Rails < 4 with the 2013 migration of timelines_colors
+    if index_name_exists?(:planning_element_type_colors, :timelines_colors_pkey)
+      rename_index :planning_element_type_colors, :timelines_colors_pkey, :planning_element_type_colors_pkey
     end
 
     rename_table :planning_element_type_colors, :colors


### PR DESCRIPTION
The `timeline_colors_pkey` is still the current index of `planning_element_type_colors` in many installations because Rails < 4 did not rename indexes upon renaming tables.

Now, when renaming tables the pkey index is being renamed, which will result in an error because the index name doesn't match.

Tested this on the 7.4. community  which exhibits this issue.

https://github.com/rails/rails/issues/12856

https://community.openproject.com/wp/28556