### PR TITLE
Fix/schema update in inline create

### DIFF
--- a/frontend/src/app/components/wp-copy/wp-copy.controller.ts
+++ b/frontend/src/app/components/wp-copy/wp-copy.controller.ts
@@ -32,12 +32,15 @@ import {WorkPackageChangeset} from 'core-components/wp-edit-form/work-package-ch
 import {WorkPackageCreateController} from 'core-components/wp-new/wp-create.controller';
 import {WorkPackageRelationsService} from "core-components/wp-relations/wp-relations.service";
 import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {WorkPackageEditingService} from "core-components/wp-edit-form/work-package-editing-service";
+import {IWorkPackageEditingServiceToken} from "core-components/wp-edit-form/work-package-editing.service.interface";
 
 export class WorkPackageCopyController extends WorkPackageCreateController {
   private __initialized_at:Number;
   private copiedWorkPackageId:string;
 
   private wpRelations:WorkPackageRelationsService = this.injector.get(WorkPackageRelationsService);
+  protected wpEditing:WorkPackageEditingService = this.injector.get<WorkPackageEditingService>(IWorkPackageEditingServiceToken);
 
   ngOnInit() {
     super.ngOnInit();
@@ -53,8 +56,8 @@ export class WorkPackageCopyController extends WorkPackageCreateController {
       });
   }
 
-  protected newWorkPackageFromParams(stateParams:any) {
-    this.copiedWorkPackageId = stateParams.copiedFromWorkPackageId;
+  protected createdWorkPackage() {
+    this.copiedWorkPackageId = this.stateParams.copiedFromWorkPackageId;
     return new Promise<WorkPackageChangeset>((resolve, reject) => {
       this.wpCacheService.loadWorkPackage(this.copiedWorkPackageId)
         .values$()
@@ -80,6 +83,10 @@ export class WorkPackageCopyController extends WorkPackageCreateController {
           .copyWorkPackage(form, wp.project.identifier)
           .then((changeset) => {
             this.__initialized_at = changeset.workPackage.__initialized_at;
+
+            this.wpCacheService.updateWorkPackage(changeset.workPackage);
+            this.wpEditing.updateValue('new', changeset);
+
             return changeset;
         })
     );

--- a/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
@@ -83,7 +83,7 @@ export class WorkPackageChangeset {
 
   public reset(key:string) {
     delete this.changes[key];
-    this.buildResource();
+    this.buildResource(this.schema);
   }
 
   public clear() {
@@ -142,7 +142,6 @@ export class WorkPackageChangeset {
   }
 
   public getForm():Promise<FormResource> {
-    console.log('get form called');
     if (!this.wpForm) {
       return this.updateForm();
     } else {
@@ -160,14 +159,14 @@ export class WorkPackageChangeset {
       this.wpFormPromise = this.workPackage.$links
         .update(payload)
         .then((form:FormResource) => {
-          this.buildResource();
+          this.buildResource(form.schema);
 
           this.wpFormSubject.next(form);
 
           this.wpFormPromise = null;
           return form;
         })
-        .catch((error: any) => {
+        .catch((error:any) => {
           this.resetForm();
 
           this.wpFormPromise = null;
@@ -221,7 +220,7 @@ export class WorkPackageChangeset {
             })
             .catch(error => {
               // Update the resource anyway
-              this.buildResource();
+              this.buildResource(this.schema);
               reject(error);
             })
             .catch(reject);
@@ -356,7 +355,7 @@ export class WorkPackageChangeset {
     }
   }
 
-  private buildResource() {
+  private buildResource(schema:SchemaResource) {
     if (this.empty) {
       this.resource = null;
       this.wpEditing.updateValue(this.workPackage.id, this);
@@ -367,8 +366,7 @@ export class WorkPackageChangeset {
 
     const resource = this.halResourceService.createHalResourceOfType('WorkPackage', this.mergeWithPayload(payload));
 
-    // Override the schema with the current form, if any.
-    resource.overriddenSchema = this.schema;
+    resource.overriddenSchema = schema;
     this.resource = (resource as WorkPackageResource);
     this.wpEditing.updateValue(this.workPackage.id, this);
   }

--- a/frontend/src/app/components/wp-edit-form/work-package-filter-values.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-filter-values.ts
@@ -20,48 +20,34 @@ export class WorkPackageFilterValues {
   }
 
   public applyDefaultsFromFilters() {
-    return this.changeset.getForm().then((form) => {
-      const promises:Promise<any>[] = [];
-      _.each(this.filters, filter => {
-        // Ignore any filters except =
-        if (filter.operator.id !== '=') {
-          return;
-        }
+    _.each(this.filters, filter => {
+      // Ignore any filters except =
+      if (filter.operator.id !== '=') {
+        return;
+      }
 
-        // Exclude filters specified in constructor
-        if (this.excluded.indexOf(filter.id) !== -1) {
-          return;
-        }
+      // Exclude filters specified in constructor
+      if (this.excluded.indexOf(filter.id) !== -1) {
+        return;
+      }
 
-        // Select the first value
-        var value = filter.values[0];
+      // Select the first value
+      var value = filter.values[0];
 
-        // Avoid empty values
-        if (!value) {
-          return;
-        }
-
-        promises.push(this.setAllowedValueFor(form, filter.id, value));
-      });
-
-      return Promise.all(promises);
+      // Avoid empty values
+      if (value) {
+        this.setValueFor(filter.id, value);
+      }
     });
   }
 
-  private setAllowedValueFor(form:FormResource, field:string, value:string|HalResource) {
-    // TODO: remove promise
-    //return this.allowedValuesFor(form, field).then((allowedValues) => {
-    return new Promise((resolve) => {
-      let newValue = this.findSpecialValue(value, field) || value; //this.findAllowedValue(value, allowedValues);
+  private setValueFor(field:string, value:string|HalResource) {
+    let newValue = this.findSpecialValue(value, field) || value;
 
-      if (newValue) {
-        this.changeset.setValue(field, newValue);
-        this.changeset.workPackage[field] = newValue;
-      }
-
-      resolve();
-    });
-    //});
+    if (newValue) {
+      this.changeset.setValue(field, newValue);
+      this.changeset.workPackage[field] = newValue;
+    }
   }
 
   /**
@@ -79,34 +65,5 @@ export class WorkPackageFilterValues {
     }
 
     return undefined;
-  }
-
-  private findAllowedValue(value:string|HalResource, allowedValues:HalResource[]) {
-    if (value instanceof HalResource && !!value.$href) {
-      return _.find(allowedValues,
-        (entry:any) => entry.$href === value.$href);
-    } else if (allowedValues) {
-      return _.find(allowedValues, (entry:any) => entry === value);
-    } else {
-      return value;
-    }
-  }
-
-  private allowedValuesFor(form:FormResource, field:string):Promise<HalResource[]> {
-    const fieldSchema = form.schema[field];
-
-    return new Promise<HalResource[]>(resolve => {
-      if (!fieldSchema) {
-        resolve([]);
-      } else if (fieldSchema.allowedValues && fieldSchema.allowedValues['$load']) {
-        let allowedValues = fieldSchema.allowedValues;
-
-        return allowedValues.$load().then((loadedValues:CollectionResource) => {
-          resolve(loadedValues.elements);
-        });
-      } else {
-        resolve(fieldSchema.allowedValues);
-      }
-    });
   }
 }

--- a/frontend/src/app/components/wp-edit-form/work-package-filter-values.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-filter-values.ts
@@ -32,7 +32,7 @@ export class WorkPackageFilterValues {
       }
 
       // Select the first value
-      var value = filter.values[0];
+      let value = filter.values[0];
 
       // Avoid empty values
       if (value) {

--- a/frontend/src/app/components/wp-edit-form/work-package-filter-values.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-filter-values.ts
@@ -49,14 +49,19 @@ export class WorkPackageFilterValues {
   }
 
   private setAllowedValueFor(form:FormResource, field:string, value:string|HalResource) {
-    return this.allowedValuesFor(form, field).then((allowedValues) => {
-      let newValue = this.findSpecialValue(value, field) || this.findAllowedValue(value, allowedValues);
+    // TODO: remove promise
+    //return this.allowedValuesFor(form, field).then((allowedValues) => {
+    return new Promise((resolve) => {
+      let newValue = this.findSpecialValue(value, field) || value; //this.findAllowedValue(value, allowedValues);
 
       if (newValue) {
         this.changeset.setValue(field, newValue);
         this.changeset.workPackage[field] = newValue;
       }
+
+      resolve();
     });
+    //});
   }
 
   /**

--- a/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
@@ -141,12 +141,8 @@ export class SingleRowBuilder {
 
   protected isColumnBeingEdited(workPackage:WorkPackageResource, column:QueryColumn) {
     const form = this.workPackageTable.editing.forms[workPackage.id];
-    const changeset = this.workPackageTable.editing.changeset(workPackage.id);
 
-    const isOpen = form && form.activeFields[column.id];
-    const isChanged = changeset && changeset.isOverridden(column.id);
-
-    return isOpen || isChanged;
+    return form && form.activeFields[column.id];
   }
 
   protected buildEmptyRow(workPackage:WorkPackageResource, row:HTMLElement):[HTMLElement, boolean] {

--- a/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
@@ -3,7 +3,6 @@ import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {locateTableRowByIdentifier} from 'core-components/wp-fast-table/helpers/wp-table-row-helpers';
 import {debugLog} from '../../../../helpers/debug_output';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
-import {WorkPackageChangeset} from '../../../wp-edit-form/work-package-changeset';
 import {isRelationColumn, QueryColumn} from '../../../wp-query/query-column';
 import {WorkPackageTableColumnsService} from '../../state/wp-table-columns.service';
 import {WorkPackageTableSelection} from '../../state/wp-table-selection.service';

--- a/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
@@ -274,46 +274,22 @@ export class WorkPackageInlineCreateComponent implements OnInit, OnChanges, OnDe
       promise = Promise.resolve();
     }
 
-    //changeset.wpForm$.pipe(
-    //  untilComponentDestroyed(this),
-    //  distinctUntilChanged((x:FormResource, y:FormResource) => {
-    //    console.log('received');
-    //    return x && x.type.idFromLink === y.type.idFromLink;
-    //  })
-    //).subscribe((form) => {
-      promise.then(() => {
-        // Update the changeset with any added filtered values
-        this.wpEditing.updateValue('new', changeset);
-        this.wpCacheService.updateWorkPackage(this.currentWorkPackage!);
+    promise.then(() => {
+      // Update the changeset with any added filtered values
+      this.wpEditing.updateValue('new', changeset);
+      this.wpCacheService.updateWorkPackage(this.currentWorkPackage!);
 
-        // Actually render the row
-        const form = this.workPackageEditForm = this.renderInlineCreateRow(wp);
+      // Actually render the row
+      const form = this.workPackageEditForm = this.renderInlineCreateRow(wp);
 
-        setTimeout(() => {
-          // Activate any required fields
-          form.activateMissingFields();
+      setTimeout(() => {
+        // Activate any required fields
+        form.activateMissingFields();
 
-          // Hide the button row
-          this.hideRow();
-        });
+        // Hide the button row
+        this.hideRow();
       });
-    //});
-    //promise.then(() => {
-    //  // Update the changeset with any added filtered values
-    //  this.wpEditing.updateValue('new', changeset);
-    //  this.wpCacheService.updateWorkPackage(this.currentWorkPackage!);
-
-    //  // Actually render the row
-    //  const form = this.workPackageEditForm = this.renderInlineCreateRow(wp);
-
-    //  setTimeout(() => {
-    //    // Activate any required fields
-    //    form.activateMissingFields();
-
-    //    // Hide the button row
-    //    this.hideRow();
-    //  });
-    //});
+    });
   }
 
   /**

--- a/frontend/src/app/components/wp-new/wp-create.controller.ts
+++ b/frontend/src/app/components/wp-new/wp-create.controller.ts
@@ -159,7 +159,9 @@ export class WorkPackageCreateController implements OnInit, OnDestroy {
 
     return this.wpCreate.createNewTypedWorkPackage(stateParams.projectPath, type).then(changeset => {
       const filter = new WorkPackageFilterValues(this.injector, changeset, this.wpTableFilters.current, ['type']);
-      return filter.applyDefaultsFromFilters().then(() => changeset);
+      filter.applyDefaultsFromFilters();
+
+      return changeset;
     });
   }
 

--- a/frontend/src/app/components/wp-new/wp-create.controller.ts
+++ b/frontend/src/app/components/wp-new/wp-create.controller.ts
@@ -35,8 +35,6 @@ import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-r
 import {RootResource} from 'core-app/modules/hal/resources/root-resource';
 import {WorkPackageCacheService} from '../work-packages/work-package-cache.service';
 import {WorkPackageChangeset} from '../wp-edit-form/work-package-changeset';
-import {WorkPackageEditingService} from '../wp-edit-form/work-package-editing-service';
-import {WorkPackageFilterValues} from '../wp-edit-form/work-package-filter-values';
 import {WorkPackageNotificationService} from '../wp-edit/wp-notification.service';
 import {WorkPackageTableFiltersService} from '../wp-fast-table/state/wp-table-filters.service';
 import {WorkPackageCreateService} from './wp-create.service';
@@ -44,9 +42,6 @@ import {takeUntil} from 'rxjs/operators';
 import {RootDmService} from 'core-app/modules/hal/dm-services/root-dm.service';
 import {OpTitleService} from 'core-components/html/op-title.service';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
-import {
-  IWorkPackageEditingServiceToken
-} from "../wp-edit-form/work-package-editing.service.interface";
 import {IWorkPackageCreateServiceToken} from "core-components/wp-new/wp-create.service.interface";
 import {CurrentUserService} from "core-app/components/user/current-user.service";
 
@@ -57,7 +52,6 @@ export class WorkPackageCreateController implements OnInit, OnDestroy {
   public newWorkPackage:WorkPackageResource;
   public parentWorkPackage:WorkPackageResource;
   public changeset:WorkPackageChangeset;
-  protected wpEditing:WorkPackageEditingService = this.injector.get<WorkPackageEditingService>(IWorkPackageEditingServiceToken);
 
   public stateParams = this.$transition.params('to');
   public text = {
@@ -81,15 +75,13 @@ export class WorkPackageCreateController implements OnInit, OnDestroy {
   }
 
   public ngOnInit() {
-    this.newWorkPackageFromParams(this.stateParams)
+    this
+      .createdWorkPackage()
       .then((changeset:WorkPackageChangeset) => {
         this.changeset = changeset;
         this.newWorkPackage = changeset.workPackage;
 
         this.setTitle();
-
-        this.wpCacheService.updateWorkPackage(this.newWorkPackage);
-        this.wpEditing.updateValue('new', changeset);
 
         if (this.stateParams['parent_id']) {
           this.changeset.setValue(
@@ -137,36 +129,15 @@ export class WorkPackageCreateController implements OnInit, OnDestroy {
     this.titleService.setFirstPart(this.I18n.t('js.work_packages.create.title'));
   }
 
-
-  // TODO: move to service
-
-  protected newWorkPackageFromParams(stateParams:any):Promise<WorkPackageChangeset> {
-    const type = parseInt(stateParams.type);
-
-    // If there is an open edit for this type, continue it
-    const changeset = this.wpEditing.state('new').value;
-    if (changeset !== undefined) {
-      const changeType = changeset.workPackage.type;
-
-      const hasChanges = !changeset.empty;
-      const typeEmpty = (!changeType && !type);
-      const typeMatches = (changeType && changeType.idFromLink === type.toString());
-
-      if (hasChanges && (typeEmpty || typeMatches)) {
-        return Promise.resolve(changeset);
-      }
-    }
-
-    return this.wpCreate.createNewTypedWorkPackage(stateParams.projectPath, type).then(changeset => {
-      const filter = new WorkPackageFilterValues(this.injector, changeset, this.wpTableFilters.current, ['type']);
-      filter.applyDefaultsFromFilters();
-
-      return changeset;
-    });
+  public cancelAndBackToList() {
+    this.wpCreate.cancelCreation();
+    this.$state.go('work-packages.list', this.$state.params);
   }
 
-  public cancelAndBackToList() {
-    this.wpEditing.stopEditing(this.newWorkPackage.id);
-    this.$state.go('work-packages.list', this.$state.params);
+  protected createdWorkPackage() {
+    const type = this.stateParams.type ? parseInt(this.stateParams.type) : undefined;
+    const project = this.stateParams.projectPath;
+
+    return this.wpCreate.createOrContinueWorkPackage(project, type);
   }
 }

--- a/frontend/src/app/components/wp-new/wp-create.controller.ts
+++ b/frontend/src/app/components/wp-new/wp-create.controller.ts
@@ -137,6 +137,9 @@ export class WorkPackageCreateController implements OnInit, OnDestroy {
     this.titleService.setFirstPart(this.I18n.t('js.work_packages.create.title'));
   }
 
+
+  // TODO: move to service
+
   protected newWorkPackageFromParams(stateParams:any):Promise<WorkPackageChangeset> {
     const type = parseInt(stateParams.type);
 

--- a/frontend/src/app/components/wp-new/wp-create.service.ts
+++ b/frontend/src/app/components/wp-new/wp-create.service.ts
@@ -39,7 +39,7 @@ import {HookService} from 'core-app/modules/plugins/hook-service';
 
 @Injectable()
 export class WorkPackageCreateService implements IWorkPackageCreateService {
-  protected form:Promise<HalResource>;
+  protected form:Promise<HalResource>|undefined;
 
   // Allow callbacks to happen on newly created work packages
   protected newWorkPackageCreatedSubject = new Subject<WorkPackageResource>();
@@ -52,6 +52,7 @@ export class WorkPackageCreateService implements IWorkPackageCreateService {
   }
 
   public newWorkPackageCreated(wp:WorkPackageResource) {
+    this.form = undefined;
     this.newWorkPackageCreatedSubject.next(wp);
   }
 

--- a/frontend/src/app/components/wp-table/embedded/wp-embedded-table.component.ts
+++ b/frontend/src/app/components/wp-table/embedded/wp-embedded-table.component.ts
@@ -29,6 +29,8 @@ import {OpModalService} from 'core-components/op-modals/op-modal.service';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {WorkPackageEmbeddedBaseComponent} from "core-components/wp-table/embedded/wp-embedded-base.component";
 import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
+import {WorkPackageCreateService} from "core-components/wp-new/wp-create.service";
+import {IWorkPackageCreateServiceToken} from "core-components/wp-new/wp-create.service.interface";
 
 @Component({
   selector: 'wp-embedded-table',
@@ -49,6 +51,7 @@ import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table
     WorkPackageTableAdditionalElementsService,
     WorkPackageTableRefreshService,
     WorkPackageTableHighlightingService,
+    { provide: IWorkPackageCreateServiceToken, useClass: WorkPackageCreateService },
     // Order is important here, to avoid this service
     // getting global injections
     WorkPackageStatesInitializationService,

--- a/frontend/src/app/modules/fields/edit/edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/edit-field.component.ts
@@ -74,8 +74,8 @@ export class EditFieldComponent extends Field implements OnDestroy {
       )
       .subscribe((changeset) => {
 
-        if (!this.changeset.empty && this.changeset.wpForm) {
-          const fieldSchema = changeset.wpForm!.schema[this.name];
+        if (!this.changeset.empty && this.changeset.form) {
+          const fieldSchema = changeset.form!.schema[this.name];
 
           if (!fieldSchema) {
             return handler.deactivate(false);

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -306,6 +306,7 @@ describe 'new work package', js: true do
     end
 
     it 'can create the work package, but not update it after saving' do
+      type_field.activate!
       type_field.set_value type_bug.name
       # wait after the type change
       sleep(0.2)
@@ -321,7 +322,7 @@ describe 'new work package', js: true do
     end
   end
 
-  context 'a anonymous user is prompted to login' do
+  context 'an anonymous user is prompted to login' do
     let(:user) { FactoryBot.create(:anonymous) }
     let(:wp_page) { ::Pages::Page.new }
 

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -270,11 +270,6 @@ describe 'Switching types in work package table', js: true do
                         member_through_role: role
     end
 
-    before do
-      workflow
-      login_as user
-    end
-
     let(:custom_field) do
       FactoryBot.create(
         :list_wp_custom_field,
@@ -309,6 +304,7 @@ describe 'Switching types in work package table', js: true do
     end
 
     before do
+      workflow
       login_as(user)
 
       visit new_project_work_packages_path(project.identifier, type: type.id)

--- a/spec/support/components/work_packages/columns.rb
+++ b/spec/support/components/work_packages/columns.rb
@@ -145,7 +145,6 @@ module Components
         apply if save_changes
       end
 
-
       def apply
         @opened = false
 

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -153,7 +153,6 @@ module Components
         expect(page).to have_no_selector '.wp-breadcrumb-parent', wait: 10
       end
 
-
       def remove_parent
         # Open the parent edit
         find('.wp-relation--parent-change').click


### PR DESCRIPTION
* fixes applying list custom field filters to inline created work packages by always applying the filters to the changeset. Doing that allows to have custom field filter values applied when the custom field is active only on a certain type and that type is not selected initially. It is also harmless as the schema prevents sending properties not existing on the work package.
* fixes loading the work package from 2 times from the backend on inline creation initially, and on every type/project switch
* consolidates the creation between inline and split/full view by extracting functionality into the service.