### PR TITLE
Don't redefine API constants on every reload

### DIFF
--- a/lib/api/v3/render/render_api.rb
+++ b/lib/api/v3/render/render_api.rb
@@ -36,8 +36,8 @@ module API
 
         resources :render do
           helpers do
-            SUPPORTED_CONTEXT_NAMESPACES = %w(work_packages projects news posts wiki_pages).freeze
-            SUPPORTED_MEDIA_TYPE = 'text/plain'.freeze
+            SUPPORTED_CONTEXT_NAMESPACES ||= %w(work_packages projects news posts wiki_pages).freeze
+            SUPPORTED_MEDIA_TYPE ||= 'text/plain'.freeze
 
             def allowed_content_types
               [SUPPORTED_MEDIA_TYPE]


### PR DESCRIPTION
Fixes spewing the following warnings on every start / reload due to rebinding the constant.

```
/home/oliver/openproject/dev/lib/api/v3/render/render_api.rb:39: warning: already initialized constant API::V3::Render::RenderAPI::SUPPORTED_CONTEXT_NAMESPACES
/home/oliver/openproject/dev/lib/api/v3/render/render_api.rb:39: warning: previous definition of SUPPORTED_CONTEXT_NAMESPACES was here
/home/oliver/openproject/dev/lib/api/v3/render/render_api.rb:40: warning: already initialized constant API::V3::Render::RenderAPI::SUPPORTED_MEDIA_TYPE
/home/oliver/openproject/dev/lib/api/v3/render/render_api.rb:40: warning: previous definition of SUPPORTED_MEDIA_TYPE was here
/home/oliver/openproject/dev/lib/api/v3/render/render_api.rb:39: warning: already initialized constant API::V3::Render::RenderAPI::SUPPORTED_CONTEXT_NAMESPACES
/home/oliver/openproject/dev/lib/api/v3/render/render_api.rb:39: warning: previous definition of SUPPORTED_CONTEXT_NAMESPACES was here
/home/oliver/openproject/dev/lib/api/v3/render/render_api.rb:40: warning: already initialized constant API::V3::Render::RenderAPI::SUPPORTED_MEDIA_TYPE
/home/oliver/openproject/dev/lib/api/v3/render/render_api.rb:40: warning: previous definition of SUPPORTED_MEDIA_TYPE was here
```