### PR TITLE
provide index action and documentation on document api

### DIFF
--- a/docs/api/apiv3/endpoints/documents.apib
+++ b/docs/api/apiv3/endpoints/documents.apib
@@ -1,0 +1,234 @@
+# Group Documents
+
+A document is a file containing a list of attachments.
+
+*Please note, that the endpoint is only a stub for now.*
+
+## Actions
+
+None yet
+
+## Linked Properties
+| Link          | Description                               | Type           | Constraints           | Supported operations | Condition                                 |
+| :-----------: | -------------------------------------     | -------------  | --------------------- | -------------------- | ----------------------------------------- |
+| self          | This document                             | Document       | not null              | READ                 |                                           |
+| project       | The project the document is in            | Project        | not null              | READ / WRITE         |                                           |
+| attachments   | The attachments belonging to the document | []Attachment   | not null              | READ / WRITE         |                                           |
+
+## Local Properties
+
+| Property     | Description                                               | Type     | Constraints                                          | Supported operations | Condition                                                   |
+| :----------: | --------------------------------------------------------- | -------- | ---------------------------------------------------- | -------------------- | ----------------------------------------------------------- |
+| id           | Document's id                                             | Integer  | x > 0                                                | READ                 |                                                             |
+| title        | The title chosen for the collection of documents          | String   | max 60 characters                                    | READ                 |                                                             |
+| description  | A text describing the documents                           | String   |                                                      | READ                 |                                                             |
+| createdAt    | The time the document was created at                      | DateTime |                                                      | READ                 |                                                             |
+
+## Document [/api/v3/documents/{id}]
+
++ Model
+    + Body
+
+            {
+                "_type": "Document",
+                "id": 1,
+                "title": "Some other document",
+                "description": {
+                    "format": "markdown",
+                    "raw": "Videlicet deserunt aequitas cognatus. Concedo quia est quia pariatur vorago vallum. Calco autem atavus accusamus conscendo cornu ulterius. Tam patria ago consectetur ventito sustineo nihil caecus. Supra officiis eos velociter somniculosus tonsor qui. Suffragium aduro arguo angustus cogito quia tolero vulnus. Supplanto sortitus cresco apud vestrum qui.",
+                    "html": "<p>Videlicet deserunt aequitas cognatus. Concedo quia est quia pariatur vorago vallum. Calco autem atavus accusamus conscendo cornu ulterius. Tam patria ago consectetur ventito sustineo nihil caecus. Supra officiis eos velociter somniculosus tonsor qui. Suffragium aduro arguo angustus cogito quia tolero vulnus. Supplanto sortitus cresco apud vestrum qui.</p>"
+                },
+                "createdAt": "2018-12-10T20:53:39Z",
+                "_links": {
+                    "attachments": {
+                        "href": "/api/v3/documents/1/attachments"
+                    },
+                    "addAttachment": {
+                        "href": "/api/v3/documents/1/attachments",
+                        "method": "post"
+                    },
+                    "self": {
+                        "href": "/api/v3/documents/1",
+                        "title": "Some document",
+                    },
+                    "project": {
+                        "href": "/api/v3/projects/19",
+                        "title": "Some project"
+                    }
+                },
+                "_embedded": {
+                    "project": {
+                        "_type": "Project",
+                        <-- omitted for brevity -->
+                        }
+                    },
+                    attachments": {
+                        "_type": "Collection",
+                        "total": 2,
+                        "count": 2,
+                        "_embedded": {
+                            <-- omitted for brevity -->
+                        },
+                        "_links": {
+                            "self": {
+                                "href": "/api/v3/documents/1/attachments"
+                            }
+                        }
+                    },
+                }
+            }
+
+## View document [GET]
+
++ Parameters
+    + id (required, integer, `1`) ... document id
+
++ Response 200 (application/hal+json)
+
+    [Document][]
+
++ Response 404 (application/hal+json)
+
+    Returned if the document does not exist or if the user does not have permission to view it.
+
+    **Required permission** `view documents` in the project the document belongs to
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The requested resource could not be found."
+            }
+
+
+
+## Documents [/api/v3/documents{?offset,pageSize,sortBy}]
+
++ Model
+    + Body
+
+            {
+                "_type": "Collection",
+                "total": 2,
+                "count": 2,
+                "pageSize": 30,
+                "offset": 1,
+                "_embedded": {
+                    "elements": [
+                        {
+                            "description": {
+                                "format": "markdown",
+                                "raw": "Videlicet deserunt aequitas cognatus. Concedo quia est quia pariatur vorago vallum. Calco autem atavus accusamus conscendo cornu ulterius. Tam patria ago consectetur ventito sustineo nihil caecus. Supra officiis eos velociter somniculosus tonsor qui. Suffragium aduro arguo angustus cogito quia tolero vulnus. Supplanto sortitus cresco apud vestrum qui.",
+                                "html": "<p>Videlicet deserunt aequitas cognatus. Concedo quia est quia pariatur vorago vallum. Calco autem atavus accusamus conscendo cornu ulterius. Tam patria ago consectetur ventito sustineo nihil caecus. Supra officiis eos velociter somniculosus tonsor qui. Suffragium aduro arguo angustus cogito quia tolero vulnus. Supplanto sortitus cresco apud vestrum qui.</p>"
+                            },
+                            "_type": "Document",
+                            "id": 1,
+                            "title": "Some other document",
+                            "createdAt": "2018-12-10T20:53:39Z",
+                            "_links": {
+                                "attachments": {
+                                    "href": "/api/v3/documents/1/attachments"
+                                },
+                                "addAttachment": {
+                                    "href": "/api/v3/documents/1/attachments",
+                                    "method": "post"
+                                },
+                                "self": {
+                                    "href": "/api/v3/documents/1",
+                                    "title": "Some document",
+                                },
+                                "project": {
+                                    "href": "/api/v3/projects/19",
+                                    "title": "Some project"
+                                }
+                            }
+                        },
+                        {
+                            "description": {
+                                "format": "markdown",
+                                "raw": "Videlicet deserunt aequitas cognatus. Concedo quia est quia pariatur vorago vallum. Calco autem atavus accusamus conscendo cornu ulterius. Tam patria ago consectetur ventito sustineo nihil caecus. Supra officiis eos velociter somniculosus tonsor qui. Suffragium aduro arguo angustus cogito quia tolero vulnus. Supplanto sortitus cresco apud vestrum qui.",
+                                "html": "<p>Videlicet deserunt aequitas cognatus. Concedo quia est quia pariatur vorago vallum. Calco autem atavus accusamus conscendo cornu ulterius. Tam patria ago consectetur ventito sustineo nihil caecus. Supra officiis eos velociter somniculosus tonsor qui. Suffragium aduro arguo angustus cogito quia tolero vulnus. Supplanto sortitus cresco apud vestrum qui.</p>"
+                            },
+                            "_type": "Document",
+                            "id": 2,
+                            "title": "Some other document",
+                            "createdAt": "2018-12-10T20:55:54Z",
+                            "_links": {
+                                "attachments": {
+                                    "href": "/api/v3/documents/2/attachments"
+                                },
+                                "addAttachment": {
+                                    "href": "/api/v3/documents/2/attachments",
+                                    "method": "post"
+                                },
+                                "self": {
+                                    "href": "/api/v3/documents/2",
+                                    "title": "Some other document"
+                                },
+                                "project": {
+                                    "href": "/api/v3/projects/29",
+                                    "title": "Some other project"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "_links": {
+                    "self": {
+                        "href": "/api/v3/documents?offset=1&pageSize=30"
+                    },
+                    "jumpTo": {
+                        "href": "/api/v3/documents?offset=%7Boffset%7D&pageSize=30",
+                        "templated": true
+                    },
+                    "changeSize": {
+                        "href": "/api/v3/documents?offset=1&pageSize=%7Bsize%7D",
+                        "templated": true
+                    }
+                }
+            }
+
+## List Documents [GET]
+
+The documents returned depend on the provided parameters and also on the requesting user's permissions.
+
++ Parameters
+    + offset = `1` (optional, integer, `25`) ... Page number inside the requested collection.
+
+    + pageSize (optional, integer, `25`) ... Number of elements to display per page.
+
+    + sortBy (optional, string, `[["created_at", "asc"]]`) ... JSON specifying sort criteria.
+    Accepts the same format as returned by the [queries](#queries) endpoint. Currently supported sorts are:
+      + id: Sort by primary key
+      + created_on: Sort by document creation datetime
+
++ Response 200 (application/hal+json)
+
+    [Documents][]
+
++ Response 400 (application/hal+json)
+
+    Returned if the client sends invalid request parameters e.g. filters
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidQuery",
+                "message": [
+                  "Filters Invalid filter does not exist."
+                ]
+            }
+
++ Response 403 (application/hal+json)
+
+    Returned if the client is not logged in and login is required.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not authorized to view this resource."
+            }

--- a/docs/api/apiv3/index.apib
+++ b/docs/api/apiv3/index.apib
@@ -8,6 +8,7 @@
 <!-- include(endpoints/configuration.apib) -->
 <!-- include(endpoints/custom-actions.apib) -->
 <!-- include(endpoints/custom-options.apib) -->
+<!-- include(endpoints/documents.apib) -->
 <!-- include(endpoints/forms.apib) -->
 <!-- include(endpoints/groups.apib) -->
 <!-- include(endpoints/help_texts.apib) -->

--- a/modules/documents/app/models/document.rb
+++ b/modules/documents/app/models/document.rb
@@ -51,10 +51,10 @@ class Document < ActiveRecord::Base
   validates_presence_of :project, :title, :category
   validates_length_of :title, maximum: 60
 
-  scope :visible, lambda {
+  scope :visible, ->(user = User.current) {
     includes(:project)
       .references(:projects)
-      .merge(Project.allowed_to(User.current, :view_documents))
+      .merge(Project.allowed_to(user, :view_documents))
   }
 
   scope :with_attachments, lambda {

--- a/modules/documents/app/models/queries/documents.rb
+++ b/modules/documents/app/models/queries/documents.rb
@@ -1,0 +1,35 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Queries::Documents
+  query = Queries::Documents::DocumentQuery
+
+  Queries::Register.order query, Queries::Documents::Orders::DefaultOrder
+end

--- a/modules/documents/app/models/queries/documents/document_query.rb
+++ b/modules/documents/app/models/queries/documents/document_query.rb
@@ -1,0 +1,37 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+class Queries::Documents::DocumentQuery < Queries::BaseQuery
+  def self.model
+    Document
+  end
+
+  def default_scope
+    Document.visible(User.current)
+  end
+end

--- a/modules/documents/app/models/queries/documents/orders/default_order.rb
+++ b/modules/documents/app/models/queries/documents/orders/default_order.rb
@@ -1,0 +1,37 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+class Queries::Documents::Orders::DefaultOrder < Queries::BaseOrder
+  self.model = Document
+
+  def self.key
+    /id|created_on/
+  end
+end

--- a/modules/documents/lib/api/v3/documents/document_collection_representer.rb
+++ b/modules/documents/lib/api/v3/documents/document_collection_representer.rb
@@ -1,0 +1,39 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module Documents
+      class DocumentCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
+        element_decorator ::API::V3::Documents::DocumentRepresenter
+      end
+    end
+  end
+end

--- a/modules/documents/lib/api/v3/documents/document_representer.rb
+++ b/modules/documents/lib/api/v3/documents/document_representer.rb
@@ -37,11 +37,29 @@ module API
         include API::Caching::CachedRepresenter
         include ::API::V3::Attachments::AttachableRepresenterMixin
 
+        cached_representer key_parts: %i(project),
+                           disabled: false
+
         self_link title_getter: ->(*) { represented.title }
 
         property :id
 
         property :title
+
+        property :description,
+                 exec_context: :decorator,
+                 getter: ->(*) {
+                   ::API::Decorators::Formattable.new(represented.description, object: represented)
+                 },
+                 uncacheable: true,
+                 render_nil: true
+
+        property :created_at,
+                 exec_context: :decorator,
+                 getter: ->(*) {
+                   next unless represented.created_on
+                   datetime_formatter.format_datetime(represented.created_on)
+                 }
 
         associated_resource :project,
                             link: ->(*) do

--- a/modules/documents/lib/open_project/documents/engine.rb
+++ b/modules/documents/lib/open_project/documents/engine.rb
@@ -64,6 +64,10 @@ module OpenProject::Documents
 
     patches [:CustomFieldsHelper, :Project]
 
+    add_api_path :documents do
+      "#{root}/documents"
+    end
+
     add_api_path :document do |id|
       "#{root}/documents/#{id}"
     end

--- a/modules/documents/spec/api/v3/documents/document_representer_rendering_spec.rb
+++ b/modules/documents/spec/api/v3/documents/document_representer_rendering_spec.rb
@@ -35,8 +35,10 @@ describe ::API::V3::Documents::DocumentRepresenter, 'rendering' do
   include ::API::V3::Utilities::PathHelper
 
   let(:document) do
-    FactoryBot.build_stubbed(:document) do |wp|
-      allow(wp)
+    FactoryBot.build_stubbed(:document,
+                             created_on: Time.now,
+                             description: 'Some description') do |document|
+      allow(document)
         .to receive(:project)
         .and_return(project)
     end
@@ -53,7 +55,7 @@ describe ::API::V3::Documents::DocumentRepresenter, 'rendering' do
 
   before do
     allow(user)
-      .to receive(:allowed_to?) do |permission, project|
+      .to receive(:allowed_to?) do |permission, _|
       permissions.include?(permission)
     end
   end
@@ -95,6 +97,17 @@ describe ::API::V3::Documents::DocumentRepresenter, 'rendering' do
 
     it_behaves_like 'property', :title do
       let(:value) { document.title }
+    end
+
+    it_behaves_like 'has UTC ISO 8601 date and time' do
+      let(:date) { document.created_on }
+      let(:json_path) { 'createdAt' }
+    end
+
+    it_behaves_like 'API V3 formattable', 'description' do
+      let(:format) { 'markdown' }
+      let(:raw) { document.description }
+      let(:html) { '<p>' + document.description + '</p>' }
     end
   end
 

--- a/modules/documents/spec/models/queries/documents/document_query_spec.rb
+++ b/modules/documents/spec/models/queries/documents/document_query_spec.rb
@@ -1,0 +1,47 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Queries::Documents::DocumentQuery, type: :model do
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:base_scope) { Document.visible(user) }
+  let(:instance) { described_class.new }
+
+  before do
+    login_as(user)
+  end
+
+  context 'without a filter' do
+    describe '#results' do
+      it 'is the same as getting all the visible documents' do
+        expect(instance.results.to_sql).to eql base_scope.to_sql
+      end
+    end
+  end
+end

--- a/modules/documents/spec/requests/api/v3/documents/documents_resource_spec.rb
+++ b/modules/documents/spec/requests/api/v3/documents/documents_resource_spec.rb
@@ -40,7 +40,9 @@ describe 'API v3 documents resource', type: :request do
     FactoryBot.create(:user, member_in_project: project, member_through_role: role)
   end
   let(:document) { FactoryBot.create(:document, project: project) }
+  let(:invisible_document) { FactoryBot.create(:document, project: other_project) }
   let(:project) { FactoryBot.create(:project) }
+  let(:other_project) { FactoryBot.create(:project) }
   let(:role) { FactoryBot.create(:role, permissions: permissions) }
   let(:permissions) { %i(view_documents) }
 
@@ -50,7 +52,41 @@ describe 'API v3 documents resource', type: :request do
     login_as(current_user)
   end
 
-  describe 'GET /api/v3/wiki_pages/:id' do
+  describe 'GET /api/v3/documents' do
+    let(:path) { api_v3_paths.documents }
+
+    before do
+      document
+      invisible_document
+
+      get path
+    end
+
+    it 'returns 200 OK' do
+      expect(subject.status)
+        .to eql(200)
+    end
+
+    it 'returns a Collection of visible documents' do
+      expect(subject.body)
+        .to be_json_eql('Collection'.to_json)
+        .at_path('_type')
+
+      expect(subject.body)
+        .to be_json_eql(1.to_json)
+        .at_path('total')
+
+      expect(subject.body)
+        .to be_json_eql('Document'.to_json)
+        .at_path('_embedded/elements/0/_type')
+
+      expect(subject.body)
+        .to be_json_eql(document.title.to_json)
+        .at_path('_embedded/elements/0/title')
+    end
+  end
+
+  describe 'GET /api/v3/documents/:id' do
     let(:path) { api_v3_paths.document(document.id) }
 
     before do
@@ -62,7 +98,7 @@ describe 'API v3 documents resource', type: :request do
         .to eql(200)
     end
 
-    it 'returns the wiki page' do
+    it 'returns the document' do
       expect(subject.body)
         .to be_json_eql('Document'.to_json)
         .at_path('_type')


### PR DESCRIPTION
Adds an index action to the documents api and creates a documentation for the new end point as well as for the already existing `GET /api/v3/documents/:id` end point.