### PR TITLE
[Boards] Beautify board highlighting

### DIFF
--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.html
@@ -1,5 +1,5 @@
 <div #container
-     class="work-package--cards-container -small-font">
+     class="wp-cards-container -small-font">
   <div *ngIf="inReference"
        class="wp-inline-create--reference-container">
     <ndc-dynamic [ndcDynamicComponent]="referenceClass"
@@ -8,14 +8,18 @@
     </ndc-dynamic>
   </div>
 
-  <div class="work-package--card"
+  <div class="wp-card"
        *ngFor="let wp of workPackages; trackBy:trackByHref"
        [attr.data-is-new]="wp.isNew || undefined"
        [attr.data-work-package-id]="wp.id"
-       [ngClass]="cardClasses(wp)"
-       (dblclick)="handleDblClick(wp)">
+       (dblclick)="handleDblClick(wp)"
+       [ngClass]="{'-draggable': wp.isDraggable}">
 
-    <a class="work-package-card--inline-cancel-button -no-decoration"
+    <div class="wp-card--highlighting"
+        [ngClass]="cardHighlightingClass(wp)">
+    </div>
+
+    <a class="wp-card--inline-cancel-button -no-decoration"
        *ngIf="wp.isNew || cardsRemovable"
        [ngClass]="{ '-show': wp.isNew }"
        [title]="text.removeCard"
@@ -28,24 +32,24 @@
         <wp-edit-field [workPackageId]="wp.id"
                        [wrapperClasses]="'work-packages--type-selector'"
                        [fieldName]="'type'"
-                       class="work-package--card--type">
+                       class="wp-card--type">
         </wp-edit-field>
         <wp-edit-field [workPackageId]="wp.id"
                        fieldName="subject"
-                       class="work-package--card--subject -bold">
+                       class="wp-card--subject -bold">
         </wp-edit-field>
       </div>
 
       <div class="work-packages--subject-type-row"
            *ngIf="!wp.isNew">
         <span [textContent]="wpTypeAttribute(wp)"
-              class="work-package--card--type"
+              class="wp-card--type"
               [ngClass]="typeHighlightingClass(wp)"></span>
         <span [textContent]="wpSubject(wp)"
-              class="work-package--card--subject -bold"></span>
+              class="wp-card--subject -bold"></span>
       </div>
 
-      <div class="work-package--card--author -italic"
+      <div class="wp-card--author -italic"
            [hidden]="wp.isNew"
            [textContent]="text.wpAddedBy(wp)">
       </div>
@@ -53,7 +57,7 @@
     <user-avatar *ngIf="hasAssignee(wp)"
                  [attr.data-user]="wp.assignee.$href"
                  data-class-list="avatar-mini"
-                 class="work-package--card--assignee">
+                 class="wp-card--assignee">
     </user-avatar>
   </div>
 </div>

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
@@ -1,6 +1,6 @@
 @import 'helpers'
 
-.work-package--cards-container
+.wp-cards-container
   display: flex
   flex-direction: column
   overflow: auto
@@ -10,7 +10,7 @@
   padding: 0 15px
 
 
-.work-package--card
+.wp-card
   width: 100%
   border: 1px solid var(--widget-box-block-border-color)
   border-radius: 5px
@@ -19,10 +19,18 @@
   background-color: #eeeeee6e
   position: relative
 
-  .work-package--card--assignee
+  .wp-card--assignee
     position: absolute
     bottom: 5px
     right: 0
+
+.wp-card--highlighting
+  width: 5px
+  height: 100%
+  position: absolute
+  top: 0
+  left: 0
+  border-radius: 5px 0 0 5px
 
 wp-edit-field
   width: initial
@@ -32,24 +40,24 @@ wp-edit-field
   padding-top: 1rem
   text-align: center
 
-.work-package-card--inline-cancel-button
+.wp-card--inline-cancel-button
   position: absolute
   right: 0
   top: 4px
   opacity: 0
 
-  &.-show, .work-package--card:hover &
+  &.-show, .wp-card:hover &
     opacity: 1
 
 .work-packages--subject-type-row
   margin-bottom: 10px
-  .work-package--card--type
+  .wp-card--type
     margin-right: 5px
 
   .-new
     flex-wrap: wrap
-    .work-package--card--type,
-    .work-package--card--subject
+    .wp-card--type,
+    .wp-card--subject
       flex-basis: 100%
 
 

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -159,11 +159,8 @@ export class WorkPackageCardViewComponent extends WorkPackageEmbeddedTableCompon
     return wp.subject;
   }
 
-  public cardClasses(wp:WorkPackageResource) {
-    let classes:string[] = [];
-    this.isDraggable ? classes.push('-draggable') : classes.push('');
-    classes.push(this.cardHighlighting(wp));
-    return classes;
+  public cardHighlightingClass(wp:WorkPackageResource) {
+    return this.cardHighlighting(wp);
   }
 
   public typeHighlightingClass(wp:WorkPackageResource) {

--- a/modules/boards/spec/features/board_navigation_spec.rb
+++ b/modules/boards/spec/features/board_navigation_spec.rb
@@ -63,7 +63,7 @@ describe 'Work Package boards spec', type: :feature, js: true do
     board_page.expect_notification message: I18n.t(:notice_successful_create)
 
     # Double click leads to the full view
-    click_target = board_page.find('.work-package--card--author')
+    click_target = board_page.find('.wp-card--author')
     page.driver.browser.action.double_click(click_target.native).perform
 
     wp = WorkPackage.last

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -91,9 +91,9 @@ module Pages
     end
 
     def remove_card(list_name, card_title, index)
-      source = page.all("#{list_selector(list_name)} .work-package--card")[index]
+      source = page.all("#{list_selector(list_name)} .wp-card")[index]
       source.hover
-      source.find('.work-package-card--inline-cancel-button').click
+      source.find('.wp-card--inline-cancel-button').click
 
       expect_card(list_name, card_title, present: false)
     end
@@ -117,12 +117,12 @@ module Pages
     # Expect the given titled card in the list name to be present (expect=true) or not (expect=false)
     def expect_card(list_name, card_title, present: true)
       within_list(list_name) do
-        expect(page).to have_conditional_selector(present, '.work-package--card--subject', text: card_title)
+        expect(page).to have_conditional_selector(present, '.wp-card--subject', text: card_title)
       end
     end
 
     def move_card(index, from:, to:)
-      source = page.all("#{list_selector(from)} .work-package--card")[index]
+      source = page.all("#{list_selector(from)} .wp-card")[index]
       target = page.find list_selector(to)
 
       scroll_to_element(source)


### PR DESCRIPTION
* Beautify highlighting of cards in boards
* Shorten card classes (from `work-package--card` to `wp-card`

#### Before
<img width="800" alt="Bildschirmfoto 2019-03-14 um 11 20 37" src="https://user-images.githubusercontent.com/7457313/54349295-3d830900-464b-11e9-9ba0-33665845f01a.png">

#### After
<img width="795" alt="Bildschirmfoto 2019-03-14 um 11 07 38" src="https://user-images.githubusercontent.com/7457313/54349301-41169000-464b-11e9-9c97-6493dbd5957e.png">
