### PR TITLE
[29147] Use onEnter, onExit to correctly apply body classes

### DIFF
--- a/frontend/src/app/modules/router/openproject.routes.ts
+++ b/frontend/src/app/modules/router/openproject.routes.ts
@@ -100,6 +100,23 @@ export function initializeUiRouterListeners(injector:Injector) {
     // component
     let wpBase = document.querySelector(appBaseSelector);
 
+    // Apply classes from bodyClasses in each state definition
+    // This was defined as onEnter, onExit functions in each state before
+    // but since AOT doesn't allow anonymous functions, we can't re-use them now.
+    $transitions.onEnter({}, function(transition:Transition) {
+      const toState = transition.to();
+
+      // Add body class when leaving this state
+      bodyClass(_.get(toState, 'data.bodyClasses'), 'add');
+    });
+
+    $transitions.onExit({}, function(transition:Transition) {
+      const fromState = transition.from();
+
+      // Remove body class when leaving this state
+      bodyClass(_.get(fromState, 'data.bodyClasses'), 'remove');
+    });
+
     $transitions.onStart({}, function(transition:Transition) {
       const $state = transition.router.stateService;
       const toParams = transition.params('to');
@@ -112,8 +129,7 @@ export function initializeUiRouterListeners(injector:Injector) {
 
       // Remove and add any body class definitions for entering
       // and exiting states.
-      bodyClass(_.get(fromState, 'data.bodyClasses', 'remove'));
-      bodyClass(_.get(toState, 'data.bodyClasses', 'add'));
+      bodyClass(_.get(toState, 'data.bodyClasses'), 'add');
 
       // Abort the transition and move to the url instead
       if (wpBase === null) {

--- a/frontend/src/app/modules/work_packages/routing/work-packages-routes.ts
+++ b/frontend/src/app/modules/work_packages/routing/work-packages-routes.ts
@@ -99,12 +99,12 @@ export const WORK_PACKAGES_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'work-packages.show.relations',
     url: '/relations',
-    component: WorkPackageRelationsTabComponent,
+    component: WorkPackageRelationsTabComponent
   },
   {
     name: 'work-packages.show.watchers',
     url: '/watchers',
-    component: WorkPackageWatchersTabComponent,
+    component: WorkPackageWatchersTabComponent
   },
   {
     name: 'work-packages.list',
@@ -147,6 +147,9 @@ export const WORK_PACKAGES_ROUTES:Ng2StateDeclaration[] = [
         value: true
       }
     },
+    data: {
+      bodyClasses: 'action-details'
+    },
   },
   {
     name: 'work-packages.list.details.overview',
@@ -156,7 +159,7 @@ export const WORK_PACKAGES_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'work-packages.list.details.activity',
     url: '/activity',
-    component: WorkPackageActivityTabComponent
+    component: WorkPackageActivityTabComponent,
   },
   {
     name: 'work-packages.list.details.activity.details',


### PR DESCRIPTION
The body classes were previously defined in each state with `onEnter, onExit` callbacks. Then https://github.com/opf/openproject/pull/6881 came along and put the route loading in the global routes `ngModule`. When loading these routes in the module header (with `UIRouter.forRoot( STATES )` ) , we can no longer use some JS that cannot be statically analyzed such as anonymous functions.

I thus put them in the `onStart` transition hooks which was completely wrong since body classes are not correctly added and removed. Instead they need to be put in `onEnter`, `onExit` global hooks that will apply the same behavior as before.


https://community.openproject.com/wp/29147