### PR TITLE
[29154] WP mobile info wrapper alignment

### DIFF
--- a/app/assets/stylesheets/content/_custom_actions.sass
+++ b/app/assets/stylesheets/content/_custom_actions.sass
@@ -35,8 +35,9 @@
   .custom-action
     display: flex
     justify-content: flex-end
-    flex: 1 1 auto
+    flex: 0 1 auto
     margin-bottom: 0.5rem
+    max-width: calc(100vw - 20px)
     @include text-shortener
 
     .button

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -238,6 +238,7 @@ i
 
 .wp-info-wrapper
   display: flex
+  flex-wrap: wrap
   align-items: center
   padding-top: 0.5rem
   .wp-status-button .button
@@ -263,13 +264,6 @@ i
   .wp-status-button,
   .work-packages--info-row
     margin-bottom: 0.5rem
-
-  &.-wrapped
-    flex-wrap: wrap
-    .work-packages--info-row,
-    attribute-help-text,
-    wp-custom-action
-      margin-bottom: 0.5rem
 
 .work-packages--new .wp-status-button
   padding: 3px

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -241,6 +241,7 @@ i
   flex-wrap: wrap
   align-items: center
   padding-top: 0.5rem
+
   .wp-status-button .button
     padding: 5px
     margin-bottom: 0
@@ -252,13 +253,16 @@ i
     .button--text
       margin: 0 5px
 
-  attribute-help-text .help-text--entry
-    line-height: 25px
-    margin: 0 10px 0 -10px
-    .icon:before
-      padding: 0
+  attribute-help-text
+    flex: 0
+    .help-text--entry
+      line-height: 25px
+      margin: 0 10px 0 -14px
+      .icon:before
+        padding: 0
+
   .work-packages--info-row
-    flex-grow: 2
+    flex: 1 0 50%
 
   attribute-help-text,
   .wp-status-button,

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -243,12 +243,15 @@ i
   padding-top: 0.5rem
 
   .wp-status-button .button
+    @include text-shortener
     padding: 5px
     margin-bottom: 0
     @include varprop(background-color, status-selector-bg-color)
     border: none
     color: white
     white-space: nowrap
+    // Should not be longer than mobile screen width (margin of 15px left and right)
+    max-width: calc(100vw - 30px)
 
     .button--text
       margin: 0 5px

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -265,7 +265,7 @@ i
         padding: 0
 
   .work-packages--info-row
-    flex: 1 0 50%
+    flex: 1 1 200px
 
   attribute-help-text,
   .wp-status-button,

--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -33,7 +33,7 @@
     -webkit-overflow-scrolling: touch
 
   #main-menu ~ #content-wrapper
-    padding: 5px 15px 0 15px !important
+    padding: 15px
 
   #main
     grid-template-columns: auto

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -153,7 +153,7 @@
 
     .wp-info-wrapper
       display: grid
-      grid-template-columns: 100px min-content auto
+      grid-template-columns: auto min-content auto
       grid-gap: 5px
 
       .custom-actions

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -147,8 +147,17 @@
 
       .toolbar-item
         flex-grow: 0
+
     .work-packages-full-view--split-container
       border-top: none
+
+    .wp-info-wrapper
+      display: grid
+      grid-template-columns: 100px min-content auto
+      grid-gap: 5px
+
+      .custom-actions
+        grid-column: 1 / -1
 
   body.controller-work_packages.action-details,
   body.controller-work_packages.action-create

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -151,14 +151,6 @@
     .work-packages-full-view--split-container
       border-top: none
 
-    .wp-info-wrapper
-      display: grid
-      grid-template-columns: auto min-content auto
-      grid-gap: 5px
-
-      .custom-actions
-        grid-column: 1 / -1
-
   body.controller-work_packages.action-details,
   body.controller-work_packages.action-create
     .work-packages-split-view--details-side

--- a/frontend/src/app/components/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/components/resizer/wp-resizer.component.ts
@@ -77,7 +77,6 @@ export class WpResizerDirective implements OnInit, OnDestroy {
     // Otherwise function will be executed with empty list
     jQuery(document).ready(() => {
       this.applyColumnLayout(this.resizingElement, this.elementFlex);
-      this.applyInfoRowLayout();
     });
 
     // Add event listener
@@ -95,13 +94,6 @@ export class WpResizerDirective implements OnInit, OnDestroy {
     let that = this;
     jQuery(window).resize(function() {
       jQuery('.-can-have-columns').toggleClass('-columns-2', jQuery('.work-packages-full-view--split-left').width()! > 750);
-      that.applyInfoRowLayout();
-    });
-
-    // Listen to changes from a non overview state to the overview state
-    // which requires us to reevaluate the wrapping of the info row.
-    this.unregisterTransitionListener = this.$transitions.onSuccess({ to: 'work-packages.list.details.overview' }, (transition) => {
-      setTimeout(() => this.applyInfoRowLayout());
     });
   }
 
@@ -196,9 +188,6 @@ export class WpResizerDirective implements OnInit, OnDestroy {
     // Apply two column layout
     this.applyColumnLayout(element, newValue);
 
-    // Apply info row Layout
-    this.applyInfoRowLayout();
-
     // Set new width
     element.style.flexBasis = newValue + 'px';
   }
@@ -212,12 +201,5 @@ export class WpResizerDirective implements OnInit, OnDestroy {
     else {
       element.classList.toggle('-columns-2', newWidth > 700);
     }
-  }
-
-  private applyInfoRowLayout() {
-    jQuery('.wp-info-wrapper').toggleClass(
-      '-wrapped',
-      jQuery('.wp-info-wrapper').width()! - jQuery('wp-custom-actions').width()! - jQuery('wp-status-button .button').width()! < 475
-    );
   }
 }

--- a/frontend/src/app/components/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/components/resizer/wp-resizer.component.ts
@@ -50,8 +50,6 @@ export class WpResizerDirective implements OnInit, OnDestroy {
 
   public moving:boolean = false;
 
-  private unregisterTransitionListener:Function;
-
   constructor(readonly toggleService:MainMenuToggleService,
               private elementRef:ElementRef,
               readonly $transitions:TransitionService) {
@@ -100,8 +98,6 @@ export class WpResizerDirective implements OnInit, OnDestroy {
   ngOnDestroy() {
     // Reset the style when killing this directive, otherwise the style remains
     this.resizingElement.style.flexBasis = null;
-
-    this.unregisterTransitionListener();
   }
 
   @HostListener('mousedown', ['$event'])


### PR DESCRIPTION
On the mobile work packages full view the info row should not wrap and stay next to the status button.

- Info row next to status button
- Manually calculated '-wrapped' class removed (flex wrap does that automatically)
- Margin top for toolbar buttons
- Grid solution tested in Chrome, Firefox and Opera 

https://community.openproject.com/projects/openproject/work_packages/29154/activity