### PR TITLE
[Boards] Add card view for work packages

### DIFF
--- a/app/assets/stylesheets/content/_work_packages.sass
+++ b/app/assets/stylesheets/content/_work_packages.sass
@@ -65,3 +65,6 @@
 // Resizer
 @import work_packages/resizer/resizer
 
+// Cards
+@import work_packages/cards/cards
+

--- a/app/assets/stylesheets/content/work_packages/cards/_cards.sass
+++ b/app/assets/stylesheets/content/work_packages/cards/_cards.sass
@@ -1,0 +1,30 @@
+.work-package--cards-container
+  display: flex
+  flex-wrap: wrap
+
+  .work-package--card
+    min-width: 200px
+    border: 1px solid $widget-box-block-border-color
+    border-radius: 5px
+    padding: 5px 5px 5px 10px
+    margin-top: 10px
+    background-color: #eeeeee6e
+
+  .work-package--card--subject .wp-edit-field--container
+    margin-left: -5px
+
+  .work-package--card--additional-info-container
+    margin-top: 15px
+
+    .work-package--card--additional-info
+      display: flex
+      line-height: 22px
+
+      .work-package--card--additional-info-attribute
+        max-width: 50%
+        @include text-shortener
+        margin-right: 5px
+
+      wp-edit-field
+        width: initial
+

--- a/app/assets/stylesheets/openproject/_generic.sass
+++ b/app/assets/stylesheets/openproject/_generic.sass
@@ -72,3 +72,11 @@
 
   span + span:before
     content: "| "
+
+.-bold
+  font-weight: bold
+.-italic
+  font-style: italic
+.-small-font
+  font-size: 12px
+

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -311,6 +311,7 @@ en:
     label_add_description: "Add a description for %{file}"
     label_upload_notification: "Uploading files..."
     label_work_package_upload_notification: "Uploading files for Work package #%{id}: %{subject}"
+    label_wp_id_added_by: "#%{id} added by %{author}"
     label_files_to_upload: "These files will be uploaded:"
     label_rejected_files: "These files cannot be uploaded:"
     label_rejected_files_reason: "These files cannot be uploaded as their size is greater than %{maximumFilesize}"

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.html
@@ -1,0 +1,27 @@
+<div class="work-package--cards-container -small-font">
+  <div class="work-package--card"
+       *ngFor="let wp of workPackages">
+
+    <wp-edit-field-group [workPackage]="wp">
+      <wp-edit-field [workPackageId]="wp.id"
+                     fieldName="subject"
+                     class="work-package--card--subject -bold">
+      </wp-edit-field>
+
+      <div class="work-package--card--author -italic"
+           [textContent]="text.wp_id_added_by(wp)">
+      </div>
+
+      <div class="work-package--card--additional-info-container">
+        <div *ngFor="let column of availableColumns"
+             class="work-package--card--additional-info">
+            <span [textContent]="column.name + ':'"
+                  class="work-package--card--additional-info-attribute"></span>
+            <wp-edit-field [workPackageId]="wp.id"
+                           [fieldName]="column.id">
+            </wp-edit-field>
+        </div>
+      </div>
+    </wp-edit-field-group>
+  </div>
+</div>

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -1,0 +1,130 @@
+import {ChangeDetectorRef, Component, Injector, OnInit} from "@angular/core";
+import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
+import {TableState} from "core-components/wp-table/table-state/table-state";
+import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {QueryColumn} from "app/components/wp-query/query-column";
+import {combine} from "reactivestates/dist";
+import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
+import {WorkPackageEmbeddedTableComponent} from "core-components/wp-table/embedded/wp-embedded-table.component";
+import {QueryDmService} from "core-app/modules/hal/dm-services/query-dm.service";
+import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {UrlParamsHelperService} from "app/components/wp-query/url-params-helper";
+import {LoadingIndicatorService} from "core-app/modules/common/loading-indicator/loading-indicator.service";
+import {WorkPackageStatesInitializationService} from "core-components/wp-list/wp-states-initialization.service";
+import {CurrentProjectService} from "core-components/projects/current-project.service";
+import {OpModalService} from "core-components/op-modals/op-modal.service";
+import {OpTableActionsService} from "core-components/wp-table/table-actions/table-actions.service";
+import {WorkPackageEmbeddedBaseComponent} from "core-components/wp-table/embedded/wp-embedded-base.component";
+import {WorkPackageTableTimelineService} from "core-components/wp-fast-table/state/wp-table-timeline.service";
+import {WorkPackageTablePaginationService} from "core-components/wp-fast-table/state/wp-table-pagination.service";
+import {WorkPackageInlineCreateService} from "core-components/wp-inline-create/wp-inline-create.service";
+import {WorkPackageTableRelationColumnsService} from "core-components/wp-fast-table/state/wp-table-relation-columns.service";
+import {WorkPackageTableHierarchiesService} from "core-components/wp-fast-table/state/wp-table-hierarchy.service";
+import {WorkPackageTableGroupByService} from "core-components/wp-fast-table/state/wp-table-group-by.service";
+import {WorkPackageTableFiltersService} from "core-components/wp-fast-table/state/wp-table-filters.service";
+import {WorkPackageTableColumnsService} from "core-components/wp-fast-table/state/wp-table-columns.service";
+import {WorkPackageTableSortByService} from "core-components/wp-fast-table/state/wp-table-sort-by.service";
+import {WorkPackageTableSelection} from "core-components/wp-fast-table/state/wp-table-selection.service";
+import {WorkPackageTableSumService} from "core-components/wp-fast-table/state/wp-table-sum.service";
+import {WorkPackageTableAdditionalElementsService} from "core-components/wp-fast-table/state/wp-table-additional-elements.service";
+import {WorkPackageTableRefreshService} from "core-components/wp-table/wp-table-refresh-request.service";
+import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
+import {IWorkPackageCreateServiceToken} from "core-components/wp-new/wp-create.service.interface";
+import {WorkPackageCreateService} from "core-components/wp-new/wp-create.service";
+import {WorkPackageTableConfiguration} from "core-components/wp-table/wp-table-configuration";
+
+
+@Component({
+  selector: 'wp-card-view',
+  templateUrl: './wp-card-view.component.html',
+  providers: [
+    TableState,
+    OpTableActionsService,
+    WorkPackageInlineCreateService,
+    WorkPackageTableRelationColumnsService,
+    WorkPackageTablePaginationService,
+    WorkPackageTableGroupByService,
+    WorkPackageTableHierarchiesService,
+    WorkPackageTableSortByService,
+    WorkPackageTableColumnsService,
+    WorkPackageTableFiltersService,
+    WorkPackageTableTimelineService,
+    WorkPackageTableSelection,
+    WorkPackageTableSumService,
+    WorkPackageTableAdditionalElementsService,
+    WorkPackageTableRefreshService,
+    WorkPackageTableHighlightingService,
+    { provide: IWorkPackageCreateServiceToken, useClass: WorkPackageCreateService },
+    // Order is important here, to avoid this service
+    // getting global injections
+    WorkPackageStatesInitializationService,
+  ]
+})
+export class WorkPackageCardViewComponent extends WorkPackageEmbeddedTableComponent implements OnInit {
+  public query:QueryResource;
+  public workPackages:any[];
+  public columns:QueryColumn[];
+  public availableColumns:QueryColumn[];
+  public text:any = {
+    wp_id_added_by: this.I18n.t('js.label_wp_id_added_by', {id: '', author: ''})
+  };
+
+  constructor(readonly QueryDm:QueryDmService,
+              readonly tableState:TableState,
+              readonly injector:Injector,
+              readonly opModalService:OpModalService,
+              readonly I18n:I18nService,
+              readonly urlParamsHelper:UrlParamsHelperService,
+              readonly loadingIndicatorService:LoadingIndicatorService,
+              readonly tableActionsService:OpTableActionsService,
+              readonly wpTableTimeline:WorkPackageTableTimelineService,
+              readonly wpTablePagination:WorkPackageTablePaginationService,
+              readonly wpStatesInitialization:WorkPackageStatesInitializationService,
+              readonly currentProject:CurrentProjectService,
+              readonly cdRef:ChangeDetectorRef) {
+    super(QueryDm,
+          tableState,
+          injector,
+          opModalService,
+          I18n,
+          urlParamsHelper,
+          loadingIndicatorService,
+          tableActionsService,
+          wpTableTimeline,
+          wpTablePagination,
+          wpStatesInitialization,
+          currentProject);
+  }
+
+  ngOnInit() {
+    super.ngOnInit();
+
+    this.text.wp_id_added_by = (wp:WorkPackageResource) =>
+     this.I18n.t('js.label_wp_id_added_by', {id: wp.id, author: wp.author.name});
+
+    combine(
+      this.tableState.columns,
+      this.tableState.results
+    )
+    .values$()
+    .pipe(
+      untilComponentDestroyed(this)
+    )
+    .subscribe(([columns, results]) => {
+      this.workPackages = results.$embedded.elements;
+      console.log(this.workPackages);
+
+      this.columns = columns.current;
+      this.availableColumns = this.columns.filter(function (column) {
+        return column.id != 'id' && column.id != 'subject' && column.id != 'author';
+      });
+      console.log(this.availableColumns);
+
+      this.cdRef.detectChanges();
+    });
+  }
+
+  ngOnDestroy():void {
+
+  }
+}

--- a/frontend/src/app/components/wp-table/wp-table-configuration.ts
+++ b/frontend/src/app/components/wp-table/wp-table-configuration.ts
@@ -60,6 +60,9 @@ export class WorkPackageTableConfiguration {
   /** Whether this table is in an embedded context*/
   public isEmbedded:boolean = false;
 
+  /** Whether the work packages shall be shown in cards instead of a table */
+  public isCardView:boolean = false;
+
   constructor(private providedConfig:WorkPackageTableConfigurationObject) {
     _.each(providedConfig, (value, k) => {
       let key = (k as keyof WorkPackageTableConfiguration);

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.html
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.html
@@ -8,10 +8,15 @@
            name="board_list_name"
            type="text" />
 
-    <wp-embedded-table [queryId]="query.id"
+    <wp-embedded-table *ngIf="boardTableConfiguration.isEmbedded && !boardTableConfiguration.isCardView"
+                       [queryId]="query.id"
                        [loadedQuery]="query"
                        [queryProps]="columnsQueryProps"
                        [configuration]="boardTableConfiguration">
     </wp-embedded-table>
+
+    <wp-card-view *ngIf="boardTableConfiguration.isCardView"
+                  [loadedQuery]="query"
+                  [queryProps]="columnsQueryProps"></wp-card-view>
   </ng-container>
 </div>

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -82,7 +82,8 @@ export class BoardListComponent implements OnInit, OnDestroy {
       columnMenuEnabled: false,
       actionsColumnEnabled: false,
       dragAndDropEnabled: true,
-      isEmbedded: true
+      isEmbedded: true,
+      isCardView: false
     };
   }
 

--- a/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
@@ -188,6 +188,7 @@ import {WorkPackageFilterByTextInputComponent} from "core-components/filters/qui
 import {CdkDragPortalBody} from "core-components/wp-fast-table/builders/drag-and-drop/cdk-drag-portal-body";
 import {QueryFiltersService} from "core-components/wp-query/query-filters.service";
 import {ReorderQueryService} from "core-app/modules/boards/drag-and-drop/reorder-query.service";
+import {WorkPackageCardViewComponent} from "core-components/wp-card-view/wp-card-view.component";
 
 @NgModule({
   imports: [
@@ -425,6 +426,9 @@ import {ReorderQueryService} from "core-app/modules/boards/drag-and-drop/reorder
     EmbeddedTablesMacroComponent,
     WpButtonMacroModal,
     CdkDragPortalBody,
+
+    // Card view
+    WorkPackageCardViewComponent,
   ],
   entryComponents: [
     // Split view
@@ -497,9 +501,13 @@ import {ReorderQueryService} from "core-app/modules/boards/drag-and-drop/reorder
     EmbeddedTablesMacroComponent,
     WpButtonMacroModal,
     CdkDragPortalBody,
+
+    // Card view
+    WorkPackageCardViewComponent,
   ],
   exports: [
     WorkPackageEmbeddedTableComponent,
+    WorkPackageCardViewComponent,
     WorkPackageFilterButtonComponent,
     WorkPackageFilterContainerComponent,
   ]


### PR DESCRIPTION
Introduce card view component for work packages. For now it is a basic component which inherits from the embeddedTable to access the loaded query. 

It can then be used as alternative display setting for work packages tables, initially made for the board view.


### ToDo
- [x] Add card view component
  - [x] Show WP which result from the given query
  - [x] Show all attributes which were defined as columns in the table
- [x] Styling according to visuals (further styling improvements are currently out of scope)

### Nice to have
- [ ] Drag'n'Drop between the lists of a board is possible (similar to the table rows)