### PR TITLE
[28616] Avoid label to render as buttons in login form

### DIFF
--- a/app/assets/stylesheets/layout/_drop_down.sass
+++ b/app/assets/stylesheets/layout/_drop_down.sass
@@ -66,7 +66,6 @@
 .dropdown .dropdown-menu,
 .drop-down .menu-drop-down-container
   LI > A,
-  LABEL,
   .menu-item
     display: block
     @include varprop(color, context-menu-unselected-font-color)

--- a/app/views/account/_login.html.erb
+++ b/app/views/account/_login.html.erb
@@ -70,7 +70,7 @@ See docs/COPYRIGHT.rdoc for more details.
       </div>
 
       <div class="form--field">
-        <label class="form--label" for="login-pulldown">
+        <label class="form--label">
           &nbsp;
         </label>
         <input type="submit" name="login" id="login-pulldown"


### PR DESCRIPTION
- Remove button style for LABEL in dropdown
- Remove connection from empty button label (used for positioning only)

https://community.openproject.com/wp/28616