### PR TITLE
[29520] Fix search overlapping teaser

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -29,8 +29,8 @@
 $hamburger-right: -3px
 $hamburger-width: 50px
 
-$search-input-width: 200px
-$search-input-width-expanded: 20vw
+$search-input-width: 15vw
+$search-input-width-expanded: 25vw
 $search-input-height: 30px
 
 %top-menu-hover-styles
@@ -73,7 +73,7 @@ $search-input-height: 30px
     float: left
     height: $header-height
     border-top: 0
-    position: relative
+    flex: 1 1 auto
   li.drop-down,
   li.help-menu--overridden-link,
   .accessibility-mode & #account-nav-left li
@@ -234,7 +234,6 @@ $search-input-height: 30px
 
     &.-expanded
       width: $search-input-width-expanded
-      min-width: 250px
       background: white
       border-radius: 4px
       color: $header-search-field-font-color
@@ -290,8 +289,10 @@ $search-input-height: 30px
 
 #top-menu-items
   padding-top: 0
+  display: flex
+  align-items: center
   .top-menu-items-right
-    float: right
+    display: flex
 
 #header
   .chzn-container .chzn-results .highlighted
@@ -312,7 +313,6 @@ $search-input-height: 30px
     .nosidebar &
       max-width: calc((100vW/2) - 115px)
   #projects-menu
-    padding-right: 30px
     font-weight: bold
     padding-left: 6px
     .nosidebar &
@@ -320,7 +320,6 @@ $search-input-height: 30px
 
     .button--dropdown-text
       @include text-shortener
-      float: left
       // Half viewport width minus half logo minus margins.
       max-width: calc((100vW/2) - 115px - 50px - #{$hamburger-width + $hamburger-right})
       .nosidebar &
@@ -335,6 +334,7 @@ $search-input-height: 30px
   overflow: hidden
 
 #account-nav-right
+  display: flex
   .drop-down.last-child
     .avatar
       // To accommodate the padding of the help icon which exists because of the circle
@@ -389,3 +389,18 @@ $search-input-height: 30px
 @media only screen and (max-width: 1210px)
   #logo
     display: none
+
+  // increase width of search input on tablet screen size
+  #global-search-input
+    min-width: 20vw
+    &.-expanded
+      min-width: 30vw
+
+  #account-nav-left .drop-down
+    // minus 170px teaser width
+    max-width: calc((100vW/2) - 170px - #{$hamburger-width + $hamburger-right})
+
+@media only screen and (max-width: 900px)
+  #account-nav-left .drop-down
+    // increase size again (teaser not displayed)
+    max-width: 30vw

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -29,8 +29,9 @@
 $hamburger-right: -3px
 $hamburger-width: 50px
 
-$search-input-width: 15vw
-$search-input-width-expanded: 25vw
+// search bar has a min-width of 160px and should adapt to every screen size
+$search-input-width: calc(160px + 3vw)
+$search-input-width-expanded: calc(160px + 13vw)
 $search-input-height: 30px
 
 %top-menu-hover-styles
@@ -389,18 +390,3 @@ $search-input-height: 30px
 @media only screen and (max-width: 1210px)
   #logo
     display: none
-
-  // increase width of search input on tablet screen size
-  #global-search-input
-    min-width: 20vw
-    &.-expanded
-      min-width: 30vw
-
-  #account-nav-left .drop-down
-    // minus 170px teaser width
-    max-width: calc((100vW/2) - 170px - #{$hamburger-width + $hamburger-right})
-
-@media only screen and (max-width: 900px)
-  #account-nav-left .drop-down
-    // increase size again (teaser not displayed)
-    max-width: 30vw

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -35,6 +35,21 @@
     background-color: transparent
 
   #top-menu
+    &.-global-search-expanded
+      #account-nav-right,
+      #account-nav-left,
+      #main-menu-toggle
+        display: none
+
+      .top-menu-search
+        width: 100vw
+        margin: 0
+        padding-right: 15px
+
+        .top-menu-search--button
+          display: none
+          @include varprop(color, header-item-font-color)
+
     #nav-login-content
       float: none
       padding: 15px 20px
@@ -66,39 +81,32 @@
       .nosidebar &
         left: 0px
 
-  .top-menu-search
-    &.-mobile
-      width: 100vw
-      margin: 0
-      padding-right: 15px
+    #global-search-input
+      display: none
+      &.-expanded
+        display: block
+        width: calc(100vw - 50px)
+        min-width: unset
+        position: unset
 
-      .top-menu-search--button
-        display: none
-        @include varprop(color, header-item-font-color)
+        .scroll-host
+          max-height: calc(100vh - #{$header-height})
 
-    #global-search-input.-expanded
-      width: calc(100vw - 50px)
-      min-width: unset
-      position: unset
+        .ng-clear-wrapper
+          width: 40px
+          right: 0
 
-      .scroll-host
-        max-height: calc(100vh - #{$header-height})
+        .ng-select-bottom
+          height: calc(100vh - #{$header-height})
+          overflow-y: auto
+          margin: 0
 
-      .ng-clear-wrapper
-        width: 40px
-        right: 0
+        .ng-select-container
+          height: $search-input-height-mobile !important
+          border-radius: 4px
 
-      .ng-select-bottom
-        height: calc(100vh - #{$header-height})
-        overflow-y: auto
-        margin: 0
-
-      .ng-select-container
-        height: $search-input-height-mobile !important
-        border-radius: 4px
-
-      .ng-input input
-        height: 36px
+        .ng-input input
+          height: 36px
 
     .top-menu-search--back-button
       display: initial

--- a/frontend/src/app/modules/global_search/global-search-input.component.html
+++ b/frontend/src/app/modules/global_search/global-search-input.component.html
@@ -1,4 +1,4 @@
-<div class="top-menu-search" [class.-mobile]="mobileSearch">
+<div class="top-menu-search">
     <div class="top-menu-search--loading ui-autocomplete--loading" style="display: none">
       <div class="loading-indicator -small">
         <div class="block-1"></div>
@@ -8,7 +8,7 @@
         <div class="block-5"></div>
       </div>
     </div>
-    <a *ngIf="mobileSearch"
+    <a *ngIf="expanded"
        (click)="toggleMobileSearch()"
        class="top-menu-search--back-button"
        href="#"
@@ -20,7 +20,7 @@
               name="global-search-input"
               id="global-search-input"
               placeholder="{{text.search}}"
-              [ngClass]="'top-menu-search--input hidden-for-mobile'"
+              [ngClass]="'top-menu-search--input'"
               [class.-expanded]="expanded"
               [openOnEnter]="false"
               [searchFn]="customSearchFn"

--- a/frontend/src/app/modules/global_search/global-search-input.component.ts
+++ b/frontend/src/app/modules/global_search/global-search-input.component.ts
@@ -66,7 +66,6 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
   public expanded:boolean = false;
   public results:any[];
   public suggestions:any[];
-  public mobileSearch:boolean = false;
 
   public searchTermChanged$:Subject<string> = new Subject<string>();
 
@@ -141,8 +140,8 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
 
   // open or close mobile search
   public toggleMobileSearch() {
-    jQuery('.ng-select, #account-nav-right, #account-nav-left, #main-menu-toggle').toggleClass('hidden-for-mobile');
-    this.mobileSearch = !this.mobileSearch;
+    jQuery('#top-menu').toggleClass('-global-search-expanded');
+    this.expanded = !this.expanded;
   }
 
   // load selected item
@@ -169,6 +168,7 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
 
   public onFocus() {
     this.expanded = true;
+    jQuery('#top-menu').addClass('-global-search-expanded');
     // load result list after page reload
     if (this.isFirstFocus && this.currentValue.length > 0) {
       this.isFirstFocus = false;
@@ -181,6 +181,7 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
     if (!this.deviceService.isMobile) {
       this.expanded = (this.ngSelectComponent.filterValue.length > 0);
       this.ngSelectComponent.isOpen = false;
+      jQuery('#top-menu').toggleClass('-global-search-expanded', this.expanded);
     }
   }
 


### PR DESCRIPTION
This PR is adapting the search bar width so that it is not overlapping a teaser (if present), the logo or long project titles.

See issue: https://community.openproject.com/projects/openproject/work_packages/29520

In connection with this PR opened on saas-openproject: https://github.com/finnlabs/saas-openproject/pull/49
