### PR TITLE
Force puma config

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,7 @@ OpenProject::Application.configure do
 
   # Automatically refresh translations with I18n middleware
   config.middleware.use ::I18n::JS::Middleware
+  config.middleware.insert_before Rack::Sendfile, ActionDispatch::DebugLocks
 
   # Do not eager load code on boot.
   config.eager_load = false

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,33 @@
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers: a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma.
+#
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 1 }
+threads threads_count, threads_count
+
+# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+#
+port        ENV.fetch("PORT") { 3000 }
+
+# Specifies the `environment` that Puma will run in.
+#
+environment ENV.fetch("RAILS_ENV") { "development" }
+
+# Specifies the number of `workers` to boot in clustered mode.
+# Workers are forked webserver processes. If using threads and workers together
+# the concurrency of the application would be max `threads` * `workers`.
+# Workers do not work on JRuby or Windows (both of which do not support
+# processes).
+#
+workers ENV.fetch("WEB_CONCURRENCY") { 1 }
+
+# Use the `preload_app!` method when specifying a `workers` number.
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory.
+#
+preload_app! if Rails.env.production?
+
+# Allow puma to be restarted by `rails restart` command.
+plugin :tmp_restart

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -16,7 +16,7 @@ end
 Capybara::Screenshot.prune_strategy = :keep_last_run
 
 # silence puma if we're using it
-Capybara.server = :puma, { Silent: true }
+Capybara.server = :puma
 
 # Set up S3 uploads if desired
 if ENV['OPENPROJECT_ENABLE_CAPYBARA_SCREENSHOT_S3_UPLOADS'] && ENV['AWS_ACCESS_KEY_ID']


### PR DESCRIPTION
Puma is now used as dev browser with its default threads, which will break things. However we might want to test whether we can use it multi-process on dev. For that, we have to force it not using processes on test however.