### PR TITLE
avoid adding non writeable filters multiple times

### DIFF
--- a/lib/api/utilities/payload_representer.rb
+++ b/lib/api/utilities/payload_representer.rb
@@ -36,17 +36,17 @@ module API
 
         base.representable_attrs.each do |property|
           if property.name == 'links'
-            add_filter(property, link_render_block)
+            add_filter(property, LinkRenderBlock)
           elsif property[:writeable] == false
             property.merge!(readable: false)
           else
-            add_filter(property, unwriteable_property_filter)
+            add_filter(property, UnwriteablePropertyFilter)
           end
         end
       end
 
-      def self.unwriteable_property_filter
-        ->(input, options) do
+      class UnwriteablePropertyFilter
+        def self.call(input, options)
           writeable_attr = options[:decorator].writeable_attributes
 
           as = options[:binding][:as].()
@@ -58,8 +58,8 @@ module API
         end
       end
 
-      def self.link_render_block
-        ->(input, options) do
+      class LinkRenderBlock
+        def self.call(input, options)
           writeable_attr = options[:decorator].writeable_attributes
 
           input.reject do |link|
@@ -69,6 +69,7 @@ module API
       end
 
       def self.add_filter(property, filter)
+        return if property[:render_filter].include?(filter)
         property.merge!(render_filter: filter)
       end
 


### PR DESCRIPTION
When the create_class method is called on WorkPackagePayloadRepresenter, a subclass of the class is created that includes the relevant custom fields. That class gets the PayloadRepresenter module included. The payload representer adds a render_filter to the attributes to avoid rendering unwriteable attributes. But when adding the filter, it is not added to an instance of the attribute in the subclass (WorkPackagePayloadRepresenter + CustomFields)but rather to the one in the superclass (WorkPackagePayloadRepresenter). The filter list instance is shared by all subclasses. That sideeffect is not dangerous per se as we want all WorkPackagePayloadRepresenters to have the filter. But as we have one instance of an array, adding to that array will lead to having the filter multiple times which will then all have to be evaluated on every rendering pass. By checking if the filter is already included before adding it, we can avoid this behaviour.

The better fix would be to rework the way custom fields are handled in the representers. This could be done by having one representer for the static attributes and one for the dynamic custom fields. Those two representers could be rendered/parsed independently and the results could then be merged. This approach however takes considerably more time.

https://community.openproject.com/projects/openproject/work_packages/28611/activity