### PR TITLE
[28718] Bugfix: Sidebar hidden on mobile

### DIFF
--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -61,8 +61,7 @@
   #main-menu ~ #content-wrapper
     padding: 5px 15px 0 15px !important
 
-  #breadcrumb,
-  #sidebar,
+  #breadcrumb
   .hidden-for-mobile
     display: none !important
 


### PR DESCRIPTION
The sidebar has not been displayed on mobile screen sizes due to the class "hidden-for-mobile".

https://community.openproject.com/projects/openproject/work_packages/28718