### PR TITLE
[29072] Bugfix: Remove texts of delete and edit icons in tables

### DIFF
--- a/app/cells/custom_actions/row_cell.rb
+++ b/app/cells/custom_actions/row_cell.rb
@@ -18,14 +18,24 @@ module CustomActions
     def button_links
       [
         edit_link,
-        delete_link(custom_action_path(action))
+        delete_link
       ]
     end
 
     def edit_link
-      link_to t(:button_edit),
-              edit_custom_action_path(action),
-              class: 'icon icon-edit'
+      link_to(
+        op_icon('icon icon-edit'),
+        (edit_custom_action_path(action)),
+      )
+    end
+
+    def delete_link
+      link_to(
+        op_icon('icon icon-delete'),
+        (custom_action_path(action)),
+        method: :delete,
+        data: { confirm: I18n.t(:text_are_you_sure) }
+      )
     end
   end
 end

--- a/app/cells/custom_actions/row_cell.rb
+++ b/app/cells/custom_actions/row_cell.rb
@@ -25,7 +25,8 @@ module CustomActions
     def edit_link
       link_to(
         op_icon('icon icon-edit'),
-        edit_custom_action_path(action)
+        edit_custom_action_path(action),
+        title: t(:button_edit)
       )
     end
 
@@ -34,7 +35,8 @@ module CustomActions
         op_icon('icon icon-delete'),
         custom_action_path(action),
         method: :delete,
-        data: { confirm: I18n.t(:text_are_you_sure) }
+        data: { confirm: I18n.t(:text_are_you_sure) },
+        title: t(:button_delete)
       )
     end
   end

--- a/app/cells/custom_actions/row_cell.rb
+++ b/app/cells/custom_actions/row_cell.rb
@@ -25,14 +25,14 @@ module CustomActions
     def edit_link
       link_to(
         op_icon('icon icon-edit'),
-        (edit_custom_action_path(action)),
+        edit_custom_action_path(action)
       )
     end
 
     def delete_link
       link_to(
         op_icon('icon icon-delete'),
-        (custom_action_path(action)),
+        custom_action_path(action),
         method: :delete,
         data: { confirm: I18n.t(:text_are_you_sure) }
       )

--- a/app/cells/enumerations/row_cell.rb
+++ b/app/cells/enumerations/row_cell.rb
@@ -43,7 +43,8 @@ module Enumerations
         op_icon('icon icon-delete'),
         enumeration_path(enumeration),
         method: :delete,
-        data: { confirm: I18n.t(:text_are_you_sure) }
+        data: { confirm: I18n.t(:text_are_you_sure) },
+        title: t(:button_delete)
       )
     end
   end

--- a/app/cells/enumerations/row_cell.rb
+++ b/app/cells/enumerations/row_cell.rb
@@ -41,11 +41,10 @@ module Enumerations
     def delete_link
       link_to(
         op_icon('icon icon-delete'),
-        (enumeration_path(enumeration)),
+        enumeration_path(enumeration),
         method: :delete,
         data: { confirm: I18n.t(:text_are_you_sure) }
       )
     end
-
   end
 end

--- a/app/cells/enumerations/row_cell.rb
+++ b/app/cells/enumerations/row_cell.rb
@@ -34,8 +34,18 @@ module Enumerations
 
     def button_links
       [
-        delete_link(enumeration_path(enumeration))
+        delete_link
       ]
     end
+
+    def delete_link
+      link_to(
+        op_icon('icon icon-delete'),
+        (enumeration_path(enumeration)),
+        method: :delete,
+        data: { confirm: I18n.t(:text_are_you_sure) }
+      )
+    end
+
   end
 end

--- a/app/cells/statuses/row_cell.rb
+++ b/app/cells/statuses/row_cell.rb
@@ -49,7 +49,8 @@ module Statuses
         op_icon('icon icon-delete'),
         status_path(status),
         method: :delete,
-        data: { confirm: I18n.t(:text_are_you_sure) }
+        data: { confirm: I18n.t(:text_are_you_sure) },
+        title: t(:button_delete)
       )
     end
   end

--- a/app/cells/statuses/row_cell.rb
+++ b/app/cells/statuses/row_cell.rb
@@ -40,8 +40,17 @@ module Statuses
 
     def button_links
       [
-        delete_link(status_path(status))
+        delete_link
       ]
+    end
+
+    def delete_link
+      link_to(
+        op_icon('icon icon-delete'),
+        (status_path(status)),
+        method: :delete,
+        data: { confirm: I18n.t(:text_are_you_sure) }
+      )
     end
   end
 end

--- a/app/cells/statuses/row_cell.rb
+++ b/app/cells/statuses/row_cell.rb
@@ -47,7 +47,7 @@ module Statuses
     def delete_link
       link_to(
         op_icon('icon icon-delete'),
-        (status_path(status)),
+        status_path(status),
         method: :delete,
         data: { confirm: I18n.t(:text_are_you_sure) }
       )

--- a/app/views/attribute_help_texts/_tab.html.erb
+++ b/app/views/attribute_help_texts/_tab.html.erb
@@ -79,7 +79,11 @@ See docs/COPYRIGHT.rdoc for more details.
                 </attribute-help-text>
               </td>
               <td class="buttons">
-                <%= delete_link attribute_help_text_path(attribute_help_text) %>
+                <%= link_to(
+                      op_icon('icon icon-delete'),
+                      (attribute_help_text_path(attribute_help_text)),
+                      method: :delete,
+                      data: { confirm: I18n.t(:text_are_you_sure) }) %>
               </td>
             </tr>
           <% end %>

--- a/app/views/attribute_help_texts/_tab.html.erb
+++ b/app/views/attribute_help_texts/_tab.html.erb
@@ -83,7 +83,8 @@ See docs/COPYRIGHT.rdoc for more details.
                       op_icon('icon icon-delete'),
                       (attribute_help_text_path(attribute_help_text)),
                       method: :delete,
-                      data: { confirm: I18n.t(:text_are_you_sure) }) %>
+                      data: { confirm: I18n.t(:text_are_you_sure) },
+                      title: t(:button_delete)) %>
               </td>
             </tr>
           <% end %>

--- a/app/views/auth_sources/index.html.erb
+++ b/app/views/auth_sources/index.html.erb
@@ -101,7 +101,7 @@ See docs/COPYRIGHT.rdoc for more details.
               <td><%= source.users.count %></td>
               <td class="buttons">
                 <%= link_to l(:button_test), { action: 'test_connection', id: source } %>
-                <%= link_to l(:button_delete), { action: 'destroy', id: source },
+                <%= link_to '', { action: 'destroy', id: source },
                                            method: :delete,
                                            data: { confirm: l(:text_are_you_sure) },
                                            class: 'icon icon-delete',

--- a/app/views/auth_sources/index.html.erb
+++ b/app/views/auth_sources/index.html.erb
@@ -105,13 +105,14 @@ See docs/COPYRIGHT.rdoc for more details.
                                            method: :delete,
                                            data: { confirm: l(:text_are_you_sure) },
                                            class: 'icon icon-delete',
-                                           disabled: source.users.any? %>
+                                           disabled: source.users.any?,
+                                           title: t(:button_delete) %>
               </td>
             </tr>
           <% end %>
         </tbody>
       </table>
-      
+
     </div>
   </div>
   <%= pagination_links_full @auth_sources %>

--- a/app/views/custom_fields/_custom_options.html.erb
+++ b/app/views/custom_fields/_custom_options.html.erb
@@ -112,7 +112,8 @@ See docs/COPYRIGHT.rdoc for more details.
                     delete_option_of_custom_field_path(id: custom_field.id || 0, option_id: custom_option.id || 0),
                     method: :delete,
                     data: { confirm: t(:'custom_fields.confirm_destroy_option') },
-                    class: 'icon icon-delete delete-custom-option' %>
+                    class: 'icon icon-delete delete-custom-option',
+                    title: t(:button_delete) %>
               </td>
             </tr>
           <% end %>

--- a/app/views/custom_fields/_custom_options.html.erb
+++ b/app/views/custom_fields/_custom_options.html.erb
@@ -108,7 +108,7 @@ See docs/COPYRIGHT.rdoc for more details.
                 </span>
               </td>
               <td>
-                <%= link_to t(:button_delete),
+                <%= link_to '',
                     delete_option_of_custom_field_path(id: custom_field.id || 0, option_id: custom_option.id || 0),
                     method: :delete,
                     data: { confirm: t(:'custom_fields.confirm_destroy_option') },

--- a/app/views/custom_fields/_tab.html.erb
+++ b/app/views/custom_fields/_tab.html.erb
@@ -151,7 +151,11 @@ See docs/COPYRIGHT.rdoc for more details.
                 <td><%= reorder_links('custom_field', { action: 'update', id: custom_field, back_url: custom_fields_path(tab: tab[:name]) }, method: :put) %></td>
               <% end %>
               <td class="buttons">
-                <%= delete_link custom_field_path(custom_field) %>
+                <%= link_to(
+                      op_icon('icon icon-delete'),
+                      (custom_field_path(custom_field)),
+                      method: :delete,
+                      data: { confirm: I18n.t(:text_are_you_sure) }) %>
               </td>
             </tr>
           <% end %>

--- a/app/views/custom_fields/_tab.html.erb
+++ b/app/views/custom_fields/_tab.html.erb
@@ -155,7 +155,8 @@ See docs/COPYRIGHT.rdoc for more details.
                       op_icon('icon icon-delete'),
                       (custom_field_path(custom_field)),
                       method: :delete,
-                      data: { confirm: I18n.t(:text_are_you_sure) }) %>
+                      data: { confirm: I18n.t(:text_are_you_sure) },
+                      title: t(:button_delete)) %>
               </td>
             </tr>
           <% end %>

--- a/app/views/groups/_users_table.html.erb
+++ b/app/views/groups/_users_table.html.erb
@@ -50,9 +50,10 @@ See docs/COPYRIGHT.rdoc for more details.
       <tr id="user-<%= user.id %>">
         <td class="user"><%= link_to_user user %></td>
         <td class="buttons">
-          <%= link_to l(:button_remove), member_of_group_path(@group, user),
-                      method: :delete,
-                      class: 'icon icon-remove' %>
+          <%= link_to '', member_of_group_path(@group, user),
+                          method: :delete,
+                          class: 'icon icon-remove',
+                          title: t(:button_remove) %>
         </td>
       </tr>
   <% end %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -76,12 +76,12 @@ See docs/COPYRIGHT.rdoc for more details.
             <tr>
               <td><%= link_to h(group), action: 'edit', id: group %></td>
               <td><%= group.users.size %></td>
-              <td class="buttons"><%= link_to l(:button_delete), group, data: { confirm: l(:text_are_you_sure) }, method: :delete, class: 'icon icon-delete' %></td>
+              <td class="buttons"><%= link_to '', group, data: { confirm: l(:text_are_you_sure) }, method: :delete, class: 'icon icon-delete' %></td>
             </tr>
           <% end %>
         </tbody>
       </table>
-      
+
     </div>
   </div>
 <% else %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -76,7 +76,13 @@ See docs/COPYRIGHT.rdoc for more details.
             <tr>
               <td><%= link_to h(group), action: 'edit', id: group %></td>
               <td><%= group.users.size %></td>
-              <td class="buttons"><%= link_to '', group, data: { confirm: l(:text_are_you_sure) }, method: :delete, class: 'icon icon-delete' %></td>
+              <td class="buttons">
+                <%= link_to '', group,
+                                data: { confirm: l(:text_are_you_sure) },
+                                method: :delete,
+                                class: 'icon icon-delete',
+                                title: t(:button_delete) %>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/my/blocks/_timelog.html.erb
+++ b/app/views/my/blocks/_timelog.html.erb
@@ -117,12 +117,12 @@ entries_by_day = entries.group_by(&:spent_on)
                 <td class="hours"><%= html_hours("%.2f" % entry.hours) %></td>
                 <td class="buttons">
                   <% if entry.editable_by?(@user) -%>
-                    <%= link_to icon_wrapper('icon-context icon-edit', l(:button_edit)),
+                    <%= link_to icon_wrapper('icon-context icon-edit', ''),
                                 {controller: '/timelog', action: 'edit', id: entry},
                                 alt: l(:button_edit),
                                 class: 'no-decoration-on-hover',
                                 title: l(:button_edit) %>
-                    <%= link_to icon_wrapper('icon-context icon-delete', l(:button_delete)),
+                    <%= link_to icon_wrapper('icon-context icon-delete', ''),
                                 {controller: '/timelog', action: 'destroy', id: entry},
                                 data: { confirm: l(:text_are_you_sure) },
                                 class: 'no-decoration-on-hover',
@@ -136,7 +136,7 @@ entries_by_day = entries.group_by(&:spent_on)
           <% end -%>
         </tbody>
       </table>
-      
+
     </div>
   </div>
 <% end %>

--- a/app/views/project_settings/_boards.html.erb
+++ b/app/views/project_settings/_boards.html.erb
@@ -100,12 +100,14 @@ See docs/COPYRIGHT.rdoc for more details.
                 <td class="buttons">
                   <%= link_to_if_authorized '',
                                             { controller: '/boards', action: 'edit', project_id: @project, id: board },
-                                            class: 'icon icon-edit' %>
+                                            class: 'icon icon-edit',
+                                            title: t(:button_edit) %>
                   <%= link_to_if_authorized '',
                                             { controller: '/boards', action: 'destroy', project_id: @project, id: board },
                                             data: { confirm: l(:text_are_you_sure) },
                                             method: :delete,
-                                            class: 'icon icon-delete' %>
+                                            class: 'icon icon-delete',
+                                            title: t(:button_delete) %>
                 </td>
               </tr>
             <% end %>
@@ -132,4 +134,3 @@ See docs/COPYRIGHT.rdoc for more details.
                        custom_action_text: t('projects.settings.boards.no_results_content_text') %>
   <% end %>
 </fieldset>
-

--- a/app/views/project_settings/_boards.html.erb
+++ b/app/views/project_settings/_boards.html.erb
@@ -98,10 +98,10 @@ See docs/COPYRIGHT.rdoc for more details.
                   <% end %>
                 </td>
                 <td class="buttons">
-                  <%= link_to_if_authorized l(:button_edit),
+                  <%= link_to_if_authorized '',
                                             { controller: '/boards', action: 'edit', project_id: @project, id: board },
                                             class: 'icon icon-edit' %>
-                  <%= link_to_if_authorized l(:button_delete),
+                  <%= link_to_if_authorized '',
                                             { controller: '/boards', action: 'destroy', project_id: @project, id: board },
                                             data: { confirm: l(:text_are_you_sure) },
                                             method: :delete,

--- a/app/views/project_settings/_categories.html.erb
+++ b/app/views/project_settings/_categories.html.erb
@@ -81,13 +81,14 @@ See docs/COPYRIGHT.rdoc for more details.
                   <td class="buttons">
                     <%= link_to_if_authorized '',
                                               { controller: '/categories', action: 'edit', id: category },
-                                              class: 'icon icon-edit' %>
-
+                                              class: 'icon icon-edit',
+                                              title: t(:button_edit) %>
                     <%= link_to_if_authorized '',
                                               { controller: '/categories', action: 'destroy', id: category },
                                               data: { confirm: l(:text_are_you_sure) },
                                               method: :delete,
-                                              class: 'icon icon-delete' %>
+                                              class: 'icon icon-delete',
+                                              title: t(:button_delete) %>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/project_settings/_categories.html.erb
+++ b/app/views/project_settings/_categories.html.erb
@@ -79,11 +79,11 @@ See docs/COPYRIGHT.rdoc for more details.
                   <td><%=h(category.name) %></td>
                   <td><%=h(category.assigned_to.name) if category.assigned_to %></td>
                   <td class="buttons">
-                    <%= link_to_if_authorized l(:button_edit),
+                    <%= link_to_if_authorized '',
                                               { controller: '/categories', action: 'edit', id: category },
                                               class: 'icon icon-edit' %>
 
-                    <%= link_to_if_authorized l(:button_delete),
+                    <%= link_to_if_authorized '',
                                               { controller: '/categories', action: 'destroy', id: category },
                                               data: { confirm: l(:text_are_you_sure) },
                                               method: :delete,

--- a/app/views/project_settings/_versions.html.erb
+++ b/app/views/project_settings/_versions.html.erb
@@ -143,10 +143,10 @@ See docs/COPYRIGHT.rdoc for more details.
                 </td>
                 <td class="buttons">
                   <% if version.project == @project %>
-                    <%= link_to_if_authorized l(:button_edit),
+                    <%= link_to_if_authorized '',
                                               { controller: '/versions', action: 'edit', id: version },
                                               class: 'icon icon-edit' %>
-                    <%= link_to_if_authorized l(:button_delete),
+                    <%= link_to_if_authorized '',
                                               { controller: '/versions', action: 'destroy', id: version },
                                               data: { confirm: l(:text_are_you_sure) },
                                               method: :delete,

--- a/app/views/project_settings/_versions.html.erb
+++ b/app/views/project_settings/_versions.html.erb
@@ -145,12 +145,14 @@ See docs/COPYRIGHT.rdoc for more details.
                   <% if version.project == @project %>
                     <%= link_to_if_authorized '',
                                               { controller: '/versions', action: 'edit', id: version },
-                                              class: 'icon icon-edit' %>
+                                              class: 'icon icon-edit',
+                                              title: t(:button_edit) %>
                     <%= link_to_if_authorized '',
                                               { controller: '/versions', action: 'destroy', id: version },
                                               data: { confirm: l(:text_are_you_sure) },
                                               method: :delete,
-                                              class: 'icon icon-delete' %>
+                                              class: 'icon icon-delete',
+                                              title: t(:button_delete) %>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -86,13 +86,14 @@ See docs/COPYRIGHT.rdoc for more details.
               <%= link_to('', role_path(role),
                                        method: :delete,
                                        data: { confirm: l(:text_are_you_sure) },
-                                       class: 'icon icon-delete') unless role.builtin? %>
+                                       class: 'icon icon-delete',
+                                       title: t(:button_delete)) unless role.builtin? %>
             </td>
           </tr>
         <% end %>
       </tbody>
     </table>
-    
+
   </div>
 </div>
 <%= pagination_links_full @roles %>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -83,7 +83,7 @@ See docs/COPYRIGHT.rdoc for more details.
               <% end %>
             </td>
             <td class="buttons">
-              <%= link_to(l(:button_delete), role_path(role),
+              <%= link_to('', role_path(role),
                                        method: :delete,
                                        data: { confirm: l(:text_are_you_sure) },
                                        class: 'icon icon-delete') unless role.builtin? %>

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -138,11 +138,11 @@ See docs/COPYRIGHT.rdoc for more details.
               </td>
               <td class="buttons">
                 <% if !type.is_standard? %>
-                  <%= link_to type, method: :delete,
-                                    data: { confirm: t(:text_are_you_sure) },
-                                    class: 'icon icon-delete' do %>
-                    <span class="hidden-for-sighted"><%=h type.name %></span>
-                  <% end %>
+                  <%= link_to '', type,
+                                  method: :delete,
+                                  data: { confirm: t(:text_are_you_sure) },
+                                  class: 'icon icon-delete',
+                                  title: t(:button_delete) %>
                 <% end %>
               </td>
             </tr>

--- a/app/views/types/index.html.erb
+++ b/app/views/types/index.html.erb
@@ -141,7 +141,6 @@ See docs/COPYRIGHT.rdoc for more details.
                   <%= link_to type, method: :delete,
                                     data: { confirm: t(:text_are_you_sure) },
                                     class: 'icon icon-delete' do %>
-                    <%= t(:button_delete) %>
                     <span class="hidden-for-sighted"><%=h type.name %></span>
                   <% end %>
                 <% end %>

--- a/app/views/users/_memberships.html.erb
+++ b/app/views/users/_memberships.html.erb
@@ -108,10 +108,12 @@ See docs/COPYRIGHT.rdoc for more details.
                   <td class="buttons">
                     <%= link_to_function icon_wrapper('icon icon-edit', t(:button_edit)),
                                          "jQuery('.member-#{membership.id}--edit-toggle-item').toggle();",
-                                         class: "member-#{membership.id}--edit-toggle-item user-memberships--edit-button" %>
+                                         class: "member-#{membership.id}--edit-toggle-item user-memberships--edit-button",
+                                         title: t(:button_edit) %>
                     <%= link_to(icon_wrapper('icon icon-remove', t(:button_remove)),
                                 user_membership_path(user_id: @user, id: membership),
-                                method: :delete) if membership.deletable? %>
+                                method: :delete,
+                                title: t(:button_remove)) if membership.deletable? %>
                   </td>
                 </tr>
               <% end %>

--- a/modules/backlogs/app/views/project_settings/_versions.html.erb
+++ b/modules/backlogs/app/views/project_settings/_versions.html.erb
@@ -145,16 +145,19 @@ See doc/COPYRIGHT.rdoc for more details.
                   <% if version.project == @project %>
                     <%= link_to_if_authorized '',
                                               { controller: '/versions', action: 'edit', id: version },
-                                              class: 'icon icon-edit' %>
+                                              class: 'icon icon-edit',
+                                              title: t(:button_edit) %>
                     <%= link_to_if_authorized '',
                                               { controller: '/versions', action: 'destroy', id: version },
                                               data: { confirm: l(:text_are_you_sure) },
                                               method: :delete,
-                                              class: 'icon icon-delete' %>
+                                              class: 'icon icon-delete',
+                                              title: t(:button_delete) %>
                   <% elsif @project.enabled_modules.collect(&:name).include?("backlogs") %>
                     <%= link_to_if_authorized '',
                                               { :controller => '/versions', :action => 'edit', :id => version, :project_id => @project.id },
-                                              :class => 'icon icon-edit' %>
+                                              :class => 'icon icon-edit',
+                                              title: t(:button_edit) %>
                   <% end %>
                 </td>
               </tr>

--- a/modules/backlogs/app/views/project_settings/_versions.html.erb
+++ b/modules/backlogs/app/views/project_settings/_versions.html.erb
@@ -143,16 +143,16 @@ See doc/COPYRIGHT.rdoc for more details.
                 </td>
                 <td class="buttons">
                   <% if version.project == @project %>
-                    <%= link_to_if_authorized l(:button_edit),
+                    <%= link_to_if_authorized '',
                                               { controller: '/versions', action: 'edit', id: version },
                                               class: 'icon icon-edit' %>
-                    <%= link_to_if_authorized l(:button_delete),
+                    <%= link_to_if_authorized '',
                                               { controller: '/versions', action: 'destroy', id: version },
                                               data: { confirm: l(:text_are_you_sure) },
                                               method: :delete,
                                               class: 'icon icon-delete' %>
                   <% elsif @project.enabled_modules.collect(&:name).include?("backlogs") %>
-                    <%= link_to_if_authorized l(:button_edit),
+                    <%= link_to_if_authorized '',
                                               { :controller => '/versions', :action => 'edit', :id => version, :project_id => @project.id },
                                               :class => 'icon icon-edit' %>
                   <% end %>

--- a/modules/backlogs/features/version_settings.feature
+++ b/modules/backlogs/features/version_settings.feature
@@ -94,9 +94,8 @@ Feature: Version Settings
 
     When I go to the settings/versions page of the project called "ecookbook"
 
-    Then I should see "Edit" within ".version.shared .buttons"
-
-    When I follow "Edit" within ".version.shared .buttons"
+    # Click on the edit link
+    When I click on the element with class "icon-edit" within ".version.shared .buttons"
 
     Then the editable attributes of the version should be the following:
       | Column in backlog | left |

--- a/modules/costs/app/views/cost_types/_list.html.erb
+++ b/modules/costs/app/views/cost_types/_list.html.erb
@@ -95,7 +95,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <%= form_for cost_type, url:    cost_type_path(cost_type),
                                       method: :delete,
                                       html:   { id:    "delete_cost_type_#{cost_type.id}",
-                                                class: 'delete_cost_type' } do |f| %>
+                                                class: 'delete_cost_type',
+                                                title: t(:button_delete) } do |f| %>
                 <button type="submit"
                         class="button submit_cost_type">
                   <%= icon_wrapper('icon icon-locked', I18n.t(:button_lock)) %>

--- a/modules/costs/app/views/cost_types/_rate.html.erb
+++ b/modules/costs/app/views/cost_types/_rate.html.erb
@@ -61,7 +61,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </td>
     <td class="buttons">
       <a href="#" class="delete-row-button no-decoration-on-hover">
-        <%= icon_wrapper('icon-context icon-delete', '') %>
+        <%= op_icon('icon-context icon-delete', title: t(:button_delete)) %>
       </a>
     </td>
   </tr>

--- a/modules/costs/app/views/cost_types/_rate.html.erb
+++ b/modules/costs/app/views/cost_types/_rate.html.erb
@@ -61,7 +61,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </td>
     <td class="buttons">
       <a href="#" class="delete-row-button no-decoration-on-hover">
-        <%= icon_wrapper('icon-context icon-delete', I18n.t(:button_delete)) %>
+        <%= icon_wrapper('icon-context icon-delete', '') %>
       </a>
     </td>
   </tr>

--- a/modules/costs/app/views/costlog/_list.html.erb
+++ b/modules/costs/app/views/costlog/_list.html.erb
@@ -72,11 +72,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </td>
         <td class="buttons">
           <% if entry.editable_by?(User.current) -%>
-            <%= link_to icon_wrapper('icon-context icon-edit',t(:button_edit)),
+            <%= link_to icon_wrapper('icon-context icon-edit', ''),
                         {:controller => '/costlog', :action => 'edit', :id => entry, :project_id => nil},
                         :class => 'no-decoration-on-hover',
                         :title => t(:button_edit) %>
-            <%= link_to icon_wrapper('icon-context icon-delete',t(:button_delete)),
+            <%= link_to icon_wrapper('icon-context icon-delete', ''),
                         {:controller => '/costlog', :action => 'destroy', :id => entry, :project_id => nil},
                         :confirm => t(:text_are_you_sure),
                         :method => :delete,

--- a/modules/costs/app/views/hourly_rates/_rate.html.erb
+++ b/modules/costs/app/views/hourly_rates/_rate.html.erb
@@ -52,7 +52,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </span>
     </td>
     <td class="buttons">
-      <a href="#" class="delete-row-button no-decoration-on-hover"><%= icon_wrapper('icon-context icon-delete', '') %></a>
+      <a href="#" class="delete-row-button no-decoration-on-hover">
+        <%= op_icon('icon-context icon-delete', title: t(:button_delete)) %>
+      </a>
     </td>
   </tr>
 <% end %>

--- a/modules/costs/app/views/hourly_rates/_rate.html.erb
+++ b/modules/costs/app/views/hourly_rates/_rate.html.erb
@@ -52,7 +52,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </span>
     </td>
     <td class="buttons">
-      <a href="#" class="delete-row-button no-decoration-on-hover"><%= icon_wrapper('icon-context icon-delete', I18n.t(:button_delete)) %></a>
+      <a href="#" class="delete-row-button no-decoration-on-hover"><%= icon_wrapper('icon-context icon-delete', '') %></a>
     </td>
   </tr>
 <% end %>

--- a/modules/costs/spec/features/users_hourly_rates_spec.rb
+++ b/modules/costs/spec/features/users_hourly_rates_spec.rb
@@ -53,9 +53,9 @@ describe 'hourly rates on user edit', type: :feature, js: true do
 
     describe 'deleting all rates' do
       before do
-        click_link 'Update' # go to update view for rates
-        click_on 'Delete'   # delete last existing rate
-        click_on 'Save'     # save change
+        click_link 'Update'         # go to update view for rates
+        find('.icon-delete').click  # delete last existing rate
+        click_on 'Save'             # save change
       end
 
       # regression test: clicking save used to result in a error

--- a/modules/global_roles/app/views/principal_roles/_show_table_row.html.erb
+++ b/modules/global_roles/app/views/principal_roles/_show_table_row.html.erb
@@ -27,10 +27,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <% buttons = {:edit => false} %>
 <%= call_hook(:principal_roles_edit_button_needed, :buttons => buttons) %>
 <% if buttons[:edit]%>
-    <%= link_to t(:button_edit), '', :class => 'icon icon-edit' %>
+    <%= link_to '', '', :class => 'icon icon-edit', :title => t(:button_edit) %>
 <%end%>
-    <%= link_to(t(:button_delete),
+    <%= link_to('',
                 principal_role,
-                { method: :delete, class: 'icon icon-delete' }) %>
+                { method: :delete, class: 'icon icon-delete', title: t(:button_delete) }) %>
 </td>
 </tr>

--- a/modules/global_roles/app/views/roles/index.html.erb
+++ b/modules/global_roles/app/views/roles/index.html.erb
@@ -89,7 +89,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <%= link_to('', role_path(role),
                                        method: :delete,
                                        data: { confirm: l(:text_are_you_sure) },
-                                       class: 'icon icon-delete') unless role.builtin? %>
+                                       class: 'icon icon-delete',
+                                       title: t(:button_delete)) unless role.builtin? %>
             </td>
           </tr>
         <% end %>

--- a/modules/global_roles/app/views/roles/index.html.erb
+++ b/modules/global_roles/app/views/roles/index.html.erb
@@ -86,7 +86,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <% end %>
             </td>
             <td class="buttons">
-              <%= link_to(l(:button_delete), role_path(role),
+              <%= link_to('', role_path(role),
                                        method: :delete,
                                        data: { confirm: l(:text_are_you_sure) },
                                        class: 'icon icon-delete') unless role.builtin? %>

--- a/modules/ldap_groups/app/cells/ldap_groups/synchronized_groups/row_cell.rb
+++ b/modules/ldap_groups/app/cells/ldap_groups/synchronized_groups/row_cell.rb
@@ -29,7 +29,7 @@ module LdapGroups
       end
 
       def delete_link
-        link_to I18n.t(:button_delete),
+        link_to '',
                 controller: table.target_controller, ldap_group_id: model.id, action: :destroy_info
       end
     end

--- a/modules/ldap_groups/app/cells/ldap_groups/synchronized_groups/row_cell.rb
+++ b/modules/ldap_groups/app/cells/ldap_groups/synchronized_groups/row_cell.rb
@@ -30,7 +30,8 @@ module LdapGroups
 
       def delete_link
         link_to '',
-                controller: table.target_controller, ldap_group_id: model.id, action: :destroy_info
+                { controller: table.target_controller, ldap_group_id: model.id, action: :destroy_info },
+                title: t(:button_delete)
       end
     end
   end

--- a/modules/my_project_page/app/views/my_projects_overviews/blocks/_spent_time.html.erb
+++ b/modules/my_project_page/app/views/my_projects_overviews/blocks/_spent_time.html.erb
@@ -111,12 +111,12 @@ See doc/COPYRIGHT.md for more details.
                   <td class="hours"><%= html_hours("%.2f" % entry.hours) %></td>
                   <td class="buttons -short">
                     <% if entry.editable_by?(user) -%>
-                      <%= link_to icon_wrapper('icon-context icon-edit', t(:button_edit)),
+                      <%= link_to icon_wrapper('icon-context icon-edit', ''),
                                   {:controller => '/timelog', :action => 'edit', :id => entry},
                                   :alt => l(:button_edit),
                                   :class => 'no-decoration-on-hover',
                                   :title => l(:button_edit) %>
-                      <%= link_to icon_wrapper('icon-context icon-delete', t(:button_delete)),
+                      <%= link_to icon_wrapper('icon-context icon-delete', ''),
                                   {:controller => '/timelog', :action => 'destroy', :id => entry},
                                   :confirm => l(:text_are_you_sure),
                                   :method => :delete,

--- a/modules/pdf_export/app/views/export_card_configurations/index.html.erb
+++ b/modules/pdf_export/app/views/export_card_configurations/index.html.erb
@@ -99,18 +99,28 @@ See doc/COPYRIGHT.md for more details.
             <td><%= config.active %></td>
             <td class="buttons">
               <% if config.can_delete? %>
-                <%= link_to pdf_export_export_card_configuration_path(config), :method => :delete, :confirm => t(:text_are_you_sure), :class => 'icon-context icon-delete' do %>
+                <%= link_to pdf_export_export_card_configuration_path(config),
+                            :method => :delete,
+                            :confirm => t(:text_are_you_sure),
+                            :class => 'icon-context icon-delete',
+                            :title => t(:button_delete) do %>
                   <span class="hidden-for-sighted"><%=h config.name %></span>
                 <% end %>
               <% end %>
               <% if config.can_activate? %>
-                <%= link_to activate_pdf_export_export_card_configuration_path(config), :method => :post, :class => 'icon-context icon-unlocked' do %>
+                <%= link_to activate_pdf_export_export_card_configuration_path(config),
+                            :method => :post,
+                            :class => 'icon-context icon-unlocked',
+                            :title => t(:label_export_card_activate) do %>
                   <%= t(:label_export_card_activate) %>
                   <span class="hidden-for-sighted"><%=h config.name %></span>
                 <% end %>
               <% end %>
               <% if config.can_deactivate? %>
-                <%= link_to deactivate_pdf_export_export_card_configuration_path(config), :method => :post, :class => 'icon-context icon-locked' do %>
+                <%= link_to deactivate_pdf_export_export_card_configuration_path(config),
+                            :method => :post,
+                            :class => 'icon-context icon-locked',
+                            :title => t(:label_export_card_deactivate) do %>
                   <%= t(:label_export_card_deactivate) %>
                   <span class="hidden-for-sighted"><%=h config.name %></span>
                 <% end %>
@@ -120,7 +130,7 @@ See doc/COPYRIGHT.md for more details.
         <% end %>
       </tbody>
     </table>
-    
+
   </div>
 </div>
 <div class="generic-table--action-buttons">

--- a/modules/pdf_export/app/views/export_card_configurations/index.html.erb
+++ b/modules/pdf_export/app/views/export_card_configurations/index.html.erb
@@ -100,7 +100,6 @@ See doc/COPYRIGHT.md for more details.
             <td class="buttons">
               <% if config.can_delete? %>
                 <%= link_to pdf_export_export_card_configuration_path(config), :method => :delete, :confirm => t(:text_are_you_sure), :class => 'icon-context icon-delete' do %>
-                  <%= t(:button_delete) %>
                   <span class="hidden-for-sighted"><%=h config.name %></span>
                 <% end %>
               <% end %>

--- a/modules/webhooks/app/assets/stylesheets/webhooks/webhooks.sass
+++ b/modules/webhooks/app/assets/stylesheets/webhooks/webhooks.sass
@@ -1,9 +1,3 @@
-// Add some paddings to action links
-.webhooks--outgoing-webhook-row td.buttons
-  a:not(:last-child):after
-    content: ","
-    padding: 0 1px
-
 .webhooks--delivery-success
   color: #019875
 

--- a/modules/webhooks/app/cells/webhooks/outgoing/webhooks/row_cell.rb
+++ b/modules/webhooks/app/cells/webhooks/outgoing/webhooks/row_cell.rb
@@ -72,9 +72,8 @@ module ::Webhooks
         def edit_link
           link_to(
             op_icon('icon icon-edit button--link'),
-            controller: table.target_controller,
-            action: :edit,
-            webhook_id: webhook.id
+            { controller: table.target_controller, action: :edit, webhook_id: webhook.id },
+            title: t(:button_edit)
           )
         end
 
@@ -83,7 +82,8 @@ module ::Webhooks
             op_icon('icon icon-delete button--link'),
             { controller: table.target_controller, action: :destroy, webhook_id: webhook.id },
             method: :delete,
-            data: { confirm: I18n.t(:text_are_you_sure) }
+            data: { confirm: I18n.t(:text_are_you_sure) },
+            title: t(:button_delete)
           )
         end
       end

--- a/modules/webhooks/app/cells/webhooks/outgoing/webhooks/row_cell.rb
+++ b/modules/webhooks/app/cells/webhooks/outgoing/webhooks/row_cell.rb
@@ -72,7 +72,9 @@ module ::Webhooks
         def edit_link
           link_to(
             op_icon('icon icon-edit button--link'),
-            { controller: table.target_controller, action: :edit, webhook_id: webhook.id },
+            controller: table.target_controller,
+            action: :edit,
+            webhook_id: webhook.id
           )
         end
 

--- a/modules/webhooks/app/cells/webhooks/outgoing/webhooks/row_cell.rb
+++ b/modules/webhooks/app/cells/webhooks/outgoing/webhooks/row_cell.rb
@@ -70,16 +70,19 @@ module ::Webhooks
         end
 
         def edit_link
-          link_to I18n.t(:button_edit),
-                  { controller: table.target_controller, action: :edit, webhook_id: webhook.id },
-                  class: 'button--link'
+          link_to(
+            op_icon('icon icon-edit button--link'),
+            { controller: table.target_controller, action: :edit, webhook_id: webhook.id },
+          )
         end
 
         def delete_link
-          link_to I18n.t(:button_delete),
-                  { controller: table.target_controller, action: :destroy, webhook_id: webhook.id },
-                  data: { method: 'delete', confirm: I18n.t(:text_are_you_sure) },
-                  class: 'button--link'
+          link_to(
+            op_icon('icon icon-delete button--link'),
+            { controller: table.target_controller, action: :destroy, webhook_id: webhook.id },
+            method: :delete,
+            data: { confirm: I18n.t(:text_are_you_sure) }
+          )
         end
       end
     end

--- a/modules/webhooks/spec/features/manage_webhooks_spec.rb
+++ b/modules/webhooks/spec/features/manage_webhooks_spec.rb
@@ -51,7 +51,7 @@ describe 'Manage webhooks through UI', type: :feature, js: true do
       expect(page).to have_selector('.webhooks--outgoing-webhook-row .description', text: webhook.description)
 
       # Edit this webhook
-      find(".webhooks--outgoing-webhook-row-#{webhook.id} a", text: 'Edit').click
+      find(".webhooks--outgoing-webhook-row-#{webhook.id} .icon-edit").click
 
       # Check the other event
       find('.form--check-box[value="work_package:created"]').set false
@@ -70,7 +70,7 @@ describe 'Manage webhooks through UI', type: :feature, js: true do
       expect(webhook.all_projects).to be_falsey
 
       # Delete webhook
-      find(".webhooks--outgoing-webhook-row-#{webhook.id} a", text: 'Delete').click
+      find(".webhooks--outgoing-webhook-row-#{webhook.id} .icon-delete").click
       page.driver.browser.switch_to.alert.accept
 
       expect(page).to have_selector('.flash.notice', text: I18n.t(:notice_successful_delete))

--- a/spec/features/admin/attribute_help_texts_spec.rb
+++ b/spec/features/admin/attribute_help_texts_spec.rb
@@ -102,7 +102,7 @@ describe 'Attribute help texts' do
         visit attribute_help_texts_path
 
         # Destroy
-        page.find('.attribute-help-text--entry a.icon-delete').click
+        page.find('.attribute-help-text--entry .icon-delete').click
         page.driver.browser.switch_to.alert.accept
 
         expect(page).to have_selector('.generic-table--no-results-container')

--- a/spec/features/custom_fields/custom_fields_spec.rb
+++ b/spec/features/custom_fields/custom_fields_spec.rb
@@ -168,7 +168,7 @@ describe 'custom fields', js: true do
 
       it "deletes a custom option and all values using it" do
         within all(".custom-option-row")[1] do
-          click_on "Delete"
+          find('.icon-delete').click
 
           cf_page.accept_alert_dialog!
         end

--- a/spec/support/pages/admin/custom_actions/index.rb
+++ b/spec/support/pages/admin/custom_actions/index.rb
@@ -42,7 +42,7 @@ module Pages
 
         def edit(name)
           within_buttons_of name do
-            click_link 'Edit'
+            find('.icon-edit').click
           end
 
           custom_action = CustomAction.find_by!(name: name)
@@ -51,7 +51,7 @@ module Pages
 
         def delete(name)
           within_buttons_of name do
-            click_link 'Delete'
+            find('.icon-delete').click
 
             accept_alert_dialog!
           end

--- a/spec/support/pages/types/index.rb
+++ b/spec/support/pages/types/index.rb
@@ -65,7 +65,7 @@ module Pages
 
       def delete(type)
         within_row(type) do
-          click_link 'Delete'
+          find('.icon-delete').click
         end
 
         accept_alert_dialog!


### PR DESCRIPTION
### Problem
Icons in tables were partly with and partly without texts. So we had to make it consistent and remove the texts of the icons that speak for themselves, such as 'Edit' and 'Delete'.

Instead, all Icons will get a title for accessibility reasons and to show a help text when hovering over the icon.

#### Removed on pages:
- [x] Project Settings 
   - Versions
   - Categories
   - Forums
- [x] Users
  - Global Roles
  - Projects
- [x] Groups
- [x] Roles & global roles
- [x] Work package types
- [x] Work package statuses
- [x] Custom fields
- [x] Custom actions
- [x] Attribute help texts
- [x] Enumerations
- [x] LDAP authentication
- [x] Cost Types
- [x] Export Card Configs
- [x] Webhooks: replaced the text by icons

To-Do's
- [x] Give all links a title instead (for accessibility)

https://community.openproject.com/projects/openproject/work_packages/29072/activity