### PR TITLE
[29102] Open the right-click context menu close to the mouse icon

### DIFF
--- a/frontend/src/app/components/op-context-menu/op-context-menu-handler.ts
+++ b/frontend/src/app/components/op-context-menu/op-context-menu-handler.ts
@@ -32,7 +32,7 @@ export abstract class OpContextMenuHandler {
     return {
       my: 'left top',
       at: 'right bottom',
-      of: this.$element,
+      of: openerEvent,
       collision: 'flipfit'
     };
   }


### PR DESCRIPTION
Open context menus at the position of the click event. Note that the WP table context menu is the only one affected by that. All other menus inherit from the `op-context-menu-trigger` which has a different position set.

https://community.openproject.com/projects/openproject/work_packages/29102/activity