### PR TITLE
[29578] Refactor wp-set in common work-packges-view-base

### DIFF
--- a/frontend/src/app/components/wp-table/embedded/wp-embedded-base.component.ts
+++ b/frontend/src/app/components/wp-table/embedded/wp-embedded-base.component.ts
@@ -11,8 +11,9 @@ import {QueryDmService} from 'core-app/modules/hal/dm-services/query-dm.service'
 import {UrlParamsHelperService} from 'core-components/wp-query/url-params-helper';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
+import {WorkPackagesViewBase} from "core-app/modules/work_packages/routing/wp-view-base/work-packages-view.base";
 
-export abstract class WorkPackageEmbeddedBaseComponent implements OnInit, AfterViewInit, OnDestroy {
+export abstract class WorkPackageEmbeddedBaseComponent extends WorkPackagesViewBase implements AfterViewInit {
   @Input('configuration') protected providedConfiguration:WorkPackageTableConfigurationObject;
   @Input() public uniqueEmbeddedTableName:string = `embedded-table-${Date.now()}`;
   @Input() public initialLoadingIndicator:boolean = true;
@@ -32,10 +33,9 @@ export abstract class WorkPackageEmbeddedBaseComponent implements OnInit, AfterV
   readonly wpStatesInitialization:WorkPackageStatesInitializationService = this.injector.get(WorkPackageStatesInitializationService);
   readonly currentProject:CurrentProjectService = this.injector.get(CurrentProjectService);
 
-  protected constructor(protected injector:Injector) {
-  }
-
   ngOnInit() {
+    super.ngOnInit();
+
     this.configuration = new WorkPackageTableConfiguration(this.providedConfiguration);
     // Set embedded status in configuration
     this.configuration.isEmbedded = true;
@@ -45,16 +45,10 @@ export abstract class WorkPackageEmbeddedBaseComponent implements OnInit, AfterV
   ngAfterViewInit():void {
     // Load initially
     this.refresh(this.initialLoadingIndicator);
-
-    // Reload results on refresh requests
-    this.querySpace.refreshRequired
-      .values$()
-      .pipe(untilComponentDestroyed(this))
-      .subscribe(() => this.refresh(false));
   }
 
   ngOnDestroy():void {
-    // noting to do
+    super.ngOnInit();
   }
 
   ngOnChanges(changes:SimpleChanges) {
@@ -86,8 +80,8 @@ export abstract class WorkPackageEmbeddedBaseComponent implements OnInit, AfterV
     this.renderTable = this.configuration.tableVisible;
   }
 
-  public refresh(visible:boolean = true):Promise<any> {
-    return this.loadQuery(visible);
+  public refresh(visible:boolean = true, firstPage:boolean = false):Promise<any> {
+    return this.loadQuery(visible, firstPage);
   }
 
   public get isInitialized() {
@@ -102,7 +96,7 @@ export abstract class WorkPackageEmbeddedBaseComponent implements OnInit, AfterV
     }
   }
 
-  protected abstract loadQuery(visible:boolean):Promise<any>;
+  protected abstract loadQuery(visible:boolean, firstPage:boolean):Promise<any>;
 
   protected get queryProjectScope() {
     if (!this.configuration.projectContext) {

--- a/frontend/src/app/modules/calendar/wp-calendar-entry/wp-calendar-entry.component.html
+++ b/frontend/src/app/modules/calendar/wp-calendar-entry/wp-calendar-entry.component.html
@@ -1,4 +1,5 @@
-<div class="work-packages-list-view--container">
+<div class="work-packages-list-view--container loading-indicator--location"
+     data-indicator-name="calendar-entry">
     <div class="toolbar-container -editable">
         <div class="toolbar">
             <div class="title-container">
@@ -7,8 +8,7 @@
                 </h2>
             </div>
 
-            <ul class="toolbar-items hide-when-print"
-                *ngIf="tableInformationLoaded">
+            <ul class="toolbar-items hide-when-print">
                 <li class="toolbar-item hidden-for-mobile">
                     <wp-filter-button>
                     </wp-filter-button>

--- a/frontend/src/app/modules/calendar/wp-calendar-entry/wp-calendar-entry.component.ts
+++ b/frontend/src/app/modules/calendar/wp-calendar-entry/wp-calendar-entry.component.ts
@@ -26,16 +26,26 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component} from '@angular/core';
-import {WorkPackagesSetComponent} from "core-app/modules/work_packages/routing/wp-set/wp-set.component";
+import {Component, ViewChild} from '@angular/core';
+import {WorkPackagesViewBase} from "core-app/modules/work_packages/routing/wp-view-base/work-packages-view.base";
+import {WorkPackagesCalendarController} from "core-app/modules/calendar/wp-calendar/wp-calendar.component";
 
 @Component({
   templateUrl: './wp-calendar-entry.component.html'
 })
 
-export class WorkPackagesCalendarEntryComponent extends WorkPackagesSetComponent {
-  // overrides super
-  protected initialQueryLoading() {
-    // nothing
+export class WorkPackagesCalendarEntryComponent extends WorkPackagesViewBase {
+  @ViewChild(WorkPackagesCalendarController) calendarElement:WorkPackagesCalendarController;
+
+  /** Project identifier of the list */
+  projectIdentifier = this.$state.params['projectPath'] || null;
+
+  protected set loadingIndicator(promise:Promise<unknown>) {
+    this.loadingIndicatorService.indicator('calendar-entry').promise = promise;
+  }
+
+  public refresh(visibly:boolean, firstPage:boolean):Promise<unknown> {
+    return this.loadingIndicator =
+      this.wpListService.loadCurrentQueryFromParams(this.projectIdentifier);
   }
 }

--- a/frontend/src/app/modules/grids/widgets/wp-widget/wp-widget.component.ts
+++ b/frontend/src/app/modules/grids/widgets/wp-widget/wp-widget.component.ts
@@ -15,7 +15,7 @@ export class WidgetWpListComponent extends AbstractWidgetComponent implements On
   public configuration:Partial<WorkPackageTableConfiguration> = {
     actionsColumnEnabled: false,
     columnMenuEnabled: false,
-    hierarchyToggleEnabled: false,
+    hierarchyToggleEnabled: true,
     contextMenuEnabled: false
   };
 

--- a/frontend/src/app/modules/work_packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-full-view/wp-full-view.component.ts
@@ -28,7 +28,6 @@
 
 import {UserResource} from 'core-app/modules/hal/resources/user-resource';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
-import {WorkPackageViewController} from '../wp-view-base/wp-view-base.controller';
 import {WorkPackageTableFocusService} from 'core-components/wp-fast-table/state/wp-table-focus.service';
 import {StateService} from '@uirouter/core';
 import {TypeResource} from 'core-app/modules/hal/resources/type-resource';
@@ -37,6 +36,7 @@ import {WorkPackageTableSelection} from 'core-components/wp-fast-table/state/wp-
 import {States} from 'core-components/states.service';
 import {KeepTabService} from 'core-components/wp-single-view-tabs/keep-tab/keep-tab.service';
 import {FirstRouteService} from "core-app/modules/router/first-route-service";
+import {WorkPackageSingleViewBase} from "core-app/modules/work_packages/routing/wp-view-base/work-package-single-view.base";
 
 @Component({
   templateUrl: './wp-full-view.html',
@@ -44,7 +44,7 @@ import {FirstRouteService} from "core-app/modules/router/first-route-service";
   // Required class to support inner scrolling on page
   host: { 'class': 'work-packages-page--ui-view' }
 })
-export class WorkPackagesFullViewComponent extends WorkPackageViewController {
+export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase {
 
   // Watcher properties
   public isWatched:boolean;

--- a/frontend/src/app/modules/work_packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-split-view/wp-split-view.component.ts
@@ -31,17 +31,17 @@ import {StateService} from '@uirouter/core';
 import {WorkPackageTableFocusService} from 'core-components/wp-fast-table/state/wp-table-focus.service';
 import {componentDestroyed} from 'ng2-rx-componentdestroyed';
 import {takeUntil} from 'rxjs/operators';
-import {WorkPackageViewController} from '../wp-view-base/wp-view-base.controller';
 import {States} from "core-components/states.service";
 import {FirstRouteService} from "core-app/modules/router/first-route-service";
 import {KeepTabService} from "core-components/wp-single-view-tabs/keep-tab/keep-tab.service";
 import {WorkPackageTableSelection} from "core-components/wp-fast-table/state/wp-table-selection.service";
+import {WorkPackageSingleViewBase} from "core-app/modules/work_packages/routing/wp-view-base/work-package-single-view.base";
 
 @Component({
   templateUrl: './wp-split-view.html',
   selector: 'wp-split-view-entry',
 })
-export class WorkPackageSplitViewComponent extends WorkPackageViewController {
+export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase {
 
   constructor(public injector:Injector,
               public states:States,

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/work-package-single-view.base.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/work-package-single-view.base.ts
@@ -45,7 +45,7 @@ import {
   IWorkPackageEditingServiceToken
 } from "core-components/wp-edit-form/work-package-editing.service.interface";
 
-export class WorkPackageViewController implements OnDestroy {
+export class WorkPackageSingleViewBase implements OnDestroy {
 
   public wpCacheService:WorkPackageCacheService = this.injector.get(WorkPackageCacheService);
   public states:States = this.injector.get(States);

--- a/spec/support/components/work_packages/hierarchies.rb
+++ b/spec/support/components/work_packages/hierarchies.rb
@@ -44,6 +44,10 @@ module Components
         page.find('.wp-table--table-header .icon-no-hierarchy').click
       end
 
+      def disable_via_header
+        page.find('.wp-table--table-header .icon-hierarchy').click
+      end
+
       def disable_hierarchy
         ::Components::WorkPackages::TableConfigurationModal.do_and_save do |modal|
           modal.open_and_set_display_mode :default


### PR DESCRIPTION
Use the previous wp-set as a common component for all multi-wp views
(embedded tables, wp-list, wp-calendar,...) and make that component
the parent of embedded tables.

Fixes https://community.openproject.com/work_packages/29578