### PR TITLE
Disable hierarchy toggle in embedded widgets for 8.3

### DIFF
--- a/frontend/src/app/modules/grids/widgets/wp-widget/wp-widget.component.ts
+++ b/frontend/src/app/modules/grids/widgets/wp-widget/wp-widget.component.ts
@@ -1,5 +1,9 @@
 import {AbstractWidgetComponent} from "app/modules/grids/widgets/abstract-widget.component";
 import {OnInit} from "@angular/core";
+import {
+  WorkPackageTableConfiguration,
+  WorkPackageTableConfigurationObject
+} from "core-components/wp-table/wp-table-configuration";
 
 export class WidgetWpListComponent extends AbstractWidgetComponent implements OnInit {
   // An heuristic based on paddings, margins, the widget header height and the pagination height
@@ -8,26 +12,27 @@ export class WidgetWpListComponent extends AbstractWidgetComponent implements On
   private static gridAreaHeight:number = 100;
   private static gridAreaSpace:number = 20;
 
-  public configuration:any = {
-    "actionsColumnEnabled": false,
-    "columnMenuEnabled": false,
-    "contextMenuEnabled": false
+  public configuration:Partial<WorkPackageTableConfiguration> = {
+    actionsColumnEnabled: false,
+    columnMenuEnabled: false,
+    hierarchyToggleEnabled: false,
+    contextMenuEnabled: false
   };
 
   ngOnInit() {
     this.configuration.forcePerPageOption = this.calculatePerPageOption();
   }
 
-  private calculatePerPageOption() {
+  private calculatePerPageOption():number|false {
     if (this.resource) {
       let numberOfRows = this.resource.height;
       let availableHeight = numberOfRows * WidgetWpListComponent.gridAreaHeight +
         (numberOfRows - 1) * WidgetWpListComponent.gridAreaSpace;
-      let perPageOption = Math.floor((availableHeight - WidgetWpListComponent.widgetSpaceOutsideTable) / WidgetWpListComponent.wpLineHeight);
+      let perPageOption:number = Math.floor((availableHeight - WidgetWpListComponent.widgetSpaceOutsideTable) / WidgetWpListComponent.wpLineHeight);
 
-      return perPageOption < 1 ? 1 : perPageOption
+      return perPageOption < 1 ? 1 : perPageOption;
     } else {
-      return false
+      return false;
     }
   }
 }


### PR DESCRIPTION
[The hierarchy toggle bug](https://community.openproject.com/projects/openproject/work_packages/29578/activity?query_id=1714) is caused by the embedded table not registering the change listeners that come from the wp-set component.

My suggestion: Let embedded base component derive from wp-set, but that would push this bug into 9.0. I suggest we disable the toggling of hierarchies in embedded widgets and fix this bug correctly for 9.0.