### PR TITLE
[28680] Optimize column-width

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -173,7 +173,7 @@ table.generic-table
       // become even wider.
       &.-max
         width: 100%
-        max-width: 600px
+        max-width: 500px
 
       &.info
         a

--- a/frontend/src/app/components/wp-fast-table/builders/cell-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/cell-builder.ts
@@ -19,6 +19,10 @@ export class CellBuilder {
     const td = document.createElement('td');
     td.classList.add(tdClassName, wpCellTdClassName, attribute);
 
+    if (attribute === 'subject') {
+      td.classList.add('-max');
+    }
+
     const container = document.createElement('span');
     container.classList.add(editCellContainer, editFieldContainerClass, attribute);
     const displayElement = this.fieldRenderer.render(workPackage, attribute, null);


### PR DESCRIPTION
This gives the subject row more space. As described in the comment, the class `-max` takes care that Subject cells with a long content: 

* have a width of at least 500px or
* even more if there is enough space.

Thus the space is better used and more of the subject can be seed. However this has the side effect that the horizontal scrollbar appears earlier than before. Nevertheless I think the behavior is better.  

https://community.openproject.com/projects/deutsche-bahn/work_packages/28680/activity