### PR TITLE
Feature/my page wp query

### DIFF
--- a/app/assets/stylesheets/content/_grid.sass
+++ b/app/assets/stylesheets/content/_grid.sass
@@ -27,6 +27,7 @@ $grid--header-width: 20px
     .widget-box
       height: 100%
 
+
   &.-resizing
     border: 1px solid $primary-color
     z-index: 100
@@ -46,6 +47,20 @@ $grid--header-width: 20px
   .cdk-drag-handle
     cursor: grab
 
+.grid--area-drag-handle
+  margin-left: -19px
+  padding-right: 1px
+  margin-top: 3px
+  opacity: 0
+  cursor: grab
+
+  &:before
+    padding: 0
+    color: #888
+
+  .grid--area.-widgeted:hover &
+    opacity: 1
+
 .grid--area-content
   height: 100%
 
@@ -53,6 +68,13 @@ $grid--header-width: 20px
     display: flex
     flex-direction: column
     height: 100%
+
+  input[type="text"].toolbar--editable-toolbar
+    font-size: 18px
+    font-weight: normal
+
+  .title-container
+    margin-bottom: 0px
 
 .grid--widget-content
   height: 100%

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -208,6 +208,8 @@ en:
           title: 'Work packages created by me'
         work_packages_watched:
           title: 'Work packages watched by me'
+        work_packages_table:
+          title: 'Work package table'
         work_packages_calendar:
           title: 'Calendar'
 

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -209,7 +209,7 @@ en:
         work_packages_watched:
           title: 'Work packages watched by me'
         work_packages_table:
-          title: 'Work package table'
+          title: 'Work packages'
         work_packages_calendar:
           title: 'Calendar'
 

--- a/docs/api/apiv3/endpoints/grids.apib
+++ b/docs/api/apiv3/endpoints/grids.apib
@@ -582,6 +582,18 @@ A page link must be provided in the body when calling this end point.
                             "required": true,
                             "hasDefault": false,
                             "writable": true,
+                            "_embedded": {
+                                allowedValues: [
+                                    {
+                                        "_type": "GridWidget",
+                                        "identifier": "work_packages_assigned"
+                                    },
+                                    {
+                                        "_type": "GridWidget",
+                                        "identifier": "news"
+                                    }
+                                ]
+                            },
                             "_links": {}
                         },
                         "_links": {}

--- a/frontend/src/app/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/components/wp-query/url-params-helper.ts
@@ -84,7 +84,8 @@ export class UrlParamsHelperService {
   private encodeColumns(paramsData:any, query:QueryResource) {
     paramsData.c = query.columns.map(function (column) {
       return column.id!;
-    })
+    });
+
     return paramsData;
   }
 

--- a/frontend/src/app/modules/grids/grid/add-widget.service.ts
+++ b/frontend/src/app/modules/grids/grid/add-widget.service.ts
@@ -8,6 +8,7 @@ import {GridWidgetArea} from "core-app/modules/grids/areas/grid-widget-area";
 import {GridAreaService} from "core-app/modules/grids/grid/area.service";
 import {GridDragAndDropService} from "core-app/modules/grids/grid/drag-and-drop.service";
 import {GridResizeService} from "core-app/modules/grids/grid/resize.service";
+import {SchemaResource} from "core-app/modules/hal/resources/schema-resource";
 
 @Injectable()
 export class GridAddWidgetService {
@@ -27,9 +28,9 @@ export class GridAddWidgetService {
       this.layout.widgetAreaIds.includes(area.guid);
   }
 
-  public widget(area:GridArea) {
+  public widget(area:GridArea, schema:SchemaResource) {
     this
-      .select(area)
+      .select(area, schema)
       .then((widgetResource) => {
         // try to set it to a 2 x 3 layout
         // but shrink if that is outside the grid or
@@ -75,9 +76,9 @@ export class GridAddWidgetService {
       });
   }
 
-  private select(area:GridArea) {
+  private select(area:GridArea, schema:SchemaResource) {
     return new Promise<GridWidgetResource>((resolve, reject) => {
-      const modal = this.opModalService.show(AddGridWidgetModal, this.injector);
+      const modal = this.opModalService.show(AddGridWidgetModal, this.injector, { schema: schema });
       modal.closingEvent.subscribe((modal:AddGridWidgetModal) => {
         let registered = modal.chosenWidget;
 

--- a/frontend/src/app/modules/grids/grid/add-widget.service.ts
+++ b/frontend/src/app/modules/grids/grid/add-widget.service.ts
@@ -92,7 +92,8 @@ export class GridAddWidgetService {
           startRow: area.startRow,
           endRow: area.endRow,
           startColumn: area.startColumn,
-          endColumn: area.endColumn
+          endColumn: area.endColumn,
+          options: {}
         };
 
         let resource = this.halResource.createHalResource(source) as GridWidgetResource;

--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -48,11 +48,16 @@ export class GridAreaService {
 
     this.resource.widgets = this.widgetResources;
     this.resource.rowCount = this.numRows;
+
     this.resource.columnCount = this.numColumns;
 
     if (save) {
-      this.gridDm.update(this.resource, this.schema);
+      this.saveGrid();
     }
+  }
+
+  public saveGrid() {
+    this.gridDm.update(this.resource, this.schema);
   }
 
   private buildGridAreas() {

--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -11,7 +11,7 @@ import {SchemaResource} from "core-app/modules/hal/resources/schema-resource";
 export class GridAreaService {
 
   private resource:GridResource;
-  private schema:SchemaResource;
+  public schema:SchemaResource;
 
   public numColumns:number = 0;
   public numRows:number = 0;

--- a/frontend/src/app/modules/grids/grid/grid.component.html
+++ b/frontend/src/app/modules/grids/grid/grid.component.html
@@ -52,7 +52,7 @@
       </div>
       <ndc-dynamic [ndcDynamicComponent]="widgetComponent(area.widget)"
                    [ndcDynamicInputs]="{ resource: area.widget }"
-                   [ndcDynamicOutputs]="{}">
+                   [ndcDynamicOutputs]="widgetComponentOutput(area.widget)">
       </ndc-dynamic>
     </div>
     <resizer *ngIf="!drag.currentlyDragging"

--- a/frontend/src/app/modules/grids/grid/grid.component.html
+++ b/frontend/src/app/modules/grids/grid/grid.component.html
@@ -82,7 +82,7 @@
        [cdkDropListConnectedTo]="layout.widgetAreaIds">
     <div class="grid--widget-add"
          *ngIf="add.isAddable(area)"
-         (click)="add.widget(area)">
+         (click)="add.widget(area, layout.schema)">
     </div>
   </div>
 

--- a/frontend/src/app/modules/grids/grid/grid.component.ts
+++ b/frontend/src/app/modules/grids/grid/grid.component.ts
@@ -74,6 +74,10 @@ export class GridComponent implements OnDestroy, OnInit {
     }
   }
 
+  public widgetComponentOutput(resource:GridWidgetResource) {
+    return { resourceChanged: this.layout.saveGrid.bind(this.layout) };
+  }
+
   public get gridColumnStyle() {
     return this.sanitization.bypassSecurityTrustStyle(`repeat(${this.layout.numColumns}, 1fr)`);
   }

--- a/frontend/src/app/modules/grids/openproject-grids.module.ts
+++ b/frontend/src/app/modules/grids/openproject-grids.module.ts
@@ -50,6 +50,7 @@ import {Ng2StateDeclaration, UIRouterModule} from '@uirouter/angular';
 import {WidgetDocumentsComponent} from "core-app/modules/grids/widgets/documents/documents.component";
 import {WidgetNewsComponent} from "core-app/modules/grids/widgets/news/news.component";
 import {WidgetWpAccountableComponent} from './widgets/wp-accountable/wp-accountable.component';
+import {WidgetWpTableComponent} from "core-app/modules/grids/widgets/wp-table/wp-table.component";
 
 export const GRID_ROUTES:Ng2StateDeclaration[] = [
   {
@@ -76,6 +77,7 @@ export const GRID_ROUTES:Ng2StateDeclaration[] = [
                                   WidgetWpAccountableComponent,
                                   WidgetWpCreatedComponent,
                                   WidgetWpWatchedComponent,
+                                  WidgetWpTableComponent,
                                   WidgetWpCalendarComponent,
                                   WidgetTimeEntriesCurrentUserComponent]),
 
@@ -100,6 +102,7 @@ export const GRID_ROUTES:Ng2StateDeclaration[] = [
     WidgetWpCreatedComponent,
     WidgetWpWatchedComponent,
     WidgetWpCalendarComponent,
+    WidgetWpTableComponent,
     WidgetTimeEntriesCurrentUserComponent,
     AddGridWidgetModal,
 
@@ -141,6 +144,10 @@ export function registerWidgets(injector:Injector) {
         {
           identifier: 'work_packages_watched',
           component: WidgetWpWatchedComponent
+        },
+        {
+          identifier: 'work_packages_table',
+          component: WidgetWpTableComponent
         },
         {
           identifier: 'work_packages_calendar',

--- a/frontend/src/app/modules/grids/widgets/abstract-widget.component.ts
+++ b/frontend/src/app/modules/grids/widgets/abstract-widget.component.ts
@@ -1,4 +1,4 @@
-import {HostBinding, Input} from "@angular/core";
+import {HostBinding, Input, EventEmitter, Output} from "@angular/core";
 import {GridWidgetResource} from "app/modules/hal/resources/grid-widget-resource";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 
@@ -9,6 +9,8 @@ export abstract class AbstractWidgetComponent {
   @HostBinding('style.grid-row-end') gridRowEnd:number;
 
   @Input() resource:GridWidgetResource;
+
+  @Output() resourceChanged = new EventEmitter<GridWidgetResource>();
 
   constructor(protected i18n:I18nService) { }
 }

--- a/frontend/src/app/modules/grids/widgets/abstract-widget.component.ts
+++ b/frontend/src/app/modules/grids/widgets/abstract-widget.component.ts
@@ -1,4 +1,4 @@
-import {HostBinding, Input, EventEmitter, Output} from "@angular/core";
+import {HostBinding, Input, EventEmitter, Output, HostListener} from "@angular/core";
 import {GridWidgetResource} from "app/modules/hal/resources/grid-widget-resource";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 

--- a/frontend/src/app/modules/grids/widgets/add/add.modal.ts
+++ b/frontend/src/app/modules/grids/widgets/add/add.modal.ts
@@ -26,7 +26,7 @@ export class AddGridWidgetModal extends OpModalComponent {
   }
 
   public get selectable() {
-    return this.widgetsService.registered.map((widget) => {
+    return this.eligibleWidgets.map((widget) => {
       return {
         identifier: widget.identifier,
         title: this.i18n.t(`js.grid.widgets.${widget.identifier}.title`),
@@ -44,5 +44,15 @@ export class AddGridWidgetModal extends OpModalComponent {
 
   public trackWidgetBy(widget:WidgetRegistration) {
     return widget.identifier;
+  }
+
+  private get eligibleWidgets() {
+    let schemaWidgetIdentifiers = this.locals.schema.widgets.allowedValues.map((widget:any) => {
+      return widget.identifier;
+    });
+
+    return this.widgetsService.registered.filter((widget) => {
+      return schemaWidgetIdentifiers.includes(widget.identifier);
+    });
   }
 }

--- a/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.html
@@ -1,0 +1,23 @@
+<h3 class="widget-box--header"
+    *ngIf="query"
+    cdkDragHandle>
+  <span class="grid--area-drag-handle
+               icon
+               icon-drag-handle"
+        cdkDragHandle></span>
+  <i class="icon-context icon-view-timeline" aria-hidden="true"></i>
+  <editable-toolbar-title [title]="query.name"
+                          [inFlight]="inFlight"
+                          (onSave)="renameQuery(query, $event)"
+                          [editable]="!!query.updateImmediately"
+                          class="widget-box--header-title">
+  </editable-toolbar-title>
+</h3>
+
+<ng-container wp-isolated-query-space>
+  <wp-embedded-table [queryId]="queryId"
+                     [configuration]="configuration"
+                     [externalHeight]="true"
+                     *ngIf="queryId">
+  </wp-embedded-table>
+</ng-container>

--- a/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.ts
+++ b/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.ts
@@ -1,0 +1,24 @@
+import {Component, OnInit} from "@angular/core";
+import {ApiV3FilterBuilder} from "core-components/api/api-v3/api-v3-filter-builder";
+import {WidgetWpListComponent} from "core-app/modules/grids/widgets/wp-widget/wp-widget.component";
+
+@Component({
+  templateUrl: '../wp-widget/wp-widget.component.html',
+  styleUrls: ['../wp-widget/wp-widget.component.css']
+})
+export class WidgetWpTableComponent extends WidgetWpListComponent implements OnInit {
+  public text = { title: this.i18n.t('js.grid.widgets.work_packages_table.title') };
+  public queryProps:any;
+
+  ngOnInit() {
+    super.ngOnInit();
+    // TODO: adapt to arbitrary query
+    let filters = new ApiV3FilterBuilder();
+    filters.add('watcher', '=', ["me"]);
+    filters.add('status', 'o', []);
+
+    this.queryProps = {"columns[]":["id", "project", "type", "subject"],
+      "filters":filters.toJson()};
+
+  }
+}

--- a/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.ts
+++ b/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.ts
@@ -1,24 +1,47 @@
-import {Component, OnInit} from "@angular/core";
+import {Component, OnInit, OnDestroy, ViewChild, AfterViewInit} from "@angular/core";
 import {ApiV3FilterBuilder} from "core-components/api/api-v3/api-v3-filter-builder";
 import {WidgetWpListComponent} from "core-app/modules/grids/widgets/wp-widget/wp-widget.component";
+import {WorkPackageTableConfiguration} from "core-components/wp-table/wp-table-configuration";
+import {QueryResource} from "core-app/modules/hal/resources/query-resource";
+import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
+import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
+import {WorkPackageIsolatedQuerySpaceDirective} from "core-app/modules/work_packages/query-space/wp-isolated-query-space.directive";
 
 @Component({
   templateUrl: '../wp-widget/wp-widget.component.html',
   styleUrls: ['../wp-widget/wp-widget.component.css']
 })
-export class WidgetWpTableComponent extends WidgetWpListComponent implements OnInit {
+export class WidgetWpTableComponent extends WidgetWpListComponent implements OnInit, OnDestroy, AfterViewInit {
   public text = { title: this.i18n.t('js.grid.widgets.work_packages_table.title') };
-  public queryProps:any;
+  public queryProps = {};
+
+  public configuration:Partial<WorkPackageTableConfiguration> = {
+    actionsColumnEnabled: false,
+    columnMenuEnabled: true,
+    hierarchyToggleEnabled: true,
+    contextMenuEnabled: false
+  };
+
+  @ViewChild(WorkPackageIsolatedQuerySpaceDirective) public querySpaceDirective:WorkPackageIsolatedQuerySpaceDirective;
 
   ngOnInit() {
     super.ngOnInit();
-    // TODO: adapt to arbitrary query
-    let filters = new ApiV3FilterBuilder();
-    filters.add('watcher', '=', ["me"]);
-    filters.add('status', 'o', []);
 
-    this.queryProps = {"columns[]":["id", "project", "type", "subject"],
-      "filters":filters.toJson()};
+  }
 
+  ngAfterViewInit() {
+    this
+      .querySpaceDirective
+      .querySpace
+      .query
+      .values$()
+      .pipe(
+        untilComponentDestroyed(this)
+      ).subscribe(() => console.log('query updated'));
+  }
+
+  ngOnDestroy() {
+    // nothing to do
   }
 }

--- a/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.ts
+++ b/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.ts
@@ -1,25 +1,26 @@
 import {Component, OnInit, OnDestroy, ViewChild, AfterViewInit} from "@angular/core";
-import {ApiV3Filter, ApiV3FilterBuilder} from "core-components/api/api-v3/api-v3-filter-builder";
 import {WidgetWpListComponent} from "core-app/modules/grids/widgets/wp-widget/wp-widget.component";
 import {WorkPackageTableConfiguration} from "core-components/wp-table/wp-table-configuration";
 import {QueryResource} from "core-app/modules/hal/resources/query-resource";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {WorkPackageIsolatedQuerySpaceDirective} from "core-app/modules/work_packages/query-space/wp-isolated-query-space.directive";
-import {skip} from 'rxjs/operators';
+import {skip, take} from 'rxjs/operators';
 import {UrlParamsHelperService} from "core-components/wp-query/url-params-helper";
 import {QueryFormDmService} from "core-app/modules/hal/dm-services/query-form-dm.service";
 import {QueryDmService} from "core-app/modules/hal/dm-services/query-dm.service";
 import {QueryFormResource} from "core-app/modules/hal/resources/query-form-resource";
 
 @Component({
-  templateUrl: '../wp-widget/wp-widget.component.html',
+  templateUrl: './wp-table.component.html',
   styleUrls: ['../wp-widget/wp-widget.component.css']
 })
 export class WidgetWpTableComponent extends WidgetWpListComponent implements OnInit, OnDestroy, AfterViewInit {
   public text = { title: this.i18n.t('js.grid.widgets.work_packages_table.title') };
   public queryId:string|null;
   private queryForm:QueryFormResource;
+  public inFlight = false;
+  public query:QueryResource;
 
   public configuration:Partial<WorkPackageTableConfiguration> = {
     actionsColumnEnabled: false,
@@ -63,23 +64,61 @@ export class WidgetWpTableComponent extends WidgetWpListComponent implements OnI
       .query
       .values$()
       .pipe(
+        take(1),
+        untilComponentDestroyed(this)
+      ).subscribe((query) => {
+        this.query = query;
+        this.queryId = query.id;
+      });
+
+    this
+      .querySpaceDirective
+      .querySpace
+      .query
+      .values$()
+      .pipe(
         // 2 because ... well it is a magic number and works
         skip(2),
         untilComponentDestroyed(this)
       ).subscribe((query) => {
-        if (this.queryForm) {
-          this.queryDm.update(query, this.queryForm).toPromise();
-        } else {
-          this.queryFormDm.load(query).then((form) => {
-            this.queryForm = form;
-            this.queryDm.update(query, form).toPromise();
-          });
-        }
+        this.queryId = query.id;
+        this.ensureFormAndSaveQuery(query);
       });
   }
 
   ngOnDestroy() {
     // nothing to do
+  }
+
+  private ensureFormAndSaveQuery(query:QueryResource) {
+    if (this.queryForm) {
+      this.saveQuery(query);
+    } else {
+      this.queryFormDm.load(query).then((form) => {
+        this.queryForm = form;
+        this.saveQuery(query);
+      });
+    }
+  }
+
+  public renameQuery(query:QueryResource, value:string) {
+    query.name = value;
+
+    this.ensureFormAndSaveQuery(query);
+  }
+
+  private saveQuery(query:QueryResource) {
+    this.inFlight = true;
+
+    this
+      .queryDm
+      .update(query, this.queryForm)
+      .toPromise()
+      .then((query) => {
+        this.inFlight = false;
+        return query;
+      })
+      .catch(() => this.inFlight = false);
   }
 
   private createInitial():Promise<QueryResource> {
@@ -92,6 +131,9 @@ export class WidgetWpTableComponent extends WidgetWpListComponent implements OnI
       )
       .then(form => {
         const query = this.queryFormDm.buildQueryResource(form);
+        // set a default title
+        query.name = this.text.title;
+
         return this.queryDm.create(query, form);
       });
   }

--- a/frontend/src/app/modules/grids/widgets/wp-widget/wp-widget.component.css
+++ b/frontend/src/app/modules/grids/widgets/wp-widget/wp-widget.component.css
@@ -3,3 +3,11 @@ wp-embedded-table {
   flex: 1 1 auto;
   overflow: hidden;
 }
+
+.widget-box--header {
+  display: flex
+}
+
+.widget-box--header .icon-context {
+  padding-top: 5px
+}

--- a/frontend/src/app/modules/grids/widgets/wp-widget/wp-widget.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-widget/wp-widget.component.html
@@ -4,7 +4,7 @@
 </h3>
 
 <ng-container wp-isolated-query-space>
-  <wp-embedded-table [queryProps]="queryProps"
+  <wp-embedded-table [queryId]="queryId"
                      [configuration]="configuration"
                      [externalHeight]="true">
   </wp-embedded-table>

--- a/frontend/src/app/modules/grids/widgets/wp-widget/wp-widget.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-widget/wp-widget.component.html
@@ -4,7 +4,7 @@
 </h3>
 
 <ng-container wp-isolated-query-space>
-  <wp-embedded-table [queryId]="queryId"
+  <wp-embedded-table [queryProps]="queryProps"
                      [configuration]="configuration"
                      [externalHeight]="true">
   </wp-embedded-table>

--- a/frontend/src/app/modules/grids/widgets/wp-widget/wp-widget.component.ts
+++ b/frontend/src/app/modules/grids/widgets/wp-widget/wp-widget.component.ts
@@ -2,7 +2,6 @@ import {AbstractWidgetComponent} from "app/modules/grids/widgets/abstract-widget
 import {OnInit} from "@angular/core";
 import {
   WorkPackageTableConfiguration,
-  WorkPackageTableConfigurationObject
 } from "core-components/wp-table/wp-table-configuration";
 
 export class WidgetWpListComponent extends AbstractWidgetComponent implements OnInit {

--- a/frontend/src/app/modules/work_packages/query-space/wp-isolated-query-space.directive.ts
+++ b/frontend/src/app/modules/work_packages/query-space/wp-isolated-query-space.directive.ts
@@ -114,7 +114,7 @@ import {debugLog} from "core-app/helpers/debug_output";
 export class WorkPackageIsolatedQuerySpaceDirective {
 
   constructor(private elementRef:ElementRef,
-              private querySpace:IsolatedQuerySpace,
+              public querySpace:IsolatedQuerySpace,
               private injector:Injector) {
     debugLog("Opening isolated query space %O in %O", injector, elementRef.nativeElement);
   }

--- a/modules/grids/app/contracts/grids/base_contract.rb
+++ b/modules/grids/app/contracts/grids/base_contract.rb
@@ -63,12 +63,14 @@ module Grids
       Grid
     end
 
-    def assignable_values(_column, _user)
-      nil
+    def assignable_values(column, _user)
+      if column == :widgets
+        config.all_widget_identifiers(grid_class)
+      end
     end
 
     def edit_allowed?
-      Grids::Configuration.writable?(model, user)
+      config.writable?(model, user)
     end
 
     private
@@ -81,10 +83,10 @@ module Grids
     end
 
     def validate_registered_widgets
-      return unless Grids::Configuration.registered_grid?(model.class)
+      return unless config.registered_grid?(grid_class)
 
       undestroyed_widgets.each do |widget|
-        next if Grids::Configuration.allowed_widget?(model.class, widget.identifier)
+        next if config.allowed_widget?(grid_class, widget.identifier)
 
         errors.add(:widgets, :inclusion)
       end
@@ -176,6 +178,14 @@ module Grids
 
     def undestroyed_widgets
       model.widgets.reject(&:marked_for_destruction?)
+    end
+
+    def grid_class
+      model.class
+    end
+
+    def config
+      Grids::Configuration
     end
   end
 end

--- a/modules/grids/app/contracts/grids/base_contract.rb
+++ b/modules/grids/app/contracts/grids/base_contract.rb
@@ -63,9 +63,9 @@ module Grids
       Grid
     end
 
-    def assignable_values(column, _user)
+    def assignable_values(column, user)
       if column == :widgets
-        config.all_widget_identifiers(grid_class)
+        all_allowed_widget_identifiers(user)
       end
     end
 
@@ -86,7 +86,7 @@ module Grids
       return unless config.registered_grid?(grid_class)
 
       undestroyed_widgets.each do |widget|
-        next if config.allowed_widget?(grid_class, widget.identifier)
+        next if config.allowed_widget?(grid_class, widget.identifier, user)
 
         errors.add(:widgets, :inclusion)
       end
@@ -178,6 +178,12 @@ module Grids
 
     def undestroyed_widgets
       model.widgets.reject(&:marked_for_destruction?)
+    end
+
+    def all_allowed_widget_identifiers(user)
+      config.all_widget_identifiers(grid_class).select do |identifier|
+        config.allowed_widget?(grid_class, identifier, user)
+      end
     end
 
     def grid_class

--- a/modules/grids/app/controllers/api/v3/grids/schemas/grid_schema_representer.rb
+++ b/modules/grids/app/controllers/api/v3/grids/schemas/grid_schema_representer.rb
@@ -86,6 +86,11 @@ module API
                                          required: true,
                                          has_default: false,
                                          visibility: false,
+                                         values_callback: -> do
+                                           represented.assignable_values(:widgets, current_user).map do |identifier|
+                                             OpenStruct.new(identifier: identifier)
+                                           end
+                                         end,
                                          value_representer: ::API::V3::Grids::WidgetRepresenter,
                                          link_factory: false
 

--- a/modules/grids/app/models/grids/widget.rb
+++ b/modules/grids/app/models/grids/widget.rb
@@ -34,5 +34,15 @@ module Grids
 
     belongs_to :grid
     serialize :options, Hash
+
+    after_destroy :execute_after_destroy_strategy
+
+    private
+
+    def execute_after_destroy_strategy
+      proc = Grids::Configuration.widget_strategy(grid, identifier).after_destroy
+
+      instance_exec(&proc)
+    end
   end
 end

--- a/modules/grids/app/models/grids/widget.rb
+++ b/modules/grids/app/models/grids/widget.rb
@@ -40,7 +40,7 @@ module Grids
     private
 
     def execute_after_destroy_strategy
-      proc = Grids::Configuration.widget_strategy(grid, identifier).after_destroy
+      proc = Grids::Configuration.widget_strategy(grid.class, identifier).after_destroy
 
       instance_exec(&proc)
     end

--- a/modules/grids/lib/grids/configuration.rb
+++ b/modules/grids/lib/grids/configuration.rb
@@ -28,7 +28,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Grids::Configuration
+module Grids::Configuration
   class << self
     def register_grid(grid,
                       klass)
@@ -121,114 +121,6 @@ class Grids::Configuration
 
     def url_helpers
       @url_helpers ||= OpenProject::StaticRouting::StaticUrlHelpers.new
-    end
-  end
-
-  class WidgetStrategy
-    class << self
-      def after_destroy(proc = nil)
-        if proc
-          @after_destroy = proc
-        end
-
-        @after_destroy ||= -> {}
-      end
-    end
-  end
-
-  class Registration
-    class << self
-      def grid_class(name_string = nil)
-        if name_string
-          @grid_class = name_string
-        end
-
-        @grid_class
-      end
-
-      def to_scope(path = nil)
-        if path
-          @to_scope = path
-        end
-
-        @to_scope
-      end
-
-      def widgets(*widgets)
-        if widgets.any?
-          @widgets = widgets
-        end
-
-        @widgets
-      end
-
-      def widget_strategy(widget_name, &block)
-        @widget_strategies ||= {}
-
-        if block_given?
-          @widget_strategies[widget_name.to_s] = Class.new(Grids::Configuration::WidgetStrategy, &block)
-        end
-
-        @widget_strategies[widget_name.to_s] ||= Grids::Configuration::WidgetStrategy
-      end
-
-      def defaults(hash = nil)
-        # This is called during code load, which
-        # may not have the table available.
-        return unless Grids::Widget.table_exists?
-
-        if hash
-          @defaults = hash
-        end
-
-        params = @defaults.dup
-        params[:widgets] = (params[:widgets] || []).map do |widget|
-          Grids::Widget.new(widget)
-        end
-
-        params
-      end
-
-      def from_scope(_scope)
-        raise NotImplementedError
-      end
-
-      def all_scopes
-        Array(url_helpers.send(@to_scope))
-      end
-
-      def visible(_user = User.current)
-        ::Grids::Grid
-          .where(type: grid_class)
-      end
-
-      def writable?(_grid, _user)
-        true
-      end
-
-      def register!
-        unless @grid_class
-          raise 'Need to define the grid class first. Use grid_class to do so.'
-        end
-        unless @widgets
-          raise 'Need to define at least one widget first. Use widgets to do so.'
-        end
-        unless @to_scope
-          raise 'Need to define a scope. Use to_scope to do so'
-        end
-
-        Grids::Configuration.register_grid(@grid_class, self)
-
-        widgets.each do |widget|
-          Grids::Configuration.register_widget(widget, @grid_class)
-        end
-      end
-
-      private
-
-      def url_helpers
-        @url_helpers ||= OpenProject::StaticRouting::StaticUrlHelpers.new
-      end
     end
   end
 end

--- a/modules/grids/lib/grids/configuration.rb
+++ b/modules/grids/lib/grids/configuration.rb
@@ -89,10 +89,11 @@ module Grids::Configuration
       @widget_register[identifier] = Array(grid_classes)
     end
 
-    def allowed_widget?(grid, identifier)
+    def allowed_widget?(grid, identifier, user)
       grid_classes = registered_widget_by_identifier[identifier]
 
-      (grid_classes || []).include?(grid)
+      (grid_classes || []).include?(grid) &&
+        widget_strategy(grid, identifier)&.allowed?(user)
     end
 
     def all_widget_identifiers(grid)
@@ -102,7 +103,7 @@ module Grids::Configuration
     end
 
     def widget_strategy(grid, identifier)
-      grid_register[grid.class.to_s].widget_strategy(identifier)
+      grid_register[grid.to_s]&.widget_strategy(identifier)
     end
 
     def writable?(grid, user)

--- a/modules/grids/lib/grids/configuration.rb
+++ b/modules/grids/lib/grids/configuration.rb
@@ -95,6 +95,12 @@ module Grids::Configuration
       (grid_classes || []).include?(grid)
     end
 
+    def all_widget_identifiers(grid)
+      registered_widget_by_identifier.select do |_, grid_classes|
+        grid_classes.include?(grid)
+      end.keys
+    end
+
     def widget_strategy(grid, identifier)
       grid_register[grid.class.to_s].widget_strategy(identifier)
     end

--- a/modules/grids/lib/grids/configuration/registration.rb
+++ b/modules/grids/lib/grids/configuration/registration.rb
@@ -1,0 +1,127 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Grids::Configuration
+  class Registration
+    class << self
+      def grid_class(name_string = nil)
+        if name_string
+          @grid_class = name_string
+        end
+
+        @grid_class
+      end
+
+      def to_scope(path = nil)
+        if path
+          @to_scope = path
+        end
+
+        @to_scope
+      end
+
+      def widgets(*widgets)
+        if widgets.any?
+          @widgets = widgets
+        end
+
+        @widgets
+      end
+
+      def widget_strategy(widget_name, &block)
+        @widget_strategies ||= {}
+
+        if block_given?
+          @widget_strategies[widget_name.to_s] = Class.new(Grids::Configuration::WidgetStrategy, &block)
+        end
+
+        @widget_strategies[widget_name.to_s] ||= Grids::Configuration::WidgetStrategy
+      end
+
+      def defaults(hash = nil)
+        # This is called during code load, which
+        # may not have the table available.
+        return unless Grids::Widget.table_exists?
+
+        if hash
+          @defaults = hash
+        end
+
+        params = @defaults.dup
+        params[:widgets] = (params[:widgets] || []).map do |widget|
+          Grids::Widget.new(widget)
+        end
+
+        params
+      end
+
+      def from_scope(_scope)
+        raise NotImplementedError
+      end
+
+      def all_scopes
+        Array(url_helpers.send(@to_scope))
+      end
+
+      def visible(_user = User.current)
+        ::Grids::Grid
+          .where(type: grid_class)
+      end
+
+      def writable?(_grid, _user)
+        true
+      end
+
+      def register!
+        unless @grid_class
+          raise 'Need to define the grid class first. Use grid_class to do so.'
+        end
+        unless @widgets
+          raise 'Need to define at least one widget first. Use widgets to do so.'
+        end
+        unless @to_scope
+          raise 'Need to define a scope. Use to_scope to do so'
+        end
+
+        Grids::Configuration.register_grid(@grid_class, self)
+
+        widgets.each do |widget|
+          Grids::Configuration.register_widget(widget, @grid_class)
+        end
+      end
+
+      private
+
+      def url_helpers
+        @url_helpers ||= OpenProject::StaticRouting::StaticUrlHelpers.new
+      end
+    end
+  end
+end

--- a/modules/grids/lib/grids/configuration/widget_strategy.rb
+++ b/modules/grids/lib/grids/configuration/widget_strategy.rb
@@ -38,6 +38,18 @@ module Grids::Configuration
 
         @after_destroy ||= -> {}
       end
+
+      def allowed(proc = nil)
+        if proc
+          @allowed = proc
+        end
+
+        @allowed ||= ->(_user) { true }
+      end
+
+      def allowed?(user)
+        allowed.(user)
+      end
     end
   end
 end

--- a/modules/grids/lib/grids/configuration/widget_strategy.rb
+++ b/modules/grids/lib/grids/configuration/widget_strategy.rb
@@ -1,0 +1,43 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Grids::Configuration
+  class WidgetStrategy
+    class << self
+      def after_destroy(proc = nil)
+        if proc
+          @after_destroy = proc
+        end
+
+        @after_destroy ||= -> {}
+      end
+    end
+  end
+end

--- a/modules/grids/lib/grids/my_page_grid_registration.rb
+++ b/modules/grids/lib/grids/my_page_grid_registration.rb
@@ -8,6 +8,7 @@ module Grids
             'work_packages_watched',
             'work_packages_created',
             'work_packages_calendar',
+            'work_packages_table',
             'time_entries_current_user',
             'documents',
             'news'

--- a/modules/grids/lib/grids/my_page_grid_registration.rb
+++ b/modules/grids/lib/grids/my_page_grid_registration.rb
@@ -15,6 +15,8 @@ module Grids
 
     widget_strategy 'work_packages_table' do
       after_destroy -> { ::Query.find_by(id: options[:queryId])&.destroy }
+
+      allowed ->(user) { user.allowed_to_globally?(:save_queries) }
     end
 
     defaults(

--- a/modules/grids/lib/grids/my_page_grid_registration.rb
+++ b/modules/grids/lib/grids/my_page_grid_registration.rb
@@ -13,6 +13,10 @@ module Grids
             'documents',
             'news'
 
+    widget_strategy 'work_packages_table' do
+      after_destroy -> { ::Query.find_by(id: options[:queryId])&.destroy }
+    end
+
     defaults(
       row_count: 7,
       column_count: 4,

--- a/modules/grids/spec/contracts/grids/create_contract_spec.rb
+++ b/modules/grids/spec/contracts/grids/create_contract_spec.rb
@@ -94,6 +94,19 @@ describe Grids::CreateContract do
       end
     end
 
+    context 'for widgets' do
+      it 'calls the grid configuration for the available values' do
+        widgets = double('widgets')
+
+        allow(Grids::Configuration)
+          .to receive(:all_widget_identifiers)
+          .and_return(widgets)
+
+        expect(instance.assignable_values(:widgets, user))
+          .to eql widgets
+      end
+    end
+
     context 'for something else' do
       it 'returns nil' do
         expect(instance.assignable_values(:something, user))

--- a/modules/grids/spec/contracts/grids/create_contract_spec.rb
+++ b/modules/grids/spec/contracts/grids/create_contract_spec.rb
@@ -95,15 +95,25 @@ describe Grids::CreateContract do
     end
 
     context 'for widgets' do
-      it 'calls the grid configuration for the available values' do
-        widgets = double('widgets')
+      it 'calls the grid configuration for the available values but allows only those eligible' do
+        widgets = %i[widget1 widget2]
 
         allow(Grids::Configuration)
           .to receive(:all_widget_identifiers)
           .and_return(widgets)
 
+        allow(Grids::Configuration)
+          .to receive(:allowed_widget?)
+          .with(Grids::MyPage, :widget1, user)
+          .and_return(true)
+
+        allow(Grids::Configuration)
+          .to receive(:allowed_widget?)
+          .with(Grids::MyPage, :widget2, user)
+          .and_return(false)
+
         expect(instance.assignable_values(:widgets, user))
-          .to eql widgets
+          .to match_array [:widget1]
       end
     end
 

--- a/modules/grids/spec/features/my/my_page_assigned_to_me_spec.rb
+++ b/modules/grids/spec/features/my/my_page_assigned_to_me_spec.rb
@@ -111,6 +111,7 @@ describe 'Assigned to me embedded query on my page', type: :feature, js: true do
         hierarchies.disable_via_header
         hierarchies.expect_no_hierarchies
 
+        sleep(0.2)
         # re-enable
         hierarchies.enable_via_header
 

--- a/modules/grids/spec/features/my/my_page_assigned_to_me_spec.rb
+++ b/modules/grids/spec/features/my/my_page_assigned_to_me_spec.rb
@@ -112,8 +112,11 @@ describe 'Assigned to me embedded query on my page', type: :feature, js: true do
         hierarchies.expect_no_hierarchies
 
         sleep(0.2)
+
         # re-enable
         hierarchies.enable_via_header
+
+        sleep(0.2)
 
         hierarchies.expect_mode_enabled
         hierarchies.expect_hierarchy_at assigned_work_package, collapsed: true

--- a/modules/grids/spec/features/my/my_page_time_entries_current_user_spec.rb
+++ b/modules/grids/spec/features/my/my_page_time_entries_current_user_spec.rb
@@ -88,7 +88,7 @@ describe 'My page time entries current user widget spec', type: :feature, js: tr
     sleep(0.5)
 
     # within top-right area, add an additional widget
-    my_page.add_widget(1, 1, 'Spent time (last 7 days)')
+    my_page.add_widget(1, 1, 'Spent time \(last 7 days\)')
 
     calendar_area = Components::Grids::GridArea.new('.grid--area', text: 'Spent time (last 7 days)')
     calendar_area.expect_to_span(1, 1, 4, 3)

--- a/modules/grids/spec/features/my/my_page_work_package_table_spec.rb
+++ b/modules/grids/spec/features/my/my_page_work_package_table_spec.rb
@@ -1,0 +1,96 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Arbitrary WorkPackage query table widget widget on my page', type: :feature, js: true do
+  let!(:type) { FactoryBot.create :type }
+  let!(:other_type) { FactoryBot.create :type }
+  let!(:priority) { FactoryBot.create :default_priority }
+  let!(:project) { FactoryBot.create :project, types: [type] }
+  let!(:other_project) { FactoryBot.create :project, types: [type] }
+  let!(:open_status) { FactoryBot.create :default_status }
+  let!(:type_work_package) do
+    FactoryBot.create :work_package,
+                      project: project,
+                      type: type,
+                      author: user,
+                      responsible: user
+  end
+  let!(:other_type_work_package) do
+    FactoryBot.create :work_package,
+                      project: project,
+                      type: other_type,
+                      author: user,
+                      responsible: user
+  end
+
+  let(:role) { FactoryBot.create(:role, permissions: %i[view_work_packages add_work_packages]) }
+
+  let(:user) do
+    FactoryBot.create(:user,
+                      member_in_project: project,
+                      member_through_role: role)
+  end
+  let(:my_page) do
+    Pages::My::Page.new
+  end
+
+  before do
+    login_as user
+
+    my_page.visit!
+  end
+
+  it 'can add the widget and see the work packages of the filtered for types' do
+    my_page.add_column(3, before_or_after: :before)
+
+    my_page.add_widget(2, 3, "Work package table")
+
+    sleep(0.2)
+
+    filter_area = Components::Grids::GridArea.new('.grid--area', text: "Work package table")
+    created_area = Components::Grids::GridArea.new('.grid--area', text: "Work packages created by me")
+
+    filter_area.expect_to_span(2, 3, 5, 4)
+    filter_area.resize_to(6, 4)
+
+    filter_area.expect_to_span(2, 3, 7, 5)
+    ## enlarging the accountable area will have moved the created area down
+    created_area.expect_to_span(7, 4, 13, 6)
+
+    #expect(accountable_area.area)
+    #  .to have_selector('.subject', text: accountable_work_package.subject)
+
+    #expect(accountable_area.area)
+    #  .to have_no_selector('.subject', text: accountable_by_other_work_package.subject)
+
+    #expect(accountable_area.area)
+    #  .to have_no_selector('.subject', text: accountable_but_invisible_work_package.subject)
+  end
+end

--- a/modules/grids/spec/features/my/my_page_work_package_table_spec.rb
+++ b/modules/grids/spec/features/my/my_page_work_package_table_spec.rb
@@ -50,7 +50,12 @@ describe 'Arbitrary WorkPackage query table widget on my page', type: :feature, 
                       responsible: user
   end
 
-  let(:role) { FactoryBot.create(:role, permissions: %i[view_work_packages add_work_packages]) }
+  let(:role) do
+    FactoryBot.create(:role,
+                      permissions: %i[view_work_packages
+                                      add_work_packages
+                                      save_queries])
+  end
 
   let(:user) do
     FactoryBot.create(:user,
@@ -74,11 +79,13 @@ describe 'Arbitrary WorkPackage query table widget on my page', type: :feature, 
   it 'can add the widget and see the work packages of the filtered for types' do
     my_page.add_column(3, before_or_after: :before)
 
-    my_page.add_widget(2, 3, "Work package table")
+    my_page.add_widget(2, 3, "Work packages")
 
     sleep(0.2)
 
-    filter_area = Components::Grids::GridArea.new('.grid--area', text: "Work package table")
+    sleep(1)
+
+    filter_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(3)')
     created_area = Components::Grids::GridArea.new('.grid--area', text: "Work packages created by me")
 
     filter_area.expect_to_span(2, 3, 5, 4)
@@ -115,6 +122,13 @@ describe 'Arbitrary WorkPackage query table widget on my page', type: :feature, 
     expect(filter_area.area)
       .to have_no_selector('.id', text: other_type_work_package.id)
 
+    scroll_to_element(filter_area.area)
+    within filter_area.area do
+      input = find('.editable-toolbar-title--input')
+      input.set('My WP Filter')
+      input.native.send_keys(:return)
+    end
+
     sleep(1)
 
     # The whole of the configuration survives a reload
@@ -123,7 +137,7 @@ describe 'Arbitrary WorkPackage query table widget on my page', type: :feature, 
     visit root_path
     my_page.visit!
 
-    filter_area = Components::Grids::GridArea.new('.grid--area', text: "Work package table")
+    filter_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(3)')
     expect(filter_area.area)
       .to have_selector('.id', text: type_work_package.id)
 
@@ -134,5 +148,10 @@ describe 'Arbitrary WorkPackage query table widget on my page', type: :feature, 
     # As other_type is filtered out
     expect(filter_area.area)
       .to have_no_selector('.id', text: other_type_work_package.id)
+
+    within filter_area.area do
+      expect(find('.editable-toolbar-title--input').value)
+        .to eql('My WP Filter')
+    end
   end
 end

--- a/modules/grids/spec/features/my/my_page_work_package_table_spec.rb
+++ b/modules/grids/spec/features/my/my_page_work_package_table_spec.rb
@@ -115,6 +115,8 @@ describe 'Arbitrary WorkPackage query table widget on my page', type: :feature, 
     expect(filter_area.area)
       .to have_no_selector('.id', text: other_type_work_package.id)
 
+    sleep(1)
+
     # The whole of the configuration survives a reload
     # as it is persisted in the grid
 

--- a/modules/grids/spec/lib/api/v3/grids/schemas/grid_schema_representer_spec.rb
+++ b/modules/grids/spec/lib/api/v3/grids/schemas/grid_schema_representer_spec.rb
@@ -38,14 +38,7 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
   let(:new_record) { true }
   let(:allowed_scopes) { %w(/some/path /some/other/path) }
   let(:allowed_widgets) do
-    [
-      OpenStruct.new(
-        identifier: 'first_widget'
-      ),
-      OpenStruct.new(
-        identifier: 'second_widget'
-      )
-    ]
+    %w(first_widget second_widget)
   end
   let(:contract) do
     contract = double('contract')
@@ -172,9 +165,9 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
         end
 
         it 'embeds the allowed values' do
-          allowed_widgets.each_with_index do |widget, index|
+          allowed_widgets.each_with_index do |identifier, index|
             href_path = "#{path}/_embedded/allowedValues/#{index}/identifier"
-            is_expected.to be_json_eql(widget[:identifier].to_json).at_path(href_path)
+            is_expected.to be_json_eql(identifier.to_json).at_path(href_path)
           end
         end
       end

--- a/modules/grids/spec/models/grids/my_page_spec.rb
+++ b/modules/grids/spec/models/grids/my_page_spec.rb
@@ -31,18 +31,46 @@ require 'spec_helper'
 require_relative './shared_model'
 
 describe Grids::MyPage, type: :model do
-  let(:instance) { described_class.new }
+  let(:instance) { described_class.new(row_count: 5, column_count: 5) }
   let(:user) { FactoryBot.build_stubbed(:user) }
 
   it_behaves_like 'grid attributes'
 
   context 'attributes' do
-    let(:user) { FactoryBot.build_stubbed :user }
-
     it '#user' do
       instance.user = user
       expect(instance.user)
         .to eql user
+    end
+  end
+
+  context 'altering widgets' do
+    context 'when removing a work_packages_table widget' do
+      let(:user) { FactoryBot.create(:user) }
+      let(:query) do
+        FactoryBot.create(:query,
+                          user: user,
+                          hidden: true)
+      end
+
+      before do
+        widget = Grids::Widget.new(identifier: 'work_packages_table',
+                                   start_row: 1,
+                                   end_row: 2,
+                                   start_column: 1,
+                                   end_column: 2,
+                                   options: { queryId: query.id })
+
+        instance.widgets = [widget]
+        instance.save!
+      end
+
+      it 'removes the widget\'s query' do
+        instance.widgets = []
+
+        expect(Query.find_by(id: query.id))
+          .to be_nil
+      end
     end
   end
 end

--- a/spec/support/components/work_packages/columns.rb
+++ b/spec/support/components/work_packages/columns.rb
@@ -32,9 +32,6 @@ module Components
       include Capybara::DSL
       include RSpec::Matchers
 
-      def initialize
-      end
-
       def expect_column_not_available(name)
         modal_open? or open_modal
 

--- a/spec/support/pages/my/page.rb
+++ b/spec/support/pages/my/page.rb
@@ -70,7 +70,7 @@ module Pages
           expect(page)
             .to have_content(I18n.t('js.grid.add_modal.choose_widget'))
 
-          page.find('.grid--addable-widget', text: name).click
+          page.find('.grid--addable-widget', text: Regexp.new("^#{name}$")).click
         end
       end
 

--- a/spec/support/pages/my/page.rb
+++ b/spec/support/pages/my/page.rb
@@ -62,11 +62,7 @@ module Pages
       end
 
       def add_widget(row_number, column_number, name)
-        area = area_of(row_number, column_number)
-        area.hover
-        area.find('.grid--widget-add').click
-
-        within '.op-modal--portal' do
+        within_add_widget_modal(row_number, column_number) do
           expect(page)
             .to have_content(I18n.t('js.grid.add_modal.choose_widget'))
 
@@ -74,8 +70,30 @@ module Pages
         end
       end
 
+      def expect_unable_to_add_widget(row_number, column_number, name)
+        within_add_widget_modal(row_number, column_number) do
+          expect(page)
+            .to have_content(I18n.t('js.grid.add_modal.choose_widget'))
+
+          expect(page)
+            .not_to have_selector('.grid--addable-widget', text: Regexp.new("^#{name}$"))
+        end
+      end
+
       def area_of(row_number, column_number)
         ::Components::Grids::GridArea.of(row_number, column_number).area
+      end
+
+      private
+
+      def within_add_widget_modal(row_number, column_number)
+        area = area_of(row_number, column_number)
+        area.hover
+        area.find('.grid--widget-add').click
+
+        within '.op-modal--portal' do
+          yield
+        end
       end
     end
   end


### PR DESCRIPTION
Enable having arbitrary, user configurable tables/gantt charts displayed on the my page.

![image](https://user-images.githubusercontent.com/617519/54589442-efdd1680-4a25-11e9-87b4-0fff82b359d6.png)

This is currently a side project, it might make it into 9.0 but there is no guarantee that it will.

### TODO
* [x] Create table widget
* [x] Enable configuration via modal
* [x] Persist configuration between reloads
* [x] Persist configuration between reloads via a proper query
* [x] Configurable widget name - Will need to refactor the editable-toolbar-directive in ordert to avoid duplication
* [x] Remove query on deleting the widget
* [x] Currently, a user requires the `save_queries` permission

### Remarks  - most likely separate work packages
- Can not move widgets, e.g. one row below [here ](http://openproject-pr-7153-feature-my-page-wp-53dc9f0c.my.pullpreview.com/my/page)
- Renaming work package widgets: After pressing enter the cursor is still in "edit mode".
- What happens with the predefined widgets, e.g. "Assigned to me"? Can we migrate them to a custom widget so they are editable? However for new users predefined widgets are much easier to discover.
- Seed data?

### Work packages
* https://community.openproject.com/projects/openproject/work_packages/27153
* parts of https://community.openproject.com/projects/openproject/work_packages/29665