### PR TITLE
[28712] Application not responsive for a particular screen size

### DIFF
--- a/app/assets/stylesheets/content/_calendar.sass
+++ b/app/assets/stylesheets/content/_calendar.sass
@@ -44,6 +44,10 @@ table.cal
   width: 100%
   margin: 0 0 6px 0
   border: $content-calendar-border-width solid $content-calendar-border-color
+  display: block
+  overflow-x: auto
+
+  @include styled-scroll-bar-horizontal
 
   thead th
     width: 14%
@@ -55,7 +59,8 @@ table.cal
   tbody tr
     height: 100px
   td
-    border: $content-calendar-cell-border-width solid $content-calendar-cell-border-color
+    border-left: $content-calendar-cell-border-width solid $content-calendar-cell-border-color
+    border-top: $content-calendar-cell-border-width solid $content-calendar-cell-border-color
     vertical-align: top
     font-size: 0.9em
 

--- a/app/assets/stylesheets/content/_custom_actions.sass
+++ b/app/assets/stylesheets/content/_custom_actions.sass
@@ -29,9 +29,8 @@
 .custom-actions
   display: flex
   flex-wrap: wrap
-  justify-content: flex-end
-  flex-grow: 1
-  // Cancel out the margin of the last button
+  // Cancel out the margin of the buttons
+  width: calc(100% + 10px)
   margin-right: -10px
 
   .custom-action

--- a/app/assets/stylesheets/content/_editable_toolbar.sass
+++ b/app/assets/stylesheets/content/_editable_toolbar.sass
@@ -1,15 +1,6 @@
 // Provide and editable container toolbar
 .toolbar-container.-editable
-
-  // Align editable title and toolbar with flex
-  .toolbar
-    display: flex
-    align-items: center
-
-  // Allow title container to grow
   .title-container
-    flex: 1
-
     span:hover
       text-decoration: none
 

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -811,6 +811,7 @@ input[readonly].-clickable
   clear:       both
   line-height: $base-line-height
   padding:  0 2rem 0 0
+  @include text-shortener
 
   & > .form--check-box-container
     display:  block

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -369,6 +369,10 @@ fieldset.form--fieldset
 .form--label
   @include grid-content(2)
   @extend %label-style
+  // override max-width set by including grid-content
+  max-width:    100%
+  min-width:    100px
+  flex-grow:    1
   overflow-x: hidden
   white-space: normal
   overflow-y: visible
@@ -411,9 +415,12 @@ fieldset.form--fieldset
 
 .form--field-container
   @include grid-content(10)
-  @include grid-visible-overflow
+  // override max-width set by including grid-content
+  max-width: 100%
+  overflow: hidden
   padding: 0
   display: flex
+  flex-grow: 2
   align-items: stretch
 
   &.-wrap-around

--- a/app/assets/stylesheets/content/_forms_mobile.sass
+++ b/app/assets/stylesheets/content/_forms_mobile.sass
@@ -42,8 +42,14 @@
     .form--field-instructions
       @include grid-content(12)
       display: flex
+      flex: 1
       margin-left: 0
       padding: 0
+
+  #tab-content-info form
+    .form--label,
+    .form--field-container
+      flex-basis: 100%
 
   .choice .choice--select
     width: 100%

--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -57,9 +57,8 @@ $ng-modal-image-width: $ng-modal-image-height
   background: $ng-modal-background
   position: relative
   padding: $ng-modal-padding / 2
-  width: fit-content
   min-width: 200px
-  max-width: 40vw
+  max-width: 60vw
   overflow-y: auto
   
   @include styled-scroll-bar-vertical

--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -55,13 +55,14 @@ $ng-modal-image-width: $ng-modal-image-height
 .op-modal--modal-container
   transition: opacity 0.25s ease
   background: $ng-modal-background
-  margin: auto
-  width: 50%
-  max-height: 95%
   position: relative
   padding: $ng-modal-padding / 2
+  width: fit-content
+  min-width: 200px
+  max-width: 40vw
   overflow-y: auto
-  overflow-x: hidden
+  
+  @include styled-scroll-bar-vertical
 
   &.-wide
     min-width: 75vw
@@ -143,14 +144,15 @@ $ng-modal-image-width: $ng-modal-image-height
 
 // Specific styles for export-modal
 ul.export-options
+  display: flex
+  flex-wrap: wrap
   margin: 0
   padding: 20px 0
   list-style-type: none
   li
-    margin: 0 0 30px 0
+    flex: 1 1 calc(33% - 40px)  // line break after third element
+    margin: 20px
     text-align: center
-    display: inline-block
-    width: 32%
     a
       cursor: pointer
       text-decoration: none

--- a/app/assets/stylesheets/content/_news.sass
+++ b/app/assets/stylesheets/content/_news.sass
@@ -48,3 +48,6 @@
 
 p.author
   font-style: italic
+
+.news--header
+  @include text-shortener

--- a/app/assets/stylesheets/content/_notifications.sass
+++ b/app/assets/stylesheets/content/_notifications.sass
@@ -193,11 +193,15 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
   &.-info
     color: $nm-color-info-icon
 
-.notification-box--wrapper
+.notification-box--wrapper,
+.flash, #errorExplanation
   position: absolute
-  width: $nm-notification-width
-  margin-left: -($nm-notification-width / 2)
-  left: 50%
+  max-width: $nm-notification-width
+  margin: 0 auto
+  left: 10%
+  right: 10%
+
+.notification-box--wrapper
   z-index: 901 // Higher than loading indicator!
 
   .notification-box--casing
@@ -278,13 +282,8 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
   &.-warning
     @extend %warning-placeholder
 
-
 // Use same styles for flash messages
 .flash, #errorExplanation
-  position: absolute
-  width: $nm-notification-width
-  margin-left: -($nm-notification-width / 2)
-  left: 50%
   border-radius: $nm-border-radius
   border-style: solid
   border-width: rem-calc(1)

--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -57,7 +57,11 @@ table
     .hours-dec
       font-size: 0.9em
 
-  &.workflow-table.generic-table
+#workflow_form
+  .generic-table--results-container
+    position: relative
+
+  .workflow-table.generic-table
     // Let space for the turned header
     margin-left: 30px
     width: calc(100% - 30px)

--- a/app/assets/stylesheets/content/_tabs.sass
+++ b/app/assets/stylesheets/content/_tabs.sass
@@ -72,11 +72,6 @@
         &.-disabled
           color: #999
 
-#content .tab-content
-  overflow-x: auto
-  overflow-y: hidden
-  min-height: 0 // overflows in a flexbox layout want that.
-
 div.tabs-buttons
   position: absolute
   right: 0

--- a/app/assets/stylesheets/content/_types_form_configuration.sass
+++ b/app/assets/stylesheets/content/_types_form_configuration.sass
@@ -94,6 +94,8 @@
   .attribute-name,
   .group-name
     flex-basis: 90%
+    @include text-shortener
+    white-space: normal
 
 
 // Query group styles

--- a/app/assets/stylesheets/content/work_packages/_table_configuration_modal.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_configuration_modal.sass
@@ -1,8 +1,6 @@
 .wp-table--configuration-modal
   min-height: 120px
   max-height: 90vh
-  width: 50vw
-  overflow-x: auto
 
   label.option-label
     float: left

--- a/app/assets/stylesheets/content/work_packages/fullscreen/_back_button.sass
+++ b/app/assets/stylesheets/content/work_packages/fullscreen/_back_button.sass
@@ -1,7 +1,6 @@
 .wp-show--back-button
   width: 90px
   height: 34px
-  align-self: center
   a
     padding: 0
     line-height: 32px

--- a/app/assets/stylesheets/content/work_packages/fullscreen/_back_button.sass
+++ b/app/assets/stylesheets/content/work_packages/fullscreen/_back_button.sass
@@ -1,5 +1,5 @@
 .wp-show--back-button
-  width: 90px
+  min-width: 90px
   height: 34px
   a
     padding: 0

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -252,6 +252,7 @@ i
 .wp-info-wrapper
   display: flex
   align-items: center
+  padding-top: 0.5rem
   .wp-status-button .button
     padding: 5px
     margin-bottom: 0
@@ -270,7 +271,11 @@ i
       padding: 0
   .work-packages--info-row
     flex-grow: 2
-    margin-right: 5px
+
+  attribute-help-text,
+  .wp-status-button,
+  .work-packages--info-row
+    margin-bottom: 0.5rem
 
   &.-wrapped
     flex-wrap: wrap
@@ -280,7 +285,6 @@ i
       margin-bottom: 0.5rem
 
     wp-status-button
-      margin-bottom: 0.5rem
       // In case that there is no attribute help text, the status button needs to increase.
       // This is a heuristic based on the current DOM structure.
       &:nth-last-child(3)

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -27,7 +27,6 @@
 //++
 
 html
-  min-width: 840px
   &.in_modal
     min-width: 0
 

--- a/app/assets/stylesheets/layout/_base.sass
+++ b/app/assets/stylesheets/layout/_base.sass
@@ -73,7 +73,8 @@ body
   padding: 10px 20px
   width: auto
   height: calc(100vh - #{$header-height})
-  overflow: auto
+  overflow-y: auto
+  overflow-x: hidden
   background-color: #fff
   width: 100%
   // As this is a flex item we need to set min-width to 0 so that its children's

--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -53,7 +53,6 @@
     background: #fff !important
 
   #content-wrapper
-    height: 100% !important
     margin: 0 !important
     padding: 20px !important
     width: 100% !important

--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -98,17 +98,12 @@ ul.breadcrumb
     height: initial
     li
       line-height: 20px
-      max-width: 420px
+      max-width: 100%
       @include text-shortener
 
       &:first-child
         &:before
           display: none
-
-// This is ugly. However, this way we do not need to touch complicated
-// toolbar-container positioning.
-body.action-show .wp-breadcrumb
-  margin-bottom: -10px
 
 // Hide projects in normal mode
 body:not(.accessibility-mode) .breadcrumb .breadcrumb-project-element
@@ -121,10 +116,3 @@ body:not(.accessibility-mode) .breadcrumb .breadcrumb-project-element
     margin: 10px 0 0 0 !important
     ul.breadcrumb
       line-height: 1.25
-      li
-        display: inline
-        float: unset
-        line-height: inherit
-        white-space: normal
-        margin: 0 10px 0 0
-

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -48,7 +48,7 @@ $menu-item-line-height: 30px
     -ms-overflow-style: -ms-autohiding-scrollbar
     height: calc(100vh - #{$header-height})
     position: relative
-    @include styled-scroll-bar
+    @include styled-scroll-bar-vertical
 
     // Fixed heights to allow inner scrolling
     .menu_root.closed,
@@ -65,7 +65,7 @@ $menu-item-line-height: 30px
     .main-menu--children
       height: calc(100% - (#{$main-menu-item-height} + 10px)) // 10px spacing
       overflow: auto
-      @include styled-scroll-bar
+      @include styled-scroll-bar-vertical
 
   ul
     margin: 0
@@ -325,7 +325,7 @@ a.main-menu--parent-node
   padding-left: 7px
   padding-right: 7px
 
-  @include styled-scroll-bar
+  @include styled-scroll-bar-vertical
 
 .main-menu--segment-header
   @include varprop(color, main-menu-fieldset-header-color)

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -77,17 +77,23 @@ $nm-color-success-background: #d8fdd1
 .toolbar-items
   display: flex
   flex-wrap: wrap
-  margin:  0
+  margin:  0 -10px 0 0
   padding: 0
 
   li
     list-style-type: none
+    flex-grow: 1
 
   .toolbar-item
     margin: 0 10px 10px 0 // spacing between nav items
+    flex-grow: 1
 
-    &:last-child
-      margin-right: 0
+    .button
+      width: 100%
+      overflow: hidden
+      white-space: normal
+      // For links the total height adds borders to line-height (== 34px)
+      line-height: 32px
 
     // hack around the old watchers_link implementation
     // remove once all watcher_links in plugins have no button wrappers anymore
@@ -98,7 +104,13 @@ $nm-color-success-background: #d8fdd1
       padding: 0
 
   .toolbar-button-group
+    display: flex
+    justify-content: flex-end
+    flex-direction: row-reverse
     margin-left: 0px
+
+    > li
+      margin-right: 2px
 
   button,
   .button
@@ -115,10 +127,6 @@ $nm-color-success-background: #d8fdd1
       font-size: 14px
       vertical-align: 1px
 
-    &.toolbar-icon
-      // Make sure that icon only toolbar items are squared
-      width: 34px
-
       font-size: 14px
       line-height: 1
       i
@@ -127,10 +135,6 @@ $nm-color-success-background: #d8fdd1
         &::before
           font-size: 14px
           line-height: 1
-
-  a.button
-    // For links the total height adds borders to line-height (== 34px)
-    line-height: 32px
 
   button,
   .button,
@@ -188,6 +192,7 @@ $nm-color-success-background: #d8fdd1
   margin-bottom: 10px // margin-bottom of toolbar buttons
 
   h2
+    @include text-shortener
     padding: 0
 
   div.inline-edit

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -68,13 +68,6 @@ $nm-color-success-background: #d8fdd1
   align-items: center
   justify-content: flex-end
 
-.toolbar-items
-  margin:  0
-  padding: 0
-
-  li
-    list-style-type: none
-
 // automatically clear the toolbar
 .toolbar:after
   clear: both
@@ -82,26 +75,31 @@ $nm-color-success-background: #d8fdd1
   display: table
 
 .toolbar-items
-  .toolbar-item,
-  .toolbar-button-group > li
-    float: left
-    &.toolbar-item
-      margin: 0 10px 10px 0 // spacing between nav items
+  display: flex
+  flex-wrap: wrap
+  margin:  0
+  padding: 0
 
-      &:last-child
-        margin-right: 0
+  li
+    list-style-type: none
 
-      // hack around the old watchers_link implementation
-      // remove once all watcher_links in plugins have no button wrappers anymore
-      .button .button
-        background: transparent
-        border: none
-        margin: 0
-        padding: 0
+  .toolbar-item
+    margin: 0 10px 10px 0 // spacing between nav items
+
+    &:last-child
+      margin-right: 0
+
+    // hack around the old watchers_link implementation
+    // remove once all watcher_links in plugins have no button wrappers anymore
+    .button .button
+      background: transparent
+      border: none
+      margin: 0
+      padding: 0
 
   .toolbar-button-group
     margin-left: 0px
-    
+
   button,
   .button
     // Overwrite Foundastion's default padding. Let line-height fix vertical

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -49,8 +49,8 @@ $nm-color-success-background: #d8fdd1
   line-height: 22px
 
 .toolbar-container
+  margin-bottom: 1rem
   padding: 0
-  margin-bottom: 12px
 
   > .subtitle
     font-size: rem-calc(14px)
@@ -61,9 +61,12 @@ $nm-color-success-background: #d8fdd1
   &.-with-dropdown .toolbar-item.drop-down
     position: relative
 
+// Align title and toolbar with flex
 .toolbar
   display: flex
+  flex-wrap: wrap
   align-items: center
+  justify-content: flex-end
 
 .toolbar-items
   margin:  0
@@ -83,7 +86,7 @@ $nm-color-success-background: #d8fdd1
   .toolbar-button-group > li
     float: left
     &.toolbar-item
-      margin: 0 5px //$drop-nav-spacing // spacing between nav items
+      margin: 0 10px 10px 0 // spacing between nav items
 
       &:last-child
         margin-right: 0
@@ -178,10 +181,13 @@ $nm-color-success-background: #d8fdd1
         right: 1px
         vertical-align: text-top
 
+// Allow title container to grow
 .title-container
-  flex: 1
+  flex-grow: 1
+  flex-basis: auto
   overflow: hidden
   white-space: nowrap
+  margin-bottom: 10px // margin-bottom of toolbar buttons
 
   h2
     padding: 0

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -180,7 +180,8 @@ $nm-color-success-background: #d8fdd1
 
 .title-container
   flex: 1
-  padding: 0
+  overflow: hidden
+  white-space: nowrap
 
   h2
     padding: 0

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -168,7 +168,7 @@ $nm-color-success-background: #d8fdd1
     margin-right: 0
 
   #repository-checkout-url
-    min-width: 350px
+    min-width: 320px
 
   .toolbar-item
     &.-icon-only
@@ -280,6 +280,7 @@ $nm-color-success-background: #d8fdd1
     border: 1px solid $toolbar-item--border-color
     color: $inlinelabel-color
     border-radius: 2px
+    white-space: nowrap
 
     &.-prepend
       border-right: none !important

--- a/app/assets/stylesheets/layout/_toolbar_mobile.sass
+++ b/app/assets/stylesheets/layout/_toolbar_mobile.sass
@@ -42,13 +42,14 @@
         justify-content: stretch
         width: 100%
 
-        > li
+        .toolbar-item
           -webkit-flex: 1 0 0
           flex: 1 0 0
 
           &:last-child
             margin-right: 10px
 
+        > li
           .button
             width: 100%
             white-space: nowrap
@@ -58,6 +59,9 @@
           label,
           div
             margin-top: 0
+
+        > form input.button
+          width: 100%
 
     overview-page-layout
       .toolbar-item:first-child

--- a/app/assets/stylesheets/layout/_toolbar_mobile.sass
+++ b/app/assets/stylesheets/layout/_toolbar_mobile.sass
@@ -30,7 +30,6 @@
   #content
     .toolbar-container
       margin-top: 10px
-      margin-right: -10px // Workaround (necessary because of margin of toolbar-items)
 
       .title-container
         margin-right: 10px
@@ -40,14 +39,10 @@
         display: flex
         flex-wrap: wrap
         justify-content: stretch
-        width: 100%
+        width: calc(100% + 10px)
 
-        .toolbar-item
-          -webkit-flex: 1 0 0
-          flex: 1 0 0
-
-          &:last-child
-            margin-right: 10px
+        .toolbar-item:last-child
+          margin-right: 10px
 
         > li
           .button

--- a/app/assets/stylesheets/layout/_toolbar_mobile.sass
+++ b/app/assets/stylesheets/layout/_toolbar_mobile.sass
@@ -38,8 +38,6 @@
       background: #fff
       display: flex
       width: calc(100% + 5px)
-      margin-bottom: 20px
-      margin-top: 5px
 
       &:not(:empty)
         margin-bottom: 20px

--- a/app/assets/stylesheets/layout/_toolbar_mobile.sass
+++ b/app/assets/stylesheets/layout/_toolbar_mobile.sass
@@ -27,40 +27,38 @@
 //++
 
 @include breakpoint (680px down)
-  .toolbar-container
-    margin-bottom: 0px
-    margin-top: 10px
+  #content
+    .toolbar-container
+      margin-top: 10px
+      margin-right: -10px // Workaround (necessary because of margin of toolbar-items)
 
-    .toolbar
-      flex-wrap: wrap
+      .title-container
+        margin-right: 10px
 
-    .toolbar-items
-      background: #fff
-      display: flex
-      width: calc(100% + 5px)
+      .toolbar-items
+        background: #fff
+        display: flex
+        flex-wrap: wrap
+        justify-content: stretch
+        width: 100%
 
-      &:not(:empty)
-        margin-bottom: 20px
-      > li
-        -webkit-flex: 1 0 0
-        flex: 1 0 0
+        > li
+          -webkit-flex: 1 0 0
+          flex: 1 0 0
 
-        // Add left margin for all visible toolbar elements except the first one
-        &:not(.hidden-for-mobile)
-          margin: 0px
-        &:not(.hidden-for-mobile) + :not(.hidden-for-mobile)
-          margin-left: 10px
+          &:last-child
+            margin-right: 10px
 
-        &:first-child
-          -webkit-flex: 3 0 0
-          flex: 3 0 0
+          .button
+            width: 100%
+            white-space: nowrap
 
-        .button
-          width: 100%
-          white-space: nowrap
+          .button,
+          input,
+          label,
+          div
+            margin-top: 0
 
-        .button,
-        input,
-        label,
-        div
-          margin-top: 0
+    overview-page-layout
+      .toolbar-item:first-child
+        flex-basis: calc(100% - 10px) // 10px right margin

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -218,7 +218,6 @@ input.top-menu-search--input
     float: right
 
 #header
-  min-width: 840px
   .chzn-container .chzn-results .highlighted
     background-color:  #24b3e7
 

--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -40,8 +40,7 @@ body.controller-work_packages.full-create
 
   #toolbar
     display: flex
-    justify-content: flex-end
-    flex-wrap: wrap-reverse
+    margin-right: 10px
     @include clearfix
 
   .toolbar-container
@@ -49,8 +48,8 @@ body.controller-work_packages.full-create
 
   ul#toolbar-items
     @include clearfix
-    order: 2
-    margin: 0 0 1rem 2rem
+    position: absolute
+    right: 20px
 
     button
       margin-bottom: 0
@@ -189,19 +188,14 @@ body.controller-work_packages.full-create
     @media only screen and (max-width: 679px)
       width: 100%
     @media only screen and (min-width: 679px)
-      flex: 1 1 auto
       display: flex
+      flex-wrap: wrap
       margin-bottom: 6px
 
   .subject-header
     margin: 0
     padding: 0
-    align-self: center
-    /* Leave space for the back button */
-    flex-basis: calc(100% - 90px)
-    @media only screen and (max-width: 679px)
-      // let use full width
-      flex-basis: 100%
+    flex-basis: 100%
 
     .wp-table--cell-span
       white-space: normal

--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -40,7 +40,8 @@ body.controller-work_packages.full-create
 
   #toolbar
     display: flex
-    margin-right: 10px
+    flex-wrap: wrap-reverse
+    justify-content: flex-end
     @include clearfix
 
   .toolbar-container
@@ -48,21 +49,13 @@ body.controller-work_packages.full-create
 
   ul#toolbar-items
     @include clearfix
-    position: absolute
-    right: 20px
-
-    button
-      margin-bottom: 0
 
     li
       float: left
       position: relative
 
-      &.toolbar-item:first-of-type
-        margin-left: 0
-
       &.toolbar-item
-        margin: 0 5px
+        margin: 0 10px 6px 0
 
         &:last-child
           margin-right: 0
@@ -77,7 +70,6 @@ body.controller-work_packages.full-create
 
   ul#toolbar-items, ul.subject-header
     list-style-type: none
-    padding: 0
 
     li
       margin: 0
@@ -189,13 +181,11 @@ body.controller-work_packages.full-create
       width: 100%
     @media only screen and (min-width: 679px)
       display: flex
-      flex-wrap: wrap
+      flex: 1 1 auto
       margin-bottom: 6px
 
   .subject-header
     margin: 0
-    padding: 0
-    flex-basis: 100%
 
     .wp-table--cell-span
       white-space: normal

--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -94,7 +94,6 @@ body.controller-work_packages.full-create
   overflow-x: hidden
   flex: 2
   position: relative
-  min-width: 360px
 
   .work-packages--panel-inner
     padding: 5px 15px 20px 0px

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -98,7 +98,6 @@
       padding: 0 5px 0 5px
 
     .toolbar-container
-      min-height: 36px
       padding-right: 0
 
     .attributes-key-value--key,

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -43,7 +43,6 @@
       #content-wrapper,
       #content
         height: 100% !important
-        overflow: auto
 
       #main
         padding-bottom: 0
@@ -76,6 +75,7 @@
 
           .work-packages--panel-inner
             padding: 5px 0 20px 0
+            width: calc(100vw - 30px)
 
         .work-packages-full-view--split-right
           width: initial
@@ -83,7 +83,8 @@
             margin: 0.75rem 0 2.5rem 0
 
           .work-packages--panel-inner
-            padding-right: 0
+            padding: 0
+            max-width: calc(100vw - 30px)
 
         .work-packages-full-view--resizer
           display: none
@@ -164,6 +165,7 @@
     #toolbar-items
       position: absolute
       top: 10px
+      right: 0
       justify-content: flex-end
       .toolbar-item
         flex-grow: 0

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -95,7 +95,7 @@
       contain: none
 
     .work-packages-list-view--container
-      padding-left: 5px
+      padding: 0 5px 0 5px
 
     .toolbar-container
       min-height: 36px

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -75,7 +75,6 @@
 
           .work-packages--panel-inner
             padding: 5px 0 20px 0
-            width: calc(100vw - 30px)
 
         .work-packages-full-view--split-right
           width: initial
@@ -165,7 +164,6 @@
     #toolbar-items
       position: absolute
       top: 10px
-      right: 0
       justify-content: flex-end
       .toolbar-item
         flex-grow: 0

--- a/app/assets/stylesheets/layout/work_packages/_query_menu.sass
+++ b/app/assets/stylesheets/layout/work_packages/_query_menu.sass
@@ -15,7 +15,7 @@ $wp-query-menu-search-container-height: 35px
     background: none
     z-index: 0 // Prevent overlapping with project select dropdown (https://community.openproject.com/wp/28175)
 
-    @include styled-scroll-bar
+    @include styled-scroll-bar-vertical
 
 
   .wp-query-menu--results-container

--- a/app/assets/stylesheets/layout/work_packages/_table.sass
+++ b/app/assets/stylesheets/layout/work_packages/_table.sass
@@ -69,10 +69,11 @@
   .work-packages--filters-optional-container
     // not flex-item
     height: auto
+    overflow: auto
     flex-shrink: 0
     // Filters are hidden when not expanded
-    // When expanded, add some padding to the table
-    padding-bottom: 20px
+    // When expanded, add some distance to the table
+    margin-bottom: 20px
 
 // Outer Flex container for (table+timeline)|details
 .work-packages-split-view

--- a/app/assets/stylesheets/layout/work_packages/_table.sass
+++ b/app/assets/stylesheets/layout/work_packages/_table.sass
@@ -59,7 +59,7 @@
   height: 100%
 
   > .toolbar-container
-    margin: 1rem 0
+    margin-top: 1rem
     // not flex-item
     padding-right: 15px
 

--- a/app/assets/stylesheets/openproject/_mixins.sass
+++ b/app/assets/stylesheets/openproject/_mixins.sass
@@ -113,7 +113,7 @@
   background: none
   border: none
 
-@mixin styled-scroll-bar
+@mixin styled-scroll-bar-vertical
   &::-webkit-scrollbar
     width: 8px
     height: 12px
@@ -126,4 +126,17 @@
     visibility: hidden
 
   &:hover::-webkit-scrollbar-thumb
+    visibility: visible
+
+@mixin styled-scroll-bar-horizontal
+  &::-webkit-scrollbar
+    width: 12px
+    height: 8px
+
+  &::-webkit-scrollbar-track
+    background: transparent
+
+  // Should always be visible otherwise it would not be displayed on mobile or tablet
+  &::-webkit-scrollbar-thumb
+    background: #ddd
     visibility: visible

--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -48,7 +48,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <% if @newss.any? %>
   <% @newss.each do |news| %>
-    <h3><%= avatar(news.author) %><%= link_to_project(news.project) + ': ' unless news.project == @project %>
+    <h3 class="news--header"><%= avatar(news.author) %><%= link_to_project(news.project) + ': ' unless news.project == @project %>
       <%= link_to h(news.title), news_path(news) %>
       <%= "(#{l(:label_x_comments, count: news.comments_count)})" if news.comments_count > 0 %></h3>
     <p class="author"><%= authoring news.created_on, news.author %></p>

--- a/app/views/repositories/stats.html.erb
+++ b/app/views/repositories/stats.html.erb
@@ -29,7 +29,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <%= toolbar title: l(:label_statistics) %>
 
-<p>
+<p class="autoscroll">
   <%= tag("embed", width: 800,
                    height: 300,
                    type: "image/svg+xml",
@@ -39,7 +39,7 @@ See docs/COPYRIGHT.rdoc for more details.
                                    graph: "commits_per_month")) %>
 </p>
 <% if @show_commits_per_author %>
-  <p>
+  <p class="autoscroll">
     <%= tag("embed", width: 800,
                      height: 400,
                      type: "image/svg+xml",

--- a/app/views/settings/_repositories.html.erb
+++ b/app/views/settings/_repositories.html.erb
@@ -108,19 +108,19 @@ See docs/COPYRIGHT.rdoc for more details.
         <%= I18n.t("setting_commit_fix_keywords") %>
       </div>
       <div class="form--grouping-row">
-        <div class="form--field -full-width">
-          <%= label_tag 'commit_fix_keywords', I18n.t(:setting_commit_fix_keywords), class: 'hidden-for-sighted' %>
+        <div class="form--field">
+          <%= styled_label_tag 'commit_fix_keywords', I18n.t(:label_keyword_plural) %>
           <div class="form--field-container">
             <%= setting_text_field :commit_fix_keywords, size: 30, label: false %>
           </div>
         </div>
-        <div class="form--field -wide-label">
+        <div class="form--field">
           <%= styled_label_tag :settings_commit_fix_status_id, t(:label_applied_status) %>
           <div class="form--field-container">
             <%= setting_select :commit_fix_status_id, [["--- #{t(:actionview_instancetag_blank_option)} ---", '0', { disabled: true }]] + Status.all.collect{ |status| [status.name, status.id.to_s] }, label: false %>
           </div>
         </div>
-        <div class="form--field -wide-label">
+        <div class="form--field">
           <%= styled_label_tag :settings_commit_fix_done_ratio, WorkPackage.human_attribute_name(:done_ratio) %>
           <div class="form--field-container">
             <%= setting_select :commit_fix_done_ratio, (0..10).to_a.collect {|r| ["#{r*10} %", "#{r*10}"] }, blank: :label_no_change_option, label: false %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1286,6 +1286,7 @@ en:
   label_journal_diff: "Description Comparison"
   label_language: "Language"
   label_jump_to_a_project: "Jump to a project..."
+  label_keyword_plural: 'Keywords'
   label_language_based: "Based on user's language"
   label_last_activity: "Last activity"
   label_last_change_on: "Last change on"

--- a/frontend/src/app/components/wp-query-select/wp-query-selectable-title.sass
+++ b/frontend/src/app/components/wp-query-select/wp-query-selectable-title.sass
@@ -4,6 +4,10 @@
 
 .wp-query-selectable-title--fixed
   padding: 0
+  overflow: hidden
+  text-overflow: ellipsis
+  -o-text-overflow: ellipsis
+  -ms-text-overflow: ellipsis
 
 .wp-query-selectable-title--save
   span:before

--- a/frontend/src/app/components/wp-query-select/wp-query-selectable-title.sass
+++ b/frontend/src/app/components/wp-query-select/wp-query-selectable-title.sass
@@ -4,10 +4,6 @@
 
 .wp-query-selectable-title--fixed
   padding: 0
-  overflow: hidden
-  text-overflow: ellipsis
-  -o-text-overflow: ellipsis
-  -ms-text-overflow: ellipsis
 
 .wp-query-selectable-title--save
   span:before


### PR DESCRIPTION
## Problem
There is an unresponsive behaviour of the application for a particular screen size right before the breakpoint of the mobile layout, which is causing a horizontal scroll bar. So this is especially for the tablet sizes a problem.

## To-Do's

- [x] Remove min-width
- [x] Adapt **toolbar** and title
        -> Title of default views were not trimmed, which disarranged the toolbar
        -> Flexible layout for toolbar (without new breakpoint)
- **Toolbar buttons**
   - [x] Make all buttons responsive (when toolbar is wrapped, buttons should stretch)
   - [x] Texts of buttons automatically shorter, text overflow is hidden
- [x] Adapt arrangement of elements inside modals and make modals responsive
- [x] Remove unnecessary scrollbars
- [x] Make forms responsive -> New PR https://github.com/opf/openproject/pull/6823

- [x] **Project settings** scrollbars

- [x] **Custom actions** buttons

- [x] Check CE **plugins** (Costs, Backlogs, MyProjectPage, Meetings, Avatars, twoFactorAuthentication ... )

- **Tests** in 
   - [x] Chrome
   - [x] Firefox
   - [x] Opera
   - [x] MSEdge

**Related PRs:**
* https://github.com/finnlabs/reporting_engine/pull/95
* https://github.com/finnlabs/openproject-backlogs/pull/274

https://community.openproject.com/projects/openproject/work_packages/28712