### PR TITLE
[Fix] Remove welcome parameter after language selection

### DIFF
--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -36,11 +36,11 @@ class OnboardingController < ApplicationController
              .call(request, permitted_params, params)
 
     if result && result.success
-      # Remove the first_time_user param so that the modal is not shown again after redirect
+      # Remove all query params:
+      # the first_time_user param so that the modal is not shown again after redirect,
+      # the welcome param so that the analytics is not fired again
       uri = Addressable::URI.parse(request.referrer.to_s)
-      params = uri.query_values
-      params.delete('first_time_user')
-      uri.query_values = params
+      uri.query_values = {}
 
       redirect_to uri.to_s
       flash[:notice] = l(:notice_account_updated)


### PR DESCRIPTION
When a new trial is created the user lands on the home screen with two parameters: `first_time_user=true&welcome=1`. The first one is removed after the language selection. 

This PR takes care that all parameters are removed. This is important as the `welcome` param is used for analytics tracking. Thus we want to be sure that it is used correctly. 