### PR TITLE
Adjust wiki headlines

### DIFF
--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -30,29 +30,29 @@ div.wiki
   // ------------------- FONT -------------------
 
   font-size: $wiki-default-font-size
-  $wiki-max-heading-font-size: $wiki-default-font-size * 1.5
+  $wiki-max-heading-font-size: $wiki-default-font-size * 1.75
 
-  // this needs to be the same as a normal level 2 heading (see toolbar)
   h1
     font-size: $wiki-max-heading-font-size
   h2
-    font-size: $wiki-max-heading-font-size * 0.93
+    font-size: $wiki-max-heading-font-size * 0.8
   h3
-    font-size: $wiki-max-heading-font-size * 0.86
+    font-size: $wiki-max-heading-font-size * 0.7
   h4
-    font-size: $wiki-max-heading-font-size * 0.79
+    font-size: $wiki-max-heading-font-size * 0.6
   h5
-    font-size: $wiki-max-heading-font-size * 0.72
-  h6
-    font-size: $wiki-max-heading-font-size * 0.65
+    font-size: $wiki-max-heading-font-size * 0.5
 
-  h1, h2, h3, h4, h5, h6
+  h1, h2, h3, h4, h5
     margin: 1em 0
     line-height: 1.5
     font-weight: bold
     color: #555555
     text-transform: none
     border-bottom: 1px dotted #bbbbbb
+
+  h1, h2
+    border-bottom-style: solid
 
 
   // ------------------- TABLES -------------------


### PR DESCRIPTION
Currently the wiki headers all look nearly the same. Part of the reason is the limitation of the highest headline to the toolbar size because it looks strange if the first wiki headline is larger than than the page headline. In this PR I remove this limitation, allowing the wiki headline to become at least a bit larger. Thus we can make the difference between the headlines a bit more visible.

#### Before
<img width="1172" alt="bildschirmfoto 2018-11-12 um 09 19 49" src="https://user-images.githubusercontent.com/7457313/48334930-848ccd80-e65c-11e8-8560-5f6223f11014.png">

#### After 
![bildschirmfoto 2018-11-12 um 09 34 21](https://user-images.githubusercontent.com/7457313/48335528-50b2a780-e65e-11e8-9ff2-1bc12cc69528.png)
