### PR TITLE
[28422] Fix/scroll behaviour

### DIFF
--- a/app/assets/javascripts/specific/main_menu.js.erb
+++ b/app/assets/javascripts/specific/main_menu.js.erb
@@ -115,4 +115,8 @@ jQuery(document).ready(function($) {
     $(child).before(header);
   })
 
+  if($('.menu_root').hasClass('closed')) {
+      // TODO: Instead of hiding the sidebar move sidebar's contents to submenus and cache it.
+      $('#sidebar').toggleClass('-hidden', true);
+  }
 });

--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -172,9 +172,6 @@ blockquote
 
 body.controller-wiki
 
-  #content
-    overflow: initial
-
   .ck-content
     min-height: 25vh
 

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -56,15 +56,6 @@ body
     overflow: visible
 
     #content-wrapper
-      &.hidden-navigation
-        margin-left: $main-menu-folded-width
-        width: calc(100% - #{$main-menu-folded-width})
-
-      &.nosidebar
-        padding: 0
-        width:    100%
-        margin-left: 0
-
       &.nomenus
         top: 0
         padding: 0

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -81,7 +81,8 @@ body
   margin: 0 0 0 0
   padding: 10px 20px
   width: auto
-  height: auto
+  height: calc(100vh - #{$header-height})
+  overflow: hidden
   background-color: #fff
   width: 100%
   // As this is a flex item we need to set min-width to 0 so that its children's
@@ -113,7 +114,8 @@ body
 #content
   padding: 0
   margin: 0 0 0 0
-  overflow: hidden
+  height: 100%
+  overflow: auto
   width: 100%
   z-index: 10
   background-color: $body-background

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -82,7 +82,7 @@ body
   padding: 10px 20px
   width: auto
   height: calc(100vh - #{$header-height})
-  overflow: hidden
+  overflow: auto
   background-color: #fff
   width: 100%
   // As this is a flex item we need to set min-width to 0 so that its children's
@@ -114,8 +114,6 @@ body
 #content
   padding: 0
   margin: 0 0 0 0
-  height: 100%
-  overflow: auto
   width: 100%
   z-index: 10
   background-color: $body-background

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -55,14 +55,17 @@ $menu-item-line-height: 30px
     .menu_root > li.open,
     wp-query-select,
     .wp-query-menu--container,
-    .wp-query-menu--search-container
+    .wp-query-menu--search-container,
+    .main-menu--children > li.partial:only-child
       height: 100%
 
     .main-menu--children > li.partial
-      height: inherit
+      height: initial
 
     .main-menu--children
       height: calc(100% - (#{$main-menu-item-height} + 10px)) // 10px spacing
+      overflow: auto
+      @include styled-scroll-bar
 
   ul
     margin: 0

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -59,7 +59,7 @@ $menu-item-line-height: 30px
       height: 100%
 
     .main-menu--children > li.partial
-      height: 100%
+      height: inherit
 
     .main-menu--children
       height: calc(100% - (#{$main-menu-item-height} + 10px)) // 10px spacing
@@ -314,9 +314,6 @@ a.main-menu--parent-node
   &.-hidden
     display: none
 
-  %absolute-layout-mode &
-    display: none
-
 .menu-wiki-pages-tree
   height: 100%
   overflow: auto
@@ -347,8 +344,6 @@ a.main-menu--parent-node
   vertical-align: middle
   z-index: 1
   cursor: col-resize
-  %absolute-layout-mode &
-    z-index: 100
   &:hover
     @include varprop(border-left-color, main-menu-resizer-color)
     .main-menu--navigation-toggler
@@ -395,8 +390,6 @@ a.main-menu--parent-node
     i:before
       padding-left: 0
       @include icon-mixin-arrow-left2
-  %absolute-layout-mode &
-    z-index: 100
 
 #main-menu ul ul.main-menu--children ul.pages-hierarchy
   .tree-menu--hierarchy-indicator

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -41,28 +41,28 @@ $menu-item-line-height: 30px
   @include varprop(border-right-color, main-menu-border-color)
 
   // min-height is full height minus header and footer.
-  min-height: calc(100vh - 55px)
+  min-height: calc(100vh - #{$header-height})
 
   @include varprop(background-color, main-menu-bg-color)
 
   #menu-sidebar
-    height: 100%
+    height: calc(100vh - #{$header-height})
     overflow: auto
-
-  %absolute-layout-mode &
     position: relative
 
     // Fixed heights to allow inner scrolling
     .menu_root.closed,
     .menu_root > li.open,
-    .main-menu--children > li.partial,
     wp-query-select,
     .wp-query-menu--container,
     .wp-query-menu--search-container
       height: 100%
 
+    .main-menu--children > li.partial
+      height: inherit
+
     .main-menu--children
-      height: calc(100% - (#{$main-menu-item-height} + 20px))
+      height: calc(100% - (#{$main-menu-item-height} + 10px)) // 10px spacing
 
   ul
     margin: 0

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -39,16 +39,16 @@ $menu-item-line-height: 30px
   border-right-style: solid
   @include varprop(border-right-width, main-menu-border-width)
   @include varprop(border-right-color, main-menu-border-color)
-
+  @include varprop(background-color, main-menu-bg-color)
   // min-height is full height minus header and footer.
   min-height: calc(100vh - #{$header-height})
 
-  @include varprop(background-color, main-menu-bg-color)
-
   #menu-sidebar
+    +allow-vertical-scrolling
+    -ms-overflow-style: -ms-autohiding-scrollbar
     height: calc(100vh - #{$header-height})
-    overflow: auto
     position: relative
+    @include styled-scroll-bar
 
     // Fixed heights to allow inner scrolling
     .menu_root.closed,
@@ -59,7 +59,7 @@ $menu-item-line-height: 30px
       height: 100%
 
     .main-menu--children > li.partial
-      height: inherit
+      height: 100%
 
     .main-menu--children
       height: calc(100% - (#{$main-menu-item-height} + 10px)) // 10px spacing

--- a/app/assets/stylesheets/layout/_main_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_main_menu_mobile.sass
@@ -29,8 +29,7 @@
 @include breakpoint(680px down)
 
   .main-menu
-    position: absolute !important
-    min-height: 100%
+    position: fixed
     z-index: 11
     border-bottom: 1px solid $main-menu-border-color
     width: 100vw !important

--- a/app/assets/stylesheets/layout/_main_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_main_menu_mobile.sass
@@ -36,9 +36,6 @@
     border: none
     box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.15)
 
-    %absolute-layout-mode &
-      height: auto
-
   .hidden-navigation .main-menu
     display: none
 

--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -28,8 +28,6 @@
 
 body.controller-work_packages.action-show
 body.controller-work_packages.full-create
-  overflow-x: auto
-
   // Fix selenium scrolling the #content which shouldn't be possible
   // This appears to be caused by somehow setting the scrollTop to move to an element.
   #content-wrapper,

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -50,15 +50,6 @@
         height: calc(100vh - #{$header-height})
 
         #content-wrapper
-          &.hidden-navigation
-            margin-left: 0
-            width: 100%
-
-          &.nosidebar
-            padding: 0
-            width:    100%
-            margin-left: 0
-
           &.nomenus
             top: 0
             padding: 0

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -30,8 +30,7 @@
 
     // ------------- FULL SCREEN -------------------
     &.action-show
-      overflow: auto !important
-      overflow-y: scroll !important
+
 
       #main,
       #content-wrapper,
@@ -44,10 +43,11 @@
       #content-wrapper,
       #content
         height: 100% !important
-        overflow: visible
+        overflow: auto
 
       #main
         padding-bottom: 0
+        height: calc(100vh - #{$header-height})
 
         #content-wrapper
           &.hidden-navigation
@@ -105,7 +105,7 @@
 
     .work-packages-list-view--container
       padding-left: 5px
-      
+
     .toolbar-container
       min-height: 36px
       padding-right: 0

--- a/app/assets/stylesheets/layout/work_packages/_query_menu.sass
+++ b/app/assets/stylesheets/layout/work_packages/_query_menu.sass
@@ -20,9 +20,7 @@ $wp-query-menu-search-container-height: 35px
 
   .wp-query-menu--results-container
     padding-top: 5px
-
-    %absolute-layout-mode &
-      height: calc(100% - #{$wp-query-menu-search-container-height})
+    height: calc(100% - #{$wp-query-menu-search-container-height})
 
     // Firefox needs more left padding for whatever reason
     html.-browser-firefox &


### PR DESCRIPTION
### Description

There was a different scrolling behaviour of the main menu, dependent on where you were in the project: E.g. at the WP page the main menu could scroll independently of the content. On all other pages the menu and content scroll together. This causes problems when either the menu or the content is much longer since the other one shows only white space. 

**Changes in this PR:**

- The major change is that not the body takes care of the scrolling, but the content and the menu itself. Therefore the `#content'  and `#content_wrapper'  had to be changed. Now the main menu and content always have viewport height and take care of their scrolling. Thus both are independently scrollable everywhere in the project.
- The gap at the bottom of every menu is removed by hiding the sidebar on main menu child pages per default
- Changes at the work packages page to adapt the height to the viewport

- Mobile menu to screen size (menu was to long)
  (see also: https://community.openproject.com/projects/openproject/work_packages/28720)

**ToDos:**

- [x] Browser testing (Chrome, Firefox, Safari, MSEdge)
- [x] Test different device sizes

**Note**: We tried to test it as much as possible. However the changes at the content affect every page. We should therefor **not** merge this when a release is near.

https://community.openproject.com/projects/openproject/work_packages/28422/activity

Older PR:
https://github.com/opf/openproject/pull/6732