### PR TITLE
[29783][Boards] Remove drop down selection from action boards 

### DIFF
--- a/frontend/src/app/modules/boards/new-board-modal/new-board-modal.component.ts
+++ b/frontend/src/app/modules/boards/new-board-modal/new-board-modal.component.ts
@@ -45,7 +45,7 @@ import {WorkPackageNotificationService} from "core-components/wp-edit/wp-notific
 export class NewBoardModalComponent extends OpModalComponent {
   @ViewChild('actionAttributeSelect') actionAttributeSelect:ElementRef;
 
-  public showClose:boolean;
+  public showClose:boolean = true;
 
   public confirmed = false;
 
@@ -54,11 +54,7 @@ export class NewBoardModalComponent extends OpModalComponent {
   public inFlight = false;
 
   public text:any = {
-    title: this.I18n.t('js.boards.new_board'),
-    button_continue: this.I18n.t('js.button_continue'),
-    button_cancel: this.I18n.t('js.button_cancel'),
     close_popup: this.I18n.t('js.close_popup_title'),
-
 
     free_board: this.I18n.t('js.boards.board_type.free'),
     free_board_text: this.I18n.t('js.boards.board_type.free_text'),
@@ -88,7 +84,7 @@ export class NewBoardModalComponent extends OpModalComponent {
   }
 
   createAction() {
-    this.create({ type: 'action', attribute: this.actionAttributeSelect.nativeElement.value! });
+    this.create({ type: 'action', attribute: this.available[0].attribute });
   }
 
   private create(params:{ type:BoardType, attribute?:string }) {

--- a/frontend/src/app/modules/boards/new-board-modal/new-board-modal.html
+++ b/frontend/src/app/modules/boards/new-board-modal/new-board-modal.html
@@ -10,7 +10,6 @@
             [attr.title]="text.close_popup">
         </i>
       </a>
-      <h3 class="icon-context icon-add" [textContent]="text.title"></h3>
     </div>
 
     <div class="ngdialog-body op-modal--modal-body">
@@ -29,18 +28,10 @@
         <h3 [textContent]="text.action_board"></h3>
         <p [textContent]="text.action_board_text"></p>
 
-        <div class="form--field">
-          <div class="form--field-container">
-            <div class="form--select-container -slim">
-              <label class="form--label" for="new_board_action_select" [textContent]="text.select_attribute"></label>
-              <select #actionAttributeSelect
-                      name="new_board_action_select"
-                      class="new-board--action-select">
-                <option *ngFor="let item of available" [value]="item.attribute" [textContent]="item.text"></option>
-              </select>
-            </div>
-          </div>
-        </div>
+        <p>
+          {{text.select_attribute}}:
+          <b> {{available[0].text}} </b>
+        </p>
 
         <button class="button"
                 [disabled]="inFlight"
@@ -49,13 +40,6 @@
           <span [textContent]="text.action_board"></span>
         </button>
       </section>
-    </div>
-    <div class="op-modal--modal-footer">
-      <button class="confirm-form-submit--cancel button"
-              (click)="closeMe($event)"
-              [textContent]="text.button_cancel"
-              [attr.title]="text.button_cancel">
-      </button>
     </div>
   </div>
 </div>

--- a/modules/boards/spec/features/support/board_index_page.rb
+++ b/modules/boards/spec/features/support/board_index_page.rb
@@ -62,7 +62,6 @@ module Pages
       if action == nil
         find('.button', text: 'Free board').click
       else
-        select action.to_s, from: 'new_board_action_select'
         find('.button', text: 'Action board').click
       end
 


### PR DESCRIPTION
Remove the select field from the modal to create a new action board. Currently only status boards exists, so a select does not make any sense.

https://community.openproject.com/projects/openproject/work_packages/29783/activity