### PR TITLE
[29357] Migrate my page to Grid based layout

### DIFF
--- a/db/migrate/20190220080647_migrate_my_page_layout.rb
+++ b/db/migrate/20190220080647_migrate_my_page_layout.rb
@@ -1,0 +1,129 @@
+class MigrateMyPageLayout < ActiveRecord::Migration[5.2]
+  def up
+    UserPreference.transaction do
+      user_my_page_prefs.find_each do |pref|
+        old_layout = pref.others.with_indifferent_access[:my_page_layout]
+        next unless old_layout
+
+        new_page = migrate_my_page(pref.user_id, old_layout)
+        raise "Save failed due to #{new_page.errors.full_messages.join('. ')}" unless new_page.save
+
+        remove_old_my_page pref
+      rescue StandardError => e
+        warn "Failed to migrate my_page for user##{pref.user_id}: #{e.message}"
+      end
+    end
+  end
+
+  def down
+    # This migration is not revertible.
+  end
+
+  private
+
+  ##
+  # Migrate a single preference entry and remove the my page
+  def migrate_my_page(user_id, old_layout)
+    my_page = ::Grids::MyPage.new user_id: user_id, column_count: 4
+
+    # Migrate top
+    start_row = 1
+    # Give every widget a fixed height of 4 rows
+    widget_height = 4
+    (old_layout['top'] || []).each do |block|
+      map_widget my_page,
+                 old_name: block,
+                 start_row: start_row,
+                 end_row: start_row + widget_height,
+                 start_column: 1,
+                 end_column: 5
+
+      start_row += widget_height
+    end
+
+    # Migrate left
+    left_row = start_row
+    (old_layout['left'] || []).each do |block|
+      map_widget my_page,
+                 old_name: block,
+                 start_row: left_row,
+                 end_row: left_row + widget_height,
+                 start_column: 1,
+                 end_column: 3
+
+      left_row += widget_height
+    end
+
+    # Migrate right
+    right_row = start_row
+    (old_layout['right'] || []).each do |block|
+      map_widget my_page,
+                 old_name: block,
+                 start_row: right_row,
+                 end_row: right_row + widget_height,
+                 start_column: 3,
+                 end_column: 5
+
+      left_row += widget_height
+    end
+
+    my_page.row_count = [left_row, right_row].max - 1
+    my_page
+  end
+
+  ##
+  # Remove the current my page setting
+  def remove_old_my_page(pref)
+    # There are some cases where keys where not symbolized
+    pref.others.delete(:my_page_layout)
+    pref.others.delete('my_page_layout')
+    pref.save
+  end
+
+  ##
+  # Get all preferences with my page set that do not have
+  # a grid
+  def user_my_page_prefs
+    grid_table = Grids::MyPage.table_name
+    pref_table = UserPreference.table_name
+
+    ::UserPreference
+      .joins("LEFT OUTER JOIN #{grid_table} ON #{grid_table}.user_id = #{pref_table}.user_id")
+      .where("#{pref_table}.others LIKE '%my_page_layout%'")
+      .where("#{grid_table}.user_id IS NULL")
+  end
+
+  ##
+  # Mapping of old widget names to new widgets
+  def map_widget(my_page, old_name:, start_row:, end_row:, start_column:, end_column:)
+    mapping = widget_mapping[old_name.to_sym]
+
+    if mapping.nil?
+      warn "Skipping unknown block #{old_name}"
+      return
+    end
+
+    my_page.widgets << Grids::Widget.new(
+      identifier: mapping,
+      start_row: start_row,
+      end_row: end_row,
+      start_column: start_column,
+      end_column: end_column
+    )
+  end
+
+  ##
+  # Widget mapping
+  def widget_mapping
+    @widget_mapping ||= {
+      issuesassignedtome: :work_packages_assigned,
+      workpackagesresponsiblefor: :work_packages_accountable,
+      issuesreportedbyme: :work_packages_created,
+      issueswatched: :work_packages_watched,
+      news: :news,
+      calendar: :news,
+      timelog: :time_entries_current_user,
+      documents: :documents
+    }
+  end
+end

--- a/db/migrate/20190220080647_migrate_my_page_layout.rb
+++ b/db/migrate/20190220080647_migrate_my_page_layout.rb
@@ -1,6 +1,10 @@
 class MigrateMyPageLayout < ActiveRecord::Migration[5.2]
   def up
     UserPreference.transaction do
+
+      # Remove all my page grids
+      ::Grids::MyPage.destroy_all
+
       user_my_page_prefs.find_each do |pref|
         old_layout = pref.others.with_indifferent_access[:my_page_layout]
         next unless old_layout
@@ -64,7 +68,7 @@ class MigrateMyPageLayout < ActiveRecord::Migration[5.2]
                  start_column: 3,
                  end_column: 5
 
-      left_row += widget_height
+      right_row += widget_height
     end
 
     my_page.row_count = [left_row, right_row].max - 1
@@ -84,13 +88,9 @@ class MigrateMyPageLayout < ActiveRecord::Migration[5.2]
   # Get all preferences with my page set that do not have
   # a grid
   def user_my_page_prefs
-    grid_table = Grids::MyPage.table_name
     pref_table = UserPreference.table_name
 
-    ::UserPreference
-      .joins("LEFT OUTER JOIN #{grid_table} ON #{grid_table}.user_id = #{pref_table}.user_id")
-      .where("#{pref_table}.others LIKE '%my_page_layout%'")
-      .where("#{grid_table}.user_id IS NULL")
+    ::UserPreference.where("#{pref_table}.others LIKE '%my_page_layout%'")
   end
 
   ##
@@ -121,7 +121,7 @@ class MigrateMyPageLayout < ActiveRecord::Migration[5.2]
       issuesreportedbyme: :work_packages_created,
       issueswatched: :work_packages_watched,
       news: :news,
-      calendar: :news,
+      calendar: :calendar,
       timelog: :time_entries_current_user,
       documents: :documents
     }

--- a/frontend/src/app/modules/grids/widgets/news/news.component.html
+++ b/frontend/src/app/modules/grids/widgets/news/news.component.html
@@ -10,12 +10,14 @@
   <ul class="widget-box--arrow-links">
     <li class="-widget-box--arrow-multiline" *ngFor="let news of entries">
       <div>
+        <ng-container *ngIf="news.author">
         <img class="avatar avatar-mini avatar--fallback"
              data-avatar-fallback-remove="true"
              *ngIf="newsAuthorAvatar(news)"
              [attr.src]="newsAuthorAvatar(news)"
              [attr.title]="newsAuthorName(news)"
              [attr.alt]="newsAuthorName(news)" />
+        </ng-container>
         <a [href]="newsProjectPath(news)"
            [textContent]="newsProjectName(news)">
         </a>:
@@ -23,7 +25,8 @@
            [textContent]="news.title">
         </a>
 
-        <p class="widget-box--additional-info">
+        <p *ngIf="news.author"
+           class="widget-box--additional-info">
           {{text.createdBy}}
           <a [href]="newsAuthorPath(news)"
              [textContent]="newsAuthorName(news)">

--- a/frontend/src/app/modules/grids/widgets/news/news.component.ts
+++ b/frontend/src/app/modules/grids/widgets/news/news.component.ts
@@ -40,6 +40,10 @@ export class WidgetNewsComponent extends AbstractWidgetComponent implements OnIn
         this.entriesLoaded = true;
 
         this.entries.forEach((entry) => {
+          if (!entry.author) {
+            return;
+          }
+
           this.userCache
             .require(entry.author.idFromLink)
             .then((user:UserResource) => {

--- a/frontend/src/app/modules/grids/widgets/time-entries-current-user/time-entries-current-user.component.ts
+++ b/frontend/src/app/modules/grids/widgets/time-entries-current-user/time-entries-current-user.component.ts
@@ -152,8 +152,13 @@ export class WidgetTimeEntriesCurrentUserComponent extends AbstractWidgetCompone
     //entries
   }
 
-  private formatNumber(value:number) {
-    return formatNumber(value, this.i18n.locale, '1.2-2');
+  private formatNumber(value:number):string {
+    try {
+      return formatNumber(value, this.i18n.locale, '1.2-2');
+    } catch(e) {
+      console.error("Failed to format number with Angular (missing locale?): " + e);
+      return value.toLocaleString();
+    }
   }
 
   public get noEntries() {

--- a/modules/grids/app/models/grids/grid.rb
+++ b/modules/grids/app/models/grids/grid.rb
@@ -34,6 +34,7 @@ module Grids
 
     has_many :widgets,
              class_name: 'Widget',
+             dependent: :destroy,
              autosave: true
 
     def self.new_default(_user)


### PR DESCRIPTION
Creates a migration to:

- [x] Look for all users with my_page_layout in their preferences
- [x] Migrate those entries to a grid view
- [x] While avoiding creating a grid for users with a MyPage grid already (just in case)
- [x] Removing the `my_page_layout` key after saving the grid

Also fixes:

- Trying to load a news entry without a visible author
- Trying to use angular's `format_number` without loading the locale.

https://community.openproject.com/wp/29357