### PR TITLE
[29561 ] Better errors when bulk editing

### DIFF
--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -38,6 +38,7 @@ class ServiceResult
   def initialize(success: false,
                  errors: nil,
                  context: {},
+                 dependent_results: [],
                  result: nil)
     self.success = success
     self.result = result
@@ -50,7 +51,7 @@ class ServiceResult
                     ActiveModel::Errors.new(self)
                   end
 
-    self.dependent_results = []
+    self.dependent_results = dependent_results
   end
 
   alias success? :success
@@ -65,7 +66,9 @@ class ServiceResult
   end
 
   def all_results
-    [result] + dependent_results.map(&:result)
+    dependent_results.map(&:result).tap do |results|
+      results.unshift result unless result.nil?
+    end
   end
 
   def all_errors

--- a/app/services/work_packages/bulk/update_service.rb
+++ b/app/services/work_packages/bulk/update_service.rb
@@ -1,0 +1,93 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module WorkPackages
+  module Bulk
+    class UpdateService
+      include ::Shared::ServiceContext
+      include ::HookHelper
+
+      attr_accessor :user, :work_packages, :permitted_params
+
+      def initialize(user:, work_packages:)
+        self.user = user
+        self.work_packages = work_packages
+      end
+
+      def call(params:)
+        self.permitted_params = PermittedParams.new(params, user)
+        in_context(true) do
+          bulk_update(params)
+        end
+      end
+
+      private
+
+      def bulk_update(params)
+        saved = []
+        errors = {}
+
+        work_packages.each do |work_package|
+          work_package.add_journal(user, params[:notes])
+
+          # filter parameters by whitelist and add defaults
+          attributes = parse_params_for_bulk_work_package_attributes params, work_package.project
+
+          call_hook(:controller_work_packages_bulk_edit_before_save, params: params, work_package: work_package)
+
+          service_call = WorkPackages::UpdateService
+            .new(user: user, work_package: work_package)
+            .call(attributes: attributes, send_notifications: params[:send_notification] == '1')
+
+          if service_call.success?
+            saved << work_package.id
+          else
+            errors[work_package.id] = service_call.errors.full_messages
+          end
+        end
+
+        ServiceResult.new success: errors.empty?, result: saved, errors: errors
+      end
+
+      def parse_params_for_bulk_work_package_attributes(params, project)
+        return {} unless params.has_key? :work_package
+
+        safe_params = permitted_params.update_work_package project: project
+        attributes = safe_params.reject { |_k, v| v.blank? }
+        attributes.keys.each do |k|
+          attributes[k] = '' if attributes[k] == 'none'
+        end
+        attributes[:custom_field_values].reject! { |_k, v| v.blank? } if attributes[:custom_field_values]
+        attributes.delete :custom_field_values if not attributes.has_key?(:custom_field_values) or attributes[:custom_field_values].empty?
+        attributes
+      end
+    end
+  end
+end

--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -28,8 +28,35 @@ See docs/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <% html_title l(:label_bulk_edit_selected_work_packages) %>
+
+<% if @bulk_errors.present? %>
+  <div class="notification-box -error">
+    <a title="close" class="notification-box--close icon-context icon-close"></a>
+    <div class="notification-box--content">
+      <p><strong><%= t('work_packages.bulk.could_not_be_saved') %></strong></p>
+
+      <ul>
+      <% @bulk_errors.each do |wpid, messages| %>
+        <li>
+          <%= link_to "##{wpid}", work_package_path(wpid) %>:
+          <%= safe_join messages, ', ' %>
+        </li>
+      <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>
+
 <h2><%= l(:label_bulk_edit_selected_work_packages) %></h2>
-<ul><%= @work_packages.collect {|i| content_tag('li', link_to(h("#{i.type} ##{i.id}"), work_package_path(i)) + h(": #{i.subject}")) }.join("\n").html_safe %></ul>
+<ul>
+  <% @work_packages.each do |wp| %>
+    <li>
+      <%= link_to(h("#{wp.type} ##{wp.id}"), work_package_path(wp)) %>:
+      <%= wp.subject %>
+    </li>
+  <% end %>
+</ul>
+
 <%= styled_form_tag(url_for(controller: '/work_packages/bulk', action: :update),
              method: :put, class: '-wide-labels') do %>
   <%= @work_packages.collect {|i| hidden_field_tag('ids[]', i.id)}.join.html_safe %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -255,6 +255,10 @@ en:
       one: 'One descendant work package'
       other: '%{count} work package descendants'
 
+    bulk:
+      could_not_be_saved: "The following work packages could not be saved:"
+
+
     move:
       no_common_statuses_exists: "There is no status available for all selected work packages. Their status cannot be changed."
       unsupported_for_multiple_projects: 'Bulk move/copy is not supported for work packages from multiple projects'

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -399,7 +399,7 @@ describe WorkPackages::BulkController, type: :controller do
             include_context 'update_request'
 
             it 'does not succeed' do
-              expect(flash[:error]).to include(work_package_ids.join(', #'))
+              expect(assigns[:bulk_errors].keys).to match_array(work_package_ids)
               expect(subject).to match_array [user.id]
             end
           end

--- a/spec/features/work_packages/bulk/update_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/update_work_package_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+require 'features/page_objects/notification'
+
+describe 'Bulk update work packages through Rails view', js: true do
+  let(:dev_role) do
+    FactoryBot.create :role,
+                       permissions: %i[view_work_packages]
+  end
+  let(:mover_role) do
+    FactoryBot.create :role,
+                       permissions: %i[view_work_packages copy_work_packages move_work_packages manage_subtasks add_work_packages]
+  end
+  let(:dev) do
+    FactoryBot.create :user,
+                       firstname: 'Dev',
+                       lastname: 'Guy',
+                       member_in_project: project,
+                       member_through_role: dev_role
+  end
+  let(:mover) do
+    FactoryBot.create :admin,
+                       firstname: 'Manager',
+                       lastname: 'Guy',
+                       member_in_project: project,
+                       member_through_role: mover_role
+  end
+
+  let(:type) { FactoryBot.create :type, name: 'Bug' }
+
+  let!(:project) { FactoryBot.create(:project, name: 'Source', types: [type]) }
+
+  let!(:status) { FactoryBot.create :status }
+
+  let!(:work_package) {
+    FactoryBot.create(:work_package,
+                       author: dev,
+                       status: status,
+                       project: project,
+                       type: type)
+  }
+  let!(:work_package2) {
+    FactoryBot.create(:work_package,
+                       author: dev,
+                       status: status,
+                       project: project,
+                       type: type)
+  }
+
+  let!(:status2) { FactoryBot.create :default_status }
+  let!(:workflow) do
+    FactoryBot.create :workflow,
+                       type_id: type.id,
+                       old_status: work_package.status,
+                       new_status: status2,
+                       role: mover_role
+  end
+
+  let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
+  let(:context_menu) { Components::WorkPackages::ContextMenu.new }
+
+  before do
+    login_as current_user
+    wp_table.visit!
+    expect_angular_frontend_initialized
+    wp_table.expect_work_package_listed work_package, work_package2
+
+    # Select all work packages
+    find('body').send_keys [:control, 'a']
+  end
+
+  describe 'copying work packages' do
+    context 'with permission' do
+      let(:current_user) { mover }
+
+      before do
+        context_menu.open_for work_package
+        context_menu.choose 'Bulk edit'
+
+        # On work packages edit page
+        expect(page).to have_selector('#work_package_status_id')
+        select status2.name, from: 'work_package_status_id'
+      end
+
+      it 'sets two statuses' do
+        click_on 'Submit'
+
+        expect_angular_frontend_initialized
+        wp_table.expect_work_package_count 2
+
+        # Should update the status
+        work_package2.reload
+        work_package.reload
+        expect(work_package.status_id).to eq(status2.id)
+        expect(work_package2.status_id).to eq(status2.id)
+      end
+
+      context 'when making an error in the form' do
+        it 'does not update the work packages' do
+          fill_in 'work_package_start_date', with: '123'
+          click_on 'Submit'
+
+          expect(page).to have_selector('.notification-box', text: I18n.t('work_packages.bulk.could_not_be_saved'))
+          expect(page).to have_selector('.notification-box', text: work_package.id)
+          expect(page).to have_selector('.notification-box', text: work_package2.id)
+
+          # Should not update the status
+          work_package2.reload
+          work_package.reload
+          expect(work_package.status_id).to eq(status.id)
+          expect(work_package2.status_id).to eq(status.id)
+        end
+      end
+    end
+
+    context 'without permission' do
+      let(:current_user) { dev }
+
+      it 'does not allow to copy' do
+        context_menu.open_for work_package
+        context_menu.expect_no_options 'Bulk edit'
+      end
+    end
+  end
+end


### PR DESCRIPTION
When bulk editing and receiving errors due to e.g., new required fields or invalid statuses, it's basically impossible to find out what happened.

<img width="955" alt="bildschirmfoto 2019-02-17 um 21 14 00" src="https://user-images.githubusercontent.com/459462/52918695-3db51080-32fa-11e9-935e-33fc616631d9.png">

This PR simply accumulates the errors and prints it in a separate notification instead of only outputting the faulty work package IDs.

https://community.openproject.com/wp/29561