### PR TITLE
allow group assignments to show up on predefined query

### DIFF
--- a/frontend/src/app/components/wp-query-select/wp-static-queries.service.ts
+++ b/frontend/src/app/components/wp-query-select/wp-static-queries.service.ts
@@ -105,7 +105,7 @@ export class WorkPackageStaticQueriesService {
         {
           identifier: 'assigned_to_me',
           label: this.text.assigned_to_me,
-          query_props: '{"c":["id","subject","type","status","author","updatedAt"],"hi":false,"g":"","t":"updatedAt:desc,parent:asc","f":[{"n":"status","o":"o","v":[]},{"n":"assignee","o":"=","v":["me"]}]}'
+          query_props: '{"c":["id","subject","type","status","author","updatedAt"],"hi":false,"g":"","t":"updatedAt:desc,parent:asc","f":[{"n":"status","o":"o","v":[]},{"n":"assigneeOrGroup","o":"=","v":["me"]}]}'
         }
       ]);
     }


### PR DESCRIPTION
That way, work packages assigned to a group, the user is member of, are also displayed.

https://community.openproject.com/projects/deutsche-bahn/work_packages/29508/activity