### PR TITLE
Improve layout for user notification functionality

### DIFF
--- a/app/assets/javascripts/admin_users.js
+++ b/app/assets/javascripts/admin_users.js
@@ -59,8 +59,14 @@
     }
   }
 
+  function on_password_change() {
+    var sendInformationField =  jQuery('.send-information');
+    sendInformationField.toggleClass('-hidden', jQuery(this).val() === '');
+  }
+
   jQuery(function init(){
     jQuery('#user_assign_random_password').change(on_assign_random_password_change);
     jQuery('#user_auth_source_id').on('change.togglePasswordFields', on_auth_source_change);
+    jQuery('#user_password').change(on_password_change);
   });
 })();

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -118,6 +118,18 @@ See docs/COPYRIGHT.rdoc for more details.
                                  container_class: '-middle' %>
           </div>
         <% end %>
+
+        <% if @user.active? -%>
+          <div class="form--field send-information -hidden">
+            <%= styled_label_tag 'send_information', t(:label_send_information) %>
+            <div class="form--field-container">
+              <%= styled_check_box_tag("send_information",
+                                       "1",
+                                       true) %>
+            </div>
+          </div>
+        <% end -%>
+
         <div class="form--field">
           <%= f.check_box :force_password_change,
                           disabled: assign_random_password_enabled %>

--- a/app/views/users/_general.html.erb
+++ b/app/views/users/_general.html.erb
@@ -46,15 +46,6 @@ See docs/COPYRIGHT.rdoc for more details.
                                          autocomplete: 'off' },
                               as: :user do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
-  <% if @user.active? -%>
-    <div class="form--field -no-label">
-      <div class="form--field-container">
-        <label class="form--label-with-check-box">
-          <%= styled_check_box_tag 'send_information', 1, true %>
-          <%= l(:label_send_information) %>
-        </label>
-      </div>
-    </div>
-  <% end -%>
-  <div><%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %></div>
+
+  <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
 <% end %>


### PR DESCRIPTION
Currently in the Admin/User -> Edit section there is a checkbox to notify the user about changes an admin made. There are two problems with this box: First it looks ugly. Second it only sends a notification when the password is changed. 

That is why this PR moves the (beautified) checkbox up to the password section. There it is only visible when the password is changed. 

@ulferts fyi