### PR TITLE
[29197] WP table and gantt row highlighting

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -32,6 +32,7 @@
 
 .wp-table--row
   cursor: pointer
+  height: $table-timeline--row-height
 
   // Hide collapsed rows (hierarchies, relations)
   &.-collapsed
@@ -39,8 +40,7 @@
 
 .work-package-table--container table.generic-table tbody td
   padding-left: 0
-  line-height: 24px
-  height: 41px
+  line-height: normal
 
 // Styles for inline editable attributes
 .work-package-table--container td.-editable

--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -40,12 +40,13 @@
 
 .work-package-table--container table.generic-table tbody td
   padding-left: 0
-  line-height: normal
+  padding-top: 0
+  padding-bottom: 0
+  // To display the input field border correctly (input height is 24px)
+  line-height: 24px
 
 // Styles for inline editable attributes
 .work-package-table--container td.-editable
-  padding-top: 0
-  padding-bottom: 0
   display: table-cell
   width: auto
 

--- a/app/assets/stylesheets/content/work_packages/timelines/_timelines.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/_timelines.sass
@@ -53,20 +53,18 @@
 
 // Add bottom border to timeline
 .wp-table-timeline--body
-  border-bottom: 1px solid $table-row-border-color
+  outline: 1px solid $table-row-border-color
 
-// Ensure the height of table and timeline rows
 .wp-timeline-cell
+  // Ensure the height of table and timeline rows
   height: $table-timeline--row-height
+  // Vertically center elements
+  display: flex
+  align-items: center
 
   &:first-child
     // The first table child is 1px larger
     height: calc(#{$table-timeline--row-height} + 1px)
-
-.wp-timeline-cell
-  // Vertically center elements
-  display: flex
-  align-items: center
 
   // Need to disable flex behavior on children
   > div

--- a/app/assets/stylesheets/content/work_packages/timelines/_timelines_header.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/_timelines_header.sass
@@ -3,7 +3,7 @@
   width: 100%
   position: sticky
   top: 0
-  z-index: 1
+  z-index: 2
 
 .wp-timeline--header-element
   background: white

--- a/app/assets/stylesheets/layout/work_packages/_table.sass
+++ b/app/assets/stylesheets/layout/work_packages/_table.sass
@@ -81,7 +81,7 @@
 
   .row-hovered
     background: #E5F2FA
-    z-index: 100
+    z-index: 1
 
 
 // Left part of the split view

--- a/lib/open_project/design.rb
+++ b/lib/open_project/design.rb
@@ -198,7 +198,7 @@ module OpenProject
       'timeline--header-border-color'                        => '#aaaaaa',
       'timeline--grid-color'                                 => '#dddddd',
       'timeline--separator'                                  => '3px solid #E7E7E7',
-      'table-timeline--row-height'                           => '41px',
+      'table-timeline--row-height'                           => '40px',
       'status-selector-bg-color'                             => '#F99601',
       'status-selector-bg-hover-color'                       => '#E08600'
     }.freeze


### PR DESCRIPTION
#### Problem

When hovering over the entries of a wp list view with an open gantt chart, the row highlighting in the gantt chart was shifted, which occured on all browsers but in particular on MSEdge. 

- Tested on Chrome, Opera, Firefox and MSEdge

https://community.openproject.com/projects/openproject/work_packages/29197/activity
