### PR TITLE
[28715] Ensure download disposition for non-image types

### DIFF
--- a/app/uploaders/fog_file_uploader.rb
+++ b/app/uploaders/fog_file_uploader.rb
@@ -58,7 +58,7 @@ class FogFileUploader < CarrierWave::Uploader::Base
   end
 
   def download_url
-    remote_file.url
+    remote_file.url(query: { "response-content-disposition" => model.content_disposition })
   end
 
   ##

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -158,6 +158,22 @@ describe AttachmentsController, type: :controller do
       it 'redirects to AWS' do
         expect(subject.location).to match(url)
       end
+
+      context 'with an inline image' do
+        let(:file) { FileHelpers.mock_uploaded_file name: 'foobar.jpg', content_type: 'image/jpeg' }
+
+        it 'returns a download disposition' do
+          expect(subject.location).to include 'response-content-disposition=inline'
+        end
+      end
+
+      context 'with an SVG (#28715)' do
+        let(:file) { FileHelpers.mock_uploaded_file name: 'foobar.svg', content_type: 'image/svg+xml' }
+
+        it 'returns a download disposition' do
+          expect(subject.location).to include 'response-content-disposition=attachment'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This ensures non inlineable files are always downloaded with fog.
This includes SVG files, for example.

https://community.openproject.com/wp/28715