### PR TITLE
[28217] Move export options from footer to menu

### DIFF
--- a/app/views/wiki/_wiki_export_modal.html.erb
+++ b/app/views/wiki/_wiki_export_modal.html.erb
@@ -1,0 +1,65 @@
+<%#-- copyright
+OpenProject is a project management system.
+Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2017 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See docs/COPYRIGHT.rdoc for more details.
+
+++#%>
+
+<div class="modal-wrapper--content">
+  <div class="onboarding--top-menu op-modal--modal-header">
+    <a class="op-modal--modal-close-button dynamic-content-modal--close-button"
+       title="<%= t('js.close_popup_title') %>"
+       aria-label="<%= t('js.close_popup_title') %>">
+      <%= op_icon('icon-close') %>
+    </a>
+  </div>
+
+  <h3><%= I18n.t('js.label_export') %></h3>
+
+  <div class="op-modal--modal-body">
+    <ul class="export-options">
+      <li>
+        <%= link_to url_for(controller: '/activities',
+                            action: 'index',
+                            show_wiki_edits: 1,
+                            apply: true,
+                            key: User.current.rss_key, format: 'atom') do %>
+            <%= op_icon('icon-big icon-export-atom') %>
+            <span class="export-label"><%= t('export.format.atom') %></span>
+        <% end %>
+      </li>
+      <li>
+        <%= link_to url_for(version: @content.version, id: @page, format: 'markdown') do %>
+            <%= op_icon('icon-big icon-ticket') %>
+            <span class="export-label"><%= t('text_formatting.markdown') %></span>
+        <% end %>
+      </li>
+    </ul>
+  </div>
+</div>
+
+<% content_for :header_tags do %>
+    <%= auto_discovery_link_tag(:atom, controller: '/activities', action: 'index', id: @project, show_wiki_edits: 1, format: 'atom', key: User.current.rss_key) %>
+<% end %>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -91,6 +91,18 @@ See docs/COPYRIGHT.rdoc for more details.
       <% end %>
       <%= li_unless_nil(link_to_if_authorized(l(:label_history), {action: 'history', id: @page}, class: 'icon-context icon-wiki')) %>
       <%= li_unless_nil(link_to_if_authorized(l(:button_manage_menu_entry), {controller: '/wiki_menu_items', action: 'edit', project_id: @project.identifier, id: @page}, class: 'icon-context icon-settings')) %>
+      <% if User.current.allowed_to?(:export_wiki_pages, @project) %>
+        <section data-augmented-model-wrapper
+                 data-modal-class-name="wiki-export---modal">
+          <li>
+            <%= link_to I18n.t('js.label_export'),
+                        '',
+                        title: I18n.t('js.label_export'),
+                        class: 'modal-wrapper--activation-link icon-context icon-export' %>
+          </li>
+          <%= render partial: 'wiki/wiki_export_modal' %>
+        </section>
+      <% end %>
       <%= li_unless_nil(link_to_if_authorized(l(:label_table_of_contents), {controller: '/wiki', action: 'index', project_id: @project.identifier, id: @page}, class: 'icon-context icon-view-list')) %>
     </ul>
   </li>
@@ -115,18 +127,5 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <% resource = ::API::V3::WikiPages::WikiPageRepresenter.new(@page, current_user: current_user, embed_links: true) %>
 <%= list_attachments(resource) %>
-
-<%= other_formats_links do |f| %>
-  <%= f.link_to 'Atom', url: { controller: '/activities',
-                                  action: 'index',
-                                  show_wiki_edits: 1,
-                                  key: User.current.rss_key } %>
-  <%= f.link_to 'Markdown', url: { version: @content.version, id: @page, format: 'markdown' } %>
-  <%= call_hook(:view_wiki_show_other_formats, {link_builder: f, url_params: {id: @page, version: @content.version}}) %>
-<% end if User.current.allowed_to?(:export_wiki_pages, @project) %>
-
-<% content_for :header_tags do %>
-  <%= auto_discovery_link_tag(:atom, controller: '/activities', action: 'index', id: @project, show_wiki_edits: 1, format: 'atom', key: User.current.rss_key) %>
-<% end %>
 
 <% html_title h(@page.title) %>


### PR DESCRIPTION
This moves the sport functions of the wiki form the footer to the More menu. The new styles matches the one from the WP page. 
For the Atom feed there have been an error for quite a long time. There all activities have been shown in the feed. Now only those which concern the wiki are shown.

https://community.openproject.com/projects/openproject/work_packages/28217/activity