### PR TITLE
Remove unused "styled checkboxes"

### DIFF
--- a/app/assets/stylesheets/content/_forms.lsg
+++ b/app/assets/stylesheets/content/_forms.lsg
@@ -1067,33 +1067,6 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 
 </form>
 ```
 
-## Styled checkboxes [TO BE REFACTORED]
-
-```
-<label class="checkbox-label">
-  <input type="checkbox">
-  <div class="styled-checkbox"></div>
-</label>
-
-<br>
-<br>
-
-<label class="checkbox-label">
-  checkbox label
-  <input type="checkbox">
-  <div class="styled-checkbox"></div>
-</label>
-
-<br>
-<br>
-
-<label class="checkbox-label">
-  <input type="checkbox">
-  <div class="styled-checkbox"></div>
-  checkbox label
-</label>
-```
-
 # Forms: Radio buttons
 
 ## Within a form, multiple

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -208,44 +208,6 @@ hr
     width: 18px
     opacity: 0.001
 
-  \:checked + .styled-checkbox:after
-    opacity: 1
-
-.styled-checkbox
-  box-sizing: content-box
-  display: inline-block
-  vertical-align: top
-  width: 18px
-  height: 18px
-  padding: 0 5px
-  user-select: none
-
-  &:before
-    content: ''
-    position: absolute
-    width: 18px
-    height: 18px
-    background: #ffffff
-    border: 1px solid #cacaca
-    border-radius: 2px
-    cursor: pointer
-    box-shadow: inset 0 1px #fff
-  &:after
-    opacity: 0
-    content: ''
-    position: absolute
-    margin: 5px 2px
-    // Length of check tail
-    width: 11px
-    // Length of check foot
-    height: 3px
-    background: transparent
-    border: 3px solid #666666
-    border-top: none
-    border-right: none
-    transform: rotate(-50deg)
-
-
 %form--fieldset-or-section
   padding:        1rem 0 0
   margin-bottom:  1rem


### PR DESCRIPTION
There are styles defined for a "styled checkbox" which is never used. In order to reduce the amount of special stylings I would appreciate it if we never do. So this PR removes it.