### PR TITLE
[29019] Ensure query-props are correctly encoded

### DIFF
--- a/frontend/src/app/components/routing/ui-router.config.ts
+++ b/frontend/src/app/components/routing/ui-router.config.ts
@@ -103,7 +103,7 @@ export const OPENPROJECT_ROUTES:StateDeclaration[] = [
       projectPath: {type: 'path', value: null, squash: true},
       projects: {type: 'path', value: null, squash: true},
       query_id: {type: 'query', dynamic: true},
-      query_props: {type: 'query', dynamic: true, raw: true }
+      query_props: {type: 'query', dynamic: true }
     }
   },
   {

--- a/frontend/src/app/components/wp-single-view-tabs/overview-tab/overview-tab.component.ts
+++ b/frontend/src/app/components/wp-single-view-tabs/overview-tab/overview-tab.component.ts
@@ -27,7 +27,7 @@
 // ++
 
 import {Component, Inject, OnDestroy} from '@angular/core';
-import {Transition} from '@uirouter/core';
+import {StateService, Transition} from '@uirouter/core';
 import {WorkPackageCacheService} from 'core-components/work-packages/work-package-cache.service';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {componentDestroyed} from 'ng2-rx-componentdestroyed';
@@ -44,10 +44,10 @@ export class WorkPackageOverviewTabComponent implements OnDestroy {
   public tabName = this.I18n.t('js.label_latest_activity');
 
   public constructor(readonly I18n:I18nService,
-                     readonly $transition:Transition,
+                     readonly $state:StateService,
                      readonly wpCacheService:WorkPackageCacheService) {
 
-    this.workPackageId = this.$transition.params('to').workPackageId;
+    this.workPackageId = this.$state.params.workPackageId;
     wpCacheService.loadWorkPackage(this.workPackageId)
       .values$()
       .pipe(

--- a/spec/features/work_packages/table/queries/subject_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/subject_filter_spec.rb
@@ -1,0 +1,75 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Work package filtering by subject', js: true do
+  let(:project) { FactoryBot.create :project, is_public: true }
+  let(:role) { FactoryBot.create :existing_role, permissions: [:view_work_packages] }
+  let(:admin) { FactoryBot.create :admin }
+  let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
+  let(:filters) { ::Components::WorkPackages::Filters.new }
+
+  let!(:wp_match) { FactoryBot.create :work_package, project: project, subject: 'R#1234 Foobar' }
+  let!(:wp_nomatch) { FactoryBot.create :work_package, project: project, subject: 'R!1234 Foobar' }
+
+  before do
+    login_as admin
+  end
+
+
+  it 'shows the one work package filtering for myself' do
+    wp_table.visit!
+    wp_table.expect_work_package_listed(wp_match, wp_nomatch)
+
+    # Add and save query with me filter
+    filters.open
+    filters.remove_filter 'status'
+    filters.add_filter_by('Subject', 'contains', ['R#'])
+
+    wp_table.expect_work_package_not_listed(wp_nomatch)
+    wp_table.expect_work_package_listed(wp_match)
+
+    wp_table.save_as('Subject query')
+    loading_indicator_saveguard
+
+    # Expect correct while saving
+    wp_table.expect_title 'Subject query'
+    query = Query.last
+    expect(query.filters.first.values).to eq ['R#']
+    filters.expect_filter_by('Subject', 'contains', ['R#'])
+
+    # Revisit query
+    wp_table.visit_query query
+    wp_table.expect_work_package_not_listed(wp_nomatch)
+    wp_table.expect_work_package_listed(wp_match)
+
+    filters.open
+    filters.expect_filter_by('Subject', 'contains', ['R#'])
+  end
+end


### PR DESCRIPTION
During the upgrade of ui-router with Angular 5 introduction, the query_props param was marked `raw`, which results in it not being encoded correctly. UI-router then treats control characters such as the
hash as route identifier.

Marked WIP since I'd still want to add a regression spec.

https://community.openproject.com/wp/29019