### PR TITLE
[29588] Don't replace filters service during search filter change

### DIFF
--- a/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
+++ b/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
@@ -81,7 +81,6 @@ export class WorkPackageFilterByTextInputComponent implements OnInit, OnDestroy 
           this.wpTableFilters.currentState.remove(currentSearchFilter);
         }
 
-        this.wpTableFilters.replace(this.wpTableFilters.currentState);
         this.filterChanged.emit(this.wpTableFilters.currentState);
       });
   }

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/filters-tab.component.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/filters-tab.component.html
@@ -1,2 +1,3 @@
 <query-filters *ngIf="!!filters"
+               (filtersChanged)="filters = $event"
                [filters]="filters"></query-filters>


### PR DESCRIPTION
This will not correctly replace the filters, but only the current state.
We need to pass them into the filters-tab

https://community.openproject.com/wp/29588