### PR TITLE
[28410] WP resizer is wrongly positioned in Safari and Edge

### DIFF
--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -147,7 +147,6 @@ body.controller-work_packages.full-create
   top: 50%
   bottom: 50%
   width: 18px
-  display: inline-block
   .work-packages--resizer
     left: -2px
     width: 18px

--- a/frontend/src/app/components/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/components/routing/wp-full-view/wp-full-view.html
@@ -57,10 +57,6 @@
         </div>
       </div>
       <div class="work-packages-full-view--split-right">
-        <div class="work-packages-full-view--resizer hidden-for-mobile hide-when-print">
-          <wp-resizer [elementClass]="'work-packages-full-view--split-right'"
-                    [localStorageKey]="'openProject-fullViewFlexBasis'"></wp-resizer>
-        </div>
         <div class="work-packages--panel-inner">
           <span class="hidden-for-sighted" tabindex="-1" focus [textContent]="focusAnchorLabel"></span>
           <div id="tabs">
@@ -88,6 +84,11 @@
           </div>
           <div class="tabcontent" ui-view>
           </div>
+        </div>
+
+        <div class="work-packages-full-view--resizer hidden-for-mobile hide-when-print">
+          <wp-resizer [elementClass]="'work-packages-full-view--split-right'"
+                      [localStorageKey]="'openProject-fullViewFlexBasis'"></wp-resizer>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Position the resizer after the other elements for correct layout

https://community.openproject.com/projects/openproject/work_packages/28410/activity