### PR TITLE
avoid EventedFileUpdateChecker to avoid system crashes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ ruby '~> 2.5.1'
 gem 'actionpack-xml_parser', '~> 2.0.0'
 gem 'activemodel-serializers-xml', '~> 1.0.1'
 gem 'activerecord-session_store', '~> 1.1.0'
-gem 'listen', '~> 3.1' # Use for event-based reloaders
 gem 'rails', '~> 5.2.2'
 gem 'responders', '~> 2.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -505,10 +505,6 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.7.0)
       launchy (~> 2.2)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
     livingstyleguide (2.0.3)
       minisyntax (>= 0.2.5)
       redcarpet
@@ -754,7 +750,6 @@ GEM
     ruby-rc4 (0.1.5)
     ruby-saml (1.9.0)
       nokogiri (>= 1.5.10)
-    ruby_dep (1.5.0)
     rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sanitize (5.0.0)
@@ -932,7 +927,6 @@ DEPENDENCIES
   json_spec (~> 1.1.4)
   launchy (~> 2.4.3)
   letter_opener
-  listen (~> 3.1)
   livingstyleguide (~> 2.0.1)
   lograge (~> 0.10.0)
   meta-tags (~> 2.11.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,8 +41,11 @@ OpenProject::Application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Asynchronous file watcher
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # File watcher
+  # using ActiveSupport::EventedFileUpdateChecker depends on listen which depends on fsevent
+  # which seems to be prone to creating zombie process (+200 of them) which can cause
+  # the process limit (on mac) to be reached which causes the system to need a reboot.
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local


### PR DESCRIPTION
Because of the tendency of rb-fsevent (used by listen on mac) to create zombie processes and because of the rather low default number of allowed processes on mac (709), using the EventedFileUpdateChecker can cause the system to become unusable which can then only be fixed by a reboot (as kill requires forking).

Please also see:

* https://github.com/rails/rails/issues/26158
* https://github.com/puma/puma-dev/issues/56#issuecomment-263886476
* https://github.com/ledermann/docker-rails/commit/148540d9c8c0f493864d7d532cb7ba8a070ee794