### PR TITLE
Improve error logging with lograge and log delegators

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,9 @@ gem 'secure_headers', '~> 5.0.5'
 # Providing health checks
 gem 'okcomputer', '~> 1.16.0'
 
+# Lograge to provide sane and non-verbose logging
+gem 'lograge', '~> 0.10.0'
+
 gem 'gon', '~> 6.2.0'
 
 # catch exceptions and send them to any airbrake compatible backend

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,14 +78,14 @@ GIT
 PATH
   remote: modules/auth_plugins
   specs:
-    openproject-auth_plugins (8.2.0)
+    openproject-auth_plugins (8.2.1)
       omniauth (~> 1.0)
       rails (~> 5.0)
 
 PATH
   remote: modules/avatars
   specs:
-    openproject-avatars (8.2.0)
+    openproject-avatars (8.2.1)
       fastimage (~> 2.1.0)
       gravatar_image_tag (~> 1.2.0)
       rails (~> 5.0)
@@ -93,47 +93,47 @@ PATH
 PATH
   remote: modules/backlogs
   specs:
-    openproject-backlogs (8.2.0)
+    openproject-backlogs (8.2.1)
       acts_as_silent_list (~> 3.0.0)
-      openproject-pdf_export (= 8.2.0)
+      openproject-pdf_export (= 8.2.1)
 
 PATH
   remote: modules/costs
   specs:
-    openproject-costs (8.2.0)
+    openproject-costs (8.2.1)
 
 PATH
   remote: modules/documents
   specs:
-    openproject-documents (8.2.0)
+    openproject-documents (8.2.1)
 
 PATH
   remote: modules/github_integration
   specs:
-    openproject-github_integration (8.2.0)
+    openproject-github_integration (8.2.1)
       openproject-webhooks
       rails (~> 5.0)
 
 PATH
   remote: modules/global_roles
   specs:
-    openproject-global_roles (8.2.0)
+    openproject-global_roles (8.2.1)
 
 PATH
   remote: modules/meeting
   specs:
-    openproject-meeting (8.2.0)
+    openproject-meeting (8.2.1)
       icalendar (~> 2.3.0)
 
 PATH
   remote: modules/my_project_page
   specs:
-    openproject-my_project_page (8.2.0)
+    openproject-my_project_page (8.2.1)
 
 PATH
   remote: modules/openid_connect
   specs:
-    openproject-openid_connect (8.2.0)
+    openproject-openid_connect (8.2.1)
       lobby_boy (~> 0.1.3)
       omniauth-openid_connect-providers (~> 0.1)
       openproject-auth_plugins (~> 8.0)
@@ -142,29 +142,29 @@ PATH
 PATH
   remote: modules/pdf_export
   specs:
-    openproject-pdf_export (8.2.0)
+    openproject-pdf_export (8.2.1)
       pdf-inspector (~> 1.3.0)
       prawn (~> 2.2)
 
 PATH
   remote: modules/reporting_engine
   specs:
-    reporting_engine (8.2.0)
+    reporting_engine (8.2.1)
       json
       rails (~> 5.1.0)
 
 PATH
   remote: modules/reporting
   specs:
-    openproject-reporting (8.2.0)
+    openproject-reporting (8.2.1)
       jquery-tablesorter (~> 1.25.5)
-      openproject-costs (= 8.2.0)
+      openproject-costs (= 8.2.1)
       reporting_engine (>= 1.1.0)
 
 PATH
   remote: modules/two_factor_authentication
   specs:
-    openproject-two_factor_authentication (8.2.0)
+    openproject-two_factor_authentication (8.2.1)
       aws-sdk-sns (~> 1.1.0)
       messagebird-rest (~> 1.3.2)
       rails (~> 5)
@@ -173,13 +173,13 @@ PATH
 PATH
   remote: modules/webhooks
   specs:
-    openproject-webhooks (8.2.0)
+    openproject-webhooks (8.2.1)
       rails (~> 5.0)
 
 PATH
   remote: modules/xls_export
   specs:
-    openproject-xls_export (8.2.0)
+    openproject-xls_export (8.2.1)
       spreadsheet (~> 0.8.9)
 
 GEM
@@ -397,7 +397,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.8.4)
       i18n (~> 0.5)
-    fastimage (2.1.4)
+    fastimage (2.1.5)
     ffi (1.9.25)
     flamegraph (0.9.5)
     fog-aws (0.11.0)
@@ -485,6 +485,11 @@ GEM
       omniauth (~> 1.1)
       omniauth-openid-connect (>= 0.2.1)
       rails (>= 3.2.21)
+    lograge (0.10.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -545,7 +550,7 @@ GEM
     pdf-core (0.7.0)
     pdf-inspector (1.3.0)
       pdf-reader (>= 1.0, < 3.0.a)
-    pdf-reader (2.1.0)
+    pdf-reader (2.2.0)
       Ascii85 (~> 1.0.0)
       afm (~> 0.2.1)
       hashery (~> 2.0)
@@ -871,6 +876,7 @@ DEPENDENCIES
   launchy (~> 2.4.3)
   letter_opener
   livingstyleguide (~> 2.0.1)
+  lograge (~> 0.10.0)
   meta-tags (~> 2.6.0)
   multi_json (~> 1.12.1)
   mysql2 (~> 0.5.0)
@@ -975,4 +981,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,6 +44,7 @@ class ApplicationController < ActionController::Base
   include HookHelper
   include ::OpenProject::Authentication::SessionExpiry
   include AdditionalUrlHelpers
+  include OpenProjectErrorHelper
 
   layout 'base'
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -101,6 +101,9 @@ class ApplicationController < ActionController::Base
       # greeted with the CSRF error upon login.
       message = I18n.t(:error_token_authenticity)
       message << ' ' + I18n.t(:error_cookie_missing) if openproject_cookie_missing?
+
+      log_csrf_failure
+
       render_error status: 422, message: message
     end
   end
@@ -218,6 +221,15 @@ class ApplicationController < ActionController::Base
     request.cookies[OpenProject::Configuration['session_cookie_name']].nil?
   end
   helper_method :openproject_cookie_missing?
+
+  ##
+  # Create CSRF issue
+  def log_csrf_failure
+    message = 'CSRF validation error'
+    message << ' (No session cookie present)' if openproject_cookie_missing?
+
+    op_handle_error message, reference: :csrf_validation_failed
+  end
 
   def log_requesting_user
     return unless Setting.log_requesting_user?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -505,6 +505,8 @@ class ApplicationController < ActionController::Base
     @message = l(@message) if @message.is_a?(Symbol)
     @status = arg[:status] || 500
 
+    op_handle_error "[Error #@status] #@message"
+
     respond_to do |format|
       format.html do
         render template: 'common/error', layout: use_layout, status: @status

--- a/app/helpers/open_project_error_helper.rb
+++ b/app/helpers/open_project_error_helper.rb
@@ -1,0 +1,35 @@
+##
+# Logging helper to forward to the OpenProject log delegator
+# which will log and report errors appropriately.
+module OpenProjectErrorHelper
+  def op_logger
+    ::OpenProject.logger
+  end
+
+  def op_handle_error(message_or_exception, context = {})
+    ::OpenProject.logger.error message_or_exception, context.merge(op_logging_context)
+  end
+
+  def op_handle_warning(message_or_exception, context = {})
+    ::OpenProject.logger.warn message_or_exception, context.merge(op_logging_context)
+  end
+
+  def op_handle_info(message_or_exception, context = {})
+    ::OpenProject.logger.info message_or_exception, context.merge(op_logging_context)
+  end
+
+  def op_handle_debug(message_or_exception, context = {})
+    ::OpenProject.logger.debug message_or_exception, context.merge(op_logging_context)
+  end
+
+  private
+
+  def op_logging_context
+    {
+      current_user: current_user,
+      params: params,
+      request: try(:request),
+      env: try(:env),
+    }
+  end
+end

--- a/app/helpers/open_project_error_helper.rb
+++ b/app/helpers/open_project_error_helper.rb
@@ -29,6 +29,7 @@ module OpenProjectErrorHelper
       current_user: current_user,
       params: params,
       request: try(:request),
+      session: try(:session),
       env: try(:env),
     }
   end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,9 @@
+Rails.application.configure do
+  config.lograge.enabled = true
+  config.lograge.base_controller_class = %w[ActionController::Base]
+
+  # Add custom data to event payload
+  config.lograge.custom_payload do |controller|
+    ::OpenProject::Logging::LogDelegator.controller_payload_hash controller
+  end
+end

--- a/lib/open_project.rb
+++ b/lib/open_project.rb
@@ -32,6 +32,7 @@ require 'redmine/menu_manager'
 require 'redmine/activity'
 require 'redmine/search'
 require 'open_project/custom_field_format'
+require 'open_project/logging/log_delegator'
 require 'redmine/mime_type'
 require 'redmine/core_ext'
 require 'open_project/design'
@@ -41,3 +42,13 @@ require 'redmine/plugin'
 require 'redmine/notifiable'
 
 require 'csv'
+
+module OpenProject
+
+  ##
+  # Shortcut to the OpenProject log delegator, which extends
+  # default Rails error handling with other error handlers such as sentry.
+  def self.logger
+    ::OpenProject::Logging::LogDelegator
+  end
+end

--- a/lib/open_project/logging/log_delegator.rb
+++ b/lib/open_project/logging/log_delegator.rb
@@ -1,0 +1,82 @@
+module OpenProject
+  module Logging
+    class LogDelegator
+      class << self
+
+        ##
+        # Consume a message and let it be handled
+        # by all handlers
+        def log(exception, context = {})
+          message =
+            if exception.is_a? Exception
+              context[:exception] = exception
+              context[:backtrace] = clean_backtrace(exception)
+              message = "#{exception}: #{exception.message}"
+            else
+              exception.to_s
+            end
+
+          # Set current contexts
+          context[:level] ||= context[:exception] ? :error : :info
+          context[:current_user] ||= User.current
+
+          registered_handlers.each do |handler|
+            handler.call message, context
+          end
+
+          nil
+        end
+
+        %i(debug info warn error fatal unknown).each do |level|
+          define_method(level) do |*args|
+            message = args.shift
+            context = args.shift || {}
+
+            log(message, context.merge(level: level))
+          end
+        end
+
+        ##
+        # Get a clean backtrace
+        def clean_backtrace(exception)
+          return nil unless exception&.backtrace
+          Rails.backtrace_cleaner.clean exception.backtrace
+        end
+
+        ##
+        # The active set of error handlers
+        def registered_handlers
+          @handlers ||= default_handlers
+        end
+
+        private
+
+        def default_handlers
+          [method(:rails_logger_handler)]
+        end
+
+        ##
+        # A lambda handler for logging the error
+        # to rails.
+        def rails_logger_handler(message, context = {})
+          Rails.logger.public_send(
+            context[:level],
+            message + context_string(context)
+          )
+
+          if backtrace = context[:backtrace]
+            Rails.logger.debug { backtrace.join($/) }
+          end
+        end
+
+        ##
+        # Create a context string
+        def context_string(context)
+          ''.tap do |str|
+            str << " [user=#{context[:user].id}]" if context[:user]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/open_project/logging/log_delegator.rb
+++ b/lib/open_project/logging/log_delegator.rb
@@ -11,7 +11,7 @@ module OpenProject
             if exception.is_a? Exception
               context[:exception] = exception
               context[:backtrace] = clean_backtrace(exception)
-              message = "#{exception}: #{exception.message}"
+              "#{exception}: #{exception.message}"
             else
               exception.to_s
             end
@@ -49,6 +49,14 @@ module OpenProject
           @handlers ||= default_handlers
         end
 
+        ##
+        # Create a payload for lograge from a controller request line
+        def controller_payload_hash(controller)
+          {
+            user: controller.send(:current_user).try(:id)
+          }
+        end
+
         private
 
         def default_handlers
@@ -61,19 +69,15 @@ module OpenProject
         def rails_logger_handler(message, context = {})
           Rails.logger.public_send(
             context[:level],
-            message + context_string(context)
+            context_string(context) + message
           )
-
-          if backtrace = context[:backtrace]
-            Rails.logger.debug { backtrace.join($/) }
-          end
         end
 
         ##
         # Create a context string
         def context_string(context)
           ''.tap do |str|
-            str << " [user=#{context[:user].id}]" if context[:user]
+            str << "[user=#{context[:current_user].id}] " if context[:current_user]
           end
         end
       end


### PR DESCRIPTION
- Adds lograge to straighten log reporting and adds reporting of errors inline
- Adds a `LogDelegator` that per default simply forwards to `Rails.logger` but builds and collects some extra context such as the current request, env, params, etc.

The latter will allow downstream repos implementing sentry to hook into this delegator.