### PR TITLE
Add inline-buttons element styles

### DIFF
--- a/app/assets/stylesheets/content/_forms.lsg
+++ b/app/assets/stylesheets/content/_forms.lsg
@@ -1289,3 +1289,17 @@ _with no classes applied (uses default Foundation form styling)_
   </tbody>
 </table>
 ```
+
+# Forms: Inline buttons
+
+```
+<div class="form--field">
+  <div class="form--field-container">
+    <div class="form--field-inline-buttons-container">
+      <button class="form--field-inline-button button -highlight">Highlight</button>
+      <button class="form--field-inline-button button -highlight-inverted">Alternative 1</button>
+      <button class="form--field-inline-button button -highlight-inverted">Alternative 2</button>
+    </div>
+  </div>
+</div>
+```

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -845,6 +845,14 @@ input[readonly].-clickable
   & > [data-tooltip], & > [class^="tooltip--"]
     padding-top: 0.6rem
 
+.form--field-inline-buttons-container
+  .form--field-inline-button
+    margin-right: 0
+    border-radius: 0px
+    background: transparent
+    height: 30px
+    padding: 0 10px
+
 .form--list
   display: flex
   margin: 0


### PR DESCRIPTION
Add styles for inline-buttons element. This is needed on the new pricing page.

<img width="181" alt="bildschirmfoto 2018-11-05 um 10 16 07" src="https://user-images.githubusercontent.com/7457313/47988931-d1642780-e0e3-11e8-8573-12c15d56d1e0.png">
