### PR TITLE
[28539] Fix incorrect handling of queries when quickly loading multiple queries

### DIFF
--- a/frontend/src/app/components/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/components/routing/wp-list/wp-list.component.ts
@@ -74,6 +74,7 @@ export class WorkPackagesListComponent implements OnInit, OnDestroy {
   titleEditingEnabled:boolean;
 
   currentQuery:QueryResource;
+  private removeTransitionSubscription:Function;
 
 
   constructor(readonly states:States,
@@ -115,7 +116,7 @@ export class WorkPackagesListComponent implements OnInit, OnDestroy {
     this.setupRefreshObserver();
 
     // Listen for param changes
-    this.$transitions.onSuccess({}, (transition):any => {
+    this.removeTransitionSubscription = this.$transitions.onSuccess({}, (transition):any => {
       let options = transition.options();
 
       // Avoid performing any changes when we're going to reload
@@ -135,6 +136,7 @@ export class WorkPackagesListComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy():void {
+    this.removeTransitionSubscription();
     this.wpTableRefresh.clear('Table controller scope destroyed.');
   }
 

--- a/frontend/src/app/components/wp-list/wp-list.service.ts
+++ b/frontend/src/app/components/wp-list/wp-list.service.ts
@@ -46,9 +46,30 @@ import {UrlParamsHelperService} from 'core-components/wp-query/url-params-helper
 import {NotificationsService} from 'core-app/modules/common/notifications/notifications.service';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import {input} from "reactivestates";
+import {catchError, distinctUntilChanged, map, share, switchMap, take} from "rxjs/operators";
+import {from, Observable} from "rxjs";
+
+export interface QueryDefinition {
+  queryParams:{ query_id?:number, query_props?:string };
+  projectIdentifier?:string;
+}
 
 @Injectable()
 export class WorkPackagesListService {
+
+  // We remember the query requests coming in so we can ensure only the latest request is being tended to
+  private queryRequests = input<QueryDefinition>();
+
+  // This mapped observable requests the latest query automatically.
+  private queryLoading = this.queryRequests
+    .values$()
+    .pipe(
+      switchMap((q:QueryDefinition) => this.handleQueryRequest(q.queryParams, q.projectIdentifier)),
+      distinctUntilChanged(),
+      share(),
+    );
+
   private queryChanges = new BehaviorSubject<string>('');
   public queryChanges$ = this.queryChanges.asObservable();
 
@@ -68,24 +89,47 @@ export class WorkPackagesListService {
               protected wpListInvalidQueryService:WorkPackagesListInvalidQueryService) {
   }
 
+  private handleQueryRequest(queryParams:{ query_id?:number, query_props?:string }, projectIdentifier ?:string):Observable<QueryResource> {
+    console.trace(`HANDLING REQUEST ${queryParams.query_id} ${queryParams.query_props}`);
+    const decodedProps = this.getCurrentQueryProps(queryParams);
+    const queryData = this.UrlParamsHelper.buildV3GetQueryFromJsonParams(decodedProps);
+    const stream = this.QueryDm.stream(queryData, queryParams.query_id, projectIdentifier);
+
+    return stream.pipe(
+      map((query:QueryResource) => {
+
+        // Project the loaded query into the table states and confirm the query is fully loaded
+        this.tableState.ready.doAndTransition('Query loaded', () => {
+          this.wpStatesInitialization.initialize(query, query.results);
+          return this.tableState.tableRendering.onQueryUpdated.valuesPromise();
+        });
+
+        // load the form if needed
+        this.conditionallyLoadForm(query);
+
+        return query;
+      }),
+      catchError((error) => {
+        // Load a default query
+        const queryProps = this.UrlParamsHelper.buildV3GetQueryFromJsonParams(decodedProps);
+        return from(this.handleQueryLoadingError(error, queryProps, queryParams.query_id, projectIdentifier));
+      })
+    )
+  }
+
   /**
    * Load a query.
    * The query is either a persisted query, identified by the query_id parameter, or the default query. Both will be modified by the parameters in the query_props parameter.
    */
-  public fromQueryParams(queryParams:{ query_id?:number, query_props?:string }, projectIdentifier ?:string):Promise<QueryResource> {
-    const decodedProps = this.getCurrentQueryProps(queryParams);
-    const queryData = this.UrlParamsHelper.buildV3GetQueryFromJsonParams(decodedProps);
-    const wpListPromise = this.QueryDm.find(queryData, queryParams.query_id, projectIdentifier);
-    const promise = this.updateStatesFromQueryOnPromise(wpListPromise);
+  public fromQueryParams(queryParams:{ query_id?:number, query_props?:string }, projectIdentifier ?:string):Observable<QueryResource> {
+    this.queryRequests.clear();
+    this.queryRequests.putValue({ queryParams: queryParams, projectIdentifier: projectIdentifier });
 
-    promise
-      .catch((error) => {
-        const queryProps = this.UrlParamsHelper.buildV3GetQueryFromJsonParams(decodedProps);
-
-        return this.handleQueryLoadingError(error, queryProps, queryParams.query_id, projectIdentifier);
-      });
-
-    return this.conditionallyLoadForm(promise);
+    return this
+      .queryLoading
+      .pipe(
+        take(1)
+      );
   }
 
   /**
@@ -103,7 +147,7 @@ export class WorkPackagesListService {
    * Load the default query.
    */
   public loadDefaultQuery(projectIdentifier ?:string):Promise<QueryResource> {
-    return this.fromQueryParams({}, projectIdentifier);
+    return this.fromQueryParams({}, projectIdentifier).toPromise();
   }
 
   /**
@@ -115,16 +159,17 @@ export class WorkPackagesListService {
 
     let wpListPromise = this.QueryDm.reload(query, pagination);
 
-    let promise = this.updateStatesFromQueryOnPromise(wpListPromise);
-
-    promise
+    return this.updateStatesFromQueryOnPromise(wpListPromise)
+      .then((query:QueryResource) => {
+        this.conditionallyLoadForm(query);
+        return query;
+      })
       .catch((error) => {
         let projectIdentifier = query.project && query.project.id;
 
         return this.handleQueryLoadingError(error, {}, query.id, projectIdentifier);
       });
 
-    return this.conditionallyLoadForm(promise);
   }
 
   /**
@@ -164,8 +209,10 @@ export class WorkPackagesListService {
   public loadCurrentQueryFromParams(projectIdentifier?:string) {
     this.wpListChecksumService.clear();
     this.loadingIndicator.table.promise =
-      this.fromQueryParams(this.$state.params as any, projectIdentifier).then(() => {
-        return this.tableState.rendered.valuesPromise();
+      this.fromQueryParams(this.$state.params as any, projectIdentifier)
+        .toPromise()
+        .then(() => {
+          return this.tableState.rendered.valuesPromise();
       });
   }
 
@@ -269,19 +316,12 @@ export class WorkPackagesListService {
     return this.wpTablePagination.paginationObject;
   }
 
-  private conditionallyLoadForm(promise:Promise<QueryResource>):Promise<QueryResource> {
-    promise.then(query => {
+  private conditionallyLoadForm(query:QueryResource):void {
+    let currentForm = this.states.query.form.value;
 
-      let currentForm = this.states.query.form.value;
-
-      if (!currentForm || query.$links.update.$href !== currentForm.$href) {
-        setTimeout(() => this.loadForm(query), 0);
-      }
-
-      return query;
-    });
-
-    return promise;
+    if (!currentForm || query.$links.update.$href !== currentForm.$href) {
+      setTimeout(() => this.loadForm(query), 0);
+    }
   }
 
   private updateStatesFromQueryOnPromise(promise:Promise<QueryResource>):Promise<QueryResource> {
@@ -314,7 +354,7 @@ export class WorkPackagesListService {
     return this.states.query.resource.value!;
   }
 
-  private handleQueryLoadingError(error:ErrorResource, queryProps:any, queryId?:number, projectIdentifier?:string) {
+  private handleQueryLoadingError(error:ErrorResource, queryProps:any, queryId?:number, projectIdentifier?:string):Promise<QueryResource> {
     this.NotificationsService.addError(this.I18n.t('js.work_packages.faulty_query.description'), error.message);
 
     return new Promise((resolve, reject) => {

--- a/frontend/src/app/components/wp-list/wp-list.service.ts
+++ b/frontend/src/app/components/wp-list/wp-list.service.ts
@@ -47,7 +47,7 @@ import {NotificationsService} from 'core-app/modules/common/notifications/notifi
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {input} from "reactivestates";
-import {catchError, distinctUntilChanged, map, share, switchMap, take} from "rxjs/operators";
+import {catchError, distinctUntilChanged, map, share, shareReplay, switchMap, take} from "rxjs/operators";
 import {from, Observable} from "rxjs";
 
 export interface QueryDefinition {
@@ -66,8 +66,7 @@ export class WorkPackagesListService {
     .values$()
     .pipe(
       switchMap((q:QueryDefinition) => this.handleQueryRequest(q.queryParams, q.projectIdentifier)),
-      distinctUntilChanged(),
-      share(),
+      shareReplay(1)
     );
 
   private queryChanges = new BehaviorSubject<string>('');
@@ -90,7 +89,6 @@ export class WorkPackagesListService {
   }
 
   private handleQueryRequest(queryParams:{ query_id?:number, query_props?:string }, projectIdentifier ?:string):Observable<QueryResource> {
-    console.trace(`HANDLING REQUEST ${queryParams.query_id} ${queryParams.query_props}`);
     const decodedProps = this.getCurrentQueryProps(queryParams);
     const queryData = this.UrlParamsHelper.buildV3GetQueryFromJsonParams(decodedProps);
     const stream = this.QueryDm.stream(queryData, queryParams.query_id, projectIdentifier);

--- a/frontend/src/app/components/wp-query-select/wp-static-queries.service.ts
+++ b/frontend/src/app/components/wp-query-select/wp-static-queries.service.ts
@@ -100,12 +100,12 @@ export class WorkPackageStaticQueriesService {
         {
           identifier: 'created_by_me',
           label: this.text.created_by_me,
-          query_props: "{%22c%22:[%22id%22,%22subject%22,%22type%22,%22status%22,%22assignee%22,%22updatedAt%22],%22tzl%22:%22days%22,%22hi%22:false,%22g%22:%22%22,%22t%22:%22updatedAt:desc,parent:asc%22,%22f%22:[{%22n%22:%22status%22,%22o%22:%22o%22,%22v%22:[]},{%22n%22:%22author%22,%22o%22:%22=%22,%22v%22:[%22me%22]}],%22pa%22:1,%22pp%22:20}"
+          query_props: '{"c":["id","subject","type","status","assignee","updatedAt"],"tzl":"days","hi":false,"g":"","t":"updatedAt:desc,parent:asc","f":[{"n":"status","o":"o","v":[]},{"n":"author","o":"=","v":["me"]}],"pa":1,"pp":20}'
         },
         {
           identifier: 'assigned_to_me',
           label: this.text.assigned_to_me,
-          query_props: '{%22c%22:[%22id%22,%22subject%22,%22type%22,%22status%22,%20%22author%22,%20%22updatedAt%22],%22t%22:%22updatedAt:desc,parent:asc%22,%22f%22:[{%22n%22:%22status%22,%22o%22:%22o%22,%22v%22:[]},{%22n%22:%22assignee%22,%22o%22:%22=%22,%22v%22:[%22me%22]}]}'
+          query_props: '{"c":["id","subject","type","status", "author", "updatedAt"],"t":"updatedAt:desc,parent:asc","f":[{"n":"status","o":"o","v":[]},{"n":"assignee","o":"=","v":["me"]}]}'
         }
       ]);
     }

--- a/frontend/src/app/modules/common/loading-indicator/loading-indicator.service.ts
+++ b/frontend/src/app/modules/common/loading-indicator/loading-indicator.service.ts
@@ -49,6 +49,8 @@ export class LoadingIndicator {
   }
 
   public start() {
+    // If we're currently having an active indicator, remove that one
+    this.stop();
     this.indicator.prepend(this.template);
   }
 

--- a/frontend/src/app/modules/hal/dm-services/query-dm.service.ts
+++ b/frontend/src/app/modules/hal/dm-services/query-dm.service.ts
@@ -36,6 +36,7 @@ import {ApiV3FilterBuilder} from 'core-app/components/api/api-v3/api-v3-filter-b
 import {Injectable} from '@angular/core';
 import {UrlParamsHelperService} from 'core-components/wp-query/url-params-helper';
 import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
+import {Observable} from "rxjs";
 
 export interface PaginationObject {
   pageSize:number;
@@ -50,7 +51,13 @@ export class QueryDmService {
               protected PayloadDm:PayloadDmService) {
   }
 
-  public find(queryData:Object, queryId?:number, projectIdentifier?:string):Promise<QueryResource> {
+  /**
+   * Stream the response for the given query request
+   * @param queryData
+   * @param queryId
+   * @param projectIdentifier
+   */
+  public stream(queryData:Object, queryId?:number, projectIdentifier?:string):Observable<QueryResource> {
     let path:string;
 
     if (queryId) {
@@ -60,8 +67,11 @@ export class QueryDmService {
     }
 
     return this.halResourceService
-      .get<QueryResource>(path, queryData)
-      .toPromise();
+      .get<QueryResource>(path, queryData);
+  }
+
+  public find(queryData:Object, queryId?:number, projectIdentifier?:string):Promise<QueryResource> {
+    return this.stream(queryData, queryId, projectIdentifier).toPromise();
   }
 
   public findDefault(queryData:Object, projectIdentifier?:string):Promise<QueryResource> {


### PR DESCRIPTION
Fixes a multitude of issues:

- Uses `switchMap` to only load the last query request and cancelling all previous requests.

![query-loading](https://user-images.githubusercontent.com/459462/45819626-1d4e3f00-bce5-11e8-9274-038283c75b51.gif)


- Fixes unsubscribing the transition hook in `wpListComponent` when reloading the view.
- Fixes showing multiple loading indicators when quickly loading multiple queries. This is due to the loadingIndicator being based on a promise and is not correctly cancelled by switchMap.
- Fixes two query titles 'Assigned to Me' and 'Created by me' not being correctly shown due to invalid query_props.

Even with this PR, there is a small timeframe where the query loading will result in wrong results: **After the query is loaded and put into states**, but **Before** the query form is loaded. I did not manage to run into this issue with different simulated network latencies however. In any way, this PR should reduce the possibility of running into this quite a bit.

https://community.openproject.com/wp/28539