### PR TITLE
[29417] Missing translation in work package context menu

### DIFF
--- a/frontend/src/app/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
+++ b/frontend/src/app/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
@@ -119,7 +119,7 @@ export class WorkPackageSingleContextMenuDirective extends OpContextMenuTrigger 
         {
           href: configureFormLink.href,
           icon: 'icon-settings3',
-          linkText: configureFormLink.name,
+          linkText: I18n.t('js.button_configure-form'),
           onClick: () => false
         }
       );


### PR DESCRIPTION
Add localised string for „configure form“ menu entry.

https://community.openproject.com/projects/openproject/work_packages/29417/activity