### PR TITLE
allow modals to overwrite escape behaviour

### DIFF
--- a/frontend/src/app/components/op-modals/op-modal.component.ts
+++ b/frontend/src/app/components/op-modals/op-modal.component.ts
@@ -6,6 +6,7 @@ export abstract class OpModalComponent implements OnInit, OnDestroy {
 
   /* Close on escape? */
   public closeOnEscape:boolean = true;
+  public closeOnEscapeFunction = this.closeMe;
 
   /* Close on outside click */
   public closeOnOutsideClick:boolean = true;

--- a/frontend/src/app/components/op-modals/op-modal.service.ts
+++ b/frontend/src/app/components/op-modals/op-modal.service.ts
@@ -39,7 +39,7 @@ export class OpModalService {
     // Listen to keyups on window to close context menus
     jQuery(window).on('keydown', (evt:JQueryEventObject) => {
       if (this.active && this.active.closeOnEscape && evt.which === keyCodes.ESCAPE) {
-        this.close(evt);
+        this.active.closeOnEscapeFunction(evt);
       }
 
       return true;


### PR DESCRIPTION
Should not change any behaviour for now but allows subclasses of `OpModalComponent` to overwrite the method called when the user presses 'escape'.