### PR TITLE
handle permissions on systems with fs.protected_regular=1

### DIFF
--- a/docker/entrypoint-all-in-one.sh
+++ b/docker/entrypoint-all-in-one.sh
@@ -16,8 +16,8 @@ fi
 
 dbhost=$(ruby -ruri -e 'puts URI(ENV.fetch("DATABASE_URL")).host')
 pwfile=$(mktemp)
-chown postgres $pwfile
 echo "$PGPASSWORD" > $pwfile
+chown postgres $pwfile
 
 PLUGIN_GEMFILE_TMP=$(mktemp)
 PLUGIN_GEMFILE=/usr/src/app/Gemfile.local
@@ -84,7 +84,7 @@ if [ "$dbhost" = "127.0.0.1" ]; then
 		echo "-----> Database cluster not found. Creating a new one in $PGDATA..."
 		chown -R postgres:postgres $PGDATA
 		su postgres -c "$PGBIN/initdb --pgdata=${PGDATA} --username=${PGUSER} --encoding=unicode --auth=trust --pwfile=$pwfile" | indent
-		rm -f $pwfile
+		su postgres -c "rm -f $pwfile"
 		/etc/init.d/postgresql start | indent
 		su postgres -c "$PGBIN/psql --command \"CREATE USER openproject WITH SUPERUSER PASSWORD 'openproject';\"" | indent
 		su postgres -c "$PGBIN/createdb -O openproject openproject" | indent


### PR DESCRIPTION
On newer Linux systems (>4.19), the kernel parameter fs.protected_regular=1 prohibits writing to files which do not belong to the user in world writable sticky directories like /tmp.

Due to the way openproject writes `$PGPASSWORD` to a temp file in /tmp, the dockerised openproject fails with:

`/usr/src/app/docker/entrypoint-all-in-one.sh: line 20: /tmp/tmp.SYq0Do3sUb: Permission denied`

This commit first writes the password as root to the file, then changes the ownership to postgres, and finally deletes the file as postgres.

See [this thread](https://unix.stackexchange.com/questions/503111/group-permissions-for-root-not-working-in-tmp) for a general test case and a longer explanation with further links.