### PR TITLE
[29521] Remove white space between wp table header and first row

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -210,11 +210,9 @@ thead.-sticky th
 
 .generic-table--header-outer,
 .generic-table--sort-header-outer
-  padding:      0 12px 0 6px
   line-height:  $generic-table--header-height
   height:  $generic-table--header-height
   z-index:      1
-  border-bottom: 1px solid $table-row-border-color
 
   &:hover,
   &.hover
@@ -247,6 +245,8 @@ thead.-sticky th
   clear:   both
   min-width: 40px
   display: flex
+  padding: 0 12px 0 6px
+  border-bottom: 1px solid $table-row-border-color
 
   & > a
     flex: 1 1

--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -243,7 +243,7 @@ thead.-sticky th
   white-space: nowrap
   width:   100%
   clear:   both
-  min-width: 40px
+  min-width: 60px
   display: flex
   padding: 0 12px 0 6px
   border-bottom: 1px solid $table-row-border-color

--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -72,13 +72,16 @@
     padding: 0 !important
 
 // Shrink column of details / inline-create icons
-.wp-table--configuration-modal--trigger
+.wp-table--configuration-modal--trigger .generic-table--sort-header
   width: 60px
   // Center the th icon
   text-align: center !important
   // Take care that the header can overlap the icon
   z-index: 1
   padding: 0 !important
+
+  > accessible-by-keyboard
+    width: inherit
 
 // Hide the context menu button outside mobile
 html:not(.-browser-mobile)

--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -73,7 +73,6 @@
 
 // Shrink column of details / inline-create icons
 .wp-table--configuration-modal--trigger .generic-table--sort-header
-  width: 60px
   // Center the th icon
   text-align: center !important
   // Take care that the header can overlap the icon

--- a/frontend/src/app/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/components/wp-table/wp-table.directive.html
@@ -27,14 +27,16 @@
           <th class="wp-table--configuration-modal--trigger wp-table--context-menu-th -short hide-when-print"
               *ngIf="configuration.columnMenuEnabled || configuration.actionsColumnEnabled">
             <div class="generic-table--sort-header-outer">
-              <accessible-by-keyboard
-                  (execute)="openTableConfigurationModal()"
-                  linkClass="wp-table--columns-selection"
-                  [linkTitle]="text.configureTable"
-                  [linkAriaLabel]="text.configureTable"
-                  *ngIf="configuration.columnMenuEnabled">
-                <op-icon icon-classes="icon-button icon-small icon-settings"></op-icon>
-              </accessible-by-keyboard>
+              <span class="generic-table--sort-header">
+                <accessible-by-keyboard
+                    (execute)="openTableConfigurationModal()"
+                    linkClass="wp-table--columns-selection"
+                    [linkTitle]="text.configureTable"
+                    [linkAriaLabel]="text.configureTable"
+                    *ngIf="configuration.columnMenuEnabled">
+                  <op-icon icon-classes="icon-button icon-small icon-settings"></op-icon>
+                </accessible-by-keyboard>
+              </span>
             </div>
           </th>
         </tr>


### PR DESCRIPTION
#### Problem

At certain zoom levels of the browser, a gap occurred between work package table header and first row.

Tested on Chrome, Firefox, Opera, Safari and MSEdge.
However, on Chrome and Opera the bug is with a 50% browser zoom level still occurring. All other zoom levels are working.

https://community.openproject.com/projects/openproject/work_packages/29521