### PR TITLE
[28839] Long heading in forum overlaps buttons

### DIFF
--- a/app/assets/stylesheets/content/_legacy_actions.sass
+++ b/app/assets/stylesheets/content/_legacy_actions.sass
@@ -35,14 +35,6 @@
     position: relative
     list-style: none
 
-@mixin contextual($margin-top: 8px)
-  float: right
-  white-space: nowrap
-  line-height: 1.4em
-  margin-top: $margin-top
-  padding-left: 10px
-
-
 ul.legacy-actions-main
   @include legacy-actions-defaults
   margin-left: 20px
@@ -55,7 +47,8 @@ p.subtitle + ul.legacy-actions-specific
   @include legacy-actions-defaults(-57px)
 
 .message-reply-menu
-  @include contextual(-60px)
+  float: right
+  padding-left: 10px
   > .button
     margin-right: 0
 

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -83,7 +83,7 @@ See docs/COPYRIGHT.rdoc for more details.
                                                  r: message,
                                                  anchor: "message-#{message.id}") %>
         -
-      <%= authoring message.created_on, message.author %>
+        <%= authoring message.created_on, message.author %>
       </h3>
       <div class="message-reply-menu">
         <%= link_to(icon_wrapper('icon-quote', t(:button_quote)),


### PR DESCRIPTION
Move message actions below the headline. Thus the buttons are closer to the content they affect and the headline does not overlap the buttons.

https://community.openproject.com/projects/openproject/work_packages/28839/activity