### PR TITLE
[29423] Replace class '-hidden-content' in generic tables

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -220,18 +220,18 @@ thead.-sticky th
   &.hover
     background:   #f8f8f8
 
-  &.-hidden-content
-    .generic-table--header,
-    .generic-table--sort-header
-      visibility: hidden
-      // Matches the min-width of .generic-table--header, .generic-table--sort-header
-      max-width: 40px
-
 .generic-table--empty-header
   padding:       0 6px
   height:        $generic-table--header-height
   border-bottom: 1px solid $table-row-border-color
   z-index:       1
+
+  // In case the table header contains invisible content for screen readers
+  .generic-table--header,
+  .generic-table--sort-header
+    visibility: hidden
+    // Matches the min-width of .generic-table--header, .generic-table--sort-header
+    max-width: 40px
 
 .generic-table--column-spacer
   white-space:  nowrap

--- a/app/views/repositories/_revisions.html.erb
+++ b/app/views/repositories/_revisions.html.erb
@@ -59,7 +59,7 @@ See docs/COPYRIGHT.rdoc for more details.
               </div>
             </th>
             <th>
-              <div class="generic-table--header-outer -hidden-content">
+              <div class="generic-table--empty-header">
                 <div class="generic-table--header">
                   <span>
                     <%= t(:description_compare_from) + ' ' + t(:label_changeset) %>
@@ -68,7 +68,7 @@ See docs/COPYRIGHT.rdoc for more details.
               </div>
             </th>
             <th>
-              <div class="generic-table--header-outer -hidden-content">
+              <div class="generic-table--empty-header">
                 <div class="generic-table--header">
                   <span>
                     <%= t(:description_compare_to) + ' ' + t(:label_changeset) %>

--- a/app/views/wiki/history.html.erb
+++ b/app/views/wiki/history.html.erb
@@ -64,7 +64,7 @@ See docs/COPYRIGHT.rdoc for more details.
             </th>
             </th>
             <th>
-              <div class="generic-table--header-outer -hidden-content">
+              <div class="generic-table--empty-header">
                 <div class="generic-table--header">
                   <span>
                     <%= t(:description_compare_from) + ' ' + t(:label_version) %>
@@ -73,7 +73,7 @@ See docs/COPYRIGHT.rdoc for more details.
               </div>
             </th>
             <th>
-              <div class="generic-table--header-outer -hidden-content">
+              <div class="generic-table--empty-header">
                 <div class="generic-table--header">
                   <span>
                     <%= t(:description_compare_to) + ' ' + t(:label_version) %>


### PR DESCRIPTION
Remove `-hidden-content` class for tables and replace it with `generic-table--empty-header`.

https://community.openproject.com/projects/openproject/work_packages/29423/activity