### PR TITLE
[29568] Ensure sql join in manual filter and sort column is isolated in query

### DIFF
--- a/app/models/queries/columns/base.rb
+++ b/app/models/queries/columns/base.rb
@@ -53,6 +53,10 @@ class Queries::Columns::Base
     end
   end
 
+  def sortable_join_statement(query)
+    sortable_join
+  end
+
   def caption
     raise NotImplementedError
   end

--- a/app/models/queries/work_packages/columns/manual_sorting_column.rb
+++ b/app/models/queries/work_packages/columns/manual_sorting_column.rb
@@ -29,15 +29,15 @@
 #++
 
 class Queries::WorkPackages::Columns::ManualSortingColumn < Queries::WorkPackages::Columns::WorkPackageColumn
+  include ::Queries::WorkPackages::Common::ManualSorting
+
   def initialize
     super :manual_sorting,
           default_order: 'asc',
-          sortable: %w[ordered_work_packages.position],
-          sortable_join: <<-SQL
-              LEFT OUTER JOIN
-                ordered_work_packages
-              ON
-                ordered_work_packages.work_package_id = work_packages.id
-          SQL
+          sortable: %w[ordered_work_packages.position]
+  end
+
+  def sortable_join_statement(query)
+    ordered_work_packages_join(query)
   end
 end

--- a/app/models/queries/work_packages/common/manual_sorting.rb
+++ b/app/models/queries/work_packages/common/manual_sorting.rb
@@ -2,7 +2,7 @@
 
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -13,7 +13,7 @@
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
-# as published by the Foperatorree Software Foundation; either version 2
+# as published by the Free Software Foundation; either version 2
 # of the License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -25,48 +25,31 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# See doc/COPYRIGHT.rdoc for more details.
+# See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::WorkPackages::Filter::ManualSortFilter <
-  Queries::WorkPackages::Filter::WorkPackageFilter
+module Queries::WorkPackages
+  module Common
+    module ManualSorting
 
-  include ::Queries::WorkPackages::Common::ManualSorting
+      ##
+      # We depend on ordered_work_packages association
+      # for determining sort and filter for manual sorting.
+      #
+      # We could restrict the join result with where(query_id: context.id) later
+      # but that prevents the execution planner from optimizing on the explicit join clause.
+      def ordered_work_packages_join(query)
+        join_sql = <<-SQL
+          LEFT OUTER JOIN
+            ordered_work_packages
+          ON
+            ordered_work_packages.work_package_id = work_packages.id
+            AND ordered_work_packages.query_id = :query_id
+        SQL
 
-  def available_operators
-    [Queries::Operators::OrderedWorkPackages]
-  end
-
-  def available?
-    true
-  end
-
-  def joins
-    ordered_work_packages_join(query)
-  end
-
-  def type
-    :empty_value
-  end
-
-  def where
-    WorkPackage
-      .arel_table[:id]
-      .in(context.ordered_work_packages)
-      .to_sql
-  end
-
-  def self.key
-    :manual_sort
-  end
-
-  def ar_object_filter?
-    true
-  end
-
-  private
-
-  def operator_strategy
-    Queries::Operators::OrderedWorkPackages
+        ::OpenProject::SqlSanitization
+          .sanitize join_sql, query_id: query.id
+      end
+    end
   end
 end

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -148,7 +148,7 @@ class ::Query::Results
   end
 
   def all_joins
-    query.sort_criteria_columns.map { |column, _direction| column.sortable_join }.compact
+    query.sort_criteria_columns.map { |column, _direction| column.sortable_join_statement(query) }.compact
   end
 
   def includes_for_columns(column_names)

--- a/frontend/src/app/modules/boards/drag-and-drop/reorder-query.service.ts
+++ b/frontend/src/app/modules/boards/drag-and-drop/reorder-query.service.ts
@@ -2,6 +2,7 @@ import {Injectable} from "@angular/core";
 import {TableState} from "core-components/wp-table/table-state/table-state";
 import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 import {QueryResource} from "core-app/modules/hal/resources/query-resource";
+import {debugLog} from "core-app/helpers/debug_output";
 
 @Injectable()
 export class ReorderQueryService {
@@ -61,6 +62,8 @@ export class ReorderQueryService {
     if (query && !!query.updateImmediately) {
       const orderedWorkPackages = orderedIds
         .map(id => this.pathHelper.api.v3.work_packages.id(id).toString());
+
+      debugLog("New order: " + orderedIds.join(", "));
 
       return query.updateImmediately({orderedWorkPackages: orderedWorkPackages});
     } else {

--- a/lib/open_project/sql_sanitization.rb
+++ b/lib/open_project/sql_sanitization.rb
@@ -1,8 +1,7 @@
 #-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -13,7 +12,7 @@
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
-# as published by the Foperatorree Software Foundation; either version 2
+# as published by the Free Software Foundation; either version 2
 # of the License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -25,48 +24,27 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# See doc/COPYRIGHT.rdoc for more details.
+# See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::WorkPackages::Filter::ManualSortFilter <
-  Queries::WorkPackages::Filter::WorkPackageFilter
+module OpenProject
 
-  include ::Queries::WorkPackages::Common::ManualSorting
+  ##
+  # Provides helpers from ActiveRecord::Sanitization
+  # outside model context
+  module SqlSanitization
+    include ::ActiveRecord::Sanitization
 
-  def available_operators
-    [Queries::Operators::OrderedWorkPackages]
-  end
+    def self.connection
+      ::ActiveRecord::Base.connection
+    end
 
-  def available?
-    true
-  end
-
-  def joins
-    ordered_work_packages_join(query)
-  end
-
-  def type
-    :empty_value
-  end
-
-  def where
-    WorkPackage
-      .arel_table[:id]
-      .in(context.ordered_work_packages)
-      .to_sql
-  end
-
-  def self.key
-    :manual_sort
-  end
-
-  def ar_object_filter?
-    true
-  end
-
-  private
-
-  def operator_strategy
-    Queries::Operators::OrderedWorkPackages
+    ##
+    # Shorthand for:
+    # sanitize_sql_array [str, :param0, param1]
+    # sanitize_sql_array [str, param0: foo, param1: bar]
+    def self.sanitize(sql, *args)
+      sanitize_sql_array [sql, *args]
+    end
   end
 end

--- a/spec/models/queries/work_packages/manual_sorting_spec.rb
+++ b/spec/models/queries/work_packages/manual_sorting_spec.rb
@@ -57,4 +57,28 @@ describe Query, "manual sorting ", type: :model do
       expect(query.ordered_work_packages).to eq [wp_1.id]
     end
   end
+
+  describe 'with a second query on the same work package' do
+    let(:query2) { FactoryBot.create :query, user: user, project: project }
+
+    before do
+      login_as user
+      ::OrderedWorkPackage.create(query: query, work_package: wp_1, position: 0)
+      ::OrderedWorkPackage.create(query: query, work_package: wp_2, position: 1)
+
+      ::OrderedWorkPackage.create(query: query2, work_package: wp_1, position: 4)
+      ::OrderedWorkPackage.create(query: query2, work_package: wp_2, position: 3)
+    end
+
+    it 'returns the correct number of work packages' do
+      query.add_filter('manual_sort', 'ow', [])
+      query2.add_filter('manual_sort', 'ow', [])
+
+      query.sort_criteria = [[:manual_sorting, 'asc']]
+      query2.sort_criteria = [[:manual_sorting, 'asc']]
+
+      expect(query.results.sorted_work_packages.pluck(:id)).to eq [wp_1.id, wp_2.id]
+      expect(query2.results.sorted_work_packages.pluck(:id)).to eq [wp_2.id, wp_1.id]
+    end
+  end
 end


### PR DESCRIPTION
We depend on ordered_work_packages association for determining sort and filter for manual sorting.

We could restrict the join result with where(query_id: context.id) later but that prevents the execution planner from optimizing on the explicit join clause.

This PR introduces a sql join that depends on the query_id and thus retrieves the correct order performantly.

https://community.openproject.com/wp/29568