### PR TITLE
Make module engines refer to core version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ PATH
   remote: modules/github_integration
   specs:
     openproject-github_integration (8.2.0)
-      openproject-webhooks (~> 8.2.0)
+      openproject-webhooks
       rails (~> 5.0)
 
 PATH

--- a/lib/generators/open_project/plugin/templates/%full_name%.gemspec.tt
+++ b/lib/generators/open_project/plugin/templates/%full_name%.gemspec.tt
@@ -1,11 +1,12 @@
 # encoding: UTF-8
 $:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../../lib", __dir__)
 
-require 'open_project/<%= plugin_name %>/version'
+
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "<%= full_name %>"
-  s.version     = OpenProject::<%= plugin_name.camelcase %>::VERSION
+
   s.authors     = "OpenProject GmbH"
   s.email       = "info@openproject.org"
   s.homepage    = "https://community.openproject.org/projects/<%= plugin_name.gsub('_','-') %>"  # TODO check this URL

--- a/lib/open_project/version.rb
+++ b/lib/open_project/version.rb
@@ -57,8 +57,7 @@ module OpenProject
       if revision.present?
         revision.strip[0..8]
       end
-    rescue => e
-      Rails.logger.warn("Tried to parse version REVISION, but failed with #{e.message}.")
+    rescue StandardError
       nil
     end
 
@@ -68,8 +67,7 @@ module OpenProject
         if File.exists? path
           File.read(path)
         end
-      rescue => e
-        Rails.logger.warn("Tried to parse PRODUCT_VERSION, but failed with #{e.message}.")
+      rescue StandardError
         nil
       end
 
@@ -103,8 +101,7 @@ module OpenProject
           s = File.read(path)
           Date.parse(s)
         end
-      rescue => e
-        Rails.logger.warn("Tried to parse RELEASE_DATE, but failed with #{e.message}.")
+      rescue StandardError
         nil
       end
 
@@ -115,7 +112,7 @@ module OpenProject
       defined?(@git_date) || @git_date = begin
         date, = Open3.capture3('git', 'log', '-1', '--format=%cd', '--date=short')
         Date.parse(date) if date
-      rescue
+      rescue StandardError
         nil
       end
 

--- a/modules/auth_plugins/lib/open_project/auth_plugins/version.rb
+++ b/modules/auth_plugins/lib/open_project/auth_plugins/version.rb
@@ -27,8 +27,10 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'open_project/version'
+
 module OpenProject
   module AuthPlugins
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/avatars/lib/open_project/avatars/version.rb
+++ b/modules/avatars/lib/open_project/avatars/version.rb
@@ -1,5 +1,7 @@
+require 'open_project/version'
+
 module OpenProject
   module Avatars
-    VERSION = "8.2.0".freeze
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/avatars/openproject-local_avatars.gemspec
+++ b/modules/avatars/openproject-local_avatars.gemspec
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 $:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../../lib", __dir__)
 
 require 'open_project/avatars/version'
 # Describe your gem and declare its dependencies:

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -34,7 +34,7 @@
 #++
 
 require 'open_project/plugins'
-require 'open_project/backlogs/version'
+
 
 require 'acts_as_silent_list'
 

--- a/modules/backlogs/lib/open_project/backlogs/version.rb
+++ b/modules/backlogs/lib/open_project/backlogs/version.rb
@@ -33,8 +33,10 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'open_project/version'
+
 module OpenProject
   module Backlogs
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/costs/lib/open_project/costs/engine.rb
+++ b/modules/costs/lib/open_project/costs/engine.rb
@@ -18,7 +18,7 @@
 #++
 
 require 'open_project/plugins'
-require 'open_project/costs/version'
+
 
 module OpenProject::Costs
   class Engine < ::Rails::Engine

--- a/modules/costs/lib/open_project/costs/version.rb
+++ b/modules/costs/lib/open_project/costs/version.rb
@@ -17,8 +17,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #++
 
+require 'open_project/version'
+
 module OpenProject
   module Costs
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/documents/lib/open_project/documents/version.rb
+++ b/modules/documents/lib/open_project/documents/version.rb
@@ -29,8 +29,10 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
+require 'open_project/version'
+
 module OpenProject
   module Documents
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/documents/openproject-documents.gemspec
+++ b/modules/documents/openproject-documents.gemspec
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 $:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../../lib", __dir__)
 
 require 'open_project/documents/version'
 # Describe your gem and declare its dependencies:

--- a/modules/github_integration/lib/open_project/github_integration/version.rb
+++ b/modules/github_integration/lib/open_project/github_integration/version.rb
@@ -11,9 +11,10 @@
 #
 # See doc/COPYRIGHT.md for more details.
 #++
+require 'open_project/version'
 
 module OpenProject
   module GithubIntegration
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/github_integration/openproject-github_integration.gemspec
+++ b/modules/github_integration/openproject-github_integration.gemspec
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 $:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../../lib", __dir__)
 
 require 'open_project/github_integration/version'
 # Describe your gem and declare its dependencies:
@@ -17,5 +18,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '~> 5.0'
 
-  s.add_dependency "openproject-webhooks", "~> #{OpenProject::GithubIntegration::VERSION}"
+  s.add_dependency "openproject-webhooks"
 end

--- a/modules/global_roles/lib/open_project/global_roles/version.rb
+++ b/modules/global_roles/lib/open_project/global_roles/version.rb
@@ -17,8 +17,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #++
 
+require 'open_project/version'
+
 module OpenProject
   module GlobalRoles
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/ldap_groups/lib/open_project/ldap_groups/version.rb
+++ b/modules/ldap_groups/lib/open_project/ldap_groups/version.rb
@@ -1,5 +1,7 @@
+require 'open_project/version'
+
 module OpenProject
   module LdapGroups
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/ldap_groups/openproject-ldap_groups.gemspec
+++ b/modules/ldap_groups/openproject-ldap_groups.gemspec
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 $:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../../lib", __dir__)
 
 require 'open_project/ldap_groups/version'
 Gem::Specification.new do |s|

--- a/modules/meeting/lib/open_project/meeting/version.rb
+++ b/modules/meeting/lib/open_project/meeting/version.rb
@@ -18,8 +18,10 @@
 # See doc/COPYRIGHT.md for more details.
 #++
 
+require 'open_project/version'
+
 module OpenProject
   module Meeting
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/my_project_page/lib/open_project/my_project_page/version.rb
+++ b/modules/my_project_page/lib/open_project/my_project_page/version.rb
@@ -18,8 +18,10 @@
 # See doc/COPYRIGHT.md for more details.
 #++
 
+require 'open_project/version'
+
 module OpenProject
   module MyProjectPage
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/my_project_page/openproject-my_project_page.gemspec
+++ b/modules/my_project_page/openproject-my_project_page.gemspec
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 $:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../../lib", __dir__)
 
 # Maintain your gem's version:
 require "open_project/my_project_page/version"

--- a/modules/openid_connect/lib/open_project/openid_connect/version.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/version.rb
@@ -1,5 +1,7 @@
+require 'open_project/version'
+
 module OpenProject
   module OpenIDConnect
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/pdf_export/lib/open_project/pdf_export/version.rb
+++ b/modules/pdf_export/lib/open_project/pdf_export/version.rb
@@ -23,8 +23,10 @@
 # See doc/COPYRIGHT.md for more details.
 #++
 
+require 'open_project/version'
+
 module OpenProject
   module PdfExport
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/pdf_export/openproject-pdf_export.gemspec
+++ b/modules/pdf_export/openproject-pdf_export.gemspec
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 $:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../../lib", __dir__)
 
 require 'open_project/pdf_export/version'
 # Describe your gem and declare its dependencies:

--- a/modules/reporting/lib/open_project/reporting/version.rb
+++ b/modules/reporting/lib/open_project/reporting/version.rb
@@ -17,8 +17,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #++
 
+require 'open_project/version'
+
 module OpenProject
   module Reporting
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/reporting/openproject-reporting.gemspec
+++ b/modules/reporting/openproject-reporting.gemspec
@@ -1,4 +1,5 @@
 $:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../../lib", __dir__)
 
 # Maintain your gem's version:
 require "open_project/reporting/version"

--- a/modules/reporting_engine/lib/reporting_engine/version.rb
+++ b/modules/reporting_engine/lib/reporting_engine/version.rb
@@ -16,7 +16,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #++
+require 'open_project/version'
 
 module ReportingEngine
-  VERSION = "8.2.0"
+  VERSION = ::OpenProject::VERSION.to_semver
 end

--- a/modules/reporting_engine/reporting_engine.gemspec
+++ b/modules/reporting_engine/reporting_engine.gemspec
@@ -1,4 +1,5 @@
 $:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../../lib", __dir__)
 
 # Maintain your gem's version:
 require "reporting_engine/version"

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/version.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/version.rb
@@ -1,5 +1,7 @@
+require 'open_project/version'
+
 module OpenProject
   module TwoFactorAuthentication
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/two_factor_authentication/openproject-two_factor_authentication.gemspec
+++ b/modules/two_factor_authentication/openproject-two_factor_authentication.gemspec
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 $:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../../lib", __dir__)
 
 # Maintain your gem's version:
 require "open_project/two_factor_authentication/version"

--- a/modules/webhooks/lib/open_project/webhooks/version.rb
+++ b/modules/webhooks/lib/open_project/webhooks/version.rb
@@ -12,8 +12,10 @@
 # See doc/COPYRIGHT.md for more details.
 #++
 
+require 'open_project/version'
+
 module OpenProject
   module Webhooks
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/webhooks/openproject-webhooks.gemspec
+++ b/modules/webhooks/openproject-webhooks.gemspec
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 $:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../../lib", __dir__)
 
 require 'open_project/webhooks/version'
 # Describe your gem and declare its dependencies:

--- a/modules/xls_export/lib/open_project/xls_export/version.rb
+++ b/modules/xls_export/lib/open_project/xls_export/version.rb
@@ -1,5 +1,7 @@
+require 'open_project/version'
+
 module OpenProject
   module XlsExport
-    VERSION = "8.2.0"
+    VERSION = ::OpenProject::VERSION.to_semver
   end
 end

--- a/modules/xls_export/openproject-xls_export.gemspec
+++ b/modules/xls_export/openproject-xls_export.gemspec
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 $:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../../lib", __dir__)
 
 require 'open_project/xls_export/version'
 # Describe your gem and declare its dependencies:


### PR DESCRIPTION
This ensures modules are always at the same version as the core version file