### PR TITLE
[29328] Text content overlaps table header in FF

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -87,6 +87,9 @@ table.generic-table
       text-align: left
       line-height: 34px
       padding: 0
+      // This is needed for a bug in FF as described here
+      // https://www.456bereastreet.com/archive/201305/firefox_and_the_magical_text-overflowellipsis_z-index/
+      z-index: 1
 
       &.-right
         text-align: right


### PR DESCRIPTION
Add workaround with z-index for FF [bug](https://www.456bereastreet.com/archive/201305/firefox_and_the_magical_text-overflowellipsis_z-index/). 

https://community.openproject.com/projects/openproject/work_packages/29328/activity