### PR TITLE
allow current date for custom action

### DIFF
--- a/app/assets/stylesheets/content/_custom_actions.sass
+++ b/app/assets/stylesheets/content/_custom_actions.sass
@@ -46,3 +46,6 @@
       width: 100%
       // The margin is necessary for all buttons so that the alignment is correct on small screens
       margin-right: 10px
+
+wp-custom-actions-admin-date-action
+  display: flex

--- a/app/contracts/work_packages/update_contract.rb
+++ b/app/contracts/work_packages/update_contract.rb
@@ -37,7 +37,6 @@ module WorkPackages
       end
     end
 
-
     validate :user_allowed_to_access
 
     validate :user_allowed_to_edit

--- a/app/models/custom_actions/actions/date.rb
+++ b/app/models/custom_actions/actions/date.rb
@@ -36,7 +36,7 @@ class CustomActions::Actions::Date < CustomActions::Actions::Base
   end
 
   def apply(work_package)
-    work_package.start_date = values.first
-    work_package.due_date = values.first
+    work_package.start_date = date_to_apply
+    work_package.due_date = date_to_apply
   end
 end

--- a/app/models/custom_actions/actions/strategies/date.rb
+++ b/app/models/custom_actions/actions/strategies/date.rb
@@ -37,10 +37,27 @@ module CustomActions::Actions::Strategies::Date
     :date_property
   end
 
-  def to_date_or_nil(value)
-    return nil if value.nil?
+  def apply(work_package)
+    work_package.send("#{self.class.key}=", date_to_apply)
+  end
 
-    value.to_date
+  private
+
+  def date_to_apply
+    if values.first == '%CURRENT_DATE%'
+      Date.today
+    else
+      values.first
+    end
+  end
+
+  def to_date_or_nil(value)
+    case value
+    when nil, '%CURRENT_DATE%'
+      value
+    else
+      value.to_date
+    end
   rescue TypeError, ArgumentError
     nil
   end

--- a/app/models/custom_actions/actions/strategies/date_property.rb
+++ b/app/models/custom_actions/actions/strategies/date_property.rb
@@ -30,8 +30,4 @@
 
 module CustomActions::Actions::Strategies::DateProperty
   include CustomActions::Actions::Strategies::Date
-
-  def apply(work_package)
-    work_package.send("#{self.class.key}=", values.first)
-  end
 end

--- a/app/views/custom_actions/_form.html.erb
+++ b/app/views/custom_actions/_form.html.erb
@@ -59,11 +59,9 @@
               </autocomplete-select-decoration>
             </div>
           <% elsif %i(date_property).include?(action.type) %>
-            <%= styled_text_field_tag input_name,
-                                      action.values,
-                                      container_class: '-slim',
-                                      class: '-augmented-datepicker',
-                                      size: '10' %>
+            <wp-custom-actions-admin-date-action field-value="<%= action.values.first %>"
+                                                 field-name="<%= input_name %>">
+            </wp-custom-actions-admin-date-action>
           <% elsif %i(string_property text_property).include?(action.type) %>
             <%= styled_text_field_tag input_name,
                                       action.values,

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -132,6 +132,11 @@ en:
           button: 'Embed work package table'
           text: '[Placeholder] Embedded work package table'
 
+    custom_actions:
+      date:
+        specific: 'on'
+        current_date: 'Current date'
+
     error:
       internal: "An internal error has occurred."
       cannot_save_changes_with_message: "Cannot save your changes due to the following error: %{error}"

--- a/frontend/legacy/app/components/wp-custom-actions/date-action.component.html
+++ b/frontend/legacy/app/components/wp-custom-actions/date-action.component.html
@@ -1,0 +1,19 @@
+<span class="form--select-container">
+    <select class="form--select"
+            id="{{$ctrl.fieldId}}"
+            ng-model="$ctrl.selectedOperator"
+            ng-change="$ctrl.toggleValueVisibility()"
+            ng-options="n.label for n in $ctrl.operators track by n.key">
+    </select>
+</span>
+<span class="form--text-field-container -slim"
+      ng-if="$ctrl.valueVisible" >
+    <input type="text"
+           id="{{$ctrl.fieldId + '_visible'}}"
+           ng-model="$ctrl.visibleValue"
+           ng-change="$ctrl.updateDbValue()"
+           class="-augmented-datepicker form--text-field">
+</span>
+<input type="hidden"
+       name="{{$ctrl.fieldName}}"
+       value="{{$ctrl.fieldValue}}">

--- a/frontend/legacy/app/components/wp-custom-actions/date-action.component.ts
+++ b/frontend/legacy/app/components/wp-custom-actions/date-action.component.ts
@@ -1,0 +1,99 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {openprojectLegacyModule} from "core-app/openproject-legacy-app";
+
+export class WpCustomActionsAdminDateActionComponent {
+  public valueVisible = false;
+  public fieldName:string;
+  public fieldValue:string;
+  public visibleValue:string;
+  public selectedOperator:any;
+  private i18n:any;
+
+  private onKey = 'on';
+  private currentKey = 'current';
+  private currentFieldValue = '%CURRENT_DATE%';
+
+  public operators:{key:string, label:string}[];
+
+  constructor() {
+    window.OpenProject.getPluginContext().then((context) => {
+      this.i18n = context.services.i18n;
+
+      this.initialize();
+    });
+  }
+
+  // cannot use $onInit as it would be called before the operators gets filled
+  public initialize() {
+    this.operators = [{key: this.onKey, label: this.i18n.t('js.custom_actions.date.specific')},
+      {key: this.currentKey, label: this.i18n.t('js.custom_actions.date.current_date')}];
+
+    if (this.fieldValue === this.currentFieldValue) {
+      this.selectedOperator = this.operators[1];
+    } else {
+      this.selectedOperator = this.operators[0];
+      this.visibleValue = this.fieldValue;
+    }
+
+    this.toggleValueVisibility();
+  }
+
+  public toggleValueVisibility() {
+    this.valueVisible = this.selectedOperator.key === this.onKey;
+    this.updateDbValue();
+  }
+
+  private updateDbValue() {
+    if (this.selectedOperator.key === this.currentKey) {
+      this.fieldValue = this.currentFieldValue;
+    } else {
+      this.fieldValue = this.visibleValue;
+    }
+  }
+
+  public get fieldId() {
+    // replace all square brackets by underscore
+    // to match the label's for value
+    return this.fieldName
+               .replace(/\[|\]/g, '_')
+               .replace('__', '_')
+               .replace(/_$/, '');
+  }
+}
+
+openprojectLegacyModule.component('wpCustomActionsAdminDateAction', {
+  template: require('!!raw-loader!./date-action.component.html'),
+  controller: WpCustomActionsAdminDateActionComponent,
+  bindings: {
+    fieldName: "@",
+    fieldValue: "@",
+  }
+});
+

--- a/frontend/src/app/angular4-modules.ts
+++ b/frontend/src/app/angular4-modules.ts
@@ -348,8 +348,6 @@ import {WorkPackageByVersionGraphComponent} from "core-components/wp-by-version-
     ZenModeButtonComponent,
     WpResizerDirective,
     MainMenuResizerComponent,
-    WpCustomActionComponent,
-    WpCustomActionsComponent,
     WorkPackageTableSumsRowController,
     SortHeaderDirective,
 
@@ -486,6 +484,10 @@ import {WorkPackageByVersionGraphComponent} from "core-components/wp-by-version-
     EmbeddedTablesMacroComponent,
     CkeditorAugmentedTextareaComponent,
 
+    // CustomActions
+    WpCustomActionComponent,
+    WpCustomActionsComponent,
+
     // Attachments
     AttachmentsComponent,
     AttachmentListComponent,
@@ -501,7 +503,6 @@ import {WorkPackageByVersionGraphComponent} from "core-components/wp-by-version-
     WorkPackageTablePaginationComponent,
     WorkPackagesTableController,
     TablePaginationComponent,
-    WpCustomActionsComponent,
 
     // Split view
     WorkPackageSplitViewComponent,
@@ -573,6 +574,9 @@ import {WorkPackageByVersionGraphComponent} from "core-components/wp-by-version-
     // CKEditor and macros
     CkeditorAugmentedTextareaComponent,
     EmbeddedTablesMacroComponent,
+
+    // CustomActions
+    WpCustomActionsComponent,
 
     // Attachments
     AttachmentsComponent,

--- a/frontend/src/app/components/wp-by-version-graph/wp-by-version-graph.template.html
+++ b/frontend/src/app/components/wp-by-version-graph/wp-by-version-graph.template.html
@@ -1,6 +1,6 @@
 <select [(ngModel)]="groupBy"
-      (ngModelChange)="setQueryProps()">
-<option [ngValue]="option.key" *ngFor="let option of availableGroupBy">{{option.label}}</option>
+        (ngModelChange)="setQueryProps()">
+    <option [ngValue]="option.key" *ngFor="let option of availableGroupBy">{{option.label}}</option>
 </select>
 
 <wp-embedded-graph #wpEmbeddedGraphMulti

--- a/spec/features/work_packages/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions_spec.rb
@@ -271,9 +271,11 @@ describe 'Custom actions', type: :feature, js: true do
     retry_block do
       new_ca_page.visit!
       new_ca_page.set_name('Move project')
+      # Add date custom action which has a different admin layout
+      select date_custom_field.name, from: 'Add action'
+      select 'on', from: date_custom_field.name
       date = (Date.today + 5.days).to_s
-      new_ca_page.add_action(date_custom_field.name, date)
-      page.find_field("custom_action_actions_custom_field_#{date_custom_field.id}", with: date)
+      fill_in "custom_action_actions_custom_field_#{date_custom_field.id}_visible", with: date
 
       # Close autocompleter
       if page.has_selector? '.ui-datepicker-close'

--- a/spec/models/custom_actions/actions/custom_field_spec.rb
+++ b/spec/models/custom_actions/actions/custom_field_spec.rb
@@ -508,9 +508,17 @@ describe CustomActions::Actions::CustomField, type: :model do
 
       it_behaves_like 'string custom action validations'
     end
+
+    context 'for a date custom field' do
+      let(:custom_field) { date_custom_field }
+
+      it_behaves_like 'date custom action validations'
+    end
   end
 
   describe '#apply' do
+    let(:work_package) { double('work_package') }
+
     %i[list
        version
        bool
@@ -523,7 +531,6 @@ describe CustomActions::Actions::CustomField, type: :model do
        list_multi].each do |type|
 
       let(:custom_field) { send(:"#{type}_custom_field") }
-      let(:work_package) { double('work_package') }
 
       it "sets the value for #{type} custom fields" do
         expect(work_package)
@@ -531,6 +538,20 @@ describe CustomActions::Actions::CustomField, type: :model do
           .with([42])
 
         instance.values = 42
+
+        instance.apply(work_package)
+      end
+    end
+
+    context 'for a date custom field' do
+      let(:custom_field) { date_custom_field }
+
+      it "sets the value to today for a dynamic value" do
+        expect(work_package)
+          .to receive(:"custom_field_#{custom_field.id}=")
+                .with(Date.today)
+
+        instance.values = '%CURRENT_DATE%'
 
         instance.apply(work_package)
       end

--- a/spec/models/custom_actions/actions/date_spec.rb
+++ b/spec/models/custom_actions/actions/date_spec.rb
@@ -39,7 +39,18 @@ describe CustomActions::Actions::Date, type: :model do
       let(:work_package) { FactoryBot.build_stubbed(:stubbed_work_package) }
 
       it 'sets both start and finish date to the action\'s value' do
-        instance.values = [Date.today]
+        instance.values = [Date.today + 5]
+
+        instance.apply(work_package)
+
+        expect(work_package.start_date)
+          .to eql Date.today + 5
+        expect(work_package.due_date)
+          .to eql Date.today + 5
+      end
+
+      it 'sets both start and finish date to the current date if so specified' do
+        instance.values = ['%CURRENT_DATE%']
 
         instance.apply(work_package)
 

--- a/spec/models/custom_actions/actions/due_date_spec.rb
+++ b/spec/models/custom_actions/actions/due_date_spec.rb
@@ -35,24 +35,15 @@ describe CustomActions::Actions::DueDate, type: :model do
   let(:value) { Date.today }
 
   it_behaves_like 'base custom action' do
-    describe '#apply' do
-      let(:work_package) { FactoryBot.build_stubbed(:stubbed_work_package) }
-
-      it 'sets the due_date to the action\'s value' do
-        instance.values = [Date.today]
-
-        instance.apply(work_package)
-
-        expect(work_package.due_date)
-          .to eql Date.today
-      end
-    end
-
     describe '#multi_value?' do
       it 'is false' do
         expect(instance)
           .not_to be_multi_value
       end
     end
+
+    it_behaves_like 'date custom action validations'
+    it_behaves_like 'date values transformation'
+    it_behaves_like 'date custom action apply'
   end
 end

--- a/spec/models/custom_actions/actions/start_date_spec.rb
+++ b/spec/models/custom_actions/actions/start_date_spec.rb
@@ -35,24 +35,15 @@ describe CustomActions::Actions::StartDate, type: :model do
   let(:value) { Date.today }
 
   it_behaves_like 'base custom action' do
-    describe '#apply' do
-      let(:work_package) { FactoryBot.build_stubbed(:stubbed_work_package) }
-
-      it 'sets the start_date to the action\'s value' do
-        instance.values = [Date.today]
-
-        instance.apply(work_package)
-
-        expect(work_package.start_date)
-          .to eql Date.today
-      end
-    end
-
     describe '#multi_value?' do
       it 'is false' do
         expect(instance)
           .not_to be_multi_value
       end
     end
+
+    it_behaves_like 'date custom action validations'
+    it_behaves_like 'date values transformation'
+    it_behaves_like 'date custom action apply'
   end
 end

--- a/spec/models/custom_actions/shared_expectations.rb
+++ b/spec/models/custom_actions/shared_expectations.rb
@@ -433,10 +433,10 @@ end
 shared_examples_for 'date values transformation' do
   describe '#values' do
     it 'transforms the values to integers' do
-      instance.values = ["2015-03-29", Date.today, nil, (Date.today - 1.day).to_datetime, 'bogus']
+      instance.values = ["2015-03-29", Date.today, nil, (Date.today - 1.day).to_datetime, 'bogus', '%CURRENT_DATE%']
 
       expect(instance.values)
-        .to match_array [Date.parse("2015-03-29"), Date.today, nil, Date.today - 1.day]
+        .to match_array [Date.parse("2015-03-29"), Date.today, nil, Date.today - 1.day, '%CURRENT_DATE%']
     end
   end
 end
@@ -504,6 +504,30 @@ shared_examples_for 'associated custom condition' do
 
       expect(errors.symbols_for(:conditions))
         .to eql [:inclusion]
+    end
+  end
+end
+
+shared_examples_for 'date custom action apply' do
+  describe '#apply' do
+    let(:work_package) { FactoryBot.build_stubbed(:stubbed_work_package) }
+
+    it 'sets the daate to the action\'s value' do
+      instance.values = [Date.today + 5.days]
+
+      instance.apply(work_package)
+
+      expect(work_package.send(key))
+        .to eql Date.today + 5.days
+    end
+
+    it 'sets the date to the current date if so specified' do
+      instance.values = ['%CURRENT_DATE%']
+
+      instance.apply(work_package)
+
+      expect(work_package.send(key))
+        .to eql Date.today
     end
   end
 end


### PR DESCRIPTION
Allows selecting 'Current date' as the value for a date custom action. Selecting that value will apply the current date to the work package once the user activates the custom action.

![image](https://user-images.githubusercontent.com/617519/47070995-b5f7b200-d1f2-11e8-99b9-9dbb313d7e33.png)

https://community.openproject.com/wp/28005
