### PR TITLE
[Fix] User limit info cut off

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -40,7 +40,7 @@ See docs/COPYRIGHT.rdoc for more details.
   &nbsp;
   <a href="<%= OpenProject::Enterprise.upgrade_path %>" class="display-inline button -tiny -highlight" title="<%= t(:title_enterprise_upgrade) %>"><%= t(:button_upgrade) %></a>
 <% end %>
-<%= toolbar title: t(:label_user_plural), title_class: 'no-padding-bottom', title_extra: users_info do %>
+<%= toolbar title: t(:label_user_plural), title_class: 'no-padding-bottom', subtitle: users_info do %>
   <li class="toolbar-item">
     <%= link_to new_user_path,
         { class: 'button -alt-highlight',


### PR DESCRIPTION
Prettify the user limit info

<img width="381" alt="bildschirmfoto 2018-12-07 um 09 22 55" src="https://user-images.githubusercontent.com/7457313/49636064-d3324b00-fa01-11e8-862c-6cde459f4967.png">

<img width="289" alt="bildschirmfoto 2018-12-07 um 09 24 34" src="https://user-images.githubusercontent.com/7457313/49636108-ef35ec80-fa01-11e8-83c5-de232786849f.png">
