### PR TITLE
time entries api - link actions and use correct response on delete

### DIFF
--- a/docs/api/apiv3/endpoints/time_entries.apib
+++ b/docs/api/apiv3/endpoints/time_entries.apib
@@ -1,8 +1,10 @@
 # Group Time Entries
 
 ## Actions
-| Link                | Description                                                          | Condition                                                        |
-|:-------------------:| -------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Link                | Description                                                          | Condition                                                                                           |
+|:-------------------:| -------------------------------------------------------------------- | ----------------------------------------------------------------                                    |
+| updateImmediately   | Directly perform edits on this time entry                            | **Permission**: 'edit time entries' or 'edit own time entries if the time entry belongs to the user |
+| delete              | Delete this time entry                                               | **Permission**: 'edit time entries' or 'edit own time entries if the time entry belongs to the user |
 
 None yet
 
@@ -62,6 +64,14 @@ Depending on custom fields defined for time entries, additional properties might
                     "self": {
                         "href": "/api/v3/time_entries/1"
                     },
+                    "updateImmediately": {
+                        "href": "/api/v3/time_entries/1",
+                        "method": "patch"
+                    },
+                    "delete": {
+                        "href": "/api/v3/time_entries/1",
+                        "method": "delete"
+                    },
                     "project": {
                         "href": "/api/v3/projects/1",
                         "title": "Some project"
@@ -115,12 +125,9 @@ Permanently deletes the specified time entry.
 + Parameters
     + id (required, integer, `1`) ... Time entry id
 
-+ Response 202
++ Response 204
 
     Returned if the time entry was deleted successfully.
-
-    Note that the response body is empty as of now. In future versions of the API a body
-    *might* be returned, indicating the progress of deletion.
 
     + Body
 
@@ -173,6 +180,14 @@ Permanently deletes the specified time entry.
                           "_links": {
                               "self": {
                                   "href": "/api/v3/time_entries/1"
+                              },
+                              "updateImmediately": {
+                                  "href": "/api/v3/time_entries/1",
+                                  "method": "patch"
+                              },
+                              "delete": {
+                                  "href": "/api/v3/time_entries/1",
+                                  "method": "delete"
                               },
                               "project": {
                                   "href": "/api/v3/projects/1",

--- a/lib/api/v3/time_entries/time_entries_api.rb
+++ b/lib/api/v3/time_entries/time_entries_api.rb
@@ -110,7 +110,7 @@ module API
               call = ::TimeEntries::DeleteService.new(time_entry: @time_entry, user: current_user).call
 
               if call.success?
-                status 202
+                status 204
               else
                 fail ::API::Errors::ErrorBase.create_and_merge_errors(call.errors)
               end

--- a/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/lib/api/v3/time_entries/time_entry_representer.rb
@@ -39,6 +39,24 @@ module API
 
         defaults render_nil: true
 
+        link :updateImmediately do
+          next unless update_allowed?
+
+          {
+            href: api_v3_paths.time_entry(represented.id),
+            method: :patch
+          }
+        end
+
+        link :delete do
+          next unless update_allowed?
+
+          {
+            href: api_v3_paths.time_entry(represented.id),
+            method: :delete
+          }
+        end
+
         property :id
 
         property :comments,
@@ -108,6 +126,15 @@ module API
 
         def _type
           'TimeEntry'
+        end
+
+        def update_allowed?
+          current_user_allowed_to(:edit_time_entries, context: represented.project) ||
+            represented.user_id == current_user.id && current_user_allowed_to(:edit_own_time_entries, context: represented.project)
+        end
+
+        def current_user_allowed_to(permission, context:)
+          current_user.allowed_to?(permission, context)
         end
       end
     end

--- a/spec/requests/api/v3/time_entry_resource_spec.rb
+++ b/spec/requests/api/v3/time_entry_resource_spec.rb
@@ -625,7 +625,7 @@ describe 'API v3 time_entry resource', type: :request do
     end
 
     it 'deleted the time entry' do
-      expect(subject.status).to eq(202)
+      expect(subject.status).to eq(204)
     end
 
     context 'when lacking permissions' do
@@ -641,7 +641,7 @@ describe 'API v3 time_entry resource', type: :request do
 
     shared_examples_for 'deletes the time_entry' do
       it 'responds with HTTP No Content' do
-        expect(subject.status).to eq 202
+        expect(subject.status).to eq 204
       end
 
       it 'removes the time_entry from the DB' do
@@ -664,7 +664,7 @@ describe 'API v3 time_entry resource', type: :request do
     end
 
     context 'with the user not being the author' do
-      let(:time_entry) { other_time_entry } 
+      let(:time_entry) { other_time_entry }
 
       context 'but permission to edit all time entries' do
         let(:permissions) { %i(edit_time_entries view_time_entries view_work_packages) }


### PR DESCRIPTION
As we now have edit and delete end points, they should be linked in the time entry representation.