### PR TITLE
[29145] Alignment of icon not right in relation tab

### DIFF
--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -79,9 +79,6 @@
     textarea
       resize: vertical
 
-  .panel-toggler .button
-    margin-right: 0
-
 .report-category-actions
   margin-top: -28px
   width: 100%

--- a/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
+++ b/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
@@ -147,3 +147,9 @@
 // To allow results indicator to overflow it
 .wp-relations-create--form .grid-content
   overflow-y: visible
+
+.detail-panel--relations
+  .panel-toggler .icon-small
+    height: 18px
+    display: inline-block
+    vertical-align: middle

--- a/frontend/src/app/components/wp-relations/wp-relations-group/wp-relations-group.template.html
+++ b/frontend/src/app/components/wp-relations/wp-relations-group/wp-relations-group.template.html
@@ -10,8 +10,9 @@
       <div id="wp-relation-group-by-toggle"
            #wpRelationGroupByToggler
            class="panel-toggler ng-scope ng-isolate-scope hide-when-print">
-        <accessible-by-keyboard linkClass="icon-context icon-small icon-group-by button -transparent"
+        <accessible-by-keyboard linkClass="button -transparent"
                                 (execute)="toggleButton()">
+          <op-icon icon-classes="icon-small icon-group-by icon4"></op-icon>
           <span [textContent]="togglerText"></span>
         </accessible-by-keyboard>
       </div>


### PR DESCRIPTION
Align icon correctly. There are some styles above the DOM from the `button` & `panel-toggler` that create the misalignment. So now it gets aligned correctly.

https://community.openproject.com/projects/openproject/work_packages/29145/activity