### PR TITLE
Extend onboarding tour library to accept timeout functions 

### DIFF
--- a/app/assets/javascripts/onboarding/work_package_tour.js
+++ b/app/assets/javascripts/onboarding/work_package_tour.js
@@ -27,7 +27,18 @@
                 'next .add-work-package': I18n.t('js.onboarding.steps.wp_create_button'),
                 'showSkip': false,
                 'nextButton': {text: I18n.t('js.onboarding.buttons.next')},
-                'shape': 'circle'
+                'shape': 'circle',
+                'timeout': function() {
+                    return new Promise(function(resolve) {
+                        // We are waiting here for the badge to appear,
+                        // because its the last that appears and it shifts the WP create button to the left.
+                        // Thus it is important that the tour rendering starts after the badge is visible
+                        waitForElement('#work-packages-filter-toggle-button .badge', '#content', function() {
+                            resolve();
+                        });
+                    });
+
+                }
             },
             {
                 'next .timeline-toolbar--button': I18n.t('js.onboarding.steps.wp_timeline_button'),

--- a/app/assets/javascripts/vendor/enjoyhint.js
+++ b/app/assets/javascripts/vendor/enjoyhint.js
@@ -115,10 +115,19 @@ var EnjoyHint;
                 step_data.onBeforeStart();
             }
 
-            var timeout = step_data.timeout || 0;
+            // Allow a wait function in as timout parameter
+            if(step_data.timeout && typeof step_data.timeout === 'function') {
+                step_data.timeout().then(function() {
+                    toggleNext();
+                })
+            } else {
+                var timeout = step_data.timeout || 0;
+                setTimeout(function () {
+                    toggleNext();
+                }, timeout);
+            }
 
-            setTimeout(function () {
-
+            function toggleNext() {
                 if (!step_data.selector) {
 
                     for (var prop in step_data) {
@@ -297,7 +306,7 @@ var EnjoyHint;
 
                     $body.enjoyhint('render_label_with_shape', shape_data, that.stop);
                 }, step_data.scrollAnimationSpeed + 20 || 270);
-            }, timeout);
+            }
         };
 
         var nextStep = function() {


### PR DESCRIPTION
#### Problem
The onboarding tour got stuck when leaving the full screen mode of a WP and returning to the list. This happens because the back button seem to reload the table now and thus takes more time to load.

#### Solution
This extends the enjoyhint library to accept timeout functions. This way we can be sure that the work package table and the rest of the content is loaded before the tour continues. 