### PR TITLE
[29902][Boards] It is possible to delete a list without permissions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -310,6 +310,19 @@ class ApplicationController < ActionController::Base
     authorize(ctrl, action, global)
   end
 
+  # Pass some visibility settings via gon that are not
+  # available through the global grids API
+  def set_gon_settings
+    gon.settings = client_preferences
+
+    unless @project.nil?
+      gon.permission_flags = {
+        manage_board_views: current_user.allowed_to_in_project?(:manage_board_views, @project),
+        edit_work_packages: current_user.allowed_to_in_project?(:edit_work_packages, @project)
+      }
+    end
+  end
+
   # Find project of id params[:id]
   # Note: find() is Project.friendly.find()
   def find_project

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -78,12 +78,13 @@ class WorkPackagesController < ApplicationController
     end
   end
 
-  protected
-
   def set_gon_settings
-    gon.settings = client_preferences
+    super
+
     gon.settings[:enabled_modules] = project ? project.enabled_modules.collect(&:name) : []
   end
+
+  protected
 
   def export_list(mime_type)
     exporter = WorkPackage::Exporter.for_list(mime_type)

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.html
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.html
@@ -13,7 +13,7 @@
       <editable-toolbar-title [title]="query.name"
                               [inFlight]="inFlight"
                               (onSave)="renameQuery(query, $event)"
-                              [editable]="!!query.updateImmediately"
+                              [editable]="canRename"
                               [initialFocus]="initiallyFocused()"
                               class="-small">
       </editable-toolbar-title>
@@ -31,7 +31,7 @@
       </button>
 
       <div class="board-list--delete-icon">
-        <accessible-by-keyboard *ngIf="!!query.delete"
+        <accessible-by-keyboard *ngIf="canDelete"
                                 linkClass="button -narrow -no-decoration"
                                 (execute)="deleteList(query)">
           <op-icon icon-classes="icon-small icon-delete"></op-icon>

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -104,7 +104,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     this.authorisationService
       .observeUntil(componentDestroyed(this))
       .subscribe(() => {
-        this.showAddButton = this.wpInlineCreate.canAdd || this.canReference;
+        this.showAddButton = (this.wpInlineCreate.canAdd || this.canReference) && this.canManage;
       });
 
     this.querySpace.query
@@ -142,6 +142,14 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
   public get canManage() {
     return this.boardService.canManage;
+  }
+
+  public get canDelete() {
+    return this.canManage && !!this.query.delete;
+  }
+
+  public get canRename() {
+    return this.canManage && !!this.query.updateImmediately;
   }
 
   public initiallyFocused() {

--- a/modules/boards/app/controllers/boards/boards_controller.rb
+++ b/modules/boards/app/controllers/boards/boards_controller.rb
@@ -11,7 +11,7 @@ module ::Boards
 
     # Pass some visibility settings via gon that are not
     # available through the global grids API
-    before_action :pass_gon
+    before_action :set_gon_settings
 
     menu_item :board_view
 
@@ -25,12 +25,8 @@ module ::Boards
 
     private
 
-    def pass_gon
-      gon.settings = client_preferences
-      gon.permission_flags = {
-        manage_board_views: current_user.allowed_to_in_project?(:manage_board_views, @project),
-        edit_work_packages: current_user.allowed_to_in_project?(:edit_work_packages, @project),
-      }
+    def set_gon_settings
+      super
     end
 
     def authorize_work_package_permission

--- a/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
+++ b/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
@@ -33,7 +33,16 @@ describe 'boards onboarding tour', js: true do
   let(:user) { FactoryBot.create :admin,
                                  member_in_project: demo_project,
                                  member_through_role: role}
-  let(:permissions) { %i[show_board_views manage_board_views view_work_packages manage_public_queries] }
+  let(:permissions) do
+    %i[
+      show_board_views
+      manage_board_views
+      view_work_packages
+      edit_work_packages
+      add_work_packages
+      manage_public_queries
+    ]
+  end
   let(:role) { FactoryBot.create(:role, permissions: permissions) }
 
   let(:demo_project) do


### PR DESCRIPTION
Forbid changes to a board list without the according permissions. Therefore the `gon` permission needed to be set globally. This is necessary for the case that I switch from the WP view to a board view via the menu. The the boards controller was not called and the permissions not set.

https://community.openproject.com/projects/openproject/work_packages/29902/activity