### PR TITLE
[29752] Missing warning when switching from meetings (agenda / minutes) to other page

### DIFF
--- a/modules/meeting/app/assets/javascripts/meeting/meeting.js
+++ b/modules/meeting/app/assets/javascripts/meeting/meeting.js
@@ -1,4 +1,5 @@
 jQuery(function($) {
+  var formSubmitting = false;
   function toggleContentTypeForm(content_type, edit) {
     jQuery('.edit-' + content_type).toggle(edit);
     jQuery('.show-' + content_type).toggle(!edit);
@@ -11,6 +12,17 @@ jQuery(function($) {
     var content_type = $(this).data('contentType');
     toggleContentTypeForm(content_type, true);
 
+
+    $(window).on("beforeunload", function (e) {
+      if (formSubmitting) {
+        return undefined;
+      }
+
+      // For browser compatibility we need to set the event return value
+      e.returnValue = '';
+      return '';
+    });
+
     return false;
   });
 
@@ -18,7 +30,13 @@ jQuery(function($) {
     var content_type = $(this).data('contentType');
     toggleContentTypeForm(content_type, false);
 
+    $(window).off("beforeunload");
+
     return false;
+  });
+
+  $('.button--save-agenda').click(function() {
+    formSubmitting = true;
   });
 
 

--- a/modules/meeting/app/views/meeting_contents/_form.html.erb
+++ b/modules/meeting/app/views/meeting_contents/_form.html.erb
@@ -31,7 +31,7 @@ See doc/COPYRIGHT.md for more details.
   <%= wikitoolbar_for "#{content_type}_text", preview_context: preview_context(content.meeting, @project) %>
 
   <p><label for="<%= content_type %>_comment"><%= Meeting.human_attribute_name(:comments) %></label><%= f.text_field :comment, :size => 120 %></p>
-  <p><%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
+  <p><%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark button--save-agenda' %>
   <%= link_to l(:button_cancel), "#", data: { 'content-type': content_type }, class: 'button button--cancel-agenda' %>
 <% end %>
 


### PR DESCRIPTION
Show warning before leaving meeting agenda with unsafed content

https://community.openproject.com/projects/openproject/work_packages/29752/activity