### PR TITLE
[29204] Cost reports: broken scrolling behaviour

### DIFF
--- a/modules/reporting_engine/lib/assets/stylesheets/reporting_engine/reporting.css.erb
+++ b/modules/reporting_engine/lib/assets/stylesheets/reporting_engine/reporting.css.erb
@@ -412,16 +412,6 @@ div.calendar table div { /* make sure the nested divs are large enough, too */
   padding: 1px 3px 1px 1px;
 }
 
-/* Accessibility specific styles */
-fieldset#filters table td > label.hidden-for-sighted, .hidden-for-sighted {
-  position:absolute;
-  left:-10000px;
-  top:auto;
-  width:1px;
-  height:1px;
-  overflow:hidden;
-}
-
 .advanced-filters--filter-value.-binary {
   display: flex;
 }


### PR DESCRIPTION
The hidden labels have an absolute position which moves them out of view. For some reasons the reporting plugin changes this implementation for all these labels to `top: auto`. However this seems to crash with the new grid layout. I have no idea why it only crashes under some circumstances on the cost reports page and not everywhere else, too.


https://community.openproject.com/projects/openproject/work_packages/29204/activity