### PR TITLE
[28869] Creating a new version is too complicated

### DIFF
--- a/app/views/project_settings/_boards.html.erb
+++ b/app/views/project_settings/_boards.html.erb
@@ -32,6 +32,16 @@ See docs/COPYRIGHT.rdoc for more details.
     <legend class="form--fieldset-legend">
       <%= l(:label_available_project_boards) %>
     </legend>
+    <div class="form--fieldset-control">
+      <span class="form--fieldset-control-container">
+        <%= link_to_if_authorized({ controller: '/boards', action: 'new', project_id: @project },
+                                  { aria: { label: t(:label_board_new) },
+                                    title: t(:label_board_new) }) do %>
+          <%= op_icon('icon-add icon-small') %>
+            <span><%= t('activerecord.models.board') %></span>
+        <% end %>
+      </span>
+    </div>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
         <table class="generic-table">

--- a/app/views/project_settings/_categories.html.erb
+++ b/app/views/project_settings/_categories.html.erb
@@ -31,6 +31,16 @@ See docs/COPYRIGHT.rdoc for more details.
     <legend class="form--fieldset-legend">
       <%= l(:label_available_project_work_package_categories) %>
     </legend>
+    <div class="form--fieldset-control">
+      <span class="form--fieldset-control-container">
+        <%= link_to_if_authorized({ controller: '/categories', action: 'new', project_id: @project },
+                                  { aria: { label: t(:label_work_package_category_new) },
+                                    title: t(:label_work_package_category_new) }) do %>
+          <%= op_icon('icon-add icon-small') %>
+            <span><%= t('activerecord.models.category') %></span>
+        <% end %>
+      </span>
+    </div>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
         <table class="generic-table">

--- a/app/views/project_settings/_versions.html.erb
+++ b/app/views/project_settings/_versions.html.erb
@@ -31,6 +31,16 @@ See docs/COPYRIGHT.rdoc for more details.
     <legend class="form--fieldset-legend">
       <%= l(:label_available_project_versions) %>
     </legend>
+    <div class="form--fieldset-control">
+      <span class="form--fieldset-control-container">
+        <%= link_to_if_authorized({ controller: '/versions', action: 'new', project_id: @project },
+                                  { aria: { label: t(:label_version_new) },
+                                    title: t(:label_version_new) }) do %>
+          <%= op_icon('icon-add icon-small') %>
+            <span><%= l(:label_version) %></span>
+        <% end %>
+      </span>
+    </div>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
         <table class="generic-table">

--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -27,7 +27,17 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= toolbar title: l(:label_roadmap) %>
+<%= toolbar title: t(:label_roadmap) do %>
+  <li class="toolbar-item">
+    <%= link_to_if_authorized({ controller: '/versions', action: 'new', project_id: @project },
+                { class: 'button -alt-highlight',
+                  aria: { label: t(:label_version_new) },
+                  title: t(:label_version_new) }) do %>
+        <%= op_icon('button--icon icon-add') %>
+        <span class="button--text"><%= t('activerecord.models.version') %></span>
+    <% end %>
+  </li>
+<% end %>
 
 <% if @versions.empty? %>
   <%= no_results_box %>

--- a/modules/backlogs/app/views/project_settings/_versions.html.erb
+++ b/modules/backlogs/app/views/project_settings/_versions.html.erb
@@ -31,6 +31,16 @@ See doc/COPYRIGHT.rdoc for more details.
     <legend class="form--fieldset-legend">
       <%= l(:label_available_project_versions) %>
     </legend>
+    <div class="form--fieldset-control">
+      <span class="form--fieldset-control-container">
+        <%= link_to_if_authorized({ controller: '/versions', action: 'new', project_id: @project },
+                                  { aria: { label: t(:label_version_new) },
+                                    title: t(:label_version_new) }) do %>
+          <%= op_icon('icon-add icon-small') %>
+            <span><%= l(:label_version) %></span>
+        <% end %>
+      </span>
+    </div>
     <div class="generic-table--container">
       <div class="generic-table--results-container">
         <table class="generic-table">

--- a/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
@@ -41,7 +41,18 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <div class='contextual'></div>
 <% html_title l(:label_backlogs) %>
-<%= toolbar title: l(:label_backlogs) %>
+
+<%= toolbar title: t(:label_backlogs) do %>
+    <li class="toolbar-item">
+      <%= link_to_if_authorized({ controller: '/versions', action: 'new', project_id: @project },
+                                { class: 'button -alt-highlight',
+                                  aria: { label: t(:label_version_new) },
+                                  title: t(:label_version_new) }) do %>
+          <%= op_icon('button--icon icon-add') %>
+          <span class="button--text"><%= t('activerecord.models.version') %></span>
+      <% end %>
+    </li>
+<% end %>
 
 <% if (@owner_backlogs.empty? && @sprint_backlogs.empty?) %>
   <%= no_results_box action_url: new_project_version_path(@project),


### PR DESCRIPTION
This simplifies creating a version. Therefore buttons to create a version are added on the roadmap, backlogs and in the project settings. In the settings it was necessary because the button is at the bottom of the list making it hard to see when the list is long. For unification the other setting pages the look similar where changed, too.
