### PR TITLE
Change block order in version overview

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -766,6 +766,7 @@ input[readonly].-clickable
     background: none
     border: none
     line-height: 2
+    margin-right: 5px
 
   > .form-label
     line-height: 2rem

--- a/app/assets/stylesheets/content/_widget_box.sass
+++ b/app/assets/stylesheets/content/_widget_box.sass
@@ -28,14 +28,13 @@
 
 $widget-box--enumeration-width: 20px
 
-.widget-boxes--screen-header
-  margin-left: 10px
-
 .widget-boxes
 
   &.-flex
     display: flex
     flex-flow: row wrap
+    // cancel the margin of the outer elements to align with the rest of the page
+    margin: 0 -10px
 
     .widget-box
       flex: 1
@@ -67,8 +66,10 @@ $widget-box--enumeration-width: 20px
     word-wrap: break-word
     overflow: hidden
 
-    &.-small
+    &.-thin
       min-height: 100px
+    &.-wider
+      flex-grow: 3
 
     .widget-box--header
       font-weight: bold

--- a/app/assets/stylesheets/openproject/_homescreen.sass
+++ b/app/assets/stylesheets/openproject/_homescreen.sass
@@ -73,9 +73,3 @@
       flex: auto
       margin: 20px 0
       width: 50%
-
-  .controller-homescreen
-    .widget-boxes--screen-header
-      margin-left: 0px
-    .widget-boxes .widget-box
-      margin: 10px 0px

--- a/app/views/homescreen/index.html.erb
+++ b/app/views/homescreen/index.html.erb
@@ -27,12 +27,10 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% breadcrumb_paths(nil) %>
-<div class="widget-boxes--screen-header">
-  <h2>
-    <span><%= organization_icon %></span>
-    <%= organization_name %>
-  </h2>
-</div>
+<h2>
+  <span><%= organization_icon %></span>
+  <%= organization_name %>
+</h2>
 
 <%= render partial: 'announcements/show' %>
 

--- a/app/views/versions/_work_package_counts.html.erb
+++ b/app/views/versions/_work_package_counts.html.erb
@@ -26,11 +26,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<% tag_for_selection = select_tag('status_by',
-                                  status_by_options_for_select(criteria),
-                                  id: 'status_by_select',
-                                  class: 'form--select -narrow') %>
-
 <%= form_tag status_by_version_path(version),
              id: "status_by_form" do %>
 
@@ -41,10 +36,12 @@ See docs/COPYRIGHT.rdoc for more details.
     </legend>
 
     <span class="inline-label">
-      <span class="form-label -transparent">
+      <span class="form-label -transparent" style="width: 130px">
         <%= l(:label_group_by) %>
       </span>
-      <%= tag_for_selection %>
+      <%= styled_select_tag('status_by', status_by_options_for_select(criteria),
+                                             id: 'status_by_select',
+                                             container_class: '-slim') %>
     </span>
     <% if counts.empty? %>
 
@@ -55,16 +52,16 @@ See docs/COPYRIGHT.rdoc for more details.
       <table>
         <% counts.each do |count| %>
           <tr>
-            <td width="130px" align="right" >
+            <td style="width: 130px" align="left" >
               <%= link_to h(count[:group]),
                             project_version_property_path(version, "#{criteria}_id", count[:group].id) %>
             </td>
-            <td width="240px">
+            <td style="width: 240px">
               <%= progress_bar((count[:closed].to_f / count[:total])*100,
                       legend: "#{count[:closed]}/#{count[:total]}",
                       hide_total_progress: true,
                       hide_percent_sign: true,
-                      width: "#{(count[:total].to_f / max * 200).floor}px;") %>
+                      width: "#{(count[:total].to_f / max * 190).floor}px;") %>
             </td>
           </tr>
 

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -28,60 +28,60 @@ See docs/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%= toolbar title: @version.name do %>
- <% if authorize_for(:versions, :edit) %>
-    <li class="toolbar-item">
-      <%= link_to(edit_version_path(@version), class: 'button') do %>
-        <%= op_icon('button--icon icon-edit') %>
-        <span class="button--text"><%= l(:button_edit) %></span>
-      <% end %>
-    </li>
-  <% end %>
-  <% if authorize_for(:wiki, :edit) && !(@version.wiki_page_title.blank? || @version.project.wiki.nil?) %>
-    <li class="toolbar-item">
-      <%= link_to({controller: '/wiki', action: 'edit',
-                   project_id: @version.project,
-                   id: @version.wiki_page_title},
-                   class: 'button') do %>
-        <%= op_icon('button--icon icon-edit') %>
-        <span class="button--text"><%= l(:button_edit_associated_wikipage, page_title: truncate(@version.wiki_page_title, length: 50, separator: ' ')) %></span>
-      <% end %>
-    </li>
-  <% end %>
-  <%= call_hook(:view_versions_show_contextual, { version: @version, project: @project }) %>
+    <% if authorize_for(:versions, :edit) %>
+        <li class="toolbar-item">
+          <%= link_to(edit_version_path(@version), class: 'button') do %>
+              <%= op_icon('button--icon icon-edit') %>
+              <span class="button--text"><%= l(:button_edit) %></span>
+          <% end %>
+        </li>
+    <% end %>
+    <% if authorize_for(:wiki, :edit) && !(@version.wiki_page_title.blank? || @version.project.wiki.nil?) %>
+        <li class="toolbar-item">
+          <%= link_to({controller: '/wiki', action: 'edit',
+                       project_id: @version.project,
+                       id: @version.wiki_page_title},
+                      class: 'button') do %>
+              <%= op_icon('button--icon icon-edit') %>
+              <span class="button--text"><%= l(:button_edit_associated_wikipage, page_title: truncate(@version.wiki_page_title, length: 50, separator: ' ')) %></span>
+          <% end %>
+        </li>
+    <% end %>
+    <%= call_hook(:view_versions_show_contextual, { version: @version, project: @project }) %>
 <% end %>
 
 <%= render partial: 'versions/overview', locals: {version: @version} %>
 
 <div class="widget-boxes -flex">
-  <% if @version.estimated_hours > 0 || User.current.allowed_to?(:view_time_entries, @project) %>
-    <div class="widget-box -small">
-      <fieldset class="form--fieldset"><legend class="form--fieldset-legend"><%= l(:label_time_tracking) %></legend>
-        <table>
-          <tr>
-            <td width="130px" align="right"><%= Version.human_attribute_name(:estimated_hours) %></td>
-            <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.estimated_hours)) %></td>
-          </tr>
-          <% if User.current.allowed_to?(:view_time_entries, @project) %>
-            <tr>
-              <td width="130px" align="right"><%= l(:label_spent_time) %></td>
-              <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.spent_hours)) %></td>
-            </tr>
-          <% end %>
-        </table>
-      </fieldset>
-    </div>
-  <% end %>
-
   <% if @version.fixed_issues.count > 0 %>
-    <div class="widget-box -small">
+    <div class="widget-box -thin -wider">
       <div id="status_by">
         <%= render_status_by(@version, params[:status_by])  %>
       </div>
     </div>
   <% end %>
 
+  <% if @version.estimated_hours > 0 || User.current.allowed_to?(:view_time_entries, @project) %>
+      <div class="widget-box -thin">
+        <fieldset class="form--fieldset"><legend class="form--fieldset-legend"><%= l(:label_time_tracking) %></legend>
+          <table>
+            <tr>
+              <td width="130px" align="right"><%= Version.human_attribute_name(:estimated_hours) %></td>
+              <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.estimated_hours)) %></td>
+            </tr>
+            <% if User.current.allowed_to?(:view_time_entries, @project) %>
+                <tr>
+                  <td width="130px" align="right"><%= l(:label_spent_time) %></td>
+                  <td width="240px" class="total-hours" align="right"><%= html_hours(l_hours(@version.spent_hours)) %></td>
+                </tr>
+            <% end %>
+          </table>
+        </fieldset>
+      </div>
+  <% end %>
+
   <% if @version.wiki_page || @issues.present? %>
-    <div class="widget-box -small">
+    <div class="widget-box -thin -wider">
       <%= render(partial: "wiki/content", locals: {content: @version.wiki_page.content}) if @version.wiki_page %>
 
       <% if @issues.present? %>


### PR DESCRIPTION
Change order of blocks in version overview and minor style changes

#### Before
<img width="1422" alt="bildschirmfoto 2018-10-04 um 11 05 03" src="https://user-images.githubusercontent.com/7457313/46463902-5e565100-c7c5-11e8-9430-071e33e20657.png">

#### After
<img width="1420" alt="bildschirmfoto 2018-10-04 um 11 00 42" src="https://user-images.githubusercontent.com/7457313/46463882-4ed70800-c7c5-11e8-95f6-afc80bb498be.png">