### PR TITLE
[29625] Forum page shows boards submenu 

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -50,6 +50,10 @@ class BoardsController < ApplicationController
     end
   end
 
+  current_menu_item [:index, :show] do
+    :boards
+  end
+
   def show
     sort_init 'updated_on', 'desc'
     sort_update 'created_on' => "#{Message.table_name}.created_on",

--- a/modules/boards/app/controllers/boards/boards_controller.rb
+++ b/modules/boards/app/controllers/boards/boards_controller.rb
@@ -19,6 +19,10 @@ module ::Boards
       render layout: 'angular'
     end
 
+    current_menu_item :index do
+      :board_view
+    end
+
     private
 
     def pass_gon


### PR DESCRIPTION
The highlighting of the current menu item is handled implicitly over the controller name if nothing is set. Because of the naming conflicts of the forum and the new board view, the wrong menu was highlighted. Thus, this PR sets explicitly the menu items for forum and board view.

https://community.openproject.com/projects/openproject/work_packages/29625/activity