### PR TITLE
Fix distinct hours in time entries

### DIFF
--- a/app/controllers/timelog_controller.rb
+++ b/app/controllers/timelog_controller.rb
@@ -84,6 +84,7 @@ class TimelogController < ApplicationController
                        .includes(:project, :work_package)
                        .references(:projects)
                        .where(cond.conditions)
+                       .distinct(false)
                        .sum(:hours).to_f
 
         set_entries(cond)


### PR DESCRIPTION
### There is a bug that leads to non-obvious `DISTINCT` in sql queries.

`@total_hours = TimeEntry.visible.sum(:hours)` produces `SELECT SUM(DISTINCT "time_entries"."hours") ...` query, so it will sum only **unique** hours from visible time entries. But it should sum **all** hours from visible time entries.
![2018-10-22 16 50 05](https://user-images.githubusercontent.com/3923930/47296513-1d5e9900-d61b-11e8-9b8c-22db707f2895.png)
`@total_hours = TimeEntry.visible`**.distinct(false)**`.sum(:hours)` produces `SELECT SUM("time_entries"."hours") ...` query, so it resolves the problem in this case. But it can be presented in other places.
![2018-10-22 16 50 32](https://user-images.githubusercontent.com/3923930/47296520-20f22000-d61b-11e8-9ac5-b837c70578f5.png)

https://community.openproject.com/wp/28797
