### PR TITLE
Allow to load rack-mini-profiler with OPENPROJECT_RACK_PROFILER_ENABLED

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -253,6 +253,11 @@ group :development, :test do
   gem 'ruby-prof', require: false
   gem 'puma', '~> 3.11.3'
 
+  # Tracing and profiling gems
+  gem 'rack-mini-profiler', require: false
+  gem 'flamegraph', require: false
+  gem 'stackprof', require: false
+
   gem 'pry-rails', '~> 0.3.6'
   gem 'pry-stack_explorer', '~> 0.4.9.2'
   gem 'pry-rescue', '~> 1.4.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,6 +399,7 @@ GEM
       i18n (~> 0.5)
     fastimage (2.1.4)
     ffi (1.9.25)
+    flamegraph (0.9.5)
     fog-aws (0.11.0)
       fog-core (~> 1.38)
       fog-json (~> 1.0)
@@ -585,6 +586,8 @@ GEM
       rack (>= 0.4)
     rack-attack (5.2.0)
       rack
+    rack-mini-profiler (1.0.0)
+      rack (>= 1.2.0)
     rack-oauth2 (1.9.3)
       activesupport
       attr_required
@@ -749,6 +752,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    stackprof (0.2.12)
     stringex (2.7.1)
     svg-graph (2.1.3)
     swd (1.1.2)
@@ -853,6 +857,7 @@ DEPENDENCIES
   factory_bot (~> 4.8)
   factory_bot_rails (~> 4.8)
   faker
+  flamegraph
   fog-aws
   friendly_id (~> 5.2.1)
   fuubar (~> 2.3.1)
@@ -909,6 +914,7 @@ DEPENDENCIES
   puma (~> 3.11.3)
   rabl (~> 0.13.0)
   rack-attack (~> 5.2.0)
+  rack-mini-profiler
   rack-protection (~> 2.0.0)
   rack-test (~> 1.0.0)
   rack_session_access
@@ -948,6 +954,7 @@ DEPENDENCIES
   simplecov (~> 0.16.0)
   sprockets (~> 3.7.0)
   sqlite3
+  stackprof
   stringex (~> 2.7.1)
   svg-graph (~> 2.1.0)
   sys-filesystem (~> 1.1.4)

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+if Rails.env.development? && ENV['OPENPROJECT_RACK_PROFILER_ENABLED']
+  require "rack-mini-profiler"
+  require 'flamegraph'
+  require 'stackprof'
+
+  # initialization is skipped so trigger it
+  Rack::MiniProfilerRails.initialize!(Rails.application)
+
+  Rack::MiniProfiler.config.position = 'bottom-right'
+end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -32,6 +32,14 @@ SecureHeaders::Configuration.default do |config|
     assets_src += proxied
   end
 
+  # Allow to extend the script-src in specific situations
+  script_src = assets_src
+
+  # Allow unsafe-eval for rack-mini-profiler
+  if Rails.env.development? && ENV['OPENPROJECT_RACK_PROFILER_ENABLED']
+    script_src += %w('unsafe-eval')
+  end
+
   config.csp = {
     preserve_schemes: true,
 
@@ -50,7 +58,7 @@ SecureHeaders::Configuration.default do |config|
     # Allow images from anywhere including data urls and blobs (used in resizing)
     img_src: %w(* data: blob:),
     # Allow scripts from self
-    script_src: assets_src,
+    script_src: script_src,
     # Allow unsafe-inline styles
     style_src: assets_src + %w('unsafe-inline'),
     # disallow all object-src

--- a/frontend/src/app/components/routing/ui-router.config.ts
+++ b/frontend/src/app/components/routing/ui-router.config.ts
@@ -226,6 +226,9 @@ export function initializeUiRouterConfiguration(injector:Injector) {
     let wpBase = document.querySelector(wpBaseAppSelector);
 
     $transitions.onStart({}, function(transition:Transition) {
+      const profiler:any = (window as any).MiniProfiler;
+      profiler && profiler.pageTransition();
+
       const $state = transition.router.stateService;
       const toParams = transition.params('to');
       const toState = transition.to();

--- a/spec/features/work_packages/copy_spec.rb
+++ b/spec/features/work_packages/copy_spec.rb
@@ -125,7 +125,7 @@ RSpec.feature 'Work package copy', js: true, selenium: true do
 
     work_package_page.visit_tab! :relations
     expect_angular_frontend_initialized
-    expect(page).to have_selector('.relation-group--header', text: 'RELATED TO')
+    expect(page).to have_selector('.relation-group--header', text: 'RELATED TO', wait: 20)
     expect(page).to have_selector('.wp-relations--subject-field', text: original_work_package.subject)
   end
 
@@ -162,7 +162,7 @@ RSpec.feature 'Work package copy', js: true, selenium: true do
 
     work_package_page.visit_tab!('relations')
     expect_angular_frontend_initialized
-    expect(page).to have_selector('.relation-group--header', text: 'RELATED TO')
+    expect(page).to have_selector('.relation-group--header', text: 'RELATED TO', wait: 20)
     expect(page).to have_selector('.wp-relations--subject-field', text: original_work_package.subject)
   end
 end


### PR DESCRIPTION
Adds the option to profile the current request with rack-mini-profiler, which gets only loaded when the ENV `OPENPROJECT_RACK_PROFILER_ENABLED` is passed to avoid any impact on development when not profiling.

Adds a small JS helper to inspect the request (however requires unsafe-eval, which is not too bad since enabled manually for it)
![screenshot from 2018-11-30 15-41-12](https://user-images.githubusercontent.com/459462/49295612-7e994800-f4b6-11e8-842d-a4444cfc79ec.png)

Allows live flamegraphs of a request
![screenshot from 2018-11-30 15-41-25](https://user-images.githubusercontent.com/459462/49295613-7f31de80-f4b6-11e8-870d-4cc108d5ee2c.png)
