### PR TITLE
[29125] Allow multiple sessions with remember tokens

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -819,7 +819,9 @@ input[readonly].-clickable
   clear:       both
   line-height: $base-line-height
   padding:  0 2rem 0 0
-  @include text-shortener
+
+  &:not(.-no-ellipsis)
+    @include text-shortener
 
   & > .form--check-box-container
     display:  block

--- a/app/models/token/expirable_token.rb
+++ b/app/models/token/expirable_token.rb
@@ -51,5 +51,14 @@ module Token
         self.class.where(["expires_on < ?", Time.now]).delete_all
       end
     end
+
+    module ClassMethods
+
+      ##
+      # Return a scope of active tokens
+      def not_expired
+        where(["expires_on > ?", Time.now])
+      end
+    end
   end
 end

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/my/two_factor_devices_controller.rb
@@ -24,7 +24,8 @@ module ::TwoFactorAuthentication
 
       def index
         @two_factor_devices = @user.otp_devices.reload
-        @remember_token = get_2fa_remember_cookie(current_user)
+        @has_remember_token_for_user = any_remember_token_present?(current_user)
+        @remember_token = get_2fa_remember_token(current_user)
       end
 
       ##

--- a/modules/two_factor_authentication/app/models/two_factor_authentication/remembered_auth_token.rb
+++ b/modules/two_factor_authentication/app/models/two_factor_authentication/remembered_auth_token.rb
@@ -11,6 +11,16 @@ module TwoFactorAuthentication
       allow_remember_for_days.days
     end
 
+    protected
+
+    ##
+    # Potentially multiple sessions may exist
+    # for a user with remember tokens set.
+    # (e.g., two different browsers)
+    def single_value?
+      false
+    end
+
     private
 
     def validate_remember_time

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/request_otp.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/request_otp.html.erb
@@ -28,7 +28,7 @@ end %>
     </div>
     <% if remember_2fa_enabled? %>
     <div class="form--field -wide-label">
-      <label class="form--label-with-check-box">
+      <label class="form--label-with-check-box -no-ellipsis">
         <div class="form--check-box-container">
           <%= styled_check_box_tag 'remember_me', true, false %>
         </div>

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/my/two_factor_devices/index.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/my/two_factor_devices/index.html.erb
@@ -1,14 +1,18 @@
 <%= render partial: '/two_factor_authentication/header_tags' %>
 <% html_title(t(:label_my_account), t('two_factor_authentication.label_two_factor_authentication')) -%>
 
-<% if @remember_token.present? %>
+<% if @has_remember_token_for_user %>
   <section class="account--section" id="two_factor_authentication_remember_cookie">
     <div class="notification-box show-when-print -info">
       <div class="notification-box--content">
         <p>
           <strong><%= t(:note) %></strong>
-          <%= t 'two_factor_authentication.remember.active_session_notice',
-                expires_on: format_date(@remember_token.expires_on) %>
+          <% if @remember_token %>
+            <%= t 'two_factor_authentication.remember.active_session_notice',
+                  expires_on: format_date(@remember_token.expires_on) %>
+          <% else %>
+            <%= t 'two_factor_authentication.remember.other_active_session_notice' %>
+          <% end %>
           <br/>
           <strong>
             <%= link_to t('two_factor_authentication.remember.clear_cookie'),

--- a/modules/two_factor_authentication/config/locales/en.yml
+++ b/modules/two_factor_authentication/config/locales/en.yml
@@ -156,9 +156,11 @@ en:
       active_session_notice: >
         Your account has an active remember cookie valid until %{expires_on}.
         This cookie allows you to log in without a second factor to your account until that time.
+      other_active_session_notice:
+        Your account has an active remember cookie on another session.
       label: 'Remember'
-      clear_cookie: 'Click here to remove this cookie'
-      cookie_removed: 'The remember cookie has been removed.'
+      clear_cookie: 'Click here to remove all remembered 2FA sessions.'
+      cookie_removed: 'All remembered 2FA sessions have been removed.'
       dont_ask_again: "Create cookie to remember 2FA authentication on this client for %{days} days."
   field_phone: "Cell phone"
   field_otp: "One-time password"


### PR DESCRIPTION
Whenever creating a new remember token, all other previous tokens where automatically invalidated.
This results in cumbersome logins for users with multiple browsers.

Instead, this PR allows multiple tokens, but shows to the user a notice whenever ANY remember token exists for his account, even when it is not in the current session.

This will allow the user to invalidate *all* remember tokens.

https://community.openproject.com/wp/29125