### PR TITLE
move time entry validations to contract

### DIFF
--- a/app/contracts/time_entries/base_contract.rb
+++ b/app/contracts/time_entries/base_contract.rb
@@ -36,6 +36,14 @@ module TimeEntries
       TimeEntry
     end
 
+    def validate
+      validate_hours_are_in_range
+      validate_project_is_set
+      validate_work_package
+
+      super
+    end
+
     attribute :project_id
     attribute :work_package_id
     attribute :activity_id
@@ -45,5 +53,32 @@ module TimeEntries
     attribute :tyear
     attribute :tmonth
     attribute :tweek
+
+    private
+
+    def validate_work_package
+      return unless model.work_package || model.work_package_id_changed?
+
+      if work_package_invisible? ||
+         work_package_not_in_project?
+        errors.add :work_package_id, :invalid
+      end
+    end
+
+    def validate_hours_are_in_range
+      errors.add :hours, :invalid if model.hours&.negative?
+    end
+
+    def validate_project_is_set
+      errors.add :project_id, :invalid if model.project.nil?
+    end
+
+    def work_package_invisible?
+      model.work_package.nil? || !model.work_package.visible?(user)
+    end
+
+    def work_package_not_in_project?
+      model.work_package && model.project != model.work_package.project
+    end
   end
 end

--- a/app/contracts/time_entries/update_contract.rb
+++ b/app/contracts/time_entries/update_contract.rb
@@ -49,9 +49,9 @@ module TimeEntries
       edit_own = user.allowed_to?(:edit_own_time_entries, model.project)
 
       if model.user == user
-        return edit_own || edit_all
+        edit_own || edit_all
       else
-        return edit_all
+        edit_all
       end
     end
   end

--- a/app/controllers/timelog_controller.rb
+++ b/app/controllers/timelog_controller.rb
@@ -163,7 +163,7 @@ class TimelogController < ApplicationController
 
     @time_entry = call.result
 
-    respond_for_saving call.success?
+    respond_for_saving call
   end
 
   def edit
@@ -174,8 +174,8 @@ class TimelogController < ApplicationController
 
   def update
     service = TimeEntries::UpdateService.new user: current_user, time_entry: @time_entry
-    result = service.call(attributes: permitted_params.time_entry)
-    respond_for_saving result.success?
+    call = service.call(attributes: permitted_params.time_entry)
+    respond_for_saving call
   end
 
   def destroy
@@ -256,13 +256,10 @@ class TimelogController < ApplicationController
     time_entry
   end
 
-  def save_time_entry_and_respond(time_entry)
-    call_hook(:controller_timelog_edit_before_save, params: params, time_entry: time_entry)
-    respond_for_saving @time_entry.save
-  end
+  def respond_for_saving(call)
+    @errors = call.errors
 
-  def respond_for_saving(success)
-    if success
+    if call.success?
       respond_to do |format|
         format.html do
           flash[:notice] = l(:notice_successful_update)

--- a/app/helpers/error_message_helper.rb
+++ b/app/helpers/error_message_helper.rb
@@ -37,10 +37,19 @@ module ErrorMessageHelper
     render_error_messages_partial(error_messages, options[:object])
   end
 
+  # Will take a contract to display the errors in a rails form.
+  # In order to have faulty field highlighted, the method sets
+  # all errors in the contract on the object as well.
   def error_messages_for_contract(object, errors)
     return unless errors
 
     error_messages = errors.full_messages
+
+    errors.details.each do |attribute, details|
+      details.map { |d| d[:error] }.flatten.each do |message|
+        object.errors.add(attribute, message)
+      end
+    end
 
     render_error_messages_partial(error_messages, object)
   end

--- a/app/models/time_entry.rb
+++ b/app/models/time_entry.rb
@@ -49,10 +49,6 @@ class TimeEntry < ActiveRecord::Base
   validates_numericality_of :hours, allow_nil: true, message: :invalid
   validates_length_of :comments, maximum: 255, allow_nil: true
 
-  validate :validate_hours_are_in_range
-  validate :validate_project_is_set
-  validate :validate_consistency_of_work_package_id
-
   scope :on_work_packages, ->(work_packages) { where(work_package_id: work_packages) }
 
   def self.visible(*args)
@@ -104,21 +100,5 @@ class TimeEntry < ActiveRecord::Base
     else
       activity.root
     end
-  end
-
-  private
-
-  # TODO: move to contract
-
-  def validate_hours_are_in_range
-    errors.add :hours, :invalid if hours&.negative?
-  end
-
-  def validate_project_is_set
-    errors.add :project_id, :invalid if project.nil?
-  end
-
-  def validate_consistency_of_work_package_id
-    errors.add :work_package_id, :invalid if (work_package_id && !work_package) || (work_package && project != work_package.project)
   end
 end

--- a/app/services/time_entries/update_service.rb
+++ b/app/services/time_entries/update_service.rb
@@ -41,15 +41,7 @@ class TimeEntries::UpdateService
   def call(attributes: {})
     set_attributes attributes
 
-    success, errors = validate_and_yield(time_entry, user) do
-      ##
-      # Perform additional validations on the model,
-      # since the errors from reform are not merged into the model for form errors
-      validate_visible_work_package
-
-      time_entry.errors.empty? && time_entry.save
-    end
-
+    success, errors = validate_and_save(time_entry, user)
     ServiceResult.new success: success, errors: errors, result: time_entry
   end
 
@@ -62,14 +54,6 @@ class TimeEntries::UpdateService
     # Update project context if moving time entry
     if time_entry.work_package && time_entry.work_package_id_changed?
       time_entry.project_id = time_entry.work_package.project_id
-    end
-  end
-
-  def validate_visible_work_package
-    return unless time_entry.work_package || time_entry.work_package_id_changed?
-
-    if time_entry.work_package.nil? || !time_entry.work_package.visible?(user)
-      time_entry.errors.add :work_package_id, :invalid
     end
   end
 end

--- a/app/views/timelog/edit.html.erb
+++ b/app/views/timelog/edit.html.erb
@@ -29,7 +29,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <%= toolbar title: t(:label_spent_time) %>
 <%= labelled_tabular_form_for [@time_entry.project, @time_entry], as: :time_entry do |f| %>
-  <%= error_messages_for 'time_entry' %>
+  <%= error_messages_for_contract @time_entry, @errors %>
   <%= back_url_hidden_field_tag %>
 
   <div class="form--field">

--- a/spec/contracts/time_entries/create_contract_spec.rb
+++ b/spec/contracts/time_entries/create_contract_spec.rb
@@ -28,147 +28,46 @@
 #++
 
 require 'spec_helper'
+require_relative './shared_contract_examples'
 
 describe TimeEntries::CreateContract do
-  let(:current_user) do
-    FactoryBot.build_stubbed(:user) do |user|
-      allow(user)
-        .to receive(:allowed_to?) do |permission, permission_project|
-        permissions.include?(permission) && time_entry_project == permission_project
+  it_behaves_like 'time entry contract' do
+    let(:time_entry) do
+      TimeEntry.new(project: time_entry_project,
+                    work_package: time_entry_work_package,
+                    user: time_entry_user,
+                    activity: time_entry_activity,
+                    spent_on: time_entry_spent_on,
+                    hours: time_entry_hours,
+                    comments: time_entry_comments)
+    end
+    let(:permissions) { %i(log_time) }
+    let(:other_user) { FactoryBot.build_stubbed(:user) }
+
+    subject(:contract) { described_class.new(time_entry, current_user) }
+
+    context 'when user is not allowed to log time' do
+      let(:permissions) { [] }
+
+      it 'is invalid' do
+        expect_valid(false, base: %i(error_unauthorized))
       end
     end
-  end
-  let(:other_user) { FactoryBot.build_stubbed(:user) }
-  let(:time_entry_work_package) do
-    FactoryBot.build_stubbed(:work_package,
-                             project: time_entry_project)
-  end
-  let(:time_entry_project) { FactoryBot.build_stubbed(:project) }
-  let(:time_entry_user) { current_user }
-  let(:time_entry_activity) { FactoryBot.build_stubbed(:time_entry_activity) }
-  let(:time_entry_spent_on) { Date.today }
-  let(:time_entry_hours) { 5 }
-  let(:time_entry_comments) { "A comment" }
-  let(:time_entry) do
-    TimeEntry.new(project: time_entry_project,
-                  work_package: time_entry_work_package,
-                  user: time_entry_user,
-                  activity: time_entry_activity,
-                  spent_on: time_entry_spent_on,
-                  hours: time_entry_hours,
-                  comments: time_entry_comments)
-  end
-  let(:permissions) { %i(log_time) }
 
-  subject(:contract) { described_class.new(time_entry, current_user) }
+    context 'when time_entry user is not contract user' do
+      let(:time_entry_user) { other_user }
 
-  def expect_valid(valid, symbols = {})
-    expect(contract.validate).to eq(valid)
-
-    symbols.each do |key, arr|
-      expect(contract.errors.symbols_for(key)).to match_array arr
+      it 'is invalid' do
+        expect_valid(false, user_id: %i(invalid))
+      end
     end
-  end
 
-  shared_examples 'is valid' do
-    it 'is valid' do
-      expect_valid(true)
+    context 'when the user is nil' do
+      let(:time_entry_user) { nil }
+
+      it 'is invalid' do
+        expect_valid(false, user_id: %i(blank invalid))
+      end
     end
-  end
-
-  it_behaves_like 'is valid'
-
-  context 'when user is not allowed to log time' do
-    let(:permissions) { [] }
-
-    it 'is invalid' do
-      expect_valid(false, base: %i(error_unauthorized))
-    end
-  end
-
-  context 'when time_entry user is not contract user' do
-    let(:time_entry_user) { other_user }
-
-    it 'is invalid' do
-      expect_valid(false, user_id: %i(invalid))
-    end
-  end
-
-  context 'when the work_package is within a differnt project than the provided project' do
-    let(:time_entry_work_package) { FactoryBot.build_stubbed(:work_package) }
-
-    it 'is invalid' do
-      expect_valid(false, work_package_id: %i(invalid))
-    end
-  end
-
-  context 'when the project is nil' do
-    let(:time_entry_project) { nil }
-
-    it 'is invalid' do
-      expect_valid(false, project_id: %i(invalid blank))
-    end
-  end
-
-  context 'when the user is nil' do
-    let(:time_entry_user) { nil }
-
-    it 'is invalid' do
-      expect_valid(false, user_id: %i(blank invalid))
-    end
-  end
-
-  context 'when activity is nil' do
-    let(:time_entry_activity) { nil }
-
-    it 'is invalid' do
-      expect_valid(false, activity_id: %i(blank))
-    end
-  end
-
-  context 'when spent_on is nil' do
-    let(:time_entry_spent_on) { nil }
-
-    it 'is invalid' do
-      expect_valid(false, spent_on: %i(blank))
-    end
-  end
-
-  context 'when hours is nil' do
-    let(:time_entry_hours) { nil }
-
-    it 'is invalid' do
-      expect_valid(false, hours: %i(blank))
-    end
-  end
-
-  context 'when hours is smaller negative' do
-    let(:time_entry_hours) { -1 }
-
-    it 'is invalid' do
-      expect_valid(false, hours: %i(invalid))
-    end
-  end
-
-  context 'when hours is nil' do
-    let(:time_entry_hours) { nil }
-
-    it 'is invalid' do
-      expect_valid(false, hours: %i(blank))
-    end
-  end
-
-  context 'when comment is longer than 255' do
-    let(:time_entry_comments) { "a" * 256 }
-
-    it 'is invalid' do
-      expect_valid(false, comments: %i(too_long))
-    end
-  end
-
-  context 'when comment is nil' do
-    let(:time_entry_comments) { nil }
-
-    it_behaves_like 'is valid'
   end
 end

--- a/spec/contracts/time_entries/shared_contract_examples.rb
+++ b/spec/contracts/time_entries/shared_contract_examples.rb
@@ -1,0 +1,147 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+shared_examples_for 'time entry contract' do
+  let(:current_user) do
+    FactoryBot.build_stubbed(:user) do |user|
+      allow(user)
+        .to receive(:allowed_to?) do |permission, permission_project|
+        permissions.include?(permission) && time_entry_project == permission_project
+      end
+    end
+  end
+  let(:other_user) { FactoryBot.build_stubbed(:user) }
+  let(:time_entry_work_package) do
+    FactoryBot.build_stubbed(:work_package,
+                             project: time_entry_project)
+  end
+  let(:time_entry_project) { FactoryBot.build_stubbed(:project) }
+  let(:time_entry_user) { current_user }
+  let(:time_entry_activity) { FactoryBot.build_stubbed(:time_entry_activity) }
+  let(:time_entry_spent_on) { Date.today }
+  let(:time_entry_hours) { 5 }
+  let(:time_entry_comments) { "A comment" }
+  let(:work_package_visible) { true }
+
+  before do
+    allow(time_entry_work_package)
+      .to receive(:visible?)
+      .with(current_user)
+      .and_return(work_package_visible)
+  end
+
+  def expect_valid(valid, symbols = {})
+    expect(contract.validate).to eq(valid)
+
+    symbols.each do |key, arr|
+      expect(contract.errors.symbols_for(key)).to match_array arr
+    end
+  end
+
+  shared_examples 'is valid' do
+    it 'is valid' do
+      expect_valid(true)
+    end
+  end
+
+  it_behaves_like 'is valid'
+
+  context 'when the work_package is within a different project than the provided project' do
+    let(:time_entry_work_package) { FactoryBot.build_stubbed(:work_package) }
+
+    it 'is invalid' do
+      expect_valid(false, work_package_id: %i(invalid))
+    end
+  end
+
+  context 'when the project is nil' do
+    let(:time_entry_project) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, project_id: %i(invalid blank))
+    end
+  end
+
+  context 'when activity is nil' do
+    let(:time_entry_activity) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, activity_id: %i(blank))
+    end
+  end
+
+  context 'when spent_on is nil' do
+    let(:time_entry_spent_on) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, spent_on: %i(blank))
+    end
+  end
+
+  context 'when hours is nil' do
+    let(:time_entry_hours) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, hours: %i(blank))
+    end
+  end
+
+  context 'when hours is negative' do
+    let(:time_entry_hours) { -1 }
+
+    it 'is invalid' do
+      expect_valid(false, hours: %i(invalid))
+    end
+  end
+
+  context 'when hours is nil' do
+    let(:time_entry_hours) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, hours: %i(blank))
+    end
+  end
+
+  context 'when comment is longer than 255' do
+    let(:time_entry_comments) { "a" * 256 }
+
+    it 'is invalid' do
+      expect_valid(false, comments: %i(too_long))
+    end
+  end
+
+  context 'when comment is nil' do
+    let(:time_entry_comments) { nil }
+
+    it_behaves_like 'is valid'
+  end
+end

--- a/spec/contracts/time_entries/update_contract_spec.rb
+++ b/spec/contracts/time_entries/update_contract_spec.rb
@@ -28,83 +28,62 @@
 #++
 
 require 'spec_helper'
+require_relative './shared_contract_examples'
 
 describe TimeEntries::UpdateContract do
-  let(:current_user) do
-    FactoryBot.build_stubbed(:user) do |user|
-      allow(user)
-        .to receive(:allowed_to?) do |permission, permission_project|
-        permissions.include?(permission) && time_entry_project == permission_project
-      end
+  it_behaves_like 'time entry contract' do
+    let(:time_entry) do
+      FactoryBot.build_stubbed(:time_entry,
+                               project: time_entry_project,
+                               work_package: time_entry_work_package,
+                               user: time_entry_user,
+                               activity: time_entry_activity,
+                               spent_on: time_entry_spent_on,
+                               hours: time_entry_hours,
+                               comments: time_entry_comments)
     end
-  end
-  let(:other_user) { FactoryBot.build_stubbed(:user) }
-  let(:time_entry_work_package) do
-    FactoryBot.build_stubbed(:work_package,
-                             project: time_entry_project)
-  end
-  let(:time_entry_project) { FactoryBot.build_stubbed(:project) }
-  let(:time_entry_activity) { FactoryBot.build_stubbed(:time_entry_activity) }
-  let(:time_entry_user) { current_user }
-  let(:time_entry_spent_on) { Date.today }
-  let(:time_entry_hours) { 5 }
-  let(:time_entry_comments) { "A comment" }
-  let(:time_entry) do
-    TimeEntry.create(project: time_entry_project,
-                     work_package: time_entry_work_package,
-                     user: time_entry_user,
-                     activity: time_entry_activity,
-                     spent_on: time_entry_spent_on,
-                     hours: time_entry_hours,
-                     comments: time_entry_comments)
-  end
-  let(:permissions) { %i(edit_time_entries) }
+    subject(:contract) { described_class.new(time_entry, current_user) }
+    let(:permissions) { %i(edit_time_entries) }
 
-  subject(:contract) { described_class.new(time_entry, current_user) }
+    context 'when user is not allowed to edit time entries' do
+      let(:permissions) { [] }
 
-  before do
-    allow(Project).to receive(:find).with(time_entry_project.id).and_return(time_entry_project)
-  end
-
-  def expect_valid(valid, symbols = {})
-    expect(contract.validate).to eq(valid)
-
-    symbols.each do |key, arr|
-      expect(contract.errors.symbols_for(key)).to match_array arr
-    end
-  end
-
-  shared_examples 'is valid' do
-    it 'is valid' do
-      expect_valid(true)
-    end
-  end
-
-  it_behaves_like 'is valid'
-
-  context 'when user is not allowed to edit time entries' do
-    let(:permissions) { [] }
-
-    it 'is invalid' do
-      expect_valid(false, base: %i(error_unauthorized))
-    end
-  end
-
-  context 'when time_entry user is not contract user' do
-    let(:time_entry_user) { other_user }
-
-    context 'when has permission' do
-      let(:permissions) { %i[edit_time_entries] }
-
-      it 'is valid' do
-        expect_valid(true)
-      end
-    end
-
-    context 'when has no permission' do
-      let(:permissions) { %i[edit_own_time_entries] }
       it 'is invalid' do
         expect_valid(false, base: %i(error_unauthorized))
+      end
+    end
+
+    context 'when the user is nil' do
+      let(:time_entry_user) { nil }
+
+      it 'is invalid' do
+        expect_valid(false, user_id: %i(blank))
+      end
+    end
+
+    context 'when the user is changed' do
+      it 'is invalid' do
+        time_entry.user = other_user
+        expect_valid(false, user_id: %i(error_readonly))
+      end
+    end
+
+    context 'when time_entry user is not contract user' do
+      let(:time_entry_user) { other_user }
+
+      context 'when has permission' do
+        let(:permissions) { %i[edit_time_entries] }
+
+        it 'is valid' do
+          expect_valid(true)
+        end
+      end
+
+      context 'when has no permission' do
+        let(:permissions) { %i[edit_own_time_entries] }
+        it 'is invalid' do
+          expect_valid(false, base: %i(error_unauthorized))
+        end
       end
     end
   end

--- a/spec/models/time_entry_spec.rb
+++ b/spec/models/time_entry_spec.rb
@@ -69,14 +69,14 @@ describe TimeEntry, type: :model do
 
       let(:child_activity_active) do
         FactoryBot.create(:time_entry_activity,
-                           parent: activity,
-                           project: project1)
+                          parent: activity,
+                          project: project1)
       end
       let(:child_activity_inactive) do
         FactoryBot.create(:time_entry_activity,
-                           parent: activity,
-                           project: project2,
-                           active: false)
+                          parent: activity,
+                          project: project2,
+                          active: false)
       end
 
       before do


### PR DESCRIPTION
Extracts the last of the non-trivial validations from time entries and by that is able to completely work wit h contracts. 

In order to have the error messages displayed in the rails form the `error_messages_for_contract` helper is used. As that helper did not lead to the fields being highlighted on error, it now merges the contract's errors back to the model. This is a hack but at least for time entries we should be able to get rid of it as the time entries api is almost complete enough to replace the rails based view with an angular one.