### PR TITLE
[28422] Fix different scrolling behaviour of main menu

### DIFF
--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -39,15 +39,19 @@ $menu-item-line-height: 30px
   border-right-style: solid
   @include varprop(border-right-width, main-menu-border-width)
   @include varprop(border-right-color, main-menu-border-color)
-
-  // min-height is full height minus header and footer.
+  @include varprop(background-color, main-menu-bg-color)
+  // min-height is full height minus header
   min-height: calc(100vh - 55px)
 
-  @include varprop(background-color, main-menu-bg-color)
-
   #menu-sidebar
-    height: 100%
+    height: calc(100vh - 55px)
     overflow: auto
+    // sidebar is fixed, so that it always has same height and position
+    position: fixed
+    top: 55px
+    @include varprop(width, main-menu-width)
+
+    @include styled-scroll-bar
 
   %absolute-layout-mode &
     position: relative
@@ -194,8 +198,13 @@ $arrow-left-width: 40px
         @include varprop(background, main-menu-bg-hover-color)
 
 .main-menu--children-menu-header
-  padding: 10px 10px 0 10px
-  height: calc(#{$main-menu-item-height} + 10px)
+  padding: 10px
+  height: calc(#{$main-menu-item-height} + 20px)  // Header and spacing
+  // submenu header is fixed at the top
+  position: sticky
+  top: 0
+  z-index: 22
+  @include varprop(background, main-menu-bg-color)
 
 .main-menu--arrow-left-to-project
   display: inline-block

--- a/app/assets/stylesheets/layout/_main_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_main_menu_mobile.sass
@@ -40,6 +40,9 @@
     %absolute-layout-mode &
       height: auto
 
+    #menu-sidebar
+      width: 100vw
+
   .hidden-navigation .main-menu
     display: none
 

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -49,13 +49,14 @@ $hamburger-width: 50px
   width: 100%
   padding: 0
   z-index: 22
-  position: relative
+  position: sticky
+  top: 0
   border-bottom-style: solid
   @include varprop(border-bottom-width, header-border-bottom-width)
   @include varprop(border-bottom-color, header-border-bottom-color)
 
   %absolute-layout-mode &
-    position: absolute
+    position: fixed
 
   ::-webkit-input-placeholder
     color: $header-search-field-font-color
@@ -331,7 +332,7 @@ input.top-menu-search--input
 
   .nosidebar &
     display: none
-    
+
   &:hover
     @include varprop(background, header-item-bg-hover-color)
     @include varprop(color, header-item-font-hover-color)

--- a/app/assets/stylesheets/layout/work_packages/_query_menu.sass
+++ b/app/assets/stylesheets/layout/work_packages/_query_menu.sass
@@ -17,10 +17,6 @@ $wp-query-menu-search-container-height: 35px
 
     @include styled-scroll-bar
 
-
-  .wp-query-menu--results-container
-    padding-top: 5px
-
     %absolute-layout-mode &
       height: calc(100% - #{$wp-query-menu-search-container-height})
 
@@ -37,8 +33,7 @@ $wp-query-menu-search-container-height: 35px
     font-size: $main-menu-font-size
 
   .wp-query-menu--search-container
-    padding-top: 10px
-    overflow: hidden
+    // overflow: hidden
     @include varprop(color, main-menu-font-color)
 
     // Specific fix for Firefox
@@ -66,10 +61,13 @@ $wp-query-menu-search-container-height: 35px
 
   // The actual search input
   .wp-query-menu--search-bar
-    height: $wp-query-menu-search-container-height
-    position: relative
-    margin: 0 10px
+    height: calc(#{$wp-query-menu-search-container-height} + 10px) // 10px for spacing
+    padding: 0 10px
     min-width: 55px
+    position: sticky
+    top: calc(#{$main-menu-item-height} + 20px) // Height of main menu header and padding (search bar should stick under header)
+    z-index: 22
+    @include varprop(background, main-menu-bg-color)
 
   // Category collapsible links
   .wp-query-menu--category-icon
@@ -150,6 +148,6 @@ $wp-query-menu-search-container-height: 35px
   .wp-query-menu--search-icon
     position: absolute
     top:   5px
-    right: 10px
+    right: 20px
     @include varprop(color, main-menu-font-color)
     opacity: 0.5


### PR DESCRIPTION
### Description

There was a different scrolling behaviour of the main menu, dependent on where you were in the project: E.g. at the work packages subpage the menu had the height of the viewport and was therefore scrollable itself, while it had its full length when opening the work packages menu (via the arrow) from anywhere else in the project - even if the content on the right side would be much smaller. This caused, that not the menu was scrollable but the whole page.

**Changes in this PR:**

- Sidebar always has viewport height 
-> Sidebar and content are independently scrollable everywhere in the project
-> The top bar now has a fixed position, so that it always stays at the top of the screen
-> Tested in Chrome, Opera and Firefox (style of scrollbar is unfortunately not adaptable here with pure css) and tested on different device sizes

- Mobile menu to full size

- Wiki scrollbar bug fixed (wiki menu was not full height which caused a scrollbar when collapsing the last wiki menu point)

**Bugs:**

- Sometimes not the correct side is scrolling

- [ ] Width of searchbar in the wp submenu is changing, when the scrollbar is disappearing (e.g. when collapsing categories)


https://community.openproject.com/projects/openproject/work_packages/28422/activity
