### PR TITLE
[29879][Boards] Improve lists title selection and focussing

### DIFF
--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.html
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.html
@@ -14,7 +14,7 @@
                               [inFlight]="inFlight"
                               (onSave)="renameQuery(query, $event)"
                               [editable]="!!query.updateImmediately"
-                              [initialFocus]="isInitiallyFocused()"
+                              [initialFocus]="initiallyFocused()"
                               class="-small">
       </editable-toolbar-title>
       <button [title]="text.addCard"

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -34,6 +34,7 @@ import {GonService} from "core-app/modules/common/gon/gon.service";
 import {WorkPackageStatesInitializationService} from "core-components/wp-list/wp-states-initialization.service";
 import {ApiV3Filter} from "core-components/api/api-v3/api-v3-filter-builder";
 import {BoardService} from "app/modules/boards/board/board.service";
+import {BoardListsService} from "core-app/modules/boards/board/board-list/board-lists.service";
 
 @Component({
   selector: 'board-list',
@@ -91,7 +92,8 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
               private readonly authorisationService:AuthorisationService,
               private readonly wpInlineCreate:WorkPackageInlineCreateService,
               private readonly loadingIndicator:LoadingIndicatorService,
-              private readonly boardService:BoardService) {
+              private readonly boardService:BoardService,
+              private readonly boardListService:BoardListsService) {
     super(I18n);
   }
 
@@ -142,12 +144,8 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     return this.boardService.canManage;
   }
 
-  /*
-  *  Unnamed lists shall be focused to make editing easier
-  */
-  public isInitiallyFocused() {
-    return !this.state.params.isNew &&
-           this.listName === this.text.unnamed_list;
+  public initiallyFocused() {
+    return this.boardListService.isNew && this.query.name === this.text.unnamed_list;
   }
 
   public addReferenceCard() {
@@ -176,6 +174,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
       .toPromise()
       .then(() => {
         this.inFlight = false;
+        this.boardListService.isNew = false;
         this.notifications.addSuccess(this.text.updateSuccessful);
       })
       .catch(() => this.inFlight = false);

--- a/frontend/src/app/modules/boards/board/board-list/board-lists.service.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-lists.service.ts
@@ -14,6 +14,8 @@ export class BoardListsService {
 
   private readonly v3 = this.pathHelper.api.v3;
 
+  private _isNewQuery:boolean = false;
+
   constructor(private readonly CurrentProject:CurrentProjectService,
               private readonly pathHelper:PathHelperService,
               private readonly QueryDm:QueryDmService,
@@ -73,6 +75,14 @@ export class BoardListsService {
     board.addQuery(resource);
 
     return board;
+  }
+
+  public set isNew(val:boolean) {
+    this._isNewQuery = val;
+  }
+
+  public get isNew():boolean {
+    return this._isNewQuery;
   }
 
   private buildQueryRequest(params:Object) {

--- a/frontend/src/app/modules/boards/board/board.component.ts
+++ b/frontend/src/app/modules/boards/board/board.component.ts
@@ -131,6 +131,7 @@ export class BoardComponent implements OnInit, OnDestroy {
         .then(board => this.Boards.save(board))
         .then(saved => {
           this.BoardCache.update(saved);
+          this.BoardList.isNew = true;
         })
         .catch(error => this.showError(error));
     } else {

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.component.ts
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.component.ts
@@ -106,6 +106,12 @@ export class EditableToolbarTitleComponent implements OnInit, OnChanges {
     }
   }
 
+  public selectInputOnInitalFocus(event:FocusEvent) {
+    if (this.initialFocus) {
+      (event.target as HTMLInputElement).select();
+    }
+  }
+
   public saveWhenFocusOutside($event:FocusEvent) {
     ContainHelpers.whenOutside(this.elementRef.nativeElement, () => this.save($event));
   }

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
@@ -14,6 +14,7 @@
          aria-required="true"
          [attr.name]="selectableTitleIdentifier"
          [focus]="this.initialFocus || undefined"
+         (focus)="selectInputOnInitalFocus($event)"
          (keydown.escape)="reset($event)"
          (keydown.enter)="save($event)"
          [attr.placeholder]="text.input_placeholder"


### PR DESCRIPTION
This PR does two things:

1. When a new board list is created, the name is fully selected so that the user can directly type in the name.
2. Unnamed lists are not focused per default any more.

https://community.openproject.com/projects/openproject/work_packages/29879/activity
https://community.openproject.com/projects/openproject/work_packages/29819/activity