### PR TITLE
[29820] [Forum] Trying to start editing a forum board returns an exception

### DIFF
--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -32,7 +32,7 @@ class ForumsController < ApplicationController
   before_action :find_project_by_project_id,
                 :authorize
   before_action :new_forum, only: %i[new create]
-  before_action :find_forum, only: %i[show update move destroy]
+  before_action :find_forum, only: %i[show edit update move destroy]
   accept_key_auth :index, :show
 
   include SortHelper


### PR DESCRIPTION
Add missing `edit` route to before_actions for @forum setup.


https://community.openproject.com/projects/openproject/work_packages/29820/activity