### PR TITLE
Remove uncalled code in wpFiltersService#loadFilterSchema

### DIFF
--- a/frontend/src/app/components/wp-fast-table/state/wp-table-filters.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-filters.service.ts
@@ -105,39 +105,6 @@ export class WorkPackageTableFiltersService extends WorkPackageTableBaseService<
   }
 
   private loadCurrentFiltersSchemas(filters:QueryFilterInstanceResource[]):Promise<{}> {
-    return Promise.all(_.map(filters,
-                       (filter:QueryFilterInstanceResource) => this.loadFilterSchema(filter)));
-  }
-
-  private loadFilterSchema(filter:QueryFilterInstanceResource):Promise<{}> {
-    return new Promise((resolve, reject) => {
-      filter.schema.$load()
-        .catch(reject)
-        .then(() => {
-        if (_.has(filter, ['values.length', 'currentSchema.values.allowedValues.$load'])) {
-          (filter.currentSchema!.values!.allowedValues as CollectionResource).$load()
-            .then((options:CollectionResource) => {
-              this.setLoadedValues(filter, options);
-
-              resolve();
-            });
-        } else {
-          resolve();
-        }
-      });
-    });
-  }
-
-  private setLoadedValues(filter:QueryFilterInstanceResource, options:CollectionResource) {
-    _.each(filter.values, (value:any, index:any) => {
-      let loadedHalResource = _.find(options.elements,
-                                     option => option.$href === value.$href);
-
-      if (loadedHalResource) {
-        filter.values[index] = loadedHalResource;
-      } else {
-        throw "HalResource not in list of allowed values.";
-      }
-    });
+    return Promise.all(filters.map((filter:QueryFilterInstanceResource) => filter.schema.$load()));
   }
 }


### PR DESCRIPTION
This code will never get called due to how `._has` is being used, since the path array matches segments, not individually matched paths

So we can probably safely remove it then