### PR TITLE
[29257] Auto completion for work package attributes

### DIFF
--- a/app/assets/stylesheets/content/_attributes_group.sass
+++ b/app/assets/stylesheets/content/_attributes_group.sass
@@ -28,6 +28,8 @@
 
 .attributes-group
   margin-top: 1.6875rem
+  position: relative
+
 
 .attributes-group--header
   @include grid-block

--- a/app/assets/stylesheets/content/_attributes_key_value.sass
+++ b/app/assets/stylesheets/content/_attributes_key_value.sass
@@ -36,6 +36,7 @@
     @extend .form--label
     display: flex
     flex: 1 0 35%
+    max-width: 35%
     margin-bottom: 0.1875rem
     padding: 0.375rem 0
     font-weight: bold
@@ -47,9 +48,9 @@
   .attributes-key-value--value-container
     display: flex
     flex: 1 0 65%
+    max-width: 65%
     margin-bottom: 0.1875rem
     align-self: center
-    overflow: hidden
 
     &.not-editable
       padding: 6px

--- a/app/assets/stylesheets/content/_autocomplete.sass
+++ b/app/assets/stylesheets/content/_autocomplete.sass
@@ -144,6 +144,13 @@ mark.ui-autocomplete-match
 
   .ng-value-container
     width: calc(100% - 30px)
-
+    
+  .ng-select-container
+    z-index: auto !important
   .ng-value
     @include text-shortener
+
+.ng-option
+  font-size: 0.875rem
+  line-height: 1.6
+

--- a/app/assets/stylesheets/content/_autocomplete.sass
+++ b/app/assets/stylesheets/content/_autocomplete.sass
@@ -136,3 +136,14 @@ mark.ui-autocomplete-match
   padding: 0
   font-weight: bold
   text-transform: uppercase
+
+
+// -------------------------- ng-select --------------------------
+.ng-select
+  width: 100%
+
+  .ng-value-container
+    width: calc(100% - 30px)
+
+  .ng-value
+    @include text-shortener

--- a/app/assets/stylesheets/content/_autocomplete.sass
+++ b/app/assets/stylesheets/content/_autocomplete.sass
@@ -141,6 +141,7 @@ mark.ui-autocomplete-match
 // -------------------------- ng-select --------------------------
 .ng-select
   width: 100%
+  font-size: 14px
 
   .ng-value-container
     width: calc(100% - 30px)

--- a/app/assets/stylesheets/content/_autocomplete.sass
+++ b/app/assets/stylesheets/content/_autocomplete.sass
@@ -153,4 +153,5 @@ mark.ui-autocomplete-match
 .ng-option
   font-size: 0.875rem
   line-height: 1.6
-
+.work-package-table--container .ng-dropdown-panel
+  z-index: auto !important

--- a/app/assets/stylesheets/content/_autocomplete.sass
+++ b/app/assets/stylesheets/content/_autocomplete.sass
@@ -148,6 +148,10 @@ mark.ui-autocomplete-match
     
   .ng-select-container
     z-index: auto !important
+    .ng-value-container input
+      -webkit-box-sizing: border-box !important
+      -moz-box-sizing: border-box !important
+      box-sizing: border-box !important
   .ng-value
     @include text-shortener
 

--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_display_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_display_fields.sass
@@ -30,6 +30,8 @@
 .wp-edit-field--display-field
   display: inline-block
   max-width: 100%
+  @include text-shortener
+  white-space: inherit
 
   &.-placeholder
     font-style: italic
@@ -37,5 +39,6 @@
   p
     word-wrap: break-word
 
-.wp-edit-field--text
+.wp-edit-field--text,
+wp-edit-field
   width: 100%

--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_textareas.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_textareas.sass
@@ -58,7 +58,6 @@
   text-align: center
   // Align controls via flex
   display: flex
-  z-index: 1
 
 // Disabled submit styles when not applicable
 .inplace-edit--control--save[disabled] a,

--- a/app/assets/stylesheets/content/work_packages/new/_type_status_row.sass
+++ b/app/assets/stylesheets/content/work_packages/new/_type_status_row.sass
@@ -7,6 +7,7 @@
   #wp-new-inline-edit--field-type,
   .work-packages--type-selector
     margin-left: 5px
+    width: 100px
 
   // Fix display left padding of tpye
   .wp-edit-field--display-field

--- a/app/assets/stylesheets/content/work_packages/new/_type_status_row.sass
+++ b/app/assets/stylesheets/content/work_packages/new/_type_status_row.sass
@@ -3,10 +3,6 @@
   display: flex
   font-size: 24px
 
-  // Set the correct height when editing these fields
-  .wp-inline-edit--field
-    height: 40px
-
   // Add some minor margin between active status and type field
   #wp-new-inline-edit--field-type,
   .work-packages--type-selector

--- a/app/assets/stylesheets/content/work_packages/new/_type_status_row.sass
+++ b/app/assets/stylesheets/content/work_packages/new/_type_status_row.sass
@@ -7,7 +7,7 @@
   #wp-new-inline-edit--field-type,
   .work-packages--type-selector
     margin-left: 5px
-    width: 100px
+    min-width: 100px
 
   // Fix display left padding of tpye
   .wp-edit-field--display-field

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -208,7 +208,6 @@ i
 
     .-columns-2
       @include two-column-layout
-      column-gap: 3rem
 
       @supports (column-span: all)
         // Let some elements still span both columns

--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -195,8 +195,11 @@ i
   // These values are what matches best at the moment. So be careful when changing them.
   .attributes-key-value--key
     flex: 1 0 45%
+    max-width: 45%
   .attributes-key-value--value-container
+    position: relative
     flex: 1 0 55%
+    max-width: 55%
 
 // Implement two column layout for WP full screen view
 @media screen and (min-width: 92rem), print

--- a/app/assets/stylesheets/layout/work_packages/_details_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_details_view.sass
@@ -97,7 +97,6 @@ body.action-create
     .wp-inline-edit--field
       height: 38px
       line-height: 36px
-      padding: 0 0.375rem
 
 .work-packages--type-selector
   flex-shrink: 0
@@ -108,6 +107,9 @@ body.action-create
 
 .work-package--new-state
   margin-bottom: 55px
+
+  .title-container
+    overflow: visible
 
   .work-packages--attachments
     margin-bottom: 25px

--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -197,6 +197,7 @@
 
 .work-packages--subject-type-row
   display: flex
+  position: relative
 
   // Fix: align and size hover border like buttons in toolbar.
   .wp-edit-field.-no-label:not(.-active) .wp-table--cell-span

--- a/app/assets/stylesheets/openproject/_mixins.sass
+++ b/app/assets/stylesheets/openproject/_mixins.sass
@@ -143,13 +143,12 @@
 
 @mixin two-column-layout
   column-count: 2
-  column-gap: 4rem
+  column-gap: 3rem
 
   .attributes-key-value
     -webkit-column-break-inside: avoid
     page-break-inside: avoid
     break-inside: avoid
-    overflow: hidden
     // For some reason chrome seems to treat a two column layout
     // as if it would result in showing the backside of this element.
     // This leads to input and select elements not showing their values.

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -89,7 +89,7 @@ See docs/COPYRIGHT.rdoc for more details.
   <% end %>
   <%= crowdin_in_context_translation %>
 </head>
-<body class="<%= body_css_classes %>" data-relative_url_root="<%= root_path %>">
+<body class="<%= body_css_classes %> __overflowing_element_container __overflowing_abc" data-relative_url_root="<%= root_path %>" data-overflowing-identifier=".__overflowing_abc">
 <noscript>
   <div class="top-shelf icon icon-warning">
     <h1><%= l(:noscript_heading) %></h1>

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -594,8 +594,6 @@ en:
       label_filter_by_text: "Filter by text"
       label_options: "Options"
       label_column_multiselect: "Combined dropdown field: Select with arrow keys, confirm selection with enter, delete with backspace"
-      label_switch_to_single_select: "Switch to single select"
-      label_switch_to_multi_select: "Switch to multi select"
       message_error_during_bulk_delete: An error occurred while trying to delete work packages.
       message_successful_bulk_delete: Successfully deleted work packages.
       message_successful_show_in_fullscreen: "Click here to open this work package in fullscreen view."

--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -571,6 +571,13 @@
         "tslib": "^1.9.0"
       }
     },
+    "@ng-select/ng-select": {
+      "version": "git+https://github.com/HDinger/ng-select.git#55fa145cf7fea4fdaf96dde0f1584c7d7b10dbd4",
+      "from": "git+https://github.com/HDinger/ng-select.git#55fa145cf7fea4fdaf96dde0f1584c7d7b10dbd4",
+      "requires": {
+        "yarn": "^1.13.0"
+      }
+    },
     "@ngtools/webpack": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-7.1.1.tgz",
@@ -3762,8 +3769,8 @@
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "foundation-apps": {
-      "version": "git://github.com/opf/foundation-apps.git#921e942c70dd9e50dc576cabdc8fd0616d9dddce",
-      "from": "git://github.com/opf/foundation-apps.git#921e942c70dd9e50dc576cabdc8fd0616d9dddce"
+      "version": "git+https://github.com/opf/foundation-apps.git#921e942c70dd9e50dc576cabdc8fd0616d9dddce",
+      "from": "git+https://github.com/opf/foundation-apps.git#921e942c70dd9e50dc576cabdc8fd0616d9dddce"
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -10684,6 +10691,11 @@
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         }
       }
+    },
+    "yarn": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.13.0.tgz",
+      "integrity": "sha512-Unfw2eefv8imt4ZMPhvFVP44WCz38huDxkHs+Yqrx4wBTK75Tr0mh3V4rh+2Nw5iQq0rcM/VafotCZo9qTb5DA=="
     },
     "yeast": {
       "version": "0.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "@angular/platform-browser": "7.1.1",
     "@angular/platform-browser-dynamic": "7.1.1",
     "@angular/router": "7.1.1",
+    "@ng-select/ng-select": "~2.13.3",
     "@types/angular": "^1.6.51",
     "@types/assertion-error": "^1.0.30",
     "@types/chart.js": "^2.7.40",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "@angular/platform-browser": "7.1.1",
     "@angular/platform-browser-dynamic": "7.1.1",
     "@angular/router": "7.1.1",
-    "@ng-select/ng-select": "~2.13.3",
+    "@ng-select/ng-select": "git+https://github.com/HDinger/ng-select.git#55fa145cf7fea4fdaf96dde0f1584c7d7b10dbd4",
     "@types/angular": "^1.6.51",
     "@types/assertion-error": "^1.0.30",
     "@types/chart.js": "^2.7.40",

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
@@ -44,6 +44,7 @@ import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
 import {IWorkPackageEditingServiceToken} from '../../wp-edit-form/work-package-editing.service.interface';
 import {DynamicCssService} from '../../../modules/common/dynamic-css/dynamic-css.service';
 import {HookService} from 'core-app/modules/plugins/hook-service';
+import {randomString} from "core-app/helpers/random-string";
 
 export interface FieldDescriptor {
   name:string;
@@ -56,6 +57,7 @@ export interface FieldDescriptor {
 
 export interface GroupDescriptor {
   name:string;
+  id:string;
   members:FieldDescriptor[];
   query?:QueryResource;
   type:string;
@@ -243,12 +245,14 @@ export class WorkPackageSingleViewComponent implements OnInit, OnDestroy {
       if (group._type === 'WorkPackageFormAttributeGroup') {
         return {
           name: group.name,
+          id: randomString(16),
           members: this.getFields(resource, group.attributes),
           type: group._type
         };
       } else {
         return {
           name: group.name,
+          id: randomString(16),
           query: group._embedded.query,
           relationType: group.relationType,
           members: [group._embedded.query],

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, Inject, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, ElementRef, Inject, Input, OnDestroy, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
 import {componentDestroyed} from 'ng2-rx-componentdestroyed';
@@ -68,6 +68,8 @@ export interface ResourceContextChange {
   schema:string|null;
   project:string|null;
 }
+
+export const overflowingContainerAttribute = 'overflowingIdentifier';
 
 @Component({
   templateUrl: './wp-single-view.html',
@@ -113,6 +115,7 @@ export class WorkPackageSingleViewComponent implements OnInit, OnDestroy {
   };
 
   protected firstTimeFocused:boolean = false;
+  public $element:JQuery;
 
   constructor(readonly I18n:I18nService,
               protected currentProject:CurrentProjectService,
@@ -122,10 +125,13 @@ export class WorkPackageSingleViewComponent implements OnInit, OnDestroy {
               @Inject(IWorkPackageEditingServiceToken) protected wpEditing:WorkPackageEditingService,
               protected displayFieldService:DisplayFieldService,
               protected wpCacheService:WorkPackageCacheService,
-              protected hook:HookService) {
+              protected hook:HookService,
+              readonly elementRef:ElementRef) {
   }
 
   public ngOnInit() {
+    this.$element = jQuery(this.elementRef.nativeElement);
+
     if (this.workPackage.attachments) {
       this.workPackage.attachments.updateElements();
     }
@@ -242,17 +248,19 @@ export class WorkPackageSingleViewComponent implements OnInit, OnDestroy {
     }
 
     return attributeGroups.map((group:any) => {
+      let groupId = this.getAttributesGroupId(group);
+
       if (group._type === 'WorkPackageFormAttributeGroup') {
         return {
           name: group.name,
-          id: randomString(16),
+          id: groupId || randomString(16),
           members: this.getFields(resource, group.attributes),
           type: group._type
         };
       } else {
         return {
           name: group.name,
-          id: randomString(16),
+          id: groupId || randomString(16),
           query: group._embedded.query,
           relationType: group.relationType,
           members: [group._embedded.query],
@@ -350,5 +358,17 @@ export class WorkPackageSingleViewComponent implements OnInit, OnDestroy {
       resource.schema[name],
       { container: 'single-view', options: {} }
     ) as DisplayField;
+  }
+
+  private getAttributesGroupId(group:any):string {
+    let overflowingIdentifier = this.$element
+      .find("[data-group-name=\'" + group.name + "\']")
+      .data(overflowingContainerAttribute);
+
+    if (overflowingIdentifier) {
+      return overflowingIdentifier.replace('.__overflowing_','');
+    } else {
+      return ''
+    }
   }
 }

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
@@ -92,7 +92,8 @@
   <div *ngFor="let group of groupedFields; trackBy:trackByName"
        [hidden]="shouldHideGroup(group)"
        [attr.data-group-name]="group.name"
-       class="attributes-group">
+       class="attributes-group"
+       id="attributes-group--{{group.name.toLowerCase()}}">
 
     <div class="attributes-group--header">
       <div class="attributes-group--header-container">

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
@@ -32,8 +32,9 @@
     <wp-custom-actions [workPackage]="workPackage" class="custom-actions"></wp-custom-actions>
   </div>
 
-  <div class="attributes-group -project-context"
-       *ngIf="projectContext.field">
+  <div class="attributes-group -project-context __overflowing_element_container __overflowing_project_context"
+       *ngIf="projectContext.field"
+       data-overflowing-identifier=".__overflowing_project_context">
     <div class="attributes-group--header">
       <div class="attributes-group--header-container"></div>
     </div>

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
@@ -92,8 +92,9 @@
   <div *ngFor="let group of groupedFields; trackBy:trackByName"
        [hidden]="shouldHideGroup(group)"
        [attr.data-group-name]="group.name"
-       class="attributes-group"
-       id="attributes-group--{{group.name.toLowerCase()}}">
+       [ngClass]="'__overflowing_' + group.id"
+       [attr.data-overflowing-identifier]="'.__overflowing_' + group.id"
+       class="attributes-group __overflowing_element_container">
 
     <div class="attributes-group--header">
       <div class="attributes-group--header-container">

--- a/frontend/src/app/components/work-packages/wp-subject/wp-subject.component.ts
+++ b/frontend/src/app/components/work-packages/wp-subject/wp-subject.component.ts
@@ -32,6 +32,7 @@ import {componentDestroyed} from 'ng2-rx-componentdestroyed';
 import {takeUntil} from 'rxjs/operators';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {WorkPackageCacheService} from '../work-package-cache.service';
+import {randomString} from "core-app/helpers/random-string";
 
 @Component({
   selector: 'wp-subject',
@@ -39,6 +40,8 @@ import {WorkPackageCacheService} from '../work-package-cache.service';
 })
 export class WorkPackageSubjectComponent implements OnInit, OnDestroy {
   @Input('workPackage') workPackage:WorkPackageResource;
+
+  public readonly uniqueElementIdentifier = `work-packages--subject-type-row-${randomString(16)}`;
 
   constructor(protected uiRouterGlobals:UIRouterGlobals,
               protected wpCacheService:WorkPackageCacheService) {

--- a/frontend/src/app/components/work-packages/wp-subject/wp-subject.html
+++ b/frontend/src/app/components/work-packages/wp-subject/wp-subject.html
@@ -1,5 +1,7 @@
 <div *ngIf="workPackage"
-     class="work-packages--subject-type-row">
+     class="work-packages--subject-type-row __overflowing_element_container"
+     [ngClass]="'__overflowing_' + uniqueElementIdentifier"
+     [attr.data-overflowing-identifier]="'.__overflowing_' + uniqueElementIdentifier">
   <div class="work-packages--type-selector work-packages--subject-element">
     <wp-edit-field [workPackageId]="workPackage.id"
                    [wrapperClasses]="'work-packages--type-selector work-packages--subject-element -no-label'"

--- a/frontend/src/app/components/wp-edit-form/work-package-edit-field-handler.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-edit-field-handler.ts
@@ -86,6 +86,10 @@ export class WorkPackageEditFieldHandler extends EditFieldHandler {
     return this.form.changeset.inFlight;
   }
 
+  public get context():WorkPackageEditContext {
+    return this.form.editContext;
+  }
+
   public get active() {
     return true;
   }

--- a/frontend/src/app/components/wp-edit-form/work-package-edit-field-handler.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-edit-field-handler.ts
@@ -53,6 +53,9 @@ export class WorkPackageEditFieldHandler extends EditFieldHandler {
   // Reference to the active component, if any
   public componentInstance:EditFieldComponent;
 
+  // Subject to fire when user demanded activation
+  public $onUserActivate = new Subject<void>();
+
   // Current errors of the field
   public errors:string[];
 
@@ -115,8 +118,6 @@ export class WorkPackageEditFieldHandler extends EditFieldHandler {
     this.errors = newErrors;
     this.element.classList.toggle('-error', this.isErrorenous);
   }
-
-
 
   /**
    * Handle a user submitting the field (e.g, ng-change)

--- a/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field.component.ts
+++ b/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field.component.ts
@@ -154,6 +154,12 @@ export class WorkPackageEditFieldComponent implements OnInit {
     return false;
   }
 
+  public overflowingSelector() {
+    return this.$element
+      .closest('.attributes-group')
+      .data ('groupIdentifier');
+  }
+
   public activateOnForm(noWarnings:boolean = false) {
     // Activate the field
     this.active = true;

--- a/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field.component.ts
+++ b/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field.component.ts
@@ -178,7 +178,12 @@ export class WorkPackageEditFieldComponent implements OnInit {
 
     this.activateOnForm()
       .then((handler) => {
-        handler && handler.focus(positionOffset);
+        if (!handler) {
+          return;
+        }
+
+        handler.$onUserActivate.next();
+        handler.focus(positionOffset);
       });
 
     return false;

--- a/frontend/src/app/components/wp-fast-table/handlers/cell/edit-cell-handler.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/cell/edit-cell-handler.ts
@@ -67,7 +67,10 @@ export class EditCellHandler extends ClickOrEnterHandler implements TableEventHa
 
     // Activate the field
     form.activate(fieldName)
-      .then((handler) => handler.focus(positionOffset))
+      .then((handler) => {
+        handler.$onUserActivate.next();
+        handler.focus(positionOffset);
+      })
       .catch(() => target.addClass(readOnlyClassName));
 
     return false;

--- a/frontend/src/app/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/components/wp-table/wp-table.directive.html
@@ -1,6 +1,8 @@
 <div class="work-packages-split-view--tabletimeline-content">
   <div class="work-packages-tabletimeline--table-side work-package-table--container">
-    <table class="keyboard-accessible-list generic-table work-package-table">
+    <table class="keyboard-accessible-list generic-table work-package-table __overflowing_element_container"
+          [ngClass]="'__overflowing_' + uniqueTableIdentifier"
+          [attr.data-overflowing-identifier]="'.__overflowing_' + uniqueTableIdentifier">
       <colgroup>
         <col highlight-col *ngFor="let column of columns"/>
         <col highlight-col/>
@@ -56,9 +58,7 @@
         </td>
       </tr>
       </tbody>
-      <tbody class="results-tbody work-package--results-tbody __overflowing_element_container"
-             [ngClass]="'__overflowing_' + uniqueTbodyIdentifier"
-             [attr.data-overflowing-identifier]="'.__overflowing_' + uniqueTbodyIdentifier">
+      <tbody class="results-tbody work-package--results-tbody">
       </tbody>
       <tbody *ngIf="tableElement && configuration.inlineCreateEnabled"
              wpInlineCreate

--- a/frontend/src/app/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/components/wp-table/wp-table.directive.html
@@ -56,7 +56,9 @@
         </td>
       </tr>
       </tbody>
-      <tbody class="results-tbody work-package--results-tbody">
+      <tbody class="results-tbody work-package--results-tbody __overflowing_element_container"
+             [ngClass]="'__overflowing_' + uniqueTbodyIdentifier"
+             [attr.data-overflowing-identifier]="'.__overflowing_' + uniqueTbodyIdentifier">
       </tbody>
       <tbody *ngIf="tableElement && configuration.inlineCreateEnabled"
              wpInlineCreate

--- a/frontend/src/app/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/components/wp-table/wp-table.directive.html
@@ -1,8 +1,6 @@
 <div class="work-packages-split-view--tabletimeline-content">
   <div class="work-packages-tabletimeline--table-side work-package-table--container">
-    <table class="keyboard-accessible-list generic-table work-package-table __overflowing_element_container"
-          [ngClass]="'__overflowing_' + uniqueTableIdentifier"
-          [attr.data-overflowing-identifier]="'.__overflowing_' + uniqueTableIdentifier">
+    <table class="keyboard-accessible-list generic-table work-package-table">
       <colgroup>
         <col highlight-col *ngFor="let column of columns"/>
         <col highlight-col/>

--- a/frontend/src/app/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/components/wp-table/wp-table.directive.html
@@ -1,5 +1,5 @@
 <div class="work-packages-split-view--tabletimeline-content">
-  <div class="work-packages-tabletimeline--table-side work-package-table--container">
+  <div class="work-packages-tabletimeline--table-side work-package-table--container __hidden_overflow_container">
     <table class="keyboard-accessible-list generic-table work-package-table">
       <colgroup>
         <col highlight-col *ngFor="let column of columns"/>

--- a/frontend/src/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/src/app/components/wp-table/wp-table.directive.ts
@@ -61,6 +61,7 @@ import {
 import {QueryColumn} from 'core-components/wp-query/query-column';
 import {OpModalService} from 'core-components/op-modals/op-modal.service';
 import {WpTableConfigurationModalComponent} from 'core-components/wp-table/configuration-modal/wp-table-configuration.modal';
+import {randomString} from "core-app/helpers/random-string";
 
 @Component({
   templateUrl: './wp-table.directive.html',
@@ -104,6 +105,8 @@ export class WorkPackagesTableController implements OnInit, OnDestroy {
   public numTableColumns:number;
 
   public timelineVisible:boolean;
+
+  public readonly uniqueTbodyIdentifier = `tbody-${randomString(16)}`;
 
   constructor(readonly elementRef:ElementRef,
               readonly  injector:Injector,

--- a/frontend/src/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/src/app/components/wp-table/wp-table.directive.ts
@@ -106,7 +106,7 @@ export class WorkPackagesTableController implements OnInit, OnDestroy {
 
   public timelineVisible:boolean;
 
-  public readonly uniqueTbodyIdentifier = `tbody-${randomString(16)}`;
+  public readonly uniqueTableIdentifier = `wp-table--container-${randomString(16)}`;
 
   constructor(readonly elementRef:ElementRef,
               readonly  injector:Injector,

--- a/frontend/src/app/helpers/random-string.ts
+++ b/frontend/src/app/helpers/random-string.ts
@@ -5,4 +5,4 @@ export function randomString(length:number = 16) {
     random += pattern.charAt(Math.floor(Math.random() * pattern.length));
   }
   return random;
-};
+}

--- a/frontend/src/app/helpers/random-string.ts
+++ b/frontend/src/app/helpers/random-string.ts
@@ -1,0 +1,8 @@
+export function randomString(length:number = 16) {
+  let pattern = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let random = '';
+  for (let _element of new Array(length)) {
+    random += pattern.charAt(Math.floor(Math.random() * pattern.length));
+  }
+  return random;
+};

--- a/frontend/src/app/modules/common/openproject-common.module.ts
+++ b/frontend/src/app/modules/common/openproject-common.module.ts
@@ -70,6 +70,7 @@ import {UIRouterModule} from "@uirouter/angular";
 import {PortalModule} from "@angular/cdk/portal";
 import {CommonModule} from "@angular/common";
 import {CollapsibleSectionComponent} from "core-app/modules/common/collapsible-section/collapsible-section.component";
+import {NgSelectModule} from "@ng-select/ng-select";
 
 export function bootstrapModule(injector:Injector) {
   return () => {
@@ -138,6 +139,9 @@ export function bootstrapModule(injector:Injector) {
     ZenModeButtonComponent,
 
     OPContextMenuComponent,
+
+    // Autocompleter Component
+    NgSelectModule,
   ],
   declarations: [
     OpDatePickerComponent,

--- a/frontend/src/app/modules/common/openproject-common.module.ts
+++ b/frontend/src/app/modules/common/openproject-common.module.ts
@@ -70,7 +70,7 @@ import {UIRouterModule} from "@uirouter/angular";
 import {PortalModule} from "@angular/cdk/portal";
 import {CommonModule} from "@angular/common";
 import {CollapsibleSectionComponent} from "core-app/modules/common/collapsible-section/collapsible-section.component";
-import {NgSelectModule} from "@ng-select/ng-select";
+import {NgSelectModule} from "@ng-select/ng-select/dist";
 
 export function bootstrapModule(injector:Injector) {
   return () => {

--- a/frontend/src/app/modules/common/openproject-common.module.ts
+++ b/frontend/src/app/modules/common/openproject-common.module.ts
@@ -70,7 +70,7 @@ import {UIRouterModule} from "@uirouter/angular";
 import {PortalModule} from "@angular/cdk/portal";
 import {CommonModule} from "@angular/common";
 import {CollapsibleSectionComponent} from "core-app/modules/common/collapsible-section/collapsible-section.component";
-import {NgSelectModule} from "@ng-select/ng-select/dist";
+import {NgSelectModule} from "@ng-select/ng-select";
 
 export function bootstrapModule(injector:Injector) {
   return () => {

--- a/frontend/src/app/modules/fields/edit/edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/edit-field.component.ts
@@ -97,9 +97,6 @@ export class EditFieldComponent extends Field implements OnInit, OnDestroy {
 
   ngOnInit():void {
     this.$element = jQuery(this.elementRef.nativeElement);
-
-    // TODO
-    console.log(this.overflowingSelector);
   }
 
   ngOnDestroy() {
@@ -107,9 +104,13 @@ export class EditFieldComponent extends Field implements OnInit, OnDestroy {
   }
 
   public get overflowingSelector() {
-    return this.$element
-      .closest(overflowingContainerSelector)
-      .data(overflowingContainerAttribute);
+    if(this.$element) {
+      return this.$element
+        .closest(overflowingContainerSelector)
+        .data(overflowingContainerAttribute);
+    } else {
+      return null;
+    }
   }
 
   public get inFlight() {

--- a/frontend/src/app/modules/fields/edit/edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/edit-field.component.ts
@@ -48,13 +48,19 @@ export const OpEditingPortalSchemaToken = new InjectionToken('wp-editing-portal-
 export const OpEditingPortalHandlerToken = new InjectionToken('wp-editing-portal--handler');
 export const OpEditingPortalChangesetToken = new InjectionToken('wp-editing-portal--changeset');
 
+export const overflowingContainerSelector = '.__overflowing_element_container';
+export const overflowingContainerAttribute = 'overflowingIdentifier';
+
 @Component({
   template: ''
 })
-export class EditFieldComponent extends Field implements OnDestroy {
+export class EditFieldComponent extends Field implements OnInit, OnDestroy {
 
   /** Self reference */
   public self = this;
+
+  /** JQuery accessor to element ref */
+  protected $element:JQuery<HTMLElement>;
 
   constructor(readonly I18n:I18nService,
               readonly elementRef:ElementRef,
@@ -89,8 +95,21 @@ export class EditFieldComponent extends Field implements OnDestroy {
       });
   }
 
+  ngOnInit():void {
+    this.$element = jQuery(this.elementRef.nativeElement);
+
+    // TODO
+    console.log(this.overflowingSelector);
+  }
+
   ngOnDestroy() {
     // Nothing to do
+  }
+
+  public get overflowingSelector() {
+    return this.$element
+      .closest(overflowingContainerSelector)
+      .data(overflowingContainerAttribute);
   }
 
   public get inFlight() {

--- a/frontend/src/app/modules/fields/edit/edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/edit-field.component.ts
@@ -123,6 +123,10 @@ export class EditFieldComponent extends Field implements OnDestroy {
     return this.changeset.workPackage;
   }
 
+  public get groupName() {
+    return this.changeset.form!.schema[this.name].attributeGroup;
+  }
+
   /**
    * Initialize the field after constructor was called.
    */

--- a/frontend/src/app/modules/fields/edit/edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/edit-field.component.ts
@@ -104,7 +104,7 @@ export class EditFieldComponent extends Field implements OnInit, OnDestroy {
   }
 
   public get overflowingSelector() {
-    if(this.$element) {
+    if (this.$element) {
       return this.$element
         .closest(overflowingContainerSelector)
         .data(overflowingContainerAttribute);

--- a/frontend/src/app/modules/fields/edit/editing-portal/edit-field-handler.ts
+++ b/frontend/src/app/modules/fields/edit/editing-portal/edit-field-handler.ts
@@ -51,6 +51,10 @@ export abstract class EditFieldHandler {
    */
   fieldName:string;
 
+  /**
+   * Activation handler firing upon user requesting activation.
+   */
+  $onUserActivate:Subject<void>;
 
   /**
    * Accessibility label for the field

--- a/frontend/src/app/modules/fields/edit/editing-portal/wp-editing-portal-service.ts
+++ b/frontend/src/app/modules/fields/edit/editing-portal/wp-editing-portal-service.ts
@@ -9,6 +9,7 @@ import {EditFormPortalComponent} from "core-app/modules/fields/edit/editing-port
 import {createLocalInjector} from "core-app/modules/fields/edit/editing-portal/edit-form-portal.injector";
 import {take} from "rxjs/operators";
 import {IFieldSchema} from "core-app/modules/fields/field.base";
+import {WorkPackageEditContext} from "core-components/wp-edit-form/work-package-edit-context";
 
 @Injectable()
 export class WorkPackageEditingPortalService {

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
@@ -2,6 +2,7 @@
   <ng-select [(ngModel)]="selectedOption"
              [ngClass]="'wp-inline-edit--field'"
              [required]="required"
+             [clearable]="!required"
              [disabled]="inFlight"
              [id]="handler.htmlId"
              [items]="valueOptions"

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
@@ -14,7 +14,9 @@
              [multiple]="true"
              [closeOnSelect]="false"
              [appendTo]="appendTo"
-             [dropdownPosition]="'top'">
+             [dropdownPosition]="'top'"
+             (open)="onOpen()"
+             (close)="onClose()">
   </ng-select>
 
   <edit-field-controls [fieldController]="self"

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
@@ -1,21 +1,19 @@
-<div>
-  <div class="inline-label">
-    <ng-select [(ngModel)]="selectedOption"
-               class="wp-inline-edit--field"
-               [required]="required"
-               [disabled]="inFlight"
-               [id]="handler.htmlId"
-               [items]="valueOptions"
-               bindLabel="name"
-               [virtualScroll]="true"
-               autofocus
-               (keydown)="handler.handleUserKeydown($event, true)"
-               [multiple]="true"
-               [closeOnSelect]="false"
-               appendTo="#attributes-group--{{groupName.toLowerCase()}}"
-               [dropdownPosition]="'top'">
-    </ng-select>
-  </div>
+<div class="textarea-wrapper">
+  <ng-select [(ngModel)]="selectedOption"
+             class="wp-inline-edit--field"
+             [required]="required"
+             [disabled]="inFlight"
+             [id]="handler.htmlId"
+             [items]="valueOptions"
+             bindLabel="name"
+             [virtualScroll]="true"
+             autofocus
+             (keydown)="handler.handleUserKeydown($event, true)"
+             [multiple]="true"
+             [closeOnSelect]="false"
+             [appendTo]="appendTo"
+             [dropdownPosition]="'top'">
+  </ng-select>
 
   <edit-field-controls [fieldController]="self"
                        *ngIf="!handler.inEditMode"

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
@@ -1,75 +1,22 @@
-<div [ngClass]="isMultiselect ? 'textarea-wrapper' : ''">
+<div>
   <div class="inline-label">
-    <select
-        *ngIf="!isMultiselect"
-        class="focus-input wp-inline-edit--field inplace-edit--field -animated form--select"
-        [(ngModel)]="selectedOption"
-        [attr.aria-required]="required"
-        [required]="required"
-        [disabled]="inFlight"
-        [id]="handler.htmlId"
-        (keydown)="handler.handleUserKeydown($event, true)"
-        (change)="handler.handleUserSubmit()"
-    >
-      <option
-          value=""
-          [textContent]="text.requiredPlaceholder"
-          [attr.label]="text.requiredPlaceholder"
-          *ngIf="currentValueInvalid || options.length == 0"
-          [selected]="currentValueInvalid || options.length == 0"
-          [attr.selected]="currentValueInvalid || options.length == 0 || undefined"
-          disabled>
-      </option>
-      <option
-          *ngFor="let value of valueOptions"
-          [ngValue]="value"
-          [attr.label]="value.name"
-          [textContent]="value.name">
-      </option>
-    </select>
-
-    <select
-        *ngIf="isMultiselect"
-        [(ngModel)]="selectedOption"
-        class="focus-input wp-inline-edit--field inplace-edit--textarea -animated form--select"
-        [attr.aria-required]="required"
-        [required]="required"
-        [disabled]="inFlight"
-        [id]="handler.htmlId"
-        (keydown)="handler.handleUserKeydown($event, true)"
-        (change)="submitOnSingleSelect()"
-        multiple
-        size=5
-    >
-      <option
-          value=""
-          [textContent]="text.requiredPlaceholder"
-          *ngIf="currentValueInvalid || options.length == 0"
-          [attr.label]="text.requiredPlaceholder"
-          [selected]="currentValueInvalid || options.length == 0"
-          disabled>
-      </option>
-      <option
-          *ngFor="let value of valueOptions"
-          [ngValue]="value"
-          [attr.label]="value.name"
-          [textContent]="value.name">
-      </option>
-    </select>
-
-    <a href class="wp-inline-edit--toggle-multiselect form-label no-decoration-on-hover -transparent"
-       (click)="toggleMultiselect()">
-      <op-icon *ngIf="isMultiselect"
-               icon-classes="icon-minus2 icon4"
-               [icon-title]="text.switch_to_single_select"></op-icon>
-      <op-icon *ngIf="!isMultiselect"
-               icon-classes="icon-add icon4"
-               [icon-title]="text.switch_to_multi_select"></op-icon>
-    </a>
+    <ng-select [(ngModel)]="selectedOption"
+               class="wp-inline-edit--field"
+               [required]="required"
+               [disabled]="inFlight"
+               [id]="handler.htmlId"
+               [items]="valueOptions"
+               bindLabel="name"
+               [virtualScroll]="true"
+               autofocus
+               (keydown)="handler.handleUserKeydown($event, true)"
+               [multiple]="true"
+               [closeOnSelect]="false">
+    </ng-select>
   </div>
 
   <edit-field-controls [fieldController]="self"
-                       *ngIf="isMultiselect && !handler.inEditMode"
+                       *ngIf="!handler.inEditMode"
                        (onSave)="handler.handleUserSubmit()"
                        (onCancel)="handler.handleUserCancel()"
                        [saveTitle]="text.save"

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
@@ -1,12 +1,13 @@
 <div class="textarea-wrapper">
   <ng-select [(ngModel)]="selectedOption"
-             class="wp-inline-edit--field"
+             [ngClass]="'wp-inline-edit--field'"
              [required]="required"
              [disabled]="inFlight"
              [id]="handler.htmlId"
              [items]="valueOptions"
              bindLabel="name"
              [virtualScroll]="true"
+             [clearSearchOnAdd]="true"
              autofocus
              (keydown)="handler.handleUserKeydown($event, true)"
              [multiple]="true"

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
@@ -11,7 +11,9 @@
                autofocus
                (keydown)="handler.handleUserKeydown($event, true)"
                [multiple]="true"
-               [closeOnSelect]="false">
+               [closeOnSelect]="false"
+               appendTo="#attributes-group--{{groupName.toLowerCase()}}"
+               [dropdownPosition]="'top'">
     </ng-select>
   </div>
 

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
@@ -9,14 +9,13 @@
              bindLabel="name"
              [virtualScroll]="true"
              [clearSearchOnAdd]="true"
-             autofocus
              (keydown)="handler.handleUserKeydown($event, true)"
+             (open)="onOpen()"
+             (close)="onClose()"
              [multiple]="true"
              [closeOnSelect]="false"
              [appendTo]="appendTo"
-             [dropdownPosition]="'top'"
-             (open)="onOpen()"
-             (close)="onClose()">
+             [dropdownPosition]="'top'">
   </ng-select>
 
   <edit-field-controls [fieldController]="self"

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -45,18 +45,13 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
     placeholder: this.I18n.t('js.placeholders.default'),
     save: this.I18n.t('js.inplace.button_save', { attribute: this.schema.name }),
     cancel: this.I18n.t('js.inplace.button_cancel', { attribute: this.schema.name }),
-    switch_to_single_select: this.I18n.t('js.work_packages.label_switch_to_single_select'),
-    switch_to_multi_select: this.I18n.t('js.work_packages.label_switch_to_multi_select'),
   };
-  public isMultiselect:boolean;
 
   public currentValueInvalid:boolean = false;
   private nullOption:ValueOption;
-  private _selectedOption:ValueOption|ValueOption[];
+  private _selectedOption:ValueOption[];
 
   ngOnInit() {
-    this.isMultiselect = this.isValueMulti();
-
     this.nullOption = { name: this.text.placeholder, $href: null };
 
     if (Array.isArray(this.schema.allowedValues)) {
@@ -77,12 +72,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
 
   public get value() {
     const val = this.changeset.value(this.name);
-
-    if (!Array.isArray(val) || this.isMultiselect) {
-      return val;
-    } else {
-      return val[0];
-    }
+    return val[0];
   }
 
   /**
@@ -91,23 +81,8 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
    * @returns {any}
    */
   public buildSelectedOption() {
-    const value:HalResource|HalResource[] = this.changeset.value(this.name);
-
-    if (this.isMultiselect) {
-      if (!Array.isArray(value)) {
-        return [this.findValueOption(value)];
-      }
-
-      return value.map(val => this.findValueOption(val));
-    }
-
-    if (!Array.isArray(value)) {
-      return this.findValueOption(value);
-    } else if (value.length > 0) {
-      return this.findValueOption(value[0]);
-    }
-
-    return this.nullOption;
+    const value:HalResource[] = this.changeset.value(this.name);
+    return value.map(val => this.findValueOption(val));
   }
 
   public get selectedOption() {
@@ -118,9 +93,8 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
    * Map the ValueOption to the actual HalResource option
    * @param val
    */
-  public set selectedOption(val:ValueOption|ValueOption[]) {
+  public set selectedOption(val:ValueOption[]) {
     this._selectedOption = val;
-    let selected:any;
     let mapper = (val:ValueOption) => {
       let option = _.find(this.options, o => o.$href === val.$href) || this.nullOption;
 
@@ -135,22 +109,6 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
 
     const value = _.castArray(val).map(el => mapper(el));
     this.changeset.setValue(this.name, value);
-  }
-
-  public isValueMulti() {
-    const val = this.changeset.value(this.name);
-    return val && val.length > 1;
-  }
-
-  public toggleMultiselect() {
-    this.isMultiselect = !this.isMultiselect;
-    this._selectedOption = this.buildSelectedOption();
-  }
-
-  public submitOnSingleSelect() {
-    if (!this.isMultiselect) {
-      this.handler.handleUserSubmit();
-    }
   }
 
   private findValueOption(option?:HalResource):ValueOption {
@@ -173,7 +131,6 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
     }
 
     this.options = availableValues;
-    this.addEmptyOption();
     this.valueOptions = this.options.map(el => {
       return { name: el.name, $href: el.$href };
     });
@@ -185,32 +142,15 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
     if (this.value) {
       this.currentValueInvalid = !!(
         // (If value AND)
-        // MultiSelect AND there is no value which href is not in the options hrefs OR
-        // SingleSelect AND the given values href is not within the options hrefs
-        (this.isMultiselect && !_.some(this.value, (value:HalResource) => {
+        // MultiSelect AND there is no value which href is not in the options hrefs
+        (!_.some(this.value, (value:HalResource) => {
           return _.some(this.options, (option) => (option.$href === value.$href))
-        })) ||
-        (!this.isMultiselect && !_.some(this.options,
-          (option) => (option.$href === this.value.$href)))
+        }))
       );
     }
     else {
       // If no value but required
       this.currentValueInvalid = !!this.schema.required;
-    }
-  }
-
-  private addEmptyOption() {
-    // Empty options are not available for required fields
-    if (this.schema.required) {
-      return;
-    }
-
-    // Since we use the original schema values, avoid adding
-    // the option if one is returned / exists already.
-    const emptyOption = _.find(this.options, el => el.name === this.text.placeholder);
-    if (emptyOption === undefined) {
-      this.options.unshift(this.nullOption);
     }
   }
 }

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -47,6 +47,8 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
     cancel: this.I18n.t('js.inplace.button_cancel', { attribute: this.schema.name }),
   };
 
+  public appendTo:any = null;
+
   public currentValueInvalid:boolean = false;
   private nullOption:ValueOption;
   private _selectedOption:ValueOption[];
@@ -68,6 +70,9 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
     } else {
       this.setValues([]);
     }
+
+    super.ngOnInit();
+    this.appendTo = this.overflowingSelector;
   }
 
   public get value() {

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -48,6 +48,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   };
 
   public appendTo:any = null;
+  private wpTableContainerIdentifier = '.work-package-table--container';
 
   public currentValueInvalid:boolean = false;
   private nullOption:ValueOption;
@@ -114,6 +115,14 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
 
     const value = _.castArray(val).map(el => mapper(el));
     this.changeset.setValue(this.name, value);
+  }
+
+  public onOpen() {
+    jQuery(this.wpTableContainerIdentifier).addClass('-hidden-overflow');
+  }
+
+  public onClose() {
+    jQuery(this.wpTableContainerIdentifier).removeClass('-hidden-overflow');
   }
 
   private findValueOption(option?:HalResource):ValueOption {

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -53,7 +53,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   };
 
   public appendTo:any = null;
-  private wpTableContainerIdentifier = '.work-package-table--container';
+  private hiddenOverflowContainer = '.__hidden_overflow_container';
 
   public currentValueInvalid:boolean = false;
   private nullOption:ValueOption;
@@ -130,11 +130,11 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   }
 
   public onOpen() {
-    jQuery(this.wpTableContainerIdentifier).addClass('-hidden-overflow');
+    jQuery(this.hiddenOverflowContainer).addClass('-hidden-overflow');
   }
 
   public onClose() {
-    jQuery(this.wpTableContainerIdentifier).removeClass('-hidden-overflow');
+    jQuery(this.hiddenOverflowContainer).removeClass('-hidden-overflow');
   }
 
   private openAutocompleteSelectField() {

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -32,7 +32,7 @@ import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {Component, OnInit} from "@angular/core";
 import {EditFieldComponent} from "core-app/modules/fields/edit/edit-field.component";
 import {ValueOption} from "core-app/modules/fields/edit/field-types/select-edit-field.component";
-import {NgSelectComponent} from "@ng-select/ng-select/dist";
+import {NgSelectComponent} from "@ng-select/ng-select";
 import {ViewChild} from "@angular/core";
 import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -32,7 +32,7 @@ import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {Component, OnInit} from "@angular/core";
 import {EditFieldComponent} from "core-app/modules/fields/edit/edit-field.component";
 import {ValueOption} from "core-app/modules/fields/edit/field-types/select-edit-field.component";
-import {NgSelectComponent} from "@ng-select/ng-select";
+import {NgSelectComponent} from "@ng-select/ng-select/dist";
 import {ViewChild} from "@angular/core";
 import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -32,11 +32,16 @@ import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {Component, OnInit} from "@angular/core";
 import {EditFieldComponent} from "core-app/modules/fields/edit/edit-field.component";
 import {ValueOption} from "core-app/modules/fields/edit/field-types/select-edit-field.component";
+import {NgSelectComponent} from "@ng-select/ng-select";
+import {ViewChild} from "@angular/core";
+import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 
 @Component({
   templateUrl: './multi-select-edit-field.component.html'
 })
 export class MultiSelectEditFieldComponent extends EditFieldComponent implements OnInit {
+  @ViewChild(NgSelectComponent) public ngSelectComponent:NgSelectComponent;
+
   readonly I18n:I18nService = this.injector.get(I18nService);
   public options:any[];
   public valueOptions:ValueOption[];
@@ -55,6 +60,13 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   private _selectedOption:ValueOption[];
 
   ngOnInit() {
+    this.handler
+      .$onUserActivate
+      .pipe(
+        untilComponentDestroyed(this)
+      )
+      .subscribe(() => this.openAutocompleteSelectField());
+
     this.nullOption = { name: this.text.placeholder, $href: null };
 
     if (Array.isArray(this.schema.allowedValues)) {
@@ -123,6 +135,10 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
 
   public onClose() {
     jQuery(this.wpTableContainerIdentifier).removeClass('-hidden-overflow');
+  }
+
+  private openAutocompleteSelectField() {
+    this.ngSelectComponent.open();
   }
 
   private findValueOption(option?:HalResource):ValueOption {

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
@@ -1,27 +1,12 @@
-<select [(ngModel)]="selectedOption"
-        [compareWith]="compareByHref"
-        class="wp-inline-edit--field form--select"
-        [attr.aria-required]="required"
-        [required]="required"
-        [disabled]="inFlight"
-        [id]="handler.htmlId"
-        (keydown)="handler.handleUserKeydown($event, true)"
-        (change)="handler.handleUserSubmit()"
-        role="listbox">
-  <option
-      [ngValue]="undefined"
-      [textContent]="text.requiredPlaceholder"
-      [attr.selected]="currentValueInvalid || undefined"
-      [attr.label]="text.requiredPlaceholder"
-      *ngIf="currentValueInvalid"
-      disabled>
-  </option>
-  <option
-      *ngFor="let value of valueOptions"
-      [attr.selected]="compareByHref(selectedOption, value) || undefined"
-      [attr.label]="value.name"
-      [ngValue]="value"
-      [textContent]="value.name">
-  </option>
-
-</select>
+<ng-select [(ngModel)]="selectedOption"
+           class="wp-inline-edit--field"
+           [required]="required"
+           [disabled]="inFlight"
+           [id]="handler.htmlId"
+           [items]="valueOptions"
+           bindLabel="name"
+           [virtualScroll]="true"
+           autofocus
+           (keydown)="handler.handleUserKeydown($event, true)"
+           (change)="handler.handleUserSubmit()">
+</ng-select>

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
@@ -9,6 +9,6 @@
            autofocus
            (keydown)="handler.handleUserKeydown($event, true)"
            (change)="handler.handleUserSubmit()"
-           appendTo="#attributes-group--{{groupName.toLowerCase()}}"
+           [appendTo]="appendTo"
            [dropdownPosition]="'bottom'">
 </ng-select>

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
@@ -1,5 +1,5 @@
 <ng-select [(ngModel)]="selectedOption"
-           class="wp-inline-edit--field"
+           [ngClass]="'wp-inline-edit--field'"
            [required]="required"
            [disabled]="inFlight"
            [id]="handler.htmlId"

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
@@ -1,6 +1,7 @@
 <ng-select [(ngModel)]="selectedOption"
            [ngClass]="'wp-inline-edit--field'"
            [required]="required"
+           [clearable]="!required"
            [disabled]="inFlight"
            [id]="handler.htmlId"
            [items]="valueOptions"
@@ -9,6 +10,5 @@
            autofocus
            (keydown)="handler.handleUserKeydown($event, true)"
            (change)="handler.handleUserSubmit()"
-           [appendTo]="appendTo"
-           [dropdownPosition]="'bottom'">
+           [appendTo]="appendTo">
 </ng-select>

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
@@ -8,5 +8,7 @@
            [virtualScroll]="true"
            autofocus
            (keydown)="handler.handleUserKeydown($event, true)"
-           (change)="handler.handleUserSubmit()">
+           (change)="handler.handleUserSubmit()"
+           appendTo="#attributes-group--{{groupName.toLowerCase()}}"
+           [dropdownPosition]="'bottom'">
 </ng-select>

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
@@ -7,8 +7,9 @@
            [items]="valueOptions"
            bindLabel="name"
            [virtualScroll]="true"
-           autofocus
            (keydown)="handler.handleUserKeydown($event, true)"
            (change)="handler.handleUserSubmit()"
+           (open)="onOpen()"
+           (close)="onClose()"
            [appendTo]="appendTo">
 </ng-select>

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component} from "@angular/core";
+import {Component, OnInit} from "@angular/core";
 import {HalResourceSortingService} from "core-app/modules/hal/services/hal-resource-sorting.service";
 import {CollectionResource} from "core-app/modules/hal/resources/collection-resource";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
@@ -41,11 +41,13 @@ export interface ValueOption {
 @Component({
   templateUrl: './select-edit-field.component.html'
 })
-export class SelectEditFieldComponent extends EditFieldComponent {
+export class SelectEditFieldComponent extends EditFieldComponent implements OnInit {
   public options:any[];
   public valueOptions:ValueOption[];
   public template:string = '/components/wp-edit/field-types/wp-edit-select-field.directive.html';
   public text:{ requiredPlaceholder:string, placeholder:string };
+
+  public appendTo:any = null;
 
   public halSorting:HalResourceSortingService;
 
@@ -66,6 +68,11 @@ export class SelectEditFieldComponent extends EditFieldComponent {
     } else {
       this.setValues([]);
     }
+  }
+
+  public ngOnInit() {
+    super.ngOnInit();
+    this.appendTo = this.overflowingSelector;
   }
 
   public get selectedOption() {

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -48,7 +48,6 @@ export class SelectEditFieldComponent extends EditFieldComponent {
   public text:{ requiredPlaceholder:string, placeholder:string };
 
   public halSorting:HalResourceSortingService;
-  public compareByHref = AngularTrackingHelpers.compareByHref;
 
   protected initialize() {
     this.halSorting = this.injector.get(HalResourceSortingService);

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -32,6 +32,7 @@ import {CollectionResource} from "core-app/modules/hal/resources/collection-reso
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {EditFieldComponent} from "../edit-field.component";
 import {AngularTrackingHelpers} from "core-components/angular/tracking-functions";
+import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 
 export interface ValueOption {
   name:string;
@@ -52,6 +53,14 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   public halSorting:HalResourceSortingService;
 
   protected initialize() {
+
+    this.handler
+      .$onUserActivate
+      .pipe(
+        untilComponentDestroyed(this)
+      )
+      .subscribe(() => this.openDamnedAutoCompleter());
+
     this.halSorting = this.injector.get(HalResourceSortingService);
 
     this.text = {

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -52,12 +52,11 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   public text:{ requiredPlaceholder:string, placeholder:string };
 
   public appendTo:any = null;
-  private wpTableContainerIdentifier = '.work-package-table--container';
+  private hiddenOverflowContainer = '.__hidden_overflow_container';
 
   public halSorting:HalResourceSortingService;
 
   protected initialize() {
-
     this.handler
       .$onUserActivate
       .pipe(
@@ -122,11 +121,11 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   }
 
   public onOpen() {
-    jQuery(this.wpTableContainerIdentifier).addClass('-hidden-overflow');
+    jQuery(this.hiddenOverflowContainer).addClass('-hidden-overflow');
   }
 
   public onClose() {
-    jQuery(this.wpTableContainerIdentifier).removeClass('-hidden-overflow');
+    jQuery(this.hiddenOverflowContainer).removeClass('-hidden-overflow');
   }
 
   private openAutocompleteSelectField() {

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -33,7 +33,7 @@ import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {EditFieldComponent} from "../edit-field.component";
 import {AngularTrackingHelpers} from "core-components/angular/tracking-functions";
 import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
-import {NgSelectComponent} from "@ng-select/ng-select/dist";
+import {NgSelectComponent} from "@ng-select/ng-select";
 
 export interface ValueOption {
   name:string;

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -26,13 +26,14 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, OnInit} from "@angular/core";
+import {Component, OnInit, ViewChild} from "@angular/core";
 import {HalResourceSortingService} from "core-app/modules/hal/services/hal-resource-sorting.service";
 import {CollectionResource} from "core-app/modules/hal/resources/collection-resource";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {EditFieldComponent} from "../edit-field.component";
 import {AngularTrackingHelpers} from "core-components/angular/tracking-functions";
 import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {NgSelectComponent} from "@ng-select/ng-select";
 
 export interface ValueOption {
   name:string;
@@ -43,12 +44,15 @@ export interface ValueOption {
   templateUrl: './select-edit-field.component.html'
 })
 export class SelectEditFieldComponent extends EditFieldComponent implements OnInit {
+  @ViewChild(NgSelectComponent) public ngSelectComponent:NgSelectComponent;
+
   public options:any[];
   public valueOptions:ValueOption[];
   public template:string = '/components/wp-edit/field-types/wp-edit-select-field.directive.html';
   public text:{ requiredPlaceholder:string, placeholder:string };
 
   public appendTo:any = null;
+  private wpTableContainerIdentifier = '.work-package-table--container';
 
   public halSorting:HalResourceSortingService;
 
@@ -59,7 +63,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
       .pipe(
         untilComponentDestroyed(this)
       )
-      .subscribe(() => this.openDamnedAutoCompleter());
+      .subscribe(() => this.openAutocompleteSelectField());
 
     this.halSorting = this.injector.get(HalResourceSortingService);
 
@@ -115,6 +119,18 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
       ||
       (!this.value && this.schema.required)
     );
+  }
+
+  public onOpen() {
+    jQuery(this.wpTableContainerIdentifier).addClass('-hidden-overflow');
+  }
+
+  public onClose() {
+    jQuery(this.wpTableContainerIdentifier).removeClass('-hidden-overflow');
+  }
+
+  private openAutocompleteSelectField() {
+    this.ngSelectComponent.open();
   }
 
   private addEmptyOption() {

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -33,7 +33,7 @@ import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {EditFieldComponent} from "../edit-field.component";
 import {AngularTrackingHelpers} from "core-components/angular/tracking-functions";
 import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
-import {NgSelectComponent} from "@ng-select/ng-select";
+import {NgSelectComponent} from "@ng-select/ng-select/dist";
 
 export interface ValueOption {
   name:string;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,2 +1,3 @@
 /* You can add global styles to this file, and also import other style files */
 @import "../vendor/select2/select2.css";
+@import "~@ng-select/ng-select/themes/default.theme.css";

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -32,6 +32,7 @@
       "dom"
     ],
     "paths": {
+      "@ng-select/ng-select": ["../node_modules/@ng-select/ng-select/dist/"],
       "core-app/*": ["./app/*"],
       "core-components/*": ["./app/components/*"]
     }

--- a/modules/costs/spec/features/costs_edit_fields_spec.rb
+++ b/modules/costs/spec/features/costs_edit_fields_spec.rb
@@ -49,6 +49,8 @@ describe 'Work Package cost fields', type: :feature, js: true do
     expect(page).to have_no_selector('.wp-edit-field--container.materialCosts')
     expect(page).to have_no_selector('.wp-edit-field--container.overallCosts')
 
-    select budget.name, from: 'wp-new-inline-edit--field-costObject'
+    field = split_create.edit_field(:costObject)
+    field.openSelectField
+    field.set_value budget.name
   end
 end

--- a/spec/features/custom_fields/multi_user_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_user_custom_field_spec.rb
@@ -15,6 +15,12 @@ describe "multi select custom values", js: true do
     )
   end
 
+  let(:cf_edit_field) do
+    field = wp_page.edit_field "customField#{custom_field.id}"
+    field.field_type = 'ng-select'
+    field
+  end
+
   let(:member_names) { ["Billy Nobbler", "Cooper Quatermaine", "Anton Lupin"] }
 
   # We include an invited member to check at the same time that invited users are properly
@@ -70,10 +76,9 @@ describe "multi select custom values", js: true do
 
       page.find("div.custom-option", text: "Billy Nobbler").click
 
-      sel = page.find(:select)
-
-      sel.unselect "Anton Lupin"
-      sel.select "Cooper Quatermaine"
+      cf_edit_field.openSelectField
+      cf_edit_field.unset_value "Anton Lupin", true
+      cf_edit_field.set_value "Cooper Quatermaine"
 
       click_on "Reviewer: Save"
 

--- a/spec/features/custom_fields/multi_user_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_user_custom_field_spec.rb
@@ -76,7 +76,6 @@ describe "multi select custom values", js: true do
 
       page.find("div.custom-option", text: "Billy Nobbler").click
 
-      cf_edit_field.openSelectField
       cf_edit_field.unset_value "Anton Lupin", true
       cf_edit_field.set_value "Cooper Quatermaine"
 

--- a/spec/features/custom_fields/multi_value_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_value_custom_field_spec.rb
@@ -54,7 +54,7 @@ describe "multi select custom values", js: true do
     describe 'in single view' do
       let(:edit_field) do
         field = wp_page.edit_field "customField#{custom_field.id}"
-        field.field_type = 'select'
+        field.field_type = 'ng-select'
         field
       end
 
@@ -72,10 +72,9 @@ describe "multi select custom values", js: true do
         expect(page).to have_text "onions"
 
         edit_field.activate!
-        sel = edit_field.input_element
 
-        sel.unselect "pineapple"
-        sel.select "mushrooms"
+        edit_field.unset_value "pineapple", true
+        edit_field.set_value "mushrooms"
 
         edit_field.submit_by_dashboard
 
@@ -93,7 +92,7 @@ describe "multi select custom values", js: true do
     describe 'in the WP table' do
       let(:table_edit_field) do
         field = wp_table.edit_field work_package, "customField#{custom_field.id}"
-        field.field_type = 'select'
+        field.field_type = 'ng-select'
         field
       end
 
@@ -129,10 +128,9 @@ describe "multi select custom values", js: true do
         expect(page).to have_selector('.group--value', text: 'ham (1)')
 
         table_edit_field.activate!
-        sel = table_edit_field.input_element
 
-        sel.unselect "pineapple"
-        sel.unselect "onions"
+        table_edit_field.unset_value "pineapple", true
+        table_edit_field.unset_value "onions", true
 
         table_edit_field.submit_by_dashboard
 
@@ -145,12 +143,7 @@ describe "multi select custom values", js: true do
         field = WorkPackageMultiSelectField.new(split_view.container, "customField#{custom_field.id}")
 
         field.activate!
-        sel = field.input_element
-        expect(field).not_to be_multiselect
-
-        field.toggle_multiselect
-        expect(field).to be_multiselect
-        sel.unselect "ham"
+        field.unset_value "ham", true
         field.submit_by_dashboard
 
         # Expect none selected in split and table
@@ -159,10 +152,9 @@ describe "multi select custom values", js: true do
 
         # Activate again
         field.activate!
-        field.toggle_multiselect
-        expect(field).to be_multiselect
-        sel.select "ham"
-        sel.select "onions"
+
+        field.set_value "ham"
+        field.set_value "onions"
 
         field.submit_by_dashboard
 
@@ -171,10 +163,8 @@ describe "multi select custom values", js: true do
         table_edit_field.expect_state_text 'ham, onions'
 
         field.activate!
-        # Is now multiselect from the start, since multiple values enabled
-        expect(field).to be_multiselect
-        sel.select "pineapple"
-        sel.select "mushrooms"
+        field.set_value "pineapple"
+        field.set_value "mushrooms"
 
         field.submit_by_dashboard
         expect(field.display_element).to have_text('ham')

--- a/spec/features/my/assigned_to_me_embedded_table_spec.rb
+++ b/spec/features/my/assigned_to_me_embedded_table_spec.rb
@@ -63,12 +63,13 @@ describe 'Assigned to me embedded query on my page', type: :feature, js: true do
     # Set project
     project_field = embedded_table.edit_field(nil, :project)
     project_field.expect_active!
-
+    project_field.openSelectField
     project_field.set_value project.name
 
     # Set type
     type_field = embedded_table.edit_field(nil, :type)
     type_field.expect_active!
+    type_field.openSelectField
     type_field.set_value type.name
 
     embedded_table.expect_notification(

--- a/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
+++ b/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
@@ -76,12 +76,12 @@ describe 'custom field inplace editor', js: true do
     let(:custom_fields) { [custom_field1, custom_field2] }
     let(:field1) do
       f = wp_page.custom_edit_field(custom_field1)
-      f.field_type = 'select'
+      f.field_type = 'ng-select'
       f
     end
     let(:field2) do
       f = wp_page.custom_edit_field(custom_field2)
-      f.field_type = 'select'
+      f.field_type = 'ng-select'
       f
     end
     let(:initial_custom_values) { {} }

--- a/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
@@ -43,8 +43,10 @@ describe 'subject inplace editor', js: true, selenium: true do
 
     field = work_package_page.work_package_field(:version)
     field.activate!
+    field.openSelectField
 
-    options = field.input_element.all("option")
+    options = field.all(".ng-option-label")
+
     expect(options.map(&:text)).to eq(['-', version3.name, version2.name, version.name])
 
     options[1].select_option

--- a/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
@@ -43,7 +43,6 @@ describe 'subject inplace editor', js: true, selenium: true do
 
     field = work_package_page.work_package_field(:version)
     field.activate!
-    field.openSelectField
 
     options = field.all(".ng-option-label")
 

--- a/spec/features/work_packages/new/attributes_from_filter_spec.rb
+++ b/spec/features/work_packages/new/attributes_from_filter_spec.rb
@@ -166,7 +166,7 @@ RSpec.feature 'Work package create uses attributes from filters', js: true, sele
 
       # Assignee is synced
       assignee_field = split_view_create.edit_field :assignee
-      expect(assignee_field.input_element.find('option[selected]').text).to eql('An assignee')
+      expect(assignee_field.input_element.find('.ng-value-label').text).to eql('An assignee')
 
       within '.work-packages--edit-actions' do
         click_button 'Save'

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -60,7 +60,6 @@ describe 'new work package', js: true do
     project_field.openSelectField
     project_field.set_value project
 
-    expect(page).to have_selector("#wp-new-inline-edit--field-type option[label=#{type}]", wait: 10)
     type_field.openSelectField
     type_field.set_value type
     sleep 1
@@ -182,9 +181,11 @@ describe 'new work package', js: true do
           cf1 = find(".customField#{ids.first} input")
           expect(cf1).not_to be_nil
 
-          expect(page).to have_selector(".customField#{ids.last} select")
+          expect(page).to have_selector(".customField#{ids.last} ng-select")
 
-          find(".customField#{ids.last} option", text: 'foo').select_option
+          cf = wp_page.edit_field "customField#{ids.last}"
+          cf.openSelectField
+          cf.set_value 'foo'
           save_work_package!(false)
 
           notification.expect_error("#{custom_field1.name} can't be blank.")

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -57,9 +57,11 @@ describe 'new work package', js: true do
     loading_indicator_saveguard
     wp_page.subject_field.set(subject)
 
+    project_field.openSelectField
     project_field.set_value project
 
     expect(page).to have_selector("#wp-new-inline-edit--field-type option[label=#{type}]", wait: 10)
+    type_field.openSelectField
     type_field.set_value type
     sleep 1
   end

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -141,6 +141,7 @@ describe 'new work package', js: true do
       it 'can switch types and keep attributes' do
         wp_page.subject_field.set(subject)
         type_field.activate!
+        type_field.openSelectField
         type_field.set_value 'Bug'
 
         save_work_package!

--- a/spec/features/work_packages/table/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table/edit_work_packages_spec.rb
@@ -181,8 +181,8 @@ describe 'Inline editing work packages', js: true do
       cf_text.update('my custom text', expect_failure: true)
 
       cf_list = wp_table.edit_field(work_package, "customField#{custom_fields.first.id}")
-      cf_list.field_type = 'select'
-      expect(cf_list.input_element).to have_selector('option[selected]', text: 'Please select')
+      cf_list.field_type = 'ng-select'
+      cf_list.openSelectField
       cf_list.set_value('bar')
 
       cf_text.expect_inactive!

--- a/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
+++ b/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
@@ -148,12 +148,14 @@ describe 'inline create work package', js: true do
           project_field = wp_table.edit_field(nil, :project)
           project_field.expect_active!
 
+          project_field.openSelectField
           project_field.set_value project.name
 
           # Set type
           type_field = wp_table.edit_field(nil, :type)
           type_field.expect_active!
 
+          type_field.openSelectField
           type_field.set_value type.name
         }
       end

--- a/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
+++ b/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
@@ -110,6 +110,7 @@ describe 'inline create work package', js: true do
 
         type_field = wp_table.edit_field(nil, :type)
         type_field.activate!
+        type_field.openSelectField
         type_field.set_value cf_type.name
 
         wp_table.expect_notification(

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -324,13 +324,9 @@ describe 'Switching types in work package table', js: true do
       # Scroll to element so it is fully visible
       scroll_to_element(cf_edit_field.field_container)
 
-      cf_edit_field.field_container.find('.wp-inline-edit--toggle-multiselect').click
-      sel = cf_edit_field.input_element
-
-      scroll_to_element(sel)
-
-      sel.select "pineapple"
-      sel.select "mushrooms"
+      cf_edit_field.openSelectField
+      cf_edit_field.set_value "pineapple"
+      cf_edit_field.set_value "mushrooms"
 
       wp_page.save!
 

--- a/spec/support/work_packages/work_package_field.rb
+++ b/spec/support/work_packages/work_package_field.rb
@@ -71,7 +71,7 @@ class WorkPackageField
   alias :activate_edition :activate!
 
   def openSelectField
-    field_container.find('.ng-input input').click
+    autocomplete_selector.click
   end
 
   def expect_state!(open:)
@@ -133,6 +133,23 @@ class WorkPackageField
     end
   end
 
+  ##
+  # Set or select the given value.
+  # For fields of type select, will check for an option with that value.
+  def unset_value(content, multi=false)
+    scroll_to_element(input_element)
+
+    if input_element.tag_name == 'ng-select'
+      if multi
+        page.find('.ng-dropdown-panel .ng-option', text: content).click
+      else
+        page.find('.ng-dropdown-panel .ng-option', text: '-').click
+      end
+    else
+      input_element.set('')
+    end
+  end
+
   def type(text)
     scroll_to_element(input_element)
     input_element.send_keys text
@@ -155,11 +172,19 @@ class WorkPackageField
   end
 
   def submit_by_enter
-    input_element.native.send_keys(:return)
+    if field_type == 'ng-select'
+      autocomplete_selector.send_keys :return
+    else
+      input_element.native.send_keys :return
+    end
   end
 
   def cancel_by_escape
-    input_element.native.send_keys :escape
+    if field_type == 'ng-select'
+      autocomplete_selector.send_keys :escape
+    else
+      input_element.native.send_keys :escape
+    end
   end
 
   def editable?
@@ -172,6 +197,10 @@ class WorkPackageField
     else
       '.wp-inline-edit--field'
     end
+  end
+
+  def autocomplete_selector
+    field_container.find('.ng-input input')
   end
 
   def field_type

--- a/spec/support/work_packages/work_package_field.rb
+++ b/spec/support/work_packages/work_package_field.rb
@@ -63,11 +63,15 @@ class WorkPackageField
         raise "Expected WP field input type '#{field_type}' for attribute '#{property_name}'."
       end
     end
+
+    if field_type == 'ng-select'
+      openSelectField
+    end
   end
   alias :activate_edition :activate!
 
   def openSelectField
-    find('.ng-input input').click
+    field_container.find('.ng-input input').click
   end
 
   def expect_state!(open:)
@@ -122,8 +126,8 @@ class WorkPackageField
   def set_value(content)
     scroll_to_element(input_element)
 
-    if input_element.tag_name == 'select'
-      input_element.find(:option, content).select_option
+    if input_element.tag_name == 'ng-select'
+      page.find('.ng-dropdown-panel .ng-option', text: content).click
     else
       input_element.set(content)
     end
@@ -145,7 +149,7 @@ class WorkPackageField
       set_value value
 
       # select fields are saved on change
-      save! if save && field_type != 'select'
+      save! if save && field_type != 'ng-select'
       expect_state! open: expect_failure
     end
   end
@@ -180,7 +184,7 @@ class WorkPackageField
            'type',
            'version',
            'category'
-        :select
+        'ng-select'
       else
         :input
       end.to_s

--- a/spec/support/work_packages/work_package_field.rb
+++ b/spec/support/work_packages/work_package_field.rb
@@ -66,6 +66,10 @@ class WorkPackageField
   end
   alias :activate_edition :activate!
 
+  def openSelectField
+    find('.ng-input input').click
+  end
+
   def expect_state!(open:)
     if open
       expect_active!

--- a/spec/support/work_packages/work_package_field.rb
+++ b/spec/support/work_packages/work_package_field.rb
@@ -180,6 +180,7 @@ class WorkPackageField
       when 'assignee',
            'responsible',
            'priority',
+           'status',
            'project',
            'type',
            'version',

--- a/spec/support/work_packages/work_package_field.rb
+++ b/spec/support/work_packages/work_package_field.rb
@@ -63,10 +63,6 @@ class WorkPackageField
         raise "Expected WP field input type '#{field_type}' for attribute '#{property_name}'."
       end
     end
-
-    if field_type == 'ng-select'
-      openSelectField
-    end
   end
   alias :activate_edition :activate!
 

--- a/spec/support/work_packages/work_package_multi_select_field.rb
+++ b/spec/support/work_packages/work_package_multi_select_field.rb
@@ -6,10 +6,6 @@ class WorkPackageMultiSelectField < WorkPackageField
     field_container.has_selector?('.wp-inline-edit--toggle-multiselect .icon-minus2')
   end
 
-  def toggle_multiselect
-    field_container.find('.wp-inline-edit--toggle-multiselect').click
-  end
-
   def expect_save_button(enabled: true)
     if enabled
       expect(field_container).to have_no_selector("#{control_link}[disabled]")
@@ -23,7 +19,7 @@ class WorkPackageMultiSelectField < WorkPackageField
   end
 
   def field_type
-    'select'
+    'ng-select'
   end
 
   def control_link(action = :save)


### PR DESCRIPTION
Introduce an autocomplete for the WP single-/multi-select field with the `ng-select` component.

- [x] Replace single select with autocompleter
- [x] Replace multi-select with autocomplete
- [x] Remove obsolete code
- [x] Adapt tests

Bugs
- [x] Deselection of options in mobile view

https://community.openproject.com/projects/14/work_packages/29257/activity