### PR TITLE
Add the support of SSL smtp server

### DIFF
--- a/app/views/settings/_notifications.html.erb
+++ b/app/views/settings/_notifications.html.erb
@@ -60,6 +60,7 @@ See docs/COPYRIGHT.rdoc for more details.
         <div class="form--field"><%= setting_text_field :smtp_user_name, container_class: '-middle' %></div>
         <div class="form--field"><%= setting_password :smtp_password, container_class: '-middle' %></div>
         <div class="form--field"><%= setting_check_box :smtp_enable_starttls_auto %></div>
+        <div class="form--field"><%= setting_check_box :smtp_ssl %></div>
       </div>
       <div id="email_delivery_method_sendmail" class="email_delivery_method_settings">
         <div class="form--field"><%= setting_text_field :sendmail_location %></div>

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -91,6 +91,18 @@
 #   smtp_user_name: "your_email@gmail.com"
 #   smtp_password: "your_password"
 #
+# ==== SMTP server at using SSL
+#
+# production:
+#   email_delivery_method: "smtp"
+#   smtp_enable_starttls_auto: false
+#   smtp_ssl: true
+#   smtp_address: "smtp.gmail.com"
+#   smtp_port: 587
+#   smtp_domain: "smtp.gmail.com" # 'your.domain.com' for GoogleApps
+#   smtp_authentication: :plain
+#   smtp_user_name: "your_email@gmail.com"
+#   smtp_password: "your_password"
 #
 # === More configuration options
 #

--- a/config/locales/crowdin/zh.yml
+++ b/config/locales/crowdin/zh.yml
@@ -713,7 +713,7 @@ zh:
     - 周五
     - 周六
     abbr_month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -739,7 +739,7 @@ zh:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -1924,6 +1924,7 @@ zh:
   setting_email_delivery_method: 电子邮件发送方法
   setting_sendmail_location: Sendmail 的执行位置
   setting_smtp_enable_starttls_auto: 如果可用，自动使用 STARTTLS
+  setting_smtp_ssl: "使用 SSL 连接"
   setting_smtp_address: SMTP 服务器
   setting_smtp_port: SMTP 端口
   setting_smtp_authentication: SMTP 身份验证

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2000,6 +2000,7 @@ en:
   setting_email_delivery_method: "Email delivery method"
   setting_sendmail_location: "Location of the sendmail executable"
   setting_smtp_enable_starttls_auto: "Automatically use STARTTLS if available"
+  setting_smtp_ssl: "Use SSL connection"
   setting_smtp_address: "SMTP server"
   setting_smtp_port: "SMTP port"
   setting_smtp_authentication: "SMTP authentication"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,6 +41,9 @@ smtp_openssl_verify_mode:
 smtp_enable_starttls_auto:
   default: 0
   format: boolean
+smtp_ssl:
+  default: 0
+  format: boolean
 smtp_address:
   default: ""
 smtp_port:

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -352,6 +352,7 @@ module OpenProject
         end
 
         ActionMailer::Base.smtp_settings[:enable_starttls_auto] = Setting.smtp_enable_starttls_auto?
+        ActionMailer::Base.smtp_settings[:ssl] = Setting.smtp_ssl?
       end
 
       ##

--- a/packaging/conf/configuration.yml
+++ b/packaging/conf/configuration.yml
@@ -37,6 +37,7 @@ default:
   smtp_user_name: <%= ENV['SMTP_USERNAME'] %>
   smtp_password: <%= ENV['SMTP_PASSWORD'] %>
   smtp_enable_starttls_auto: <%= ENV.fetch('SMTP_ENABLE_STARTTLS_AUTO') { "false" } %>
+  smtp_ssl: <%= ENV.fetch('SMTP_SSL') { "false" } %>
   attachments_storage_path: <%= ENV.fetch('ATTACHMENTS_STORAGE_PATH') { "/var/db/_APP_NAME_/files" } %>
 <% git_configured = ENV['GIT_REPOSITORIES'].present? %>
 <% svn_configured = ENV['SVN_REPOSITORIES'].present? %>


### PR DESCRIPTION
The current version support the SMTP server with TLS connection, but does not support the SMTP server with SSL connection. 

This patch add the support of SMTP server with SSL connection.