### PR TITLE
[29812] Double click needed to edit the list name

### DIFF
--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.component.ts
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.component.ts
@@ -106,10 +106,6 @@ export class EditableToolbarTitleComponent implements OnInit, OnChanges {
     }
   }
 
-  public selectInput(event:FocusEvent) {
-    (event.target as HTMLInputElement).select();
-  }
-
   public saveWhenFocusOutside($event:FocusEvent) {
     ContainHelpers.whenOutside(this.elementRef.nativeElement, () => this.save($event));
   }

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
@@ -14,7 +14,6 @@
          aria-required="true"
          [attr.name]="selectableTitleIdentifier"
          [focus]="this.initialFocus || undefined"
-         (focus)="selectInput($event)"
          (keydown.escape)="reset($event)"
          (keydown.enter)="save($event)"
          [attr.placeholder]="text.input_placeholder"


### PR DESCRIPTION
Skip text selection when clicking in editable toolbar and set cursor directly.

https://community.openproject.com/projects/openproject/work_packages/29812/activity