### PR TITLE
On bulk copying, collect errors from dependent results

### DIFF
--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -32,13 +32,16 @@ class ServiceResult
   attr_accessor :success,
                 :errors,
                 :result,
+                :context,
                 :dependent_results
 
   def initialize(success: false,
                  errors: nil,
+                 context: {},
                  result: nil)
     self.success = success
     self.result = result
+    self.context = context
     self.errors = if errors
                     errors
                   elsif result.respond_to?(:errors)
@@ -68,6 +71,23 @@ class ServiceResult
   def all_errors
     [errors] + dependent_results.map(&:errors)
   end
+
+  ##
+  # Collect all present errors for the given result
+  # and dependent results.
+  #
+  # Returns a map of the service reuslt to the error object
+  def results_with_errors(include_self: true)
+    results =
+      if include_self
+        [self] + dependent_results
+      else
+        dependent_results
+      end
+
+    results.reject { |call| call.errors.empty? }
+  end
+
 
   def self_and_dependent
     [self] + dependent_results

--- a/app/services/work_packages/copy_service.rb
+++ b/app/services/work_packages/copy_service.rb
@@ -59,6 +59,8 @@ class WorkPackages::CopyService
       copy_watchers(copied.result)
     end
 
+    copied.context = { copied_from: work_package }
+
     copied
   end
 


### PR DESCRIPTION
Otherwise, when errors exist in children, only the parent will be marked invalid, but not the actual child that caused the error.

https://community.openproject.com/wp/29298