### PR TITLE
[29191] Fix wp attributes truncation

### DIFF
--- a/app/assets/stylesheets/content/_attributes_key_value.sass
+++ b/app/assets/stylesheets/content/_attributes_key_value.sass
@@ -37,10 +37,15 @@
     @extend .form--label
     @include grid-size(4)
     @include text-shortener
+    display: flex
     margin-bottom: 0.1875rem
     padding: 0.375rem 0 !important
     font-weight: bold
     align-self: center
+    // Ensure that the text is shortened while the help icon will be displayed
+    > wp-replacement-label
+      @include text-shortener
+      flex: 0 1 auto
 
   .attributes-key-value--value-container
     @include grid-content(8)

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -196,6 +196,11 @@ i
   .attributes-key-value--key
     flex: 0 0 45%
     max-width: 45%
+    // Ensure that the text is shortened while the help icon will be displayed
+    display: flex
+    > wp-replacement-label
+      @include text-shortener
+      flex: 0 1 auto
   .attributes-key-value--value-container
     flex: 0 0 55%
     max-width: 55%

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -196,11 +196,6 @@ i
   .attributes-key-value--key
     flex: 0 0 45%
     max-width: 45%
-    // Ensure that the text is shortened while the help icon will be displayed
-    display: flex
-    > wp-replacement-label
-      @include text-shortener
-      flex: 0 1 auto
   .attributes-key-value--value-container
     flex: 0 0 55%
     max-width: 55%

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
@@ -47,9 +47,9 @@
             {{ descriptor.label }}
             <span class="required"
                   *ngIf="descriptor.field.required && descriptor.field.writable">*</span>
-            <attribute-help-text [attribute]="descriptor.name"
-                                 [attributeScope]="'WorkPackage'"></attribute-help-text>
           </wp-replacement-label>
+          <attribute-help-text [attribute]="descriptor.name"
+                               [attributeScope]="'WorkPackage'"></attribute-help-text>
         </div>
         <div class="attributes-key-value--value-container">
           <wp-edit-field [workPackageId]="workPackage.id"

--- a/frontend/src/app/components/wp-form-group/wp-attribute-group.template.html
+++ b/frontend/src/app/components/wp-form-group/wp-attribute-group.template.html
@@ -10,8 +10,8 @@
           {{ descriptor.label }}
           <span class="required"
                 *ngIf="descriptor.field!.required && descriptor.field!.writable"> *</span>
-          <attribute-help-text [attribute]="descriptor.name" [attributeScope]="'WorkPackage'"></attribute-help-text>
         </wp-replacement-label>
+        <attribute-help-text [attribute]="descriptor.name" [attributeScope]="'WorkPackage'"></attribute-help-text>
       </div>
       <div *ngIf="!descriptor.multiple && descriptor.field"
            class="attributes-key-value--value-container">
@@ -33,8 +33,8 @@
         *ngIf="descriptor.multiple">
         <wp-replacement-label [fieldName]="descriptor.name">
           {{ descriptor.label }}
-          <attribute-help-text [attribute]="descriptor.name" [attributeScope]="'WorkPackage'"></attribute-help-text>
         </wp-replacement-label>
+        <attribute-help-text [attribute]="descriptor.name" [attributeScope]="'WorkPackage'"></attribute-help-text>
       </div>
       <div
         *ngIf="descriptor.multiple"


### PR DESCRIPTION
### Problem
The help icons of the wp attributes are handled as text and that's why there are also cut off when the space gets too small for text and icon. The expected behaviour would be, that the attribute text is shortened (if it's too long) while the help icon is always displayed.

https://community.openproject.com/projects/openproject/work_packages/29191/activity