### PR TITLE
[29139] Use our own encoder/decoder for params to ensure correctness

### DIFF
--- a/frontend/src/app/components/op-context-menu/handlers/op-columns-context-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/op-columns-context-menu.directive.ts
@@ -155,7 +155,6 @@ export class OpColumnsContextMenu extends OpContextMenuTrigger {
         linkText: this.I18n.t('js.work_packages.query.hide_column'),
         icon: 'icon-delete',
         onClick: () => {
-          this.wpTableColumns.shift(c, 1);
           let focusColumn = this.wpTableColumns.previous(c) || this.wpTableColumns.next(c);
           this.wpTableColumns.removeColumn(c);
 

--- a/frontend/src/app/modules/router/openproject.routes.ts
+++ b/frontend/src/app/modules/router/openproject.routes.ts
@@ -72,6 +72,20 @@ export function bodyClass(className:string|null|undefined, action:'add'|'remove'
 export function uiRouterConfiguration(uiRouter:UIRouter, injector:Injector, module:StatesModule) {
   // Allow optional trailing slashes
   uiRouter.urlService.config.strictMode(false);
+
+  // Register custom URL params type
+  // to ensure query props are correctly set
+  uiRouter.urlService.config.type(
+    'opQueryString',
+    {
+      encode: encodeURIComponent,
+      decode: decodeURIComponent,
+      raw: true,
+      dynamic: true,
+      is: (val:unknown) => typeof(val) === 'string',
+      equals: (a:any, b:any) => _.isEqual(a, b),
+    }
+  );
 }
 
 export function initializeUiRouterListeners(injector:Injector) {

--- a/frontend/src/app/modules/work_packages/routing/work-packages-routes.ts
+++ b/frontend/src/app/modules/work_packages/routing/work-packages-routes.ts
@@ -41,6 +41,8 @@ import {Ng2StateDeclaration} from "@uirouter/angular";
 import {WorkPackagesBaseComponent} from "core-app/modules/work_packages/routing/wp-base/wp--base.component";
 
 
+
+
 export const WORK_PACKAGES_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'work-packages',
@@ -49,10 +51,9 @@ export const WORK_PACKAGES_ROUTES:Ng2StateDeclaration[] = [
     url: '/work_packages?query_id&query_props',
     abstract: true,
     params: {
-      // value: null makes the parameter optional
-      // squash: true avoids duplicate slashes when the parameter is not provided
-      query_id: {type: 'query', dynamic: true},
-      query_props: {type: 'query', dynamic: true }
+      query_id: { type: 'query', dynamic: true },
+      // Use custom encoder/decoder that ensures validity of URL string
+      query_props: { type: 'opQueryString' }
     }
   },
   {


### PR DESCRIPTION
There must be some bug in handling of ui-router params when it comes to encoded query strings that result in double-encoding. 

Using our own raw param definition that always uses `encodeURIComponent` and `decodeURIComponent`, this no longer happens.

https://community.openproject.com/wp/29139