### PR TITLE
Fix/load search results only once

### DIFF
--- a/frontend/src/app/components/wp-table/embedded/wp-embedded-table.component.ts
+++ b/frontend/src/app/components/wp-table/embedded/wp-embedded-table.component.ts
@@ -108,7 +108,7 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
       });
   }
 
-  private initializeStates(query:QueryResource, results:WorkPackageCollectionResource) {
+  protected initializeStates(query:QueryResource, results:WorkPackageCollectionResource) {
     this.tableState.ready.doAndTransition('Query loaded', () => {
       this.wpStatesInitialization.clearStates();
       this.wpStatesInitialization.initializeFromQuery(query, results);

--- a/frontend/src/app/components/wp-table/embedded/wp-embedded-table.component.ts
+++ b/frontend/src/app/components/wp-table/embedded/wp-embedded-table.component.ts
@@ -86,14 +86,18 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
     }
 
     // Reload results on changes to pagination
-    this.tableState.ready.fireOnStateChange(this.wpTablePagination.state,
-      'Query loaded').values$().pipe(
-      untilComponentDestroyed(this),
-      withLatestFrom(this.tableState.query.values$())
-    ).subscribe(([pagination, query]) => {
-      this.loadingIndicator = this.QueryDm.loadResults(query, this.wpTablePagination.paginationObject)
-        .then((results) => this.initializeStates(query, results));
-    });
+    this
+      .tableState
+      .ready.fireOnStateChange(this.wpTablePagination.state,
+                       'Query loaded')
+      .values$()
+      .pipe(
+        untilComponentDestroyed(this),
+        withLatestFrom(this.tableState.query.values$())
+      )
+      .subscribe(([pagination, query]) => {
+        this.refreshResults(query);
+      });
   }
 
   public openConfigurationModal(onUpdated:() => void) {
@@ -165,5 +169,10 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
     }
 
     return promise;
+  }
+
+  protected refreshResults(query:QueryResource) {
+    this.loadingIndicator = this.QueryDm.loadResults(query, this.wpTablePagination.paginationObject)
+      .then((results) => this.initializeStates(query, results));
   }
 }

--- a/frontend/src/app/modules/global_search/global-search-work-packages.component.ts
+++ b/frontend/src/app/modules/global_search/global-search-work-packages.component.ts
@@ -126,8 +126,7 @@ export class GlobalSearchWorkPackagesComponent extends WorkPackageEmbeddedTableC
       this.query.filters = filters.current;
       this.queryProps = this.UrlParamsHelper.buildV3GetQueryFromQueryResource(this.query);
 
-      this.loadingIndicator = this.QueryDm.loadResults(this.query, this.wpTablePagination.paginationObject)
-        .then((results) => this.initializeStates(this.query, results));
+      this.refreshResults(this.query);
     }
   }
 

--- a/frontend/src/app/modules/global_search/global-search-work-packages.component.ts
+++ b/frontend/src/app/modules/global_search/global-search-work-packages.component.ts
@@ -126,7 +126,7 @@ export class GlobalSearchWorkPackagesComponent extends WorkPackageEmbeddedTableC
       )
       .subscribe((resultsHidden:boolean) => this.show = !resultsHidden);
 
-    this.setQueryProps();
+    this.setQueryProps(false);
   }
 
   public onFiltersChanged(filters:WorkPackageTableFilters) {
@@ -155,7 +155,7 @@ export class GlobalSearchWorkPackagesComponent extends WorkPackageEmbeddedTableC
     });
   }
 
-  private setQueryProps():void {
+  private setQueryProps(refresh:boolean = true):void {
     let filters:any[] = [];
     let columns = ['id', 'project', 'subject', 'type', 'status', 'updatedAt'];
 
@@ -185,7 +185,9 @@ export class GlobalSearchWorkPackagesComponent extends WorkPackageEmbeddedTableC
       showHierarchies: false
     };
 
-    this.refresh();
+    if (refresh) {
+      this.refresh();
+    }
   }
 
   ngOnDestroy():void {

--- a/frontend/src/app/modules/global_search/global-search-work-packages.component.ts
+++ b/frontend/src/app/modules/global_search/global-search-work-packages.component.ts
@@ -125,7 +125,9 @@ export class GlobalSearchWorkPackagesComponent extends WorkPackageEmbeddedTableC
     if (filters.isComplete()) {
       this.query.filters = filters.current;
       this.queryProps = this.UrlParamsHelper.buildV3GetQueryFromQueryResource(this.query);
-      this.refresh();
+
+      this.loadingIndicator = this.QueryDm.loadResults(this.query, this.wpTablePagination.paginationObject)
+        .then((results) => this.initializeStates(this.query, results));
     }
   }
 

--- a/frontend/src/app/modules/global_search/global-search-work-packages.component.ts
+++ b/frontend/src/app/modules/global_search/global-search-work-packages.component.ts
@@ -31,29 +31,21 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
-  HostListener, Injector,
+  Injector,
   OnDestroy,
   Renderer2,
   ViewChild
 } from '@angular/core';
-import {ContainHelpers} from 'app/modules/common/focus/contain-helpers';
 import {FocusHelperService} from 'app/modules/common/focus/focus-helper';
 import {I18nService} from 'app/modules/common/i18n/i18n.service';
 import {DynamicBootstrapper} from "app/globals/dynamic-bootstrapper";
-import {PathHelperService} from "app/modules/common/path-helper/path-helper.service";
 import {HalResourceService} from "app/modules/hal/services/hal-resource.service";
-import {WorkPackageResource} from "app/modules/hal/resources/work-package-resource";
-import {CollectionResource} from "app/modules/hal/resources/collection-resource";
-import {DynamicCssService} from "app/modules/common/dynamic-css/dynamic-css.service";
 import {GlobalSearchService} from "app/modules/global_search/global-search.service";
-import {debounceTime, distinctUntilChanged} from "rxjs/operators";
-import {componentDestroyed, untilComponentDestroyed} from "ng2-rx-componentdestroyed";
-import {CurrentProjectService} from "app/components/projects/current-project.service";
-import {GlobalSearchInputComponent} from "app/modules/global_search/global-search-input.component";
-import {combineLatest, Subscription} from "rxjs";
+import {debounceTime, distinctUntilChanged, skip} from "rxjs/operators";
+import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {combineLatest} from "rxjs";
 import {WorkPackageTableFilters} from "app/components/wp-fast-table/wp-table-filters";
 import {WorkPackageTableFiltersService} from "app/components/wp-fast-table/state/wp-table-filters.service";
-import {QueryFiltersComponent} from "app/components/filters/query-filters/query-filters.component";
 import {WorkPackageEmbeddedTableComponent} from "app/components/wp-table/embedded/wp-embedded-table.component";
 import {QueryResource} from "app/modules/hal/resources/query-resource";
 import {QueryFormResource} from "app/modules/hal/resources/query-form-resource";
@@ -72,7 +64,6 @@ export class GlobalSearchWorkPackagesComponent extends WorkPackageEmbeddedTableC
   @ViewChild('wpTable') wpTable:WorkPackageEmbeddedTableComponent;
 
   private query:QueryResource;
-  private firstTimeLoadForm:boolean = false;
 
   public filters:WorkPackageTableFilters;
   public queryProps:{ [key:string]:any };
@@ -108,14 +99,15 @@ export class GlobalSearchWorkPackagesComponent extends WorkPackageEmbeddedTableC
       this.globalSearchService.projectScope$
     )
     .pipe(
+      skip(1),
       distinctUntilChanged(),
       debounceTime(10),
       untilComponentDestroyed(this)
     )
     .subscribe(([newSearchTerm, newProjectScope]) => {
       this.WpFilter.visible = false;
-      this.firstTimeLoadForm = true;
       this.setQueryProps();
+      this.refresh();
     });
 
     this.globalSearchService
@@ -126,7 +118,7 @@ export class GlobalSearchWorkPackagesComponent extends WorkPackageEmbeddedTableC
       )
       .subscribe((resultsHidden:boolean) => this.show = !resultsHidden);
 
-    this.setQueryProps(false);
+    this.setQueryProps();
   }
 
   public onFiltersChanged(filters:WorkPackageTableFilters) {
@@ -139,10 +131,7 @@ export class GlobalSearchWorkPackagesComponent extends WorkPackageEmbeddedTableC
 
   protected loadQuery(visible:boolean = true) {
     return super.loadQuery(visible).then((query:QueryResource) => {
-      if (this.firstTimeLoadForm) {
-        this.firstTimeLoadForm = false;
-        this.loadForm(query);
-      }
+      this.loadForm(query);
       this.query = query;
       return query;
     });
@@ -155,7 +144,7 @@ export class GlobalSearchWorkPackagesComponent extends WorkPackageEmbeddedTableC
     });
   }
 
-  private setQueryProps(refresh:boolean = true):void {
+  private setQueryProps():void {
     let filters:any[] = [];
     let columns = ['id', 'project', 'subject', 'type', 'status', 'updatedAt'];
 
@@ -184,10 +173,6 @@ export class GlobalSearchWorkPackagesComponent extends WorkPackageEmbeddedTableC
       sortBy: JSON.stringify([['updatedAt', 'desc']]),
       showHierarchies: false
     };
-
-    if (refresh) {
-      this.refresh();
-    }
   }
 
   ngOnDestroy():void {


### PR DESCRIPTION
Reduces the times, search results are loaded from three to one and by that improves performance quite a bit.

https://community.openproject.com/projects/openproject/work_packages/29715