### PR TITLE
[29699][Boards] Make board view Enterprise Edition feature

### DIFF
--- a/app/services/authorization/enterprise_service.rb
+++ b/app/services/authorization/enterprise_service.rb
@@ -42,7 +42,8 @@ class Authorization::EnterpriseService
                        custom_actions
                        conditional_highlighting
                        readonly_work_packages
-                       attachment_filters).freeze
+                       attachment_filters
+                       board_view).freeze
 
   def initialize(token)
     self.token = token

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -47,6 +47,11 @@ en:
     close_filter_title: "Close filter"
     close_form_title: "Close form"
 
+    boards:
+      upsale:
+        boards: 'Need to freely structure your work in a board view?'
+        check_out_link: 'Check out the Enterprise Edition.'
+
     card:
       add_new: 'Add new card'
       highlighting:

--- a/frontend/src/app/components/enterprise-banner/enterprise-banner.component.sass
+++ b/frontend/src/app/components/enterprise-banner/enterprise-banner.component.sass
@@ -1,0 +1,3 @@
+.notification-box .notification-box--content
+  p
+    margin-bottom: 10px

--- a/frontend/src/app/components/enterprise-banner/enterprise-banner.component.ts
+++ b/frontend/src/app/components/enterprise-banner/enterprise-banner.component.ts
@@ -1,0 +1,38 @@
+import {Component, Input} from "@angular/core";
+import {enterpriseEditionUrl} from "core-app/globals/constants.const";
+import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+
+@Component({
+  selector: 'enterprise-banner',
+  template: `
+      <div class="notification-box">
+        <div class="notification-box--content">
+          <p class="-bold" [textContent]="text.enterpriseFeature"></p>
+          <p [textContent]="textMessage"></p>
+          <a [href]="eeLink()"
+             target='blank'
+             [textContent]="linkMessage"></a>
+        </div>
+      </div>
+  `
+})
+export class EnterpriseBannerComponent {
+  @Input() public textMessage:string;
+  @Input() public linkMessage:string;
+  @Input() public opReferrer:string;
+
+  public text:any = {
+    enterpriseFeature: this.I18n.t('js.upsale.ee_only'),
+  }
+
+  constructor(protected I18n:I18nService) {
+  }
+
+  public eeLink() {
+    if (this.opReferrer) {
+      return enterpriseEditionUrl + '&op_referrer=' + this.opReferrer;
+    } else {
+      return enterpriseEditionUrl;
+    }
+  }
+}

--- a/frontend/src/app/components/enterprise-banner/enterprise-banner.component.ts
+++ b/frontend/src/app/components/enterprise-banner/enterprise-banner.component.ts
@@ -4,8 +4,9 @@ import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 
 @Component({
   selector: 'enterprise-banner',
+  styleUrls: ['./enterprise-banner.component.sass'],
   template: `
-      <div class="notification-box">
+      <div class="notification-box -ee-upsale">
         <div class="notification-box--content">
           <p class="-bold" [textContent]="text.enterpriseFeature"></p>
           <p [textContent]="textMessage"></p>
@@ -23,7 +24,7 @@ export class EnterpriseBannerComponent {
 
   public text:any = {
     enterpriseFeature: this.I18n.t('js.upsale.ee_only'),
-  }
+  };
 
   constructor(protected I18n:I18nService) {
   }

--- a/frontend/src/app/components/filters/query-filters/query-filters.component.html
+++ b/frontend/src/app/components/filters/query-filters/query-filters.component.html
@@ -63,17 +63,12 @@
         </select>
       </div>
 
-      <div class="advanced-filters--add-filter-info"
-           *ngIf="eeShowBanners">
-        <div class="notification-box">
-          <div class="notification-box--content">
-            {{ text.upsale_for_more }}
-            <a href="https://www.openproject.org/enterprise-edition/?op_edtion=community-edition&op_referrer=wp-filter#filters"
-               target='blank'
-               [textContent]="text.upsale_link"></a>
-          </div>
-        </div>
-      </div>
+      <enterprise-banner class="advanced-filters--add-filter-info"
+                         *ngIf="eeShowBanners"
+                         [linkMessage]="text.upsale_link"
+                         [textMessage]="text.upsale_for_more"
+                         opReferrer="wp-filter#filters">
+      </enterprise-banner>
     </li>
   </ul>
 </fieldset>

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/columns-tab.component.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/columns-tab.component.html
@@ -12,9 +12,10 @@
     </div>
   </ng-container>
 </div>
-<div *ngIf="eeShowBanners" class="ee-relation-columns-upsale">
-  {{text.upsaleRelationColumns}}
-  <a href="https://www.openproject.org/enterprise-edition/?op_edtion=community-edition&op_referrer=wp-list-columns#relations"
-     target='blank'
-     [textContent]="text.upsaleCheckOutLink"></a>
-</div>
+
+<enterprise-banner class="ee-relation-columns-upsale"
+                   *ngIf="eeShowBanners"
+                   [linkMessage]="text.upsaleCheckOutLink"
+                   [textMessage]="text.upsaleRelationColumns"
+                   opReferrer="wp-list-columns#relations">
+</enterprise-banner>

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.html
@@ -1,15 +1,10 @@
 <div>
-  <div *ngIf="eeShowBanners" class="ee-attribute-highlighting-upsale notification-box -ee-upsale">
-    <div class="notification-box--content">
-      <p><strong [textContent]="text.upsaleEnterpriseOnly"></strong></p>
-      <p [textContent]="text.upsaleAttributeHighlighting"></p>
-      <p>
-        <a href="https://www.openproject.org/enterprise-edition/?op_edtion=community-edition&op_referrer=wp-attribute-highlighting#attribute-highlighting"
-           target='blank'
-           [textContent]="text.upsaleCheckOutLink"></a>
-      </p>
-    </div>
-  </div>
+  <enterprise-banner class="ee-attribute-highlighting-upsale -ee-upsale"
+                     *ngIf="eeShowBanners"
+                     [linkMessage]="text.upsaleCheckOutLink"
+                     [textMessage]="text.upsaleAttributeHighlighting"
+                     opReferrer="wp-attribute-highlighting#attribute-highlighting">
+  </enterprise-banner>
   <form>
     <p [textContent]="text.highlighting_mode.description"></p>
     <div class="form--field -full-width">

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.html
@@ -1,5 +1,5 @@
 <div>
-  <enterprise-banner class="ee-attribute-highlighting-upsale -ee-upsale"
+  <enterprise-banner class="ee-attribute-highlighting-upsale"
                      *ngIf="eeShowBanners"
                      [linkMessage]="text.upsaleCheckOutLink"
                      [textMessage]="text.upsaleAttributeHighlighting"

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
@@ -37,7 +37,6 @@ export class WpTableConfigurationHighlightingTab implements TabComponent {
       priority: this.I18n.t('js.work_packages.table_configuration.highlighting_mode.priority'),
       entire_row_by: this.I18n.t('js.work_packages.table_configuration.highlighting_mode.entire_row_by'),
     },
-    upsaleEnterpriseOnly: this.I18n.t('js.upsale.ee_only'),
     upsaleAttributeHighlighting: this.I18n.t('js.work_packages.table_configuration.upsale.attribute_highlighting'),
     upsaleCheckOutLink: this.I18n.t('js.work_packages.table_configuration.upsale.check_out_link')
   };

--- a/frontend/src/app/globals/constants.const.ts
+++ b/frontend/src/app/globals/constants.const.ts
@@ -1,0 +1,1 @@
+export const enterpriseEditionUrl = "https://www.openproject.org/enterprise-edition/?op_edtion=community-edition";

--- a/frontend/src/app/modules/boards/board/board.component.html
+++ b/frontend/src/app/modules/boards/board/board.component.html
@@ -19,7 +19,8 @@
                                 [editable]="board.editable">
         </editable-toolbar-title>
 
-        <ul class="toolbar-items">
+        <ul class="toolbar-items"
+            *ngIf="showBoardListView()">
           <li class="toolbar-item">
             <zen-mode-toggle-button></zen-mode-toggle-button>
           </li>
@@ -38,6 +39,7 @@
   </div>
 
   <div class="boards-list--container"
+       *ngIf="showBoardListView()"
        cdkDropList
        [cdkDropListDisabled]="!board.editable"
        cdkDropListOrientation="horizontal"
@@ -64,4 +66,11 @@
       </div>
     </div>
   </div>
+
+
+  <enterprise-banner *ngIf="!showBoardListView()"
+                     [linkMessage]="text.upsaleCheckOutLink"
+                     [textMessage]="text.upsaleBoards"
+                     opReferrer="boards">
+  </enterprise-banner>
 </div>

--- a/frontend/src/app/modules/boards/board/board.component.html
+++ b/frontend/src/app/modules/boards/board/board.component.html
@@ -67,10 +67,9 @@
     </div>
   </div>
 
-
   <enterprise-banner *ngIf="!showBoardListView()"
                      [linkMessage]="text.upsaleCheckOutLink"
                      [textMessage]="text.upsaleBoards"
-                     opReferrer="boards">
+                     [opReferrer]="opReferrer(board)">
   </enterprise-banner>
 </div>

--- a/frontend/src/app/modules/boards/board/board.component.ts
+++ b/frontend/src/app/modules/boards/board/board.component.ts
@@ -150,4 +150,8 @@ export class BoardComponent implements OnInit, OnDestroy {
   public showBoardListView() {
     return !this.Banner.eeShowBanners;
   }
+
+  public opReferrer(board:Board) {
+    return board.isFree ? 'boards#free' : 'boards#status';
+  }
 }

--- a/frontend/src/app/modules/boards/board/board.component.ts
+++ b/frontend/src/app/modules/boards/board/board.component.ts
@@ -17,6 +17,7 @@ import {OpModalService} from "core-components/op-modals/op-modal.service";
 import {AddListModalComponent} from "core-app/modules/boards/board/add-list-modal/add-list-modal.component";
 import {DynamicCssService} from "core-app/modules/common/dynamic-css/dynamic-css.service";
 import {init} from "protractor/built/launcher";
+import {BannersService} from "core-app/modules/common/enterprise/banners.service";
 
 
 @Component({
@@ -49,7 +50,9 @@ export class BoardComponent implements OnInit, OnDestroy {
     updateSuccessful: this.I18n.t('js.notice_successful_update'),
     unnamedBoard: this.I18n.t('js.boards.label_unnamed_board'),
     loadingError: 'No such board found',
-    addList: this.I18n.t('js.boards.add_list')
+    addList: this.I18n.t('js.boards.add_list'),
+    upsaleBoards: this.I18n.t('js.boards.upsale.boards'),
+    upsaleCheckOutLink: this.I18n.t('js.boards.upsale.check_out_link')
   };
 
   trackByQueryId = (index:number, widget:GridWidgetResource) => widget.options.query_id;
@@ -64,7 +67,8 @@ export class BoardComponent implements OnInit, OnDestroy {
               private readonly boardActions:BoardActionsRegistryService,
               private readonly BoardCache:BoardCacheService,
               private readonly dynamicCss:DynamicCssService,
-              private readonly Boards:BoardService) {
+              private readonly Boards:BoardService,
+              private readonly Banner:BannersService) {
   }
 
   goBack() {
@@ -141,5 +145,9 @@ export class BoardComponent implements OnInit, OnDestroy {
   removeList(board:Board, query:GridWidgetResource) {
     board.removeQuery(query);
     return this.saveBoard(board);
+  }
+
+  public showBoardListView() {
+    return !this.Banner.eeShowBanners;
   }
 }

--- a/frontend/src/app/modules/boards/index-page/boards-index-page.component.html
+++ b/frontend/src/app/modules/boards/index-page/boards-index-page.component.html
@@ -3,7 +3,8 @@
     <h2 [textContent]="text.boards">
     </h2>
   </div>
-  <ul class="toolbar-items">
+  <ul class="toolbar-items"
+      *ngIf="showBoardIndexView()">
     <li *ngIf="canManage"
         class="toolbar-item">
       <a class="button -alt-highlight"
@@ -18,7 +19,7 @@
   </ul>
 </div>
 
-<div *ngIf="(boards$ | async) as boards"
+<div *ngIf="showBoardIndexView() && (boards$ | async) as boards"
      class="boards--listing-group loading-indicator--location"
      data-indicator-name="boards-module">
   <div class="generic-table--container">
@@ -101,3 +102,9 @@
     </div>
   </div>
 </div>
+
+<enterprise-banner *ngIf="!showBoardIndexView()"
+                   [linkMessage]="text.upsaleCheckOutLink"
+                   [textMessage]="text.upsaleBoards"
+                   opReferrer="boards">
+</enterprise-banner>

--- a/frontend/src/app/modules/boards/index-page/boards-index-page.component.ts
+++ b/frontend/src/app/modules/boards/index-page/boards-index-page.component.ts
@@ -1,6 +1,5 @@
 import {Component, Injector} from "@angular/core";
 import {Observable} from "rxjs";
-import {StateService} from "@uirouter/core";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {BoardService} from "core-app/modules/boards/board/board.service";
 import {Board} from "core-app/modules/boards/board/board";
@@ -8,6 +7,7 @@ import {BoardCacheService} from "core-app/modules/boards/board/board-cache.servi
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
 import {OpModalService} from "core-components/op-modals/op-modal.service";
 import {NewBoardModalComponent} from "core-app/modules/boards/new-board-modal/new-board-modal.component";
+import {BannersService} from "core-app/modules/common/enterprise/banners.service";
 
 @Component({
   templateUrl: './boards-index-page.component.html'
@@ -26,7 +26,9 @@ export class BoardsIndexPageComponent {
     delete: this.I18n.t('js.button_delete'),
     areYouSure: this.I18n.t('js.text_are_you_sure'),
     deleteSuccessful: this.I18n.t('js.notice_successful_delete'),
-    noResults: this.I18n.t('js.notice_no_results_to_display')
+    noResults: this.I18n.t('js.notice_no_results_to_display'),
+    upsaleBoards: this.I18n.t('js.boards.upsale.boards'),
+    upsaleCheckOutLink: this.I18n.t('js.boards.upsale.check_out_link')
   };
 
   public boards$:Observable<Board[]> = this.boardCache.observeAll();
@@ -37,7 +39,7 @@ export class BoardsIndexPageComponent {
               private readonly notifications:NotificationsService,
               private readonly opModalService:OpModalService,
               private readonly injector:Injector,
-              private readonly state:StateService) {
+              private readonly bannerService:BannersService) {
     this.boardService.loadAllBoards();
   }
 
@@ -61,5 +63,9 @@ export class BoardsIndexPageComponent {
         this.notifications.addSuccess(this.text.deleteSuccessful);
       })
       .catch((error) => this.notifications.addError("Deletion failed: " + error));
+  }
+
+  public showBoardIndexView() {
+    return !this.bannerService.eeShowBanners;
   }
 }

--- a/frontend/src/app/modules/common/openproject-common.module.ts
+++ b/frontend/src/app/modules/common/openproject-common.module.ts
@@ -80,6 +80,7 @@ import {EditableToolbarTitleComponent} from "core-app/modules/common/editable-to
 import {UserAvatarComponent} from "core-components/user/user-avatar/user-avatar.component";
 import {GonService} from "core-app/modules/common/gon/gon.service";
 import {BackRoutingService} from "core-app/modules/common/back-routing/back-routing.service";
+import {EnterpriseBannerComponent} from "core-components/enterprise-banner/enterprise-banner.component";
 
 export function bootstrapModule(injector:Injector) {
   return () => {
@@ -165,6 +166,9 @@ export function bootstrapModule(injector:Injector) {
 
     // User Avatar
     UserAvatarComponent,
+
+    // Enterprise Edition
+    EnterpriseBannerComponent,
   ],
   declarations: [
     OpDatePickerComponent,
@@ -218,6 +222,9 @@ export function bootstrapModule(injector:Injector) {
 
     // User Avatar
     UserAvatarComponent,
+
+    // Enterprise Edition
+    EnterpriseBannerComponent,
   ],
   entryComponents: [
     OpDateTimeComponent,

--- a/modules/boards/lib/open_project/boards/engine.rb
+++ b/modules/boards/lib/open_project/boards/engine.rb
@@ -50,6 +50,8 @@ module OpenProject::Boards
            caption: :'boards.label_boards'
     end
 
+    patch_with_namespace :BasicData, :SettingSeeder
+
     config.to_prepare do
       OpenProject::Boards::GridRegistration.register!
     end

--- a/modules/boards/lib/open_project/boards/patches/setting_seeder_patch.rb
+++ b/modules/boards/lib/open_project/boards/patches/setting_seeder_patch.rb
@@ -1,0 +1,36 @@
+#-- copyright
+# OpenProject Costs Plugin
+#
+# Copyright (C) 2009 - 2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#++
+
+module OpenProject::Boards::Patches::SettingSeederPatch
+  def self.included(base) # :nodoc:
+    base.prepend InstanceMethods
+  end
+
+  module InstanceMethods
+    def data
+      original_data = super
+
+      unless original_data['default_projects_modules'].include? 'board_view'
+        original_data['default_projects_modules'] << 'board_view'
+      end
+
+      original_data
+    end
+  end
+end

--- a/modules/boards/spec/features/board_highlighting_spec.rb
+++ b/modules/boards/spec/features/board_highlighting_spec.rb
@@ -67,6 +67,7 @@ describe 'Work Package boards spec', type: :feature, js: true do
   let(:color2) { FactoryBot.create :color }
 
   before do
+    with_enterprise_token :board_view
     project
     login_as(user)
   end

--- a/modules/boards/spec/features/board_management_spec.rb
+++ b/modules/boards/spec/features/board_management_spec.rb
@@ -43,6 +43,7 @@ describe 'Board management spec', type: :feature, js: true do
   let(:board_index) { Pages::BoardIndex.new(project) }
 
   before do
+    with_enterprise_token :board_view
     project
     login_as(user)
   end

--- a/modules/boards/spec/features/board_navigation_spec.rb
+++ b/modules/boards/spec/features/board_navigation_spec.rb
@@ -48,6 +48,7 @@ describe 'Work Package boards spec', type: :feature, js: true do
   let(:project_html_title) { ::Components::HtmlTitle.new project }
 
   before do
+    with_enterprise_token :board_view
     project
     login_as(user)
   end

--- a/modules/boards/spec/features/status_board_spec.rb
+++ b/modules/boards/spec/features/status_board_spec.rb
@@ -69,6 +69,7 @@ describe 'Status action board', type: :feature, js: true do
   }
 
   before do
+    with_enterprise_token :board_view
     project
     login_as(user)
   end

--- a/spec/support/enterprise_token_helper.rb
+++ b/spec/support/enterprise_token_helper.rb
@@ -40,6 +40,8 @@ module AuthenticationHelpers
           .and_return(true)
       end
     end
+
+    allow(OpenProject::Configuration).to receive(:ee_manager_visible?).and_return(false)
   end
 end
 


### PR DESCRIPTION
Make board view an enterprise feature.

#### ToDo

- [x] Board module is enabled per default for new projects
- [x] For users of the Community Edition an EE banner is shown:
  - [x] Add reusable component for enterprise banner
  - [x] There is also a link shown to purchase the Enterprise Edition. This link should contain a recognisable referrer.

#### Out of scope

* For users of the Community Edition a video is shown when clicking on the Board view which shows how to use it (as there is no video yet).


