### PR TITLE
[29049] Fix missing start-of-week without user_specific_includes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -422,26 +422,6 @@ module ApplicationHelper
     end
   end
 
-  # Returns the javascript tags that are included in the html layout head
-  def user_specific_javascript_includes
-    tags = ''
-    tags += nonced_javascript_tag do
-      %{
-      window.openProject = new OpenProject({
-        urlRoot : '#{OpenProject::Configuration.rails_relative_url_root}',
-        environment: '#{Rails.env}',
-        loginUrl: '#{url_for controller: '/account', action: 'login'}'
-      });
-      I18n.defaultLocale = "#{I18n.default_locale}";
-      I18n.locale = "#{I18n.locale}";
-      I18n.firstDayOfWeek = "#{locale_first_day_of_week}"
-
-      }.html_safe
-    end
-
-    tags.html_safe
-  end
-
   def calendar_for(*args)
     ActiveSupport::Deprecation.warn "calendar_for has been removed. Please add the class '-augmented-datepicker' instead.", caller
   end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -54,6 +54,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
   <meta name="openproject_initializer"
         data-locale="<%= I18n.locale %>"
+        data-first-day-of-week="<%= locale_first_day_of_week %>"
         data-default-locale="<%= I18n.default_locale %>"
         data-environment="<%= Rails.env %>"/>
   <meta name="current_menu_item" content="<%= current_menu_item %>"/>

--- a/frontend/src/app/init-globals.ts
+++ b/frontend/src/app/init-globals.ts
@@ -48,6 +48,7 @@ window.appBasePath = jQuery('meta[name=app_base_path]').attr('content') || '';
 const meta = jQuery('meta[name=openproject_initializer]');
 I18n.locale = meta.data('defaultLocale');
 I18n.locale = meta.data('locale');
+I18n.firstDayOfWeek = parseInt(meta.data('firstDayOfWeek'), 10);
 
 // Enable debug logging for reactive states
 whenDebugging(() => {

--- a/frontend/src/app/modules/common/i18n/i18n.service.ts
+++ b/frontend/src/app/modules/common/i18n/i18n.service.ts
@@ -7,6 +7,7 @@ export interface GlobalI18n {
   t(translateId:string, parameters?:any):string;
   lookup(translateId:string):boolean | undefined;
   locale:string;
+  firstDayOfWeek:number;
 }
 
 @Injectable()

--- a/frontend/src/test/i18n-shim.ts
+++ b/frontend/src/test/i18n-shim.ts
@@ -3,6 +3,7 @@ import {GlobalI18n} from "core-app/modules/common/i18n/i18n.service";
 export class I18nShim implements GlobalI18n {
 
   public defaultLocale = 'en';
+  public firstDayOfWeek = 1;
   public locale = 'en';
   public translations = {
     en: {}


### PR DESCRIPTION
user_specific_javascript_includes was removed in the transition to Angular4, however the start of week attribute was not communicated since then.

https://community.openproject.com/wp/29049