### PR TITLE
Remove scroll bar from activity tab when on medium desktop.

### DIFF
--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -130,10 +130,7 @@ body.controller-work_packages.full-create
   position: relative
 
   .work-packages--panel-inner
-    position: absolute
-    display: inline-block
-    padding: 15px 15px 0px 0px
-    width: calc(100% - 18px)
+    padding: 15px 15px 0px 15px
 
   .work-package-details-activities-activity-contents ul.work-package-details-activities-messages
     padding-left: 0
@@ -176,6 +173,9 @@ body.controller-work_packages.full-create
   .work-packages--show-view
     // Important for Safari
     height: initial
+  .work-packages-full-view--split-right
+    overflow: visible
+    flex-basis: initial !important
 
 @media only screen and (max-width: 679px)
   #toolbar

--- a/app/assets/stylesheets/layout/work_packages/_print.sass
+++ b/app/assets/stylesheets/layout/work_packages/_print.sass
@@ -106,13 +106,15 @@
       .work-packages-full-view--split-container
         display: block
 
-  // ------------------Only WP full scren view ------------------
+  // ------------------Only WP full screen view ------------------
   body.controller-work_packages.action-show
     // Since there is no toolbar and WP-back button the header can span 100%
     .wp-show--header-container
       flex-basis: 100%
     .work-packages-full-view--split-right
-      overflow: auto
+      overflow: visible
+      flex-basis: initial !important
+
 
     // decrease padding under subject
     .work-packages--show-view > .toolbar-container

--- a/config/locales/crowdin/fr.yml
+++ b/config/locales/crowdin/fr.yml
@@ -2382,7 +2382,7 @@ fr:
   text_journal_changed: "%{label} a changé de %{old} <br/><strong>à</strong> %{new}"
   text_journal_changed_plain: "%{label} changé de %{old} à %{new}"
   text_journal_changed_no_detail: "%{label} mis à jour"
-  text_journal_changed_with_diff: "%{label} changè (%{link})"
+  text_journal_changed_with_diff: "%{label} changé (%{link})"
   text_journal_deleted: "%{label} supprimé (%{old})"
   text_journal_deleted_with_diff: "%{label} supprimé (%{link})"
   text_journal_set_to: "%{label} mis à %{value}"

--- a/config/locales/crowdin/js-pt-BR.yml
+++ b/config/locales/crowdin/js-pt-BR.yml
@@ -61,11 +61,12 @@ pt-BR:
     description_subwork_package: 'Filho do pacote de trabalho #%{id}'
     editor:
       preview: Alternar modo de visualização
-      source_code: Toggle Markdown source mode
-      error_saving_failed: 'Saving the document failed with the following error: %{error}'
+      source_code: Alternar modo de fonte Markdown
+      error_saving_failed: 'Não foi possível salvar o documento pelo seguinte erro:
+        %{error}'
       mode:
-        manual: Switch to Markdown source
-        wysiwyg: Switch to WYSIWYG editor
+        manual: Troque para a fonte Markdown
+        wysiwyg: Troque para o editor de WYSIWYG
       macro:
         child_pages:
           button: Links para páginas filhas

--- a/docs/development/running-tests.md
+++ b/docs/development/running-tests.md
@@ -269,7 +269,7 @@ you can access both from inside a VM with nat/bridged networking as follows:
 npm run serve-public
 
 # Start your openproject server with the CLI proxy configuration set
-OPENPROJECT_CLI_PROXY='<your local ip>:4200' ./bin/rails s -b 0.0.0.0 -p 3000
+OPENPROJECT_CLI_PROXY='http://<your local ip>:4200' ./bin/rails s -b 0.0.0.0 -p 3000
 
 # Now access your server from http://<your local ip>:3000 with code reloading
 ```

--- a/frontend/src/app/components/work-packages/work-package-comment/work-package-comment.component.ts
+++ b/frontend/src/app/components/work-packages/work-package-comment/work-package-comment.component.ts
@@ -137,7 +137,9 @@ export class WorkPackageCommentComponent implements IEditFieldHandler, OnInit, O
 
     this.reset(withText);
 
-    this.scrollToBottom();
+    if (!this.showAbove) {
+      this.scrollToBottom();
+    }
   }
 
   public get project() {

--- a/frontend/src/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
+++ b/frontend/src/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
@@ -57,6 +57,7 @@ import {
   TimelineViewParameters,
   zoomLevelOrder
 } from '../wp-timeline';
+import {DynamicCssService} from "core-app/modules/common/dynamic-css/dynamic-css.service";
 
 @Component({
   selector: 'wp-timeline-container',
@@ -96,6 +97,7 @@ export class WorkPackageTimelineTableController implements AfterViewInit, OnDest
               private elementRef:ElementRef,
               private states:States,
               public wpTableDirective:WorkPackagesTableController,
+              private dynamicCssService:DynamicCssService,
               private NotificationsService:NotificationsService,
               private wpTableTimeline:WorkPackageTableTimelineService,
               private wpNotificationsService:WorkPackageNotificationService,
@@ -208,6 +210,9 @@ export class WorkPackageTimelineTableController implements AfterViewInit, OnDest
       debugLog('refreshView() requested, but TL is invisible.');
       return;
     }
+
+    // Require dynamic CSS to be visible
+    this.dynamicCssService.requireHighlighting();
 
     timeOutput('refreshView() in timeline container', () => {
       // Reset the width of the outer container if its content shrinks


### PR DESCRIPTION
Remove scroll bar from activity tab when on medium desktop.

I removed some `position: absolute` stuff, that really did look wrong. I have no clue why it was there. I must have overlooked it my review back then.

This commit also fixes printing of single WPs with their full activity.

I also updated the docs for VM testing as I needed to connect from my mobile and a `http://` was missing to have a valid URL.

https://community.openproject.org/wp/28553