### PR TITLE
explicitly cast to arel instead of relying on delegation

### DIFF
--- a/modules/costs/app/models/work_package/abstract_costs.rb
+++ b/modules/costs/app/models/work_package/abstract_costs.rb
@@ -66,7 +66,7 @@ class WorkPackage
       if work_packages.respond_to?(:pluck)
         work_packages.pluck(:id)
       else
-        Array(work_packages).map { |wp| wp.id }
+        Array(work_packages).map(&:id)
       end
     end
 
@@ -100,8 +100,9 @@ class WorkPackage
     def sum_arel(base_scope)
       subselect = sum_subselect(base_scope)
                   .as(subselect_alias)
-      wp_table.
-        outer_join(subselect).on(subselect[:id].eq(wp_table[:id]))
+      wp_table
+        .outer_join(subselect)
+        .on(subselect[:id].eq(wp_table[:id]))
     end
 
     def sum_subselect(base_scope)
@@ -110,6 +111,7 @@ class WorkPackage
         .except(:select)
         .select("#{costs_sum} AS #{costs_sum_alias}")
         .select(wp_table[:id])
+        .arel
         .outer_join(ce_table).on(ce_table_join_condition)
         .group(wp_table[:id])
     end
@@ -128,7 +130,7 @@ class WorkPackage
 
     def ce_table_join_condition
       authorization_scope = filter_authorized costs_model.all
-      authorization_where = authorization_scope.ast.cores.last.wheres.last
+      authorization_where = authorization_scope.arel.ast.cores.last.wheres.last
 
       # relies on the scope having the wp descendants joined at least
       # when #to_sql is called.

--- a/modules/costs/lib/open_project/costs/patches/work_package_eager_loading_patch.rb
+++ b/modules/costs/lib/open_project/costs/patches/work_package_eager_loading_patch.rb
@@ -67,8 +67,8 @@ module OpenProject::Costs::Patches::WorkPackageEagerLoadingPatch
     labor_scope = work_package_labor_scope(scope)
 
     scope
-      .joins(material_scope.join_sources)
-      .joins(labor_scope.join_sources)
+      .joins(material_scope.arel.join_sources)
+      .joins(labor_scope.arel.join_sources)
       .joins(time_join.join_sources)
       .select(material_scope.select_values)
       .select(labor_scope.select_values)


### PR DESCRIPTION
Should get rid of all the deprecation warnings related to arel.