### PR TITLE
[29055] Small responsiveness issues

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -248,6 +248,7 @@ hr
   border:         0
   // Flexbox needs that parents of children with overflow set to have a width:
   min-width: 0
+  word-break: break-word
 
 
 %form--fieldset-legend-or-section-title

--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -48,6 +48,7 @@ body.controller-work_packages.full-create
     @include clearfix
 
   ul#toolbar-items
+    margin-left: 10px
     @include clearfix
 
     li
@@ -184,6 +185,7 @@ body.controller-work_packages.full-create
       margin-bottom: 6px
 
   .subject-header
+    width: 100%
     margin: 0
 
     .wp-table--cell-span


### PR DESCRIPTION
This fixes the two issues described in the ticket:
* The edit form of the WP subject spans the whole width again.
* In forms long words are wrapped to a new line. 

https://community.openproject.com/projects/openproject/work_packages/29055/activity