### PR TITLE
[29468] Deactivate option "Use current date as start date for new work packages" by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -328,7 +328,7 @@ emails_header:
   default:
     en: ''
 work_package_startdate_is_adddate:
-  default: 1
+  default: 0
   format: boolean
 user_default_timezone:
   default: ""


### PR DESCRIPTION
Change default value for `work_package_startdate_is_adddate` setting.

https://community.openproject.com/projects/openproject/work_packages/29468/activity