### PR TITLE
Fix #28639. Use api_v3_path helpers for linking work package's available relation candidates

### DIFF
--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.upgraded.component.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.upgraded.component.ts
@@ -103,7 +103,7 @@ export class WpRelationsAutocompleteComponent implements OnInit {
   private autocompleteWorkPackages(query:string):Promise<WorkPackageResource[]> {
     this.$element.find('.ui-autocomplete--loading').show();
 
-    return this.workPackage.available_relation_candidates.$link.$fetch({
+    return this.workPackage.availableRelationCandidates.$link.$fetch({
       query: query,
       type: this.filterCandidatesFor || this.selectedRelationType
     }).then((collection:CollectionResource) => {

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -406,6 +406,10 @@ module API
             "#{work_package_relations(work_package_id)}/#{id}"
           end
 
+          def self.work_package_available_relation_candidates(id)
+            "#{work_package(id)}/available_relation_candidates"
+          end
+
           def self.work_package_revisions(id)
             "#{work_package(id)}/revisions"
           end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -138,7 +138,7 @@ module API
           next if represented.new_record?
 
           {
-            href: "/api/v3/work_packages/#{represented.id}/available_relation_candidates",
+            href: api_v3_paths.work_package_available_relation_candidates(represented.id),
             title: "Potential work packages to relate to"
           }
         end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -134,7 +134,7 @@ module API
           }
         end
 
-        link :available_relation_candidates do
+        link :availableRelationCandidates do
           next if represented.new_record?
 
           {


### PR DESCRIPTION
When the OP instance is configured to be live in a subdirectory, such as `/open_project` then the Work Package Representer would not reflect that subdirectory when linking `available_relation_candidates`

https://community.openproject.com/wp/28639