### PR TITLE
[29239] Wp table header sticky for all browsers

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -192,12 +192,11 @@ table.generic-table
       margin: 0
 
 
-// Enable sticky headers in chrome
-html.-supports-sticky-headers
-  thead.-sticky th
-    position: sticky
-    top: 0
-    background: white
+// Enable sticky headers
+thead.-sticky th
+  position: sticky
+  top: 0
+  background: white
 
 
 .generic-table--footer-outer

--- a/app/assets/stylesheets/content/work_packages/timelines/_timelines_header.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/_timelines_header.sass
@@ -24,7 +24,7 @@ wp-timeline-header
   white-space: nowrap
 
   &.-top-border
-    outline: 1px solid $timeline--header-border-color
+    border-top: 1px solid $timeline--header-border-color
 
 .wp-timeline--header-day-element
   height: 12px
@@ -33,6 +33,7 @@ wp-timeline-header
 
 .wp-timeline--header-middle-element
   border-top: 1px solid $timeline--header-border-color
+  border-bottom: 1px solid $timeline--header-border-color
   padding-top: 5px
   height: 20px
 

--- a/app/assets/stylesheets/content/work_packages/timelines/_timelines_header.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/_timelines_header.sass
@@ -1,4 +1,7 @@
-.wp-table-timeline--header
+// In Safari custom elements have width and height 0 per default
+// That is why position: sticky in its children won't work
+wp-timeline-header
+  display: block
   height: $generic-table--header-height
   width: 100%
   position: sticky
@@ -39,4 +42,3 @@
   font-weight: bold
   font-size: 11px
   height: 15px
-

--- a/app/assets/stylesheets/content/work_packages/timelines/_timelines_header.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/_timelines_header.sass
@@ -24,7 +24,7 @@ wp-timeline-header
   white-space: nowrap
 
   &.-top-border
-    border-top: 1px solid $timeline--header-border-color
+    outline: 1px solid $timeline--header-border-color
 
 .wp-timeline--header-day-element
   height: 12px
@@ -33,7 +33,6 @@ wp-timeline-header
 
 .wp-timeline--header-middle-element
   border-top: 1px solid $timeline--header-border-color
-  border-bottom: 1px solid $timeline--header-border-color
   padding-top: 5px
   height: 20px
 

--- a/frontend/src/app/globals/browser-specific-flags.ts
+++ b/frontend/src/app/globals/browser-specific-flags.ts
@@ -29,10 +29,6 @@
 jQuery(function() {
   const doc = document.documentElement!;
 
-  if (bowser.chrome && bowser.version >= '58' || bowser.firefox && bowser.version >= '59') {
-    doc.classList.add('-supports-sticky-headers');
-  }
-
   if (bowser.chrome) {
     doc.classList.add('-browser-chrome');
   }
@@ -61,4 +57,3 @@ jQuery(function() {
     doc.classList.add('-browser-mobile');
   }
 });
-


### PR DESCRIPTION
### Problem
The "position:sticky" css rule is only fully supported on Firefox and Safari, on other browsers it's (if supported at all) mostly only supported for th elements and not thead. Therefore, to make it work on all browsers, we have to always apply this rule to the th elements.

See also: https://caniuse.com/#feat=css-sticky

https://community.openproject.com/projects/openproject/work_packages/29239/activity