### PR TITLE
Fix LDAP synchronized group plugin loading and deletion

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,11 @@ PATH
     grids (8.2.1)
 
 PATH
+  remote: modules/ldap_groups
+  specs:
+    openproject-ldap_groups (8.2.1)
+
+PATH
   remote: modules/meeting
   specs:
     openproject-meeting (8.2.1)
@@ -501,6 +506,8 @@ GEM
       multi_json (~> 1.0)
       rspec (>= 2.0, < 4.0)
     kgio (2.11.2)
+    ladle (1.0.1)
+      open4 (~> 1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.7.0)
@@ -560,6 +567,7 @@ GEM
     omniauth-saml (1.10.1)
       omniauth (~> 1.3, >= 1.3.2)
       ruby-saml (~> 1.7)
+    open4 (1.3.4)
     openid_connect (1.1.6)
       activemodel
       attr_required (>= 1.0.0)
@@ -925,6 +933,7 @@ DEPENDENCIES
   htmldiff
   i18n-js (~> 3.2.0)
   json_spec (~> 1.1.4)
+  ladle
   launchy (~> 2.4.3)
   letter_opener
   livingstyleguide (~> 2.0.1)
@@ -949,6 +958,7 @@ DEPENDENCIES
   openproject-documents!
   openproject-github_integration!
   openproject-global_roles!
+  openproject-ldap_groups!
   openproject-meeting!
   openproject-my_project_page!
   openproject-openid_connect!

--- a/Gemfile.modules
+++ b/Gemfile.modules
@@ -4,6 +4,10 @@
 # see also https://github.com/bundler/bundler/issues/1041
 gem 'omniauth-saml', '~> 1.10.1'
 
+group :development, :test do
+  gem 'ladle'
+end
+
 gem 'omniauth-openid_connect-providers',
 		git: 'https://github.com/finnlabs/omniauth-openid_connect-providers.git',
 		ref: 'b8b9d4be88fb48a1fa4f4afd9fd226dac54430f8'
@@ -33,6 +37,7 @@ group :opf_plugins do
 	gem 'openproject-two_factor_authentication', path: 'modules/two_factor_authentication'
 	gem 'openproject-webhooks',                  path: 'modules/webhooks'
 	gem 'openproject-github_integration',        path: 'modules/github_integration'
+	gem 'openproject-ldap_groups',               path: 'modules/ldap_groups'
 
     gem 'grids',                                 path: 'modules/grids'
 end

--- a/modules/ldap_groups/app/cells/ldap_groups/synchronized_groups/row_cell.rb
+++ b/modules/ldap_groups/app/cells/ldap_groups/synchronized_groups/row_cell.rb
@@ -29,8 +29,9 @@ module LdapGroups
       end
 
       def delete_link
-        link_to '',
+        link_to I18n.t(:button_delete),
                 { controller: table.target_controller, ldap_group_id: model.id, action: :destroy_info },
+                class: 'icon icon-delete',
                 title: t(:button_delete)
       end
     end


### PR DESCRIPTION
Addresses two issues

- The LDAP group sync plugin was integrated, but not loaded by default
- The delete button for synchronized groups were missing