### PR TITLE
[28958] Saving cost reports not working on Laptop-sized screens

### DIFF
--- a/modules/reporting/app/views/cost_reports/index.html.erb
+++ b/modules/reporting/app/views/cost_reports/index.html.erb
@@ -36,7 +36,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <div id="result-table">
   <%= render_widget Widget::Table, @query %>
 </div>
-<div style="height: 1em; background: none;">&nbsp;</div> <!-- IE7 band-aid -->
 <p class="footnote">
   <%= l(:text_costs_are_rounded_note) %>
   <%= "<br />#{l(:information_restricted_depending_on_permission)}".html_safe if !User.current.admin?%>

--- a/modules/reporting_engine/lib/assets/stylesheets/reporting_engine/reporting.css.erb
+++ b/modules/reporting_engine/lib/assets/stylesheets/reporting_engine/reporting.css.erb
@@ -137,7 +137,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 }
 
 #result-table {
-  margin-top: 10px !important;
+  margin: 10px 0;
   overflow-x: auto;
 }
 
@@ -365,11 +365,11 @@ td:hover .drill_down, th:hover .drill_down {
 
 /*Buttons*/
 
-.form_controls {
-  margin-top: 6px;
+.form--buttons.-with-button-form {
+  position: relative;
 }
 
-.form_controls .button {
+.form--buttons.-with-button-form .button {
   margin-bottom: 0;
 }
 

--- a/modules/reporting_engine/lib/widget/settings.rb
+++ b/modules/reporting_engine/lib/widget/settings.rb
@@ -37,7 +37,7 @@ class Widget::Settings < Widget::Base
   end
 
   def render_controls_settings
-    content_tag :div, class: 'buttons form_controls' do
+    content_tag :div, class: 'form--buttons -with-button-form' do
       widgets = ''.html_safe
       render_widget(Widget::Controls::Apply, @subject, to: widgets)
       render_widget(Widget::Controls::Save, @subject, to: widgets,


### PR DESCRIPTION
Position the „save as“ modal correctly.

https://community.openproject.com/projects/openproject/work_packages/28958/activity