### PR TITLE
Epic/boards backend

### DIFF
--- a/db/migrate/20190129083842_add_project_to_grid.rb
+++ b/db/migrate/20190129083842_add_project_to_grid.rb
@@ -1,0 +1,7 @@
+class AddProjectToGrid < ActiveRecord::Migration[5.2]
+  def change
+    change_table :grids do |t|
+      t.references :project
+    end
+  end
+end

--- a/docs/api/apiv3/endpoints/grids.apib
+++ b/docs/api/apiv3/endpoints/grids.apib
@@ -84,7 +84,7 @@ Currently, the following pages employ grids:
                 "createdAt": "2018-12-03T16:58:30Z",
                 "updatedAt": "2018-12-13T19:36:40Z",
                 "_links": {
-                    "page": {
+                    "scope": {
                         "href": "/my/page",
                         "type": "text/html"
                     },
@@ -173,7 +173,7 @@ Currently, the following pages employ grids:
                             "createdAt": "2018-12-03T16:58:30Z",
                             "updatedAt": "2018-12-13T19:36:40Z",
                             "_links": {
-                                "page": {
+                                "scope": {
                                     "href": "/my/page",
                                     "type": "text/html"
                                 },
@@ -189,19 +189,70 @@ Currently, the following pages employ grids:
                                     "href": "/api/v3/grids/2"
                                 }
                             }
+                        },
+                        {
+                            "_type": "Grid",
+                            "id": 5,
+                            "rowCount": 1,
+                            "columnCount": 4,
+                            "widgets": [
+                                {
+                                    "_type": "GridWidget",
+                                    "identifier": "work_package_query",
+                                    "startRow": 1,
+                                    "endRow": 8,
+                                    "startColumn": 1,
+                                    "endColumn": 3
+                                },
+                                {
+                                    "_type": "GridWidget",
+                                    "identifier": "work_package_query",
+                                    "startRow": 3,
+                                    "endRow": 8,
+                                    "startColumn": 4,
+                                    "endColumn": 5
+                                },
+                                {
+                                    "_type": "GridWidget",
+                                    "identifier": "work_package_query",
+                                    "startRow": 1,
+                                    "endRow": 3,
+                                    "startColumn": 3,
+                                    "endColumn": 6
+                                }
+                            ],
+                            "createdAt": "2019-01-05T16:58:30Z",
+                            "updatedAt": "2019-01-07T19:36:40Z",
+                            "_links": {
+                                "scope": {
+                                    "href": "/projects/a_project/boards",
+                                    "type": "text/html"
+                                },
+                                "updateImmediately": {
+                                    "href": "/api/v3/grids/5",
+                                    "method": "patch"
+                                },
+                                "update": {
+                                    "href": "/api/v3/grids/5/form",
+                                    "method": "post"
+                                },
+                                "self": {
+                                    "href": "/api/v3/grids/5"
+                                }
+                            }
                         }
                     ]
                 },
                 "_links": {
                     "self": {
-                        "href": "/api/v3/time_entries?offset=1&pageSize=30"
+                        "href": "/api/v3/grids?offset=1&pageSize=30"
                     },
                     "jumpTo": {
-                        "href": "/api/v3/time_entries?offset=%7Boffset%7D&pageSize=30",
+                        "href": "/api/v3/grids?offset=%7Boffset%7D&pageSize=30",
                         "templated": true
                     },
                     "changeSize": {
-                        "href": "/api/v3/time_entries?offset=1&pageSize=%7Bsize%7D",
+                        "href": "/api/v3/grids?offset=1&pageSize=%7Bsize%7D",
                         "templated": true
                     }
                 }
@@ -286,7 +337,7 @@ Creates a new grid applying the attributes provided in the body. The constraints
                      }
                 ],
                 "_links": {
-                    "page": {
+                    "scope": {
                         "href": "/my/page"
                     }
                 }
@@ -467,7 +518,7 @@ A page link must be provided in the body when calling this end point.
                             }
                         ],
                         "_links": {
-                            "page": {
+                            "scope": {
                                 "href": "/my/page",
                                 "type": "text/html"
                             }
@@ -510,7 +561,7 @@ A page link must be provided in the body when calling this end point.
                             "hasDefault": false,
                             "writable": true
                         },
-                        "page": {
+                        "scope": {
                             "type": "Href",
                             "name": "Page",
                             "required": true,
@@ -707,7 +758,7 @@ For more details and all possible responses see the general specification of [Fo
                             "hasDefault": false,
                             "writable": true
                         },
-                        "page": {
+                        "scope": {
                             "type": "Href",
                             "name": "Page",
                             "required": true,

--- a/frontend/src/app/components/routing/my-page/my-page.component.ts
+++ b/frontend/src/app/components/routing/my-page/my-page.component.ts
@@ -33,7 +33,7 @@ export class MyPageComponent implements OnInit {
   private loadMyPage():Promise<GridResource> {
     return this
              .gridDm
-             .list({ filters: [['page', '=', [this.pathHelper.myPagePath()]]] })
+             .list({ filters: [['scope', '=', [this.pathHelper.myPagePath()]]] })
              .then(collection => {
                if (collection.total === 0) {
                  return this.myPageForm();
@@ -47,7 +47,7 @@ export class MyPageComponent implements OnInit {
     return new Promise<GridResource>((resolve, reject) => {
       let payload = {
         '_links': {
-          'page': {
+          'scope': {
             'href': this.pathHelper.myPagePath()
           }
         }

--- a/modules/boards/app/models/boards/grid.rb
+++ b/modules/boards/app/models/boards/grid.rb
@@ -33,14 +33,5 @@ require_dependency 'grids/grid'
 module Boards
   class Grid < ::Grids::Grid
     belongs_to :project
-
-    def self.new_default(user: nil, project:)
-      new(
-        project: project,
-        row_count: 1,
-        column_count: 4,
-        widgets: []
-      )
-    end
   end
 end

--- a/modules/boards/app/models/boards/grid.rb
+++ b/modules/boards/app/models/boards/grid.rb
@@ -42,28 +42,5 @@ module Boards
         widgets: []
       )
     end
-
-    def writable?(user)
-      super &&
-        Project.allowed_to(user, :manage_boards).exists?(project_id)
-    end
-
-    class << self
-      alias_method :super_visible, :visible
-
-      def visible(user = User.current)
-        in_project_with_permission(user, :view_boards)
-          .or(in_project_with_permission(user, :manage_boards))
-      end
-
-      private
-
-      def in_project_with_permission(user, permission)
-        super_visible
-          .where(project_id: Project.allowed_to(user, permission))
-      end
-    end
-
-    private_class_method :super_visible
   end
 end

--- a/modules/boards/config/routes.rb
+++ b/modules/boards/config/routes.rb
@@ -1,4 +1,6 @@
 OpenProject::Application.routes.draw do
+  get '/boards/:id', to: 'boards/boards#index', as: 'board'
+
   scope '', as: 'boards' do
     scope 'projects/:project_id', as: 'project' do
       get '/boards(/*state)', to: 'boards/boards#index'

--- a/modules/boards/lib/open_project/boards/engine.rb
+++ b/modules/boards/lib/open_project/boards/engine.rb
@@ -41,35 +41,7 @@ module OpenProject::Boards
     end
 
     config.to_prepare do
-      Grids::Configuration.register_grid('Boards::Grid',
-                                         ->(path) {
-                                           begin
-                                             recognized = Rails.application.routes.recognize_path(path)
-
-                                             if recognized[:controller] == 'boards/boards'
-                                               recognized.slice(:project_id, :id, :user_id)&.merge(class: Boards::Grid)
-                                             end
-                                           rescue ActionController::RoutingError
-                                             nil
-                                           end
-                                         },
-                                         :project_boards_path,
-                                         -> {
-                                           view_allowed = Project.allowed_to(User.current, :view_boards)
-                                           manage_allowed = Project.allowed_to(User.current, :manage_boards)
-
-                                           board_projects = Project
-                                                              .where(id: view_allowed)
-                                                              .or(Project.where(id: manage_allowed))
-
-                                           url_helper = OpenProject::StaticRouting::StaticUrlHelpers.new
-
-                                           paths = board_projects.map { |p| url_helper.project_boards_path(p) }
-
-                                           paths if paths.any?
-                                         })
-
-      Grids::Configuration.register_widget('work_package_query', 'Boards::Grid')
+      OpenProject::Boards::GridRegistration.register!
     end
   end
 end

--- a/modules/boards/lib/open_project/boards/grid_registration.rb
+++ b/modules/boards/lib/open_project/boards/grid_registration.rb
@@ -6,6 +6,12 @@ module OpenProject
 
       widgets 'work_package_query'
 
+      defaults(
+        row_count: 1,
+        column_count: 4,
+        widgets: []
+      )
+
       class << self
         def from_scope(scope)
           recognized = Rails.application.routes.recognize_path(scope)

--- a/modules/boards/lib/open_project/boards/grid_registration.rb
+++ b/modules/boards/lib/open_project/boards/grid_registration.rb
@@ -1,0 +1,56 @@
+module OpenProject
+  module Boards
+    class GridRegistration < ::Grids::Configuration::Registration
+      grid_class 'Boards::Grid'
+      to_scope :project_boards_path
+
+      widgets 'work_package_query'
+
+      class << self
+        def from_scope(scope)
+          recognized = Rails.application.routes.recognize_path(scope)
+
+          if recognized[:controller] == 'boards/boards'
+            recognized.slice(:project_id, :id, :user_id)&.merge(class: ::Boards::Grid)
+          end
+        rescue ActionController::RoutingError
+          nil
+        end
+
+        def all_scopes
+          view_allowed = Project.allowed_to(User.current, :view_boards)
+          manage_allowed = Project.allowed_to(User.current, :manage_boards)
+
+          board_projects = Project
+                           .where(id: view_allowed)
+                           .or(Project.where(id: manage_allowed))
+
+          paths = board_projects.map { |p| url_helpers.project_boards_path(p) }
+
+          paths if paths.any?
+        end
+
+        alias_method :super_visible, :visible
+
+        def visible(user = User.current)
+          in_project_with_permission(user, :view_boards)
+            .or(in_project_with_permission(user, :manage_boards))
+        end
+
+        def writable?(model, user)
+          super &&
+            Project.allowed_to(user, :manage_boards).exists?(model.project_id)
+        end
+
+        private
+
+        def in_project_with_permission(user, permission)
+          super_visible
+            .where(project_id: Project.allowed_to(user, permission))
+        end
+      end
+
+      private_class_method :super_visible
+    end
+  end
+end

--- a/modules/boards/spec/contracts/grids/create_contract_spec.rb
+++ b/modules/boards/spec/contracts/grids/create_contract_spec.rb
@@ -34,7 +34,7 @@ describe Grids::CreateContract, 'for Boards::Grid' do
   let(:project) { FactoryBot.build_stubbed(:project) }
   let(:user) { FactoryBot.build_stubbed(:user) }
   let(:grid) do
-    Boards::Grid.new_default(user: user, project: project)
+    FactoryBot.create(:board_grid, project: project)
   end
   include_context 'model contract'
 

--- a/modules/boards/spec/contracts/grids/create_contract_spec.rb
+++ b/modules/boards/spec/contracts/grids/create_contract_spec.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -25,26 +25,32 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# See docs/COPYRIGHT.rdoc for more details.
+# See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require_dependency 'grids/grid'
+require 'spec_helper'
 
-class BoardGrid < ::Grids::Grid
-  belongs_to :user
+describe Grids::CreateContract, 'for Boards::Grid' do
+  let(:project) { FactoryBot.build_stubbed(:project) }
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:grid) do
+    Boards::Grid.new_default(user: user, project: project)
+  end
+  include_context 'model contract'
 
-  def self.new_default(project = nil)
-    new(
-      # TODO project: project,
-      row_count: 1,
-      column_count: 4,
-      widgets: []
-    )
+  let(:instance) { described_class.new(grid, user) }
+
+  describe 'user_id' do
+    it_behaves_like 'is not writable' do
+      let(:attribute) { :user_id }
+      let(:value) { 5 }
+    end
   end
 
-  def self.visible_scope(project = nil)
-    # Use base class to avoid incompatibility scope merging
-    # TODO project scope
-    ::Grids::Grid.where(type: 'BoardGrid')
+  describe 'project_id' do
+    it_behaves_like 'is writable' do
+      let(:attribute) { :project_id }
+      let(:value) { 5 }
+    end
   end
 end

--- a/modules/boards/spec/factories/board_factory.rb
+++ b/modules/boards/spec/factories/board_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :board_grid, class: Boards::Grid do
+    project
+    row_count { 1 }
+    column_count { 4 }
+  end
+end

--- a/modules/boards/spec/lib/open_project/boards/grid_registration_spec.rb
+++ b/modules/boards/spec/lib/open_project/boards/grid_registration_spec.rb
@@ -1,7 +1,7 @@
 describe OpenProject::Boards::GridRegistration do
   let(:project) { FactoryBot.create(:project) }
   let(:permissions) { [:view_boards] }
-  let(:board) { Boards::Grid.new_default(project: project).tap(&:save!) }
+  let(:board) { FactoryBot.create(:board_grid, project: project) }
   let(:user) do
     FactoryBot.create(:user,
                       member_in_project: project,

--- a/modules/boards/spec/lib/open_project/boards/grid_registration_spec.rb
+++ b/modules/boards/spec/lib/open_project/boards/grid_registration_spec.rb
@@ -1,0 +1,37 @@
+describe OpenProject::Boards::GridRegistration do
+  let(:project) { FactoryBot.create(:project) }
+  let(:permissions) { [:view_boards] }
+  let(:board) { Boards::Grid.new_default(project: project).tap(&:save!) }
+  let(:user) do
+    FactoryBot.create(:user,
+                      member_in_project: project,
+                      member_with_permissions: permissions)
+  end
+
+  describe '.visible' do
+    context 'when having the view_boards permission' do
+      it 'returns the board' do
+        expect(described_class.visible(user))
+          .to match_array(board)
+      end
+    end
+
+    context 'when having the manage_boards permission' do
+      let(:permissions) { [:manage_boards] }
+
+      it 'returns the board' do
+        expect(described_class.visible(user))
+          .to match_array(board)
+      end
+    end
+
+    context 'when having neither of the permissions' do
+      let(:permissions) { [] }
+
+      it 'returns the board' do
+        expect(described_class.visible(user))
+          .to be_empty
+      end
+    end
+  end
+end

--- a/modules/boards/spec/models/boards/grid_spec.rb
+++ b/modules/boards/spec/models/boards/grid_spec.rb
@@ -72,40 +72,4 @@ describe Boards::Grid, type: :model do
         .to eql 4
     end
   end
-
-  describe '.visible' do
-    let(:project) { FactoryBot.create(:project) }
-    let(:permissions) { [:view_boards] }
-    let(:board) { Boards::Grid.new_default(project: project).tap(&:save!) }
-    let(:user) do
-      FactoryBot.create(:user,
-                        member_in_project: project,
-                        member_with_permissions: permissions)
-    end
-
-    context 'when having the view_boards permission' do
-      it 'returns the board' do
-        expect(described_class.visible(user))
-          .to match_array(board)
-      end
-    end
-
-    context 'when having the manage_boards permission' do
-      let(:permissions) { [:manage_boards] }
-
-      it 'returns the board' do
-        expect(described_class.visible(user))
-          .to match_array(board)
-      end
-    end
-
-    context 'when having neither of the permissions' do
-      let(:permissions) { [] }
-
-      it 'returns the board' do
-        expect(described_class.visible(user))
-          .to be_empty
-      end
-    end
-  end
 end

--- a/modules/boards/spec/models/boards/grid_spec.rb
+++ b/modules/boards/spec/models/boards/grid_spec.rb
@@ -31,45 +31,12 @@ require 'spec_helper'
 describe Boards::Grid, type: :model do
   let(:instance) { described_class.new }
   let(:project) { FactoryBot.build_stubbed(:project) }
-  let(:user) { FactoryBot.build_stubbed(:user) }
 
   context 'attributes' do
     it '#project' do
       instance.project = project
       expect(instance.project)
         .to eql project
-    end
-  end
-
-  describe '.new_default' do
-    it 'builds a new Board grid' do
-      expect(described_class.new_default(project: project))
-        .to be_a_kind_of(Boards::Grid)
-    end
-
-    it 'is not persisted' do
-      expect(described_class.new_default(project: project))
-        .to be_new_record
-    end
-
-    it 'assigns the project' do
-      expect(described_class.new_default(project: project).project)
-        .to eql project
-    end
-
-    it 'assigns no widgets' do
-      expect(described_class.new_default(project: project).widgets)
-        .to be_empty
-    end
-
-    it 'defines default for row_count' do
-      expect(described_class.new_default(project: project).row_count)
-        .to eql 1
-    end
-
-    it 'defines default for row_count' do
-      expect(described_class.new_default(project: project).column_count)
-        .to eql 4
     end
   end
 end

--- a/modules/boards/spec/models/boards/grid_spec.rb
+++ b/modules/boards/spec/models/boards/grid_spec.rb
@@ -1,0 +1,111 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Boards::Grid, type: :model do
+  let(:instance) { described_class.new }
+  let(:project) { FactoryBot.build_stubbed(:project) }
+  let(:user) { FactoryBot.build_stubbed(:user) }
+
+  context 'attributes' do
+    it '#project' do
+      instance.project = project
+      expect(instance.project)
+        .to eql project
+    end
+  end
+
+  describe '.new_default' do
+    it 'builds a new Board grid' do
+      expect(described_class.new_default(project: project))
+        .to be_a_kind_of(Boards::Grid)
+    end
+
+    it 'is not persisted' do
+      expect(described_class.new_default(project: project))
+        .to be_new_record
+    end
+
+    it 'assigns the project' do
+      expect(described_class.new_default(project: project).project)
+        .to eql project
+    end
+
+    it 'assigns no widgets' do
+      expect(described_class.new_default(project: project).widgets)
+        .to be_empty
+    end
+
+    it 'defines default for row_count' do
+      expect(described_class.new_default(project: project).row_count)
+        .to eql 1
+    end
+
+    it 'defines default for row_count' do
+      expect(described_class.new_default(project: project).column_count)
+        .to eql 4
+    end
+  end
+
+  describe '.visible' do
+    let(:project) { FactoryBot.create(:project) }
+    let(:permissions) { [:view_boards] }
+    let(:board) { Boards::Grid.new_default(project: project).tap(&:save!) }
+    let(:user) do
+      FactoryBot.create(:user,
+                        member_in_project: project,
+                        member_with_permissions: permissions)
+    end
+
+    context 'when having the view_boards permission' do
+      it 'returns the board' do
+        expect(described_class.visible(user))
+          .to match_array(board)
+      end
+    end
+
+    context 'when having the manage_boards permission' do
+      let(:permissions) { [:manage_boards] }
+
+      it 'returns the board' do
+        expect(described_class.visible(user))
+          .to match_array(board)
+      end
+    end
+
+    context 'when having neither of the permissions' do
+      let(:permissions) { [] }
+
+      it 'returns the board' do
+        expect(described_class.visible(user))
+          .to be_empty
+      end
+    end
+  end
+end

--- a/modules/boards/spec/queries/grids/query_integration_spec.rb
+++ b/modules/boards/spec/queries/grids/query_integration_spec.rb
@@ -1,0 +1,83 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Grids::Query, type: :model do
+  include OpenProject::StaticRouting::UrlHelpers
+
+  shared_let(:project) { FactoryBot.create(:project) }
+  shared_let(:other_project) { FactoryBot.create(:project) }
+  shared_let(:view_boards_role) { FactoryBot.create(:role, permissions: [:view_boards]) }
+  shared_let(:other_role) { FactoryBot.create(:role, permissions: []) }
+  shared_let(:current_user) do
+    FactoryBot.create(:user).tap do |user|
+      FactoryBot.create(:member, user: user, project: project, roles: [view_boards_role])
+      FactoryBot.create(:member, user: user, project: other_project, roles: [other_role])
+    end
+  end
+  let!(:board_grid) do
+    Boards::Grid.new_default(project: project).tap(&:save!)
+  end
+  let!(:other_board_grid) do
+    Boards::Grid.new_default(project: other_project).tap(&:save!)
+  end
+  let(:instance) { described_class.new }
+
+  before do
+    login_as(current_user)
+  end
+
+  context 'without a filter' do
+    describe '#results' do
+      it 'is the same as getting all the boards visible to the user' do
+        expect(instance.results).to match_array [board_grid]
+      end
+    end
+  end
+
+  context 'with a scope filter' do
+    context 'filtering for a projects/:project_id/boards' do
+      before do
+        instance.where('scope', '=', [project_boards_path(project)])
+      end
+
+      describe '#results' do
+        it 'yields boards assigned to the project' do
+          expect(instance.results).to match_array [board_grid]
+        end
+      end
+
+      describe '#valid?' do
+        it 'is true' do
+          expect(instance).to be_valid
+        end
+      end
+    end
+  end
+end

--- a/modules/boards/spec/queries/grids/query_integration_spec.rb
+++ b/modules/boards/spec/queries/grids/query_integration_spec.rb
@@ -42,10 +42,10 @@ describe Grids::Query, type: :model do
     end
   end
   let!(:board_grid) do
-    Boards::Grid.new_default(project: project).tap(&:save!)
+    FactoryBot.create(:board_grid, project: project)
   end
   let!(:other_board_grid) do
-    Boards::Grid.new_default(project: other_project).tap(&:save!)
+    FactoryBot.create(:board_grid, project: other_project)
   end
   let(:instance) { described_class.new }
 

--- a/modules/boards/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
+++ b/modules/boards/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
@@ -1,0 +1,171 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe "POST /api/v3/grids/form for Board Grids", type: :request, content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  shared_let(:project) do
+    FactoryBot.create(:project)
+  end
+
+  let(:current_user) { allowed_user }
+
+  shared_let(:current_user) do
+    FactoryBot.create(:user, member_in_project: project, member_with_permissions: [:manage_boards])
+  end
+
+  shared_let(:prohibited_user) do
+    FactoryBot.create(:user, member_in_project: project, member_with_permissions: [:view_boards])
+  end
+
+  let(:path) { api_v3_paths.create_grid_form }
+  let(:params) { {} }
+  subject(:response) { last_response }
+
+  before do
+    login_as(current_user)
+  end
+
+  describe '#post' do
+    before do
+      post path, params.to_json, 'CONTENT_TYPE' => 'application/json'
+    end
+
+    context 'with a valid boards scope' do
+      let(:params) do
+        {
+          '_links': {
+            'scope': {
+              'href': project_boards_path(project)
+            }
+          }
+        }
+      end
+
+      it 'contains default data in the payload' do
+        expected = {
+          "rowCount": 1,
+          "columnCount": 4,
+          "widgets": [],
+          "_links": {
+            "scope": {
+              'href': project_boards_path(project),
+              "type": "text/html"
+            }
+          }
+        }
+
+        expect(subject.body)
+          .to be_json_eql(expected.to_json)
+          .at_path('_embedded/payload')
+      end
+
+      it 'has no validationErrors' do
+        expect(subject.body)
+          .to be_json_eql({}.to_json)
+          .at_path('_embedded/validationErrors')
+      end
+
+      it 'has a commit link' do
+        expect(subject.body)
+          .to be_json_eql(api_v3_paths.grids.to_json)
+          .at_path('_links/commit/href')
+      end
+    end
+
+    context 'with boards scope for which the user does not have the necessary permissions' do
+      let(:current_user) { prohibited_user }
+      let(:params) do
+        {
+          '_links': {
+            'scope': {
+              'href': project_boards_path(project)
+            }
+          }
+        }
+      end
+
+      it 'has a validationError on widget' do
+        expect(subject.body)
+          .to be_json_eql("Scope is not set to one of the allowed values.".to_json)
+          .at_path('_embedded/validationErrors/scope/message')
+      end
+    end
+
+    context 'with an invalid boards scope' do
+      let(:params) do
+        {
+          '_links': {
+            'scope': {
+              'href': project_boards_path(project_id: project.id + 1)
+            }
+          }
+        }
+      end
+
+      it 'has a validationError on widget' do
+        expect(subject.body)
+          .to be_json_eql("Scope is not set to one of the allowed values.".to_json)
+          .at_path('_embedded/validationErrors/scope/message')
+      end
+    end
+
+    context 'with an unsupported widget identifier' do
+      let(:params) do
+        {
+          "_links": {
+            "scope": {
+              'href': project_boards_path(project),
+              "type": "text/html"
+            }
+          },
+          "widgets": [
+            {
+              "_type": "GridWidget",
+              "identifier": "bogus_identifier",
+              "startRow": 1,
+              "endRow": 2,
+              "startColumn": 1,
+              "endColumn": 2
+            }
+          ]
+        }
+      end
+
+      it 'has a validationError on widget' do
+        expect(subject.body)
+          .to be_json_eql("Widgets is not set to one of the allowed values.".to_json)
+          .at_path('_embedded/validationErrors/widgets/message')
+      end
+    end
+  end
+end

--- a/modules/boards/spec/requests/api/v3/grids/grids_resource_spec.rb
+++ b/modules/boards/spec/requests/api/v3/grids/grids_resource_spec.rb
@@ -48,19 +48,13 @@ describe 'API v3 Grids resource for Board Grids', type: :request, content_type: 
   end
 
   let(:manage_boards_grid) do
-    grid = Boards::Grid.new_default(project: manage_boards_project)
-    grid.save!
-    grid
+    FactoryBot.create(:board_grid, project: manage_boards_project)
   end
   let(:view_boards_grid) do
-    grid = Boards::Grid.new_default(project: view_boards_project)
-    grid.save!
-    grid
+    FactoryBot.create(:board_grid, project: view_boards_project)
   end
   let(:other_board_grid) do
-    grid = Boards::Grid.new_default(project: other_project)
-    grid.save!
-    grid
+    FactoryBot.create(:board_grid, project: other_project)
   end
 
   before do
@@ -271,7 +265,7 @@ describe 'API v3 Grids resource for Board Grids', type: :request, content_type: 
 
       it 'does not persist the changes to widgets' do
         expect(manage_boards_grid.reload.widgets.count)
-          .to eql Boards::Grid.new_default(project: manage_boards_project, user: current_user).widgets.size
+          .to eql OpenProject::Boards::GridRegistration.defaults[:widgets].size
       end
     end
 

--- a/modules/boards/spec/requests/api/v3/grids/grids_update_form_resource_spec.rb
+++ b/modules/boards/spec/requests/api/v3/grids/grids_update_form_resource_spec.rb
@@ -44,9 +44,7 @@ describe "PATCH /api/v3/grids/:id/form for Board Grids", type: :request, content
   end
 
   let(:grid) do
-    grid = Boards::Grid.new_default(user: current_user, project: project)
-    grid.save!
-    grid
+    FactoryBot.create(:board_grid, project: project)
   end
   let(:path) { api_v3_paths.grid_form(grid.id) }
   let(:params) { {} }

--- a/modules/boards/spec/requests/api/v3/grids/grids_update_form_resource_spec.rb
+++ b/modules/boards/spec/requests/api/v3/grids/grids_update_form_resource_spec.rb
@@ -1,0 +1,169 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe "PATCH /api/v3/grids/:id/form for Board Grids", type: :request, content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  shared_let(:project) do
+    FactoryBot.create(:project)
+  end
+  shared_let(:allowed_user) do
+    FactoryBot.create(:user, member_in_project: project, member_with_permissions: [:manage_boards])
+  end
+  shared_let(:prohibited_user) do
+    FactoryBot.create(:user, member_in_project: project, member_with_permissions: [:view_boards])
+  end
+
+  let(:grid) do
+    grid = Boards::Grid.new_default(user: current_user, project: project)
+    grid.save!
+    grid
+  end
+  let(:path) { api_v3_paths.grid_form(grid.id) }
+  let(:params) { {} }
+  subject(:response) { last_response }
+
+  let(:current_user) { allowed_user }
+  before do
+    login_as(current_user)
+  end
+
+  describe '#post' do
+    before do
+      post path, params.to_json, 'CONTENT_TYPE' => 'application/json'
+    end
+
+    it 'returns 200 OK' do
+      expect(subject.status)
+        .to eql 200
+    end
+
+    it 'is of type form' do
+      expect(subject.body)
+        .to be_json_eql("Form".to_json)
+        .at_path('_type')
+    end
+
+    it 'contains a Schema disallowing setting scope' do
+      expect(subject.body)
+        .to be_json_eql("Schema".to_json)
+        .at_path('_embedded/schema/_type')
+
+      expect(subject.body)
+        .to be_json_eql(false.to_json)
+        .at_path('_embedded/schema/scope/writable')
+    end
+
+    it 'contains the current data in the payload' do
+      expected = {
+        "rowCount": 1,
+        "columnCount": 4,
+        "widgets": [],
+        "_links": {
+          "scope": {
+            "href": project_boards_path(project),
+            "type": "text/html"
+          }
+        }
+      }
+
+      expect(subject.body)
+        .to be_json_eql(expected.to_json)
+        .at_path('_embedded/payload')
+    end
+
+    it 'has a commit link' do
+      expect(subject.body)
+        .to be_json_eql(api_v3_paths.grid(grid.id).to_json)
+        .at_path('_links/commit/href')
+    end
+
+    context 'with some value for the scope value' do
+      let(:params) do
+        {
+          '_links': {
+            'scope': {
+              'href': '/some/path'
+            }
+          }
+        }
+      end
+
+      it 'has a validation error on scope as the value is not writeable' do
+        expect(subject.body)
+          .to be_json_eql("You must not write a read-only attribute.".to_json)
+          .at_path('_embedded/validationErrors/scope/message')
+      end
+    end
+
+    context 'with an unsupported widget identifier' do
+      let(:params) do
+        {
+          "widgets": [
+            {
+              "_type": "GridWidget",
+              "identifier": "bogus_identifier",
+              "startRow": 1,
+              "endRow": 2,
+              "startColumn": 1,
+              "endColumn": 2
+            }
+          ]
+        }
+      end
+
+      it 'has a validationError on widget' do
+        expect(subject.body)
+          .to be_json_eql("Widgets is not set to one of the allowed values.".to_json)
+          .at_path('_embedded/validationErrors/widgets/message')
+      end
+    end
+
+    context 'for a non existing grid' do
+      let(:path) { api_v3_paths.grid_form(grid.id + 5) }
+
+      it 'returns 404 NOT FOUND' do
+        expect(subject.status)
+          .to eql 404
+      end
+    end
+
+    context 'for a grid for which the user does not have permission' do
+      let(:current_user) { prohibited_user }
+
+      it 'returns 404 NOT FOUND' do
+        expect(subject.status)
+          .to eql 404
+      end
+    end
+  end
+end

--- a/modules/grids/app/contracts/grids/base_contract.rb
+++ b/modules/grids/app/contracts/grids/base_contract.rb
@@ -44,7 +44,7 @@ module Grids
     attribute_alias :type, :scope
 
     def validate
-      validate_class_and_allowed
+      validate_allowed
       validate_registered_widgets
       validate_widget_collisions
       validate_widgets_within
@@ -63,11 +63,14 @@ module Grids
       nil
     end
 
+    def writeable?
+      Grids::Configuration.writable?(model, user)
+    end
+
     private
 
-    def validate_class_and_allowed
-      unless Grids::Configuration.registered_grid?(model.class) &&
-             model.writable?(user)
+    def validate_allowed
+      unless writeable?
         # scope because that is what is exposed to the outside
         errors.add(:scope, :inclusion)
       end

--- a/modules/grids/app/contracts/grids/base_contract.rb
+++ b/modules/grids/app/contracts/grids/base_contract.rb
@@ -63,14 +63,14 @@ module Grids
       nil
     end
 
-    def writeable?
+    def edit_allowed?
       Grids::Configuration.writable?(model, user)
     end
 
     private
 
     def validate_allowed
-      unless writeable?
+      unless edit_allowed?
         # scope because that is what is exposed to the outside
         errors.add(:scope, :inclusion)
       end

--- a/modules/grids/app/contracts/grids/base_contract.rb
+++ b/modules/grids/app/contracts/grids/base_contract.rb
@@ -41,10 +41,10 @@ module Grids
       validate_positive_integer(:column_count)
     end
 
-    attribute_alias :type, :page
+    attribute_alias :type, :scope
 
     def validate
-      validate_registered_subclass
+      validate_class_and_allowed
       validate_registered_widgets
       validate_widget_collisions
       validate_widgets_within
@@ -65,10 +65,11 @@ module Grids
 
     private
 
-    def validate_registered_subclass
-      unless Grids::Configuration.registered_grid?(model.class)
-        # page because that is what is exposed to the outside
-        errors.add(:page, :inclusion)
+    def validate_class_and_allowed
+      unless Grids::Configuration.registered_grid?(model.class) &&
+             model.writable?(user)
+        # scope because that is what is exposed to the outside
+        errors.add(:scope, :inclusion)
       end
     end
 

--- a/modules/grids/app/contracts/grids/create_contract.rb
+++ b/modules/grids/app/contracts/grids/create_contract.rb
@@ -33,21 +33,24 @@ require 'grids/base_contract'
 module Grids
   class CreateContract < BaseContract
     attribute :user_id,
-              writeable: -> { model.class.reflect_on_association(:user) }
+              writeable: -> { !!model.class.reflect_on_association(:user) }
+
+    attribute :project_id,
+              writeable: -> { !!model.class.reflect_on_association(:project) }
 
     attribute :type
 
     def assignable_values(column, _user)
       case column
-      when :page
-        Grids::Configuration.registered_pages
+      when :scope
+        Grids::Configuration.all_scopes
       else
         super
       end
     end
 
     def writable?(attribute)
-      attribute == :page || super
+      attribute == :scope || super
     end
   end
 end

--- a/modules/grids/app/controllers/api/v3/grids/create_form_api.rb
+++ b/modules/grids/app/controllers/api/v3/grids/create_form_api.rb
@@ -41,8 +41,7 @@ module API
                      .call(request_body)
                      .result
 
-            grid_class = ::Grids::Configuration.class_from_scope(params.delete(:scope))
-            grid = grid_class.new_default(user: current_user)
+            grid = ::Grids::Factory.build(params.delete(:scope), current_user)
 
             call = ::Grids::SetAttributesService
                    .new(user: current_user,

--- a/modules/grids/app/controllers/api/v3/grids/create_form_api.rb
+++ b/modules/grids/app/controllers/api/v3/grids/create_form_api.rb
@@ -41,8 +41,8 @@ module API
                      .call(request_body)
                      .result
 
-            grid_class = ::Grids::Configuration.grid_for_page(params.delete(:page))
-            grid = grid_class.new_default(current_user)
+            grid_class = ::Grids::Configuration.class_from_scope(params.delete(:scope))
+            grid = grid_class.new_default(user: current_user)
 
             call = ::Grids::SetAttributesService
                    .new(user: current_user,

--- a/modules/grids/app/controllers/api/v3/grids/grid_representer.rb
+++ b/modules/grids/app/controllers/api/v3/grids/grid_representer.rb
@@ -32,11 +32,21 @@ module API
       class GridRepresenter < ::API::Decorators::Single
         include API::Decorators::LinkedResource
 
-        resource_link :page,
+        resource_link :scope,
                       getter: ->(*) {
-                        path = ::Grids::Configuration.grid_for_class(represented.class)
+                        path_attributes = represented
+                                          .attributes
+                                          .slice("id", "user_id", "project_id")
+                                          .compact
+                                          .symbolize_keys
+
+                        path = ::Grids::Configuration.to_scope(represented.class,
+                                                               path_attributes)
 
                         next unless path
+
+                        # Remove all query params
+                        path.gsub!(/\?.+\z/,'')
 
                         {
                           href: path,
@@ -44,7 +54,7 @@ module API
                         }
                       },
                       setter: ->(fragment:, **) {
-                        represented.page = fragment['href']
+                        represented.scope = fragment['href']
                       }
 
         self_link title_getter: ->(*) { nil }

--- a/modules/grids/app/controllers/api/v3/grids/grids_api.rb
+++ b/modules/grids/app/controllers/api/v3/grids/grids_api.rb
@@ -74,14 +74,19 @@ module API
           mount ::API::V3::Grids::Schemas::GridSchemaAPI
 
           route_param :id do
+            helpers do
+              def raise_if_lacking_manage_permission
+                unless ::Grids::UpdateContract.new(@grid, current_user).edit_allowed?
+                  raise ActiveRecord::RecordNotFound
+                end
+              end
+            end
+
             before do
               @grid = ::Grids::Query
                       .new(user: current_user)
                       .results
-                      .where(id: params['id'])
-                      .first
-
-              raise ActiveRecord::RecordNotFound unless @grid
+                      .find(params['id'])
             end
 
             get do
@@ -90,10 +95,16 @@ module API
             end
 
             patch do
+              raise_if_lacking_manage_permission
+
               params = API::V3::ParseResourceParamsService
                        .new(current_user, representer: GridRepresenter)
                        .call(request_body)
                        .result
+
+              if params[:scope]
+                params[:type] = ::Grids::Configuration.class_from_scope(params.delete(:scope)).to_s
+              end
 
               call = ::Grids::UpdateService
                      .new(user: current_user,

--- a/modules/grids/app/controllers/api/v3/grids/schemas/grid_schema_representer.rb
+++ b/modules/grids/app/controllers/api/v3/grids/schemas/grid_schema_representer.rb
@@ -60,7 +60,7 @@ module API
                  type: 'Integer',
                  visibility: false
 
-          schema_with_allowed_collection :page,
+          schema_with_allowed_collection :scope,
                                          type: 'Href',
                                          required: true,
                                          has_default: false,

--- a/modules/grids/app/controllers/api/v3/grids/update_form_api.rb
+++ b/modules/grids/app/controllers/api/v3/grids/update_form_api.rb
@@ -36,6 +36,8 @@ module API
           end
 
           post do
+            raise_if_lacking_manage_permission
+
             params = API::V3::ParseResourceParamsService
                      .new(current_user, representer: GridPayloadRepresenter)
                      .call(request_body)

--- a/modules/grids/app/controllers/api/v3/grids/update_form_api.rb
+++ b/modules/grids/app/controllers/api/v3/grids/update_form_api.rb
@@ -41,8 +41,8 @@ module API
                      .call(request_body)
                      .result
 
-            if params[:page]
-              params[:type] = ::Grids::Configuration.grid_for_page(params.delete(:page)).to_s
+            if params[:scope]
+              params[:type] = ::Grids::Configuration.class_from_scope(params.delete(:scope)).to_s
             end
 
             call = ::Grids::SetAttributesService

--- a/modules/grids/app/controllers/api/v3/grids/widget_representer.rb
+++ b/modules/grids/app/controllers/api/v3/grids/widget_representer.rb
@@ -36,8 +36,6 @@ module API
         property :start_column
         property :end_column
 
-        property :options
-
         def _type
           'GridWidget'
         end

--- a/modules/grids/app/models/grids/grid.rb
+++ b/modules/grids/app/models/grids/grid.rb
@@ -36,21 +36,12 @@ module Grids
              class_name: 'Widget',
              autosave: true
 
-    def writable?(_user)
-      true
-    end
-
     def self.new_default(user: nil, project: nil)
       new(
         row_count: 4,
         column_count: 5,
         widgets: []
       )
-    end
-
-    def self.visible(_user = User.current)
-      Grid
-        .where(type: name)
     end
   end
 end

--- a/modules/grids/app/models/grids/grid.rb
+++ b/modules/grids/app/models/grids/grid.rb
@@ -35,13 +35,5 @@ module Grids
     has_many :widgets,
              class_name: 'Widget',
              autosave: true
-
-    def self.new_default(user: nil, project: nil)
-      new(
-        row_count: 4,
-        column_count: 5,
-        widgets: []
-      )
-    end
   end
 end

--- a/modules/grids/app/models/grids/grid.rb
+++ b/modules/grids/app/models/grids/grid.rb
@@ -36,12 +36,21 @@ module Grids
              class_name: 'Widget',
              autosave: true
 
-    def self.new_default(_user)
+    def writable?(_user)
+      true
+    end
+
+    def self.new_default(user: nil, project: nil)
       new(
         row_count: 4,
         column_count: 5,
         widgets: []
       )
+    end
+
+    def self.visible(_user = User.current)
+      Grid
+        .where(type: name)
     end
   end
 end

--- a/modules/grids/app/models/grids/my_page.rb
+++ b/modules/grids/app/models/grids/my_page.rb
@@ -32,7 +32,7 @@ module Grids
   class MyPage < Grid
     belongs_to :user
 
-    def self.new_default(user)
+    def self.new_default(user:, project: nil)
       new(
         user: user,
         row_count: 7,
@@ -56,8 +56,9 @@ module Grids
       )
     end
 
-    def self.visible_scope
-      Grid.where(user_id: User.current.id)
+    def self.visible(user = User.current)
+      super
+        .where(user_id: user.id)
     end
   end
 end

--- a/modules/grids/app/models/grids/my_page.rb
+++ b/modules/grids/app/models/grids/my_page.rb
@@ -31,29 +31,5 @@
 module Grids
   class MyPage < Grid
     belongs_to :user
-
-    def self.new_default(user:, project: nil)
-      new(
-        user: user,
-        row_count: 7,
-        column_count: 4,
-        widgets: [
-          Grids::Widget.new(
-            identifier: 'work_packages_assigned',
-            start_row: 1,
-            end_row: 7,
-            start_column: 1,
-            end_column: 3
-          ),
-          Grids::Widget.new(
-            identifier: 'work_packages_created',
-            start_row: 1,
-            end_row: 7,
-            start_column: 3,
-            end_column: 5
-          )
-        ]
-      )
-    end
   end
 end

--- a/modules/grids/app/models/grids/my_page.rb
+++ b/modules/grids/app/models/grids/my_page.rb
@@ -55,10 +55,5 @@ module Grids
         ]
       )
     end
-
-    def self.visible(user = User.current)
-      super
-        .where(user_id: user.id)
-    end
   end
 end

--- a/modules/grids/app/queries/grids/query.rb
+++ b/modules/grids/app/queries/grids/query.rb
@@ -35,10 +35,10 @@ module Grids
     def default_scope
       grid_classes = ::Grids::Configuration.registered_grids
 
-      or_scope = grid_classes.pop.visible_scope
+      or_scope = grid_classes.pop.visible(User.current)
 
       while grid_classes.any?
-        or_scope = or_scope.or(grid_classes.pop.visible_scope)
+        or_scope = or_scope.or(grid_classes.pop.visible(User.current))
       end
 
       # Have to use the subselect as AR will otherwise remove

--- a/modules/grids/app/queries/grids/query.rb
+++ b/modules/grids/app/queries/grids/query.rb
@@ -33,12 +33,12 @@ module Grids
     end
 
     def default_scope
-      grid_classes = ::Grids::Configuration.registered_grids
+      configs = ::Grids::Configuration.all
 
-      or_scope = grid_classes.pop.visible(User.current)
+      or_scope = configs.pop.visible(User.current)
 
-      while grid_classes.any?
-        or_scope = or_scope.or(grid_classes.pop.visible(User.current))
+      while configs.any?
+        or_scope = or_scope.or(configs.pop.visible(User.current))
       end
 
       # Have to use the subselect as AR will otherwise remove

--- a/modules/grids/app/services/grids/create_service.rb
+++ b/modules/grids/app/services/grids/create_service.rb
@@ -48,7 +48,7 @@ class Grids::CreateService
   protected
 
   def create(attributes)
-    grid = new_grid(attributes.delete(:page))
+    grid = new_grid(attributes.delete(:scope))
 
     set_attributes_call = set_attributes(attributes, grid)
 
@@ -69,8 +69,16 @@ class Grids::CreateService
       .call(attributes)
   end
 
-  def new_grid(page)
-    grid_class = ::Grids::Configuration.grid_for_page(page)
-    grid_class.new_default(user)
+  def new_grid(scope)
+    attributes = ::Grids::Configuration.attributes_from_scope(scope)
+
+    grid_class = attributes[:class]
+    grid_project = project_from_id(attributes[:project_id])
+
+    grid_class.new_default(user: user, project: grid_project)
+  end
+
+  def project_from_id(id)
+    Project.find(id) if id
   end
 end

--- a/modules/grids/app/services/grids/update_service.rb
+++ b/modules/grids/app/services/grids/update_service.rb
@@ -50,7 +50,7 @@ class Grids::UpdateService
   protected
 
   def create(attributes)
-    set_type_for_error_message(attributes.delete(:page))
+    set_type_for_error_message(attributes.delete(:scope))
 
     set_attributes_call = set_attributes(attributes, grid)
 
@@ -71,11 +71,11 @@ class Grids::UpdateService
       .call(attributes)
   end
 
-  # Changing the page/type after the grid has been created is prohibited.
+  # Changing the scope/type after the grid has been created is prohibited.
   # But we set the value so that an error message can be displayed
-  def set_type_for_error_message(page)
-    if page
-      grid_class = ::Grids::Configuration.grid_for_page(page)
+  def set_type_for_error_message(scope)
+    if scope
+      grid_class = ::Grids::Configuration.class_from_scope(scope)
       grid.type = grid_class.name
     end
   end

--- a/modules/grids/config/locales/en.yml
+++ b/modules/grids/config/locales/en.yml
@@ -2,7 +2,7 @@ en:
   activerecord:
     attributes:
       grids/grid:
-        page: "Page"
+        scope: "Scope"
         row_count: "Number of rows"
         column_count: "Number of columns"
         widgets: "Widgets"

--- a/modules/grids/lib/grids/configuration.rb
+++ b/modules/grids/lib/grids/configuration.rb
@@ -63,6 +63,10 @@ class Grids::Configuration
       end
     end
 
+    def defaults(klass)
+      grid_register[klass.name]&.defaults
+    end
+
     def class_from_scope(page)
       attributes_from_scope(page)[:class]
     end
@@ -140,6 +144,19 @@ class Grids::Configuration
         end
 
         @widgets
+      end
+
+      def defaults(hash = nil)
+        if hash
+          @defaults = hash
+        end
+
+        params = @defaults.dup
+        params[:widgets] = (params[:widgets] || []).map do |widget|
+          Grids::Widget.new(widget)
+        end
+
+        params
       end
 
       def from_scope(_scope)

--- a/modules/grids/lib/grids/engine.rb
+++ b/modules/grids/lib/grids/engine.rb
@@ -7,28 +7,11 @@ module Grids
     config.to_prepare do
       query = Grids::Query
 
-      #Queries::Register.filter query, Grids::Filters::PageFilter
       Queries::Register.filter query, Grids::Filters::ScopeFilter
     end
 
     config.to_prepare do
-      Grids::Configuration.register_grid('Grids::MyPage',
-                                         ->(path) {
-                                           if path == OpenProject::StaticRouting::StaticUrlHelpers.new.my_page_path
-                                             { class: Grids::MyPage }
-                                           end
-                                         },
-                                         :my_page_path
-                                        )
-
-      Grids::Configuration.register_widget('work_packages_assigned', 'Grids::MyPage')
-      Grids::Configuration.register_widget('work_packages_accountable', 'Grids::MyPage')
-      Grids::Configuration.register_widget('work_packages_watched', 'Grids::MyPage')
-      Grids::Configuration.register_widget('work_packages_created', 'Grids::MyPage')
-      Grids::Configuration.register_widget('work_packages_calendar', 'Grids::MyPage')
-      Grids::Configuration.register_widget('time_entries_current_user', 'Grids::MyPage')
-      Grids::Configuration.register_widget('documents', 'Grids::MyPage')
-      Grids::Configuration.register_widget('news', 'Grids::MyPage')
+      Grids::MyPageGridRegistration.register!
     end
   end
 end

--- a/modules/grids/lib/grids/engine.rb
+++ b/modules/grids/lib/grids/engine.rb
@@ -7,11 +7,20 @@ module Grids
     config.to_prepare do
       query = Grids::Query
 
-      Queries::Register.filter query, Grids::Filters::PageFilter
+      #Queries::Register.filter query, Grids::Filters::PageFilter
+      Queries::Register.filter query, Grids::Filters::ScopeFilter
     end
 
     config.to_prepare do
-      Grids::Configuration.register_grid('Grids::MyPage', 'my_page_path')
+      Grids::Configuration.register_grid('Grids::MyPage',
+                                         ->(path) {
+                                           if path == OpenProject::StaticRouting::StaticUrlHelpers.new.my_page_path
+                                             { class: Grids::MyPage }
+                                           end
+                                         },
+                                         :my_page_path
+                                        )
+
       Grids::Configuration.register_widget('work_packages_assigned', 'Grids::MyPage')
       Grids::Configuration.register_widget('work_packages_accountable', 'Grids::MyPage')
       Grids::Configuration.register_widget('work_packages_watched', 'Grids::MyPage')

--- a/modules/grids/lib/grids/factory.rb
+++ b/modules/grids/lib/grids/factory.rb
@@ -37,7 +37,29 @@ module Grids
         grid_class = attributes[:class]
         grid_project = project_from_id(attributes[:project_id])
 
-        grid_class.new_default(user: user, project: grid_project)
+        new_default(grid_class, grid_project, user)
+      end
+
+      private
+
+      def new_default(klass, project, user)
+        params = class_defaults(klass)
+
+        if klass.reflect_on_association(:project)
+          params[:project] = project
+        end
+
+        if klass.reflect_on_association(:user)
+          params[:user] = user
+        end
+
+        klass.new(params)
+      end
+
+      def class_defaults(klass)
+        params = ::Grids::Configuration.defaults(klass)
+
+        params || { row_count: 4, column_count: 5, widgets: [] }
       end
 
       def project_from_id(id)

--- a/modules/grids/lib/grids/my_page_grid_registration.rb
+++ b/modules/grids/lib/grids/my_page_grid_registration.rb
@@ -12,6 +12,27 @@ module Grids
             'documents',
             'news'
 
+    defaults(
+      row_count: 7,
+      column_count: 4,
+      widgets: [
+        {
+          identifier: 'work_packages_assigned',
+          start_row: 1,
+          end_row: 7,
+          start_column: 1,
+          end_column: 3
+        },
+        {
+          identifier: 'work_packages_created',
+          start_row: 1,
+          end_row: 7,
+          start_column: 3,
+          end_column: 5
+        }
+      ]
+    )
+
     class << self
       def from_scope(scope)
         if scope == url_helpers.my_page_path

--- a/modules/grids/lib/grids/my_page_grid_registration.rb
+++ b/modules/grids/lib/grids/my_page_grid_registration.rb
@@ -1,0 +1,28 @@
+module Grids
+  class MyPageGridRegistration < ::Grids::Configuration::Registration
+    grid_class 'Grids::MyPage'
+    to_scope :my_page_path
+
+    widgets 'work_packages_assigned',
+            'work_packages_accountable',
+            'work_packages_watched',
+            'work_packages_created',
+            'work_packages_calendar',
+            'time_entries_current_user',
+            'documents',
+            'news'
+
+    class << self
+      def from_scope(scope)
+        if scope == url_helpers.my_page_path
+          { class: Grids::MyPage }
+        end
+      end
+
+      def visible(user = User.current)
+        super
+          .where(user_id: user.id)
+      end
+    end
+  end
+end

--- a/modules/grids/spec/contracts/grids/create_contract_spec.rb
+++ b/modules/grids/spec/contracts/grids/create_contract_spec.rb
@@ -33,6 +33,7 @@ require_relative './shared_examples'
 
 describe Grids::CreateContract do
   include_context 'grid contract'
+  include_context 'model contract'
 
   it_behaves_like 'shared grid contract attributes'
 
@@ -44,18 +45,15 @@ describe Grids::CreateContract do
   end
 
   describe 'user_id' do
-    let(:grid) do
-      FactoryBot.build_stubbed(:grid, default_values)
-    end
+    let(:grid) { FactoryBot.build_stubbed(:grid, default_values) }
+
     it_behaves_like 'is not writable' do
       let(:attribute) { :user_id }
       let(:value) { 5 }
     end
 
     context 'for a Grids::MyPage' do
-      let(:grid) do
-        FactoryBot.build_stubbed(:my_page, default_values)
-      end
+      let(:grid) { FactoryBot.build_stubbed(:my_page, default_values) }
 
       it_behaves_like 'is writable' do
         let(:attribute) { :user_id }
@@ -64,14 +62,40 @@ describe Grids::CreateContract do
     end
   end
 
-  describe '#assignable_values' do
-    context 'for page' do
-      it 'returns the array of supported pages' do
-        expect(instance.assignable_values(:page, user))
-          .to match_array [OpenProject::StaticRouting::StaticUrlHelpers.new.my_page_path]
-      end
+  describe 'project_id' do
+    let(:grid) { FactoryBot.build_stubbed(:grid, default_values) }
 
-      it 'returns the nil for something else' do
+    it_behaves_like 'is not writable' do
+      let(:attribute) { :project_id }
+      let(:value) { 5 }
+    end
+
+    context 'for a Grids::MyPage' do
+      let(:grid) { FactoryBot.build_stubbed(:my_page, default_values) }
+
+      it_behaves_like 'is not writable' do
+        let(:attribute) { :project_id }
+        let(:value) { 5 }
+      end
+    end
+  end
+
+  describe '#assignable_values' do
+    context 'for scope' do
+      it 'calls the grid configuration for the available values' do
+        scopes = double('scopes')
+
+        allow(Grids::Configuration)
+          .to receive(:all_scopes)
+          .and_return(scopes)
+
+        expect(instance.assignable_values(:scope, user))
+          .to eql scopes
+      end
+    end
+
+    context 'for something else' do
+      it 'returns nil' do
         expect(instance.assignable_values(:something, user))
           .to be_nil
       end

--- a/modules/grids/spec/contracts/grids/shared_examples.rb
+++ b/modules/grids/spec/contracts/grids/shared_examples.rb
@@ -41,34 +41,6 @@ shared_context 'grid contract' do
     FactoryBot.build_stubbed(:my_page, default_values)
   end
 
-  shared_examples_for 'is not writable' do
-    before do
-      grid.attributes = { attribute => value }
-    end
-
-    it 'is not writable' do
-      expect(instance.validate)
-        .to be_falsey
-    end
-
-    it 'explains the not writable error' do
-      instance.validate
-      expect(instance.errors.details[attribute])
-        .to match_array [{ error: :error_readonly }]
-    end
-  end
-
-  shared_examples_for 'is writable' do
-    before do
-      grid.attributes = { attribute => value }
-    end
-
-    it 'is writable' do
-      expect(instance.validate)
-        .to be_truthy
-    end
-  end
-
   shared_examples_for 'validates positive integer' do
     context 'when the value is negative' do
       let(:value) { -1 }
@@ -95,6 +67,9 @@ shared_context 'grid contract' do
 end
 
 shared_examples_for 'shared grid contract attributes' do
+  include_context 'model contract'
+  let(:model) { grid }
+
   describe 'row_count' do
     it_behaves_like 'is writable' do
       let(:attribute) { :row_count }
@@ -402,7 +377,7 @@ shared_examples_for 'shared grid contract attributes' do
       end
 
       it 'is invalid for the grid superclass itself' do
-        expect(instance.errors.details[:page])
+        expect(instance.errors.details[:scope])
           .to match_array [{ error: :inclusion }]
       end
     end

--- a/modules/grids/spec/contracts/grids/shared_examples.rb
+++ b/modules/grids/spec/contracts/grids/shared_examples.rb
@@ -34,7 +34,8 @@ shared_context 'grid contract' do
   let(:default_values) do
     {
       row_count: 6,
-      column_count: 7
+      column_count: 7,
+      widgets: []
     }
   end
   let(:grid) do

--- a/modules/grids/spec/factories/grid_factory.rb
+++ b/modules/grids/spec/factories/grid_factory.rb
@@ -3,5 +3,26 @@ FactoryBot.define do
   end
 
   factory :my_page, class: Grids::MyPage do
+    user
+    row_count { 7 }
+    column_count { 4 }
+    widgets do
+      [
+        Grids::Widget.new(
+          identifier: 'work_packages_assigned',
+          start_row: 1,
+          end_row: 7,
+          start_column: 1,
+          end_column: 3
+        ),
+        Grids::Widget.new(
+          identifier: 'work_packages_created',
+          start_row: 1,
+          end_row: 7,
+          start_column: 3,
+          end_column: 5
+        )
+      ]
+    end
   end
 end

--- a/modules/grids/spec/lib/api/v3/grids/grid_payload_representer_parsing_spec.rb
+++ b/modules/grids/spec/lib/api/v3/grids/grid_payload_representer_parsing_spec.rb
@@ -70,7 +70,7 @@ describe ::API::V3::Grids::GridPayloadRepresenter, 'parsing' do
         }
       ],
       "_links" => {
-        "page" => {
+        "scope" => {
           "href" => my_page_path
         }
       }
@@ -78,10 +78,10 @@ describe ::API::V3::Grids::GridPayloadRepresenter, 'parsing' do
   end
 
   describe '_links' do
-    context 'page' do
+    context 'scope' do
       it 'updates page' do
         grid = representer.from_hash(hash)
-        expect(grid.page)
+        expect(grid.scope)
           .to eql(my_page_path)
       end
     end

--- a/modules/grids/spec/lib/api/v3/grids/grid_representer_rendering_spec.rb
+++ b/modules/grids/spec/lib/api/v3/grids/grid_representer_rendering_spec.rb
@@ -81,7 +81,7 @@ describe ::API::V3::Grids::GridRepresenter, 'rendering' do
       it 'identifies the url the grid is stored for' do
         is_expected
           .to be_json_eql(my_page_path.to_json)
-          .at_path('_links/page/href')
+          .at_path('_links/scope/href')
       end
 
       it 'has an id' do
@@ -174,9 +174,9 @@ describe ::API::V3::Grids::GridRepresenter, 'rendering' do
         end
       end
 
-      context 'page link' do
+      context 'scope link' do
         it_behaves_like 'has an untitled link' do
-          let(:link) { 'page' }
+          let(:link) { 'scope' }
           let(:href) { my_page_path }
           let(:type) { "text/html" }
 

--- a/modules/grids/spec/lib/api/v3/grids/schemas/grid_schema_representer_spec.rb
+++ b/modules/grids/spec/lib/api/v3/grids/schemas/grid_schema_representer_spec.rb
@@ -36,7 +36,7 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
   let(:self_link) { '/a/self/link' }
   let(:embedded) { true }
   let(:new_record) { true }
-  let(:allowed_pages) { %w(/some/path /some/other/path) }
+  let(:allowed_scopes) { %w(/some/path /some/other/path) }
   let(:allowed_widgets) do
     [
       OpenStruct.new(
@@ -55,7 +55,7 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
       writable = %w(row_count column_count widgets)
 
       if new_record
-        writable << 'page'
+        writable << 'scope'
       end
 
       writable.include?(attribute.to_s)
@@ -63,8 +63,8 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
 
     allow(contract)
       .to receive(:assignable_values)
-      .with(:page, current_user)
-      .and_return(allowed_pages)
+      .with(:scope, current_user)
+      .and_return(allowed_scopes)
 
     allow(contract)
       .to receive(:assignable_values)
@@ -186,13 +186,13 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
       end
     end
 
-    describe 'page' do
-      let(:path) { 'page' }
+    describe 'scope' do
+      let(:path) { 'scope' }
 
       context 'when having a new record' do
         it_behaves_like 'has basic schema properties' do
           let(:type) { 'Href' }
-          let(:name) { Grids::Grid.human_attribute_name('page') }
+          let(:name) { Grids::Grid.human_attribute_name('scope') }
           let(:required) { true }
           let(:writable) { true }
         end
@@ -201,12 +201,12 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
           let(:embedded) { true }
 
           it_behaves_like 'links to allowed values directly' do
-            let(:hrefs) { allowed_pages }
+            let(:hrefs) { allowed_scopes }
           end
 
           it 'does not embed' do
             expect(generated)
-              .not_to have_json_path('page/embedded')
+              .not_to have_json_path('scope/embedded')
           end
         end
 
@@ -217,18 +217,18 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
 
           it 'does not embed' do
             expect(generated)
-              .not_to have_json_path('page/embedded')
+              .not_to have_json_path('scope/embedded')
           end
         end
       end
 
       context 'when not having a new record' do
         let(:new_record) { false }
-        let(:allowed_pages) { nil }
+        let(:allowed_scopes) { nil }
 
         it_behaves_like 'has basic schema properties' do
           let(:type) { 'Href' }
-          let(:name) { Grids::Grid.human_attribute_name('page') }
+          let(:name) { Grids::Grid.human_attribute_name('scope') }
           let(:required) { true }
           let(:writable) { false }
         end
@@ -240,7 +240,7 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
 
           it 'does not embed' do
             expect(generated)
-              .not_to have_json_path('page/embedded')
+              .not_to have_json_path('scope/embedded')
           end
         end
 
@@ -251,7 +251,7 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
 
           it 'does not embed' do
             expect(generated)
-              .not_to have_json_path('page/embedded')
+              .not_to have_json_path('scope/embedded')
           end
         end
       end

--- a/modules/grids/spec/models/grids/my_page_spec.rb
+++ b/modules/grids/spec/models/grids/my_page_spec.rb
@@ -45,39 +45,4 @@ describe Grids::MyPage, type: :model do
         .to eql user
     end
   end
-
-  describe '.new_default' do
-    it 'builds a new MyPage grid' do
-      expect(described_class.new_default(user: user))
-        .to be_a_kind_of(Grids::MyPage)
-    end
-
-    it 'is not persisted' do
-      expect(described_class.new_default(user: user))
-        .to be_new_record
-    end
-
-    it 'assigns the user' do
-      expect(described_class.new_default(user: user).user)
-        .to eql user
-    end
-
-    it 'assigns two widgets' do
-      expect(described_class.new_default(user: user).widgets[0].identifier)
-        .to eql 'work_packages_assigned'
-
-      expect(described_class.new_default(user: user).widgets[1].identifier)
-        .to eql 'work_packages_created'
-    end
-
-    it 'defines default so row_count' do
-      expect(described_class.new_default(user: user).row_count)
-        .to eql 7
-    end
-
-    it 'defines default so row_count' do
-      expect(described_class.new_default(user: user).column_count)
-        .to eql 4
-    end
-  end
 end

--- a/modules/grids/spec/models/grids/my_page_spec.rb
+++ b/modules/grids/spec/models/grids/my_page_spec.rb
@@ -32,6 +32,7 @@ require_relative './shared_model'
 
 describe Grids::MyPage, type: :model do
   let(:instance) { described_class.new }
+  let(:user) { FactoryBot.build_stubbed(:user) }
 
   it_behaves_like 'grid attributes'
 
@@ -42,6 +43,41 @@ describe Grids::MyPage, type: :model do
       instance.user = user
       expect(instance.user)
         .to eql user
+    end
+  end
+
+  describe '.new_default' do
+    it 'builds a new MyPage grid' do
+      expect(described_class.new_default(user: user))
+        .to be_a_kind_of(Grids::MyPage)
+    end
+
+    it 'is not persisted' do
+      expect(described_class.new_default(user: user))
+        .to be_new_record
+    end
+
+    it 'assigns the user' do
+      expect(described_class.new_default(user: user).user)
+        .to eql user
+    end
+
+    it 'assigns two widgets' do
+      expect(described_class.new_default(user: user).widgets[0].identifier)
+        .to eql 'work_packages_assigned'
+
+      expect(described_class.new_default(user: user).widgets[1].identifier)
+        .to eql 'work_packages_created'
+    end
+
+    it 'defines default so row_count' do
+      expect(described_class.new_default(user: user).row_count)
+        .to eql 7
+    end
+
+    it 'defines default so row_count' do
+      expect(described_class.new_default(user: user).column_count)
+        .to eql 4
     end
   end
 end

--- a/modules/grids/spec/queries/grids/query_integration_spec.rb
+++ b/modules/grids/spec/queries/grids/query_integration_spec.rb
@@ -32,10 +32,10 @@ describe Grids::Query, type: :model do
   let(:user) { FactoryBot.create(:user) }
   let(:other_user) { FactoryBot.create(:user) }
   let!(:my_page_grid) do
-    Grids::MyPage.new_default(user: user).tap(&:save!)
+    FactoryBot.create(:my_page, user: user)
   end
   let!(:other_my_page_grid) do
-    Grids::MyPage.new_default(user: other_user).tap(&:save!)
+    FactoryBot.create(:my_page, user: other_user)
   end
   let(:instance) { described_class.new }
 

--- a/modules/grids/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
+++ b/modules/grids/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
@@ -68,7 +68,7 @@ describe "POST /api/v3/grids/form", type: :request, content_type: :json do
 
       expect(subject.body)
         .to be_json_eql(my_page_path.to_json)
-        .at_path('_embedded/schema/page/_links/allowedValues/0/href')
+        .at_path('_embedded/schema/scope/_links/allowedValues/0/href')
     end
 
     it 'contains default data in the payload' do
@@ -84,10 +84,10 @@ describe "POST /api/v3/grids/form", type: :request, content_type: :json do
         .at_path('_embedded/payload')
     end
 
-    it 'has a validation error on page' do
+    it 'has a validation error on scope' do
       expect(subject.body)
-        .to be_json_eql("Page is not set to one of the allowed values.".to_json)
-        .at_path('_embedded/validationErrors/page/message')
+        .to be_json_eql("Scope is not set to one of the allowed values.".to_json)
+        .at_path('_embedded/validationErrors/scope/message')
     end
 
     it 'does not have a commit link' do
@@ -95,11 +95,11 @@ describe "POST /api/v3/grids/form", type: :request, content_type: :json do
         .not_to have_json_path('_links/commit')
     end
 
-    context 'with /my/page for the page value' do
+    context 'with /my/page for the scope value' do
       let(:params) do
         {
           '_links': {
-            'page': {
+            'scope': {
               'href': my_page_path
             }
           }
@@ -129,7 +129,7 @@ describe "POST /api/v3/grids/form", type: :request, content_type: :json do
             }
           ],
           "_links": {
-            "page": {
+            "scope": {
               "href": "/my/page",
               "type": "text/html"
             }
@@ -158,7 +158,7 @@ describe "POST /api/v3/grids/form", type: :request, content_type: :json do
       let(:params) do
         {
           '_links': {
-            'page': {
+            'scope': {
               'href': my_page_path
             }
           },

--- a/modules/grids/spec/requests/api/v3/grids/grids_resource_spec.rb
+++ b/modules/grids/spec/requests/api/v3/grids/grids_resource_spec.rb
@@ -46,7 +46,9 @@ describe 'API v3 Grids resource', type: :request, content_type: :json do
     FactoryBot.create(:user)
   end
   let(:other_my_page_grid) do
-    Grids::MyPage.new_default(user: other_user).save
+    grid = Grids::MyPage.new_default(user: other_user)
+    grid.save!
+    grid
   end
 
   before do
@@ -179,7 +181,7 @@ describe 'API v3 Grids resource', type: :request, content_type: :json do
         other_my_page_grid
       end
 
-      let(:path) { api_v3_paths.grid(other_my_page_grid) }
+      let(:path) { api_v3_paths.grid(other_my_page_grid.id) }
 
       it 'responds with 404 NOT FOUND' do
         expect(subject.status).to eql 404
@@ -314,7 +316,7 @@ describe 'API v3 Grids resource', type: :request, content_type: :json do
         other_my_page_grid
       end
 
-      let(:path) { api_v3_paths.grid(other_my_page_grid) }
+      let(:path) { api_v3_paths.grid(other_my_page_grid.id) }
 
       it 'responds with 404 NOT FOUND' do
         expect(subject.status).to eql 404

--- a/modules/grids/spec/requests/api/v3/grids/grids_resource_spec.rb
+++ b/modules/grids/spec/requests/api/v3/grids/grids_resource_spec.rb
@@ -37,19 +37,11 @@ describe 'API v3 Grids resource', type: :request, content_type: :json do
     FactoryBot.create(:user)
   end
 
-  let(:my_page_grid) do
-    grid = Grids::MyPage.new_default(user: current_user)
-    grid.save!
-    grid
-  end
+  let(:my_page_grid) { FactoryBot.create(:my_page, user: current_user) }
   let(:other_user) do
     FactoryBot.create(:user)
   end
-  let(:other_my_page_grid) do
-    grid = Grids::MyPage.new_default(user: other_user)
-    grid.save!
-    grid
-  end
+  let(:other_my_page_grid) { FactoryBot.create(:my_page, user: other_user) }
 
   before do
     login_as(current_user)
@@ -270,7 +262,7 @@ describe 'API v3 Grids resource', type: :request, content_type: :json do
 
       it 'does not persist the changes to widgets' do
         expect(my_page_grid.reload.widgets.count)
-          .to eql Grids::MyPage.new_default(user: current_user).widgets.size
+          .to eql Grids::MyPageGridRegistration.defaults[:widgets].size
       end
     end
 

--- a/modules/grids/spec/requests/api/v3/grids/grids_update_form_resource_spec.rb
+++ b/modules/grids/spec/requests/api/v3/grids/grids_update_form_resource_spec.rb
@@ -38,7 +38,7 @@ describe "PATCH /api/v3/grids/:id/form", type: :request, content_type: :json do
   end
 
   let(:grid) do
-    grid = Grids::MyPage.new_default(current_user)
+    grid = Grids::MyPage.new_default(user: current_user)
     grid.save!
     grid
   end
@@ -66,14 +66,14 @@ describe "PATCH /api/v3/grids/:id/form", type: :request, content_type: :json do
         .at_path('_type')
     end
 
-    it 'contains a Schema disallowing setting page' do
+    it 'contains a Schema disallowing setting scope' do
       expect(subject.body)
         .to be_json_eql("Schema".to_json)
         .at_path('_embedded/schema/_type')
 
       expect(subject.body)
         .to be_json_eql(false.to_json)
-        .at_path('_embedded/schema/page/writable')
+        .at_path('_embedded/schema/scope/writable')
     end
 
     it 'contains the current data in the payload' do
@@ -99,7 +99,7 @@ describe "PATCH /api/v3/grids/:id/form", type: :request, content_type: :json do
           }
         ],
         "_links": {
-          "page": {
+          "scope": {
             "href": "/my/page",
             "type": "text/html"
           }
@@ -117,21 +117,21 @@ describe "PATCH /api/v3/grids/:id/form", type: :request, content_type: :json do
         .at_path('_links/commit/href')
     end
 
-    context 'with some value for the page value' do
+    context 'with some value for the scope value' do
       let(:params) do
         {
           '_links': {
-            'page': {
+            'scope': {
               'href': '/some/path'
             }
           }
         }
       end
 
-      it 'has a validation error on page as the value is not writeable' do
+      it 'has a validation error on scope as the value is not writeable' do
         expect(subject.body)
           .to be_json_eql("You must not write a read-only attribute.".to_json)
-          .at_path('_embedded/validationErrors/page/message')
+          .at_path('_embedded/validationErrors/scope/message')
       end
     end
 
@@ -170,7 +170,7 @@ describe "PATCH /api/v3/grids/:id/form", type: :request, content_type: :json do
     context 'for another user\'s grid' do
       let(:other_user) { FactoryBot.create(:user) }
       let(:other_grid) do
-        grid = Grids::MyPage.new_default(other_user)
+        grid = Grids::MyPage.new_default(user: other_user)
         grid.save!
         grid
       end

--- a/modules/grids/spec/requests/api/v3/grids/grids_update_form_resource_spec.rb
+++ b/modules/grids/spec/requests/api/v3/grids/grids_update_form_resource_spec.rb
@@ -38,9 +38,7 @@ describe "PATCH /api/v3/grids/:id/form", type: :request, content_type: :json do
   end
 
   let(:grid) do
-    grid = Grids::MyPage.new_default(user: current_user)
-    grid.save!
-    grid
+    FactoryBot.create(:my_page, user: current_user)
   end
   let(:path) { api_v3_paths.grid_form(grid.id) }
   let(:params) { {} }
@@ -169,11 +167,7 @@ describe "PATCH /api/v3/grids/:id/form", type: :request, content_type: :json do
 
     context 'for another user\'s grid' do
       let(:other_user) { FactoryBot.create(:user) }
-      let(:other_grid) do
-        grid = Grids::MyPage.new_default(user: other_user)
-        grid.save!
-        grid
-      end
+      let(:other_grid) { FactoryBot.create(:my_page, user: other_user) }
 
       let(:path) { api_v3_paths.grid_form(other_grid.id) }
 

--- a/modules/grids/spec/services/grids/create_service_spec.rb
+++ b/modules/grids/spec/services/grids/create_service_spec.rb
@@ -63,11 +63,11 @@ describe Grids::CreateService, type: :model do
                       errors: set_attributes_errors
   end
   let!(:grid) do
-    grid = FactoryBot.build_stubbed(grid_class.name.demodulize.underscore.to_sym)
+    grid = FactoryBot.build(grid_class.name.demodulize.underscore.to_sym)
 
-    allow(grid_class)
-      .to receive(:new_default)
-      .with(user: user, project: project)
+    allow(Grids::Factory)
+      .to receive(:build)
+      .with(scope, user)
       .and_return(grid)
 
     allow(grid)

--- a/modules/grids/spec/services/grids/set_attributes_service_spec.rb
+++ b/modules/grids/spec/services/grids/set_attributes_service_spec.rb
@@ -58,7 +58,7 @@ describe Grids::SetAttributesService, type: :model do
   let(:call_attributes) { {} }
   let(:grid_class) { Grids::MyPage }
   let(:grid) do
-    FactoryBot.build_stubbed(grid_class.name.demodulize.underscore.to_sym)
+    FactoryBot.build_stubbed(grid_class.name.demodulize.underscore.to_sym, widgets: [])
   end
 
   describe 'call' do
@@ -126,7 +126,7 @@ describe Grids::SetAttributesService, type: :model do
           .to be_new_record
       end
 
-      it 'applies the provided valuees' do
+      it 'applies the provided values' do
         expect(grid.widgets[0].attributes.except('id'))
           .to eql widgets[0].attributes.except('id').merge('grid_id' => grid.id)
       end

--- a/spec/models/relation/hierarchy_paths_spec.rb
+++ b/spec/models/relation/hierarchy_paths_spec.rb
@@ -46,7 +46,7 @@ describe Relation, 'hierarchy_paths', type: :model do
     SQL
   end
 
-  def path_for(id)
+  def to_scope(id)
     record_for(id)[0][1]
   end
 

--- a/spec/support/contracts/shared.rb
+++ b/spec/support/contracts/shared.rb
@@ -1,0 +1,26 @@
+shared_context 'model contract' do
+  shared_examples_for 'is not writable' do
+    before do
+      instance.model.attributes = { attribute => value }
+    end
+
+    it 'explains the not writable error' do
+      instance.validate
+      expect(instance.errors.details[attribute])
+        .to match_array [{ error: :error_readonly }]
+    end
+  end
+
+  shared_examples_for 'is writable' do
+    before do
+      instance.model.attributes = { attribute => value }
+    end
+
+    it 'is writable' do
+      instance.validate
+
+      expect(instance.errors.details[attribute])
+        .not_to include(error: :error_readonly)
+    end
+  end
+end


### PR DESCRIPTION
Extends the grid backend to also be able to handle boards. In particular, it adds the ability of boards to be attached to projects and changes the page property of grids to a scope property that better describes that more than one board can belong to the same scope (e.g. /projects/:project_id/boards).

For a fully featured board, though, widgets need to be able to store options, so that they can store queries. Those widgets might also need to have custom processing and validation. That part has not been implemented. 