### PR TITLE
Avoid trying to access user if association does not exist

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -157,7 +157,7 @@ class AccountController < ApplicationController
   def activate
     token = ::Token::Invitation.find_by_plaintext_value(params[:token])
 
-    if token.nil? || token.expired?
+    if token.nil? || token.expired? || token.user.nil?
       handle_expired_token token
     elsif token.user.invited?
       activate_by_invite_token token


### PR DESCRIPTION
This might happen if the user was deleted before the token was activate
https://sentry.openproject.com/sentry/saas-openproject/issues/65