### PR TITLE
[28580] Correctly replace the work package to avoid invalid update link

### DIFF
--- a/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
@@ -184,11 +184,11 @@ export class WorkPackageChangeset {
 
           this.workPackage.$links.updateImmediately(payload)
             .then((savedWp:WorkPackageResource) => {
-              // Initialize any potentially new HAL values
-              this.workPackage.$initialize(savedWp.$source);
-
               // Ensure the schema is loaded before updating
-              this.schemaCacheService.ensureLoaded(this.workPackage).then(() => {
+              this.schemaCacheService.ensureLoaded(savedWp).then(() => {
+
+                // Initialize any potentially new HAL values
+                this.workPackage = savedWp;
 
                 if (wasNew) {
                   this.workPackage.overriddenSchema = undefined;

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -296,6 +296,29 @@ describe 'new work package', js: true do
     end
   end
 
+  context 'as a user with add_work_packages permission, but not edit_work_packages permission (Regression 28580)' do
+    let(:user) { FactoryBot.create(:user, member_in_project: project, member_through_role: role) }
+    let(:role) { FactoryBot.create :role, permissions: %i(view_work_packages add_work_packages) }
+    let(:wp_page) { Pages::FullWorkPackageCreate.new }
+
+    before do
+      visit new_project_work_packages_path(project)
+    end
+
+    it 'can create the work package, but not update it after saving' do
+      type_field.set_value type_bug.name
+      subject_field.update('new work package')
+
+      wp_page.expect_and_dismiss_notification(
+        message: 'Successful creation.'
+      )
+
+      subject_field.expect_read_only
+      subject_field.display_element.click
+      subject_field.expect_inactive!
+    end
+  end
+
   context 'a anonymous user is prompted to login' do
     let(:user) { FactoryBot.create(:anonymous) }
     let(:wp_page) { ::Pages::Page.new }

--- a/spec/support/work_packages/work_package_field.rb
+++ b/spec/support/work_packages/work_package_field.rb
@@ -19,7 +19,7 @@ class WorkPackageField
   end
 
   def field_container
-    @context.find @selector
+    context.find @selector
   end
 
   def display_selector
@@ -27,15 +27,19 @@ class WorkPackageField
   end
 
   def display_element
-    @context.find "#{@selector} #{display_selector}"
+    context.find "#{@selector} #{display_selector}"
   end
 
   def input_element
-    @context.find "#{@selector} #{input_selector}"
+    context.find "#{@selector} #{input_selector}"
   end
 
   def clear
     input_element.native.clear
+  end
+
+  def expect_read_only
+    expect(context).to have_selector "#{@selector} #{display_selector}.-read-only"
   end
 
   def expect_state_text(text)


### PR DESCRIPTION
The permission to edit the work package is controlled through the HAL link workPackage.update

For new work packages, add_work_packages permission leads update link of /api/v3/projects/X/work_packages/form

When saving the work package, no update links is returned (correct, since you don't have the permission).

The returning HAL+JSON is merged back into the frontend resource, leaving the old update link, which is now invalid.

https://community.openproject.com/wp/28580