### PR TITLE
[29460] Fix redundant wp type in relations tab  

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_relations.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_relations.sass
@@ -41,6 +41,9 @@ body:not(.accessibility-mode )
   margin-right: 5px
   font-size: 0.7rem
 
+.relation-row--type
+  cursor: default
+
 // Reduce padding of relations icon in relation columns
 .relations-header--icon:before
   padding: 0 2px 0 0

--- a/frontend/src/app/components/wp-relations/wp-relation-row/wp-relation-row.template.html
+++ b/frontend/src/app/components/wp-relations/wp-relation-row/wp-relation-row.template.html
@@ -36,8 +36,8 @@
       <a uiSref="work-packages.show.relations"
          [uiParams]="{ workPackageId: relatedWorkPackage.id }"
          class="wp-relations--subject-field"
-         [textContent]="relatedWorkPackage.subjectWithType()"
-         [attr.aria-label]="normalizedRelationType + ' ' + relatedWorkPackage.subjectWithType()">
+         [textContent]="relatedWorkPackage.subjectWithId()"
+         [attr.aria-label]="normalizedRelationType + ' ' + relatedWorkPackage.subjectWithId()">
       </a>
     </div>
 

--- a/frontend/src/app/modules/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/modules/hal/resources/work-package-resource.ts
@@ -153,14 +153,23 @@ export class WorkPackageBaseResource extends HalResource {
   }
 
   /**
-   * Return "<type name>: <subject>" if the type is known.
+   * Return "<type name>: <subject> (#<id>)" if type and id are known.
    */
   public subjectWithType(truncateSubject:number = 40):string {
     const type = this.type ? `${this.type.name}: ` : '';
+    const subject = this.subjectWithId(truncateSubject);
+
+    return `${type}${subject}`;
+  }
+
+  /**
+   * Return "<subject> (#<id>)" if the id is known.
+   */
+  public subjectWithId(truncateSubject:number = 40):string {
     const id = this.isNew ? '' : ` (#${this.id})`;
     const subject = _.truncate(this.subject, { length: truncateSubject });
 
-    return `${type}${subject}${id}`;
+    return `${subject}${id}`;
   }
 
   public get isNew():boolean {

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -173,10 +173,12 @@ module Components
       end
 
       def openChildrenAutocompleter
-        find('.wp-inline-create--reference-link', text: I18n.t('js.relation_buttons.add_existing_child')).click
+        retry_block do
+          find('.wp-inline-create--reference-link', text: I18n.t('js.relation_buttons.add_existing_child')).click
 
-        # Security check to be sure that the autocompleter has finished loading
-        expect(page).to have_selector '.wp-relations-autocomplete--results'
+          # Security check to be sure that the autocompleter has finished loading
+          page.find '.wp-relations-autocomplete--results'
+        end
       end
 
       def add_existing_child(work_package)


### PR DESCRIPTION
#### Problem
In the relations tab the 'related to' work packages had a duplicate type. 

#### Changes
- Type from 'subject' field removed
- Cursor set to default (to show that the field is not editable)

https://community.openproject.com/projects/openproject/work_packages/29460