### PR TITLE
Add custom getter for Setting.installation_uuid

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -92,6 +92,7 @@ class Setting < ActiveRecord::Base
   end
 
   def self.create_setting_accessors(name)
+    return if [:installation_uuid].include?(name.to_sym)
     # Defines getter and setter for each setting
     # Then setting values can be read using: Setting.some_setting_name
     # or set using Setting.some_setting_name = "some value"
@@ -189,7 +190,13 @@ class Setting < ActiveRecord::Base
 
   def self.installation_uuid
     if settings_table_exists_yet?
-      self[:installation_uuid] ||= generate_installation_uuid
+      # we avoid the default getters and setters since the cache messes things up
+      setting = find_or_initialize_by(name: "installation_uuid")
+      if setting.value.blank?
+        setting.value = generate_installation_uuid
+        setting.save!
+      end
+      setting.value
     else
       "unknown"
     end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -187,6 +187,22 @@ class Setting < ActiveRecord::Base
     @@available_settings.has_key?(name)
   end
 
+  def self.installation_uuid
+    if settings_table_exists_yet?
+      self[:installation_uuid] ||= generate_installation_uuid
+    else
+      "unknown"
+    end
+  end
+
+  def self.generate_installation_uuid
+    if Rails.env.test?
+      "test"
+    else
+      SecureRandom.uuid
+    end
+  end
+
   [:emails_header, :emails_footer].each do |mail|
     src = <<-END_SRC
     def self.localized_#{mail}

--- a/config/initializers/security_badge.rb
+++ b/config/initializers/security_badge.rb
@@ -1,7 +1,0 @@
-OpenProject::Application.configure do
-  config.after_initialize do
-    if Setting.settings_table_exists_yet?
-      Setting.installation_uuid ||= SecureRandom.uuid
-    end
-  end
-end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -85,6 +85,33 @@ describe Setting, type: :model do
     end
   end
 
+  describe ".installation_uuid" do
+    it "returns unknown if the settings table isn't available yet" do
+      Setting.stub(settings_table_exists_yet?: false)
+      expect(Setting.installation_uuid).to eq("unknown")
+    end
+
+    context "with settings table ready" do
+      it "returns the existing value if any", with_settings: { installation_uuid: "abcd1234" } do
+        expect(Setting.installation_uuid).to eq("abcd1234")
+      end
+
+      context "with no existing value" do
+        it "returns 'test' as the UUID if environment == test" do
+          expect(Setting.installation_uuid).to eq("test")
+        end
+
+        it "returns a random UUID if environment != test" do
+          Rails.env.stub(test?: false)
+          installation_uuid = Setting.installation_uuid
+          expect(installation_uuid).not_to eq("test")
+          expect(installation_uuid.size).to eq(36)
+          expect(Setting.installation_uuid).to eq(installation_uuid)
+        end
+      end
+    end
+  end
+
   # Check that when reading certain setting values that they get overwritten if needed.
   describe "filter saved settings" do
     before do


### PR DESCRIPTION
This adds a custom getter for `Setting.installation_uuid`, so that we get more chances to generate a proper UUID for the installation.

Previously, it seems that the initializer could be called before the Settings table was available, which resulted, for some installations, in an empty installation_uuid being sent to the Release API.