### PR TITLE
remove limit of 100

### DIFF
--- a/modules/reporting/app/models/cost_query/filter/user_id.rb
+++ b/modules/reporting/app/models/cost_query/filter/user_id.rb
@@ -49,7 +49,6 @@ class CostQuery::Filter::UserId < Report::Filter::Base
     users = User.joins(members: :project)
                 .merge(Project.visible)
                 .not_builtin
-                .limit(100)
                 .select(User::USER_FORMATS_STRUCTURE[Setting.user_format].map(&:to_s) << :id)
                 .distinct
 


### PR DESCRIPTION
Removing the limit in CostQuery filter. The limit leads to list only 100 users in the drop down in the user filter section while taking cost reports page.