### PR TITLE
Fix global search input hover color

### DIFF
--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -205,8 +205,6 @@ $search-input-height: 30px
     .ng-select-container
       background: transparent
       @include varprop(border-color, header-item-font-color)
-      &:hover
-        @include varprop(border-color, header-item-font-hover-color)
 
     .ng-arrow-wrapper
       display: none


### PR DESCRIPTION
#### Problem

When hover settings invert the background and font colors, the global search border will be invisible on hover.

![image](https://user-images.githubusercontent.com/39332861/53330498-e7922f80-38ee-11e9-8660-3a78d851b19a.png)
