### PR TITLE
Fix: expanded mobile search bar on init

### DIFF
--- a/frontend/src/app/modules/global_search/global-search-input.component.ts
+++ b/frontend/src/app/modules/global_search/global-search-input.component.ts
@@ -98,8 +98,11 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.$element = jQuery(this.elementRef.nativeElement);
+
+    // check searchterm on init, expand / collapse search bar and set correct classes
     this.ngSelectComponent.filterValue = this.currentValue = this.globalSearchService.searchTerm;
     this.expanded = (this.ngSelectComponent.filterValue.length > 0);
+    jQuery('#top-menu').toggleClass('-global-search-expanded', this.expanded);
 
     this.searchTermChanged$
       .pipe(
@@ -141,8 +144,8 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
 
   // open or close mobile search
   public toggleMobileSearch() {
-    jQuery('#top-menu').toggleClass('-global-search-expanded');
     this.expanded = !this.expanded;
+    jQuery('#top-menu').toggleClass('-global-search-expanded', this.expanded);
   }
 
   // load selected item


### PR DESCRIPTION
Problem

After submitting a search with a page reload, on mobile screen sizes the search bar was correctly expanded but the other icons were still visible (because the '-global-search-expanded' class was missing on init of the page).

![image](https://user-images.githubusercontent.com/39332861/53480112-ccecc180-3a7a-11e9-9ecf-a515fe00a074.png)
