### PR TITLE
Allow to refresh a work package blocked by 409 conflict

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -550,6 +550,7 @@ en:
       description_options_hide: "Hide options"
       description_options_show: "Show options"
       error:
+        update_conflict_refresh: "Click here to refresh the work package and update to the newest version."
         edit_prohibited: "Editing %{attribute} is blocked for this work package. Either this attribute is derived from relations (e.g, children) or otherwise not configurable."
         format:
           date: "%{attribute} is no valid date - YYYY-MM-DD expected."

--- a/frontend/src/app/components/work-packages/work-package-cache.service.ts
+++ b/frontend/src/app/components/work-packages/work-package-cache.service.ts
@@ -47,7 +47,6 @@ export class WorkPackageCacheService extends StateCacheService<WorkPackageResour
 
   /*@ngInject*/
   constructor(private states:States,
-              private wpNotificationsService:WorkPackageNotificationService,
               private schemaCacheService:SchemaCacheService,
               private apiWorkPackages:ApiWorkPackagesService) {
     super();
@@ -85,24 +84,6 @@ export class WorkPackageCacheService extends StateCacheService<WorkPackageResour
         this.multiState.get(workPackageId).putValue(wp);
       });
     }
-  }
-
-  saveWorkPackage(workPackage:WorkPackageResource):Promise<WorkPackageResource | null> {
-    if (!(workPackage.dirty || workPackage.isNew)) {
-      return Promise.reject<any>(null);
-    }
-
-    return new Promise<WorkPackageResource | null>((resolve, reject) => {
-      return workPackage.save()
-        .then(() => {
-          this.wpNotificationsService.showSave(workPackage);
-          resolve(workPackage);
-        })
-        .catch((error:any) => {
-          this.wpNotificationsService.handleRawError(error, workPackage);
-          reject(workPackage);
-        });
-    });
   }
 
   /**
@@ -150,7 +131,6 @@ export class WorkPackageCacheService extends StateCacheService<WorkPackageResour
     return new Promise<WorkPackageResource>((resolve, reject) => {
 
       const errorAndReject = (error:any) => {
-        this.wpNotificationsService.handleRawError(error);
         reject(error);
       };
 

--- a/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field.component.ts
+++ b/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field.component.ts
@@ -172,7 +172,7 @@ export class WorkPackageEditFieldComponent implements OnInit {
 
     this.activateOnForm()
       .then((handler) => {
-        handler.focus(positionOffset);
+        handler && handler.focus(positionOffset);
       });
 
     return false;

--- a/frontend/src/app/components/wp-edit/wp-notification.service.ts
+++ b/frontend/src/app/components/wp-edit/wp-notification.service.ts
@@ -35,11 +35,13 @@ import {LoadingIndicatorService} from 'core-app/modules/common/loading-indicator
 import {NotificationsService} from 'core-app/modules/common/notifications/notifications.service';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {HttpErrorResponse} from "@angular/common/http";
+import {WorkPackageCacheService} from "core-components/work-packages/work-package-cache.service";
 
 @Injectable()
 export class WorkPackageNotificationService {
   constructor(readonly I18n:I18nService,
               protected $state:StateService,
+              protected wpCacheService:WorkPackageCacheService,
               protected halResourceService:HalResourceService,
               protected NotificationsService:NotificationsService,
               protected loadingIndicator:LoadingIndicatorService) {
@@ -131,6 +133,21 @@ export class WorkPackageNotificationService {
   }
 
   private showCustomError(errorResource:any, workPackage:WorkPackageResource) {
+    if (errorResource.errorIdentifier === 'urn:openproject-org:api:v3:errors:UpdateConflict') {
+      this.NotificationsService.addError({
+        message: errorResource.message,
+        type: 'error',
+        link: {
+          text: this.I18n.t('js.work_packages.error.update_conflict_refresh'),
+          target: () => this.wpCacheService.require(workPackage.id, true)
+        }
+      });
+
+
+      return true;
+    }
+
+
     if (errorResource.errorIdentifier === 'urn:openproject-org:api:v3:errors:PropertyFormatError') {
 
       let attributeName = workPackage.schema[errorResource.details.attribute].name;

--- a/frontend/src/app/modules/fields/edit/edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/edit-field.component.ts
@@ -74,8 +74,8 @@ export class EditFieldComponent extends Field implements OnDestroy {
       )
       .subscribe((changeset) => {
 
-        if (!this.changeset.empty && this.changeset.wpForm.hasValue()) {
-          const fieldSchema = changeset.wpForm.value!.schema[this.name];
+        if (!this.changeset.empty && this.changeset.wpForm) {
+          const fieldSchema = changeset.wpForm!.schema[this.name];
 
           if (!fieldSchema) {
             return handler.deactivate(false);


### PR DESCRIPTION
When a work package has been updated concurrently, there is no way to edit the work package again without refreshing the page or table.

However, we can actually refresh the work package any time we want to allow the user to update. This PR does exactly this in a notification link.

![conflict-update](https://user-images.githubusercontent.com/459462/47923279-49023e80-deb9-11e8-915c-560ff117d62e.gif)


This does not perform any magic regarding local modifications before hitting the conflict, but is primarily targeted at the initial form request (before editing any field).

This PR also cleans up some of the promises that were not correctly rejected up the chain in the case of an error.