### PR TITLE
[28543] Validate Type#attribute_groups in contract

### DIFF
--- a/app/contracts/types/base_contract.rb
+++ b/app/contracts/types/base_contract.rb
@@ -1,0 +1,97 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'model_contract'
+
+module Types
+  class BaseContract < ::ModelContract
+
+    def self.model
+      Type
+    end
+
+    attribute :name
+    attribute :is_in_roadmap
+    attribute :is_milestone
+    attribute :is_default
+    attribute :color_id
+    attribute :project_ids
+    attribute :attribute_groups
+
+    validate :validate_current_user_is_admin
+    validate :validate_attribute_group_names
+    validate :validate_attribute_groups
+
+    def validate_current_user_is_admin
+      unless user.admin?
+        errors.add(:base, :error_unauthorized)
+      end
+    end
+
+    def validate_attribute_group_names
+      seen = Set.new
+      model.attribute_groups.each do |group|
+        errors.add(:attribute_groups, :group_without_name) unless group.key.present?
+        errors.add(:attribute_groups, :duplicate_group, group: group.key) if seen.add?(group.key).nil?
+      end
+    end
+
+    def validate_attribute_groups
+      model.attribute_groups_objects.each do |group|
+        if group.is_a?(Type::QueryGroup)
+          validate_query_group(group)
+        else
+          validate_attribute_group(group)
+        end
+      end
+    end
+
+    def validate_query_group(group)
+      query = group.query
+
+      contract_class = query.persisted? ? Queries::UpdateContract : Queries::CreateContract
+      contract = contract_class.new(query, user)
+
+      unless contract.validate
+        errors.add(:attribute_groups, :query_invalid, group: group.key, details: contract.errors.full_messages.join)
+      end
+    end
+
+    def validate_attribute_group(group)
+      valid_attributes = model.work_package_attributes.keys
+
+      group.attributes.each do |key|
+        if key.is_a?(String) && valid_attributes.exclude?(key)
+          errors.add(:attribute_groups, :attribute_unknown)
+        end
+      end
+    end
+  end
+end

--- a/app/services/create_type_service.rb
+++ b/app/services/create_type_service.rb
@@ -29,8 +29,7 @@
 
 class CreateTypeService < BaseTypeService
   def initialize(user)
-    super
-    self.type = Type.new
+    super Type.new, user
   end
 
   private

--- a/app/services/update_type_service.rb
+++ b/app/services/update_type_service.rb
@@ -28,11 +28,6 @@
 #++
 
 class UpdateTypeService < BaseTypeService
-  def initialize(type, user)
-    super(user)
-    self.type = type
-  end
-
   def call(params)
     # forbid renaming if it is a standard type
     params[:type].delete :name if type.is_standard?

--- a/spec/models/type/attribute_groups_spec.rb
+++ b/spec/models/type/attribute_groups_spec.rb
@@ -156,51 +156,6 @@ describe ::Type, type: :model do
     end
   end
 
-  describe "#validate_attribute_groups" do
-    it 'raises an exception for invalid structure' do
-      # Exampel for invalid structure:
-      type.attribute_groups = ['foo']
-      expect { type.save }.to raise_exception(NoMethodError)
-      # Exampel for invalid structure:
-      expect { type.attribute_groups = [[]] }.to raise_exception(NoMethodError)
-      # Exampel for invalid group name:
-      type.attribute_groups = [['', ['date']]]
-      expect(type).not_to be_valid
-    end
-
-    it 'fails for duplicate group names' do
-      type.attribute_groups = [['foo', ['date']], ['foo', ['date']]]
-      expect(type).not_to be_valid
-    end
-
-    it 'passes validations for known attributes' do
-      type.attribute_groups = [['foo', ['date']]]
-      expect(type).to be_valid
-    end
-
-    it 'passes validation for defaults' do
-      expect(type).to be_valid
-    end
-
-    it 'passes validation for reset' do
-      # A reset is to save an empty Array
-      type.attribute_groups = []
-      expect(type).to be_valid
-    end
-
-    context 'with an invalid query' do
-      let(:query) { FactoryBot.build(:global_query, name: '') }
-
-      before do
-        type.attribute_groups = [['some name', [query]]]
-      end
-
-      it 'is invalid' do
-        expect(type).to be_invalid
-      end
-    end
-  end
-
   describe 'custom fields' do
     let!(:custom_field) do
       FactoryBot.create(

--- a/spec/services/create_type_service_spec.rb
+++ b/spec/services/create_type_service_spec.rb
@@ -32,10 +32,10 @@ require 'services/shared_type_service'
 
 describe CreateTypeService do
   let(:type) { instance.type }
-  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:user) { FactoryBot.build_stubbed(:admin) }
 
   let(:instance) { described_class.new(user) }
-  let(:service_call) { instance.call(params, {}) }
+  let(:service_call) { instance.call({ name: 'foo' }.merge(params), {}) }
 
   it_behaves_like 'type service'
 end

--- a/spec/services/shared_type_service.rb
+++ b/spec/services/shared_type_service.rb
@@ -33,7 +33,7 @@ shared_examples_for 'type service' do
 
   describe '#call' do
     before do
-      expect(type)
+      allow(type)
         .to receive(:save)
         .and_return(success)
     end
@@ -127,7 +127,7 @@ shared_examples_for 'type service' do
         ['group1', query_params]
       end
       let(:params) { { attribute_groups: [query_group_params] } }
-      let(:query) { FactoryBot.build_stubbed(:query) }
+      let(:query) { FactoryBot.create(:query) }
       let(:service_result) { ServiceResult.new(success: true, result: query) }
 
       before do
@@ -155,13 +155,15 @@ shared_examples_for 'type service' do
           .to eql query
 
         expect(query.filters.length)
-          .to eql 1
+          .to eql 2
 
         expect(query.filters[0].name)
+          .to eql :status_id
+        expect(query.filters[1].name)
           .to eql :parent
-        expect(query.filters[0].operator)
+        expect(query.filters[1].operator)
           .to eql '='
-        expect(query.filters[0].values)
+        expect(query.filters[1].values)
           .to eql [::Queries::Filters::TemplatedValue::KEY]
       end
 
@@ -180,6 +182,7 @@ shared_examples_for 'type service' do
 
     context 'on failure' do
       let(:success) { false }
+      let(:params) { { name: nil } }
 
       subject { service_call }
 
@@ -188,12 +191,8 @@ shared_examples_for 'type service' do
       end
 
       it 'returns the errors of the type' do
-        type_errors = 'all the errors'
-        allow(type)
-          .to receive(:errors)
-          .and_return(type_errors)
-
-        expect(subject.errors).to eql type_errors
+        type.name = nil
+        expect(subject.errors.symbols_for(:name)).to include :blank
       end
     end
   end

--- a/spec/services/update_type_service_spec.rb
+++ b/spec/services/update_type_service_spec.rb
@@ -32,10 +32,58 @@ require 'services/shared_type_service'
 
 describe UpdateTypeService do
   let(:type) { FactoryBot.build_stubbed(:type) }
-  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:user) { FactoryBot.build_stubbed(:admin) }
 
   let(:instance) { described_class.new(type, user) }
   let(:service_call) { instance.call(params) }
 
   it_behaves_like 'type service'
+
+  describe "#validate_attribute_groups" do
+    let(:params) { { name: 'blubs blubs' } }
+
+    it 'raises an exception for invalid structure' do
+      # Example for invalid structure:
+      result = instance.call(attribute_groups: ['foo'])
+      expect(result.success?).to be_falsey
+      # Example for invalid structure:
+      result = instance.call(attribute_groups: [[]])
+      expect(result.success?).to be_falsey
+      # Example for invalid group name:
+      result = instance.call(attribute_groups: [['', ['date']]])
+      expect(result.success?).to be_falsey
+    end
+
+    it 'fails for duplicate group names' do
+      result = instance.call(attribute_groups: [['foo', ['date']], ['foo', ['date']]])
+      expect(result.success?).to be_falsey
+    end
+
+    it 'passes validations for known attributes' do
+      expect(type).to receive(:save).and_return(true)
+      result = instance.call(attribute_groups: [['foo', ['date']]])
+      expect(result.success?).to be_truthy
+    end
+
+    it 'passes validation for defaults' do
+      expect(type).to be_valid
+    end
+
+    it 'passes validation for reset' do
+      # A reset is to save an empty Array
+      expect(type).to receive(:save).and_return(true)
+      result = instance.call(attribute_groups: [])
+      expect(result.success?).to be_truthy
+      expect(type).to be_valid
+    end
+
+    context 'with an invalid query' do
+      let(:query) { FactoryBot.build(:global_query, name: '') }
+      let(:params) { { attribute_groups: [['some name', [query]]] } }
+
+      it 'is invalid' do
+        expect(service_call.success?).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
Validating attribute groups is only relevant when creating or
updating the type in the administration. There's no need to validate
this in the type itself.

https://community.openproject.com/wp/28543