### PR TITLE
Avoid brackets in mail subject prefix

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -313,9 +313,8 @@ class UserMailer < BaseMailer
 
   private
 
-  def subject_for_work_package(work_package)
-    subject =  "[#{work_package.project.name} - #{work_package.type.name} ##{work_package.id}] "
-    subject << "(#{work_package.status.name}) " << work_package.subject
+  def subject_for_work_package(wp)
+    "#{wp.project.name} - #{wp.status.name} #{wp.type.name} ##{wp.id}: #{wp.subject}"
   end
 
   # like #mail, but contains special author based filters

--- a/spec_legacy/unit/repository_spec.rb
+++ b/spec_legacy/unit/repository_spec.rb
@@ -107,7 +107,7 @@ describe Repository, type: :model do
     assert_equal 5, ActionMailer::Base.deliveries.size
     mail = ActionMailer::Base.deliveries.first
     assert_kind_of Mail::Message, mail
-    assert mail.subject.starts_with?("[#{fixed_work_package.project.name} - #{fixed_work_package.type.name} ##{fixed_work_package.id}]")
+    assert mail.subject.starts_with?("#{fixed_work_package.project.name} - #{fixed_work_package.status.name} #{fixed_work_package.type.name} ##{fixed_work_package.id}")
     assert mail.body.encoded.include?(
       "<strong>Status</strong> changed from <i title=\"#{old_status}\">#{old_status}</i> <br/><strong>to</strong> <i title=\"#{fixed_work_package.status}\">#{fixed_work_package.status}</i>"
     )


### PR DESCRIPTION
Replaces the square brackets of the mail subject project to conform with
RFC 5256

Now the mail subject is of the form:
`<Project> - <Status> <Type> #<ID>:<Subject>`

For example
Demo project - New Task #123456: This is the subject of the new task

https://community.openproject.com/wp/29415