### PR TITLE
[29252] Fix ckeditor toolbar

### DIFF
--- a/app/assets/stylesheets/content/editor/_ckeditor.sass
+++ b/app/assets/stylesheets/content/editor/_ckeditor.sass
@@ -59,3 +59,12 @@
 .ck.ck-block-toolbar-button
   transform: translateX( -15px )
   z-index: 1000 !important
+
+
+// Override fixed position of toolbar
+// Otherwise the toolbar will 'disappear' behind the topmenu
+.ck.ck-sticky-panel__placeholder
+  height: 0 !important
+  
+.ck.ck-sticky-panel__content
+  position: unset !important


### PR DESCRIPTION
### Problem

When scrolling the ckeditor toolbar outside the screen, it disappears behind the topbar.
This probably happens because the ckeditor sets "position:fixed" and "top:0" rules for the toolbar, so that it sticks to the top of the page.
Overwriting these CSS styles might not be the best solution, but a quick and easy one to at least make the toolbar fixed again.

Of course, especially for very long texts, it would be nicer to make the toolbar sticky under the top menu so that it is always visible.


https://community.openproject.com/projects/openproject/work_packages/29252/activity