### PR TITLE
[26126] Relations counter also includes parent and children

### DIFF
--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -136,7 +136,7 @@ i
     text-align: center
     cursor: pointer
 
-    .wp-relations-count
+    .wp-tabs-count
       margin-left: 5px
       border-radius: 0.5rem
       min-width: 1rem
@@ -167,7 +167,7 @@ i
     @include varprop(border-bottom-color, content-link-color)
     a
       @include varprop(color, content-link-color)
-    .wp-relations-count
+    .wp-tabs-count
       @include varprop(color, content-link-color)
       &:hover
         @include varprop(color, content-link-color)

--- a/frontend/src/app/angular4-modules.ts
+++ b/frontend/src/app/angular4-modules.ts
@@ -73,6 +73,7 @@ import {UserLinkComponent} from 'core-components/user/user-link/user-link.compon
 import {WorkPackageCacheService} from 'core-components/work-packages/work-package-cache.service';
 import {WorkPackageBreadcrumbComponent} from 'core-components/work-packages/wp-breadcrumb/wp-breadcrumb.component';
 import {WorkPackageRelationsCountComponent} from 'core-components/work-packages/wp-relations-count/wp-relations-count.component';
+import {WorkPackageWatchersCountComponent} from 'core-components/work-packages/wp-relations-count/wp-watchers-count.component';
 import {WorkPackageSingleViewComponent} from 'core-components/work-packages/wp-single-view/wp-single-view.component';
 import {WorkPackageSubjectComponent} from 'core-components/work-packages/wp-subject/wp-subject.component';
 import {WorkPackageTypeStatusComponent} from 'core-components/work-packages/wp-type-status/wp-type-status.component';
@@ -365,6 +366,7 @@ import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table
     // Split view
     WorkPackageSplitViewComponent,
     WorkPackageRelationsCountComponent,
+    WorkPackageWatchersCountComponent,
     WorkPackageBreadcrumbComponent,
     WorkPackageEditFieldGroupComponent,
     WorkPackageSplitViewToolbarComponent,

--- a/frontend/src/app/components/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/components/routing/wp-full-view/wp-full-view.html
@@ -79,6 +79,7 @@
                   [uiParams]="{workPackageId: workPackage.id}"
                   uiSrefActive="selected">
                 <a href="" [textContent]="text.tabs.watchers"></a>
+                <wp-watchers-count [wpId]="workPackage.id"></wp-watchers-count>
               </li>
             </ul>
           </div>

--- a/frontend/src/app/components/routing/wp-split-view/wp-split-view.html
+++ b/frontend/src/app/components/routing/wp-split-view/wp-split-view.html
@@ -22,6 +22,7 @@
             uiSref="work-packages.list.details.watchers"
             uiSrefActive="selected">
           <a href="" [textContent]="text.tabs.watchers"></a>
+          <wp-watchers-count [wpId]="workPackage.id"></wp-watchers-count>
         </li>
         <li class="tab-icon">
           <accessible-by-keyboard (execute)="switchToFullscreen()"

--- a/frontend/src/app/components/work-packages/wp-relations-count/wp-relations-count.component.ts
+++ b/frontend/src/app/components/work-packages/wp-relations-count/wp-relations-count.component.ts
@@ -2,6 +2,8 @@ import {Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {componentDestroyed} from 'ng2-rx-componentdestroyed';
 import {takeUntil} from 'rxjs/operators';
 import {RelationsStateValue, WorkPackageRelationsService} from '../../wp-relations/wp-relations.service';
+import {WorkPackageCacheService} from '../../work-packages/work-package-cache.service';
+import {combineLatest} from 'rxjs';
 
 @Component({
   templateUrl: './wp-relations-count.html',
@@ -11,20 +13,26 @@ export class WorkPackageRelationsCountComponent implements OnInit, OnDestroy {
   @Input('wpId') wpId:string;
   public count:number = 0;
 
-  constructor(public wpRelations:WorkPackageRelationsService) {
+  constructor(protected wpCacheService:WorkPackageCacheService,
+              protected wpRelations:WorkPackageRelationsService) {
   }
 
   ngOnInit():void {
     this.wpRelations.require(this.wpId.toString());
 
-    this.wpRelations.state(this.wpId.toString()).values$()
-      .pipe(
-        takeUntil(componentDestroyed(this))
-      )
-      .subscribe((relations:RelationsStateValue) => {
-        this.count = _.size(relations);
-      });
-  }
+    combineLatest(
+      this.wpRelations.state(this.wpId.toString()).values$(),
+      this.wpCacheService.loadWorkPackage(this.wpId.toString()).values$()
+    ).pipe(
+      takeUntil(componentDestroyed(this))
+    ).subscribe(([relations, workPackage]) => {
+      let relationCount = _.size(relations);
+      let parentCount = workPackage.parent ? 1 : 0;
+      let childrenCount = _.size(workPackage.children);
+
+      this.count = relationCount + parentCount + childrenCount;
+    });
+}
 
   ngOnDestroy():void {
     // Nothing to do

--- a/frontend/src/app/components/work-packages/wp-relations-count/wp-relations-count.html
+++ b/frontend/src/app/components/work-packages/wp-relations-count/wp-relations-count.html
@@ -1,3 +1,3 @@
-<span class="wp-relations-count"
+<span class="wp-tabs-count"
       *ngIf="count > 0"
       [textContent]="count"></span>

--- a/frontend/src/app/components/work-packages/wp-relations-count/wp-watchers-count.component.ts
+++ b/frontend/src/app/components/work-packages/wp-relations-count/wp-watchers-count.component.ts
@@ -1,0 +1,30 @@
+import {Component, Input, OnDestroy, OnInit} from '@angular/core';
+import {componentDestroyed} from 'ng2-rx-componentdestroyed';
+import {takeUntil} from 'rxjs/operators';
+import {WorkPackageCacheService} from '../../work-packages/work-package-cache.service';
+import {combineLatest} from 'rxjs';
+
+@Component({
+  templateUrl: './wp-relations-count.html',
+  selector: 'wp-watchers-count',
+})
+export class WorkPackageWatchersCountComponent implements OnInit, OnDestroy {
+  @Input('wpId') wpId:string;
+  public count:number = 0;
+
+  constructor(protected wpCacheService:WorkPackageCacheService) {
+  }
+
+  ngOnInit():void {
+    this.wpCacheService.loadWorkPackage(this.wpId.toString()).values$()
+      .pipe(
+        takeUntil(componentDestroyed(this))
+      ).subscribe((workPackage) => {
+        this.count =  _.size(workPackage.watchers.elements);
+      });
+}
+
+  ngOnDestroy():void {
+    // Nothing to do
+  }
+}

--- a/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
@@ -196,6 +196,11 @@ export class WorkPackageChangeset {
                 }
 
                 this.wpActivity.clear(this.workPackage.id);
+
+                // If there is a parent, its view has to be updated as well
+                if (this.workPackage.parent) {
+                  this.wpCacheService.loadWorkPackage(this.workPackage.parent.id.toString(), true);
+                }
                 this.wpCacheService.updateWorkPackage(this.workPackage);
                 this.resource = null;
                 this.clear();
@@ -357,4 +362,3 @@ export class WorkPackageChangeset {
     this.wpEditing.updateValue(this.workPackage.id, this);
   }
 }
-

--- a/frontend/src/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.directive.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.directive.ts
@@ -83,7 +83,7 @@ export class WorkPackageRelationsHierarchyComponent implements OnInit, OnDestroy
         let toLoad:string[] = [];
 
         if (this.workPackage.parent) {
-          toLoad.push(this.workPackage.parent.id);
+          toLoad.push(this.workPackage.parent.id.toString());
 
           this.wpCacheService.loadWorkPackage(this.workPackage.parent.id).values$()
             .pipe(

--- a/frontend/src/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
@@ -117,6 +117,7 @@ export class WorkPackageRelationsHierarchyService {
 
   public removeChild(childWorkPackage:WorkPackageResource) {
     return childWorkPackage.$load().then(() => {
+      let parentWorkPackage = childWorkPackage.parent;
       return childWorkPackage.changeParent({
         _links: {
           parent: {
@@ -125,6 +126,7 @@ export class WorkPackageRelationsHierarchyService {
         },
         lockVersion: childWorkPackage.lockVersion
       }).then(wp => {
+        this.wpCacheService.loadWorkPackage(parentWorkPackage.id.toString(), true);
         this.wpCacheService.updateWorkPackage(wp);
       })
       .catch((error) => {


### PR DESCRIPTION
The relations counter badge only displayed the number of relations a WP had, but should also include the parent and children relations for a better understanding.

As a new feature the counter badge was also added to the watchers.

https://community.openproject.com/projects/openproject/work_packages/26126