### PR TITLE
remove protection of the name `sidebar` from wiki

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -62,7 +62,6 @@ class WikiPage < ActiveRecord::Base
   validate :validate_non_circular_dependency
   validate :validate_same_project
 
-  after_initialize :check_and_mark_as_protected
   before_save :update_redirects
   before_destroy :remove_redirects
 
@@ -82,16 +81,7 @@ class WikiPage < ActiveRecord::Base
       .merge(Project.allowed_to(user, :view_wiki_pages))
   }
 
-  # Wiki pages that are protected by default
-  DEFAULT_PROTECTED_PAGES = %w(sidebar)
-
   after_destroy :delete_wiki_menu_item
-
-  def check_and_mark_as_protected
-    if new_record? && DEFAULT_PROTECTED_PAGES.include?(title.to_s.downcase)
-      self.protected = true
-    end
-  end
 
   def slug
     read_attribute(:slug).presence || title.try(:to_url)

--- a/spec_legacy/unit/wiki_page_spec.rb
+++ b/spec_legacy/unit/wiki_page_spec.rb
@@ -50,12 +50,6 @@ describe WikiPage, type: :model do
     assert @wiki.pages.include?(page)
   end
 
-  it 'should sidebar should be protected by default' do
-    page = @wiki.find_or_new_page('sidebar')
-    assert page.new_record?
-    assert page.protected?
-  end
-
   it 'should find or new page' do
     page = @wiki.find_or_new_page('CookBook documentation')
     assert_kind_of WikiPage, page


### PR DESCRIPTION
This should have been removed with #caad6495a5.

It also removes:
```
/app/models/wiki_page.rb:86: warning: already initialized constant WikiPage::DEFAULT_PROTECTED_PAGES
/app/models/wiki_page.rb:86: warning: previous definition of DEFAULT_PROTECTED_PAGES was here
```
on startup