### PR TITLE
[26758] Show unit on group by headers

### DIFF
--- a/frontend/src/app/components/wp-fast-table/builders/modes/grouped/grouped-render-pass.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/modes/grouped/grouped-render-pass.ts
@@ -69,6 +69,11 @@ export class GroupedRenderPass extends PlainRenderPass {
       // Otherwise, fall back to simple value comparison.
       let value = group.value === '' ? null : group.value;
 
+      if (value) {
+        // For matching we have to remove the % sign which is shown when grouping after progress
+        value = value.replace('%', '');
+      }
+
       // Values provided by the API are always string
       // so avoid triple equal here
       // tslint:disable-next-line

--- a/lib/api/decorators/aggregation_group.rb
+++ b/lib/api/decorators/aggregation_group.rb
@@ -112,7 +112,9 @@ module API
       end
 
       def value
-        if represented == true || represented == false
+        if query.group_by_column.name == :done_ratio
+          "#{represented}%"
+        elsif represented == true || represented == false
           represented
         else
           represented ? represented.to_s : nil

--- a/spec/features/work_packages/table/group_by/group_by_progress_spec.rb
+++ b/spec/features/work_packages/table/group_by/group_by_progress_spec.rb
@@ -34,9 +34,9 @@ describe 'Work Package group by progress', js: true do
 
     # Expect table to be grouped as WP created above
     expect(page).to have_selector('.group--value .count', count: 3)
-    expect(page).to have_selector('.group--value', text: '0 (1)')
-    expect(page).to have_selector('.group--value', text: '10 (2)')
-    expect(page).to have_selector('.group--value', text: '50 (1)')
+    expect(page).to have_selector('.group--value', text: '0% (1)')
+    expect(page).to have_selector('.group--value', text: '10% (2)')
+    expect(page).to have_selector('.group--value', text: '50% (1)')
 
     # Update category of wp_none
     cat = wp_table.edit_field(wp_1, :percentageDone)
@@ -46,8 +46,8 @@ describe 'Work Package group by progress', js: true do
 
     # Expect changed groups
     expect(page).to have_selector('.group--value .count', count: 2)
-    expect(page).to have_selector('.group--value', text: '10 (2)')
-    expect(page).to have_selector('.group--value', text: '50 (2)')
+    expect(page).to have_selector('.group--value', text: '10% (2)')
+    expect(page).to have_selector('.group--value', text: '50% (2)')
   end
 
   context 'with grouped query' do


### PR DESCRIPTION
This shows units for WP group headers. As for currencies the backend already provides the unit, this PR adds a percentage sign for the progress. 

https://community.openproject.com/projects/openproject/work_packages/26758/activity