### PR TITLE
[28885] Improve html title consistency when navigating to queries

### DIFF
--- a/frontend/src/app/components/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/components/routing/wp-list/wp-list.component.ts
@@ -53,6 +53,7 @@ import {LoadingIndicatorService} from "core-app/modules/common/loading-indicator
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {WorkPackageStaticQueriesService} from 'core-components/wp-query-select/wp-static-queries.service';
 import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
+import {OpTitleService} from "core-components/html/op-title.service";
 
 @Component({
   selector: 'wp-list',
@@ -70,7 +71,6 @@ export class WorkPackagesListComponent implements OnInit, OnDestroy {
 
   tableInformationLoaded = false;
   selectedTitle?:string;
-  staticTitle?:string;
   titleEditingEnabled:boolean;
 
   currentQuery:QueryResource;
@@ -96,6 +96,7 @@ export class WorkPackagesListComponent implements OnInit, OnDestroy {
               readonly $transitions:TransitionService,
               readonly $state:StateService,
               readonly I18n:I18nService,
+              readonly titleService:OpTitleService,
               readonly wpStaticQueries:WorkPackageStaticQueriesService) {
 
   }
@@ -114,6 +115,13 @@ export class WorkPackagesListComponent implements OnInit, OnDestroy {
 
     // Listen for refresh changes
     this.setupRefreshObserver();
+
+    // Update title on entering this state
+    this.$transitions.onSuccess({ to: 'work-packages.list' }, () => {
+      if (this.selectedTitle) {
+        this.titleService.setFirstPart(this.selectedTitle);
+      }
+    });
 
     // Listen for param changes
     this.removeTransitionSubscription = this.$transitions.onSuccess({}, (transition):any => {
@@ -255,6 +263,11 @@ export class WorkPackagesListComponent implements OnInit, OnDestroy {
     } else {
       this.selectedTitle =  this.wpStaticQueries.getStaticName(query);
       this.titleEditingEnabled = false;
+    }
+
+    // Update the title if we're in the list state alone
+    if (this.$state.current.name === 'work-packages.list') {
+      this.titleService.setFirstPart(this.selectedTitle);
     }
   }
 }

--- a/spec/support/components/html_title.rb
+++ b/spec/support/components/html_title.rb
@@ -1,0 +1,52 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Components
+  class HtmlTitle
+    include Capybara::DSL
+    include RSpec::Matchers
+
+    attr_reader :project
+
+    def initialize(project = nil)
+      @project = project
+    end
+
+    def expect_first_segment(title_part)
+      expect(page).to have_title full_title(title_part)
+    end
+
+    def full_title(first_segment)
+      if project
+        "#{first_segment} | #{project.name} | #{Setting.app_title}"
+      else
+        "#{first_segment} | #{Setting.app_title}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, query names are not reflected in the HTML title. This results in 'wrong' titles being shown when entering a split or full view and then returning back to the list.

https://community.openproject.com/wp/28885