### PR TITLE
[29639] Selected entry in auto-completion not removed from list of options

### DIFF
--- a/frontend/src/app/modules/common/autocomplete/user-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/user-autocompleter.component.ts
@@ -42,7 +42,8 @@ import {I18nService} from "core-app/modules/common/i18n/i18n.service";
                [ngModel]="initialSelection"
                [virtualScroll]="true"
                (search)="onSearch($event)"
-               (change)="onModelChange($event)" >
+               (change)="onModelChange($event)"
+               (focus)="onFocus()">
       <ng-template ng-option-tmp let-item="item" let-index="index">
         <user-avatar *ngIf="item.href"
                      [attr.data-user-name]="item.name"
@@ -95,6 +96,7 @@ export class UserAutocompleterComponent implements OnInit {
   public onModelChange(user:any) {
     if (user) {
       this.onChange.emit(user);
+      this.setAvailableUsers(this.url, '');
 
       if (this.clearAfterSelection) {
         this.ngSelectComponent.clearItem(user);
@@ -115,6 +117,12 @@ export class UserAutocompleterComponent implements OnInit {
     }
 
     this.setAvailableUsers(this.url, urlQuery);
+  }
+
+  public onFocus(){
+    // For dynamic changes of the available users
+    // we have to reload them on focus (e.g. watchers)
+    this.setAvailableUsers(this.url, '');
   }
 
   private setAvailableUsers(url:string, filters:any) {

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
@@ -15,7 +15,8 @@
              [multiple]="true"
              [closeOnSelect]="false"
              [appendTo]="appendTo"
-             [dropdownPosition]="'top'">
+             [dropdownPosition]="'top'"
+             [hideSelected]="true">
   </ng-select>
 
   <edit-field-controls [fieldController]="self"

--- a/spec/support/work_packages/work_package_field.rb
+++ b/spec/support/work_packages/work_package_field.rb
@@ -137,7 +137,7 @@ class WorkPackageField
 
     if input_element.tag_name == 'ng-select'
       if multi
-        page.find('.ng-dropdown-panel .ng-option', text: content).click
+        page.find('.ng-value-label', text: content).sibling('.ng-value-icon').click
       else
         page.find('.ng-dropdown-panel .ng-option', text: '-').click
       end


### PR DESCRIPTION
Multi-select edit fields shall show only those elements as options that are not already selected. The watcher "multi"-select is a special case as it is actually a single select field. Since the elements are loaded dynamically from the API, we have to update the list of available watchers once a watcher is added or removed. 

https://community.openproject.com/projects/openproject/work_packages/29639/activity