### PR TITLE
[29673] Avoid stale? with CSP nonces on activities controller

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -52,30 +52,20 @@ class ActivitiesController < ApplicationController
 
     events = @activity.events(@date_from, @date_to)
     censor_events_from_projects_with_disabled_activity!(events) unless @project
-
-    if events.empty? || stale?(etag: [@activity.scope,
-                                      @date_to,
-                                      @date_from,
-                                      @with_subprojects,
-                                      @author,
-                                      events.first,
-                                      User.current,
-                                      current_language,
-                                      DesignColor.overwritten])
-      respond_to do |format|
-        format.html do
-          @events_by_day = events.group_by { |e| e.event_datetime.in_time_zone(User.current.time_zone).to_date }
-          render layout: false if request.xhr?
+    
+    respond_to do |format|
+      format.html do
+        @events_by_day = events.group_by { |e| e.event_datetime.in_time_zone(User.current.time_zone).to_date }
+        render layout: false if request.xhr?
+      end
+      format.atom do
+        title = l(:label_activity)
+        if @author
+          title = @author.name
+        elsif @activity.scope.size == 1
+          title = l("label_#{@activity.scope.first.singularize}_plural")
         end
-        format.atom do
-          title = l(:label_activity)
-          if @author
-            title = @author.name
-          elsif @activity.scope.size == 1
-            title = l("label_#{@activity.scope.first.singularize}_plural")
-          end
-          render_feed(events, title: "#{@project || Setting.app_title}: #{title}")
-        end
+        render_feed(events, title: "#{@project || Setting.app_title}: #{title}")
       end
     end
 


### PR DESCRIPTION
On activities, the `stale?` results in a 304 Not Modified which replays the previous cached request, but not necessarily with all headers.

Not all headers treat 304 responses equally, some do replay the CSP headers from the original 200 GET, but we cannot rely on that. 

If the header is not replayed, the frontend-cached nonces will not bevalid resulting in a CSP violation.

A short-term fix is to move the caching into the view.

```
References:
https://github.com/w3c/webappsec-csp/issues/161
https://bugs.chromium.org/p/chromium/issues/detail?id=174301
```

https://community.openproject.com/wp/29673