### PR TITLE
[29619] Follows-precedes relationship arrow in Gantt chart not correctly connected

### DIFF
--- a/frontend/src/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
+++ b/frontend/src/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
@@ -63,7 +63,7 @@ function newSegment(vp:TimelineViewParameters,
   );
 
   // segment.style.backgroundColor = color;
-  segment.style.top = ((yPosition * 41) + top) + 'px';
+  segment.style.top = ((yPosition * 40) + top) + 'px';
   segment.style.left = left + 'px';
   segment.style.width = width + 'px';
   segment.style.height = height + 'px';


### PR DESCRIPTION
A while ago the height of WP table rows was reduced by 1px. However this change was not made for the calculation of relationship segments in the timeline. As a result, the segment was more shifted the further down it was in the table.

https://community.openproject.com/projects/openproject/work_packages/29619/activity