### PR TITLE
Fix/extract angular modules

### DIFF
--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -7445,7 +7445,7 @@
     "jquery-mockjax": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/jquery-mockjax/-/jquery-mockjax-2.2.2.tgz",
-      "integrity": "sha1-nH0rEDpEz2HJnMeKnueHhQS2CQc=",
+      "integrity": "sha512-stVgUln5bo7g14KjeU45c31nAYlBHAUVBo4JbdoDYIJ3i6Nzlu8mkjKcAviwad9AU1dBEHHpuzA7R6mKcWgvZA==",
       "dev": true,
       "requires": {
         "jquery": ">=1.5.2"
@@ -8541,6 +8541,11 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
       "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0="
+    },
+    "ng-dynamic-component": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ng-dynamic-component/-/ng-dynamic-component-4.0.0.tgz",
+      "integrity": "sha512-EQpT3gIeaz1GUZu063mZinZFMi/w7+Bpgggkm8A5dJffUi8hlBXSAj03z9drDwJEFRC4astfV34FOde4XZ9Ubg=="
     },
     "ng-fullcalendar": {
       "version": "1.7.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,6 +99,7 @@
     "moment-timezone": "^0.5.11",
     "mousetrap": "~1.6.0",
     "ng-fullcalendar": "^1.7.0",
+    "ng-dynamic-component": "^4.0.0",
     "ng2-charts": "^1.1.0",
     "ng2-rx-componentdestroyed": "3.0.0",
     "ngtemplate-loader": "^2.0.1",

--- a/frontend/src/app/angular4-modules.ts
+++ b/frontend/src/app/angular4-modules.ts
@@ -30,202 +30,51 @@ import {PortalModule} from '@angular/cdk/portal';
 import {APP_INITIALIZER, ApplicationRef, Injector, NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {BrowserModule} from '@angular/platform-browser';
-import {TablePaginationComponent} from 'core-app/components/table-pagination/table-pagination.component';
-import {QueryFormDmService} from 'core-app/modules/hal/dm-services/query-form-dm.service';
 import {OpenprojectHalModule} from 'core-app/modules/hal/openproject-hal.module';
-import {ApiWorkPackagesService} from 'core-components/api/api-work-packages/api-work-packages.service';
 
-import {TimezoneService} from 'core-components/datetime/timezone.service';
-import {FilterBooleanValueComponent} from 'core-components/filters/filter-boolean-value/filter-boolean-value.component';
-import {WorkPackageFilterContainerComponent} from 'core-components/filters/filter-container/filter-container.directive';
-import {FilterDateTimeValueComponent} from 'core-components/filters/filter-date-time-value/filter-date-time-value.component';
-import {FilterDateTimesValueComponent} from 'core-components/filters/filter-date-times-value/filter-date-times-value.component';
-import {FilterDateValueComponent} from 'core-components/filters/filter-date-value/filter-date-value.component';
-import {FilterDatesValueComponent} from 'core-components/filters/filter-dates-value/filter-dates-value.component';
-import {FilterIntegerValueComponent} from 'core-components/filters/filter-integer-value/filter-integer-value.component';
-import {FilterStringValueComponent} from 'core-components/filters/filter-string-value/filter-string-value.component';
-import {FilterToggledMultiselectValueComponent} from 'core-components/filters/filter-toggled-multiselect-value/filter-toggled-multiselect-value.component';
-import {QueryFilterComponent} from 'core-components/filters/query-filter/query-filter.component';
-import {QueryFiltersComponent} from 'core-components/filters/query-filters/query-filters.component';
-import {WorkPackageFiltersService} from 'core-components/filters/wp-filters/wp-filters.service';
-import {OpColumnsContextMenu} from 'core-components/op-context-menu/handlers/op-columns-context-menu.directive';
 import {OpContextMenuTrigger} from 'core-components/op-context-menu/handlers/op-context-menu-trigger.directive';
-import {OpSettingsMenuDirective} from 'core-components/op-context-menu/handlers/op-settings-dropdown-menu.directive';
-import {OpTypesContextMenuDirective} from 'core-components/op-context-menu/handlers/op-types-context-menu.directive';
-import {WorkPackageCreateSettingsMenuDirective} from 'core-components/op-context-menu/handlers/wp-create-settings-menu.directive';
-import {WorkPackageStatusDropdownDirective} from 'core-components/op-context-menu/handlers/wp-status-dropdown-menu.directive';
-import {OPContextMenuComponent} from 'core-components/op-context-menu/op-context-menu.component';
 import {OPContextMenuService} from 'core-components/op-context-menu/op-context-menu.service';
-import {WorkPackageSingleContextMenuDirective} from 'core-components/op-context-menu/wp-context-menu/wp-single-context-menu';
 import {OpModalService} from 'core-components/op-modals/op-modal.service';
 import {CurrentProjectService} from 'core-components/projects/current-project.service';
 import {ProjectCacheService} from 'core-components/projects/project-cache.service';
 import {FirstRouteService} from 'core-components/routing/first-route-service';
-import {WorkPackagesFullViewComponent} from 'core-components/routing/wp-full-view/wp-full-view.component';
-import {WorkPackagesListComponent} from 'core-components/routing/wp-list/wp-list.component';
-import {WorkPackageSplitViewComponent} from 'core-components/routing/wp-split-view/wp-split-view.component';
-import {SchemaCacheService} from 'core-components/schemas/schema-cache.service';
 import {States} from 'core-components/states.service';
 import {ExpandableSearchComponent} from 'core-components/expandable-search/expandable-search.component';
 import {PaginationService} from 'core-components/table-pagination/pagination-service';
 import {UserCacheService} from 'core-components/user/user-cache.service';
-import {UserLinkComponent} from 'core-components/user/user-link/user-link.component';
-import {WorkPackageCacheService} from 'core-components/work-packages/work-package-cache.service';
-import {WorkPackageBreadcrumbComponent} from 'core-components/work-packages/wp-breadcrumb/wp-breadcrumb.component';
-import {WorkPackageRelationsCountComponent} from 'core-components/work-packages/wp-relations-count/wp-relations-count.component';
-import {WorkPackageWatchersCountComponent} from 'core-components/work-packages/wp-relations-count/wp-watchers-count.component';
-import {WorkPackageSingleViewComponent} from 'core-components/work-packages/wp-single-view/wp-single-view.component';
-import {WorkPackageSubjectComponent} from 'core-components/work-packages/wp-subject/wp-subject.component';
-import {WorkPackageTypeStatusComponent} from 'core-components/work-packages/wp-type-status/wp-type-status.component';
-import {WorkPackageWatcherButtonComponent} from 'core-components/work-packages/wp-watcher-button/wp-watcher-button.component';
-import {WorkPackageCreateButtonComponent} from 'core-components/wp-buttons/wp-create-button/wp-create-button.component';
-import {WorkPackageDetailsViewButtonComponent} from 'core-components/wp-buttons/wp-details-view-button/wp-details-view-button.component';
-import {WorkPackageFilterButtonComponent} from 'core-components/wp-buttons/wp-filter-button/wp-filter-button.component';
-import {WorkPackageStatusButtonComponent} from 'core-components/wp-buttons/wp-status-button/wp-status-button.component';
-import {WorkPackageTimelineButtonComponent} from 'core-components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component';
-import {ZenModeButtonComponent} from 'core-components/wp-buttons/zen-mode-toggle-button/zen-mode-toggle-button.component';
-import {WorkPackageCopyFullViewComponent} from 'core-components/wp-copy/wp-copy-full-view.component';
-import {WorkPackageCopySplitViewComponent} from 'core-components/wp-copy/wp-copy-split-view.component';
-import {WpCustomActionsComponent} from 'core-components/wp-custom-actions/wp-custom-actions.component';
-import {WpCustomActionComponent} from 'core-components/wp-custom-actions/wp-custom-actions/wp-custom-action.component';
-import {WorkPackageSplitViewToolbarComponent} from 'core-components/wp-details/wp-details-toolbar.component';
-import {WorkPackageEditingService} from 'core-components/wp-edit-form/work-package-editing-service';
-import {WorkPackageEditFieldGroupComponent} from 'core-components/wp-edit/wp-edit-field/wp-edit-field-group.directive';
-import {WorkPackageEditFieldComponent} from 'core-components/wp-edit/wp-edit-field/wp-edit-field.component';
-import {WorkPackageReplacementLabelComponent} from 'core-components/wp-edit/wp-edit-field/wp-replacement-label.component';
-import {WorkPackageNotificationService} from 'core-components/wp-edit/wp-notification.service';
-import {WorkPackageTableAdditionalElementsService} from 'core-components/wp-fast-table/state/wp-table-additional-elements.service';
-import {WorkPackageTableColumnsService} from 'core-components/wp-fast-table/state/wp-table-columns.service';
-import {WorkPackageTableFiltersService} from 'core-components/wp-fast-table/state/wp-table-filters.service';
-import {WorkPackageTableFocusService} from 'core-components/wp-fast-table/state/wp-table-focus.service';
-import {WorkPackageTableGroupByService} from 'core-components/wp-fast-table/state/wp-table-group-by.service';
-import {WorkPackageTableHierarchiesService} from 'core-components/wp-fast-table/state/wp-table-hierarchy.service';
-import {WorkPackageTablePaginationService} from 'core-components/wp-fast-table/state/wp-table-pagination.service';
-import {WorkPackageTableRelationColumnsService} from 'core-components/wp-fast-table/state/wp-table-relation-columns.service';
-import {WorkPackageTableSelection} from 'core-components/wp-fast-table/state/wp-table-selection.service';
-import {WorkPackageTableSortByService} from 'core-components/wp-fast-table/state/wp-table-sort-by.service';
-import {WorkPackageTableSumService} from 'core-components/wp-fast-table/state/wp-table-sum.service';
-import {WorkPackageTableTimelineService} from 'core-components/wp-fast-table/state/wp-table-timeline.service';
-import {WorkPackageInlineCreateComponent} from 'core-components/wp-inline-create/wp-inline-create.component';
-import {KeepTabService} from 'core-components/wp-single-view-tabs/keep-tab/keep-tab.service';
-import {WpResizerDirective} from 'core-components/resizer/wp-resizer.component';
 import {MainMenuResizerComponent} from 'core-components/resizer/main-menu-resizer.component';
 import {WorkPackageFormAttributeGroupComponent} from 'core-components/wp-form-group/wp-attribute-group.component';
-import {WorkPackagesListChecksumService} from 'core-components/wp-list/wp-list-checksum.service';
-import {WorkPackagesListInvalidQueryService} from 'core-components/wp-list/wp-list-invalid-query.service';
-import {WorkPackagesListService} from 'core-components/wp-list/wp-list.service';
-import {WorkPackageStaticQueriesService} from 'core-components/wp-query-select/wp-static-queries.service';
-import {WorkPackageStatesInitializationService} from 'core-components/wp-list/wp-states-initialization.service';
-import {WorkPackageCreateService} from 'core-components/wp-new/wp-create.service';
-import {WorkPackageNewFullViewComponent} from 'core-components/wp-new/wp-new-full-view.component';
-import {WorkPackageNewSplitViewComponent} from 'core-components/wp-new/wp-new-split-view.component';
-import {WorkPackageQuerySelectDropdownComponent} from 'core-components/wp-query-select/wp-query-select-dropdown.component';
-import {WorkPackageQuerySelectableTitleComponent} from 'core-components/wp-query-select/wp-query-selectable-title.component';
 import {UrlParamsHelperService} from 'core-components/wp-query/url-params-helper';
-import {WorkPackageRelationsHierarchyComponent} from 'core-components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.directive';
-import {WorkPackageRelationsHierarchyService} from 'core-components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service';
-import {WorkPackageRelationsService} from 'core-components/wp-relations/wp-relations.service';
-import {NewestActivityOnOverviewComponent} from 'core-components/wp-single-view-tabs/activity-panel/activity-on-overview.component';
-import {WorkPackageActivityTabComponent} from 'core-components/wp-single-view-tabs/activity-panel/activity-tab.component';
-import {WorkPackagesActivityService} from 'core-components/wp-single-view-tabs/activity-panel/wp-activity.service';
-import {WorkPackageOverviewTabComponent} from 'core-components/wp-single-view-tabs/overview-tab/overview-tab.component';
-import {WorkPackageRelationsTabComponent} from 'core-components/wp-single-view-tabs/relations-tab/relations-tab.component';
-import {WorkPackageWatchersTabComponent} from 'core-components/wp-single-view-tabs/watchers-tab/watchers-tab.component';
-import {WorkPackageWatcherEntryComponent} from 'core-components/wp-single-view-tabs/watchers-tab/wp-watcher-entry.component';
-import {WorkPackageWatchersService} from 'core-components/wp-single-view-tabs/watchers-tab/wp-watchers.service';
-import {WpTableConfigurationColumnsTab} from 'core-components/wp-table/configuration-modal/tabs/columns-tab.component';
-import {WpTableConfigurationDisplaySettingsTab} from 'core-components/wp-table/configuration-modal/tabs/display-settings-tab.component';
-import {WpTableConfigurationFiltersTab} from 'core-components/wp-table/configuration-modal/tabs/filters-tab.component';
-import {WpTableConfigurationSortByTab} from 'core-components/wp-table/configuration-modal/tabs/sort-by-tab.component';
-import {WpTableConfigurationTimelinesTab} from 'core-components/wp-table/configuration-modal/tabs/timelines-tab.component';
-import {WpTableConfigurationModalComponent} from 'core-components/wp-table/configuration-modal/wp-table-configuration.modal';
-import {WpTableConfigurationService} from 'core-components/wp-table/configuration-modal/wp-table-configuration.service';
-import {WorkPackageContextMenuHelperService} from 'core-components/wp-table/context-menu-helper/wp-context-menu-helper.service';
-import {WorkPackageEmbeddedTableComponent} from 'core-components/wp-table/embedded/wp-embedded-table.component';
-import {SortHeaderDirective} from 'core-components/wp-table/sort-header/sort-header.directive';
-import {OpTableActionsService} from 'core-components/wp-table/table-actions/table-actions.service';
-import {WorkPackageTablePaginationComponent} from 'core-components/wp-table/table-pagination/wp-table-pagination.component';
-import {TableState} from 'core-components/wp-table/table-state/table-state';
-import {WorkPackageTimelineTableController} from 'core-components/wp-table/timeline/container/wp-timeline-container.directive';
-import {WorkPackageTableTimelineRelations} from 'core-components/wp-table/timeline/global-elements/wp-timeline-relations.directive';
-import {WorkPackageTableTimelineStaticElements} from 'core-components/wp-table/timeline/global-elements/wp-timeline-static-elements.directive';
-import {WorkPackageTableTimelineGrid} from 'core-components/wp-table/timeline/grid/wp-timeline-grid.directive';
-import {WorkPackageTimelineHeaderController} from 'core-components/wp-table/timeline/header/wp-timeline-header.directive';
-import {WorkPackageTableRefreshService} from 'core-components/wp-table/wp-table-refresh-request.service';
-import {WorkPackageTableSumsRowController} from 'core-components/wp-table/wp-table-sums-row/wp-table-sums-row.directive';
-import {WorkPackagesTableController} from 'core-components/wp-table/wp-table.directive';
-import {ExternalQueryConfigurationComponent} from 'core-components/wp-table/external-configuration/external-query-configuration.component';
 import {ExternalQueryConfigurationService} from 'core-components/wp-table/external-configuration/external-query-configuration.service';
-import {WpTableExportModal} from "core-components/modals/export-modal/wp-table-export.modal";
 import {ConfirmDialogModal} from "core-components/modals/confirm-dialog/confirm-dialog.modal";
 import {ConfirmDialogService} from "core-components/modals/confirm-dialog/confirm-dialog.service";
 import {DynamicContentModal} from "core-components/modals/modal-wrapper/dynamic-content.modal";
 import {PasswordConfirmationModal} from "core-components/modals/request-for-confirmation/password-confirmation.modal";
-import {QuerySharingModal} from "core-components/modals/share-modal/query-sharing.modal";
-import {SaveQueryModal} from "core-components/modals/save-modal/save-query.modal";
-import {QuerySharingForm} from "core-components/modals/share-modal/query-sharing-form.component";
-import {WpDestroyModal} from "core-components/modals/wp-destroy-modal/wp-destroy.modal";
 import {WorkPackageChildrenQueryComponent} from 'core-components/wp-relations/wp-relation-children/wp-children-query.component';
 import {OpTitleService} from 'core-components/html/op-title.service';
-import {WorkPackageRelationsComponent} from "core-components/wp-relations/wp-relations.component";
-import {WorkPackageRelationsGroupComponent} from "core-components/wp-relations/wp-relations-group/wp-relations-group.component";
-import {WorkPackageRelationRowComponent} from "core-components/wp-relations/wp-relation-row/wp-relation-row.component";
-import {WorkPackageRelationsCreateComponent} from "core-components/wp-relations/wp-relations-create/wp-relations-create.component";
-import {WpRelationsAutocompleteComponent} from "core-components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.upgraded.component";
 import {OpenprojectFieldsModule} from "core-app/modules/fields/openproject-fields.module";
 import {OpenprojectCommonModule} from "core-app/modules/common/openproject-common.module";
 import {OpenprojectAccessibilityModule} from "core-app/modules/a11y/openproject-a11y.module";
-import {ActivityEntryComponent} from "core-components/wp-activity/activity-entry.component";
-import {UserActivityComponent} from "core-components/wp-activity/user/user-activity.component";
-import {ActivityLinkComponent} from "core-components/wp-activity/activity-link.component";
-import {RevisionActivityComponent} from "core-components/wp-activity/revision/revision-activity.component";
 import {CommentService} from "core-components/wp-activity/comment-service";
-import {WorkPackageCommentComponent} from "core-components/work-packages/work-package-comment/work-package-comment.component";
 import {OpDragScrollDirective} from "core-app/modules/common/ui/op-drag-scroll.directive";
 import {UIRouterModule} from "@uirouter/angular";
 import {initializeUiRouterConfiguration} from "core-components/routing/ui-router.config";
-import {WorkPackagesBaseComponent} from "core-components/routing/main/work-packages-base.component";
-import {WorkPackageService} from "core-components/work-packages/work-package.service";
 import {OpenprojectPluginsModule} from "core-app/modules/plugins/openproject-plugins.module";
 import {ConfirmFormSubmitController} from "core-components/modals/confirm-form-submit/confirm-form-submit.directive";
 import {ProjectMenuAutocompleteComponent} from "core-components/projects/project-menu-autocomplete/project-menu-autocomplete.component";
 import {MainMenuToggleComponent} from "core-components/resizer/main-menu-toggle.component";
 import {MainMenuToggleService} from "core-components/resizer/main-menu-toggle.service";
-import {IWorkPackageCreateServiceToken} from "core-components/wp-new/wp-create.service.interface";
-import {IWorkPackageEditingServiceToken} from "core-components/wp-edit-form/work-package-editing.service.interface";
 import {OpenProjectFileUploadService} from "core-components/api/op-file-upload/op-file-upload.service";
 import {AttributeHelpTextModal} from "./modules/common/help-texts/attribute-help-text.modal";
-import {WorkPackageEmbeddedTableEntryComponent} from "core-components/wp-table/embedded/wp-embedded-table-entry.component";
 import {LinkedPluginsModule} from "core-app/modules/plugins/linked-plugins.module";
 import {HookService} from "core-app/modules/plugins/hook-service";
 import {ModalWrapperAugmentService} from "core-app/globals/augmenting/modal-wrapper.augment.service";
-import {EmbeddedTablesMacroComponent} from "core-components/wp-table/embedded/embedded-tables-macro.component";
-import {WpButtonMacroModal} from "core-components/modals/editor/macro-wp-button-modal/wp-button-macro.modal";
 import {EditorMacrosService} from "core-components/modals/editor/editor-macros.service";
-import {WikiIncludePageMacroModal} from "core-components/modals/editor/macro-wiki-include-page-modal/wiki-include-page-macro.modal";
-import {CodeBlockMacroModal} from "core-components/modals/editor/macro-code-block-modal/code-block-macro.modal";
 import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
-import {ChildPagesMacroModal} from "core-components/modals/editor/macro-child-pages-modal/child-pages-macro.modal";
-import {AttachmentListComponent} from 'core-components/attachments/attachment-list/attachment-list.component';
-import {AttachmentListItemComponent} from 'core-components/attachments/attachment-list/attachment-list-item.component';
-import {AttachmentsUploadComponent} from 'core-components/attachments/attachments-upload/attachments-upload.component';
-import {AttachmentsComponent} from 'core-components/attachments/attachments.component';
 import {CurrentUserService} from 'core-components/user/current-user.service';
-import {CkeditorAugmentedTextareaComponent} from "core-app/ckeditor/ckeditor-augmented-textarea.component";
-import {WpTableConfigurationHighlightingTab} from "core-components/wp-table/configuration-modal/tabs/highlighting-tab.component";
-import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
-import {ChartsModule} from "ng2-charts";
-import {WorkPackageEmbeddedGraphComponent} from "core-components/wp-table/embedded/wp-embedded-graph.component";
-import {WorkPackageByVersionGraphComponent} from "core-components/wp-by-version-graph/wp-by-version-graph.component";
-import {WorkPackageInlineCreateService} from "core-components/wp-inline-create/wp-inline-create.service";
-import {WorkPackageCommentFieldComponent} from "core-components/work-packages/work-package-comment/wp-comment-field.component";
-import {WorkPackageInlineAddExistingChildService} from "core-components/wp-relations/wp-relation-add-child/wp-inline-add-existing-child.service";
-import {WorkPackageInlineAddExistingChildComponent} from "core-components/wp-relations/wp-relation-add-child/wp-inline-add-existing-child.component";
-import {WorkPackagesCalendarComponent} from './components/routing/wp-calendar/wp.calendar.component';
-import {FullCalendarModule} from 'ng-fullcalendar';
-import {WorkPackagesCalendarController} from "core-components/wp-calendar/wp-calendar.component";
-import {WorkPackagesEmbeddedCalendarEntryComponent} from "core-components/wp-table/embedded/wp-embedded-calendar-entry.component";
-import {WorkPackageBreadcrumbParentComponent} from './components/work-packages/wp-breadcrumb/wp-breadcrumb-parent.component';
+import {OpenprojectWorkPackagesModule} from 'core-app/modules/work_packages/openproject-work-packages.module';
+import {OpenprojectAttachmentsModule} from 'core-app/modules/attachments/openproject-attachments.module';
+import {OpenprojectEditorModule} from 'core-app/modules/editor/openproject-editor.module';
 
 @NgModule({
   imports: [
@@ -241,16 +90,18 @@ import {WorkPackageBreadcrumbParentComponent} from './components/work-packages/w
     OpenprojectAccessibilityModule,
     // Hal Module
     OpenprojectHalModule,
+
+    // CKEditor
+    OpenprojectEditorModule,
     // Display + Edit field functionality
     OpenprojectFieldsModule,
+
+    OpenprojectAttachmentsModule,
+    OpenprojectWorkPackagesModule,
     // Plugin hooks and modules
     OpenprojectPluginsModule,
     // Linked plugins dynamically generated by bundler
     LinkedPluginsModule,
-    // Rendering charts
-    ChartsModule,
-    // Calendar component
-    FullCalendarModule
   ],
   providers: [
     {
@@ -266,226 +117,41 @@ import {WorkPackageBreadcrumbParentComponent} from './components/work-packages/w
       multi: true
     },
     OpTitleService,
-    TimezoneService,
-    WorkPackageRelationsService,
     UrlParamsHelperService,
-    WorkPackageCacheService,
-    SchemaCacheService,
     ProjectCacheService,
     UserCacheService,
     CurrentUserService,
     {provide: States, useValue: new States()},
     PaginationService,
-    KeepTabService,
-    WorkPackageNotificationService,
-    WorkPackagesListChecksumService,
-    WorkPackageRelationsHierarchyService,
-    WorkPackageFiltersService,
-    WorkPackageService,
-    ApiWorkPackagesService,
     OpenProjectFileUploadService,
-    // Table and query states services
-    WorkPackageTableRelationColumnsService,
-    WorkPackageTablePaginationService,
-    WorkPackageTableGroupByService,
-    WorkPackageTableHierarchiesService,
-    WorkPackageTableSortByService,
-    WorkPackageTableColumnsService,
-    WorkPackageTableFiltersService,
-    WorkPackageTableTimelineService,
-    WorkPackageTableSumService,
-    WorkPackageTableHighlightingService,
-    WorkPackageStatesInitializationService,
-    WorkPackagesListService,
-    WorkPackageStaticQueriesService,
-    WorkPackageTableRefreshService,
-    WorkPackageTableAdditionalElementsService,
-    WorkPackagesListInvalidQueryService,
-    WorkPackageTableFocusService,
-    WorkPackageTableSelection,
-
-    // Provide both serves with tokens to avoid tight dependency cycles
-    { provide: IWorkPackageCreateServiceToken, useClass: WorkPackageCreateService },
-    { provide: IWorkPackageEditingServiceToken, useClass: WorkPackageEditingService },
-
-    // Provide a separate service for creation events of WP Inline create
-    // This can be hierarchically injected to provide isolated events on an embedded table
-    WorkPackageInlineCreateService,
-    WorkPackageInlineAddExistingChildService,
-
-    OpTableActionsService,
     CurrentProjectService,
     FirstRouteService,
     // Split view
     CommentService,
-    WorkPackagesActivityService,
-    WorkPackageWatchersService,
     // Context menus
     OPContextMenuService,
-    WorkPackageContextMenuHelperService,
-    QueryFormDmService,
-    TableState,
-
     // OP Modals service
     OpModalService,
-    WpTableConfigurationService,
     ConfirmDialogService,
-
-    // CKEditor
-    EditorMacrosService,
 
     // Main Menu
     MainMenuToggleService,
-
-    // External query configuration
-    ExternalQueryConfigurationService,
 
     // Augmenting Rails
     ModalWrapperAugmentService,
   ],
   declarations: [
     ConfirmFormSubmitController,
-    WorkPackagesBaseComponent,
-    WorkPackagesListComponent,
-    WorkPackagesCalendarComponent,
     OpContextMenuTrigger,
-    TablePaginationComponent,
-    WorkPackageTablePaginationComponent,
-    WorkPackageTimelineHeaderController,
-    WorkPackageTableTimelineRelations,
-    WorkPackageTableTimelineStaticElements,
-    WorkPackageTableTimelineGrid,
-    WorkPackageTimelineTableController,
-    WorkPackagesTableController,
-    WorkPackageCreateButtonComponent,
-    WorkPackageFilterButtonComponent,
-    WorkPackageDetailsViewButtonComponent,
-    WorkPackageTimelineButtonComponent,
-    ZenModeButtonComponent,
-    WpResizerDirective,
     MainMenuResizerComponent,
-    WorkPackageTableSumsRowController,
-    SortHeaderDirective,
-
-    // Query filters
-    WorkPackageFilterContainerComponent,
-    QueryFiltersComponent,
-    QueryFilterComponent,
-    FilterBooleanValueComponent,
-    FilterDateValueComponent,
-    FilterDatesValueComponent,
-    FilterDateTimeValueComponent,
-    FilterDateTimesValueComponent,
-    FilterIntegerValueComponent,
-    FilterStringValueComponent,
-    FilterToggledMultiselectValueComponent,
-
-
-    // Split view
-    WorkPackageSplitViewComponent,
-    WorkPackageRelationsCountComponent,
-    WorkPackageWatchersCountComponent,
-    WorkPackageBreadcrumbComponent,
-    WorkPackageBreadcrumbParentComponent,
-    WorkPackageEditFieldGroupComponent,
-    WorkPackageSplitViewToolbarComponent,
-    WorkPackageWatcherButtonComponent,
-    WorkPackageSubjectComponent,
-
-    // Full view
-    WorkPackagesFullViewComponent,
-
-    // Single view
-    WorkPackageOverviewTabComponent,
-    WorkPackageSingleViewComponent,
-    WorkPackageStatusButtonComponent,
-    WorkPackageReplacementLabelComponent,
-    UserLinkComponent,
-    WorkPackageChildrenQueryComponent,
-    WorkPackageFormAttributeGroupComponent,
-
-    // Activity Tab
-    NewestActivityOnOverviewComponent,
-    WorkPackageCommentComponent,
-    WorkPackageCommentFieldComponent,
-    ActivityEntryComponent,
-    UserActivityComponent,
-    RevisionActivityComponent,
-    ActivityLinkComponent,
-    WorkPackageActivityTabComponent,
-
-    // Relations Tab
-    WorkPackageRelationsTabComponent,
-    WorkPackageRelationsComponent,
-    WorkPackageRelationsGroupComponent,
-    WorkPackageRelationRowComponent,
-    WorkPackageRelationsCreateComponent,
-    WorkPackageRelationsHierarchyComponent,
-    WpRelationsAutocompleteComponent,
-
-    // Watchers tab
-    WorkPackageWatchersTabComponent,
-    WorkPackageWatcherEntryComponent,
 
     // Searchbar
     ExpandableSearchComponent,
 
-    // WP Edit Fields
-    WorkPackageEditFieldComponent,
-
-    // WP New
-    WorkPackageNewFullViewComponent,
-    WorkPackageNewSplitViewComponent,
-    WorkPackageTypeStatusComponent,
-
-    // WP Copy
-    WorkPackageCopyFullViewComponent,
-    WorkPackageCopySplitViewComponent,
-
-    // Context menus
-    OpTypesContextMenuDirective,
-    OPContextMenuComponent,
-    OpColumnsContextMenu,
-    OpSettingsMenuDirective,
-    WorkPackageStatusDropdownDirective,
-    WorkPackageCreateSettingsMenuDirective,
-    WorkPackageSingleContextMenuDirective,
-    WorkPackageQuerySelectableTitleComponent,
-    WorkPackageQuerySelectDropdownComponent,
-
-    // Inline create
-    WorkPackageInlineCreateComponent,
-    WorkPackageInlineAddExistingChildComponent,
-
-    // Embedded table
-    WorkPackageEmbeddedTableComponent,
-    WorkPackageEmbeddedTableEntryComponent,
-    // Embedded graphs
-    WorkPackageEmbeddedGraphComponent,
-
     // Modals
-    WpTableConfigurationModalComponent,
-    WpTableConfigurationColumnsTab,
-    WpTableConfigurationDisplaySettingsTab,
-    WpTableConfigurationFiltersTab,
-    WpTableConfigurationSortByTab,
-    WpTableConfigurationTimelinesTab,
-    WpTableConfigurationHighlightingTab,
-    WpTableExportModal,
     ConfirmDialogModal,
     DynamicContentModal,
     PasswordConfirmationModal,
-    QuerySharingModal,
-    SaveQueryModal,
-    QuerySharingForm,
-    WpDestroyModal,
-    WpButtonMacroModal,
-    WikiIncludePageMacroModal,
-    CodeBlockMacroModal,
-    ChildPagesMacroModal,
-
-    // External query configuration
-    ExternalQueryConfigurationComponent,
 
     // Main menu
     MainMenuResizerComponent,
@@ -496,126 +162,23 @@ import {WorkPackageBreadcrumbParentComponent} from './components/work-packages/w
 
     // Form configuration
     OpDragScrollDirective,
-
-    // CKEditor and Macros
-    EmbeddedTablesMacroComponent,
-    CkeditorAugmentedTextareaComponent,
-
-    // CustomActions
-    WpCustomActionComponent,
-    WpCustomActionsComponent,
-
-    // Attachments
-    AttachmentsComponent,
-    AttachmentListComponent,
-    AttachmentListItemComponent,
-    AttachmentsUploadComponent,
-
-    // Work package graphs on version page
-    WorkPackageByVersionGraphComponent,
-
-    // Work package calendars
-    WorkPackagesCalendarController,
-    WorkPackagesEmbeddedCalendarEntryComponent
   ],
   entryComponents: [
-    WorkPackagesBaseComponent,
-    WorkPackagesListComponent,
-    WorkPackagesCalendarComponent,
-    WorkPackagesEmbeddedCalendarEntryComponent,
-    WorkPackageTablePaginationComponent,
-    WorkPackagesTableController,
-    TablePaginationComponent,
-
-    // Split view
-    WorkPackageSplitViewComponent,
-
-    // Full view
-    WorkPackagesFullViewComponent,
-
-    // Single view tabs
-    WorkPackageActivityTabComponent,
-    WorkPackageRelationsTabComponent,
-    WorkPackageWatchersTabComponent,
-
-    // Single view
-    WorkPackageOverviewTabComponent,
-    WorkPackageEditFieldGroupComponent,
-    WorkPackageCommentFieldComponent,
-
-    // Inline create
-    WorkPackageInlineAddExistingChildComponent,
-
     // Searchbar
     ExpandableSearchComponent,
 
     // Project Auto completer
     ProjectMenuAutocompleteComponent,
 
-    // WP new
-    WorkPackageNewFullViewComponent,
-    WorkPackageNewSplitViewComponent,
-
-    // WP copy
-    WorkPackageCopyFullViewComponent,
-    WorkPackageCopySplitViewComponent,
-
-    OPContextMenuComponent,
-    WorkPackageQuerySelectDropdownComponent,
-
-    // Embedded table
-    WorkPackageEmbeddedTableComponent,
-    WorkPackageEmbeddedTableEntryComponent,
-
-    // Embedded calendar
-    WorkPackagesCalendarController,
-
-    // Relations tab (ng1 -> ng2)
-    WorkPackageRelationsHierarchyComponent,
-
     // Modals
-    WpTableConfigurationModalComponent,
-    WpTableConfigurationColumnsTab,
-    WpTableConfigurationDisplaySettingsTab,
-    WpTableConfigurationFiltersTab,
-    WpTableConfigurationSortByTab,
-    WpTableConfigurationTimelinesTab,
-    WpTableConfigurationHighlightingTab,
-    WpTableExportModal,
     DynamicContentModal,
     ConfirmDialogModal,
     PasswordConfirmationModal,
-    QuerySharingModal,
-    SaveQueryModal,
-    WpDestroyModal,
     AttributeHelpTextModal,
-    WpButtonMacroModal,
-    WikiIncludePageMacroModal,
-    CodeBlockMacroModal,
-    ChildPagesMacroModal,
-
-    // External query configuration
-    ExternalQueryConfigurationComponent,
 
     // Main menu
     MainMenuResizerComponent,
     MainMenuToggleComponent,
-
-    // CKEditor and macros
-    CkeditorAugmentedTextareaComponent,
-    EmbeddedTablesMacroComponent,
-
-    // CustomActions
-    WpCustomActionsComponent,
-
-    // Attachments
-    AttachmentsComponent,
-
-    // Zen mode button
-    ZenModeButtonComponent,
-
-    // Work package graphs on version page
-    WorkPackageByVersionGraphComponent,
   ]
 })
 export class OpenProjectModule {

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
@@ -38,13 +38,12 @@ import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-r
 import {WorkPackageEditingService} from '../../wp-edit-form/work-package-editing-service';
 import {WorkPackageCacheService} from '../work-package-cache.service';
 import {input, InputState} from 'reactivestates';
-import {DisplayFieldService} from "core-app/modules/fields/display/display-field.service";
-import {DisplayField} from "core-app/modules/fields/display/display-field.module";
-import {QueryResource} from "core-app/modules/hal/resources/query-resource";
-import {IWorkPackageEditingServiceToken} from "../../wp-edit-form/work-package-editing.service.interface";
-import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
-import {WorkPackageInlineHighlightingService} from "core-components/wp-fast-table/state/wp-table-inline-highlighting.service";
-import {DynamicCssService} from "../../../modules/common/dynamic-css/dynamic-css.service";
+import {DisplayFieldService} from 'core-app/modules/fields/display/display-field.service';
+import {DisplayField} from 'core-app/modules/fields/display/display-field.module';
+import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
+import {IWorkPackageEditingServiceToken} from '../../wp-edit-form/work-package-editing.service.interface';
+import {DynamicCssService} from '../../../modules/common/dynamic-css/dynamic-css.service';
+import {HookService} from 'core-app/modules/plugins/hook-service';
 
 export interface FieldDescriptor {
   name:string;
@@ -120,7 +119,8 @@ export class WorkPackageSingleViewComponent implements OnInit, OnDestroy {
               protected dynamicCssService:DynamicCssService,
               @Inject(IWorkPackageEditingServiceToken) protected wpEditing:WorkPackageEditingService,
               protected displayFieldService:DisplayFieldService,
-              protected wpCacheService:WorkPackageCacheService) {
+              protected wpCacheService:WorkPackageCacheService,
+              protected hook:HookService) {
   }
 
   public ngOnInit() {
@@ -195,6 +195,12 @@ export class WorkPackageSingleViewComponent implements OnInit, OnDestroy {
    */
   public trackByName(_index:number, elem:{ name:string }) {
     return elem.name;
+  }
+
+  public attributeGroupComponent(group:GroupDescriptor) {
+    // we take the last registered group component which means that
+    // plugins will have their say if they register for it.
+    return this.hook.call('attributeGroupComponent', group, this.workPackage).pop() || null;
   }
 
   /*

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
@@ -29,7 +29,7 @@
       <op-date-time [dateTimeValue]="workPackage.updatedAt"></op-date-time>.
      </div>
 
-    <wp-custom-actions [workPackage]="workPackage"class="custom-actions"></wp-custom-actions>
+    <wp-custom-actions [workPackage]="workPackage" class="custom-actions"></wp-custom-actions>
   </div>
 
   <div class="attributes-group -project-context"
@@ -101,14 +101,11 @@
       </div>
     </div>
 
-    <wp-attribute-group *ngIf="group.type === 'WorkPackageFormAttributeGroup'"
-                        [workPackage]="workPackage"
-                        [group]="group">
-    </wp-attribute-group>
-    <wp-children-query *ngIf="!workPackage.isNew && group.type === 'WorkPackageFormQueryGroup'"
-                    [workPackage]="workPackage"
-                    [query]="group.query">
-    </wp-children-query>
+    <ndc-dynamic [ndcDynamicComponent]="attributeGroupComponent(group)"
+                 [ndcDynamicInputs]="{ workPackage: workPackage,
+                                       group: group,
+                                       query: group.query }" >
+    </ndc-dynamic>
   </div>
 </div>
 

--- a/frontend/src/app/components/wp-form-group/wp-attribute-group.component.ts
+++ b/frontend/src/app/components/wp-form-group/wp-attribute-group.component.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, Inject, Input} from '@angular/core';
+import {Component, Input} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {WorkPackageEditFieldGroupComponent} from 'core-components/wp-edit/wp-edit-field/wp-edit-field-group.directive';
 import {

--- a/frontend/src/app/modules/attachments/openproject-attachments.module.ts
+++ b/frontend/src/app/modules/attachments/openproject-attachments.module.ts
@@ -1,0 +1,64 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {AttachmentsComponent} from 'core-components/attachments/attachments.component';
+import {AttachmentListComponent} from 'core-components/attachments/attachment-list/attachment-list.component';
+import {AttachmentListItemComponent} from 'core-components/attachments/attachment-list/attachment-list-item.component';
+import {AttachmentsUploadComponent} from 'core-components/attachments/attachments-upload/attachments-upload.component';
+import {NgModule} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {BrowserModule} from '@angular/platform-browser';
+import {OpenprojectCommonModule} from 'core-app/modules/common/openproject-common.module';
+
+@NgModule({
+  imports: [
+    FormsModule,
+    BrowserModule,
+
+    OpenprojectCommonModule,
+  ],
+  providers: [
+  ],
+  declarations: [
+    AttachmentsComponent,
+    AttachmentListComponent,
+    AttachmentListItemComponent,
+    AttachmentsUploadComponent,
+  ],
+  entryComponents: [
+    AttachmentsComponent,
+  ],
+  exports: [
+    AttachmentsUploadComponent,
+    AttachmentListComponent,
+    AttachmentsComponent,
+  ]
+})
+export class OpenprojectAttachmentsModule {
+}
+

--- a/frontend/src/app/modules/common/openproject-common.module.ts
+++ b/frontend/src/app/modules/common/openproject-common.module.ts
@@ -65,6 +65,11 @@ import {ColorsAutocompleter} from "core-app/modules/common/colors/colors-autocom
 import {DynamicCssService} from "./dynamic-css/dynamic-css.service";
 import {MultiToggledSelectComponent} from "core-app/modules/common/multi-toggled-select/multi-toggled-select.component";
 import {BannersService} from "core-app/modules/common/enterprise/banners.service";
+import {TablePaginationComponent} from 'core-components/table-pagination/table-pagination.component';
+import {SortHeaderDirective} from 'core-components/wp-table/sort-header/sort-header.directive';
+import {ZenModeButtonComponent} from 'core-components/wp-buttons/zen-mode-toggle-button/zen-mode-toggle-button.component';
+import {OPContextMenuComponent} from 'core-components/op-context-menu/op-context-menu.component';
+import {TimezoneService} from 'core-components/datetime/timezone.service';
 
 export function bootstrapModule(injector:Injector) {
   return () => {
@@ -110,8 +115,12 @@ export function bootstrapModule(injector:Injector) {
     // Multi select component
     MultiToggledSelectComponent,
 
-    // CKEditor
-    OpCkeditorComponent,
+    TablePaginationComponent,
+    SortHeaderDirective,
+
+    ZenModeButtonComponent,
+
+    OPContextMenuComponent,
   ],
   declarations: [
     OpDatePickerComponent,
@@ -131,6 +140,7 @@ export function bootstrapModule(injector:Injector) {
     UploadProgressComponent,
     OpDateTimeComponent,
 
+    OPContextMenuComponent,
     // Entries for ng1 downgraded components
     AttributeHelpTextComponent,
 
@@ -140,13 +150,16 @@ export function bootstrapModule(injector:Injector) {
     // Add functionality to rails rendered templates
     CopyToClipboardDirective,
 
-    // CKEditor
-    OpCkeditorComponent,
-
     CopyToClipboardDirective,
     ColorsAutocompleter,
 
     MultiToggledSelectComponent,
+
+    TablePaginationComponent,
+    SortHeaderDirective,
+
+    // Zen mode button
+    ZenModeButtonComponent,
   ],
   entryComponents: [
     OpDateTimeComponent,
@@ -155,6 +168,10 @@ export function bootstrapModule(injector:Injector) {
     HighlightColDirective,
     HighlightColDirective,
     ColorsAutocompleter,
+
+    TablePaginationComponent,
+
+    OPContextMenuComponent,
   ],
   providers: [
     { provide: APP_INITIALIZER, useFactory: bootstrapModule, deps: [Injector], multi: true },
@@ -169,8 +186,8 @@ export function bootstrapModule(injector:Injector) {
     ConfigurationService,
     PathHelperService,
     HTMLSanitizeService,
-    CKEditorSetupService,
-    CKEditorPreviewService
+
+    TimezoneService,
   ]
 })
 export class OpenprojectCommonModule { }

--- a/frontend/src/app/modules/editor/openproject-editor.module.ts
+++ b/frontend/src/app/modules/editor/openproject-editor.module.ts
@@ -1,0 +1,77 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {NgModule} from '@angular/core';
+import {WikiIncludePageMacroModal} from 'core-components/modals/editor/macro-wiki-include-page-modal/wiki-include-page-macro.modal';
+import {CodeBlockMacroModal} from 'core-components/modals/editor/macro-code-block-modal/code-block-macro.modal';
+import {ChildPagesMacroModal} from 'core-components/modals/editor/macro-child-pages-modal/child-pages-macro.modal';
+import {CkeditorAugmentedTextareaComponent} from 'core-app/ckeditor/ckeditor-augmented-textarea.component';
+import {OpenprojectAttachmentsModule} from 'core-app/modules/attachments/openproject-attachments.module';
+import {OpCkeditorComponent} from 'core-app/modules/common/ckeditor/op-ckeditor.component';
+import {BrowserModule} from '@angular/platform-browser';
+import {FormsModule} from '@angular/forms';
+import {EditorMacrosService} from 'core-components/modals/editor/editor-macros.service';
+import {CKEditorSetupService} from 'core-app/modules/common/ckeditor/ckeditor-setup.service';
+import {CKEditorPreviewService} from 'core-app/modules/common/ckeditor/ckeditor-preview.service';
+
+@NgModule({
+  imports: [
+    FormsModule,
+    BrowserModule,
+    OpenprojectAttachmentsModule
+  ],
+  providers: [
+    // CKEditor
+    EditorMacrosService,
+    CKEditorSetupService,
+    CKEditorPreviewService,
+  ],
+  exports: [
+    CkeditorAugmentedTextareaComponent,
+    OpCkeditorComponent,
+  ],
+  declarations: [
+    // CKEditor and Macros
+    CkeditorAugmentedTextareaComponent,
+    OpCkeditorComponent,
+    WikiIncludePageMacroModal,
+    CodeBlockMacroModal,
+    ChildPagesMacroModal,
+  ],
+  entryComponents: [
+    // CKEditor and macros
+    CkeditorAugmentedTextareaComponent,
+
+    WikiIncludePageMacroModal,
+    CodeBlockMacroModal,
+    ChildPagesMacroModal,
+
+  ]
+})
+export class OpenprojectEditorModule {
+}

--- a/frontend/src/app/modules/fields/openproject-fields.module.ts
+++ b/frontend/src/app/modules/fields/openproject-fields.module.ts
@@ -49,6 +49,7 @@ import {EditFormPortalComponent} from "core-app/modules/fields/edit/editing-port
 import {EditFieldControlsComponent,} from "core-app/modules/fields/edit/field-controls/edit-field-controls.component";
 import {OpenprojectAccessibilityModule} from "core-app/modules/a11y/openproject-a11y.module";
 import {WorkPackageEditFieldComponent} from "core-app/modules/fields/edit/field-types/work-package-edit-field.component";
+import {OpenprojectEditorModule} from 'core-app/modules/editor/openproject-editor.module';
 
 @NgModule({
   imports: [
@@ -56,6 +57,7 @@ import {WorkPackageEditFieldComponent} from "core-app/modules/fields/edit/field-
     BrowserModule,
     OpenprojectCommonModule,
     OpenprojectAccessibilityModule,
+    OpenprojectEditorModule,
   ],
   exports: [
     EditFieldControlsComponent,

--- a/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
@@ -1,0 +1,507 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {WorkPackageChildrenQueryComponent} from 'core-components/wp-relations/wp-relation-children/wp-children-query.component';
+import {FormsModule} from '@angular/forms';
+import {PortalModule} from '@angular/cdk/portal';
+import {OpenprojectCommonModule} from 'core-app/modules/common/openproject-common.module';
+import {WorkPackageFormAttributeGroupComponent} from 'core-components/wp-form-group/wp-attribute-group.component';
+import {OpenprojectAccessibilityModule} from 'core-app/modules/a11y/openproject-a11y.module';
+import {OpenprojectHalModule} from 'core-app/modules/hal/openproject-hal.module';
+import {OpenprojectFieldsModule} from 'core-app/modules/fields/openproject-fields.module';
+import {ChartsModule} from 'ng2-charts';
+import {DynamicModule} from 'ng-dynamic-component';
+import {APP_INITIALIZER, Injector, NgModule, ApplicationRef} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {
+  GroupDescriptor,
+  WorkPackageSingleViewComponent
+} from 'core-components/work-packages/wp-single-view/wp-single-view.component';
+import {HookService} from 'core-app/modules/plugins/hook-service';
+import {WorkPackageEmbeddedTableComponent} from 'core-components/wp-table/embedded/wp-embedded-table.component';
+import {WorkPackageEmbeddedTableEntryComponent} from 'core-components/wp-table/embedded/wp-embedded-table-entry.component';
+import {WorkPackagesTableController} from 'core-components/wp-table/wp-table.directive';
+import {WorkPackageTablePaginationService} from 'core-components/wp-fast-table/state/wp-table-pagination.service';
+import {WorkPackageTablePaginationComponent} from 'core-components/wp-table/table-pagination/wp-table-pagination.component';
+import {WpResizerDirective} from 'core-components/resizer/wp-resizer.component';
+import {WorkPackageTimelineTableController} from 'core-components/wp-table/timeline/container/wp-timeline-container.directive';
+import {WorkPackageInlineCreateComponent} from 'core-components/wp-inline-create/wp-inline-create.component';
+import {WorkPackageInlineAddExistingChildComponent} from 'core-components/wp-relations/wp-relation-add-child/wp-inline-add-existing-child.component';
+import {WpRelationsAutocompleteComponent} from 'core-components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.upgraded.component';
+import {OpTypesContextMenuDirective} from 'core-components/op-context-menu/handlers/op-types-context-menu.directive';
+import {OPContextMenuComponent} from 'core-components/op-context-menu/op-context-menu.component';
+import {OpColumnsContextMenu} from 'core-components/op-context-menu/handlers/op-columns-context-menu.directive';
+import {OpSettingsMenuDirective} from 'core-components/op-context-menu/handlers/op-settings-dropdown-menu.directive';
+import {WorkPackageStatusDropdownDirective} from 'core-components/op-context-menu/handlers/wp-status-dropdown-menu.directive';
+import {WorkPackageCreateSettingsMenuDirective} from 'core-components/op-context-menu/handlers/wp-create-settings-menu.directive';
+import {WorkPackageSingleContextMenuDirective} from 'core-components/op-context-menu/wp-context-menu/wp-single-context-menu';
+import {WorkPackageQuerySelectableTitleComponent} from 'core-components/wp-query-select/wp-query-selectable-title.component';
+import {WorkPackageQuerySelectDropdownComponent} from 'core-components/wp-query-select/wp-query-select-dropdown.component';
+import {WorkPackageTimelineHeaderController} from 'core-components/wp-table/timeline/header/wp-timeline-header.directive';
+import {WorkPackageTableTimelineRelations} from 'core-components/wp-table/timeline/global-elements/wp-timeline-relations.directive';
+import {WorkPackageTableTimelineStaticElements} from 'core-components/wp-table/timeline/global-elements/wp-timeline-static-elements.directive';
+import {WorkPackageTableTimelineGrid} from 'core-components/wp-table/timeline/grid/wp-timeline-grid.directive';
+import {WorkPackageTableTimelineService} from 'core-components/wp-fast-table/state/wp-table-timeline.service';
+import {WorkPackageTimelineButtonComponent} from 'core-components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component';
+import {WorkPackageOverviewTabComponent} from 'core-components/wp-single-view-tabs/overview-tab/overview-tab.component';
+import {WorkPackageStatusButtonComponent} from 'core-components/wp-buttons/wp-status-button/wp-status-button.component';
+import {WorkPackageReplacementLabelComponent} from 'core-components/wp-edit/wp-edit-field/wp-replacement-label.component';
+import {NewestActivityOnOverviewComponent} from 'core-components/wp-single-view-tabs/activity-panel/activity-on-overview.component';
+import {UserLinkComponent} from 'core-components/user/user-link/user-link.component';
+import {WorkPackageCommentComponent} from 'core-components/work-packages/work-package-comment/work-package-comment.component';
+import {WorkPackageCommentFieldComponent} from 'core-components/work-packages/work-package-comment/wp-comment-field.component';
+import {ActivityEntryComponent} from 'core-components/wp-activity/activity-entry.component';
+import {UserActivityComponent} from 'core-components/wp-activity/user/user-activity.component';
+import {RevisionActivityComponent} from 'core-components/wp-activity/revision/revision-activity.component';
+import {ActivityLinkComponent} from 'core-components/wp-activity/activity-link.component';
+import {WorkPackageActivityTabComponent} from 'core-components/wp-single-view-tabs/activity-panel/activity-tab.component';
+import {OpenprojectAttachmentsModule} from 'core-app/modules/attachments/openproject-attachments.module';
+import {WorkPackageEditFieldComponent} from 'core-app/components/wp-edit/wp-edit-field/wp-edit-field.component';
+import {WpCustomActionComponent} from 'core-components/wp-custom-actions/wp-custom-actions/wp-custom-action.component';
+import {WpCustomActionsComponent} from 'core-components/wp-custom-actions/wp-custom-actions.component';
+import {UIRouterModule} from '@uirouter/angular';
+import {WorkPackageSplitViewComponent} from 'core-components/routing/wp-split-view/wp-split-view.component';
+import {WorkPackageRelationsCountComponent} from 'core-components/work-packages/wp-relations-count/wp-relations-count.component';
+import {WorkPackageWatchersCountComponent} from 'core-components/work-packages/wp-relations-count/wp-watchers-count.component';
+import {WorkPackageBreadcrumbComponent} from 'core-components/work-packages/wp-breadcrumb/wp-breadcrumb.component';
+import {WorkPackageEditFieldGroupComponent} from 'core-components/wp-edit/wp-edit-field/wp-edit-field-group.directive';
+import {WorkPackageSplitViewToolbarComponent} from 'core-components/wp-details/wp-details-toolbar.component';
+import {WorkPackageWatcherButtonComponent} from 'core-components/work-packages/wp-watcher-button/wp-watcher-button.component';
+import {WorkPackageSubjectComponent} from 'core-components/work-packages/wp-subject/wp-subject.component';
+import {WorkPackagesFullViewComponent} from 'core-components/routing/wp-full-view/wp-full-view.component';
+import {WorkPackageRelationsTabComponent} from 'core-components/wp-single-view-tabs/relations-tab/relations-tab.component';
+import {WorkPackageRelationsComponent} from 'core-components/wp-relations/wp-relations.component';
+import {WorkPackageRelationsGroupComponent} from 'core-components/wp-relations/wp-relations-group/wp-relations-group.component';
+import {WorkPackageRelationRowComponent} from 'core-components/wp-relations/wp-relation-row/wp-relation-row.component';
+import {WorkPackageRelationsCreateComponent} from 'core-components/wp-relations/wp-relations-create/wp-relations-create.component';
+import {WorkPackageRelationsHierarchyComponent} from 'core-components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.directive';
+import {WorkPackageCreateButtonComponent} from 'core-components/wp-buttons/wp-create-button/wp-create-button.component';
+import {WorkPackagesCalendarController} from 'core-components/wp-calendar/wp-calendar.component';
+import {WorkPackagesEmbeddedCalendarEntryComponent} from 'core-components/wp-table/embedded/wp-embedded-calendar-entry.component';
+import {FullCalendarModule} from 'ng-fullcalendar';
+import {WorkPackagesCalendarComponent} from 'core-components/routing/wp-calendar/wp.calendar.component';
+import {WorkPackageBreadcrumbParentComponent} from 'core-components/work-packages/wp-breadcrumb/wp-breadcrumb-parent.component';
+import {WorkPackageFilterButtonComponent} from 'core-components/wp-buttons/wp-filter-button/wp-filter-button.component';
+import {WorkPackageFilterContainerComponent} from 'core-components/filters/filter-container/filter-container.directive';
+import {QueryFiltersComponent} from 'core-components/filters/query-filters/query-filters.component';
+import {QueryFilterComponent} from 'core-components/filters/query-filter/query-filter.component';
+import {FilterBooleanValueComponent} from 'core-components/filters/filter-boolean-value/filter-boolean-value.component';
+import {FilterDateValueComponent} from 'core-components/filters/filter-date-value/filter-date-value.component';
+import {FilterDatesValueComponent} from 'core-components/filters/filter-dates-value/filter-dates-value.component';
+import {FilterDateTimeValueComponent} from 'core-components/filters/filter-date-time-value/filter-date-time-value.component';
+import {FilterDateTimesValueComponent} from 'core-components/filters/filter-date-times-value/filter-date-times-value.component';
+import {FilterIntegerValueComponent} from 'core-components/filters/filter-integer-value/filter-integer-value.component';
+import {FilterStringValueComponent} from 'core-components/filters/filter-string-value/filter-string-value.component';
+import {FilterToggledMultiselectValueComponent} from 'core-components/filters/filter-toggled-multiselect-value/filter-toggled-multiselect-value.component';
+import {WorkPackagesBaseComponent} from 'core-components/routing/main/work-packages-base.component';
+import {WorkPackagesListComponent} from 'core-components/routing/wp-list/wp-list.component';
+import {WorkPackageDetailsViewButtonComponent} from 'core-components/wp-buttons/wp-details-view-button/wp-details-view-button.component';
+import {WpTableConfigurationModalComponent} from 'core-components/wp-table/configuration-modal/wp-table-configuration.modal';
+import {WpTableConfigurationColumnsTab} from 'core-components/wp-table/configuration-modal/tabs/columns-tab.component';
+import {WpTableConfigurationDisplaySettingsTab} from 'core-components/wp-table/configuration-modal/tabs/display-settings-tab.component';
+import {WpTableConfigurationFiltersTab} from 'core-components/wp-table/configuration-modal/tabs/filters-tab.component';
+import {WpTableConfigurationSortByTab} from 'core-components/wp-table/configuration-modal/tabs/sort-by-tab.component';
+import {WpTableConfigurationTimelinesTab} from 'core-components/wp-table/configuration-modal/tabs/timelines-tab.component';
+import {WpTableConfigurationHighlightingTab} from 'core-components/wp-table/configuration-modal/tabs/highlighting-tab.component';
+import {WorkPackageWatchersTabComponent} from 'core-components/wp-single-view-tabs/watchers-tab/watchers-tab.component';
+import {WorkPackageWatcherEntryComponent} from 'core-components/wp-single-view-tabs/watchers-tab/wp-watcher-entry.component';
+import {WorkPackageCopyFullViewComponent} from 'core-components/wp-copy/wp-copy-full-view.component';
+import {WorkPackageCopySplitViewComponent} from 'core-components/wp-copy/wp-copy-split-view.component';
+import {WorkPackageTypeStatusComponent} from 'core-components/work-packages/wp-type-status/wp-type-status.component';
+import {WorkPackageNewSplitViewComponent} from 'core-components/wp-new/wp-new-split-view.component';
+import {WorkPackageNewFullViewComponent} from 'core-components/wp-new/wp-new-full-view.component';
+import {WpTableExportModal} from 'core-components/modals/export-modal/wp-table-export.modal';
+import {QuerySharingModal} from 'core-components/modals/share-modal/query-sharing.modal';
+import {SaveQueryModal} from 'core-components/modals/save-modal/save-query.modal';
+import {WpDestroyModal} from 'core-components/modals/wp-destroy-modal/wp-destroy.modal';
+import {QuerySharingForm} from 'core-components/modals/share-modal/query-sharing-form.component';
+import {WorkPackageEmbeddedGraphComponent} from 'core-components/wp-table/embedded/wp-embedded-graph.component';
+import {WorkPackageByVersionGraphComponent} from 'core-components/wp-by-version-graph/wp-by-version-graph.component';
+import {EmbeddedTablesMacroComponent} from 'core-components/wp-table/embedded/embedded-tables-macro.component';
+import {WpButtonMacroModal} from 'core-components/modals/editor/macro-wp-button-modal/wp-button-macro.modal';
+import {OpenprojectEditorModule} from 'core-app/modules/editor/openproject-editor.module';
+import {WorkPackageTableSumsRowController} from 'core-components/wp-table/wp-table-sums-row/wp-table-sums-row.directive';
+import {ExternalQueryConfigurationComponent} from 'core-components/wp-table/external-configuration/external-query-configuration.component';
+import {ExternalQueryConfigurationService} from 'core-components/wp-table/external-configuration/external-query-configuration.service';
+import {WorkPackageTableRelationColumnsService} from 'core-components/wp-fast-table/state/wp-table-relation-columns.service';
+import {WorkPackageTableGroupByService} from 'core-components/wp-fast-table/state/wp-table-group-by.service';
+import {WorkPackageTableHierarchiesService} from 'core-components/wp-fast-table/state/wp-table-hierarchy.service';
+import {WorkPackageTableSortByService} from 'core-components/wp-fast-table/state/wp-table-sort-by.service';
+import {WorkPackageTableColumnsService} from 'core-components/wp-fast-table/state/wp-table-columns.service';
+import {WorkPackageTableFiltersService} from 'core-components/wp-fast-table/state/wp-table-filters.service';
+import {WorkPackageTableSumService} from 'core-components/wp-fast-table/state/wp-table-sum.service';
+import {WorkPackageTableHighlightingService} from 'core-components/wp-fast-table/state/wp-table-highlighting.service';
+import {WorkPackageStatesInitializationService} from 'core-components/wp-list/wp-states-initialization.service';
+import {WorkPackagesListService} from 'core-components/wp-list/wp-list.service';
+import {WorkPackageTableAdditionalElementsService} from 'core-components/wp-fast-table/state/wp-table-additional-elements.service';
+import {WorkPackageTableRefreshService} from 'core-components/wp-table/wp-table-refresh-request.service';
+import {WorkPackageStaticQueriesService} from 'core-components/wp-query-select/wp-static-queries.service';
+import {WorkPackagesListInvalidQueryService} from 'core-components/wp-list/wp-list-invalid-query.service';
+import {WorkPackageTableFocusService} from 'core-components/wp-fast-table/state/wp-table-focus.service';
+import {WorkPackageTableSelection} from 'core-components/wp-fast-table/state/wp-table-selection.service';
+import {IWorkPackageCreateServiceToken} from 'core-components/wp-new/wp-create.service.interface';
+import {WorkPackageCreateService} from 'core-components/wp-new/wp-create.service';
+import {WorkPackageEditingService} from 'core-components/wp-edit-form/work-package-editing-service';
+import {IWorkPackageEditingServiceToken} from 'core-components/wp-edit-form/work-package-editing.service.interface';
+import {WorkPackageInlineCreateService} from 'core-components/wp-inline-create/wp-inline-create.service';
+import {WorkPackageInlineAddExistingChildService} from 'core-components/wp-relations/wp-relation-add-child/wp-inline-add-existing-child.service';
+import {OpTableActionsService} from 'core-components/wp-table/table-actions/table-actions.service';
+import {WorkPackageRelationsService} from 'core-components/wp-relations/wp-relations.service';
+import {WorkPackageCacheService} from 'core-components/work-packages/work-package-cache.service';
+import {SchemaCacheService} from 'core-components/schemas/schema-cache.service';
+import {WorkPackageContextMenuHelperService} from 'core-components/wp-table/context-menu-helper/wp-context-menu-helper.service';
+import {WorkPackageWatchersService} from 'core-components/wp-single-view-tabs/watchers-tab/wp-watchers.service';
+import {WorkPackagesActivityService} from 'core-components/wp-single-view-tabs/activity-panel/wp-activity.service';
+import {ApiWorkPackagesService} from 'core-components/api/api-work-packages/api-work-packages.service';
+import {WorkPackageService} from 'core-components/work-packages/work-package.service';
+import {WorkPackageFiltersService} from 'core-components/filters/wp-filters/wp-filters.service';
+import {WorkPackageRelationsHierarchyService} from 'core-components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service';
+import {WorkPackagesListChecksumService} from 'core-components/wp-list/wp-list-checksum.service';
+import {WorkPackageNotificationService} from 'core-components/wp-edit/wp-notification.service';
+import {KeepTabService} from 'core-components/wp-single-view-tabs/keep-tab/keep-tab.service';
+import {QueryFormDmService} from 'core-app/modules/hal/dm-services/query-form-dm.service';
+import {TableState} from 'core-components/wp-table/table-state/table-state';
+import {WpTableConfigurationService} from 'core-components/wp-table/configuration-modal/wp-table-configuration.service';
+import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
+
+@NgModule({
+  imports: [
+    UIRouterModule,
+
+    BrowserModule,
+    FormsModule,
+    // Angular CDK
+    PortalModule,
+    // Commons
+    OpenprojectCommonModule,
+    // A11y
+    OpenprojectAccessibilityModule,
+    // Hal Module
+    OpenprojectHalModule,
+    // Display + Edit field functionality
+    OpenprojectFieldsModule,
+    // CKEditor
+    OpenprojectEditorModule,
+
+    ChartsModule,
+
+    // Calendar component
+    FullCalendarModule,
+
+    OpenprojectAttachmentsModule,
+
+    // Work package custom actions
+    //WpCustomActionsModule,
+    DynamicModule.withComponents([WorkPackageFormAttributeGroupComponent, WorkPackageChildrenQueryComponent])
+  ],
+  providers: [
+    WorkPackageTablePaginationService,
+
+    // Timeline
+    WorkPackageTableTimelineService,
+
+    // External query configuration
+    ExternalQueryConfigurationService,
+
+    // Table and query states services
+    WorkPackageTableRelationColumnsService,
+    WorkPackageTableGroupByService,
+    WorkPackageTableHierarchiesService,
+    WorkPackageTableSortByService,
+    WorkPackageTableColumnsService,
+    WorkPackageTableFiltersService,
+    WorkPackageTableSumService,
+    WorkPackageTableHighlightingService,
+    WorkPackageStatesInitializationService,
+    WorkPackagesListService,
+    WorkPackageStaticQueriesService,
+    WorkPackageTableRefreshService,
+    WorkPackageTableAdditionalElementsService,
+    WorkPackagesListInvalidQueryService,
+    WorkPackageTableFocusService,
+    WorkPackageTableSelection,
+
+    // Provide both serves with tokens to avoid tight dependency cycles
+    { provide: IWorkPackageCreateServiceToken, useClass: WorkPackageCreateService },
+    { provide: IWorkPackageEditingServiceToken, useClass: WorkPackageEditingService },
+
+    // Provide a separate service for creation events of WP Inline create
+    // This can be hierarchically injected to provide isolated events on an embedded table
+    WorkPackageInlineCreateService,
+    WorkPackageInlineAddExistingChildService,
+
+    OpTableActionsService,
+
+    WorkPackageRelationsService,
+    WorkPackageCacheService,
+    SchemaCacheService,
+
+    KeepTabService,
+    WorkPackageNotificationService,
+    WorkPackagesListChecksumService,
+    WorkPackageRelationsHierarchyService,
+    WorkPackageFiltersService,
+    WorkPackageService,
+    ApiWorkPackagesService,
+
+    WorkPackagesActivityService,
+    WorkPackageWatchersService,
+
+    WorkPackageContextMenuHelperService,
+
+    QueryFormDmService,
+    TableState,
+
+    WpTableConfigurationService,
+  ],
+  declarations: [
+    // views
+    WorkPackagesBaseComponent,
+    WorkPackagesListComponent,
+
+    // WP New
+    WorkPackageNewFullViewComponent,
+    WorkPackageNewSplitViewComponent,
+    WorkPackageTypeStatusComponent,
+
+    // WP Copy
+    WorkPackageCopyFullViewComponent,
+    WorkPackageCopySplitViewComponent,
+
+    // Embedded table
+    WorkPackageEmbeddedTableComponent,
+    WorkPackageEmbeddedTableEntryComponent,
+    // External query configuration
+    ExternalQueryConfigurationComponent,
+
+    // Inline create
+    WorkPackageInlineCreateComponent,
+    WorkPackageInlineAddExistingChildComponent,
+
+    WorkPackagesTableController,
+    WorkPackageTablePaginationComponent,
+
+    WpResizerDirective,
+
+    WorkPackageTableSumsRowController,
+
+    // WP Edit Fields
+    WorkPackageEditFieldComponent,
+
+    // Filters
+    QueryFiltersComponent,
+    QueryFilterComponent,
+    FilterBooleanValueComponent,
+    FilterDateValueComponent,
+    FilterDatesValueComponent,
+    FilterDateTimeValueComponent,
+    FilterDateTimesValueComponent,
+    FilterIntegerValueComponent,
+    FilterStringValueComponent,
+    FilterToggledMultiselectValueComponent,
+
+    WorkPackageFilterContainerComponent,
+    WorkPackageFilterButtonComponent,
+
+    // Context menus
+    OpTypesContextMenuDirective,
+    OpColumnsContextMenu,
+    OpSettingsMenuDirective,
+    WorkPackageStatusDropdownDirective,
+    WorkPackageCreateSettingsMenuDirective,
+    WorkPackageSingleContextMenuDirective,
+    WorkPackageQuerySelectableTitleComponent,
+    WorkPackageQuerySelectDropdownComponent,
+
+    // Timeline
+    WorkPackageTimelineButtonComponent,
+    WorkPackageTimelineHeaderController,
+    WorkPackageTableTimelineRelations,
+    WorkPackageTableTimelineStaticElements,
+    WorkPackageTableTimelineGrid,
+    WorkPackageTimelineTableController,
+
+    WorkPackageCreateButtonComponent,
+
+    // Single view
+    WorkPackageOverviewTabComponent,
+    WorkPackageSingleViewComponent,
+    WorkPackageStatusButtonComponent,
+    WorkPackageReplacementLabelComponent,
+    UserLinkComponent,
+    WorkPackageChildrenQueryComponent,
+    WorkPackageFormAttributeGroupComponent,
+
+    // Activity Tab
+    NewestActivityOnOverviewComponent,
+    WorkPackageCommentComponent,
+    WorkPackageCommentFieldComponent,
+    ActivityEntryComponent,
+    UserActivityComponent,
+    RevisionActivityComponent,
+    ActivityLinkComponent,
+    WorkPackageActivityTabComponent,
+
+    // Watchers tab
+    WorkPackageWatchersTabComponent,
+    WorkPackageWatcherEntryComponent,
+
+    // Relations
+    WorkPackageRelationsTabComponent,
+    WorkPackageRelationsComponent,
+    WorkPackageRelationsGroupComponent,
+    WorkPackageRelationRowComponent,
+    WorkPackageRelationsCreateComponent,
+    WorkPackageRelationsHierarchyComponent,
+    WpRelationsAutocompleteComponent,
+    WorkPackageBreadcrumbParentComponent,
+
+    // Split view
+    WorkPackageDetailsViewButtonComponent,
+    WorkPackageSplitViewComponent,
+    WorkPackageRelationsCountComponent,
+    WorkPackageWatchersCountComponent,
+    WorkPackageBreadcrumbComponent,
+    WorkPackageEditFieldGroupComponent,
+    WorkPackageSplitViewToolbarComponent,
+    WorkPackageWatcherButtonComponent,
+    WorkPackageSubjectComponent,
+
+    // Full view
+    WorkPackagesFullViewComponent,
+
+    // Modals
+    WpTableConfigurationModalComponent,
+    WpTableConfigurationColumnsTab,
+    WpTableConfigurationDisplaySettingsTab,
+    WpTableConfigurationFiltersTab,
+    WpTableConfigurationSortByTab,
+    WpTableConfigurationTimelinesTab,
+    WpTableConfigurationHighlightingTab,
+    WpTableExportModal,
+    QuerySharingForm,
+    QuerySharingModal,
+    SaveQueryModal,
+    WpDestroyModal,
+
+    // CustomActions
+    WpCustomActionComponent,
+    WpCustomActionsComponent,
+
+    // Work package calendars
+    WorkPackagesCalendarController,
+    WorkPackagesCalendarComponent,
+    WorkPackagesEmbeddedCalendarEntryComponent,
+
+    // Embedded graphs
+    WorkPackageEmbeddedGraphComponent,
+    // Work package graphs on version page
+    WorkPackageByVersionGraphComponent,
+
+    // CKEditor macros which could not be included in the
+    // editor module to avoid circular dependencies
+    EmbeddedTablesMacroComponent,
+    WpButtonMacroModal,
+  ],
+  entryComponents: [
+    // Split view
+    WorkPackageSplitViewComponent,
+
+    // Full view
+    WorkPackagesFullViewComponent,
+
+    // Single view tabs
+    WorkPackageActivityTabComponent,
+    WorkPackageRelationsTabComponent,
+    WorkPackageWatchersTabComponent,
+
+    // Single view
+    WorkPackageOverviewTabComponent,
+    WorkPackageCommentFieldComponent,
+
+    // Inline create
+    WorkPackageInlineAddExistingChildComponent,
+    WorkPackagesBaseComponent,
+    WorkPackagesListComponent,
+
+    // WP new
+    WorkPackageNewFullViewComponent,
+    WorkPackageNewSplitViewComponent,
+
+    // WP copy
+    WorkPackageCopyFullViewComponent,
+    WorkPackageCopySplitViewComponent,
+
+    // Embedded table
+    WorkPackageEmbeddedTableComponent,
+    WorkPackageEmbeddedTableEntryComponent,
+    // External query configuration
+    ExternalQueryConfigurationComponent,
+
+    WorkPackageFormAttributeGroupComponent,
+    WorkPackageChildrenQueryComponent,
+
+    WorkPackagesTableController,
+    WorkPackagesEmbeddedCalendarEntryComponent,
+
+    // Embedded calendar
+    WorkPackagesCalendarComponent,
+    WorkPackagesCalendarController,
+
+    // Work package graphs on version page
+    WorkPackageByVersionGraphComponent,
+
+    // Modals
+    WpTableConfigurationModalComponent,
+    WpTableConfigurationColumnsTab,
+    WpTableConfigurationDisplaySettingsTab,
+    WpTableConfigurationFiltersTab,
+    WpTableConfigurationSortByTab,
+    WpTableConfigurationTimelinesTab,
+    WpTableConfigurationHighlightingTab,
+    WpTableExportModal,
+    QuerySharingModal,
+    SaveQueryModal,
+    WpDestroyModal,
+
+    // Queries in menu
+    WorkPackageQuerySelectDropdownComponent,
+
+    // Relations tab (ng1 -> ng2)
+    WorkPackageRelationsHierarchyComponent,
+
+    // CKEditor macros which could not be included in the
+    // editor module to avoid circular dependencies
+    EmbeddedTablesMacroComponent,
+    WpButtonMacroModal,
+  ],
+  exports: [
+    WorkPackageEmbeddedTableComponent,
+  ]
+})
+export class OpenprojectWorkPackagesModule {}

--- a/lib/api/v3/queries/query_params_representer.rb
+++ b/lib/api/v3/queries/query_params_representer.rb
@@ -37,7 +37,6 @@ module API
   module V3
     module Queries
       class QueryParamsRepresenter
-
         def initialize(query)
           self.query = query
         end


### PR DESCRIPTION
* Extracts a couple of angular modules from the catchall angular4.module:
  * WorkPackages
  * Editor
  * Attachments 
* Introduces a hook for determining the component rendered for an attribute group on the work package show page. That way, plugins can alter how attributes are rendered.