### PR TITLE
[28847] Fix body of full screen cut off in print view

### DIFF
--- a/app/assets/stylesheets/layout/work_packages/_print.sass
+++ b/app/assets/stylesheets/layout/work_packages/_print.sass
@@ -115,6 +115,9 @@
       overflow: visible
       flex-basis: initial !important
 
+    // Ensure left side is not set to overflow: hidden
+    .work-packages-full-view--split-left
+      overflow: visible
 
     // decrease padding under subject
     .work-packages--show-view > .toolbar-container


### PR DESCRIPTION
This is caused by an overflow: hidden and larger flex-basis of the
collapsed activity section. If the activity section is large enough, it
will reduce the width of body section. We do not want overflow in print
view anyway.

https://community.openproject.com/wp/28847