### PR TITLE
[28879] Automatically create "related to" relation on copy

### DIFF
--- a/frontend/src/app/components/wp-copy/wp-copy.controller.ts
+++ b/frontend/src/app/components/wp-copy/wp-copy.controller.ts
@@ -30,18 +30,40 @@ import {take} from 'rxjs/operators';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {WorkPackageChangeset} from 'core-components/wp-edit-form/work-package-changeset';
 import {WorkPackageCreateController} from 'core-components/wp-new/wp-create.controller';
+import {WorkPackageRelationsService} from "core-components/wp-relations/wp-relations.service";
+import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 
 export class WorkPackageCopyController extends WorkPackageCreateController {
+  private __initialized_at:Number;
+  private copiedWorkPackageId:string;
+
+  private wpRelations:WorkPackageRelationsService = this.injector.get(WorkPackageRelationsService);
+
+  ngOnInit() {
+    super.ngOnInit();
+
+    this.wpCreate.onNewWorkPackage()
+      .pipe(
+        untilComponentDestroyed(this)
+      )
+      .subscribe((wp:WorkPackageResource) => {
+        if (wp.__initialized_at === this.__initialized_at) {
+          this.wpRelations.addCommonRelation(wp.id, 'relates', this.copiedWorkPackageId);
+        }
+      });
+  }
+
   protected newWorkPackageFromParams(stateParams:any) {
+    this.copiedWorkPackageId = stateParams.copiedFromWorkPackageId;
     return new Promise<WorkPackageChangeset>((resolve, reject) => {
-      this.wpCacheService.loadWorkPackage(stateParams.copiedFromWorkPackageId)
+      this.wpCacheService.loadWorkPackage(this.copiedWorkPackageId)
         .values$()
         .pipe(
           take(1)
         )
-        .subscribe(
-          (wp:WorkPackageResource) => this.createCopyFrom(wp).then(resolve),
-          reject);
+        .subscribe((wp:WorkPackageResource) => {
+          this.createCopyFrom(wp).then(resolve, reject);
+        });
     });
   }
 
@@ -50,9 +72,16 @@ export class WorkPackageCopyController extends WorkPackageCreateController {
   }
 
   private createCopyFrom(wp:WorkPackageResource) {
-    const changeset = this.wpEditing.changesetFor(wp);
-    return changeset.getForm().then((form:any) => {
-      return this.wpCreate.copyWorkPackage(form, wp.project.identifier);
-    });
+    return this.wpEditing
+      .changesetFor(wp)
+      .getForm()
+      .then((form:any) =>
+        this.wpCreate
+          .copyWorkPackage(form, wp.project.identifier)
+          .then((changeset) => {
+            this.__initialized_at = changeset.workPackage.__initialized_at;
+            return changeset;
+        })
+    );
   }
 }

--- a/spec/features/work_packages/copy_spec.rb
+++ b/spec/features/work_packages/copy_spec.rb
@@ -44,9 +44,10 @@ RSpec.feature 'Work package copy', js: true, selenium: true do
 
   let(:create_role) do
     FactoryBot.create(:role,
-                      permissions: [:view_work_packages,
-                                    :add_work_packages,
-                                    :edit_work_packages])
+                      permissions: %i[view_work_packages
+                                      add_work_packages
+                                      manage_work_package_relations
+                                      edit_work_packages])
   end
   let(:type) { FactoryBot.create(:type) }
   let(:project) { FactoryBot.create(:project, types: [type]) }
@@ -121,6 +122,11 @@ RSpec.feature 'Work package copy', js: true, selenium: true do
 
     work_package_page.expect_activity user, number: 1
     work_package_page.expect_current_path
+
+    work_package_page.visit_tab! :relations
+    expect_angular_frontend_initialized
+    expect(page).to have_selector('.relation-group--header', text: 'RELATED TO')
+    expect(page).to have_selector('.wp-relations--subject-field', text: original_work_package.subject)
   end
 
   scenario 'on split screen page' do
@@ -152,5 +158,11 @@ RSpec.feature 'Work package copy', js: true, selenium: true do
 
     work_package_page.expect_activity user, number: 1
     work_package_page.expect_current_path
+
+
+    work_package_page.visit_tab!('relations')
+    expect_angular_frontend_initialized
+    expect(page).to have_selector('.relation-group--header', text: 'RELATED TO')
+    expect(page).to have_selector('.wp-relations--subject-field', text: original_work_package.subject)
   end
 end


### PR DESCRIPTION
This creates automatically a relation between a copied WP and its origin.