### PR TITLE
[28891] Required fields implementation adapted to LSG

### DIFF
--- a/app/assets/stylesheets/content/_forms.lsg
+++ b/app/assets/stylesheets/content/_forms.lsg
@@ -957,13 +957,13 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 
 ### Standalone
 
 ```
-<label class="form--label-with-check-box">
+<label class="form--label-with-check-box -required">
   <div class="form--check-box-container">
     <input type="checkbox" class="form--check-box">
   </div>
   Pera
 </label>
-<label class="form--label-with-check-box">
+<label class="form--label-with-check-box -required">
   <div class="form--check-box-container">
     <input type="checkbox" class="form--check-box">
   </div>

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -327,6 +327,13 @@ fieldset.form--fieldset
     input.form--text-field:invalid
       // avoids the box-shadow from Firefox at required input fields
       box-shadow: none
+
+    .form--label:after
+      @include default-transition
+      @include varprop(color, primary-color-dark)
+      content:  '*'
+      padding: 0 0.325rem
+
   &.-reduced-margin
     margin-bottom: 0.5rem
 
@@ -374,11 +381,6 @@ fieldset.form--fieldset
   &.-top
     align-self: flex-start
     line-height: 2.15rem
-
-.form--label-required
-  @include default-transition
-  @include varprop(color, primary-color-dark)
-  padding: 0 0.325rem
 
   .form--label.-error &
     color: $content-form-error-color

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -47,6 +47,12 @@ $form--field-types: (text-field, text-area, select, check-box, radio-button, ran
   height: 40px
   line-height: 22px
 
+%required-star
+  @include default-transition
+  @include varprop(color, primary-color-dark)
+  content:  '*'
+  padding: 0 0.325rem
+
 form
   display: inline
 
@@ -329,10 +335,7 @@ fieldset.form--fieldset
       box-shadow: none
 
     .form--label:after
-      @include default-transition
-      @include varprop(color, primary-color-dark)
-      content:  '*'
-      padding: 0 0.325rem
+      @extend %required-star
 
   &.-reduced-margin
     margin-bottom: 0.5rem
@@ -763,10 +766,7 @@ input[readonly].-clickable
     &.-required,
     .form--field.-required > &
       &::after
-        @include default-transition
-        content:  '*'
-        @include varprop(color, primary-color-dark)
-        padding:  0 0.325rem
+        @extend %required-star
       &:hover::after
         @include varprop(color, primary-color)
 
@@ -800,6 +800,9 @@ input[readonly].-clickable
 
     input[type="checkbox"]
       vertical-align: middle
+
+  &.-required:after
+    @extend %required-star
 
 .form--field-affix
   flex:           0 0 auto

--- a/app/views/account/_password_login_form.html.erb
+++ b/app/views/account/_password_login_form.html.erb
@@ -30,14 +30,14 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= styled_form_tag({action: "login"}, autocomplete: 'off', class: '-wide-labels') do %>
   <%= back_url_hidden_field_tag %>
 
-  <div class="form--field">
+  <div class="form--field -required">
     <%= styled_label_tag 'username', User.human_attribute_name(:login) %>
     <div class="form--field-container">
       <%= styled_text_field_tag 'username', params[:username], autofocus: params[:username].blank?, autocapitalize: 'none' %>
     </div>
   </div>
 
-  <div class="form--field">
+  <div class="form--field -required">
     <%= styled_label_tag 'password', User.human_attribute_name(:password) %>
     <div class="form--field-container">
       <%= styled_password_field_tag 'password', nil, autofocus: !params[:username].blank? %>

--- a/app/views/account/_password_login_form.html.erb
+++ b/app/views/account/_password_login_form.html.erb
@@ -27,7 +27,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= styled_form_tag({action: "login"}, autocomplete: 'off', class: '-wide-labels') do %>
+<%= styled_form_tag({action: "login"}, autocomplete: 'off', class: '-wide-labels user-login--form') do %>
   <%= back_url_hidden_field_tag %>
 
   <div class="form--field -required">

--- a/app/views/account/_register.html.erb
+++ b/app/views/account/_register.html.erb
@@ -49,7 +49,7 @@ See docs/COPYRIGHT.rdoc for more details.
       <h2><%= t(:label_register) %></h2>
       <section class="form--section">
         <% if @user.auth_source_id.nil? %>
-          <div class="form--field -wide-label">
+          <div class="form--field -required -wide-label">
             <% if Setting.email_login? %>
               <%= email_field(f) %>
             <% else %>
@@ -57,16 +57,16 @@ See docs/COPYRIGHT.rdoc for more details.
             <% end %>
           </div>
         <% end %>
-        <div class="form--field -wide-label">
+        <div class="form--field -required -wide-label">
           <%= f.text_field :firstname, required: true %>
         </div>
 
-        <div class="form--field -wide-label">
+        <div class="form--field -required -wide-label">
           <%= f.text_field :lastname,  required: true %>
         </div>
 
         <% if registration_show_email? %>
-          <div class="form--field -wide-label">
+          <div class="form--field -required -wide-label">
             <%= email_field(f) %>
           </div>
         <% end %>
@@ -82,7 +82,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
         <br/><br/>
         <% if @user.change_password_allowed? %>
-          <div class="form--field -wide-label -reduced-margin">
+          <div class="form--field -required -wide-label -reduced-margin">
             <%= f.password_field :password,
                                  required: true,
                                  size: 25,
@@ -91,7 +91,7 @@ See docs/COPYRIGHT.rdoc for more details.
               <%= password_complexity_requirements %>
             </div>
           </div>
-          <div class="form--field -wide-label">
+          <div class="form--field -required -wide-label">
             <%= f.password_field :password_confirmation,
                                  required: true,
                                  size: 25,

--- a/app/views/account/_user_consent_check.html.erb
+++ b/app/views/account/_user_consent_check.html.erb
@@ -3,13 +3,12 @@
     <%= format_text user_consent_instructions(consenting_user) %>
   </p>
 
-  <label class="form--label-with-check-box">
+  <label class="form--label-with-check-box -required">
     <div class="form--check-box-container">
       <input type="checkbox" name="consent_check" class="form--check-box" required="required" />
     </div>
 
     <%= t('consent.checkbox_label') %>
-    <span class="form--label-required" aria-hidden="true">*</span>
   </label>
 </section>
 

--- a/app/views/boards/_form.html.erb
+++ b/app/views/boards/_form.html.erb
@@ -28,10 +28,10 @@ See docs/COPYRIGHT.rdoc for more details.
 ++#%>
 <%= error_messages_for 'board' %>
 <!--[form:board]-->
-<div class="form--field">
+<div class="form--field -required">
   <%= f.text_field :name, required: true, container_class: '-wide' %>
 </div>
-<div class="form--field">
+<div class="form--field -required">
   <%= f.text_field :description, required: true, container_class: '-wide' %>
 </div>
 <hr class="form--separator" />

--- a/app/views/colors/_form.html.erb
+++ b/app/views/colors/_form.html.erb
@@ -37,11 +37,8 @@ See docs/COPYRIGHT.rdoc for more details.
   <div class="form--field">
     <%= f.text_field :name, required: true, container_class: '-slim' %>
   </div>
-  <div class="form--field">
-    <label class="form--label -required">
-      <%= t('activerecord.attributes.color.hexcode') %>
-      <span class="form--label-required" aria-hidden="true">*</span>
-    </label>
+  <div class="form--field -required">
+    <label class="form--label"><%= t('activerecord.attributes.color.hexcode') %></label>
     <span class="form--field-container">
       <span class="form--text-field-container -xslim">
         <%= text_field_tag "color_hexcode",

--- a/app/views/colors/_form.html.erb
+++ b/app/views/colors/_form.html.erb
@@ -34,7 +34,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <fieldset class="form--fieldset">
   <legend class="form--fieldset-legend"><%= t('timelines.properties') %></legend>
 
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_field :name, required: true, container_class: '-slim' %>
   </div>
   <div class="form--field -required">

--- a/app/views/custom_actions/_form.html.erb
+++ b/app/views/custom_actions/_form.html.erb
@@ -3,7 +3,7 @@
 <%= initialize_hide_sections_with @custom_action.all_actions.map { |a| { key: a.key, label: a.human_name } },
                                   @custom_action.actions.map { |a| { key: a.key, label: a.human_name } } %>
 
-<div class="form--field">
+<div class="form--field -required">
   <%= f.text_field :name, required: true, container_class: '-middle' %>
 </div>
 <div class="form--field">

--- a/app/views/enumerations/_form.html.erb
+++ b/app/views/enumerations/_form.html.erb
@@ -35,7 +35,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= error_messages_for :enumeration %>
 <section class="form--section">
   <%= f.hidden_field 'type' %>
-  <div class="form--field"><%= f.text_field 'name', required: true, container_class: '-middle' %></div>
+  <div class="form--field -required"><%= f.text_field 'name', required: true, container_class: '-middle' %></div>
   <div class="form--field"><%= f.check_box 'active' %></div>
   <div class="form--field"><%= f.check_box 'is_default' %></div>
 

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -35,7 +35,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= error_messages_for :group %>
 
 <section class="form--section">
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_field :lastname,
                      label: Group.human_attribute_name(:name),
                      required: true,

--- a/app/views/ldap_auth_sources/_form.html.erb
+++ b/app/views/ldap_auth_sources/_form.html.erb
@@ -35,9 +35,9 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= error_messages_for :auth_source %>
 
 <section class="form--section">
-  <div class="form--field"><%= f.text_field 'name', required: true, container_class: '-middle' %></div>
-  <div class="form--field"><%= f.text_field 'host', required: true, container_class: '-middle' %></div>
-  <div class="form--field"><%= f.text_field 'port', required: true, size: 6, container_class: '-xslim' %></div>
+  <div class="form--field -required"><%= f.text_field 'name', required: true, container_class: '-middle' %></div>
+  <div class="form--field -required"><%= f.text_field 'host', required: true, container_class: '-middle' %></div>
+  <div class="form--field -required"><%= f.text_field 'port', required: true, size: 6, container_class: '-xslim' %></div>
   <div class="form--field"><%= f.check_box 'tls', label: 'LDAPS' %> </div>
   <div class="form--field"><%= f.text_field 'account', container_class: '-middle'  %></div>
   <div class="form--field"><%= f.password_field 'account_password',
@@ -50,7 +50,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <fieldset class="form--fieldset">
   <legend class="form--fieldset-legend"><%=t(:label_attribute_plural)%></legend>
-  <div class="form--field"><%= f.text_field 'attr_login', label: AuthSource.human_attribute_name(:login), required: true, size: 20, container_class: '-middle'  %></div>
+  <div class="form--field -required"><%= f.text_field 'attr_login', label: AuthSource.human_attribute_name(:login), required: true, size: 20, container_class: '-middle'  %></div>
   <div class="form--field"><%= f.text_field 'attr_firstname', label: AuthSource.human_attribute_name(:firstname), size: 20, container_class: '-middle'  %></div>
   <div class="form--field"><%= f.text_field 'attr_lastname', label: AuthSource.human_attribute_name(:lastname), size: 20, container_class: '-middle'  %></div>
   <div class="form--field"><%= f.text_field 'attr_mail', label: AuthSource.human_attribute_name(:mail), size: 20, container_class: '-middle'  %></div>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -35,7 +35,7 @@ See docs/COPYRIGHT.rdoc for more details.
                         end %>
 <% resource = message_attachment_representer(representer_object) %>
 
-<div class="form--field">
+<div class="form--field -required">
   <%= f.text_field :subject, required: true, container_class: '-wide', autofocus: true %>
 </div>
 <% unless replying %>

--- a/app/views/my/_password_form_fields.html.erb
+++ b/app/views/my/_password_form_fields.html.erb
@@ -38,8 +38,8 @@ See docs/COPYRIGHT.rdoc for more details.
     </div>
 <% end %>
 
-<div class="form--field">
-  <%= styled_label_tag 'password', User.human_attribute_name(:current_password), class: '-required' %>
+<div class="form--field -required">
+  <%= styled_label_tag 'password', User.human_attribute_name(:current_password) %>
   <div class="form--field-container">
     <%= styled_password_field_tag 'password',
                                   nil,
@@ -49,8 +49,8 @@ See docs/COPYRIGHT.rdoc for more details.
   </div>
 </div>
 
-<div class="form--field" style="padding-top: 1em">
-  <%= styled_label_tag 'new_password', User.human_attribute_name(:new_password), class: '-required' %>
+<div class="form--field -required" style="padding-top: 1em">
+  <%= styled_label_tag 'new_password', User.human_attribute_name(:new_password) %>
   <div class="form--field-container">
     <%= styled_password_field_tag 'new_password',
                                   nil,
@@ -67,9 +67,9 @@ See docs/COPYRIGHT.rdoc for more details.
 
 
 
-<div class="form--field">
+<div class="form--field -required">
   <%= styled_label_tag 'new_password_confirmation',
-        User.human_attribute_name(:password_confirmation), class: '-required' %>
+        User.human_attribute_name(:password_confirmation) %>
   <div class="form--field-container">
     <%= styled_password_field_tag 'new_password_confirmation',
                                   nil,

--- a/app/views/my/account.html.erb
+++ b/app/views/my/account.html.erb
@@ -49,9 +49,9 @@ See docs/COPYRIGHT.rdoc for more details.
           <%= @user.login %>
         </div>
       </div>
-      <div class="form--field"><%= f.text_field :firstname, required: true, container_class: '-middle' %></div>
-      <div class="form--field"><%= f.text_field :lastname, required: true, container_class: '-middle' %></div>
-      <div class="form--field"><%= f.text_field :mail, required: true, container_class: '-middle' %></div>
+      <div class="form--field -required"><%= f.text_field :firstname, required: true, container_class: '-middle' %></div>
+      <div class="form--field -required"><%= f.text_field :lastname, required: true, container_class: '-middle' %></div>
+      <div class="form--field -required"><%= f.text_field :mail, required: true, container_class: '-middle' %></div>
 
       <%= fields_for :pref, @user.pref, builder: TabularFormBuilder, lang: current_language do |pref_fields| %>
         <div class="form--field"><%= pref_fields.check_box :hide_mail %></div>

--- a/app/views/news/_form.html.erb
+++ b/app/views/news/_form.html.erb
@@ -27,7 +27,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= error_messages_for 'news' %>
-<div class="form--field">
+<div class="form--field -required">
   <%= f.text_field :title, required: true, size: 60, container_class: '-xxwide' %>
 </div>
 <div class="form--field">

--- a/app/views/oauth/applications/_form.html.erb
+++ b/app/views/oauth/applications/_form.html.erb
@@ -30,13 +30,13 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= error_messages_for_contract @application, @errors %>
 
 <section class="form--section">
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_field :name, required: true, size: 25, container_class: '-middle' %>
     <span class="form--field-instructions">
       <%= t('oauth.application.instructions.name') %>
     </span>
   </div>
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_area :redirect_uri, required: true, container_class: '-middle' %>
     <span class="form--field-instructions">
       <%= t('oauth.application.instructions.redirect_uri_html') %>

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -30,7 +30,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= error_messages_for 'role' %>
 
 <% unless @role.builtin? %>
-  <div class="form--field"><%= f.text_field :name, required: true, container_class: '-middle' %></div>
+  <div class="form--field -required"><%= f.text_field :name, required: true, container_class: '-middle' %></div>
   <div class="form--field"><%= f.check_box :assignable %></div>
   <% if @role.new_record? && @roles.any? %>
     <div id="member_attributes">

--- a/app/views/statuses/_form.html.erb
+++ b/app/views/statuses/_form.html.erb
@@ -30,7 +30,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= error_messages_for :status %>
 
 <section class="form--section">
-  <div class="form--field"><%= f.text_field 'name', required: true, container_class: '-middle' %></div>
+  <div class="form--field -required"><%= f.text_field 'name', required: true, container_class: '-middle' %></div>
   <% if WorkPackage.use_status_for_done_ratio? %>
     <div class="form--field"><%= f.select :default_done_ratio,
                     ((0..10).to_a.collect {|r| ["#{r*10} %", r*10] }),

--- a/app/views/types/form/_settings.html.erb
+++ b/app/views/types/form/_settings.html.erb
@@ -30,7 +30,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <div class="grid-block">
   <div class="grid-content">
     <!--[form:type]-->
-    <div class="form--field -wide-label"><%= f.text_field :name, required: true, disabled: @type.is_standard?, container_class: '-middle' %></div>
+    <div class="form--field -required -wide-label"><%= f.text_field :name, required: true, disabled: @type.is_standard?, container_class: '-middle' %></div>
     <div class="form--field -wide-label"><%= f.check_box :is_in_roadmap %></div>
     <%= render partial: '/colors/color_autocomplete_field',
                locals: {

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -33,10 +33,10 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <!--[form:user]-->
 <section class="form--section">
-  <div class="form--field"><%= f.text_field :login, required: true, size: 25, container_class: '-middle' %></div>
-  <div class="form--field"><%= f.text_field :firstname, required: true, container_class: '-middle' %></div>
-  <div class="form--field"><%= f.text_field :lastname, required: true, container_class: '-middle' %></div>
-  <div class="form--field"><%= f.text_field :mail, required: true, container_class: '-middle' %></div>
+  <div class="form--field -required"><%= f.text_field :login, required: true, size: 25, container_class: '-middle' %></div>
+  <div class="form--field -required"><%= f.text_field :firstname, required: true, container_class: '-middle' %></div>
+  <div class="form--field -required"><%= f.text_field :lastname, required: true, container_class: '-middle' %></div>
+  <div class="form--field -required"><%= f.text_field :mail, required: true, container_class: '-middle' %></div>
   <div class="form--field"><%= f.select :language, lang_options_for_select, prompt: "--- #{t(:actionview_instancetag_blank_option)} ---", container_class: '-slim' %></div>
   <div class="form--field"><%= f.check_box :admin, disabled: (@user == User.current) %></div>
 

--- a/app/views/users/_simple_form.html.erb
+++ b/app/views/users/_simple_form.html.erb
@@ -33,9 +33,9 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <!--[form:user]-->
 <section class="form--section">
-  <div class="form--field"><%= f.text_field :mail, required: true, autofocus: true, container_class: '-middle' %></div>
-  <div class="form--field"><%= f.text_field :firstname, required: true, container_class: '-middle' %></div>
-  <div class="form--field"><%= f.text_field :lastname, required: true, container_class: '-middle' %></div>
+  <div class="form--field -required"><%= f.text_field :mail, required: true, autofocus: true, container_class: '-middle' %></div>
+  <div class="form--field -required"><%= f.text_field :firstname, required: true, container_class: '-middle' %></div>
+  <div class="form--field -required"><%= f.text_field :lastname, required: true, container_class: '-middle' %></div>
 
   <%= render partial:     'customizable/field',
              collection:  @user.custom_field_values,

--- a/app/views/versions/_form.html.erb
+++ b/app/views/versions/_form.html.erb
@@ -36,7 +36,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= error_messages_for 'version' %>
 <%= back_url_hidden_field_tag %>
 
-<div class="form--field">
+<div class="form--field -required">
   <%= f.text_field :name, required: true, container_class: '-wide' %>
 </div>
 

--- a/app/views/workflows/copy.html.erb
+++ b/app/views/workflows/copy.html.erb
@@ -32,10 +32,8 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <%= styled_form_tag({}, id: 'workflow_copy_form') do %>
   <section class="form--section">
-    <div class="form--field">
-      <label class="form--label -required" for="source_type_id"><%= l(:label_copy_source) %>
-        <span class="form--label-required" aria-hidden="true">*</span>
-      </label>
+    <div class="form--field -required">
+      <label class="form--label" for="source_type_id"><%= l(:label_copy_source) %></label>
       <div class="form--field-container">
         <div class="form--select-container -middle">
           <label class="form--label" for="source_type_id"><%= Type.model_name.human %></label>
@@ -54,10 +52,8 @@ See docs/COPYRIGHT.rdoc for more details.
       </div>
     </div>
     <br />
-    <div class="form--field">
-      <label class="form--label -required" for="target_type_ids"><%= l(:label_copy_target) %>
-        <span class="form--label-required" aria-hidden="true">*</span>
-      </label>
+    <div class="form--field -required">
+      <label class="form--label" for="target_type_ids"><%= l(:label_copy_target) %></label>
       <div class="form--field-container">
         <div class="form--select-container -middle">
           <label class="form--label" for="target_type_ids"><%= Type.model_name.human %></label>

--- a/lib/custom_field_form_builder.rb
+++ b/lib/custom_field_form_builder.rb
@@ -112,18 +112,15 @@ class CustomFieldFormBuilder < TabularFormBuilder
   # Return custom field label tag
   def custom_field_label_tag
     custom_value = object
-    is_required = object.custom_field.is_required?
 
     classes = 'form--label'
     classes << ' error' unless custom_value.errors.empty?
-    classes << ' -required'if is_required
 
     content_tag 'label',
                 for: custom_field_field_id,
                 class: classes,
                 title: custom_value.custom_field.name do
-      content_tag('span', custom_value.custom_field.name) +
-        (content_tag('span', '*', class: 'form--label-required', :'aria-hidden' => true) if is_required)
+      custom_value.custom_field.name
     end
   end
 end

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -238,7 +238,6 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
 
     content = h(text)
     label_for_field_errors(content, label_options, field)
-    label_for_field_required(content, label_options, options[:required])
     label_for_field_for(options, label_options, field)
     label_for_field_prefix(content, options)
 
@@ -256,16 +255,6 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
       error_label = I18n.t('errors.field_erroneous_label',
                            full_errors: @object.errors.full_messages_for(field).join(' '))
       content << content_tag('p', error_label, class: 'hidden-for-sighted')
-    end
-  end
-
-  def label_for_field_required(content, options, is_required)
-    if is_required
-      options[:class] << ' -required'
-      content << content_tag('span',
-                             '*',
-                             class: 'form--label-required',
-                             'aria-hidden': true)
     end
   end
 

--- a/modules/backlogs/app/views/versions/_form.html.erb
+++ b/modules/backlogs/app/views/versions/_form.html.erb
@@ -38,7 +38,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= back_url_hidden_field_tag %>
 
 <% if @version.project == @project %>
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_field :name, required: true, container_class: '-wide'  %>
   </div>
   <div class="form--field">

--- a/modules/costs/app/views/cost_objects/_form.html.erb
+++ b/modules/costs/app/views/cost_objects/_form.html.erb
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <% resource = budget_attachment_representer(f.object) %>
 
-<div class="form--field">
+<div class="form--field -required">
   <%= f.text_field :subject, required: true, autofocus: true, container_class: '-wide' %>
 </div>
 <div class="form--field">

--- a/modules/costs/app/views/cost_types/edit.html.erb
+++ b/modules/costs/app/views/cost_types/edit.html.erb
@@ -37,13 +37,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <%= error_messages_for 'cost_type' %>
   <%= back_url_hidden_field_tag %>
 
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_field :name, required: true, container_class: '-wide' %>
   </div>
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_field :unit, required: true, container_class: '-middle' %>
   </div>
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_field :unit_plural, required: true, container_class: '-middle' %>
   </div>
   <div class="form--field">

--- a/modules/costs/app/views/costlog/edit.html.erb
+++ b/modules/costs/app/views/costlog/edit.html.erb
@@ -40,7 +40,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <%= f.hidden_field :element_id, value: 'cost_entry', class: 'remote-field--input', data: { :'remote-field-key' =>'element_id' } %>
 
     <div class="box">
-      <div class="form--field">
+      <div class="form--field -required">
         <%= f.text_field :work_package_id,
                          size: 6,
                          required: true,
@@ -53,7 +53,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           </div>
         <% end %>
       </div>
-      <div class="form--field">
+      <div class="form--field -required">
         <%= f.text_field :spent_on,
                          size: 10,
                          required: true,
@@ -74,7 +74,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <% else %>
         <%= f.hidden_field :user_id, value: User.current.id %>
       <% end %>
-      <div class="form--field">
+      <div class="form--field -required">
         <%# see above %>
         <%= f.select :cost_type_id,
                      cost_types_collection_for_select_options,
@@ -86,7 +86,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                        data: { :'remote-field-key' => 'cost_type_id' }
                      } %></p>
       </div>
-      <div class="form--field">
+      <div class="form--field -required">
         <% if @cost_entry.cost_type.nil? %>
             <%= f.text_field :units, size: 6, required: true, container_class: '-slim' %>
         <% else %>

--- a/modules/documents/app/views/documents/_form.html.erb
+++ b/modules/documents/app/views/documents/_form.html.erb
@@ -35,13 +35,13 @@ See doc/COPYRIGHT.rdoc for more details.
                                                             current_user: current_user,
                                                             embed_links: true) %>
 
-<div class="form--field">
+<div class="form--field -required">
   <%= f.select :category_id,
                DocumentCategory.all.map { |c| [c.name, c.id] },
                required: true,
                container_class: '-slim' %>
 </div>
-<div class="form--field">
+<div class="form--field -required">
   <%= f.text_field :title, required: true, container_class: '-wide' %>
 </div>
 <div class="form--field">

--- a/modules/global_roles/app/views/roles/_form.html.erb
+++ b/modules/global_roles/app/views/roles/_form.html.erb
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <% roles ||= nil %>
 
 <%= error_messages_for :role %>
-<div class="form--field">
+<div class="form--field -required">
   <%= f.text_field :name, required: true, container_class: '-slim' %>
 </div>
 <div class="form--field">

--- a/modules/global_roles/app/views/roles/_member_form.html.erb
+++ b/modules/global_roles/app/views/roles/_member_form.html.erb
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ++#%>
 
 <% unless role.builtin? %>
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_field :name, required: true %>
   </div>
   <div class="form--field">

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/index.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/index.html.erb
@@ -19,9 +19,9 @@
                       id: 'update-ldap-group-settings-form') do %>
     <fieldset class="form--fieldset">
       <legend class="form--fieldset-legend"><%= t(:label_settings) %></legend>
-      <div class="form--field">
+      <div class="form--field -required">
         <label class="form--label" for='group_key'><%= t('ldap_groups.settings.group_key') %></label>
-        <div class="form--field-container ">
+        <div class="form--field-container">
           <%= styled_text_field_tag 'group_key',
                                     ::OpenProject::LdapGroups.group_key,
                                     container_class: '-middle',

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/new.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/new.html.erb
@@ -11,7 +11,7 @@
   <fieldset class="form--fieldset">
     <legend class="form--fieldset-legend"><%= @group.class.human_attribute_name 'auth_source'  %></legend>
 
-    <div class="form--field">
+    <div class="form--field -required">
       <%= f.select :auth_source_id,
                    LdapAuthSource.pluck(:name, :id),
                    required: true,
@@ -25,7 +25,7 @@
   <fieldset class="form--fieldset">
     <legend class="form--fieldset-legend"><%= @group.class.model_name.human  %></legend>
 
-    <div class="form--field">
+    <div class="form--field -required">
       <%= f.text_field :entry,
                        required: true,
                        container_class: '-middle',
@@ -36,7 +36,7 @@
       </div>
     </div>
 
-    <div class="form--field">
+    <div class="form--field -required">
       <%= f.select :group_id,
                    Group.pluck(:lastname, :id),
                    required: true,

--- a/modules/meeting/app/views/meetings/_form.html.erb
+++ b/modules/meeting/app/views/meetings/_form.html.erb
@@ -23,7 +23,7 @@ See doc/COPYRIGHT.md for more details.
 
 <section class="form--section">
 
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_field :title, :required => true, :size => 60, container_class: '-wide' %>
   </div>
 

--- a/modules/meeting/app/views/meetings/_form.html.erb
+++ b/modules/meeting/app/views/meetings/_form.html.erb
@@ -31,13 +31,11 @@ See doc/COPYRIGHT.md for more details.
     <%= f.text_field :location, :size => 60, container_class: '-wide' %>
   </div>
 
-  <div class="form--field">
-    <label for="meeting-form-start-date" class="form--label -required">
-      <span aria-hidden="true"><%= Meeting.human_attribute_name(:start_date) %>
-        <span class="form--label-required" aria-hidden="true">*</span>
+  <div class="form--field -required">
+    <label for="meeting-form-start-date" class="form--label"><%= Meeting.human_attribute_name(:start_date) %>
+      <span class="hidden-for-sighted">
+        <%= t(:label_start_date)%><%= t(:text_hint_date_format) %>
       </span>
-      <span class="hidden-for-sighted"><%= t(:label_start_date)%>
-        <%= t(:text_hint_date_format) %></span>
     </label>
 
     <div class="form--field-container">
@@ -66,13 +64,8 @@ See doc/COPYRIGHT.md for more details.
     </div>
   </div>
 
-  <div class="form--field">
-    <label for="meeting-form-duration" class="form--label -required">
-      <span><%= Meeting.human_attribute_name(:duration) %>
-        <span class="form--label-required" aria-hidden="true">*</span>
-      </span>
-    </label>
-
+  <div class="form--field -required">
+    <label for="meeting-form-duration" class="form--label"><%= Meeting.human_attribute_name(:duration) %></label>
     <div class="form--field-container">
       <%= f.number_field :duration,
             id: 'meeting-form-duration',

--- a/modules/pdf_export/app/views/export_card_configurations/_form.html.erb
+++ b/modules/pdf_export/app/views/export_card_configurations/_form.html.erb
@@ -24,19 +24,19 @@ See doc/COPYRIGHT.md for more details.
 
 ++#%>
 
-<div class="form--field">
+<div class="form--field -required">
   <%= f.text_field :name, required: true, container_class: '-wide' %>
 </div>
 <div class="form--field">
   <%= f.text_area :description, container_class: '-middle' %>
 </div>
-<div class="form--field">
+<div class="form--field -required">
   <%= f.number_field :per_page,
                      required: true,
                      label: I18n.t('export_config_per_page'),
                      container_class: '-xslim' %>
 </div>
-<div class="form--field">
+<div class="form--field -required">
   <%= f.text_field :page_size,
                    required: true,
                    value: "A4",
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.md for more details.
                    label: I18n.t('export_config_page_size'),
                    container_class: '-xslim'  %>
 </div>
-<div class="form--field">
+<div class="form--field -required">
   <%= f.select :orientation,
                [:landscape, :portrait],
                :required => true,

--- a/modules/pdf_export/app/views/export_card_configurations/_rows_format_help.html.erb
+++ b/modules/pdf_export/app/views/export_card_configurations/_rows_format_help.html.erb
@@ -1,4 +1,4 @@
-<div class="form--field">
+<div class="form--field -required">
   <%= f.text_area :rows,
                   required: true,
                   label: I18n.t('export_config_rows'),

--- a/modules/reporting_engine/lib/widget/controls/save_as.rb
+++ b/modules/reporting_engine/lib/widget/controls/save_as.rb
@@ -36,15 +36,10 @@ class Widget::Controls::SaveAs < Widget::Controls
 
   def render_popup_form
     name = content_tag :p,
-                       class: 'form--field -wide-label' do
+                       class: 'form--field -required -wide-label' do
       label_tag(:query_name,
-                class: 'form--label -transparent -required') do
-        (Query.human_attribute_name(:name) +
-          content_tag(:span,
-                      '*',
-                      class: 'form--label-required',
-                      'aria-hidden': true)).html_safe
-      end +
+                Query.human_attribute_name(:name),
+                class: 'form--label -transparent')
       content_tag(:span,
                   class: 'form--field-container') do
         content_tag(:span,

--- a/modules/reporting_engine/lib/widget/controls/save_as.rb
+++ b/modules/reporting_engine/lib/widget/controls/save_as.rb
@@ -38,8 +38,9 @@ class Widget::Controls::SaveAs < Widget::Controls
     name = content_tag :p,
                        class: 'form--field -required -wide-label' do
       label_tag(:query_name,
-                Query.human_attribute_name(:name),
-                class: 'form--label -transparent')
+                class: 'form--label -transparent') do
+        Query.human_attribute_name(:name).html_safe
+      end +
       content_tag(:span,
                   class: 'form--field-container') do
         content_tag(:span,

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/enter_backup_code.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/enter_backup_code.html.erb
@@ -10,7 +10,7 @@
     <h2><%= t 'two_factor_authentication.login.enter_backup_code_title' %></h2>
     <p><%= I18n.t('two_factor_authentication.login.enter_backup_code_text') %></p>
     <hr class="form--separator">
-    <div class="form--field -wide-label">
+    <div class="form--field -required -wide-label">
       <%= styled_label_tag 'backup_code', t('two_factor_authentication.backup_codes.singular') %>
       <div class="form--field-container">
         <%= styled_text_field_tag 'backup_code', nil, required: true, autocomplete: 'off', size: 20, maxlength: 20, tabindex: 1, focus: true  %>

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/confirm.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/confirm.html.erb
@@ -8,7 +8,7 @@
   <p><%= message.html_safe %></p>
   <hr class="form--separator">
   <%= back_url_hidden_field_tag %>
-  <div class="form--field -wide-label">
+  <div class="form--field -required -wide-label">
     <%= styled_label_tag 'otp', l(:field_otp) %>
     <div class="form--field-container">
       <%= styled_text_field_tag 'otp', nil, required: true, autocomplete: 'off', size: 6, maxlength: 6, tabindex: 1, focus: true  %>

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/sms/_form.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/sms/_form.html.erb
@@ -3,14 +3,14 @@
 
   <p><%= t('two_factor_authentication.devices.sms.description') %></p>
 
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_field :identifier, required: true, container_class: '-middle' %>
     <div class="form--field-instructions">
       <%= t('two_factor_authentication.devices.text_identifier') %>
     </div>
   </div>
 
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.telephone_field :phone_number, required: true, container_class: '-wide' %>
     <div class="form--field-instructions">
       <%= t('notice_phone_number_format') %>

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/totp/_form.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/totp/_form.html.erb
@@ -3,7 +3,7 @@
 
   <p><%= t('two_factor_authentication.devices.totp.description') %></p>
 
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_field :identifier, required: true, container_class: '-middle' %>
     <div class="form--field-instructions">
       <%= t('two_factor_authentication.devices.text_identifier') %>

--- a/modules/webhooks/app/views/webhooks/outgoing/admin/_form.html.erb
+++ b/modules/webhooks/app/views/webhooks/outgoing/admin/_form.html.erb
@@ -5,11 +5,11 @@
     <%= link_to t('webhooks.outgoing.form.apiv3_doc_url'), OpenProject::Static::Links.links[:api_docs][:href] %>
   </p>
 
-  <div class="form--field">
+  <div class="form--field -required">
     <%= f.text_field :name, required: true, container_class: '-middle' %>
   </div>
 
-  <div class="form--field">
+  <div class="form--field -required">
       <%= f.url_field :url, required: true, container_class: '-wide' %>
   </div>
 

--- a/spec/features/auth/login_spec.rb
+++ b/spec/features/auth/login_spec.rb
@@ -115,10 +115,7 @@ describe 'Login', type: :feature do
       expect(page)
         .to have_field('Login')
 
-      fill_in('Login', with: user.login)
-      fill_in('Password', with: user_password)
-
-      click_button(I18n.t(:button_login))
+      login_with(user.login, user_password)
 
       expect(page)
         .to have_current_path my_page_path

--- a/spec/features/users/brute_force_spec.rb
+++ b/spec/features/users/brute_force_spec.rb
@@ -44,9 +44,7 @@ describe 'Loggin (with brute force protection)', type: :feature do
     expect(page)
       .to have_field 'Login', with: login_attempt
 
-    fill_in 'Password', with: password_attempt
-
-    click_button 'Sign in'
+    login_with(login_attempt, password_attempt)
   end
 
   def pretend_to_have_waited(time)

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -574,13 +574,12 @@ JJ Abrams</textarea>
         }).at_path('label')
       end
 
-      def expected_required_label_like(expected_title, expected_classes = 'form--label')
+      def expected_form_label_like(expected_title, expected_classes = 'form--label')
         expect(output).to be_html_eql(%{
           <label class="#{expected_classes}"
                  for="user_name"
                  title="#{expected_title}">
             #{expected_title}
-            <span class="form--label-required" aria-hidden="true">*</span>
           </label>
         }).at_path('label')
       end
@@ -661,7 +660,7 @@ JJ Abrams</textarea>
         end
 
         it 'uses the label' do
-          expected_required_label_like(I18n.t(:name), 'form--label -required')
+          expected_form_label_like(I18n.t(:name), 'form--label')
         end
       end
     end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -44,7 +44,7 @@ module AuthenticationHelpers
   def login_with(login, password, autologin: false, visit_signin_path: true)
     visit signin_path if visit_signin_path
 
-    within('#login-form') do
+    within('.user-login--form') do
       fill_in 'username', with: login
       fill_in 'password', with: password
       check I18n.t(:label_stay_logged_in) if autologin


### PR DESCRIPTION
This PR adapts the implementation of 'required' fields to the Style Guide specifications, which means: 
1) All 'form--label-required' and 'form--label -required' classes had been removed and replaced by the '-required' class on 'form--fields'. 
2) Tests were adapted
3) Styling rule had been added
4) Missing '-required' classes had been added


#### Missing required fields:

**Within a project**

- Roadmap Version: Name field

- Forum: Subject field
- New Forum: Name, Description field

- News: Title field

- Budgets: Subject field

- Meeting: Title field

**Login**

- Register: all fields
- Login: password, login field

**Account** 

- Change Password: Current, new, pwd confirmation
- Profile: First name, Last name, Mail

**Administration**

- User: Login, First name, Last name, Mail
- New User: Email First name, Last name

- Groups: Name field

- Roles: Name field

- Work package types: Name field
- Work package statuses: Name field

- Workflows - Copy: Source, Target field

- Custom fields: Name field

- Custom actions: Name field

- Enumerations: Name field

- LDAP: Name, Host, Port, Login fields

- OAuth: Name, Redirect URI field

- Colors: Name field 
- Cost Types: Name, Unit name, Pluralized unit name field

- Export Card Configs: Name, Per page, Page size field

- Webhooks: Name, Paload URL


https://community.openproject.com/projects/openproject/work_packages/28891
