### PR TITLE
[29189] [Boards] Active input field after clicking "New list" in Boards module

### DIFF
--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -149,7 +149,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
   }
 
   public initiallyFocused() {
-    return this.boardListService.isNew && this.query.name === this.text.unnamed_list;
+    return !this.state.params.isNew && this.boardListService.isNew;
   }
 
   public addReferenceCard() {

--- a/frontend/src/app/modules/boards/board/board.component.ts
+++ b/frontend/src/app/modules/boards/board/board.component.ts
@@ -120,7 +120,7 @@ export class BoardComponent implements OnInit, OnDestroy {
         this.BoardCache.update(board);
         this.notifications.addSuccess(this.text.updateSuccessful);
         this.inFlight = false;
-        this.state.go('.', { query_props: null }, {custom: {notify: false}});
+        this.state.go('.', { query_props: null, isNew: false }, {custom: {notify: false}});
       });
   }
 

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.component.ts
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.component.ts
@@ -33,7 +33,8 @@ import {
   Input,
   OnChanges,
   OnInit,
-  Output, SimpleChanges,
+  Output,
+  SimpleChanges,
   ViewChild
 } from "@angular/core";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
@@ -104,11 +105,22 @@ export class EditableToolbarTitleComponent implements OnInit, OnChanges {
     if (changes.inputTitle) {
       this.selectedTitle = changes.inputTitle.currentValue;
     }
+
+    if (changes.initialFocus && changes.initialFocus.firstChange && this.inputField!) {
+      const field:HTMLInputElement = this.inputField!.nativeElement;
+      this.selectInputOnInitalFocus(field);
+    }
+
   }
 
-  public selectInputOnInitalFocus(event:FocusEvent) {
+  public onFocus(event:FocusEvent) {
+    this.selectInputOnInitalFocus(event.target as HTMLInputElement);
+  }
+
+  public selectInputOnInitalFocus(input:HTMLInputElement) {
     if (this.initialFocus) {
-      (event.target as HTMLInputElement).select();
+      input.select();
+      this.initialFocus = false;
     }
   }
 

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
@@ -14,7 +14,7 @@
          aria-required="true"
          [attr.name]="selectableTitleIdentifier"
          [focus]="this.initialFocus || undefined"
-         (focus)="selectInputOnInitalFocus($event)"
+         (focus)="onFocus($event)"
          (keydown.escape)="reset($event)"
          (keydown.enter)="save($event)"
          [attr.placeholder]="text.input_placeholder"


### PR DESCRIPTION
This PR does two things:

1. When a board is newly created, the board name shall be selected for an easier change. It sometimes happened that the first list was highlighted instead
2. The name of newly created lists shall also be selected for easier change. It sometimes happened that the focus event was fired to early.

https://community.openproject.com/projects/openproject/work_packages/29819/activity