### PR TITLE
Global search title component

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -255,7 +255,6 @@ input.top-menu-search--input.-expanded
   padding: 3px 4px
   margin-left: 5px
 
-
 .top-menu-search--loading
   top: $header-height
   left: 0

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -31,7 +31,7 @@ See docs/COPYRIGHT.rdoc for more details.
   <%= call_hook :search_index_head %>
   <%= include_gon(nonce: content_security_policy_script_nonce) %>
 <% end %>
-<%= toolbar title: l(:label_search) %>
+<global-search-title></global-search-title>
 
 <% current_module = params.slice(*@object_types).keys.first.to_s %>
 

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -829,3 +829,4 @@ en:
       title:
         all_projects: "all projects"
         project_and_subprojects: "and all subprojects"
+        search_for: "Search for"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -826,4 +826,6 @@ en:
       search: "Search"
       this_project: "In this project"
       this_project_and_all_descendants: "In this project + subprojects"
-
+      title:
+        all_projects: "all projects"
+        project_and_subprojects: "and all subprojects"

--- a/frontend/src/app/angular4-modules.ts
+++ b/frontend/src/app/angular4-modules.ts
@@ -82,6 +82,7 @@ import {FullCalendarModule} from "ng-fullcalendar";
 import {GlobalSearchService} from "core-components/global-search/global-search.service";
 import {GlobalSearchWorkPackagesComponent} from "core-components/global-search/global-search-work-packages.component";
 import {GlobalSearchTabsComponent} from "core-components/global-search/global-search-tabs.component";
+import {GlobalSearchTitleComponent} from "core-components/global-search/global-search-title.component";
 
 @NgModule({
   imports: [
@@ -155,6 +156,7 @@ import {GlobalSearchTabsComponent} from "core-components/global-search/global-se
     GlobalSearchInputComponent,
     GlobalSearchWorkPackagesComponent,
     GlobalSearchTabsComponent,
+    GlobalSearchTitleComponent,
 
     // Modals
     ConfirmDialogModal,
@@ -177,6 +179,7 @@ import {GlobalSearchTabsComponent} from "core-components/global-search/global-se
     GlobalSearchInputComponent,
     GlobalSearchWorkPackagesComponent,
     GlobalSearchTabsComponent,
+    GlobalSearchTitleComponent,
 
     // Project Auto completer
     ProjectMenuAutocompleteComponent,

--- a/frontend/src/app/components/global-search/global-search-input.component.ts
+++ b/frontend/src/app/components/global-search/global-search-input.component.ts
@@ -118,7 +118,7 @@ export class GlobalSearchInputComponent implements OnDestroy {
                          `${I18n.t('global_search.search')}: ${this.searchValue}`,
                               this.globalSearchService.searchPath());
         }
-
+        
         this.cdRef.detectChanges();
       });
 

--- a/frontend/src/app/components/global-search/global-search-title.component.html
+++ b/frontend/src/app/components/global-search/global-search-title.component.html
@@ -4,7 +4,7 @@
       <h2 [attr.title]="searchTitle">
         Search for
         <i>"{{ searchTerm }}"</i>
-        {{ project !== '' ? 'in' : ''}}
+        {{ project === '' ? '' : text.in }}
         <i>{{ project }}</i>
       </h2>
       <ul class="toolbar-items"></ul>

--- a/frontend/src/app/components/global-search/global-search-title.component.html
+++ b/frontend/src/app/components/global-search/global-search-title.component.html
@@ -1,0 +1,13 @@
+<div class="toolbar-container">
+  <div class="toolbar">
+    <div class="title-container">
+      <h2 [attr.title]="searchTerm">
+        Search for
+        <i>"{{ searchTerm }}"</i>
+        {{ project !== '' ? 'in' : ''}}
+        <i>{{ project }}</i>
+        {{ projectScope === '' ? 'and all Subprojects' : ''}} </h2>
+      <ul class="toolbar-items"></ul>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/global-search/global-search-title.component.html
+++ b/frontend/src/app/components/global-search/global-search-title.component.html
@@ -1,12 +1,12 @@
 <div class="toolbar-container">
   <div class="toolbar">
     <div class="title-container">
-      <h2 [attr.title]="searchTerm">
+      <h2 [attr.title]="searchTitle">
         Search for
         <i>"{{ searchTerm }}"</i>
         {{ project !== '' ? 'in' : ''}}
         <i>{{ project }}</i>
-        {{ projectScope === '' ? 'and all Subprojects' : ''}} </h2>
+      </h2>
       <ul class="toolbar-items"></ul>
     </div>
   </div>

--- a/frontend/src/app/components/global-search/global-search-title.component.ts
+++ b/frontend/src/app/components/global-search/global-search-title.component.ts
@@ -1,0 +1,105 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+import {
+  ChangeDetectorRef,
+  Component,
+  Input,
+  ElementRef,
+  HostListener,
+  OnDestroy,
+  Renderer2,
+  ViewChild
+} from '@angular/core';
+import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
+import {BehaviorSubject} from 'rxjs';
+import {distinctUntilChanged} from 'rxjs/operators';
+import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
+import {combineLatest} from 'rxjs';
+import {GlobalSearchService} from "core-components/global-search/global-search.service";
+import {CurrentProjectService} from "core-components/projects/current-project.service";
+import {Injector} from "@angular/core";
+// import {GlobalSearchInputComponent} from "core-components/global-search/global-search-input.component";
+
+export const globalSearchTitleSelector = 'global-search-title';
+
+@Component({
+  selector: 'global-search-title',
+  templateUrl: './global-search-title.component.html'
+})
+export class GlobalSearchTitleComponent implements OnDestroy {
+  @Input() public searchTerm:string;
+  @Input() public project:string;
+  @Input() public projectScope:string;
+
+  private currentProjectService:CurrentProjectService = this.injector.get(CurrentProjectService);
+
+  constructor(readonly elementRef:ElementRef,
+              readonly cdRef:ChangeDetectorRef,
+              readonly globalSearchService:GlobalSearchService,
+              protected injector:Injector) {
+  }
+
+  ngOnInit() {
+    // Listen on changes of search input value and project scope
+    combineLatest(
+        this.globalSearchService.searchTerm$,
+        this.globalSearchService.projectScope$
+    )
+    .pipe(
+      distinctUntilChanged(),
+      untilComponentDestroyed(this)
+    )
+    .subscribe(([newSearchTerm, newProjectScope]) => {
+      this.searchTerm = newSearchTerm;
+      this.projectScope = newProjectScope;
+      this.project = this.projectText(newProjectScope);
+
+      this.cdRef.detectChanges();
+    });
+
+  }
+
+  ngOnDestroy() {
+    // Nothing to do
+  }
+
+  private projectText(scope:string):string {
+    let currentProjectName = this.currentProjectService.name ? this.currentProjectService.name : '';
+
+    if(scope === 'all') {
+      return 'all projects';
+    } else {
+      return currentProjectName;
+    }
+  }
+}
+
+
+DynamicBootstrapper.register({
+  selector: globalSearchTitleSelector, cls: GlobalSearchTitleComponent
+});

--- a/frontend/src/app/components/global-search/global-search-title.component.ts
+++ b/frontend/src/app/components/global-search/global-search-title.component.ts
@@ -30,13 +30,9 @@ import {
   Component,
   Input,
   ElementRef,
-  HostListener,
-  OnDestroy,
-  Renderer2,
-  ViewChild
+  OnDestroy
 } from '@angular/core';
 import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
-import {BehaviorSubject} from 'rxjs';
 import {distinctUntilChanged} from 'rxjs/operators';
 import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {combineLatest} from 'rxjs';

--- a/frontend/src/app/components/global-search/global-search-title.component.ts
+++ b/frontend/src/app/components/global-search/global-search-title.component.ts
@@ -36,6 +36,7 @@ import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
 import {distinctUntilChanged} from 'rxjs/operators';
 import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {combineLatest} from 'rxjs';
+import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {GlobalSearchService} from "core-components/global-search/global-search.service";
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {Injector} from "@angular/core";
@@ -51,12 +52,19 @@ export class GlobalSearchTitleComponent implements OnDestroy {
   @Input() public searchTerm:string;
   @Input() public project:string;
   @Input() public projectScope:string;
+  @Input() public searchTitle:string;
 
   private currentProjectService:CurrentProjectService = this.injector.get(CurrentProjectService);
+
+  public text:{ [key:string]:string } = {
+    all_projects: this.I18n.t('js.global_search.title.all_projects'),
+    project_and_subprojects: this.I18n.t('js.global_search.title.project_and_subprojects')
+  };
 
   constructor(readonly elementRef:ElementRef,
               readonly cdRef:ChangeDetectorRef,
               readonly globalSearchService:GlobalSearchService,
+              readonly I18n:I18nService,
               protected injector:Injector) {
   }
 
@@ -72,8 +80,8 @@ export class GlobalSearchTitleComponent implements OnDestroy {
     )
     .subscribe(([newSearchTerm, newProjectScope]) => {
       this.searchTerm = newSearchTerm;
-      this.projectScope = newProjectScope;
       this.project = this.projectText(newProjectScope);
+      this.searchTitle = 'Search for ' + this.searchTerm + ' in ' + this.project;
 
       this.cdRef.detectChanges();
     });
@@ -86,10 +94,18 @@ export class GlobalSearchTitleComponent implements OnDestroy {
   private projectText(scope:string):string {
     let currentProjectName = this.currentProjectService.name ? this.currentProjectService.name : '';
 
-    if(scope === 'all') {
-      return 'all projects';
-    } else {
-      return currentProjectName;
+    switch(scope){
+      case 'all':
+        return this.text.all_projects;
+        break;
+      case 'current_project':
+        return currentProjectName;
+        break;
+      case '':
+        return currentProjectName + ' ' + this.text.project_and_subprojects;
+        break;
+      default:
+        return '';
     }
   }
 }

--- a/frontend/src/app/components/global-search/global-search-title.component.ts
+++ b/frontend/src/app/components/global-search/global-search-title.component.ts
@@ -81,7 +81,6 @@ export class GlobalSearchTitleComponent implements OnDestroy {
 
       this.cdRef.detectChanges();
     });
-
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/components/global-search/global-search-title.component.ts
+++ b/frontend/src/app/components/global-search/global-search-title.component.ts
@@ -40,7 +40,6 @@ import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {GlobalSearchService} from "core-components/global-search/global-search.service";
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {Injector} from "@angular/core";
-// import {GlobalSearchInputComponent} from "core-components/global-search/global-search-input.component";
 
 export const globalSearchTitleSelector = 'global-search-title';
 
@@ -58,7 +57,9 @@ export class GlobalSearchTitleComponent implements OnDestroy {
 
   public text:{ [key:string]:string } = {
     all_projects: this.I18n.t('js.global_search.title.all_projects'),
-    project_and_subprojects: this.I18n.t('js.global_search.title.project_and_subprojects')
+    project_and_subprojects: this.I18n.t('js.global_search.title.project_and_subprojects'),
+    search_for: this.I18n.t('js.global_search.title.search_for'),
+    in: this.I18n.t('js.label_in')
   };
 
   constructor(readonly elementRef:ElementRef,
@@ -81,7 +82,7 @@ export class GlobalSearchTitleComponent implements OnDestroy {
     .subscribe(([newSearchTerm, newProjectScope]) => {
       this.searchTerm = newSearchTerm;
       this.project = this.projectText(newProjectScope);
-      this.searchTitle = 'Search for ' + this.searchTerm + ' in ' + this.project;
+      this.searchTitle = `${this.text.search_for} ${this.searchTerm} ${this.project === '' ? '' : this.text.in} ${this.project}`;
 
       this.cdRef.detectChanges();
     });
@@ -94,7 +95,7 @@ export class GlobalSearchTitleComponent implements OnDestroy {
   private projectText(scope:string):string {
     let currentProjectName = this.currentProjectService.name ? this.currentProjectService.name : '';
 
-    switch(scope){
+    switch (scope) {
       case 'all':
         return this.text.all_projects;
         break;


### PR DESCRIPTION
This PR adds a title component for the global search which listens on changes of the 'global-search.service.ts' and updates the title (search term and project) automatically.

To-Do
- [x] Title incorrect when coming from a project (e.g. title says 'in all projects' although you wanted to search within the current project)
- [x] When changing the search tab (to anything else than work packages) the title will not update immediately like before
- [ ] Easier way to put the title together?