### PR TITLE
Sorting within hierarchies

### DIFF
--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -57,12 +57,35 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
     parent: {
       association: 'ancestors_relations',
       default_order: 'asc',
-      sortable: ["CONCAT_WS(',', hierarchy_paths.path, work_packages.id)"],
+      sortable: ["COALESCE(depth_relations.from_id, #{WorkPackage.table_name}.id)",
+                 "COALESCE(depth_relations.hierarchy, 0)"],
       sortable_join: <<-SQL
-        LEFT OUTER JOIN
-          hierarchy_paths
-        ON
-          hierarchy_paths.work_package_id = work_packages.id
+        LEFT OUTER JOIN (
+          SELECT
+            r1.from_id,
+            r1.to_id,
+            r1.hierarchy
+          FROM relations r1
+          LEFT OUTER JOIN relations r2
+            ON
+              r1.to_id = r2.to_id
+              AND r1.hierarchy < r2.hierarchy
+              AND r2.relates = 0
+              AND r2.duplicates = 0
+              AND r2.follows = 0
+              AND r2.blocks = 0
+              AND r2.includes = 0
+              AND r2.requires = 0
+          WHERE
+            r2.id IS NULL
+            AND r1.relates = 0
+            AND r1.duplicates = 0
+            AND r1.follows = 0
+            AND r1.blocks = 0
+            AND r1.includes = 0
+            AND r1.requires = 0
+        ) depth_relations
+        ON depth_relations.to_id = work_packages.id
       SQL
     },
     status: {


### PR DESCRIPTION
This PR aims to implement sorting within a work package hierarchy. 

### Background

By sorting, two different modes of sorting is referred to:

* automatically by a work package column 
* manually as defined by the user (similar to how sorting is introduced in #7008)

The former stores its information to sort by within the `work_packages` or the `custom_values` table, while the later uses `ordered_work_packages` table.

### Current status

Currently, the hierarchy information is persisted in the `hierarchy_paths` table. Whenever a work package is created, removed, or its parent/child-relationship changes, that table is updated. That overhead enables fast ordering when rendering work package tables. 

But it is also a static sorting. In order to avoid having children appear before their parent, the full path (including the element under consideration) is stored in the table. Therefore, it is currently not possible to sort by any other criteria when sorting for hierarchy.

That limitation had been accepted as sorting for hierarchy dynamically  (as now done again in c4c7512cad) will become increasingly slow as the amount of work packages and relations increases, up until the point where a web request cannot be answered in time before the connection is considered non responding by e.g. a proxy.

### Approach

Only sorting in the database can be fast enough and can produce correct results. 

c4c7512cad will already implement an on the fly ordering by work package `id` taking into account all the ancestor `id`s.

The approach has a couple of limitations:

* *Performance*: Because it is build on the fly it will be unacceptably slow for larger data sets
* *Static*: Because the ordering is always by `id`, ordering by other columns or manually is not supported.

Both limitations need to be overcome before the PR can be merged.

#### ToDos Performance

*  Avoid having to build the complete hierarchy for all work packages when only the relationship of a subset (the ones that are in the filter results) need to be considered. This currently happens because of the subquery. Possibilities:
    * Forgo the subquery and use joins instead (Preferred).
    * Retrieve the ids of work packages in the result set first. And then pass those ids into the subquery when getting the full work package information.
* As a worst case, the result set will contain all work packages (the user is admin and has removed all filters). In that case, there exists no possible means to reduce the amount of computing the database has to do to provide a complete sorting. There therefore has to be a limit to the amount of work packages that can be sorted while in hierarchy.
* _Possibly_ drop MySQL support because of its lack of partial indices (https://www.postgresql.org/docs/8.0/indexes-partial.html) or impose a lower limit when on MySql.

#### ToDos Static

* Join additional tables to the dynamic sorting query of c4c7512cad. Depending on the sorting criteria chosen by the user, different tables (`work_packages`, `custom_values` or `ordered_work_packages`) need to be joined. They must not be joined statically all the time as this will further decrease performance.
* Dynamically change the criteria used for sorting (the `sortable` property of the `PropertyColumn` definition) or find a means to express the select within the subselect dynamically (if the subselect remains) or for the join.

#### ToDos other

* No longer consider the `parent` column to be a valid sorting criteria. It is not now and will not be even more once the changes proposed have been completed. It needs to be a flag set on the query. The front end will also benefit from that more explicit definition as the `parent` sorting criteria has always been misleading. 
* Think about whether it is possible to support multiple sorting criterias.
* Think about how to support work packages that have not been ordered by the user explicitly when applying manual sorting. Even when storing manual sorting information for all work packages upon query creation, new work packages can be added to the query by a couple of different means. 
* Remove `hierarchy_paths` table and the callbacks implemented in services to maintain the table.
* The frontend part

https://community.openproject.com/projects/openproject/work_packages/29539



 