### PR TITLE
Add postgres support in packager

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,2 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git#v106
 https://github.com/pkgr/heroku-buildpack-ruby.git#v183-1
-https://github.com/istrategylabs/heroku-buildpack-node-cleanup

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
-https://github.com/pkgr/pkgr-buildpack-imagemagick.git
 https://github.com/heroku/heroku-buildpack-nodejs.git#v106
 https://github.com/pkgr/heroku-buildpack-ruby.git#v183-1
+https://github.com/istrategylabs/heroku-buildpack-node-cleanup

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,23 +1,9 @@
 user: openproject
 group: openproject
 targets:
-  debian-8: &debian8
+  ubuntu-18.04:
     build_dependencies:
       - libsqlite3-dev
-  debian-9:
-    <<: *debian8
-  ubuntu-14.04:
-    <<: *debian8
-  ubuntu-16.04:
-    <<: *debian8
-  ubuntu-18.04:
-    <<: *debian8
-  centos-7:
-   dependencies:
-      - epel-release
-  sles-12:
-    build_dependencies:
-      - sqlite3-devel
 before_precompile: "packaging/setup"
 after_precompile: "packaging/teardown"
 crons:
@@ -35,5 +21,5 @@ wizards:
   - https://github.com/finnlabs/addon-repositories.git
   - https://github.com/pkgr/addon-smtp.git
   - https://github.com/pkgr/addon-memcached.git
-  - https://github.com/pkgr/addon-openproject.git
+  - https://github.com/opf/addon-openproject.git#dynamic-node-dependencies
 buildpack: https://github.com/opf/heroku-buildpack-multi.git

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,9 +1,23 @@
 user: openproject
 group: openproject
 targets:
-  ubuntu-18.04:
+  debian-8: &debian8
     build_dependencies:
       - libsqlite3-dev
+  debian-9:
+    <<: *debian8
+  ubuntu-14.04:
+    <<: *debian8
+  ubuntu-16.04:
+    <<: *debian8
+  ubuntu-18.04:
+    <<: *debian8
+  centos-7:
+   dependencies:
+      - epel-release
+  sles-12:
+    build_dependencies:
+      - sqlite3-devel
 before_precompile: "packaging/setup"
 after_precompile: "packaging/teardown"
 crons:

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -29,7 +29,7 @@ services:
 installer: https://github.com/pkgr/installer.git
 wizards:
   - https://github.com/pkgr/addon-legacy-installer.git
-  - https://github.com/pkgr/addon-mysql.git
+  - https://github.com/pkgr/addon-postgres
   - https://github.com/pkgr/addon-apache2.git
   - https://github.com/finnlabs/addon-repositories.git
   - https://github.com/pkgr/addon-smtp.git

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -19,6 +19,7 @@ targets:
     build_dependencies:
       - sqlite3-devel
 before_precompile: "packaging/setup"
+after_precompile: "packaging/teardown"
 crons:
   - packaging/cron/openproject-hourly-tasks
   - packaging/cron/openproject-clear-old-sessions

--- a/lib/tasks/packager.rake
+++ b/lib/tasks/packager.rake
@@ -47,16 +47,6 @@ namespace :packager do
   # avoids to load the environment multiple times.
   # Removes older assets
   task postinstall: [:environment, 'assets:clean', 'setup:scm'] do
-
-    # We need to precompile assets when either
-    # 1. packager requested it (e.g., due to a server prefix being set)
-    # 2. When a custom Gemfile is added
-    if ENV['REBUILD_ASSETS'] == 'true'
-      Rake::Task['assets:precompile'].invoke
-      FileUtils.chmod_R 'a+rx', "#{ENV['APP_HOME']}/public/assets/"
-      shell_setup(['config:set', 'REBUILD_ASSETS=""'])
-    end
-
     # Clear any caches
     OpenProject::Cache.clear
 
@@ -96,7 +86,6 @@ namespace :packager do
         new_root = relative_root.chomp('/')
 
         shell_setup(['config:set', "RAILS_RELATIVE_URL_ROOT=#{new_root}"])
-        shell_setup(['config:set', 'REBUILD_ASSETS="true"'])
       end
     end
 

--- a/lib/tasks/packager.rake
+++ b/lib/tasks/packager.rake
@@ -47,6 +47,16 @@ namespace :packager do
   # avoids to load the environment multiple times.
   # Removes older assets
   task postinstall: [:environment, 'assets:clean', 'setup:scm'] do
+
+    # We need to precompile assets when either
+    # 1. packager requested it
+    # 2. When a custom Gemfile is added
+    if ENV['MUST_REBUILD_ASSETS'] == 'true'
+      Rake::Task['assets:precompile'].invoke
+      FileUtils.chmod_R 'a+rx', "#{ENV['APP_HOME']}/public/assets/"
+      shell_setup(['config:set', 'MUST_REBUILD_ASSETS=""'])
+    end
+
     # Clear any caches
     OpenProject::Cache.clear
 

--- a/packaging/teardown
+++ b/packaging/teardown
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+: ${APP_HOME?"Need to set APP_HOME for teardown"}
+
+echo "Cleaning up NODE installation"
+pushd $APP_HOME
+rm -rf .heroku/node node_modules frontend/node_modules || true

--- a/packaging/teardown
+++ b/packaging/teardown
@@ -2,8 +2,5 @@
 
 set -e
 
-: ${APP_HOME?"Need to set APP_HOME for teardown"}
-
-echo "Cleaning up NODE installation"
-pushd $APP_HOME
-rm -rf .heroku/node node_modules frontend/node_modules || true
+echo "Cleaning up current node_modules folders"
+rm -rf node_modules frontend/node_modules || true


### PR DESCRIPTION
This branch is being built with postgres as the default packager DB. Also this entertains the idea that we can remove `node_modules` to reduce package size by 75% since we don't need to precompile assets in almost all cases. 

Only when the user decides to have custom gemfiles with assets, they need to be installed. In this case, we can re-use the node installation that's left in the package and run `npm install` before precompilation.

Tests:
- [x] ubuntu 18.04 with new install
- [x] ubuntu 16.04 with new install
- [x] ubuntu 14.04 with new install
- [x] debian 8 with new install
- [x] debian 9 with new install
- [x] sles 12 with new install
- [x] el 7 with new install
- [x] ubuntu 18.04 with existing postgres 10 install. should go through successfully if "reuse" option selected.
- [x] ubuntu 18.04 with stable/8.1 mysql install then upgrade to newer package. should not break. should not install postgres.
- [x] ubuntu 18.04 with existing postgres 10 install. should abort install if autoinstall selected.
- [x] ubuntu 16.04 with existing postgres != 10 install. should peacefully cohabit if autoinstall selected.
