### PR TITLE
Fix/wp list eager loading

### DIFF
--- a/app/models/queries/work_packages/filter/or_filter_for_wp_mixin.rb
+++ b/app/models/queries/work_packages/filter/or_filter_for_wp_mixin.rb
@@ -45,6 +45,10 @@ module Queries::WorkPackages::Filter::OrFilterForWpMixin
     @filters.keep_if(&:validate)
   end
 
+  def joins
+    filters.map(&:joins).flatten.compact
+  end
+
   def includes
     filters.map(&:includes).flatten.uniq.reject(&:blank?)
   end

--- a/app/models/queries/work_packages/filter/search_filter.rb
+++ b/app/models/queries/work_packages/filter/search_filter.rb
@@ -30,9 +30,9 @@
 
 class Queries::WorkPackages::Filter::SearchFilter <
   Queries::WorkPackages::Filter::WorkPackageFilter
-
   include Queries::WorkPackages::Filter::OrFilterForWpMixin
   include Queries::WorkPackages::Filter::FilterOnTsvMixin
+
   CONTAINS_OPERATOR = '~'.freeze
 
   CE_FILTERS = [
@@ -84,7 +84,13 @@ class Queries::WorkPackages::Filter::SearchFilter <
 
   def filter_configurations
     list = CE_FILTERS
-    list += EE_TSV_FILTERS if EnterpriseToken.allows_to?(:attachment_filters) && OpenProject::Database.allows_tsv?
+    list += EE_TSV_FILTERS if attachment_filters_allowed?
     list
+  end
+
+  private
+
+  def attachment_filters_allowed?
+    EnterpriseToken.allows_to?(:attachment_filters) && OpenProject::Database.allows_tsv?
   end
 end

--- a/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
+++ b/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
@@ -84,8 +84,11 @@ module API
           end
 
           def add_eager_loading(scope, current_user)
+            # The eager loading on status is required for the readonly? check in the
+            # work package schema
             scope
               .includes(WorkPackageRepresenter.to_eager_load)
+              .includes(:status)
               .include_spent_hours(current_user)
               .select('work_packages.*')
               .distinct

--- a/lib/open_project/database.rb
+++ b/lib/open_project/database.rb
@@ -128,12 +128,17 @@ module OpenProject
     # Set the +raw+ argument to true to return the unmangled string
     # from the database.
     def self.version(raw = false)
-      case name
-      when :mysql
-        ActiveRecord::Base.connection.select_value('SELECT VERSION()')
-      when :postgresql
-        version = ActiveRecord::Base.connection.select_value('SELECT version()')
-        raw ? version : version.match(/\APostgreSQL (\S+)/i)[1]
+      @version ||= case name
+                   when :mysql
+                     ActiveRecord::Base.connection.select_value('SELECT VERSION()')
+                   when :postgresql
+                     ActiveRecord::Base.connection.select_value('SELECT version()')
+                   end
+
+      if name == :postgresql
+        raw ? @version : @version.match(/\APostgreSQL (\S+)/i)[1]
+      else
+        @version
       end
     end
 

--- a/spec/lib/database_spec.rb
+++ b/spec/lib/database_spec.rb
@@ -29,6 +29,14 @@
 require 'spec_helper'
 
 describe OpenProject::Database do
+  before do
+    described_class.instance_variable_set(:@version, nil)
+  end
+
+  after do
+    described_class.instance_variable_set(:@version, nil)
+  end
+
   it 'should return the correct identifier' do
     allow(OpenProject::Database).to receive(:adapter_name).and_return 'PostgresQL'
 

--- a/spec/models/queries/work_packages/filter/attachment_content_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/attachment_content_filter_spec.rb
@@ -55,7 +55,7 @@ describe Queries::WorkPackages::Filter::AttachmentContentFilter, type: :model do
       end
 
       it 'finds WP through attachment content' do
-        expect(WorkPackage.joins(:attachments).where(instance.where))
+        expect(WorkPackage.joins(instance.joins).where(instance.where))
           .to match_array [work_package]
       end
     end

--- a/spec/models/queries/work_packages/filter/search_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/search_filter_spec.rb
@@ -41,18 +41,20 @@ describe Queries::WorkPackages::Filter::SearchFilter, type: :model do
   end
 
   shared_examples "subject, description, and comment filter" do
+    subject { WorkPackage.joins(instance.joins).where(instance.where) }
+
     context '' do
       let!(:work_package) { FactoryBot.create(:work_package, subject: "A bogus subject", description: "And a short description") }
 
       it 'finds in subject' do
         instance.values = ['bogus subject']
-        expect(WorkPackage.eager_load(instance.includes).where(instance.where))
+        is_expected
           .to match_array [work_package]
       end
 
       it 'finds in description' do
         instance.values = ['short description']
-        expect(WorkPackage.eager_load(instance.includes).where(instance.where))
+        is_expected
           .to match_array [work_package]
       end
 
@@ -61,7 +63,7 @@ describe Queries::WorkPackages::Filter::SearchFilter, type: :model do
         journal.save
 
         instance.values = [journal.notes]
-        expect(WorkPackage.eager_load(instance.includes).where(instance.where))
+        is_expected
           .to match_array [work_package]
       end
     end
@@ -91,13 +93,13 @@ describe Queries::WorkPackages::Filter::SearchFilter, type: :model do
 
           it "finds in attachment content" do
             instance.values = ['ipsum']
-            expect(WorkPackage.eager_load(instance.includes).where(instance.where))
+            expect(WorkPackage.joins(instance.joins).where(instance.where))
               .to match_array [work_package]
           end
 
           it "finds in attachment file name" do
             instance.values = [filename]
-            expect(WorkPackage.eager_load(instance.includes).where(instance.where))
+            expect(WorkPackage.joins(instance.joins).where(instance.where))
               .to match_array [work_package]
           end
         end


### PR DESCRIPTION
Improves the performance of the `/api/v3/work_packages` and `/api/v3/queries` endpoint especially when filtering using the search filter. It therefore in particular improves the experience on the search page. 

When running a query typically issued when searching on the community db dump, this drops the response time from 4.5 seconds to 1.2 seconds for 50 work packages. This is mostly due to a drop in the number of db accesses (from which every request to filter work packages should profit) and a restructuring of the SQL query used by the search filter. By moving the filter conditions to the `JOIN ... ON` condition, the DBMS is able to remove entries more quickly.  