### PR TITLE
[28719] Bugfix: Loading indicator not disappearing

### DIFF
--- a/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
+++ b/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
@@ -32,7 +32,7 @@ import {WorkPackagesListService} from '../wp-list/wp-list.service';
 import {WorkPackagesListChecksumService} from '../wp-list/wp-list-checksum.service';
 import {WorkPackagesListComponent} from 'core-components/routing/wp-list/wp-list.component';
 import {StateService, TransitionService} from '@uirouter/core';
-import {Component, ElementRef, OnDestroy, OnInit, ViewChild} from "@angular/core";
+import {Component, ElementRef, OnDestroy, OnInit, ViewChild, ChangeDetectorRef} from "@angular/core";
 import {QueryDmService} from 'core-app/modules/hal/dm-services/query-dm.service';
 import {LoadingIndicatorService} from "core-app/modules/common/loading-indicator/loading-indicator.service";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
@@ -107,7 +107,8 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
   private initialized = false;
 
 
-  constructor(readonly element:ElementRef,
+  constructor(readonly ref:ChangeDetectorRef,
+              readonly element:ElementRef,
               readonly QueryDm:QueryDmService,
               readonly $state:StateService,
               readonly $transitions:TransitionService,
@@ -233,7 +234,6 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
   private loadQueries() {
     return this.loadingPromise = this.QueryDm
       .all(this.CurrentProject.identifier);
-
   }
 
   private set loadingPromise(promise:Promise<any>) {
@@ -413,6 +413,8 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
             let thisCategory:string = jQuery(category).attr("category");
             this.expandCollapseCategory(thisCategory);
           });
+          // Update view
+          this.ref.detectChanges();
         });
       });
   }


### PR DESCRIPTION
### Description

The loading indicator was not disappearing on mobile - even if all queries were loaded - until the user clicked somewhere else. The variable values have all been correctly adapted at any time but the other way around the view did not update and adapt to the new values (probably because of the asynchronous functions, which updated the variables after the view was refreshed) until there was another event fired (e.g. a click of the user). So after loading all queries, the view had to be updated again.

https://community.openproject.com/projects/openproject/work_packages/28719