### PR TITLE
[29052] Only take cached perPage if it is still valid

### DIFF
--- a/frontend/src/app/components/table-pagination/pagination-service.ts
+++ b/frontend/src/app/components/table-pagination/pagination-service.ts
@@ -71,7 +71,7 @@ export class PaginationService {
     if (value !== undefined) {
       const perPage = parseInt(value, 10);
 
-      if (perPage > 0) {
+      if (perPage > 0 && (initialPageOptions.length === 0 || initialPageOptions.indexOf(perPage) !== -1)) {
         return perPage;
       }
     }


### PR DESCRIPTION
Will not reuse an old perPage value if it's not in the valid set of page
options (unless it's empty).

https://community.openproject.com/wp/29052