### PR TITLE
[29492][29531] Styling issues with the WP field autocompleter

### DIFF
--- a/app/assets/stylesheets/content/_autocomplete.sass
+++ b/app/assets/stylesheets/content/_autocomplete.sass
@@ -152,11 +152,17 @@ mark.ui-autocomplete-match
 
   .ng-select-container
     z-index: auto !important
-    .ng-value-container input
-      height: 100%
-      -webkit-box-sizing: border-box !important
-      -moz-box-sizing: border-box !important
-      box-sizing: border-box !important
+    height: 30px !important
+    min-height: 30px !important
+
+    .ng-value-container
+      overflow: visible !important
+
+      input
+        height: 100%
+        -webkit-box-sizing: border-box !important
+        -moz-box-sizing: border-box !important
+        box-sizing: border-box !important
   .ng-value
     @include text-shortener
 


### PR DESCRIPTION
This PR does two things:

* Reduce height of autocompleter. Thus it looks more similar to the other fields and column break is avoided when the elect field is opened.
* It takes care that the input search text is always visible.

https://community.openproject.com/projects/openproject/work_packages/29492/activity
https://community.openproject.com/projects/openproject/work_packages/29531/activity