### PR TITLE
[29497] Gantt chart not properly aligned when using groups

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -61,8 +61,10 @@
   color: $nm-color-error-icon
 
 // Remove padding from grouping rows (exceeds allowed width of 41px)
-.wp-table--group-header td
-  padding: 0 !important
+.wp-table--group-header
+  height: $table-timeline--row-height
+  td
+    padding: 0 !important
 
 // Shrink column of details / inline-create icons
 .wp-table--configuration-modal--trigger


### PR DESCRIPTION
Adapt height of group headers in the gantt chart to avoid misalignment.

https://community.openproject.com/projects/openproject/work_packages/29497/activity