### PR TITLE
checkout foundation-apps via git+https as well

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -83,7 +83,7 @@
     "exports-loader": "^0.7.0",
     "expose-loader": "^0.7.5",
     "file-loader": "^2.0.0",
-    "foundation-apps": "git://github.com/opf/foundation-apps.git#921e942c70dd9e50dc576cabdc8fd0616d9dddce",
+    "foundation-apps": "git+https://github.com/opf/foundation-apps.git#921e942c70dd9e50dc576cabdc8fd0616d9dddce",
     "fuse.js": "^3.3.0",
     "glob": "^7.1.3",
     "happypack": "^5.0.0",


### PR DESCRIPTION
jquery-ui is already fetched via git+https so fetch foundation-apps like that as well. This prevents users from running into issues in corporate environments when using e.g. a proxy and/or when the plain git protocol is blocked.