### PR TITLE
[28828] Implement regexp-based suffix lookup for mail addresses

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -499,9 +499,34 @@ class User < Principal
     end
   end
 
-  # Makes find_by_mail case-insensitive
+  ##
+  # Finds all users with the mail address matching the given mail
+  # Includes searching for suffixes from +Setting.mail_suffix_separtors+.
+  #
+  # For example:
+  #  - With Setting.mail_suffix_separators = '+'
+  #  - Will find 'foo+bar@example.org' with input of 'foo@example.org'
+  def self.where_mail_with_suffix(mail)
+    skip_suffix_check, regexp = mail_regexp(mail)
+
+    # If the recipient part already contains a suffix, don't expand
+    return where("LOWER(mail) = ?", mail) if skip_suffix_check
+
+    command =
+      if OpenProject::Database.mysql?
+        'REGEXP'
+      else
+        '~*'
+      end
+
+    where("LOWER(mail) #{command} ?", regexp)
+  end
+
+  ##
+  # Finds a user by mail where it checks whether the mail exists
+  # NOTE: This will return the FIRST matching user.
   def self.find_by_mail(mail)
-    where(['LOWER(mail) = ?', mail.to_s.downcase]).first
+    where_mail_with_suffix(mail).first
   end
 
   def rss_key
@@ -730,6 +755,15 @@ class User < Principal
   end
 
   private
+
+  def self.mail_regexp(mail)
+    separators = Regexp.escape(Setting.mail_suffix_separators)
+    recipient, domain = mail.split('@').map { |part| Regexp.escape(part) }
+    skip_suffix_check = Setting.mail_suffix_separators.empty? || recipient.match?(/.+[#{separators}].+/)
+    regexp = "#{recipient}([#{separators}][^@]+)*@#{domain}"
+
+    [skip_suffix_check, regexp]
+  end
 
   def authorization_service
     @authorization_service ||= ::Authorization::UserAllowedService.new(self)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -254,6 +254,8 @@ mail_handler_api_enabled:
   default: 0
 mail_handler_api_key:
   default:
+mail_suffix_separators:
+  default: '+'
 work_package_list_default_columns:
   serialized: true
   default:

--- a/docs/configuration/incoming-emails.md
+++ b/docs/configuration/incoming-emails.md
@@ -104,8 +104,13 @@ If a matching account is found, the mail handler impersonates the user to create
 If no matching account is found, the mail is rejected. To override this behavior and allow unknown mail address
 to create work packages, set the option `no_permission_check=1` and specify with `unknown_user=ACTION`
 
-**Note**: This feature only provides a mapping of mail to user account, it does not authenticate the user based on the mail.
-Since you can easily spoof mail addresses, you should not rely on the authenticity of work packages created that way.
+**Note**: This feature only provides a mapping of mail to user account, it does not authenticate the user based on the mail. Since you can easily spoof mail addresses, you should not rely on the authenticity of work packages created that way.
+
+**Users with mail suffixes**
+
+If you're used to using mail accounts with suffix support such as Google Mail, where you can specify `account+suffix@googlemail.com`, you will receive mails to that account but respond with your regular account `account@googlemail.com` . To mitigiate this, OpenProject by default will expand searching for mail ddresses `account@domain` to accounts `account+suffix@domain`  through regex searching the mail column. If you do not wish that behavior or want to customize the prefix, alter the setting `mail_suffix_separators` by running `bundle exec rails runner "Setting.mail_suffix_separators = ''"`
+
+
 
 #### Attributes
 

--- a/spec_legacy/functional/repositories_git_controller_spec.rb
+++ b/spec_legacy/functional/repositories_git_controller_spec.rb
@@ -52,12 +52,6 @@ describe RepositoriesController, 'Git', type: :controller do
       path_encoding: 'ISO-8859-1'
     )
 
-    # see repositories_subversion_controller_test.rb
-    def @repository.reload
-      ActiveRecord::Base.connection.clear_query_cache
-      self.class.find(id)
-    end
-
     assert @repository
   end
 

--- a/spec_legacy/functional/repositories_subversion_controller_spec.rb
+++ b/spec_legacy/functional/repositories_subversion_controller_spec.rb
@@ -47,14 +47,6 @@ describe RepositoriesController, 'Subversion', type: :controller do
                                                 scm_type: 'local',
                                                 url: self.class.subversion_repository_url)
 
-    # #reload is broken for repositories because it defines
-    # `has_many :changes` which conflicts with AR's #changes method
-    # here we implement #reload differently for that single repository instance
-    def @repository.reload
-      ActiveRecord::Base.connection.clear_query_cache
-      self.class.find(id)
-    end
-
     assert @repository
   end
 


### PR DESCRIPTION
Finds all users with the mail address matching the given mail
Includes searching for suffixes from a new setting +Setting.mail_suffix_separtors+.

For example:
 - With Setting.mail_suffix_separators = '+'
 - Will find 'foo+bar@example.org' with input of 'foo@example.org'
 - Will fall back to normal lookup if mail recipient already contains
suffix character

https://community.openproject.com/wp/28828