### PR TITLE
[29057] Mobile styling issues on MSEdge

### DIFF
--- a/app/assets/stylesheets/content/work_packages/timelines/_timelines_header.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/_timelines_header.sass
@@ -3,7 +3,7 @@
   width: 100%
   position: sticky
   top: 0
-  z-index: 1000
+  z-index: 1
 
 .wp-timeline--header-element
   background: white

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -40,7 +40,6 @@ $menu-item-line-height: 30px
 
   #menu-sidebar
     +allow-vertical-scrolling
-    -ms-overflow-style: -ms-autohiding-scrollbar
     height: calc(100vh - #{$header-height})
     position: relative
     @include styled-scroll-bar-vertical


### PR DESCRIPTION
Fix mobile issues on MS Edge.

* The timeline was shown before the main menu.
* The scrollbar overlapped the menu content. 
* The misplaced top menus (as described in the ticket) did not happen for me.

https://community.openproject.com/projects/openproject/work_packages/29057/activity