### PR TITLE
[29845] Pagination in embedded tables not working

### DIFF
--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
@@ -110,14 +110,13 @@ export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
       .values$()
       .pipe(
         untilComponentDestroyed(this),
-        withLatestFrom(this.querySpace.query.values$()
-      )
-    ).subscribe(([pagination, query]) => {
-      if (this.wpListChecksumService.isQueryOutdated(query, pagination)) {
-        this.wpListChecksumService.update(query, pagination);
-        this.refresh(true, false);
-      }
-    });
+        withLatestFrom(this.querySpace.query.values$())
+      ).subscribe(([pagination, query]) => {
+        if (this.wpListChecksumService.isQueryOutdated(query, pagination)) {
+          this.wpListChecksumService.update(query, pagination);
+          this.refresh(true, false);
+        }
+      });
 
     this.setupChangeObserver(this.wpTableFilters, true);
     this.setupChangeObserver(this.wpTableGroupBy);

--- a/modules/grids/spec/features/my/my_page_assigned_to_me_spec.rb
+++ b/modules/grids/spec/features/my/my_page_assigned_to_me_spec.rb
@@ -41,6 +41,14 @@ describe 'Assigned to me embedded query on my page', type: :feature, js: true do
                       author: user,
                       assigned_to: user
   end
+  let!(:assigned_work_package_2) do
+    FactoryBot.create :work_package,
+                      project: project,
+                      subject: 'My task 2',
+                      type: type,
+                      author: user,
+                      assigned_to: user
+  end
   let!(:assigned_to_other_work_package) do
     FactoryBot.create :work_package,
                       project: project,
@@ -153,5 +161,25 @@ describe 'Assigned to me embedded query on my page', type: :feature, js: true do
     expect(wp.assigned_to_id).to eq(user.id)
 
     embedded_table.expect_work_package_listed wp
+  end
+
+  it 'can paginate in embedded tables (Regression test #29845)' do
+    my_page.visit!
+
+    # exists as default
+    assigned_area.expect_to_exist
+    assigned_area.resize_to(2, 2)
+
+    expect(assigned_area.area)
+      .to have_selector('.subject', text: assigned_work_package.subject)
+    expect(assigned_area.area)
+      .not_to have_selector('.subject', text: assigned_work_package_2.subject)
+
+    assigned_area.area.find('.pagination--item a', text: '2').click
+
+    expect(assigned_area.area)
+      .not_to have_selector('.subject', text: assigned_work_package.subject)
+    expect(assigned_area.area)
+      .to have_selector('.subject', text: assigned_work_package_2.subject)
   end
 end


### PR DESCRIPTION
### Problem
In the baseView there is a check for a query changes before the table reloaded. This check is always false for queries of embedded tables. Thus the pagination change event won't trigger a table change.

### Solution 
The embedded table triggers its own change like it was before (https://github.com/opf/openproject/commit/a923b8fbef4e28f69118d3ea452a99738585197a#diff-ff655d8bf6010321d50fa2fbb9ce051e)

https://community.openproject.com/projects/openproject/work_packages/29845/activity