### PR TITLE
[29801] Fine tune split view (Part 1)

### DIFF
--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -274,20 +274,8 @@ i
 
   &.-wrapped
     flex-wrap: wrap
-    .work-packages--info-row
-      order: -1
-      flex-basis: 100%
-      margin-bottom: 0.5rem
-
-    wp-status-button
-      // In case that there is no attribute help text, the status button needs to increase.
-      // This is a heuristic based on the current DOM structure.
-      &:nth-last-child(3)
-        flex-grow: 2
-    attribute-help-text
-      // Take care that the help text is next to the button and the action buttons are still at the right side
-      flex-grow: 2
-      margin-bottom: 0.5rem
+    .work-packages--info-row,
+    attribute-help-text,
     wp-custom-action
       margin-bottom: 0.5rem
 

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -416,7 +416,7 @@ en:
       children_headline: "Children"
 
     relation_buttons:
-      set_parent: "Set parent work package"
+      set_parent: "Set parent"
       change_parent: "Change parent"
       remove_parent: "Remove parent"
       group_by_wp_type: "Group by work package type"


### PR DESCRIPTION
Let only custom action button wrap to new line not the info row. This is part one of this ticket: https://community.openproject.com/projects/openproject/work_packages/29081/activity