### PR TITLE
Fix/api reloading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -273,7 +273,7 @@ end
 gem 'bootsnap', '~> 1.3.2', require: true
 
 # API gems
-gem 'grape', '~> 1.1'
+gem 'grape', '~> 1.2.3'
 
 gem 'reform', '~> 2.2.0'
 gem 'reform-rails', '~> 0.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,7 +456,7 @@ GEM
       actionpack (>= 3.0)
       multi_json
       request_store (>= 1.0)
-    grape (1.1.0)
+    grape (1.2.3)
       activesupport
       builder
       mustermann-grape (~> 1.0.0)
@@ -918,7 +918,7 @@ DEPENDENCIES
   friendly_id (~> 5.2.1)
   fuubar (~> 2.3.2)
   gon (~> 6.2.1)
-  grape (~> 1.1)
+  grape (~> 1.2.3)
   grids!
   health_check
   html-pipeline (~> 2.8.0)

--- a/config/constants/api_patch_registry.rb
+++ b/config/constants/api_patch_registry.rb
@@ -26,7 +26,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
+module Constants
   class APIPatchRegistry
     class << self
       def add_patch(class_name, path, &block)

--- a/lib/api/open_project_api.rb
+++ b/lib/api/open_project_api.rb
@@ -28,6 +28,37 @@
 
 module API
   class OpenProjectAPI < ::Grape::API
-    include ::API::PatchableAPI
+    class << self
+      def inherited(api, *)
+        super
+
+        # run unscoped patches (i.e. patches that are on the class root, not in a namespace)
+        api.apply_patches(nil)
+      end
+    end
+  end
+end
+
+Grape::DSL::Routing::ClassMethods.module_eval do
+  # Be reload safe. otherwise, an infinite loop occurs on reload.
+  unless instance_methods.include?(:orig_namespace)
+    alias :orig_namespace :namespace
+  end
+
+  def namespace(space = nil, options = {}, &block)
+    orig_namespace(space, options) do
+      instance_eval(&block)
+      apply_patches(space)
+    end
+  end
+
+  def apply_patches(path)
+    (patches[path] || []).each do |patch|
+      instance_eval(&patch)
+    end
+  end
+
+  def patches
+    ::Constants::APIPatchRegistry.patches_for(base)
   end
 end

--- a/lib/api/patchable_api.rb
+++ b/lib/api/patchable_api.rb
@@ -29,15 +29,17 @@
 module API
   module PatchableAPI
     def self.included(base)
-      base.extend ClassMethods
+      base.class_eval do
+        prepend ClassMethods
+      end
     end
 
     module ClassMethods
-      def inherited(subclass)
+      def inherited(api, base_instance_parent = Grape::API::Instance)
         super
 
         # run unscoped patches (i.e. patches that are on the class root, not in a namespace)
-        subclass.send(:execute_patches_for, nil)
+        api.send(:execute_patches_for, nil)
       end
 
       def namespace(name, *args, &block)
@@ -64,7 +66,7 @@ module API
       end
 
       def patches
-        ::API::APIPatchRegistry.patches_for(self)
+        ::Constants::APIPatchRegistry.patches_for(self)
       end
     end
   end

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -30,7 +30,7 @@
 
 # Root class of the API v3
 # This is the place for all API v3 wide configuration, helper methods, exceptions
-# rescuing, mounting of differnet API versions etc.
+# rescuing, mounting of different API versions etc.
 
 module API
   module V3

--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -27,6 +27,7 @@
 #++
 
 require_dependency 'open_project/ui/extensible_tabs'
+require_dependency 'config/constants/api_patch_registry'
 
 module OpenProject::Plugins
   module ActsAsOpEngine
@@ -225,7 +226,7 @@ module OpenProject::Plugins
           # 1. it does not seem possible to pass it as constant (auto loader not ready yet)
           # 2. we can't constantize it here, because that would evaluate
           #    the API before it can be patched
-          ::API::APIPatchRegistry.add_patch base_endpoint, path, &block
+          ::Constants::APIPatchRegistry.add_patch base_endpoint, path, &block
         end
       end
 


### PR DESCRIPTION
API endpoints that are patched in, are no longer lost when reloading the application after changing the code in development mode.