### PR TITLE
[29632] changed send() name argument from symbol to string

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -236,10 +236,10 @@ class Member < ActiveRecord::Base
   end
 
   def save_notification
-    ::OpenProject::Notifications.send(:member_updated, member: self)
+    ::OpenProject::Notifications.send('member_updated', member: self)
   end
 
   def destroy_notification
-    ::OpenProject::Notifications.send(:member_removed, member: self)
+    ::OpenProject::Notifications.send('member_removed', member: self)
   end
 end


### PR DESCRIPTION
See the details in OpenProject Workpackage [29632](https://community.openproject.com/projects/openproject/work_packages/details/29632/overview), I have converted the name argument from a symbol to a string to match what subscribe is expecting.