### PR TITLE
[29409] Bugfix disarranged time sheet filters

### DIFF
--- a/app/assets/stylesheets/content/_advanced_filters.sass
+++ b/app/assets/stylesheets/content/_advanced_filters.sass
@@ -120,9 +120,6 @@
   &.hidden
     display: none !important
 
-fieldset#date-range p
-  margin: 2px 0 2px 0
-
 @include breakpoint(680px down)
   .advanced-filters--filters
     .advanced-filters--filter

--- a/app/assets/stylesheets/content/_simple_filters.sass
+++ b/app/assets/stylesheets/content/_simple_filters.sass
@@ -91,6 +91,24 @@ $filters--border-color: $gray !default
     @include text-shortener
     margin: auto 0
 
+fieldset#date-range
+  p
+    margin: 2px 0 2px 0
+
+  // Special case: simple filters with a radiobutton
+  .simple-filters--filter
+    grid-template-columns: 10% repeat(auto-fill, 45%)
+    grid-template-rows: 50% 50%
+    grid-gap: 10px 0
+
+  .simple-filters--filter-name.form--label
+    grid-column: 2
+
+
 @include breakpoint(680px down)
   .simple-filters--filter-value
     grid-column: 1 / -1
+
+  fieldset#date-range
+    .simple-filters--filter-value
+      grid-column: unset

--- a/app/assets/stylesheets/content/_simple_filters.sass
+++ b/app/assets/stylesheets/content/_simple_filters.sass
@@ -75,13 +75,17 @@ $filters--border-color: $gray !default
     grid-template-columns: repeat(auto-fill, 50%)
     align-items: center
 
-    .form--radio-button-container
-      margin-right: 20px
-      flex-grow: 0
-
     button,
     .button
       margin: 0 10px 10px 0
+
+  .simple-filters--filter.-with-radio-buttons
+    grid-template-columns: 10% repeat(auto-fit, minmax(45%, 1fr))
+    grid-template-rows: repeat(auto-fill, 35px)
+    grid-gap: 10px 0
+
+    .simple-filters--filter-name.form--label
+      grid-column: 2
 
   .simple-filters--controls
     grid-column: 1 / -1
@@ -91,24 +95,7 @@ $filters--border-color: $gray !default
     @include text-shortener
     margin: auto 0
 
-fieldset#date-range
-  p
-    margin: 2px 0 2px 0
-
-  // Special case: simple filters with a radiobutton
-  .simple-filters--filter
-    grid-template-columns: 10% repeat(auto-fill, 45%)
-    grid-template-rows: 50% 50%
-    grid-gap: 10px 0
-
-  .simple-filters--filter-name.form--label
-    grid-column: 2
-
-
 @include breakpoint(680px down)
-  .simple-filters--filter-value
-    grid-column: 1 / -1
-
-  fieldset#date-range
+  .simple-filters--filter:not(.-with-radio-buttons)
     .simple-filters--filter-value
-      grid-column: unset
+      grid-column: 1 / -1

--- a/app/views/timelog/_date_range.html.erb
+++ b/app/views/timelog/_date_range.html.erb
@@ -29,7 +29,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <fieldset id="date-range" class="simple-filters--container">
   <legend><%= l(:label_date_range) %></legend>
   <ul class="simple-filters--filters">
-    <li class="simple-filters--filter -full-width">
+    <li class="simple-filters--filter">
       <%= styled_label_tag "period_type_list", l(:description_date_range_list), class: "hidden-for-sighted simple-filters--filter-name" %>
       <%= styled_radio_button_tag 'period_type', '1',
                                   !@free_period,
@@ -40,7 +40,7 @@ See docs/COPYRIGHT.rdoc for more details.
                               class: "-narrow" %>
       </div>
     </li>
-    <li class="simple-filters--filter -full-width">
+    <li class="simple-filters--filter">
       <%= styled_label_tag "period_type_interval", l(:description_date_range_interval), class: "hidden-for-sighted simple-filters--filter-name" %>
       <%= styled_radio_button_tag 'period_type', '2', @free_period, id: "period_type_interval" %>
       <%= styled_label_tag("from", l(:label_date_from), class: 'simple-filters--filter-name') %>

--- a/app/views/timelog/_date_range.html.erb
+++ b/app/views/timelog/_date_range.html.erb
@@ -29,7 +29,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <fieldset id="date-range" class="simple-filters--container">
   <legend><%= l(:label_date_range) %></legend>
   <ul class="simple-filters--filters">
-    <li class="simple-filters--filter">
+    <li class="simple-filters--filter -with-radio-buttons">
       <%= styled_label_tag "period_type_list", l(:description_date_range_list), class: "hidden-for-sighted simple-filters--filter-name" %>
       <%= styled_radio_button_tag 'period_type', '1',
                                   !@free_period,
@@ -40,7 +40,7 @@ See docs/COPYRIGHT.rdoc for more details.
                               class: "-narrow" %>
       </div>
     </li>
-    <li class="simple-filters--filter">
+    <li class="simple-filters--filter -with-radio-buttons">
       <%= styled_label_tag "period_type_interval", l(:description_date_range_interval), class: "hidden-for-sighted simple-filters--filter-name" %>
       <%= styled_radio_button_tag 'period_type', '2', @free_period, id: "period_type_interval" %>
       <%= styled_label_tag("from", l(:label_date_from), class: 'simple-filters--filter-name') %>


### PR DESCRIPTION
Due to the leading radiobuttons the time sheet filters didn't fit into the generally used grid for simple filters.

https://community.openproject.com/projects/openproject/work_packages/29409/activity