### PR TITLE
Improve usage of I18n in model specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -195,7 +195,7 @@ group :test do
 
   # Test prof provides factories from code
   # and other niceties
-  gem 'test-prof', '~> 0.4.0'
+  gem 'test-prof', '~> 0.7.3'
 
   gem 'cucumber', '~> 3.0.0'
   gem 'cucumber-rails', '~> 1.6.0', require: false
@@ -250,6 +250,7 @@ end
 
 group :development, :test do
   gem 'thin', '~> 1.7.2'
+  gem 'ruby-prof', require: false
 
   gem 'pry-rails', '~> 0.3.6'
   gem 'pry-stack_explorer', '~> 0.4.9.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -700,6 +700,7 @@ GEM
     ruby-enum (0.7.2)
       i18n
     ruby-ole (1.2.12.1)
+    ruby-prof (0.17.0)
     ruby-progressbar (1.9.0)
     ruby-rc4 (0.1.5)
     ruby-saml (1.9.0)
@@ -753,7 +754,7 @@ GEM
       httpclient (>= 2.4)
     sys-filesystem (1.1.9)
       ffi
-    test-prof (0.4.9)
+    test-prof (0.7.3)
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -929,6 +930,7 @@ DEPENDENCIES
   rspec-retry (~> 0.5.6)
   rubocop
   ruby-duration (~> 3.2.0)
+  ruby-prof
   ruby-progressbar (~> 1.9.0)
   rubytree!
   sanitize (~> 4.6.0)
@@ -945,7 +947,7 @@ DEPENDENCIES
   stringex (~> 2.7.1)
   svg-graph (~> 2.1.0)
   sys-filesystem (~> 1.1.4)
-  test-prof (~> 0.4.0)
+  test-prof (~> 0.7.3)
   thin (~> 1.7.2)
   timecop (~> 0.9.0)
   transactional_lock!

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -47,7 +47,7 @@ class CustomField < ActiveRecord::Base
 
   validates :field_format, presence: true
   validates :custom_options,
-            presence: { message: I18n.t(:'activerecord.errors.models.custom_field.at_least_one_custom_option') },
+            presence: { message: ->(*) { I18n.t(:'activerecord.errors.models.custom_field.at_least_one_custom_option') } },
             if: ->(*) { field_format == 'list' }
   validates :name, presence: true, length: { maximum: 30 }
 

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -212,10 +212,10 @@ module API
       e.error_response status: 401, message: representer.to_json, headers: warden.headers, log: false
     end
 
-    error_response ActiveRecord::RecordNotFound, ::API::Errors::NotFound.new
-    error_response ActiveRecord::StaleObjectError, ::API::Errors::Conflict.new
+    error_response ActiveRecord::RecordNotFound, ::API::Errors::NotFound
+    error_response ActiveRecord::StaleObjectError, ::API::Errors::Conflict
 
-    error_response MultiJson::ParseError, ::API::Errors::ParseError.new
+    error_response MultiJson::ParseError, ::API::Errors::ParseError
 
     error_response ::API::Errors::Unauthenticated, headers: auth_headers, log: false
     error_response ::API::Errors::ErrorBase, rescue_subclasses: true, log: false

--- a/lib/api/utilities/grape_helper.rb
+++ b/lib/api/utilities/grape_helper.rb
@@ -56,7 +56,7 @@ module API
           if error.nil?
             error_response_lambda
           else
-            lambda { instance_exec error, &error_response_lambda }
+            lambda { instance_exec error.new, &error_response_lambda }
           end
 
         # We do this lambda business because #rescue_from behaves differently

--- a/spec/support/rspec_cleanup.rb
+++ b/spec/support/rspec_cleanup.rb
@@ -11,7 +11,7 @@ RSpec.configure do |config|
   config.append_after(:each) do
     # Cleanup after specs changing locale explicitly or
     # by calling code in the app setting changing the locale.
-    I18n.locale = :en
+    I18n.locale = :en unless I18n.locale == :en
 
     # Set the class instance variable @current_user to nil
     # to avoid having users from one spec present in the next


### PR DESCRIPTION
This will avoid loading I18n translations in single-use cases where
it would not be loaded anyway