### PR TITLE
Make the log_level configurable

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -168,6 +168,8 @@ module OpenProject
 
     config.action_controller.asset_host = OpenProject::Configuration['rails_asset_host']
 
+    config.log_level = OpenProject::Configuration['log_level'].to_sym
+
     def self.root_url
       Setting.protocol + "://" + Setting.host_name
     end

--- a/config/configuration.yml.example
+++ b/config/configuration.yml.example
@@ -165,6 +165,8 @@
 
 # default configuration options for all environments
 default:
+  log_level: info
+
   # Outgoing emails configuration (see examples above)
   email_delivery_method: :smtp
   smtp_address: smtp.example.net
@@ -389,7 +391,8 @@ default:
 
 # specific configuration options for production environment
 # that overrides the default ones
-# production:
+production:
+  log_level: warn
 
 # specific configuration options for development environment
 # that overrides the default ones

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,7 +87,7 @@ OpenProject::Application.configure do
   }
 
   # Set to :debug to see everything in the log.
-  config.log_level = :warn
+  config.log_level = OpenProject::Configuration['log_level'].to_sym
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -46,6 +46,7 @@ module OpenProject
       'database_cipher_key'     => nil,
       'force_help_link'         => nil,
       'force_formatting_help_link' => nil,
+      'log_level' => 'info',
       'scm_git_command'         => nil,
       'scm_subversion_command'  => nil,
       'scm_local_checkout_path' => 'repositories', # relative to OpenProject directory


### PR DESCRIPTION
Currently the production environment is stuck at the `warn` log level, which is not very helpful if debugging is required. Having the log_level as a config flag would allow to easily switch log levels without the need to modify the code.