### PR TITLE
[29158] Allow lazily loading a module and component

### DIFF
--- a/frontend/src/app/modules/calendar/openproject-calendar.module.ts
+++ b/frontend/src/app/modules/calendar/openproject-calendar.module.ts
@@ -30,10 +30,12 @@ import {OpenprojectCommonModule} from 'core-app/modules/common/openproject-commo
 import {NgModule} from '@angular/core';
 import {FullCalendarModule} from 'ng-fullcalendar';
 import {WorkPackagesCalendarEntryComponent} from "core-app/modules/calendar/wp-calendar-entry/wp-calendar-entry.component";
-import {WorkPackagesEmbeddedCalendarEntryComponent} from "core-app/modules/calendar/wp-embedded-calendar/wp-embedded-calendar-entry.component";
 import {WorkPackagesCalendarController} from "core-app/modules/calendar/wp-calendar/wp-calendar.component";
 import {OpenprojectWorkPackagesModule} from "core-app/modules/work_packages/openproject-work-packages.module";
 import {Ng2StateDeclaration, UIRouterModule} from "@uirouter/angular";
+import {DynamicLazyLoadModule} from "core-app/modules/common/dynamic-embedding/dynamic-embeddable-module.interface";
+import {DynamicModule} from "ng-dynamic-component";
+import {WorkPackagesCalendarEmbeddedComponent} from "core-app/modules/calendar/wp-calendar-embedded/wp-calendar-entry.component";
 
 require("fullcalendar/dist/locale-all.js");
 
@@ -64,13 +66,21 @@ export const CALENDAR_ROUTES:Ng2StateDeclaration[] = [
     // Work package calendars
     WorkPackagesCalendarEntryComponent,
     WorkPackagesCalendarController,
-    WorkPackagesEmbeddedCalendarEntryComponent,
+    WorkPackagesCalendarEmbeddedComponent,
   ],
   entryComponents: [
-    WorkPackagesEmbeddedCalendarEntryComponent,
     WorkPackagesCalendarController,
+    WorkPackagesCalendarEmbeddedComponent,
     WorkPackagesCalendarEntryComponent,
   ],
 })
-export class OpenprojectCalendarModule {
+export class OpenprojectCalendarModule implements DynamicLazyLoadModule {
+
+  /**
+   * Define the components another component may lazily load in this module
+   * to allow tree shaking.
+   */
+  public lazyloadableComponents = {
+    calendar: WorkPackagesCalendarEmbeddedComponent
+  };
 }

--- a/frontend/src/app/modules/calendar/wp-calendar-embedded/wp-calendar-embedded.component.html
+++ b/frontend/src/app/modules/calendar/wp-calendar-embedded/wp-calendar-embedded.component.html
@@ -1,0 +1,1 @@
+<wp-calendar [static]="true"></wp-calendar>

--- a/frontend/src/app/modules/calendar/wp-calendar-embedded/wp-calendar-entry.component.ts
+++ b/frontend/src/app/modules/calendar/wp-calendar-embedded/wp-calendar-entry.component.ts
@@ -26,23 +26,11 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, ElementRef, OnInit} from '@angular/core';
-import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
+import {Component} from '@angular/core';
 
 @Component({
-  selector: 'wp-embedded-calendar',
-  template: `
-    <wp-calendar [static]="true">
-    </wp-calendar>
-  `
+  templateUrl: './wp-calendar-embedded.component.html'
 })
-export class WorkPackagesEmbeddedCalendarEntryComponent implements OnInit {
-  constructor(readonly elementRef:ElementRef) {
-  }
 
-  ngOnInit() {
-    const element = this.elementRef.nativeElement;
-  }
+export class WorkPackagesCalendarEmbeddedComponent {
 }
-
-DynamicBootstrapper.register({ selector: 'wp-embedded-calendar', cls: WorkPackagesEmbeddedCalendarEntryComponent });

--- a/frontend/src/app/modules/common/dynamic-embedding/dynamic-embeddable-module.interface.ts
+++ b/frontend/src/app/modules/common/dynamic-embedding/dynamic-embeddable-module.interface.ts
@@ -1,0 +1,5 @@
+import {ComponentType} from "@angular/cdk/portal";
+
+export interface DynamicLazyLoadModule {
+  lazyloadableComponents:{ [key:string]:ComponentType<any> };
+}

--- a/frontend/src/app/modules/common/dynamic-embedding/wp-embedded-calendar/wp-embedded-calendar-entry.component.ts
+++ b/frontend/src/app/modules/common/dynamic-embedding/wp-embedded-calendar/wp-embedded-calendar-entry.component.ts
@@ -1,0 +1,65 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {Component, Injector, NgModuleFactoryLoader, OnInit} from '@angular/core';
+import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
+import {DynamicLazyLoadModule} from "core-app/modules/common/dynamic-embedding/dynamic-embeddable-module.interface";
+
+@Component({
+  selector: 'wp-embedded-calendar',
+  template: `
+    <ng-container *ngIf="!!embeddedComponent">
+      <ng-container *ngComponentOutlet="embeddedComponent; injector: embeddedInjector"></ng-container>
+    </ng-container>
+    <ndc-dynamic *ngIf="false && !!embeddedComponent"
+                 [ndcDynamicComponent]="embeddedComponent"
+                 [ndcDynamicInjector]="embeddedInjector"
+                 [ndcDynamicInputs]="{ static: true }">
+    </ndc-dynamic>
+  `
+})
+export class WorkPackagesEmbeddedCalendarEntryComponent implements OnInit {
+  public embeddedComponent:any;
+  public embeddedInjector:Injector;
+
+  constructor(private readonly loader:NgModuleFactoryLoader,
+              private readonly injector:Injector) {
+  }
+
+  ngOnInit() {
+    this.loader.load('core-app/modules/calendar/openproject-calendar.module#OpenprojectCalendarModule')
+      .then(factory => {
+        const moduleRef = factory.create(this.injector);
+        const module = moduleRef.instance as DynamicLazyLoadModule;
+        this.embeddedInjector = moduleRef.injector;
+        this.embeddedComponent = module.lazyloadableComponents.calendar;
+      });
+  }
+}
+
+DynamicBootstrapper.register({ selector: 'wp-embedded-calendar', cls: WorkPackagesEmbeddedCalendarEntryComponent });

--- a/frontend/src/app/modules/common/openproject-common.module.ts
+++ b/frontend/src/app/modules/common/openproject-common.module.ts
@@ -69,6 +69,8 @@ import {UIRouterModule} from "@uirouter/angular";
 import {PortalModule} from "@angular/cdk/portal";
 import {CommonModule} from "@angular/common";
 import {CollapsibleSectionComponent} from "core-app/modules/common/collapsible-section/collapsible-section.component";
+import {WorkPackagesEmbeddedCalendarEntryComponent} from "core-app/modules/common/dynamic-embedding/wp-embedded-calendar/wp-embedded-calendar-entry.component";
+import {DynamicModule} from "ng-dynamic-component";
 
 export function bootstrapModule(injector:Injector) {
   return () => {
@@ -93,6 +95,8 @@ export function bootstrapModule(injector:Injector) {
     PortalModule,
     // Our own A11y module
     OpenprojectAccessibilityModule,
+    // Dynamic components
+    DynamicModule,
   ],
   exports: [
     // Re-export all commonly used
@@ -135,6 +139,9 @@ export function bootstrapModule(injector:Injector) {
     ZenModeButtonComponent,
 
     OPContextMenuComponent,
+
+    // Embedded components
+    WorkPackagesEmbeddedCalendarEntryComponent,
   ],
   declarations: [
     OpDatePickerComponent,
@@ -175,6 +182,8 @@ export function bootstrapModule(injector:Injector) {
 
     // Zen mode button
     ZenModeButtonComponent,
+    // Embedded components
+    WorkPackagesEmbeddedCalendarEntryComponent,
   ],
   entryComponents: [
     OpDateTimeComponent,
@@ -189,6 +198,8 @@ export function bootstrapModule(injector:Injector) {
     OPContextMenuComponent,
     ZenModeButtonComponent,
     CollapsibleSectionComponent,
+    // Embedded components
+    WorkPackagesEmbeddedCalendarEntryComponent,
   ],
   providers: [
     { provide: APP_INITIALIZER, useFactory: bootstrapModule, deps: [Injector], multi: true },

--- a/frontend/src/app/modules/work_packages/routing/work-packages-routes.ts
+++ b/frontend/src/app/modules/work_packages/routing/work-packages-routes.ts
@@ -179,6 +179,6 @@ export const WORK_PACKAGES_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'work-packages.calendar.**',
     url: '/calendar',
-    loadChildren: '../calendar/openproject-calendar.module#OpenprojectCalendarModule'
+    loadChildren: 'core-app/modules/calendar/openproject-calendar.module#OpenprojectCalendarModule'
   },
 ];


### PR DESCRIPTION
This fixes #29158, but is quite a hack:

1. We load the lazy calendar module

2. We get the lazy loadable component and put it into a ngComponentOutlet. `ng-dynamic-component` will not work in this cases because it uses a `ComponentFactoryResolver` from the including module,
not from the included  module and thus the dynamic component is not known (or rather, not in the `entryComponents` set). It would work if it were to use the injector to get the CFR.

3. We then render another component that is able to set inputs due to 2.

https://community.openproject.com/wp/29158