### PR TITLE
Let Global search also search within custom fields

### DIFF
--- a/app/models/queries/work_packages/filter/search_filter.rb
+++ b/app/models/queries/work_packages/filter/search_filter.rb
@@ -86,13 +86,17 @@ class Queries::WorkPackages::Filter::SearchFilter <
     custom_fields =
       if context&.project
         context.project.all_work_package_custom_fields.select do |custom_field|
-          %w(text string).include?(custom_field.field_format)
+          %w(text string).include?(custom_field.field_format) &&
+            custom_field.is_filter == true &&
+            custom_field.searchable == true
         end
       else
         ::WorkPackageCustomField
           .filter
           .for_all
-          .where(field_format: %w(text string))
+          .where(field_format: %w(text string),
+                 is_filter: true,
+                 searchable: true)
       end
 
     custom_fields.map do |custom_field|

--- a/app/models/queries/work_packages/filter/search_filter.rb
+++ b/app/models/queries/work_packages/filter/search_filter.rb
@@ -82,8 +82,32 @@ class Queries::WorkPackages::Filter::SearchFilter <
     I18n.t('label_search')
   end
 
+  def custom_field_configurations
+    custom_fields =
+      if context&.project
+        context.project.all_work_package_custom_fields.select do |custom_field|
+          %w(text string).include?(custom_field.field_format)
+        end
+      else
+        ::WorkPackageCustomField
+          .filter
+          .for_all
+          .where(field_format: %w(text string))
+      end
+
+    custom_fields.map do |custom_field|
+      Queries::WorkPackages::Filter::FilterConfiguration.new(
+        Queries::WorkPackages::Filter::CustomFieldFilter,
+        "cf_#{custom_field.id}",
+        CONTAINS_OPERATOR
+      )
+    end
+  end
+
   def filter_configurations
     list = CE_FILTERS
+
+    list += custom_field_configurations
     list += EE_TSV_FILTERS if attachment_filters_allowed?
     list
   end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -56,6 +56,27 @@ describe 'Search', type: :feature, js: true do
   end
 
   before do
+    custom_field_text = FactoryBot.create(:text_wp_custom_field)
+    project.work_package_custom_fields << custom_field_text
+    work_packages.first.type.custom_fields << custom_field_text
+
+    custom_field_string = FactoryBot.create(:string_wp_custom_field,
+                                            is_for_all: true,
+                                            is_filter: true)
+    custom_field_string.save
+    work_packages.first.type.custom_fields << custom_field_string
+
+    FactoryBot.create(:work_package_custom_value,
+                      custom_field: custom_field_text,
+                      customized: work_packages[0],
+                      value: "long text")
+
+    FactoryBot.create(:work_package_custom_value,
+                      custom_field: custom_field_string,
+                      customized: work_packages[1],
+                      value: "short text")
+    project.reload
+
     login_as user
 
     visit search_path(*params)
@@ -109,6 +130,19 @@ describe 'Search', type: :feature, js: true do
   end
 
   describe 'work package search' do
+    context 'search in all projects' do
+      let(:params) { [project, { q: query, work_packages: 1 }] }
+
+      it "finds global custom fields" do
+        select_autocomplete(page.find('.top-menu-search--input'),
+                                  query: "text",
+                                  select_text: "In all projects ↵")
+        table = Pages::EmbeddedWorkPackagesTable.new(find('.work-packages-embedded-view--container'))
+        table.ensure_work_package_not_listed!(work_packages[0])
+        table.expect_work_package_subject(work_packages[1].subject)
+      end
+    end
+
     context 'project search' do
       let(:subproject) { FactoryBot.create :project, parent: project }
       let!(:other_work_package) do
@@ -188,6 +222,16 @@ describe 'Search', type: :feature, js: true do
         table.ensure_work_package_not_listed! other_work_package
 
         expect(current_url).to match(/\/#{project.identifier}\/search\?q=Other%20work%20package&work_packages=1&scope=current_project$/)
+
+        # Expect to find custom field values
+        # ...for type: text
+        global_search.search "long text", submit_with_enter: true
+        table.ensure_work_package_not_listed! work_packages[1]
+        table.expect_work_package_subject(work_packages[0].subject)
+        # ... for type: string
+        global_search.search "short text", submit_with_enter: true
+        table.ensure_work_package_not_listed! work_packages[0]
+        table.expect_work_package_subject(work_packages[1].subject)
 
         # Change to project scope to include subprojects
         global_search.search other_work_package.subject


### PR DESCRIPTION
This PR extends the `search_filter` allowing to search in custom fields of type text or string.

It basically instanciates for every custom field a filter and attaches it with the `OR` operator to the `search_filter`.

To make custom fields available in the search they need to be set as
- searchable
- is filter

In case the performance is not good on large instances with many custom fields, admins can still reduce the amount of fields that get searched.