### PR TITLE
[29617] Type field too small (cut off unnecessarily)

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -48,6 +48,10 @@
   // To display the input field border correctly (input height is 24px)
   line-height: 24px
 
+  // Avoid that the select field gets too small
+  .wp-inline-edit--field.ng-select
+    min-width: 110px
+
 // Styles for inline editable attributes
 .work-package-table--container td.-editable
   display: table-cell

--- a/frontend/src/app/components/wp-edit-form/table-row-edit-context.ts
+++ b/frontend/src/app/components/wp-edit-form/table-row-edit-context.ts
@@ -75,9 +75,10 @@ export class TableRowEditContext implements WorkPackageEditContext {
       .then((cell) => {
 
         // Forcibly set the width since the edit field may otherwise
-        // be given more width
+        // be given more width. Thereby preserve a minimum width of 120.
         const td = this.findCell(fieldName);
-        const width = td.css('width');
+        var width = td.css('width');
+        width = parseInt(width) > 120 ? width : '120px';
         td.css('max-width', width);
         td.css('width', width);
 


### PR DESCRIPTION
Set min-width for table fields that are in edit mode to avoid the select field to be cut off

https://community.openproject.com/projects/openproject/work_packages/29617/activity