### PR TITLE
[29727] Removing a work package in full view does not use BackRouteService

### DIFF
--- a/frontend/src/app/components/modals/wp-destroy-modal/wp-destroy.modal.ts
+++ b/frontend/src/app/components/modals/wp-destroy-modal/wp-destroy.modal.ts
@@ -39,6 +39,7 @@ import {WorkPackageTableFocusService} from 'core-components/wp-fast-table/state/
 import {StateService} from '@uirouter/core';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {WorkPackageService} from "core-components/work-packages/work-package.service";
+import {BackRoutingService} from "core-app/modules/common/back-routing/back-routing.service";
 
 @Component({
   templateUrl: './wp-destroy.modal.html'
@@ -76,7 +77,8 @@ export class WpDestroyModal extends OpModalComponent implements OnInit {
               readonly wpTableFocus:WorkPackageTableFocusService,
               readonly wpListService:WorkPackagesListService,
               readonly wpNotificationsService:WorkPackageNotificationService,
-              readonly notificationsService:NotificationsService) {
+              readonly notificationsService:NotificationsService,
+              readonly backRoutingService:BackRoutingService) {
     super(locals, cdRef, elementRef);
   }
 
@@ -135,7 +137,7 @@ export class WpDestroyModal extends OpModalComponent implements OnInit {
         this.busy = false;
         this.closeMe($event);
         this.wpTableFocus.clear();
-        this.$state.go('work-packages.list');
+        this.backRoutingService.goBack(true);
       })
       .catch(() => {
         this.busy = false;

--- a/frontend/src/app/modules/common/back-routing/back-routing.service.ts
+++ b/frontend/src/app/modules/common/back-routing/back-routing.service.ts
@@ -45,12 +45,16 @@ export class BackRoutingService {
   constructor(protected injector:Injector) {
   }
 
-  public goBack() {
+  public goBack(preferListOverSplit:boolean = false) {
     if (!this.backRoute) {
       this.$state.go('work-packages.list', this.$state.params);
     } else {
       if (this.keepTab.isDetailsState(this.backRoute.parent)) {
-        this.$state.go(this.keepTab.currentDetailsState, this.$state.params);
+        if(preferListOverSplit) {
+          this.$state.go('work-packages.list', this.$state.params);
+        } else {
+          this.$state.go(this.keepTab.currentDetailsState, this.$state.params);
+        }
       } else {
         this.$state.go(this.backRoute.name, this.backRoute.params);
       }


### PR DESCRIPTION
* Use backRoutingService after deleting a WP in full view
* Make sure that user doesn’t see split view of a deleted WP

https://community.openproject.com/projects/openproject/work_packages/29727/activity