### PR TITLE
Fix: Submit global search on enter before results are loaded

### DIFF
--- a/frontend/src/app/modules/global_search/global-search-input.component.html
+++ b/frontend/src/app/modules/global_search/global-search-input.component.html
@@ -31,7 +31,8 @@
               (open)="openCloseMenu(currentValue)"
               (close)="select.filterValue = currentValue"
               (change)="onChange($event)"
-              (clear)="clearSearch()">
+              (clear)="clearSearch()"
+              (keydown.enter)="onEnterBeforeResultsLoaded()">
         <ng-template ng-option-tmp let-item="item" let-index="index" let-search="searchTerm">
           <div *ngIf="!item.id; else workPackageItemTemplate">
             <div tabindex="-1" class="global-search--option">

--- a/frontend/src/app/modules/global_search/global-search-input.component.ts
+++ b/frontend/src/app/modules/global_search/global-search-input.component.ts
@@ -64,6 +64,7 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
 
   public currentValue:string = '';
   public expanded:boolean = false;
+  public noResults:boolean = true;
   public results:any[];
   public suggestions:any[];
 
@@ -190,6 +191,13 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
     this.openCloseMenu(this.currentValue);
   }
 
+  // If Enter key is pressed before result list is loaded submit search in current scope
+  public onEnterBeforeResultsLoaded() {
+    if (this.noResults) {
+      this.searchInScope(this.currentScope);
+    }
+  }
+
   // get work packages result list and append it to suggestions
   private getSearchResult(term:string) {
     this.autocompleteWorkPackages(term).then((values) => {
@@ -214,6 +222,7 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
     this.dynamicCssService.requireHighlighting();
 
     this.$element.find('.ui-autocomplete--loading').show();
+    this.noResults = true;
 
     let idOnly:boolean = false;
 
@@ -306,7 +315,13 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
   }
 
   private hideSpinner():void {
-    this.$element.find('.ui-autocomplete--loading').hide();
+    this.$element.find('.ui-autocomplete--loading').hide()
+    this.noResults = false;
+  }
+
+  private get currentScope():string {
+    let serviceScope = this.globalSearchService.projectScope;
+    return (serviceScope === '') ? 'current_project_and_all_descendants' : serviceScope;
   }
 
   private unregister() {

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -164,7 +164,6 @@ describe 'Search', type: :feature, js: true do
 
         # Expect that a fresh global search will reset the advanced filters, i.e. that they are closed
         global_search_field.set(work_packages[10].subject)
-        sleep(1)
         global_search_field.send_keys(:enter)
         table.expect_work_package_not_listed(work_packages[9], wait: 20)
         table.expect_work_package_subject(work_packages[10].subject)
@@ -176,7 +175,6 @@ describe 'Search', type: :feature, js: true do
         # Expect that changing the search term without using the autocompleter will leave the project scope unchanged
         # at current_project.
         global_search_field.set(other_work_package.subject)
-        sleep(1)
         global_search_field.send_keys(:enter)
         expect(current_url).to match(/\/#{project.identifier}\/search\?q=Other%20work%20package&work_packages=1&scope=current_project$/)
 


### PR DESCRIPTION
When typing a search term fast enough, that the results have not been loaded yet, nevertheless a search should be submitted (searching in the current scope).