### PR TITLE
Global search advanced filters styling adapted

### DIFF
--- a/app/assets/stylesheets/content/_advanced_filters.sass
+++ b/app/assets/stylesheets/content/_advanced_filters.sass
@@ -120,8 +120,9 @@
   &.hidden
     display: none !important
 
-.advanced-filters--toggle
-  margin: 0
+.work-packages-embedded-view--container .advanced-filters--container
+  margin: 0 0 1rem 0
+
 
 @include breakpoint(680px down)
   .advanced-filters--filters

--- a/frontend/src/app/components/filters/filter-container/filter-container.directive.html
+++ b/frontend/src/app/components/filters/filter-container/filter-container.directive.html
@@ -1,6 +1,6 @@
 <button class="button -small advanced-filters--toggle"
         (click)="wpFiltersService.toggleVisibility()"
-        [hidden]="wpFiltersService.visible"
+        [class.-active]="wpFiltersService.visible"
         *ngIf="showFilterButton">
   <i class="button--icon icon-filter"></i>
   <span class="button--text" [textContent]="filterButtonText"></span>


### PR DESCRIPTION
#### Changes in this PR
- 'Advanced filters' button always visible (inactive when filters are open)
- Gap between advanced filters and wp embedded table added