### PR TITLE
[29705] Logged unit cost and labor cost not shown on work package view

### DIFF
--- a/modules/costs/frontend/module/wp-display/wp-display-currency-field.module.ts
+++ b/modules/costs/frontend/module/wp-display/wp-display-currency-field.module.ts
@@ -32,7 +32,7 @@ export class CurrencyDisplayField extends DisplayField {
 
     public isEmpty():boolean {
         return !this.value ||
-            !parseFloat(this.value.split(" ")[0]);
+            !parseFloat(this.value.match(/\d+/g)[0]);
     }
 }
 


### PR DESCRIPTION
Handle different currency formats with regex. For example values like `$ 30` are now also parsed correctly.


https://community.openproject.com/projects/gmbh/work_packages/29075/activity