### PR TITLE
[29482] Editor dropdown is cut off when opened to top

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -399,6 +399,9 @@ fieldset.form--fieldset
 
   &.-vertical
     display: block
+    
+  .form--field.-visible-overflow &
+    overflow: visible
 
   &:nth-of-type(n+2),
   .form--field.-no-label &

--- a/app/views/wiki/_page_form.html.erb
+++ b/app/views/wiki/_page_form.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 <% end %>
 
-<div class="attributes-group wiki--content--attribute">
+<div class="attributes-group wiki--content--attribute form--field -visible-overflow">
   <%= f.text_area :text,
                   cols: 100,
                   rows: 25,

--- a/modules/my_project_page/app/views/my_projects_overviews/_block_textilizable.html.erb
+++ b/modules/my_project_page/app/views/my_projects_overviews/_block_textilizable.html.erb
@@ -51,7 +51,7 @@ See doc/COPYRIGHT.md for more details.
             </div>
           </div>
 
-          <div class="form--field -required">
+          <div class="form--field -required -visible-overflow">
             <%= styled_label_tag "textile_#{block_name}", t('info_custom_text') %>
             <div class="form--field-container" ng-non-bindable>
 


### PR DESCRIPTION
Allow overflowing menus within the ckeditor

https://community.openproject.com/projects/openproject/work_packages/29482/activity