### PR TITLE
rework hidden filters to avoid hacking

### DIFF
--- a/frontend/src/app/components/filters/query-filters/query-filters.component.html
+++ b/frontend/src/app/components/filters/query-filters/query-filters.component.html
@@ -14,6 +14,7 @@
           [filter]="filter"
           (deactivateFilter)="deactivateFilter($event)"
           (filterChanged)="filtersChanged.emit(filters)"
+          [hidden]="isHiddenFilter(filter)"
           class="advanced-filters--filter">
       </li>
     </ng-container>

--- a/frontend/src/app/components/filters/query-filters/query-filters.component.ts
+++ b/frontend/src/app/components/filters/query-filters/query-filters.component.ts
@@ -103,6 +103,10 @@ export class QueryFiltersComponent implements OnInit, OnChanges, OnDestroy {
     this.wpFiltersService.toggleVisibility();
   }
 
+  public isHiddenFilter(filter:QueryFilterResource) {
+    return _.includes(this.filters.hidden, filter.id);
+  }
+
   public deactivateFilter(removedFilter:QueryFilterInstanceResource) {
     let index = this.filters.current.indexOf(removedFilter);
 
@@ -116,7 +120,7 @@ export class QueryFiltersComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private updateRemainingFilters() {
-    this.remainingFilters = _.sortBy(this.filters.remainingFilters, 'name');
+    this.remainingFilters = _.sortBy(this.filters.remainingVisibleFilters, 'name');
   }
 
   private updateFilterFocus(index:number) {

--- a/frontend/src/app/components/wp-buttons/wp-filter-button/wp-filter-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-filter-button/wp-filter-button.component.ts
@@ -90,7 +90,7 @@ export class WorkPackageFilterButtonComponent extends AbstractWorkPackageButtonC
     this.wpTableFilters
       .observeUntil(componentDestroyed(this))
       .subscribe(state => {
-      this.count = state.current.length;
+      this.count = state.currentVisibleFilters.length;
       this.initialized = true;
     });
   }

--- a/frontend/src/app/components/wp-fast-table/wp-table-filters.ts
+++ b/frontend/src/app/components/wp-fast-table/wp-table-filters.ts
@@ -35,6 +35,7 @@ import {cloneHalResourceCollection} from 'core-app/modules/hal/helpers/hal-resou
 export class WorkPackageTableFilters extends WorkPackageTableBaseState<QueryFilterInstanceResource[]> {
 
   public current:QueryFilterInstanceResource[] = [];
+  public hidden:string[] = ['id', 'parent'];
 
   constructor(filters:QueryFilterInstanceResource[], public availableSchemas:QueryFilterInstanceSchemaResource[]) {
     super();
@@ -66,13 +67,23 @@ export class WorkPackageTableFilters extends WorkPackageTableBaseState<QueryFilt
   }
 
   public get remainingFilters() {
-    var activeFilterHrefs = this.currentFilters.map(filter => filter.href);
+    let activeFilterHrefs = this.currentFilters.map(filter => filter.href);
 
     return _.remove(this.availableFilters, filter => activeFilterHrefs.indexOf(filter.href) === -1);
   }
 
+  public get remainingVisibleFilters() {
+    return this.remainingFilters
+               .filter((filter) => this.hidden.indexOf(filter.id) === -1);
+  }
+
   public isComplete():boolean {
     return _.every(this.current, filter => filter.isCompletelyDefined());
+  }
+
+  public get currentVisibleFilters() {
+    return this.currentFilters
+               .filter((filter) => this.hidden.indexOf(filter.id) === -1);
   }
 
   private get currentFilters() {
@@ -80,11 +91,7 @@ export class WorkPackageTableFilters extends WorkPackageTableBaseState<QueryFilt
   }
 
   private get availableFilters() {
-    let availableFilters = this.availableSchemas
-                               .map(schema => (schema.filter.allowedValues as QueryFilterResource[])[0]);
-
-    // We do not use the filters id and parent as of now as we do not have adequate
-    // means to select the values.
-    return _.filter(availableFilters, filter => filter.id !== 'id' && filter.id !== 'parent');
+    return this.availableSchemas
+               .map(schema => (schema.filter.allowedValues as QueryFilterResource[])[0]);
   }
 }

--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -298,11 +298,7 @@ module API
         end
 
         def filters
-          # HACK: we currently cannot display the id filter as there could potentially
-          # be too many candidates for the filter to be displayed.
-          # But as it is practical to have the id filter we allow users to type ids into the url. In such
-          # cases, the filter will be applied but it is not displayed as applied.
-          represented.filters.reject { |f| f.name == :id }.map do |filter|
+          represented.filters.map do |filter|
             ::API::V3::Queries::Filters::QueryFilterInstanceRepresenter
               .new(filter)
           end


### PR DESCRIPTION
Reworks the mechanism of hiding filters from the users. Hidden filters are currently `parent` and `id` because of the lack of an adequate UI for selecting filter values, i.e. a work package multi select autocompleter.

The functionality should be almost the same, with the single difference that the hidden filter is not lost once the user selects a different filter.