### PR TITLE
Silently remove parent sort_by

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -306,7 +306,12 @@ class Query < ActiveRecord::Base
   end
 
   def sort_criteria
-    read_attribute(:sort_criteria) || []
+    (read_attribute(:sort_criteria) || []).tap do |criteria|
+      criteria.map! do |attr, direction|
+        attr = 'id' if attr == 'parent'
+        [attr, direction]
+      end
+    end
   end
 
   def sort_criteria_key(arg)

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -541,6 +541,15 @@ describe Query, type: :model do
         end
       end
 
+      context 'parent' do
+        let(:sort_by) { [['parent', 'asc'], ['start_date', 'asc']] }
+
+        it 'is valid' do
+          expect(query).to be_valid
+          expect(query.sort_criteria).to match_array [['id', 'asc'], ['start_date', 'asc']]
+        end
+      end
+
       context 'partially invalid' do
         let(:sort_by) { [['cf_0815', 'desc'], ['project', 'desc']] }
 


### PR DESCRIPTION
Ensures that criteria is mapped in place without parent (ensure that valid_subset! still works which modifies the sort_criteria in place as well)