### PR TITLE
[29529] [Boards] Handle non-default types

### DIFF
--- a/app/assets/stylesheets/layout/_colors.sass
+++ b/app/assets/stylesheets/layout/_colors.sass
@@ -98,6 +98,10 @@
     margin-right: 4px
     border-radius: 50%
 
+    .-small-font &
+      width: 10px
+      height: 10px
+
 @mixin dot_border_width_style
   [class^='__hl_dot_'],
   [class*=' __hl_dot_']

--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -206,6 +206,10 @@
     padding-bottom: 3px
     margin-top: 2px
 
+    .work-packages--type-selector:not(.wp-new-top-row--element)
+      [class*='__hl_dot_']::before
+        vertical-align: 1px
+        margin-right: 6px
 .work-packages--type-selector:not(.wp-new-top-row--element)
   .wp-table--cell-span
     padding-right: 5px !important
@@ -215,11 +219,6 @@
   // Remove left padding from type
   .wp-edit-field--display-field
     padding-left: 0 !important
-
-  [class*='__hl_dot_']::before
-    vertical-align: 1px
-    margin-right: 6px
-
 
   @media only screen and (min-width: 679px)
     .wp-edit-field--container.-active

--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -210,6 +210,7 @@
       [class*='__hl_dot_']::before
         vertical-align: 1px
         margin-right: 6px
+
 .work-packages--type-selector:not(.wp-new-top-row--element)
   .wp-table--cell-span
     padding-right: 5px !important

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -47,6 +47,9 @@ en:
     close_filter_title: "Close filter"
     close_form_title: "Close form"
 
+    card:
+      add_new: 'Add new card'
+
     clipboard:
       browser_error: "Your browser doesn't support copying to clipboard. Please copy the selected text manually."
       copied_successful: "Sucessfully copied to clipboard!"

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.html
@@ -15,10 +15,12 @@
       </accessible-by-keyboard>
 
       <div class="work-packages--subject-type-row"
-           [ngClass]="{'-new': wp.isNew}">
-        <wp-edit-field [workPackageId]="wp.id"
+           [ngClass]="{'-active': activeEditField()}">
+        <wp-edit-field #wpEditField
+                       [workPackageId]="wp.id"
                        [wrapperClasses]="'work-packages--type-selector'"
-                       [fieldName]="'type'">
+                       [fieldName]="'type'"
+                       class="work-package--card--type">
         </wp-edit-field>
         <wp-edit-field [workPackageId]="wp.id"
                        fieldName="subject"

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.html
@@ -14,10 +14,17 @@
                               (execute)="removeNewCard(wp)">
       </accessible-by-keyboard>
 
-      <wp-edit-field [workPackageId]="wp.id"
-                     fieldName="subject"
-                     class="work-package--card--subject -bold">
-      </wp-edit-field>
+      <div class="work-packages--subject-type-row"
+           [ngClass]="{'-new': wp.isNew}">
+        <wp-edit-field [workPackageId]="wp.id"
+                       [wrapperClasses]="'work-packages--type-selector'"
+                       [fieldName]="'type'">
+        </wp-edit-field>
+        <wp-edit-field [workPackageId]="wp.id"
+                       fieldName="subject"
+                       class="work-package--card--subject -bold">
+        </wp-edit-field>
+      </div>
 
       <div class="work-package--card--author -italic"
            [hidden]="wp.isNew"

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
@@ -21,12 +21,6 @@
     bottom: 5px
     right: 0
 
-  .work-packages--subject-type-row.-new
-    flex-wrap: wrap
-
-.work-package--card--subject .wp-edit-field--container
-  margin-left: -5px
-
 .work-package--card--additional-info-container
   margin-top: 15px
 
@@ -51,3 +45,11 @@ wp-edit-field
   position: absolute
   right: 0
   bottom: 2px
+
+.work-packages--subject-type-row.-active
+  flex-wrap: wrap
+  .work-package--card--type,
+  .work-package--card--subject
+    flex-basis: 100%
+
+

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
@@ -21,6 +21,9 @@
     bottom: 5px
     right: 0
 
+  .work-packages--subject-type-row.-new
+    flex-wrap: wrap
+
 .work-package--card--subject .wp-edit-field--container
   margin-left: -5px
 

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -83,7 +83,7 @@ export class WorkPackageCardViewComponent extends WorkPackageEmbeddedTableCompon
   public columns:QueryColumn[];
   public availableColumns:QueryColumn[];
   public text = {
-    addNewCard: 'Add new card',
+    addNewCard:  this.I18n.t('js.card.add_new'),
     wpAddedBy: (wp:WorkPackageResource) =>
       this.I18n.t('js.label_wp_id_added_by', {id: wp.id, author: wp.author.name})
   };

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -45,6 +45,7 @@ import {AngularTrackingHelpers} from "core-components/angular/tracking-functions
 import {WorkPackageChangeset} from "core-components/wp-edit-form/work-package-changeset";
 import {DragAndDropHelpers} from "core-app/modules/boards/drag-and-drop/drag-and-drop.helpers";
 import {WorkPackageNotificationService} from "core-components/wp-edit/wp-notification.service";
+import {WorkPackageEditFieldComponent} from "app/components/wp-edit/wp-edit-field/wp-edit-field.component";
 
 
 @Component({
@@ -89,6 +90,7 @@ export class WorkPackageCardViewComponent extends WorkPackageEmbeddedTableCompon
   };
 
   @ViewChild('container') public container:ElementRef;
+  @ViewChild('wpEditField') readonly wpEditField:WorkPackageEditFieldComponent;
 
   /** Whether the card view has an active inline created wp */
   public activeInlineCreateWp?:WorkPackageResource;
@@ -171,6 +173,10 @@ export class WorkPackageCardViewComponent extends WorkPackageEmbeddedTableCompon
       'work-packages.show',
       {workPackageId: wpId}
     );
+  }
+
+  public activeEditField() {
+    return this.wpEditField && this.wpEditField.active;
   }
 
   removeDragged() {


### PR DESCRIPTION
Add type selector to card view.

### ToDo

- [x] Show type before the title in the card with the color (if defined)
- [x] When adding a new card add a type selector. Thereby the default type shall be preselected.
- [x] Take care that everything looks good (no overlapping, no type fields that are too small)

https://community.openproject.com/projects/openproject/work_packages/29529/activity