### PR TITLE
[28768] Long dropdowns scrollable

### DIFF
--- a/app/assets/stylesheets/content/menus/_project_autocompletion.sass
+++ b/app/assets/stylesheets/content/menus/_project_autocompletion.sass
@@ -1,9 +1,26 @@
 #project-search-container
   position: relative
 
+  project-menu-autocomplete
+    display: block
+    max-height: inherit
+
+    .project-menu-autocomplete--wrapper
+      display: flex
+      flex-direction: column
+      max-height: inherit
+
+#project-search-container:nth-child(3)
+  // Substract header height and the two project menu items ("view all", "create new")
+  max-height: calc(100vh - #{$header-height} - 2 * 42px)
+#project-search-container:nth-child(2)
+  // Substract header height and the project menu item ("view all")
+  max-height: calc(100vh - #{$header-height} - 42px)
 
 .project-search-results
   position: relative
+  overflow: hidden
+  max-height: inherit
   width: 400px
   background: white
   // Avoid scrolling body when autocompleter is at bottom
@@ -78,7 +95,6 @@
     // Borders to complete the menu look
     border-right: 1px solid $header-drop-down-border-color
     border-left: 1px solid $header-drop-down-border-color
-
     @include styled-scroll-bar
 
   // Cut off result element width

--- a/app/assets/stylesheets/content/menus/_project_autocompletion.sass
+++ b/app/assets/stylesheets/content/menus/_project_autocompletion.sass
@@ -3,13 +3,12 @@
 
 
 .project-search-results
-  position: absolute
+  position: relative
   width: 400px
   background: white
   // Avoid scrolling body when autocompleter is at bottom
   // (May not be supported by all browsers yet, but soonish)
   overscroll-behavior: contain
-  box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.15)
 
   @include default-font($header-drop-down-projects-search-font-color, 13px)
   li
@@ -78,8 +77,9 @@
     padding-top: 5px
     // Borders to complete the menu look
     border-right: 1px solid $header-drop-down-border-color
-    border-bottom: 1px solid $header-drop-down-border-color
     border-left: 1px solid $header-drop-down-border-color
+
+    @include styled-scroll-bar
 
   // Cut off result element width
   .ui-menu-item-wrapper

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -96,6 +96,12 @@ $hamburger-width: 50px
       border: 1px solid $header-drop-down-border-color
       border-top: 0
       background-color: $header-drop-down-bg-color
+      max-height: calc(100vh - #{$header-height})
+      overflow-y: auto
+      overflow-x: hidden
+
+      @include styled-scroll-bar
+
       li
         float: none
     > ul.drop-down--projects
@@ -277,6 +283,9 @@ input.top-menu-search--input
       position: absolute
       right: 15px
       top: calc(50% - 10px / 2)
+
+#top-menu #account-nav-left .menu-drop-down-container
+  overflow: hidden
 
 #account-nav-right
   .drop-down.last-child


### PR DESCRIPTION
## Problem
The topbar dropdowns are currently not scrollable themselves. So if a dropdown is longer than the viewport height, the whole website scrolls and this causes an additional scrollbar and an unpleasant gap at the bottom.

When the project list is long and the screen small (e.g. turned mobile) the last entries cannot be seen.

## Fixes

- Long dropdowns have viewport height and are now scrollable
- Including the newer scrollbars
- The projects menu height is set correctly so that all entries can be seen

https://community.openproject.com/projects/openproject/work_packages/28768