### PR TITLE
[29448] WP content does not close right side gap

### DIFF
--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -194,6 +194,7 @@
 
   > .toolbar-container
     margin: 10px 0 5px 0
+    padding-right: 15px
 
 .work-packages--subject-type-row
   display: flex

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -33,6 +33,7 @@
 
       #main
         #content-wrapper
+          padding: 10px 20px
           &.nomenus
             top: 0
             padding: 0
@@ -78,9 +79,6 @@
     .work-packages-tabletimeline--table-side
       contain: none
 
-    .work-packages-list-view--container
-      padding: 0 5px 0 5px
-
     .toolbar-container
       padding-right: 0
 
@@ -119,7 +117,6 @@
       font-size: 0.9rem
 
     .work-package--new-state
-      overflow: auto
       height: 100%
       padding-right: 0
 

--- a/app/assets/stylesheets/layout/work_packages/_table.sass
+++ b/app/assets/stylesheets/layout/work_packages/_table.sass
@@ -33,7 +33,8 @@
     #main
       top: 12px
 
-.controller-work_packages.action-index:not(.action-show):not(.full-create)
+.controller-work_packages.action-index:not(.full-create),
+.controller-work_packages.action-show:not(.full-create)
   #content-wrapper
     padding: 0 0 0 20px
 


### PR DESCRIPTION
Move content WP full view to right side end of the screen

https://community.openproject.com/projects/openproject/work_packages/29448/activity