### PR TITLE
[28956] Refactor filters to CSS grid and fix minor styling issues in forms

### DIFF
--- a/app/assets/stylesheets/content/_advanced_filters.sass
+++ b/app/assets/stylesheets/content/_advanced_filters.sass
@@ -43,74 +43,42 @@
     width: 1rem
     z-index: 2
 
-@mixin advanced-filters--sizing()
-  @include grid-block()
-
-  @include breakpoint(medium)
-    @include grid-size(12)
-
-  @include breakpoint(large)
-    @include grid-size(10)
-
-  @include breakpoint(xlarge)
-    @include grid-size(8)
-
-  @include breakpoint(xxlarge)
-    @include grid-size(6)
-
-  @include breakpoint(xxxlarge)
-    @include grid-size(5)
-
 .advanced-filters--filters
   list-style-type:  none
-  margin:           0
+  margin:           20px 0 0 0
 
-.advanced-filters--filter
-  @include advanced-filters--sizing
-  align-items:      center
-  padding:          0.5rem 0
-  // necessary to display tooltips
-  overflow:         visible
+  > li
+    display: grid
+    // Filters will not span the whole width,
+    // but have an orientation to the left side
+    grid-template-columns: 20% 20% 25%
+    grid-gap: 10px
+    align-items: center
+    margin-bottom: 10px
+
+  .advanced-filters--filter-name,
+  .advanced-filters--add-filter-label
+    @include text-shortener
+    margin: auto 0
+
+  .advanced-filters--filter-value,
+  .advanced-filters--filter-operator
+    .advanced-filters--select,
+    .advanced-filters--number-field
+      @include form--input-field-mixin--small
+      @include form--input-field-mixin--narrow
+      flex: 0 0 auto
 
 // The type="text" is required to be more specific
 .advanced-filters--text-field[type="text"],
 .advanced-filters--date-field[type="text"]
   @extend .form--text-field
-  @include form--input-field-mixin--small
 
   &:required
     box-shadow: none
 
 .advanced-filters--select
   @extend .form--select
-  @include form--input-field-mixin--small
-  @include form--input-field-mixin--narrow
-  margin-bottom: 0
-
-// The type="number" is required to be more specific
-.advanced-filters--number-field[type="number"]
-  @extend .form--text-field
-  @include form--input-field-mixin--small
-
-.advanced-filters--filter-name
-  @include grid-content(2)
-  @include text-shortener
-  font-size: 0.9rem
-  min-width: 156px
-  padding-right: 0
-
-.advanced-filters--filter-operator
-  @include grid-content()
-  @include grid-visible-overflow
-  min-width: 120px
-  max-width: 200px
-
-.advanced-filters--filter-value
-  @include grid-content()
-  @include grid-visible-overflow
-
-  op-date-picker
-    flex: 1
 
 .advanced-filters--affix
   @extend .form--field-affix
@@ -121,9 +89,8 @@
   @extend .advanced-filters--affix, .tooltip--right
 
 .advanced-filters--remove-filter
-  @include grid-content($size: shrink)
-  @include grid-visible-overflow
-  padding: 0
+  grid-column: -1
+  text-align: right
 
   a
     display: block
@@ -133,25 +100,9 @@
 
 .advanced-filters--remove-filter-icon
   @extend .icon-close, .icon4
-  @include grid-content(1)
-  @include grid-visible-overflow
-
-.advanced-filters--add-filter
-  @include advanced-filters--sizing
-  align-items:      center
-  padding:          0.25rem 0
-
-.advanced-filters--add-filter-label
-  @extend .advanced-filters--filter-name
 
 .advanced-filters--add-filter-label-icon
   @extend .icon-add, .icon4
-
-.advanced-filters--add-filter-value
-  @include grid-content()
-  @include grid-visible-overflow
-  min-width: 120px
-  max-width: 200px
 
 .advanced-filters--add-filter-info
   @include grid-content()
@@ -169,6 +120,24 @@
     display: none
 
 
-
 fieldset#date-range p
   margin: 2px 0 2px 0
+
+@include breakpoint(680px down)
+  .advanced-filters--filters
+    .advanced-filters--filter
+      grid-gap: 0 10px
+
+    .advanced-filters--filter-name,
+    .advanced-filters--add-filter-label
+      grid-column: 1 / -1
+
+    .advanced-filters--filter-operator,
+    .advanced-filters--filter-value
+      grid-column: span 2
+      order: 2
+
+      .advanced-filters--text-field,
+      .advanced-filters--select,
+      .advanced-filters--number-field
+        width: 100%

--- a/app/assets/stylesheets/content/_custom_actions.sass
+++ b/app/assets/stylesheets/content/_custom_actions.sass
@@ -30,7 +30,6 @@
   display: flex
   flex-wrap: wrap
   // Cancel out the margin of the buttons
-  width: calc(100% + 10px)
   margin-right: -10px
 
   .custom-action

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -59,8 +59,7 @@ form
   display: block
   position: relative
 
-  &.my-page--block-form,
-  &#revision_selector
+  .toolbar-items > &
     display: flex
     flex-wrap: wrap
 

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -59,6 +59,11 @@ form
   display: block
   position: relative
 
+  &.my-page--block-form,
+  &#revision_selector
+    display: flex
+    flex-wrap: wrap
+
   &.-inline
     display: inline
 

--- a/app/assets/stylesheets/content/_forms_mobile.sass
+++ b/app/assets/stylesheets/content/_forms_mobile.sass
@@ -38,13 +38,16 @@
     .form--field.-wide-label .form--label,
     .form--label,
     .form--field-container,
-    .form--select-container,
-    .form--field-instructions
+    .form--select-container
       @include grid-content(12)
       display: flex
       flex: 1
       margin-left: 0
       padding: 0
+    .form--field-instructions
+      margin-left: 0
+      flex-basis: 100%
+      max-width: 100%
 
   #tab-content-info form
     .form--label,

--- a/app/assets/stylesheets/content/_simple_filters.lsg
+++ b/app/assets/stylesheets/content/_simple_filters.lsg
@@ -2,7 +2,8 @@
 
 Simple filters are forms that serve the purpose of limiting the number of entries in a list. As opposed to advanced filters however, there is no operator selection to search with.
 
-By default, simple filters have a two columned layout.
+By default, simple filters can have multiple fields per row (as many as the given space allows).
+
 
 ```
 @full-width
@@ -11,39 +12,6 @@ By default, simple filters have a two columned layout.
   <a title="Close filter" class="simple-filters--close icon-context icon-close"></a>
   <legend>Simple Filters</legend>
   <ul class="simple-filters--filters">
-    <li class="simple-filters--filter">
-      <label for="filter-1" class="simple-filters--filter-name">Project</label>
-      <div class="simple-filters--filter-value">
-        <input id="filter-1" type="text" placeholder="select">
-      </div>
-    </li>
-    <li class="simple-filters--filter">
-      <label for="filter-2" class="simple-filters--filter-name">Status</label>
-      <div class="simple-filters--filter-value">
-        <select id="filter-2" class="simple-filters--select">
-          <option value="=" label="Active" selected="selected">Active</option>
-          <option value="!" label="Archived">Archived</option>
-          <option value="!*" label="All">all</option>
-        </select>
-      </div>
-    </li>
-    <li class="simple-filters--controls">
-      <a class="button -highlight -small" href="#">Apply</a>
-      <a class="button -small -with-icon icon-undo" href="#">Clear</a>
-    </li>
-  </ul>
-</fieldset>
-```
-
-If desired, the simple filter can have three columns. Analogical the filter can also have four columns with '-columns-4'.
-
-```
-@full-width
-
-<fieldset class="simple-filters--container">
-  <a title="Close filter" class="simple-filters--close icon-context icon-close"></a>
-  <legend>Simple Filters</legend>
-  <ul class="simple-filters--filters -columns-3">
     <li class="simple-filters--filter">
       <label for="filter-1" class="simple-filters--filter-name">Project</label>
       <div class="simple-filters--filter-value">

--- a/app/assets/stylesheets/content/_simple_filters.sass
+++ b/app/assets/stylesheets/content/_simple_filters.sass
@@ -36,6 +36,13 @@ $filters--border-color: $gray !default
   legend
     @extend .hidden-for-sighted
 
+%filters-grid
+  display:          grid
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr))
+  grid-gap:         10px 40px
+  list-style-type:  none
+  margin:           10px 0 0 0
+
 .simple-filters--container
   @extend %filters--container
   padding: 1rem 1rem 1rem 1rem
@@ -43,125 +50,42 @@ $filters--border-color: $gray !default
   position: relative
 
   .simple-filter--trailing-labels
-    list-style-type: none
-    display: flex
-    margin-left: 0
-
-    .simple-filters--filter
-      flex-basis: 33.33%
-      max-width: 33.33%
-      padding: 0 1rem 0 0
-
-    &.-label-columns-3
-      .simple-filters--filter
-        flex-basis: 25%
-        max-width: 25%
+    @extend %filters-grid
 
   &.collapsed
     display: none
 
   .simple-filters--close
     position: absolute
-    top: 0.75rem
-    right: 0.75rem
+    top: 5px
+    right: 5px
     width: 1rem
     z-index: 2
 
 .simple-filters--filters
-  @extend .advanced-filters--filters
-  @include grid-block
-  @include grid-layout(1)
-  justify-content: flex-start
+  @extend %filters-grid
 
-  @include breakpoint(large)
-    @include grid-layout(3)
-
-  // Cancel out foundations padding which breaks in IE. IE seems to calculate
-  // the padding on top of the flex-basis size. That means when the flex-basis
-  // is 50% and two elements should be within a row and padding is anything but
-  // 0. The elements will in sum take up more than 100% and thus the second
-  // element will move to the next row.
-  .simple-filters--filter
-    padding: 0 1rem 0 0
-    display: flex
+  > li:not(.simple-filters--controls)
+    display: grid
+    grid-template-columns: repeat(auto-fill, 50%)
     align-items: center
-    @include breakpoint(large)
-    max-width: 33.33%
-
-    &.-full-width
-      flex-basis: 100%
-      max-width: 100%
-      margin-bottom: 1rem
-
-    @media only screen and (max-width: 1200px)
-      margin-bottom: 1rem
-      max-width: 100%
-
-    .simple-filters--filter-name
-      flex-basis: 25%
-      max-width: 25%
-      padding-right: 0
-      margin-right: 1rem
-      @include text-shortener
-    .simple-filters--filter-value
-      flex-basis: 70%
-      max-width: 70%
-      // important for consistent padding between input and select fields
-      padding-right: 0.375rem
 
     .form--radio-button-container
       margin-right: 20px
       flex-grow: 0
 
-  .simple-filters--controls
-    padding: 0 0 0 1rem
-    align-self: center
-    @include breakpoint(large)
-      flex: 1
-    max-width: 33.33%
-
-    @media only screen and (max-width: 1200px)
-      padding: 0
-
     button,
     .button
-      margin-bottom: 0rem
+      margin: 0 10px 10px 0
 
-.simple-filters--filters.-columns-3
-  @include breakpoint(large)
-    @include grid-layout(4)
-
-  .simple-filters--filter,
   .simple-filters--controls
-    @include breakpoint(large)
-    max-width: 25%
-    margin-top: 1rem
+    grid-column: 1 / -1
+    margin-top: 10px
 
-    @media only screen and (max-width: 1200px)
-      max-width: 100%
-      margin-top: 0rem
+  .simple-filters--filter-name
+    @include text-shortener
+    margin: auto 0
 
-    button,
-    .button
-      margin-bottom: 0rem
-
-.simple-filters--filters.-columns-4
-  @include breakpoint(large)
-    @include grid-layout(5)
-
-  .simple-filters--filter,
-  .simple-filters--controls
-    @include breakpoint(large)
-    max-width: 20%
-    margin-top: 1rem
-
-    @media only screen and (max-width: 1200px)
-      max-width: 100%
-      margin-top: 0rem
-
-    button,
-    .button
-      margin-bottom: 0rem
-
-.simple-filters--filters + .simple-filter--trailing-labels
-  margin-top: 1rem
+@include breakpoint(680px down)
+  .simple-filters--filter-value
+    grid-column: 1 / -1

--- a/app/cells/views/user_filter/show.erb
+++ b/app/cells/views/user_filter/show.erb
@@ -31,20 +31,12 @@ See doc/COPYRIGHT.rdoc for more details.
    <% collapsed_class =  initially_visible? ? '' : 'collapsed' %>
   <fieldset class="simple-filters--container <%= collapsed_class %>">
     <legend><%= t(:label_filter_plural) %></legend>
-    <% custom_class = ''
-      if groups.present? || roles.present?
-        custom_class = '-columns-3'
-      end
-      if groups.present? && roles.present?
-        custom_class = '-columns-4'
-      end
-    %>
     <% if has_close_icon? %>
       <a title="<%= t('js.close_form_title') %>"
          class="toggle-member-filter-link simple-filters--close icon-context icon-close">
       </a>
     <% end %>
-    <ul class="simple-filters--filters <%= custom_class %>">
+    <ul class="simple-filters--filters">
       <li class="simple-filters--filter">
           <label class='simple-filters--filter-name' for='status'><%= User.human_attribute_name(:status) %>:</label>
           <%= select_tag 'status', user_status_options, class: 'simple-filters--filter-value' %>

--- a/modules/avatars/app/views/settings/_openproject_avatars.html.erb
+++ b/modules/avatars/app/views/settings/_openproject_avatars.html.erb
@@ -14,10 +14,12 @@
 
   <div class="form--field">
     <%= styled_label_tag 'settings[gravatar_default]', t('avatars.settings.gravatar_default') %>
-    <%= styled_select_tag 'settings[gravatar_default]',
-                          options_for_select(manager.default_gravatar_options, @settings['gravatar_default']),
-                          container_class: '-slim'
-    %>
+    <div class="form--field-container">
+      <%= styled_select_tag 'settings[gravatar_default]',
+                            options_for_select(manager.default_gravatar_options, @settings['gravatar_default']),
+                            container_class: '-slim'
+      %>
+    </div>
   </div>
 </fieldset>
 

--- a/modules/backlogs/app/views/shared/_settings.html.erb
+++ b/modules/backlogs/app/views/shared/_settings.html.erb
@@ -69,27 +69,35 @@ See doc/COPYRIGHT.rdoc for more details.
 <% html_title l(:label_administration), l(:label_plugins), 'Backlogs' %>
 <div class="form--field">
   <%= styled_label_tag("settings[story_types]", l(:backlogs_story_type)) %>
-  <%= styled_select_tag("settings[story_types]",
+  <div class="form--field-container">
+    <%= styled_select_tag("settings[story_types]",
                  options_from_collection_for_select(Type.all, :id, :name, Story.types),
                  :multiple => true,
                  container_class: '-slim') %>
+  </div>
 </div>
 <div class="form--field">
   <%= styled_label_tag("settings[task_type]", l(:backlogs_task_type)) %>
-  <%= styled_select_tag("settings[task_type]",
+  <div class="form--field-container">
+    <%= styled_select_tag("settings[task_type]",
                  options_from_collection_for_select(Type.all, :id, :name, Task.type),
                  container_class: '-slim') %>
+  </div>
 </div>
 <div class="form--field">
   <%= styled_label_tag("settings[points_burn_direction]", l(:backlogs_points_burn_direction)) %>
-  <%= styled_select_tag("settings[points_burn_direction]",
+  <div class="form--field-container">
+    <%= styled_select_tag("settings[points_burn_direction]",
                  options_for_select([[l(:label_points_burn_up), 'up'], [l(:label_points_burn_down), 'down']],
                                     Setting.plugin_openproject_backlogs["points_burn_direction"]),
                  container_class: '-slim') %>
+  </div>
 </div>
 <div class="form--field">
   <%= styled_label_tag("settings[wiki_template]", l(:backlogs_wiki_template)) %>
-  <%= styled_text_field_tag("settings[wiki_template]",
+  <div class="form--field-container">
+    <%= styled_text_field_tag("settings[wiki_template]",
                      Setting.plugin_openproject_backlogs["wiki_template"],
                      container_class: '-slim') %>
+  </div>
 </div>

--- a/modules/costs/app/views/settings/_openproject_costs.html.erb
+++ b/modules/costs/app/views/settings/_openproject_costs.html.erb
@@ -20,10 +20,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <% html_title l(:label_administration), l(:label_plugins), 'Openproject Costs' %>
 <div class="form--field">
   <%= styled_label_tag :label_currency, t(:label_currency) %>
-  <%= styled_text_field_tag 'settings[costs_currency]', @settings['costs_currency'], container_class: '-xslim' %>
+  <div class="form--field-container">
+    <%= styled_text_field_tag 'settings[costs_currency]', @settings['costs_currency'], container_class: '-xslim' %>
+  </div>
 </div>
 
 <div class="form--field">
   <%= styled_label_tag :label_currency_format, t(:label_currency_format) %>
-  <%= styled_text_field_tag 'settings[costs_currency_format]', @settings['costs_currency_format'], container_class: '-xslim' %>
+  <div class="form--field-container">
+    <%=  styled_text_field_tag 'settings[costs_currency_format]', @settings['costs_currency_format'], container_class: '-xslim' %>
+  </div>
 </div>

--- a/modules/global_roles/app/views/users/_available_global_role.html.erb
+++ b/modules/global_roles/app/views/users/_available_global_role.html.erb
@@ -18,5 +18,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 ++#%>
 
-<div class="principal_role_option" id= "principal_role_option_<%=h (role.id)%>">
-<%= check_box_tag 'principal_role[role_ids][]', role.id, false, :id => "principal_role_role_ids_#{role.id}", :disabled => !role.assignable_to?(@user) %><%= label_tag "principal_role_role_ids_#{role.id}", h(role) %></div>
+<div class="principal_role_option form--field" id= "principal_role_option_<%= h(role.id) %>">
+  <label class="form--label-with-check-box" for="principal_role_role_ids_<%= role.id %>">
+    <%= check_box_tag 'principal_role[role_ids][]',
+                      role.id,
+                      false,
+                      id: "principal_role_role_ids_#{role.id}",
+                      disabled: !role.assignable_to?(@user) %>
+    <%= h(role)%>
+  </label>
+</div>

--- a/modules/global_roles/app/views/users/_available_global_roles.html.erb
+++ b/modules/global_roles/app/views/users/_available_global_roles.html.erb
@@ -23,8 +23,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 end%>
 
 <div class="grid-content" id="available_principal_roles">
-  <fieldset>
-    <legend><%= Role.model_name.human(:count => 2) %></legend>
+  <fieldset class="form--fieldset">
+    <legend class="form--fieldset-legend"><%= Role.model_name.human(:count => 2) %></legend>
     <% if available_additional_global_roles(global_roles, user).count == 0 %>
       <span id="no_additional_principal_roles">
         <%= no_results_box %>

--- a/modules/reporting_engine/lib/assets/javascripts/reporting_engine/reporting/filters.js
+++ b/modules/reporting_engine/lib/assets/javascripts/reporting_engine/reporting/filters.js
@@ -111,7 +111,6 @@ Reporting.Filters = function($){
         load_available_values_for_filter(field, options.callback_func);
         $('#rm_' + field).val(field); // set the value, so the serialized form will return this filter
         value_changed(field);
-        set_filter_value_widths(100);
       } else {
         options.slowly ? field_el.fadeOut('slow') : field_el.hide();
 
@@ -119,7 +118,6 @@ Reporting.Filters = function($){
           field_el.removeAttr('data-selected');
         }
         $('#rm_' + field).val(""); // reset the value, so the serialized form will not return this filter
-        set_filter_value_widths(5000);
       }
       operator_changed(field, $("#operators\\[" + field + "\\]"));
       display_category($('#' + field_el.attr("data-label")));
@@ -142,39 +140,6 @@ Reporting.Filters = function($){
     show_filter(field, { show_filter: false, hide_only: hide_only });
     select_option_enabled($("#add_filter_select"), field, true);
   };
-
-  /*
-    Smoothly sets the width of currently displayed filters.
-    Params:
-      delay:Int
-        Time to wait before resizing the filters width */
-  var set_filter_value_widths = function (delay) {
-    window.clearTimeout(set_filter_value_widths_timeout);
-    if (visible_filters().length > 0) {
-      set_filter_value_widths_timeout = window.setTimeout(function () {
-        var table_data = $('#filter_' + visible_filters()[0] + ' .advanced-filters--filter-value').first().parent();
-        var current_width = table_data.width();
-        var filters = $(".advanced-filters--filter");
-        // First, reset all widths
-        filters.css('width', 'auto');
-        // Now, get the current width
-        // Any width will be fine, as the table layout makes all elements the same width
-        var new_width = table_data.width();
-        if (new_width < current_width) {
-          // Set all widths to previous, so we can animate
-          filters.css('width', current_width + 'px');
-        }
-        // Now, set all widths to be the widest
-        if (new_width < current_width) {
-          filters.animate('width', new_width + 'px');
-        } else {
-          filters.css('width', new_width + 'px');
-        }
-      }, delay);
-    }
-  };
-
-  var set_filter_value_widths_timeout;
 
   var last_visible_filter = function () {
     return $('.advanced-filters--filter:visible').last()[0];


### PR DESCRIPTION
This does the following things:

* Refactoring of the filters section (advanced / simple) to a CSS-Grid
  * Remove the foundation grid in the filters
  * Remove the super ugly modifier `-columns-3` and `-columns-4`
* Fix various form bugs
  * Add missing classes to plugin settings and global roles section
  * Prettify form field instructions on mobile
  * Avoid that CustomAction buttons span the whole width if not necessary

This PR is a direct extraction of https://github.com/opf/openproject/pull/6823/

https://community.openproject.com/projects/openproject/work_packages/28956
https://community.openproject.com/projects/openproject/work_packages/29033