### PR TITLE
Feature/29218/search autocompleter

### DIFF
--- a/app/assets/stylesheets/content/_loading_indicator.sass
+++ b/app/assets/stylesheets/content/_loading_indicator.sass
@@ -48,6 +48,8 @@
     width: 6px
     display: inline-block
     animation: block-waveStretchDelay 1.2s infinite ease-in-out
+    margin: 0 1px
+    
   .block-1
     animation-delay: -1.2s
   .block-2
@@ -62,9 +64,6 @@
   &.-compact
     margin: 20px auto
 
-    [class^='block-']
-      margin: 0 1px
-
   &.-small
     height: 34px
     margin: 0
@@ -72,8 +71,6 @@
 
     [class^='block-']
       width: 4px
-
-
 
 @keyframes block-waveStretchDelay
   0%, 40%, 100%

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -217,9 +217,17 @@ input.top-menu-search--input
   .top-menu-search.-collapsed &
     display: none
 
-.top-menu-search--loading
+.search-autocomplete--results
+  width: 300px
+
+.search-autocomplete--loading
   top: $header-height
   left: -($search-input-width - $header-height) - 1
+
+.search-autocomplete--wp-id
+  color: $gray-dark
+  font-size: 13px
+  white-space: nowrap
 
 #quick-search
   float: right

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -220,7 +220,7 @@ input.top-menu-search--input
 .search-autocomplete--results
   width: 300px
 
-.search-autocomplete--loading
+.top-menu-search--loading
   top: $header-height
   left: -($search-input-width - $header-height) - 1
 

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -29,6 +29,8 @@
 $hamburger-right: -3px
 $hamburger-width: 50px
 
+$search-input-width: 180px
+
 %top-menu-hover-styles
   @include varprop(background, header-item-bg-hover-color)
   @include varprop(color, header-item-font-hover-color)
@@ -206,7 +208,7 @@ input.top-menu-search--input
   display: inline-block
   border: none !important
   border-radius: 25px
-  width: 180px
+  width: $search-input-width
   outline: 0
   font-size: 0.75rem
   &::-ms-clear
@@ -214,6 +216,10 @@ input.top-menu-search--input
     width: 20px
   .top-menu-search.-collapsed &
     display: none
+
+.top-menu-search--loading
+  top: $header-height
+  left: -($search-input-width - $header-height) - 1
 
 #quick-search
   float: right

--- a/app/models/queries/work_packages.rb
+++ b/app/models/queries/work_packages.rb
@@ -73,6 +73,7 @@ module Queries::WorkPackages
   register.filter Query, filters_module::DescriptionFilter
   register.filter Query, filters_module::SearchFilter
   register.filter Query, filters_module::CommentFilter
+  register.filter Query, filters_module::SubjectOrIdFilter
 
   columns_module = Queries::WorkPackages::Columns
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1275,6 +1275,7 @@ en:
   label_history: "History"
   label_hierarchy_leaf: "Hierarchy leaf"
   label_home: "Home"
+  label_subject_or_id: "Subject or ID"
   label_in: "in"
   label_in_less_than: "in less than"
   label_in_more_than: "in more than"

--- a/frontend/src/app/angular4-modules.ts
+++ b/frontend/src/app/angular4-modules.ts
@@ -146,7 +146,6 @@ import {FullCalendarModule} from "ng-fullcalendar";
   ],
   declarations: [
     OpContextMenuTrigger,
-    MainMenuResizerComponent,
 
     // Searchbar
     ExpandableSearchComponent,

--- a/frontend/src/app/components/api/api-v3/api-v3-filter-builder.ts
+++ b/frontend/src/app/components/api/api-v3/api-v3-filter-builder.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-export type FilterOperator = '=' | '!*' | '!' | '~';
+export type FilterOperator = '=' | '!*' | '!' | '~' | '**';
 
 export interface ApiV3Filter {
   [filter:string]:{ operator:FilterOperator, values:any };

--- a/frontend/src/app/components/expandable-search/expandable-search.component.html
+++ b/frontend/src/app/components/expandable-search/expandable-search.component.html
@@ -1,7 +1,22 @@
 <div class="top-menu-search -collapsed"
      (focusout)="closeWhenFocussedOutside()"
      [ngClass]="{'-collapsed': collapsed}">
-    <input #inputEl type="text" name="q" id="q" size="20" class="top-menu-search--input" placeholder= "{{I18n.t('js.select2.searching')}}">
+    <div class="top-menu-search--loading ui-autocomplete--loading" style="display: none">
+      <div class="loading-indicator -small">
+        <div class="block-1"></div>
+        <div class="block-2"></div>
+        <div class="block-3"></div>
+        <div class="block-4"></div>
+        <div class="block-5"></div>
+      </div>
+    </div>
+    <input #inputEl
+           type="text"
+           name="q"
+           id="q"
+           size="20"
+           class="top-menu-search--input"
+           placeholder= "{{I18n.t('js.select2.searching')}}">
     <a #btn
        id="top-menu-search-button"
        class="top-menu-search--button search-form-normal"

--- a/frontend/src/app/components/expandable-search/expandable-search.component.ts
+++ b/frontend/src/app/components/expandable-search/expandable-search.component.ts
@@ -196,8 +196,14 @@ export class ExpandableSearchComponent implements OnDestroy {
 
   private autocompleteWorkPackages(query:string):Promise<WorkPackageResource[]> {
     this.$element.find('.ui-autocomplete--loading').show();
+    let idOnly:boolean = false;
 
-    let href = this.PathHelperService.api.v3.wpBySubject(query);
+    if (query.match(/^#\d+$/)) {
+      query = query.replace(/^#/, '');
+      idOnly = true;
+    }
+
+    let href = this.PathHelperService.api.v3.wpBySubjectOrId(query, idOnly);
 
     return this.halResourceService
       .get<CollectionResource<WorkPackageResource>>(href)

--- a/frontend/src/app/components/expandable-search/expandable-search.component.ts
+++ b/frontend/src/app/components/expandable-search/expandable-search.component.ts
@@ -119,7 +119,7 @@ export class ExpandableSearchComponent implements OnDestroy {
             )
             .append(
               jQuery('<span>')
-                .addClass('subject')
+                .addClass('search-autocomplete--subject')
                 .append(` ${workPackage.subject}`)
             )
         )

--- a/frontend/src/app/components/expandable-search/expandable-search.component.ts
+++ b/frontend/src/app/components/expandable-search/expandable-search.component.ts
@@ -120,7 +120,7 @@ export class ExpandableSearchComponent implements OnDestroy {
             .append(
               jQuery('<span>')
                 .addClass('subject')
-                .append(` ${workPackage.subject}`)
+                .append(` ${workPackage.subject} ${workPackage.updatedAt}`)
             )
         )
         .appendTo(ul);
@@ -205,10 +205,8 @@ export class ExpandableSearchComponent implements OnDestroy {
       .then((collection) => {
         this.noResults = collection.count === 0;
         this.$element.find('.ui-autocomplete--loading').hide();
-        console.log("collection loaded", collection.elements);
         return collection.elements || [];
       }).catch(() => {
-        console.log("collection loading catch");
         this.$element.find('.ui-autocomplete--loading').hide();
         return [];
       });

--- a/frontend/src/app/components/expandable-search/expandable-search.component.ts
+++ b/frontend/src/app/components/expandable-search/expandable-search.component.ts
@@ -39,7 +39,6 @@ import {FocusHelperService} from 'core-app/modules/common/focus/focus-helper';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
 import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
-import {LoadingIndicatorService} from "core-app/modules/common/loading-indicator/loading-indicator.service";
 import {HalResourceService} from "core-app/modules/hal/services/hal-resource.service";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {CollectionResource} from "core-app/modules/hal/resources/collection-resource";
@@ -69,7 +68,6 @@ export class ExpandableSearchComponent implements OnDestroy {
               readonly renderer:Renderer2,
               readonly I18n:I18nService,
               readonly PathHelperService:PathHelperService,
-              readonly loadingIndicatorService:LoadingIndicatorService,
               readonly halResourceService:HalResourceService) {
   }
 
@@ -93,9 +91,8 @@ export class ExpandableSearchComponent implements OnDestroy {
       source: (request:{ term:string }, response:Function) => {
         this.autocompleteWorkPackages(request.term).then((values) => {
           selected = false;
-
           response(values.map(wp => {
-            return {workPackage: wp, value: ExpandableSearchComponent.getWpIdentifier(wp)};
+            return {workPackage: wp, value: ExpandableSearchComponent.getWpLabel(wp)};
           }));
         });
       },
@@ -174,7 +171,7 @@ export class ExpandableSearchComponent implements OnDestroy {
     this.unregister();
   }
 
-  private static getWpIdentifier(workPackage:WorkPackageResource):string {
+  private static getWpLabel(workPackage:WorkPackageResource):string {
     if (workPackage) {
       return `#${workPackage.id} - ${workPackage.subject}`;
     } else {

--- a/frontend/src/app/components/expandable-search/expandable-search.component.ts
+++ b/frontend/src/app/components/expandable-search/expandable-search.component.ts
@@ -120,7 +120,7 @@ export class ExpandableSearchComponent implements OnDestroy {
             .append(
               jQuery('<span>')
                 .addClass('subject')
-                .append(` ${workPackage.subject} ${workPackage.updatedAt}`)
+                .append(` ${workPackage.subject}`)
             )
         )
         .appendTo(ul);

--- a/frontend/src/app/components/expandable-search/expandable-search.component.ts
+++ b/frontend/src/app/components/expandable-search/expandable-search.component.ts
@@ -42,6 +42,7 @@ import {PathHelperService} from "core-app/modules/common/path-helper/path-helper
 import {HalResourceService} from "core-app/modules/hal/services/hal-resource.service";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {CollectionResource} from "core-app/modules/hal/resources/collection-resource";
+import {DynamicCssService} from "core-app/modules/common/dynamic-css/dynamic-css.service";
 
 export const expandableSearchSelector = 'expandable-search';
 
@@ -68,7 +69,8 @@ export class ExpandableSearchComponent implements OnDestroy {
               readonly renderer:Renderer2,
               readonly I18n:I18nService,
               readonly PathHelperService:PathHelperService,
-              readonly halResourceService:HalResourceService) {
+              readonly halResourceService:HalResourceService,
+              readonly dynamicCssService:DynamicCssService) {
   }
 
   ngOnInit() {
@@ -132,6 +134,8 @@ export class ExpandableSearchComponent implements OnDestroy {
   public handleClick(event:JQueryEventObject):void {
     event.stopPropagation();
     event.preventDefault();
+
+    this.dynamicCssService.requireHighlighting();
 
     // If search is open, submit form when clicked on icon
     if (!this.collapsed && ContainHelpers.insideOrSelf(this.btn.nativeElement, event.target)) {

--- a/frontend/src/app/components/expandable-search/expandable-search.component.ts
+++ b/frontend/src/app/components/expandable-search/expandable-search.component.ts
@@ -210,12 +210,16 @@ export class ExpandableSearchComponent implements OnDestroy {
       .toPromise()
       .then((collection) => {
         this.noResults = collection.count === 0;
-        this.$element.find('.ui-autocomplete--loading').hide();
+        this.hideSpinner();
         return collection.elements || [];
       }).catch(() => {
-        this.$element.find('.ui-autocomplete--loading').hide();
+        this.hideSpinner();
         return [];
       });
+  }
+
+  private hideSpinner():void {
+    this.$element.find('.ui-autocomplete--loading').hide();
   }
 }
 

--- a/frontend/src/app/components/wp-fast-table/wp-table-filters.ts
+++ b/frontend/src/app/components/wp-fast-table/wp-table-filters.ts
@@ -50,6 +50,7 @@ export class WorkPackageTableFilters extends WorkPackageTableBaseState<QueryFilt
     'includes',
     'requires',
     'required',
+    'subjectOrId'
   ];
 
   constructor(filters:QueryFilterInstanceResource[], public availableSchemas:QueryFilterInstanceSchemaResource[]) {

--- a/frontend/src/app/modules/common/path-helper/apiv3/apiv3-paths.ts
+++ b/frontend/src/app/modules/common/path-helper/apiv3/apiv3-paths.ts
@@ -128,6 +128,6 @@ export class ApiV3Paths {
 
     filters.add('subject', '~', [term]);
 
-    return this.apiV3Base + '/work_packages' + '?' + filters.toParams() + encodeURI('&sortBy=[["updatedAt","DESC"]]&offset=1&pageSize=10');
+    return this.apiV3Base + '/work_packages' + '?' + filters.toParams() + encodeURI('&sortBy=[["updatedAt","desc"]]&offset=1&pageSize=10');
   }
 }

--- a/frontend/src/app/modules/common/path-helper/apiv3/apiv3-paths.ts
+++ b/frontend/src/app/modules/common/path-helper/apiv3/apiv3-paths.ts
@@ -123,10 +123,14 @@ export class ApiV3Paths {
     return this.apiV3Base + '/principals' + '?' + filters.toParams() + encodeURI('&sortBy=[["name","asc"]]&offset=1&pageSize=10');
   }
 
-  public wpBySubject(term:string) {
+  public wpBySubjectOrId(term:string, idOnly:boolean = false) {
     let filters:ApiV3FilterBuilder = new ApiV3FilterBuilder();
 
-    filters.add('subject', '~', [term]);
+    if (idOnly) {
+      filters.add('id', '=', [term]);
+    } else {
+      filters.add('subjectOrId', '**', [term]);
+    }
 
     return this.apiV3Base + '/work_packages' + '?' + filters.toParams() + encodeURI('&sortBy=[["updatedAt","desc"]]&offset=1&pageSize=10');
   }

--- a/frontend/src/app/modules/common/path-helper/apiv3/apiv3-paths.ts
+++ b/frontend/src/app/modules/common/path-helper/apiv3/apiv3-paths.ts
@@ -122,4 +122,12 @@ export class ApiV3Paths {
     }
     return this.apiV3Base + '/principals' + '?' + filters.toParams() + encodeURI('&sortBy=[["name","asc"]]&offset=1&pageSize=10');
   }
+
+  public wpBySubject(term:string) {
+    let filters:ApiV3FilterBuilder = new ApiV3FilterBuilder();
+
+    filters.add('subject', '~', [term]);
+
+    return this.apiV3Base + '/work_packages' + '?' + filters.toParams() + encodeURI('&sortBy=[["updatedAt","DESC"]]&offset=1&pageSize=10');
+  }
 }

--- a/frontend/src/app/modules/common/path-helper/path-helper.service.spec.ts
+++ b/frontend/src/app/modules/common/path-helper/path-helper.service.spec.ts
@@ -46,5 +46,14 @@ describe('PathHelper', function() {
         PathHelper.api.v3.principals(projectId, term)
       ).toEqual('/api/v3/principals?filters=' +  encodeURI('[{"status":{"operator":"!","values":["0","3"]}},{"member":{"operator":"=","values":["1"]}},{"type":{"operator":"=","values":["User","Group"]}},{"id":{"operator":"!","values":["me"]}},{"name":{"operator":"~","values":["Maria"]}}]&sortBy=[["name","asc"]]&offset=1&pageSize=10'));
     });
+
+    it('should provide a path to work package query on subject or ID ', function() {
+      expect(
+        PathHelper.api.v3.wpBySubjectOrId("bogus")
+      ).toEqual('/api/v3/work_packages?filters=' +  encodeURI('[{"subjectOrId":{"operator":"**","values":["bogus"]}}]&sortBy=[["updatedAt","desc"]]&offset=1&pageSize=10'));
+      expect(
+        PathHelper.api.v3.wpBySubjectOrId("1234", true)
+      ).toEqual('/api/v3/work_packages?filters=' +  encodeURI('[{"id":{"operator":"=","values":["1234"]}}]&sortBy=[["updatedAt","desc"]]&offset=1&pageSize=10'));
+    });
   });
 });

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -82,17 +82,19 @@ describe 'Search', type: :feature, js: true do
 
       first_wp = work_packages.first
 
-
       suggestions = search_autocomplete(page.find('.top-menu-search--input'),
                                         query: first_wp.id.to_s,
                                         results_selector: '.search-autocomplete--results')
       expect(suggestions).to have_text("No. 1")
+
+      suggestions = search_autocomplete(page.find('.top-menu-search--input'),
+                                        query: "1",
+                                        results_selector: '.search-autocomplete--results')
       expect(suggestions).to have_text("No. 11")
 
       suggestions = search_autocomplete(page.find('.top-menu-search--input'),
                                         query: "##{first_wp.id}",
                                         results_selector: '.search-autocomplete--results')
-      expect(suggestions).to have_text("No. #{first_wp.id}")
       expect(suggestions).to_not have_text("No. 11")
     end
   end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -82,18 +82,18 @@ describe 'Search', type: :feature, js: true do
       page.find('#top-menu-search-button').click
 
       suggestions = search_autocomplete(page.find('.top-menu-search--input'),
-                                        query: '1',
-                                        results_selector: '.search-autocomplete--results',
-                                        wait_for_results: 2.0)
-      expect(suggestions).to have_text('No. 1')
-      expect(suggestions).to have_text('No. 11')
-
-      suggestions = search_autocomplete(page.find('.top-menu-search--input'),
                                         query: '#1',
                                         results_selector: '.search-autocomplete--results',
                                         wait_for_results: 2.0)
       expect(suggestions).to have_text('No. 1')
       expect(suggestions).to_not have_text('No. 11')
+
+      suggestions = search_autocomplete(page.find('.top-menu-search--input'),
+                                        query: '1',
+                                        results_selector: '.search-autocomplete--results',
+                                        wait_for_results: 2.0)
+      expect(suggestions).to have_text('No. 1')
+      expect(suggestions).to have_text('No. 11')
     end
   end
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -68,8 +68,7 @@ describe 'Search', type: :feature, js: true do
 
       suggestions = search_autocomplete(page.find('.top-menu-search--input'),
                                         query: query,
-                                        results_selector: '.search-autocomplete--results',
-                                        wait_for_results: 2.0)
+                                        results_selector: '.search-autocomplete--results')
       expect(suggestions).to have_text('No. 23')
       expect(suggestions).to_not have_text('No. 13')
 
@@ -81,19 +80,20 @@ describe 'Search', type: :feature, js: true do
 
       page.find('#top-menu-search-button').click
 
-      suggestions = search_autocomplete(page.find('.top-menu-search--input'),
-                                        query: '#1',
-                                        results_selector: '.search-autocomplete--results',
-                                        wait_for_results: 2.0)
-      expect(suggestions).to have_text('No. 1')
-      expect(suggestions).to_not have_text('No. 11')
+      first_wp = work_packages.first
+
 
       suggestions = search_autocomplete(page.find('.top-menu-search--input'),
-                                        query: '1',
-                                        results_selector: '.search-autocomplete--results',
-                                        wait_for_results: 2.0)
-      expect(suggestions).to have_text('No. 1')
-      expect(suggestions).to have_text('No. 11')
+                                        query: first_wp.id.to_s,
+                                        results_selector: '.search-autocomplete--results')
+      expect(suggestions).to have_text("No. 1")
+      expect(suggestions).to have_text("No. 11")
+
+      suggestions = search_autocomplete(page.find('.top-menu-search--input'),
+                                        query: "##{first_wp.id}",
+                                        results_selector: '.search-autocomplete--results')
+      expect(suggestions).to have_text("No. #{first_wp.id}")
+      expect(suggestions).to_not have_text("No. 11")
     end
   end
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -68,7 +68,8 @@ describe 'Search', type: :feature, js: true do
 
       suggestions = search_autocomplete(page.find('.top-menu-search--input'),
                                         query: query,
-                                        results_selector: '.search-autocomplete--results')
+                                        results_selector: '.search-autocomplete--results',
+                                        wait_for_results: 2.0)
       expect(suggestions).to have_text('No. 23')
       expect(suggestions).to_not have_text('No. 13')
 
@@ -82,13 +83,15 @@ describe 'Search', type: :feature, js: true do
 
       suggestions = search_autocomplete(page.find('.top-menu-search--input'),
                                         query: '1',
-                                        results_selector: '.search-autocomplete--results')
+                                        results_selector: '.search-autocomplete--results',
+                                        wait_for_results: 2.0)
       expect(suggestions).to have_text('No. 1')
       expect(suggestions).to have_text('No. 11')
 
       suggestions = search_autocomplete(page.find('.top-menu-search--input'),
                                         query: '#1',
-                                        results_selector: '.search-autocomplete--results')
+                                        results_selector: '.search-autocomplete--results',
+                                        wait_for_results: 2.0)
       expect(suggestions).to have_text('No. 1')
       expect(suggestions).to_not have_text('No. 11')
     end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -61,6 +61,8 @@ describe 'Search', type: :feature, js: true do
   describe 'autocomplete' do
     include ::Components::UIAutocompleteHelpers
 
+    let!(:other_work_package) { FactoryBot.create(:work_package, subject: "Other work package", project: project) }
+
     it 'provides suggestions' do
       page.find('#top-menu-search-button').click
 
@@ -75,6 +77,20 @@ describe 'Search', type: :feature, js: true do
                           query: target_work_package.subject,
                           results_selector: '.search-autocomplete--results')
       expect(current_path).to match /work_packages\/#{target_work_package.id}\//
+
+      page.find('#top-menu-search-button').click
+
+      suggestions = search_autocomplete(page.find('.top-menu-search--input'),
+                                        query: '1',
+                                        results_selector: '.search-autocomplete--results')
+      expect(suggestions).to have_text('No. 1')
+      expect(suggestions).to have_text('No. 11')
+
+      suggestions = search_autocomplete(page.find('.top-menu-search--input'),
+                                        query: '#1',
+                                        results_selector: '.search-autocomplete--results')
+      expect(suggestions).to have_text('No. 1')
+      expect(suggestions).to_not have_text('No. 11')
     end
   end
 

--- a/spec/features/support/components/ui_autocomplete.rb
+++ b/spec/features/support/components/ui_autocomplete.rb
@@ -28,12 +28,12 @@
 
 module Components
   module UIAutocompleteHelpers
-    def search_autocomplete(element, query:, results_selector: nil)
+    def search_autocomplete(element, query:, results_selector: nil, wait_for_results: 0.5)
       # Open the element
       element.click
       # Insert the text to find
       element.set(query)
-      sleep(0.5)
+      sleep(wait_for_results)
 
       ##
       # Find the open dropdown

--- a/spec/features/support/components/ui_autocomplete.rb
+++ b/spec/features/support/components/ui_autocomplete.rb
@@ -28,12 +28,12 @@
 
 module Components
   module UIAutocompleteHelpers
-    def search_autocomplete(element, query:, results_selector: nil, wait_for_results: 0.5)
+    def search_autocomplete(element, query:, results_selector: nil)
       # Open the element
       element.click
       # Insert the text to find
       element.set(query)
-      sleep(wait_for_results)
+      sleep(0.5)
 
       ##
       # Find the open dropdown


### PR DESCRIPTION
Autocompleter for global search field in top menu.

Finds work packages while you tip. Selecting a suggestion redirects the page to the selected work package.

Todo:
- [x] Completion on WP IDs
- [x] Width of results should not changes depending on search results

\
Out of scope:
- Autocompleting other entities such as Wiki pages
- Separate API endpoint for search

https://community.openproject.com/wp/29218