### PR TITLE
[28818] Bottom entry in work package context menu not visible in Gantt chart on smaller screens

### DIFF
--- a/frontend/src/app/components/op-context-menu/handlers/op-columns-context-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/op-columns-context-menu.directive.ts
@@ -81,12 +81,15 @@ export class OpColumnsContextMenu extends OpContextMenuTrigger {
    *
    * @param {Event} openerEvent
    */
-  public positionArgs(openerEvent:Event) {
-    return {
-      my: 'left top',
-      at: 'left bottom',
-      of: this.$element.find('.generic-table--sort-header-outer')
+  public positionArgs(evt:JQueryEventObject) {
+    let additionalPositionArgs = {
+      of:  this.$element.find('.generic-table--sort-header-outer'),
     };
+
+    let position = super.positionArgs(evt);
+    _.assign(position, additionalPositionArgs);
+
+    return position;
   }
 
   protected get afterFocusOn():JQuery {

--- a/frontend/src/app/components/op-context-menu/handlers/op-context-menu-trigger.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/op-context-menu-trigger.directive.ts
@@ -38,4 +38,18 @@ export class OpContextMenuTrigger extends OpContextMenuHandler implements AfterV
       this.open(evt);
     });
   }
+
+  /**
+   * Positioning args for jquery-ui position.
+   *
+   * @param {Event} openerEvent
+   */
+  public positionArgs(openerEvent:Event) {
+    return {
+      my: 'left top',
+      at: 'left bottom',
+      of: this.$element,
+      collision: 'flipfit'
+    };
+  }
 }

--- a/frontend/src/app/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
@@ -112,12 +112,16 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger implements OnD
    *
    * @param {Event} openerEvent
    */
-  public positionArgs(openerEvent:Event) {
-    return {
+  public positionArgs(evt:JQueryEventObject) {
+    let additionalPositionArgs = {
       my: 'right top',
-      at: 'right bottom',
-      of: this.$element
+      at: 'right bottom'
     };
+
+    let position = super.positionArgs(evt);
+    _.assign(position, additionalPositionArgs);
+
+    return position;
   }
 
   public onClose() {

--- a/frontend/src/app/components/op-context-menu/handlers/op-types-context-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/op-types-context-menu.directive.ts
@@ -86,20 +86,6 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger {
     };
   }
 
-
-  /**
-   * Positioning args for jquery-ui position.
-   *
-   * @param {Event} openerEvent
-   */
-  public positionArgs(openerEvent:Event) {
-    return {
-      my: 'left top',
-      at: 'left bottom',
-      of: this.$element
-    };
-  }
-
   private buildItems(types:TypeResource[]) {
     this.items = types.map((type:TypeResource) => {
       return {

--- a/frontend/src/app/components/op-context-menu/handlers/wp-create-settings-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/wp-create-settings-menu.directive.ts
@@ -66,12 +66,16 @@ export class WorkPackageCreateSettingsMenuDirective extends OpContextMenuTrigger
    *
    * @param {Event} openerEvent
    */
-  public positionArgs(openerEvent:Event) {
-    return {
+  public positionArgs(evt:JQueryEventObject) {
+    let additionalPositionArgs = {
       my: 'right top',
-      at: 'right bottom',
-      of: this.$element
+      at: 'right bottom'
     };
+
+    let position = super.positionArgs(evt);
+    _.assign(position, additionalPositionArgs);
+
+    return position;
   }
 
   private buildItems(form:FormResource) {

--- a/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
@@ -72,19 +72,6 @@ export class WorkPackageStatusDropdownDirective extends OpContextMenuTrigger {
     };
   }
 
-  /**
-   * Positioning args for jquery-ui position.
-   *
-   * @param {Event} openerEvent
-   */
-  public positionArgs(openerEvent:Event) {
-    return {
-      my: 'left top',
-      at: 'left bottom',
-      of: this.$element
-    };
-  }
-
   private updateStatus(status:HalResource) {
     const changeset = this.wpEditing.changesetFor(this.workPackage);
     changeset.setValue('status', status);

--- a/frontend/src/app/components/op-context-menu/op-context-menu-handler.ts
+++ b/frontend/src/app/components/op-context-menu/op-context-menu-handler.ts
@@ -32,7 +32,8 @@ export abstract class OpContextMenuHandler {
     return {
       my: 'left top',
       at: 'right bottom',
-      of: this.$element
+      of: this.$element,
+      collision: 'flipfit'
     };
   }
 

--- a/frontend/src/app/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
+++ b/frontend/src/app/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
@@ -64,12 +64,16 @@ export class WorkPackageSingleContextMenuDirective extends OpContextMenuTrigger 
    *
    * @param {Event} openerEvent
    */
-  public positionArgs(openerEvent:Event) {
-    return {
+  public positionArgs(evt:JQueryEventObject) {
+    let additionalPositionArgs = {
       my: 'right top',
-      at: 'right bottom',
-      of: this.$element
+      at: 'right bottom'
     };
+
+    let position = super.positionArgs(evt);
+    _.assign(position, additionalPositionArgs);
+
+    return position;
   }
 
   private getPermittedActions(authorization:WorkPackageAuthorization) {


### PR DESCRIPTION
Let the context menus always fit into the page.

https://community.openproject.com/projects/openproject/work_packages/28818/activity