### PR TITLE
[28678] Top menu entries are misaligned in mobile views

### DIFF
--- a/app/assets/stylesheets/layout/_drop_down_mobile.sass
+++ b/app/assets/stylesheets/layout/_drop_down_mobile.sass
@@ -31,11 +31,5 @@
 // (dual MIT/GPL-Licensed)
 
 @include breakpoint(680px down)
-  .dropdown .dropdown-menu,
-  .drop-down .menu-drop-down-container
-    LI > A,
-    LABEL
-      padding: 8px 13px 8px 10px
-
   .dropdown .dropdown-menu
     min-width: 0


### PR DESCRIPTION
Remove unnecessary padding which causes a misalignment

https://community.openproject.com/projects/openproject/work_packages/28678/activity