### PR TITLE
add read endpoints for news to api v3

### DIFF
--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -52,11 +52,11 @@ class News < ActiveRecord::Base
   after_create :add_author_as_watcher,
                :send_news_added_mail
 
-  scope :visible, -> (*args) {
+  scope :visible, ->(*args) do
     includes(:project)
       .references(:projects)
       .merge(Project.allowed_to(args.first || User.current, :view_news))
-  }
+  end
 
   def visible?(user = User.current)
     !user.nil? && user.allowed_to?(:view_news, project)

--- a/app/models/queries/news.rb
+++ b/app/models/queries/news.rb
@@ -1,0 +1,35 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Queries::News
+  query = Queries::News::NewsQuery
+
+  Queries::Register.order query, Queries::News::Orders::DefaultOrder
+end

--- a/app/models/queries/news/news_query.rb
+++ b/app/models/queries/news/news_query.rb
@@ -1,0 +1,37 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+class Queries::News::NewsQuery < Queries::BaseQuery
+  def self.model
+    News
+  end
+
+  def default_scope
+    News.visible(User.current)
+  end
+end

--- a/app/models/queries/news/orders/default_order.rb
+++ b/app/models/queries/news/orders/default_order.rb
@@ -1,0 +1,37 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+class Queries::News::Orders::DefaultOrder < Queries::BaseOrder
+  self.model = News
+
+  def self.key
+    /id|created_on/
+  end
+end

--- a/docs/api/apiv3/endpoints/news.apib
+++ b/docs/api/apiv3/endpoints/news.apib
@@ -1,0 +1,221 @@
+# Group News
+
+News are articles written by users in order to inform other users of important information.
+
+## Actions
+
+None yet
+
+## Linked Properties
+| Link          | Description                          | Type           | Constraints           | Supported operations | Condition                                 |
+| :-----------: | -------------------------------------| -------------  | --------------------- | -------------------- | ----------------------------------------- |
+| self          | This news                            | News           | not null              | READ                 |                                           |
+| project       | The project the news is situated in  | Project        | not null              | READ / WRITE         |                                           |
+| author        | The user having created the news     | User           | not null              | READ                 |                                           |
+
+## Local Properties
+
+| Property     | Description                                               | Type     | Constraints                                          | Supported operations | Condition                                                   |
+| :----------: | --------------------------------------------------------- | -------- | ---------------------------------------------------- | -------------------- | ----------------------------------------------------------- |
+| id           | News' id                                                  | Integer  | x > 0                                                | READ                 |                                                             |
+| title        | The headline of the news                                  | String   | max 60 characters                                    | READ                 |                                                             |
+| summary      | A short summary                                           | String   | max 255 characters                                   | READ                 |                                                             |
+| description  | The main body of the news with all the details            | String   |                                                      | READ                 |                                                             |
+| createdAt    | The time the news was created at                          | DateTime |                                                      | READ                 |                                                             |
+
+## News [/api/v3/news/{id}]
+
++ Model
+    + Body
+
+            {
+                "_type": "News",
+                "id": 1,
+                "title": "asperiores possimus nam doloribus ab",
+                "summary": "Celebrer spiculum colo viscus claustrum atque. Id nulla culpa sumptus. Comparo crapula depopulo demonstro.",
+                "description": {
+                    "format": "markdown",
+                    "raw": "Videlicet deserunt aequitas cognatus. Concedo quia est quia pariatur vorago vallum. Calco autem atavus accusamus conscendo cornu ulterius. Tam patria ago consectetur ventito sustineo nihil caecus. Supra officiis eos velociter somniculosus tonsor qui. Suffragium aduro arguo angustus cogito quia tolero vulnus. Supplanto sortitus cresco apud vestrum qui.",
+                    "html": "<p>Videlicet deserunt aequitas cognatus. Concedo quia est quia pariatur vorago vallum. Calco autem atavus accusamus conscendo cornu ulterius. Tam patria ago consectetur ventito sustineo nihil caecus. Supra officiis eos velociter somniculosus tonsor qui. Suffragium aduro arguo angustus cogito quia tolero vulnus. Supplanto sortitus cresco apud vestrum qui.</p>"
+                },
+                "createdAt": "2015-03-20T12:57:01Z",
+                "_links": {
+                    "self": {
+                        "href": "/api/v3/news/1",
+                        "title": "asperiores possimus nam doloribus ab"
+                    },
+                    "project": {
+                        "href": "/api/v3/projects/1",
+                        "title": "A project"
+                    },
+                    "author": {
+                        "href": "/api/v3/users/2",
+                        "title": "Peggie Feeney"
+                    }
+                },
+                "_embedded": {
+                    "project": {
+                        "_type": "Project",
+                        <-- omitted for brevity -->
+                        }
+                    },
+                    "author": {
+                        "_type": "User",
+                        <-- omitted for brevity -->
+                    }
+                }
+            }
+
+## View news [GET]
+
++ Parameters
+    + id (required, integer, `1`) ... news id
+
++ Response 200 (application/hal+json)
+
+    [News][]
+
++ Response 404 (application/hal+json)
+
+    Returned if the news does not exist or if the user does not have permission to view it.
+
+    **Required permission** being member of the project the news belongs to
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The requested resource could not be found."
+            }
+
+
+
+## List of News [/api/v3/news{?offset,pageSize,sortBy}]
+
++ Model
+    + Body
+
+            {
+                "_type": "Collection",
+                "total": 78,
+                "count": 2,
+                "pageSize": 2,
+                "offset": 1,
+                "_embedded": {
+                    "elements": [
+                        {
+                            "_type": "News",
+                            "id": 1,
+                            "title": "asperiores possimus nam doloribus ab",
+                            "summary": "Celebrer spiculum colo viscus claustrum atque. Id nulla culpa sumptus. Comparo crapula depopulo demonstro.",
+                            "description": {
+                                "format": "markdown",
+                                "raw": "Videlicet deserunt aequitas cognatus. Concedo quia est quia pariatur vorago vallum. Calco autem atavus accusamus conscendo cornu ulterius. Tam patria ago consectetur ventito sustineo nihil caecus. Supra officiis eos velociter somniculosus tonsor qui. Suffragium aduro arguo angustus cogito quia tolero vulnus. Supplanto sortitus cresco apud vestrum qui.",
+                                "html": "<p>Videlicet deserunt aequitas cognatus. Concedo quia est quia pariatur vorago vallum. Calco autem atavus accusamus conscendo cornu ulterius. Tam patria ago consectetur ventito sustineo nihil caecus. Supra officiis eos velociter somniculosus tonsor qui. Suffragium aduro arguo angustus cogito quia tolero vulnus. Supplanto sortitus cresco apud vestrum qui.</p>"
+                            },
+                            "createdAt": "2015-03-20T12:57:01Z",
+                            "_links": {
+                                "self": {
+                                    "href": "/api/v3/news/1",
+                                    "title": "asperiores possimus nam doloribus ab"
+                                },
+                                "project": {
+                                    "href": "/api/v3/projects/1",
+                                    "title": "Seeded Project"
+                                },
+                                "author": {
+                                    "href": "/api/v3/users/2",
+                                    "title": "Peggie Feeney"
+                                }
+                            }
+                        },
+                        {
+                            "_type": "News",
+                            "id": 2,
+                            "title": "terminatio tutamen. Officia adeptio sp",
+                            "summary": "Consequatur sequi surculus creo tui aequitas.",
+                            "description": {
+                                "format": "markdown",
+                                "raw": "Amicitia alius cattus voluntarius. Virgo viduo terminatio tutamen. Officia adeptio spectaculum atavus nisi cum concido bis. Harum caecus auxilium sol theatrum eaque consequatur. Omnis aeger suus adipisci cicuta. Cur delicate alias curto cursim atqui talio fugiat.",
+                                "html": "<p>Amicitia alius cattus voluntarius. Virgo viduo terminatio tutamen. Officia adeptio spectaculum atavus nisi cum concido bis. Harum caecus auxilium sol theatrum eaque consequatur. Omnis aeger suus adipisci cicuta. Cur delicate alias curto cursim atqui talio fugiat.</p>"
+                            },
+                            "createdAt": "2015-03-20T12:57:01Z",
+                            "_links": {
+                                "self": {
+                                    "href": "/api/v3/news/2",
+                                    "title": "terminatio tutamen. Officia adeptio sp"
+                                },
+                                "project": {
+                                    "href": "/api/v3/projects/1",
+                                    "title": "Seeded Project"
+                                },
+                                "author": {
+                                    "href": "/api/v3/users/2",
+                                    "title": "Peggie Feeney"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "_links": {
+                    "self": {
+                        "href": "/api/v3/news?offset=1&pageSize=2"
+                    },
+                    "jumpTo": {
+                        "href": "/api/v3/news?offset=%7Boffset%7D&pageSize=2",
+                        "templated": true
+                    },
+                    "changeSize": {
+                        "href": "/api/v3/news?offset=1&pageSize=%7Bsize%7D",
+                        "templated": true
+                    },
+                    "nextByOffset": {
+                        "href": "/api/v3/news?offset=2&pageSize=2"
+                    }
+                }
+            }
+
+## List News [GET]
+
+Lists news. The news returned depend on the provided parameters and also on the requesting user's permissions.
+
++ Parameters
+    + offset = `1` (optional, integer, `25`) ... Page number inside the requested collection.
+
+    + pageSize (optional, integer, `25`) ... Number of elements to display per page.
+
+    + sortBy (optional, string, `[["created_at", "asc"]]`) ... JSON specifying sort criteria.
+    Accepts the same format as returned by the [queries](#queries) endpoint. Currently supported sorts are:
+      + id: Sort by primary key
+      + created_on: Sort by news creation datetime
+
++ Response 200 (application/hal+json)
+
+    [List of News][]
+
++ Response 400 (application/hal+json)
+
+    Returned if the client sends invalid request parameters e.g. filters
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidQuery",
+                "message": [
+                  "Filters Invalid filter does not exist."
+                ]
+            }
+
++ Response 403 (application/hal+json)
+
+    Returned if the client is not logged in and login is required.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not authorized to view this resource."
+            }

--- a/docs/api/apiv3/index.apib
+++ b/docs/api/apiv3/index.apib
@@ -11,6 +11,7 @@
 <!-- include(endpoints/forms.apib) -->
 <!-- include(endpoints/groups.apib) -->
 <!-- include(endpoints/help_texts.apib) -->
+<!-- include(endpoints/news.apib) -->
 <!-- include(endpoints/posts.apib) -->
 <!-- include(endpoints/principals.apib) -->
 <!-- include(endpoints/priorities.apib) -->

--- a/lib/api/v3/news/news_api.rb
+++ b/lib/api/v3/news/news_api.rb
@@ -1,0 +1,69 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module News
+      class NewsAPI < ::API::OpenProjectAPI
+        helpers ::API::Utilities::ParamsHelper
+
+        resources :news do
+          get do
+            query = ParamsToQueryService
+                    .new(::News, current_user)
+                    .call(params)
+
+            if query.valid?
+              NewsCollectionRepresenter.new(query.results,
+                                            api_v3_paths.newses,
+                                            page: to_i_or_nil(params[:offset]),
+                                            per_page: resolve_page_size(params[:pageSize]),
+                                            current_user: current_user)
+            else
+              raise ::API::Errors::InvalidQuery.new(query.errors.full_messages)
+            end
+          end
+
+          route_param :id do
+            before do
+              @time_entry = ::News
+                            .visible
+                            .find(params[:id])
+            end
+
+            get do
+              NewsRepresenter.create(@time_entry,
+                                     current_user: current_user,
+                                     embed_links: true)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/news/news_collection_representer.rb
+++ b/lib/api/v3/news/news_collection_representer.rb
@@ -1,0 +1,39 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module News
+      class NewsCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
+        element_decorator ::API::V3::News::NewsRepresenter
+      end
+    end
+  end
+end

--- a/lib/api/v3/news/news_representer.rb
+++ b/lib/api/v3/news/news_representer.rb
@@ -1,0 +1,83 @@
+#-- copyright
+# OpenProject Documents Plugin
+#
+# Former OpenProject Core functionality extracted into a plugin.
+#
+# Copyright (C) 2009-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module News
+      class NewsRepresenter < ::API::Decorators::Single
+        include API::Decorators::LinkedResource
+        include API::Caching::CachedRepresenter
+
+        cached_representer key_parts: %i(project author),
+                           disabled: false
+
+        self_link title_getter: ->(*) { represented.title }
+
+        property :id
+
+        property :title
+
+        property :summary
+
+        property :description,
+                 exec_context: :decorator,
+                 getter: ->(*) {
+                   ::API::Decorators::Formattable.new(represented.description, object: represented)
+                 },
+                 uncacheable: true,
+                 render_nil: true
+
+        property :created_at,
+                 exec_context: :decorator,
+                 getter: ->(*) {
+                   next unless represented.created_on
+                   datetime_formatter.format_datetime(represented.created_on)
+                 }
+
+        associated_resource :project,
+                            link: ->(*) do
+                              {
+                                href: api_v3_paths.project(represented.project.id),
+                                title: represented.project.name
+                              }
+                            end
+
+        associated_resource :author,
+                            v3_path: :user,
+                            representer: ::API::V3::Users::UserRepresenter
+
+        def _type
+          'News'
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -42,6 +42,7 @@ module API
       mount ::API::V3::CustomActions::CustomActionsAPI
       mount ::API::V3::CustomOptions::CustomOptionsAPI
       mount ::API::V3::HelpTexts::HelpTextsAPI
+      mount ::API::V3::News::NewsAPI
       mount ::API::V3::Posts::PostsAPI
       mount ::API::V3::Principals::PrincipalsAPI
       mount ::API::V3::Priorities::PrioritiesAPI

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -147,8 +147,12 @@ module API
             "#{root}/my_preferences"
           end
 
+          def self.newses
+            "#{root}/news"
+          end
+
           def self.news(id)
-            "#{root}/news/#{id}"
+            "#{newses}/#{id}"
           end
 
           def self.post(id)

--- a/spec/lib/api/v3/news/news_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/news/news_representer_rendering_spec.rb
@@ -1,0 +1,115 @@
+#-- copyright
+# OpenProject Documents Plugin
+#
+# Former OpenProject Core functionality extracted into a plugin.
+#
+# Copyright (C) 2009-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::News::NewsRepresenter, 'rendering' do
+  include ::API::V3::Utilities::PathHelper
+
+  let(:news) do
+    FactoryBot.build_stubbed(:news,
+                             project: project,
+                             created_on: Time.now,
+                             author: user)
+  end
+  let(:project) { FactoryBot.build_stubbed(:project) }
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:representer) do
+    described_class.create(news, current_user: user, embed_links: true)
+  end
+  let(:permissions) { all_permissions }
+  let(:all_permissions) { %i() }
+
+  subject { representer.to_json }
+
+  describe '_links' do
+    it_behaves_like 'has a titled link' do
+      let(:link) { 'self' }
+      let(:href) { api_v3_paths.news news.id }
+      let(:title) { news.title }
+    end
+
+    it_behaves_like 'has a titled link' do
+      let(:link) { :project }
+      let(:title) { project.name }
+      let(:href) { api_v3_paths.project project.id }
+    end
+
+    it_behaves_like 'has a titled link' do
+      let(:link) { :author }
+      let(:title) { user.name }
+      let(:href) { api_v3_paths.user user.id }
+    end
+  end
+
+  describe 'properties' do
+    it_behaves_like 'property', :_type do
+      let(:value) { 'News' }
+    end
+
+    it_behaves_like 'property', :id do
+      let(:value) { news.id }
+    end
+
+    it_behaves_like 'property', :title do
+      let(:value) { news.title }
+    end
+
+    it_behaves_like 'property', :summary do
+      let(:value) { news.summary }
+    end
+
+    it_behaves_like 'has UTC ISO 8601 date and time' do
+      let(:date) { news.created_on }
+      let(:json_path) { 'createdAt' }
+    end
+
+    it_behaves_like 'API V3 formattable', 'description' do
+      let(:format) { 'markdown' }
+      let(:raw) { news.description }
+      let(:html) { '<p>' + news.description + '</p>' }
+    end
+  end
+
+  describe '_embedded' do
+    it 'has project embedded' do
+      expect(subject)
+        .to be_json_eql(project.name.to_json)
+        .at_path('_embedded/project/name')
+    end
+
+    it 'has author embedded' do
+      expect(subject)
+        .to be_json_eql(user.name.to_json)
+        .at_path('_embedded/author/name')
+    end
+  end
+end

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -196,6 +196,12 @@ describe ::API::V3::Utilities::PathHelper do
     it_behaves_like 'api v3 path', '/my_preferences'
   end
 
+  describe '#newses' do
+    subject { helper.newses }
+
+    it_behaves_like 'api v3 path', '/news'
+  end
+
   describe '#news' do
     subject { helper.news(42) }
 

--- a/spec/models/queries/news/news_query_spec.rb
+++ b/spec/models/queries/news/news_query_spec.rb
@@ -1,0 +1,47 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Queries::News::NewsQuery, type: :model do
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:base_scope) { News.visible(user) }
+  let(:instance) { described_class.new }
+
+  before do
+    login_as(user)
+  end
+
+  context 'without a filter' do
+    describe '#results' do
+      it 'is the same as getting all the visible news' do
+        expect(instance.results.to_sql).to eql base_scope.to_sql
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/news_resource_spec.rb
+++ b/spec/requests/api/v3/news_resource_spec.rb
@@ -1,0 +1,156 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 news resource', type: :request do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:current_user) do
+    FactoryBot.create(:user, member_in_project: project, member_through_role: role)
+  end
+  let(:news) do
+    FactoryBot.create(:news, project: project, author: current_user)
+  end
+  let(:other_news) do
+    FactoryBot.create(:news, project: project, author: other_user)
+  end
+  let(:other_user) do
+    FactoryBot.create(:user, member_in_project: project, member_through_role: role)
+  end
+  let(:invisible_news) do
+    FactoryBot.create(:news, project: other_project, author: other_user)
+  end
+  let(:project) { FactoryBot.create(:project) }
+  let(:other_project) { FactoryBot.create(:project) }
+  let(:role) { FactoryBot.create(:role, permissions: permissions) }
+  let(:permissions) { %i(view_news) }
+
+  subject(:response) { last_response }
+
+  before do
+    login_as(current_user)
+  end
+
+  describe 'GET api/v3/news' do
+    let(:path) { api_v3_paths.newses }
+
+    context 'without params' do
+      before do
+        news
+        invisible_news
+
+        get path
+      end
+
+      it 'responds 200 OK' do
+        expect(subject.status).to eq(200)
+      end
+
+      it 'returns a collection of news containing only the visible ones' do
+        expect(subject.body)
+          .to be_json_eql('Collection'.to_json)
+          .at_path('_type')
+
+        expect(subject.body)
+          .to be_json_eql('1')
+          .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql(news.id.to_json)
+          .at_path('_embedded/elements/0/id')
+      end
+    end
+
+    context 'with pageSize, offset and sortBy' do
+      let(:path) { "#{api_v3_paths.newses}?pageSize=1&offset=2&sortBy=#{[%i(id asc)].to_json}" }
+
+      before do
+        news
+        other_news
+        invisible_news
+
+        get path
+      end
+
+      it 'returns a slice of the news' do
+        expect(subject.body)
+          .to be_json_eql('Collection'.to_json)
+          .at_path('_type')
+
+        expect(subject.body)
+          .to be_json_eql('2')
+          .at_path('total')
+
+        expect(subject.body)
+          .to be_json_eql('1')
+          .at_path('count')
+
+        expect(subject.body)
+          .to be_json_eql(other_news.id.to_json)
+          .at_path('_embedded/elements/0/id')
+      end
+    end
+  end
+
+  describe 'GET /api/v3/news/:id' do
+    let(:path) { api_v3_paths.news(news.id) }
+
+    before do
+      news
+
+      get path
+    end
+
+    it 'returns 200 OK' do
+      expect(subject.status)
+        .to eql(200)
+    end
+
+    it 'returns the news' do
+      expect(subject.body)
+        .to be_json_eql('News'.to_json)
+        .at_path('_type')
+
+      expect(subject.body)
+        .to be_json_eql(news.id.to_json)
+        .at_path('id')
+    end
+
+    context 'when lacking permissions' do
+      let(:path) { api_v3_paths.news(invisible_news.id) }
+
+      it 'returns 404 NOT FOUND' do
+        expect(subject.status)
+          .to eql(404)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates read endpoints (`GET /api/v3/news` and `GET /api/v3/news/:id`) for news. This was extracted from #6834.