### PR TITLE
Add feature specs for relations count and watchers count

### DIFF
--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -12,6 +12,8 @@ describe 'Work package relations tab', js: true, selenium: true do
   let(:relations) { ::Components::WorkPackages::Relations.new(work_package) }
   let(:tabs) { ::Components::WorkPackages::Tabs.new(work_package) }
 
+  let(:relations_tab) { find('.tabrow li.selected', text: 'RELATIONS') }
+
   let(:visit) { true }
 
   before do
@@ -58,7 +60,7 @@ describe 'Work package relations tab', js: true, selenium: true do
       relations.add_existing_child(child2)
 
       # Count parent and child relations in split view
-      tabs.expect_counter(3, 3)
+      tabs.expect_counter(relations_tab, 3)
     end
 
     describe 'inline create' do
@@ -78,7 +80,7 @@ describe 'Work package relations tab', js: true, selenium: true do
         expect(work_package.children.count).to eq(1)
 
         # If new child is inline created, counter should increase
-        tabs.expect_counter(3, 1)
+        tabs.expect_counter(relations_tab, 1)
       end
     end
   end
@@ -149,7 +151,7 @@ describe 'Work package relations tab', js: true, selenium: true do
           expect(page).to have_selector('.wp-relations-hierarchy-subject', text: parent.subject)
 
           # And it should count parent and the two relations
-          tabs.expect_counter(3, 3)
+          tabs.expect_counter(relations_tab, 3)
         end
       end
 
@@ -179,7 +181,7 @@ describe 'Work package relations tab', js: true, selenium: true do
           relations.expect_child(child)
 
           # Expect counter to add up new parent and child to the existing relations
-          tabs.expect_counter(3, 4)
+          tabs.expect_counter(relations_tab, 4)
 
           # Remove parent
           relations.remove_parent(parent)
@@ -192,7 +194,7 @@ describe 'Work package relations tab', js: true, selenium: true do
           relations.expect_not_child(child)
 
           # Expect counter to only count the two existing relations
-          tabs.expect_counter(3, 2)
+          tabs.expect_counter(relations_tab, 2)
         end
       end
     end

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -10,6 +10,7 @@ describe 'Work package relations tab', js: true, selenium: true do
   let(:work_packages_page) { ::Pages::SplitWorkPackage.new(work_package) }
   let(:full_wp) { ::Pages::FullWorkPackage.new(work_package) }
   let(:relations) { ::Components::WorkPackages::Relations.new(work_package) }
+  let(:tabs) { ::Components::WorkPackages::Tabs.new(work_package) }
 
   let(:visit) { true }
 
@@ -55,7 +56,9 @@ describe 'Work package relations tab', js: true, selenium: true do
            text: I18n.t('js.relation_buttons.add_existing_child')).click
 
       relations.add_existing_child(child2)
-      expect(work_packages_page.relations_count).to have_content('3')
+
+      # Count parent and child relations in split view
+      tabs.expect_counter(3, 3)
     end
 
     describe 'inline create' do
@@ -73,6 +76,9 @@ describe 'Work package relations tab', js: true, selenium: true do
         table.expect_work_package_subject 'my new child'
         work_package.reload
         expect(work_package.children.count).to eq(1)
+
+        # If new child is inline created, counter should increase
+        tabs.expect_counter(3, 1)
       end
     end
   end
@@ -141,6 +147,9 @@ describe 'Work package relations tab', js: true, selenium: true do
 
           # But it should show the linked parent
           expect(page).to have_selector('.wp-relations-hierarchy-subject', text: parent.subject)
+
+          # And it should count parent and the two relations
+          tabs.expect_counter(3, 3)
         end
       end
 
@@ -169,6 +178,9 @@ describe 'Work package relations tab', js: true, selenium: true do
           work_packages_page.expect_and_dismiss_notification(message: 'Successful update.')
           relations.expect_child(child)
 
+          # Expect counter to add up new parent and child to the existing relations
+          tabs.expect_counter(3, 4)
+
           # Remove parent
           relations.remove_parent(parent)
           work_packages_page.expect_and_dismiss_notification(message: 'Successful update.')
@@ -178,6 +190,9 @@ describe 'Work package relations tab', js: true, selenium: true do
           relations.remove_child(child)
           # Should also check for successful update but no message is shown, yet.
           relations.expect_not_child(child)
+
+          # Expect counter to only count the two existing relations
+          tabs.expect_counter(3, 2)
         end
       end
     end

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -1,14 +1,12 @@
 require 'spec_helper'
 
-describe 'Work package relations tab', js: true, selenium: true do
+shared_examples 'work package relations tab', js: true, selenium: true do
   include_context 'ui-autocomplete helpers'
 
   let(:user) { FactoryBot.create :admin }
 
   let(:project) { FactoryBot.create(:project) }
   let(:work_package) { FactoryBot.create(:work_package, project: project) }
-  let(:work_packages_page) { ::Pages::SplitWorkPackage.new(work_package) }
-  let(:full_wp) { ::Pages::FullWorkPackage.new(work_package) }
   let(:relations) { ::Components::WorkPackages::Relations.new(work_package) }
   let(:tabs) { ::Components::WorkPackages::Tabs.new(work_package) }
 
@@ -25,9 +23,9 @@ describe 'Work package relations tab', js: true, selenium: true do
   end
 
   def visit_relations
-    work_packages_page.visit_tab!('relations')
+    wp_page.visit_tab!('relations')
     expect_angular_frontend_initialized
-    work_packages_page.expect_subject
+    wp_page.expect_subject
     loading_indicator_saveguard
   end
 
@@ -39,7 +37,7 @@ describe 'Work package relations tab', js: true, selenium: true do
     it 'allows to manage hierarchy' do
       # Shows link parent link
       expect(page).to have_selector('#hierarchy--add-parent')
-      find('.work-packages--details .wp-inline-create--add-link',
+      find('.wp-inline-create--add-link',
            text: I18n.t('js.relation_buttons.add_parent')).click
 
       # Add parent
@@ -48,14 +46,14 @@ describe 'Work package relations tab', js: true, selenium: true do
 
       ##
       # Add child #1
-      find('.work-packages--details .wp-inline-create--add-link',
+      find('.wp-inline-create--add-link',
            text: I18n.t('js.relation_buttons.add_existing_child')).click
 
       relations.add_existing_child(child)
 
       ##
       # Add child #2
-      find('.work-packages--details .wp-inline-create--add-link',
+      find('.wp-inline-create--add-link',
            text: I18n.t('js.relation_buttons.add_existing_child')).click
 
       relations.add_existing_child(child2)
@@ -113,8 +111,8 @@ describe 'Work package relations tab', js: true, selenium: true do
     before do
       visit_relations
 
-      work_packages_page.visit_tab!('relations')
-      work_packages_page.expect_subject
+      wp_page.visit_tab!('relations')
+      wp_page.expect_subject
       loading_indicator_saveguard
     end
 
@@ -164,21 +162,21 @@ describe 'Work package relations tab', js: true, selenium: true do
         it 'should be able to link parent and children' do
           # Shows link parent link
           expect(page).to have_selector('#hierarchy--add-parent')
-          find('.work-packages--details .wp-inline-create--add-link',
+          find('.wp-inline-create--add-link',
                text: I18n.t('js.relation_buttons.add_parent')).click
 
           # Add parent
           relations.add_parent(parent.id, parent)
-          work_packages_page.expect_and_dismiss_notification(message: 'Successful update.')
+          wp_page.expect_and_dismiss_notification(message: 'Successful update.')
           relations.expect_parent(parent)
 
           ##
           # Add child
-          find('.work-packages--details .wp-inline-create--add-link',
+          find('.wp-inline-create--add-link',
                text: I18n.t('js.relation_buttons.add_existing_child')).click
 
           relations.add_existing_child(child)
-          work_packages_page.expect_and_dismiss_notification(message: 'Successful update.')
+          wp_page.expect_and_dismiss_notification(message: 'Successful update.')
           relations.expect_child(child)
 
           # Expect counter to add up new parent and child to the existing relations
@@ -186,7 +184,7 @@ describe 'Work package relations tab', js: true, selenium: true do
 
           # Remove parent
           relations.remove_parent(parent)
-          work_packages_page.expect_and_dismiss_notification(message: 'Successful update.')
+          wp_page.expect_and_dismiss_notification(message: 'Successful update.')
           relations.expect_not_parent(parent)
 
           # Remove child
@@ -200,4 +198,14 @@ describe 'Work package relations tab', js: true, selenium: true do
       end
     end
   end
+end
+
+context 'Split screen' do
+  let(:wp_page) { Pages::SplitWorkPackage.new(work_package) }
+  it_behaves_like 'work package relations tab'
+end
+
+context 'Full screen' do
+  let(:wp_page) { Pages::FullWorkPackage.new(work_package) }
+  it_behaves_like 'work package relations tab'
 end

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -26,6 +26,7 @@ describe 'Work package relations tab', js: true, selenium: true do
 
   def visit_relations
     work_packages_page.visit_tab!('relations')
+    expect_angular_frontend_initialized
     work_packages_page.expect_subject
     loading_indicator_saveguard
   end

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -55,6 +55,7 @@ describe 'Work package relations tab', js: true, selenium: true do
            text: I18n.t('js.relation_buttons.add_existing_child')).click
 
       relations.add_existing_child(child2)
+      expect(work_packages_page.relations_count).to have_content('3')
     end
 
     describe 'inline create' do

--- a/spec/features/work_packages/details/relations/relations_spec.rb
+++ b/spec/features/work_packages/details/relations/relations_spec.rb
@@ -10,6 +10,7 @@ describe 'Work package relations tab', js: true, selenium: true do
   let(:work_packages_page) { ::Pages::SplitWorkPackage.new(work_package) }
   let(:full_wp) { ::Pages::FullWorkPackage.new(work_package) }
   let(:relations) { ::Components::WorkPackages::Relations.new(work_package) }
+  let(:tabs) { ::Components::WorkPackages::Tabs.new(work_package) }
 
   let(:visit) { true }
 
@@ -147,8 +148,14 @@ describe 'Work package relations tab', js: true, selenium: true do
       it 'should allow to manage relations' do
         relations.add_relation(type: 'follows', to: relatable)
 
+        # Relations counter badge should increase number of relations
+        tabs.expect_counter(3, 1)
+
         relations.remove_relation(relatable)
         expect(page).to have_no_selector('.relation-group--header', text: 'FOLLOWS')
+
+        # If there are no relations, the counter badge should not be displayed
+        tabs.expect_no_counter()
 
         work_package.reload
         expect(work_package.relations.direct).to be_empty
@@ -156,6 +163,8 @@ describe 'Work package relations tab', js: true, selenium: true do
 
       it 'should allow to move between split and full view (Regression #24194)' do
         relations.add_relation(type: 'follows', to: relatable)
+        # Relations counter should increase
+        tabs.expect_counter(3, 1)
 
         # Switch to full view
         find('.work-packages--details-fullscreen-icon').click

--- a/spec/features/work_packages/details/relations/relations_spec.rb
+++ b/spec/features/work_packages/details/relations/relations_spec.rb
@@ -26,6 +26,7 @@ describe 'Work package relations tab', js: true, selenium: true do
 
   def visit_relations
     work_packages_page.visit_tab!('relations')
+    expect_angular_frontend_initialized
     work_packages_page.expect_subject
     loading_indicator_saveguard
   end

--- a/spec/features/work_packages/details/relations/relations_spec.rb
+++ b/spec/features/work_packages/details/relations/relations_spec.rb
@@ -12,6 +12,8 @@ describe 'Work package relations tab', js: true, selenium: true do
   let(:relations) { ::Components::WorkPackages::Relations.new(work_package) }
   let(:tabs) { ::Components::WorkPackages::Tabs.new(work_package) }
 
+  let(:relations_tab) { find('.tabrow li.selected', text: 'RELATIONS') }
+
   let(:visit) { true }
 
   before do
@@ -149,13 +151,13 @@ describe 'Work package relations tab', js: true, selenium: true do
         relations.add_relation(type: 'follows', to: relatable)
 
         # Relations counter badge should increase number of relations
-        tabs.expect_counter(3, 1)
+        tabs.expect_counter(relations_tab, 1)
 
         relations.remove_relation(relatable)
         expect(page).to have_no_selector('.relation-group--header', text: 'FOLLOWS')
 
         # If there are no relations, the counter badge should not be displayed
-        tabs.expect_no_counter()
+        tabs.expect_no_counter(relations_tab)
 
         work_package.reload
         expect(work_package.relations.direct).to be_empty
@@ -164,7 +166,7 @@ describe 'Work package relations tab', js: true, selenium: true do
       it 'should allow to move between split and full view (Regression #24194)' do
         relations.add_relation(type: 'follows', to: relatable)
         # Relations counter should increase
-        tabs.expect_counter(3, 1)
+        tabs.expect_counter(relations_tab, 1)
 
         # Switch to full view
         find('.work-packages--details-fullscreen-icon').click

--- a/spec/features/work_packages/new/create_child_spec.rb
+++ b/spec/features/work_packages/new/create_child_spec.rb
@@ -30,6 +30,7 @@ require 'spec_helper'
 
 RSpec.feature 'Work package create children', js: true, selenium: true do
   let(:tabs) { ::Components::WorkPackages::Tabs.new(original_work_package) }
+  let(:relations_tab) { find('.tabrow li', text: 'RELATIONS') }
   let(:user) do
     FactoryBot.create(:user,
                        member_in_project: project,
@@ -120,7 +121,7 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
                                   text: I18n.t('js.notice_successful_create'))
 
     # Relations counter in full view (with index 2) should equal 1
-    tabs.expect_counter(2, 1)
+    tabs.expect_counter(relations_tab, 1)
 
     child_work_package = WorkPackage.order(created_at: 'desc').first
 
@@ -154,7 +155,7 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
                                   text: I18n.t('js.notice_successful_create'))
 
     # # Relations counter in split view (with index 3) should equal 1
-    tabs.expect_counter(3, 1)
+    tabs.expect_counter(relations_tab, 1)
 
     child_work_package = WorkPackage.order(created_at: 'desc').first
 

--- a/spec/features/work_packages/new/create_child_spec.rb
+++ b/spec/features/work_packages/new/create_child_spec.rb
@@ -105,6 +105,8 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
     original_work_package_page = Pages::FullWorkPackage.new(original_work_package)
 
     child_work_package_page = original_work_package_page.add_child
+    expect_angular_frontend_initialized
+
     type_field = child_work_package_page.edit_field :type
 
     type_field.expect_active!
@@ -120,7 +122,7 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
     expect(page).to have_selector('.notification-box--content',
                                   text: I18n.t('js.notice_successful_create'))
 
-    # Relations counter in full view (with index 2) should equal 1
+    # Relations counter in full view should equal 1
     tabs.expect_counter(relations_tab, 1)
 
     child_work_package = WorkPackage.order(created_at: 'desc').first
@@ -140,6 +142,8 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
     original_work_package_page = Pages::SplitWorkPackage.new(original_work_package, project)
 
     child_work_package_page = original_work_package_page.add_child
+    expect_angular_frontend_initialized
+
     type_field = child_work_package_page.edit_field :type
 
     expect(type_field.input_element).to have_selector('option[selected]', text: 'Please select')
@@ -154,7 +158,7 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
     expect(page).to have_selector('.notification-box--content',
                                   text: I18n.t('js.notice_successful_create'))
 
-    # # Relations counter in split view (with index 3) should equal 1
+    # # Relations counter in split view should equal 1
     tabs.expect_counter(relations_tab, 1)
 
     child_work_package = WorkPackage.order(created_at: 'desc').first

--- a/spec/features/work_packages/new/create_child_spec.rb
+++ b/spec/features/work_packages/new/create_child_spec.rb
@@ -119,6 +119,8 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
     expect(page).to have_selector('.notification-box--content',
                                   text: I18n.t('js.notice_successful_create'))
 
+    expect(page).to have_selector('.wp-tabs-count', text: '1')
+
     child_work_package = WorkPackage.order(created_at: 'desc').first
 
     expect(child_work_package).to_not eql original_work_package
@@ -149,6 +151,8 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
 
     expect(page).to have_selector('.notification-box--content',
                                   text: I18n.t('js.notice_successful_create'))
+
+    expect(page).to have_selector('.wp-tabs-count', text: '1')
 
     child_work_package = WorkPackage.order(created_at: 'desc').first
 

--- a/spec/features/work_packages/new/create_child_spec.rb
+++ b/spec/features/work_packages/new/create_child_spec.rb
@@ -29,6 +29,7 @@
 require 'spec_helper'
 
 RSpec.feature 'Work package create children', js: true, selenium: true do
+  let(:tabs) { ::Components::WorkPackages::Tabs.new(original_work_package) }
   let(:user) do
     FactoryBot.create(:user,
                        member_in_project: project,
@@ -41,7 +42,6 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
                        old_status: original_work_package.status,
                        new_status: FactoryBot.create(:status))
   end
-
   let(:create_role) do
     FactoryBot.create(:role,
                        permissions: [:view_work_packages,
@@ -119,7 +119,8 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
     expect(page).to have_selector('.notification-box--content',
                                   text: I18n.t('js.notice_successful_create'))
 
-    expect(page).to have_selector('.wp-tabs-count', text: '1')
+    # Relations counter in full view (with index 2) should equal 1
+    tabs.expect_counter(2, 1)
 
     child_work_package = WorkPackage.order(created_at: 'desc').first
 
@@ -152,7 +153,8 @@ RSpec.feature 'Work package create children', js: true, selenium: true do
     expect(page).to have_selector('.notification-box--content',
                                   text: I18n.t('js.notice_successful_create'))
 
-    expect(page).to have_selector('.wp-tabs-count', text: '1')
+    # # Relations counter in split view (with index 3) should equal 1
+    tabs.expect_counter(3, 1)
 
     child_work_package = WorkPackage.order(created_at: 'desc').first
 

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -6,6 +6,7 @@ require 'support/work_packages/work_package_field'
 describe 'Watcher tab', js: true, selenium: true do
   let(:project) { FactoryBot.create(:project) }
   let(:work_package) { FactoryBot.create(:work_package, project: project) }
+  let(:tabs) { ::Components::WorkPackages::Tabs.new(work_package) }
 
   let(:user) { FactoryBot.create(:user, member_in_project: project, member_through_role: role) }
   let(:role) { FactoryBot.create(:role, permissions: permissions) }
@@ -17,6 +18,7 @@ describe 'Watcher tab', js: true, selenium: true do
   }
 
   let(:watch_button) { find '#watch-button' }
+  let(:watchers_tab) { find('.tabrow li.selected', text: 'WATCHERS') }
 
   def expect_button_is_watching
     title = I18n.t('js.label_unwatch_work_package')
@@ -69,9 +71,15 @@ describe 'Watcher tab', js: true, selenium: true do
       expect(page).to have_selector('.work-package--watcher-name', count: 1, text: user.name)
       expect_button_is_watching
 
+      # Expect watchers counter to increase
+      tabs.expect_counter(watchers_tab, 1)
+
       # Remove watcher from list
       page.find('wp-watcher-entry', text: user.name).hover
       page.find('.form--selected-value--remover').click
+
+      # Watchers counter should not be displayed
+      tabs.expect_no_counter(watchers_tab)
 
       # Expect the removal of the user to toggle WP watch button
       expect(page).to have_no_selector('.work-package--watcher-name')

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -56,6 +56,7 @@ describe 'Watcher tab', js: true, selenium: true do
     before do
       login_as(user)
       wp_page.visit_tab! :watchers
+      expect_angular_frontend_initialized
       expect(page).to have_selector('.tabrow li.selected', text: 'WATCHERS')
     end
 

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -131,7 +131,7 @@ module Components
         autocomplete = container.find(".wp-relations--autocomplete")
         select_autocomplete autocomplete,
                             query: query,
-                            results_selector: '.wp-relations-autocomplete--results',
+                            results_selector: '.detail-panel--relations .wp-relations-autocomplete--results',
                             select_text: work_package.id
 
         container.find('.wp-create-relation--save').click

--- a/spec/support/components/work_packages/tabs_counter.rb
+++ b/spec/support/components/work_packages/tabs_counter.rb
@@ -13,22 +13,14 @@ module Components
         @work_package = work_package
       end
 
-      # Counter elements
-        # 2: Relation tab in split view
-        # 3: Relation tab in full view and watchers tab in split view
-        # 4: Watchers tab in full view
-      def counter_for(tabindex)
-        find('ul.tabrow > li:nth-child(' + tabindex.to_s + ') .wp-tabs-count')
+      # Check value of counter for the given tab
+      def expect_counter(tab, content)
+        expect(tab).to have_selector('.wp-tabs-count', text: "#{content}")
       end
 
-      # Check number of relations or watchers for tab with given index
-      def expect_counter(tabindex, content)
-        expect(counter_for(tabindex)).to have_content(content.to_s)
-      end
-
-      # There are no relations or watchers
-      def expect_no_counter()
-        expect(page).to have_no_selector('.wp-tabs-count')
+      # Counter should not be displayed, if there are no relations or watchers
+      def expect_no_counter(tab)
+        expect(tab).to have_no_selector('.wp-tabs-count')
       end
     end
   end

--- a/spec/support/components/work_packages/tabs_counter.rb
+++ b/spec/support/components/work_packages/tabs_counter.rb
@@ -1,0 +1,35 @@
+require 'features/support/components/ui_autocomplete'
+
+module Components
+  module WorkPackages
+    class Tabs
+      include Capybara::DSL
+      include RSpec::Matchers
+      include ::Components::UIAutocompleteHelpers
+
+      attr_reader :work_package
+
+      def initialize(work_package)
+        @work_package = work_package
+      end
+
+      # Counter elements
+        # 2: Relation tab in split view
+        # 3: Relation tab in full view and watchers tab in split view
+        # 4: Watchers tab in full view
+      def counter_for(tabindex)
+        find('ul.tabrow > li:nth-child(' + tabindex.to_s + ') .wp-tabs-count')
+      end
+
+      # Check number of relations or watchers for tab with given index
+      def expect_counter(tabindex, content)
+        expect(counter_for(tabindex)).to have_content(content.to_s)
+      end
+
+      # There are no relations or watchers
+      def expect_no_counter()
+        expect(page).to have_no_selector('.wp-tabs-count')
+      end
+    end
+  end
+end

--- a/spec/support/pages/split_work_package.rb
+++ b/spec/support/pages/split_work_package.rb
@@ -55,10 +55,6 @@ module Pages
       find(@selector)
     end
 
-    def relations_count
-      find('ul.tabrow > li:nth-child(3) .wp-tabs-count')
-    end
-
     private
 
     def path(tab = 'overview')

--- a/spec/support/pages/split_work_package.rb
+++ b/spec/support/pages/split_work_package.rb
@@ -55,6 +55,10 @@ module Pages
       find(@selector)
     end
 
+    def relations_count
+      find('ul.tabrow > li:nth-child(3) .wp-tabs-count')
+    end
+
     private
 
     def path(tab = 'overview')


### PR DESCRIPTION
## Description

Add feature specs to check the correct behaviour of the updated relations tab counter badge (should now include parent and child relations) and the new counter badge for the watchers tab.

#### Checked cases:
- [x] Add child (in split and full view) 
- [x] Inline create a child (in split and full view)
- [x] Add child / parent (in split and full view)
- [x] Remove child / parent (in split and full view)
- [x] Add / remove relation (in split view)
- [x] No relations (in split view) --> counter should not be displayed
- [x] Checks for watchers tab (add, delete, no watchers)
- [x] Check behaviour for different permissions (as admin and with limited permissions)

#### To-Do's
- [ ] Check behaviour for relations between wp's in different projects (?)