### PR TITLE
[29752] Missing warning when leaving with unsafed content in meetings

### DIFF
--- a/modules/meeting/app/assets/javascripts/meeting/meeting.js
+++ b/modules/meeting/app/assets/javascripts/meeting/meeting.js
@@ -1,8 +1,27 @@
 jQuery(function($) {
   var formSubmitting = false;
+  var editFormOpen = false;
+  if (jQuery('#edit-meeting_agenda').is(':visible') || jQuery('#edit-meeting_minutes').is(':visible')) {
+    editFormOpen = true;
+  }
+
+  $(window).on("beforeunload", function (e) {
+    // When the form is not open or just submitted,
+    // we can safely leave the page
+    if(!editFormOpen || formSubmitting) {
+      return undefined;
+    } else {
+      // Otherwise we throw a warning
+      // For browser compatibility we need to set the event return value
+      e.returnValue = '';
+      return '';
+    }
+  });
+
   function toggleContentTypeForm(content_type, edit) {
     jQuery('.edit-' + content_type).toggle(edit);
     jQuery('.show-' + content_type).toggle(!edit);
+    editFormOpen = edit;
 
     jQuery('.button--edit-agenda').toggleClass('-active', edit);
     jQuery('.button--edit-agenda').attr('disabled', edit);
@@ -11,17 +30,6 @@ jQuery(function($) {
   $('.button--edit-agenda').click(function() {
     var content_type = $(this).data('contentType');
     toggleContentTypeForm(content_type, true);
-
-
-    $(window).on("beforeunload", function (e) {
-      if (formSubmitting) {
-        return undefined;
-      }
-
-      // For browser compatibility we need to set the event return value
-      e.returnValue = '';
-      return '';
-    });
 
     return false;
   });


### PR DESCRIPTION
In https://github.com/opf/openproject/pull/7162 a warning was introduced when leaving the meetings page with unsafed content. Thereby I forgot to handle the case that the edit form is initially already opened because the there is no content. 

https://community.openproject.com/projects/openproject/work_packages/29752/activity