### PR TITLE
[29913] Perform board saving in switchmap

### DIFF
--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -32,6 +32,7 @@ import {StateService} from "@uirouter/core";
 import {States} from "core-components/states.service";
 import {input} from "reactivestates";
 import {switchMap, tap} from "rxjs/operators";
+import {RequestSwitchmap} from "core-app/helpers/rxjs/request-switchmap";
 
 
 @Component({
@@ -78,15 +79,9 @@ export class WorkPackageCardViewComponent  implements OnInit {
   public activeInlineCreateWp?:WorkPackageResource;
 
   // We remember when we want to update the query with a given order
-  private queryUpdateRequests = input<string[]>();
-
-  // This mapped observable requests the latest query automatically.
-  private queryLoading = this.queryUpdateRequests
-    .values$()
-    .pipe(
-      // Stream the query request, switchMap will call previous requests to be cancelled
-      switchMap((order:string[]) => this.reorderService.saveOrderInQuery(this.query, order))
-    );
+  private queryUpdates = new RequestSwitchmap(
+    (order:string[]) => this.reorderService.saveOrderInQuery(this.query, order)
+  );
 
   constructor(readonly querySpace:IsolatedQuerySpace,
               readonly states:States,
@@ -109,14 +104,11 @@ export class WorkPackageCardViewComponent  implements OnInit {
     this.registerCreationCallback();
 
     // Keep query loading requests
-    this.queryLoading
-      .pipe(
-        untilComponentDestroyed(this)
-      )
-      .subscribe(
-        undefined,
-        (error:any) => this.wpNotifications.handleRawError(error)
-      );
+    this.queryUpdates
+      .observe(componentDestroyed(this))
+      .subscribe({
+        error: (error:any) => this.wpNotifications.handleRawError(error)
+      });
 
     // Update permission on model updates
     this.authorisationService
@@ -235,7 +227,7 @@ export class WorkPackageCardViewComponent  implements OnInit {
 
     this.workPackages = newOrder.map(id => this.states.workPackages.get(id).value!);
     // Ensure dragged work packages are being removed.
-    this.queryUpdateRequests.putValue(newOrder);
+    this.queryUpdates.request(newOrder);
     this.cdRef.detectChanges();
   }
 

--- a/frontend/src/app/components/wp-edit/wp-notification.service.ts
+++ b/frontend/src/app/components/wp-edit/wp-notification.service.ts
@@ -36,6 +36,7 @@ import {NotificationsService} from 'core-app/modules/common/notifications/notifi
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {HttpErrorResponse} from "@angular/common/http";
 import {WorkPackageCacheService} from "core-components/work-packages/work-package-cache.service";
+import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 
 @Injectable()
 export class WorkPackageNotificationService {
@@ -70,7 +71,7 @@ export class WorkPackageNotificationService {
    * @param response
    * @param workPackage
    */
-  public handleRawError(response:any, workPackage?:WorkPackageResource) {
+  public handleRawError(response:unknown, workPackage?:WorkPackageResource) {
     console.error("Handling error message %O for work package %O", response, workPackage);
 
     // Some transformation may already have returned the error as a HAL resource,
@@ -79,23 +80,10 @@ export class WorkPackageNotificationService {
       return this.handleErrorResponse(response, workPackage);
     }
 
-    // Otherwise, we try to detect what we got, this may either be an HttpErrorResponse,
-    // some older XHR response object or a string
-    let errorBody:any|string|null;
+    const errorBody = this.retrieveError(response);
 
-    // Angular http response have an error body attribute
-    if (response instanceof HttpErrorResponse) {
-      errorBody = response.message || response.error;
-    }
-
-    // Some older response may have a data attribute
-    if (response && response.data && response.data._type === 'Error') {
-      errorBody = response.data;
-    }
-
-    if (errorBody && errorBody._type === 'Error') {
-      const resource = this.halResourceService.createHalResource(errorBody);
-      return this.handleErrorResponse(resource, workPackage);
+    if (errorBody instanceof HalResource) {
+      return this.handleErrorResponse(errorBody, workPackage);
     }
 
     if (typeof(response) === 'string') {
@@ -104,6 +92,46 @@ export class WorkPackageNotificationService {
     }
 
     this.showGeneralError(errorBody || response);
+  }
+
+  /**
+   * Retrieve an error message string from the given unknown response.
+   * @param response
+   */
+  public retrieveErrorMessage(response:unknown):string {
+    const error = this.retrieveError(response);
+
+    if (error instanceof ErrorResource) {
+      return error.message;
+    }
+
+    if (typeof(error) === 'string') {
+      return error;
+    }
+
+    return this.I18n.t('js.error.internal');
+  }
+
+  public retrieveError(response:unknown):ErrorResource|unknown {
+    // we try to detect what we got, this may either be an HttpErrorResponse,
+    // some older XHR response object or a string
+    let errorBody:any;
+
+    // Angular http response have an error body attribute
+    if (response instanceof HttpErrorResponse) {
+      errorBody = response.message || response.error;
+    }
+
+    // Some older response may have a data attribute
+    if (_.get(response, 'data._type') === 'Error') {
+      errorBody = (response as any).data;
+    }
+
+    if (errorBody && errorBody._type === 'Error') {
+      return this.halResourceService.createHalResourceOfClass(ErrorResource, errorBody);
+    }
+
+    return response;
   }
 
   protected handleErrorResponse(errorResource:any, workPackage?:WorkPackageResource) {
@@ -122,11 +150,11 @@ export class WorkPackageNotificationService {
     this.showCustomError(errorResource, workPackage) || this.showApiErrorMessages(errorResource);
   }
 
-  public showGeneralError(message?:string) {
+  public showGeneralError(message?:unknown) {
     let error = this.I18n.t('js.error.internal');
 
-    if (message) {
-      error += ' ' + message;
+    if (typeof(message) === 'string' || _.has(message, 'toString')) {
+      error += ' ' + (message as any).toString();
     }
 
     this.NotificationsService.addError(error);

--- a/frontend/src/app/helpers/rxjs/request-switchmap.ts
+++ b/frontend/src/app/helpers/rxjs/request-switchmap.ts
@@ -1,0 +1,45 @@
+import {Observable, Subject} from "rxjs";
+import {HalResource} from "core-app/modules/hal/resources/hal-resource";
+import {switchMap, takeUntil} from "rxjs/operators";
+
+export type RequestSwitchmapHandler<T, R> = (input:T) => Observable<R>;
+
+export class RequestSwitchmap<T, R = HalResource> {
+
+  /** Input request state */
+  private requests = new Subject<T>();
+
+  /** Output switchmap observable */
+  private responses$ = this.requests
+    .pipe(
+      // Stream the request, switchMap will result in previous requests to be cancelled
+      switchMap(this.handler)
+    );
+
+  /**
+   *
+   * @param handler switch map handler function to output a response observable
+   */
+  constructor(readonly handler:RequestSwitchmapHandler<T, R>) {
+  }
+
+  /**
+   * Append a new request for the given request value and pass
+   * that to the switchmap handler
+   * @param newValue
+   */
+  public request(newValue:T) {
+    this.requests.next(newValue);
+  }
+
+  /**
+   * Observe the switched response
+   */
+  public observe(until:Observable<unknown>) {
+    return this
+      .responses$
+      .pipe(
+        takeUntil(until)
+      );
+  }
+}

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.html
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.html
@@ -47,4 +47,13 @@
       </wp-card-view>
     </div>
   </ng-container>
+  <div class="notification-box -error" *ngIf="loadingError">
+    <p>
+      <span [textContent]="errorMessage"></span>
+      &ngsp;
+      <a role="button" (accessibleClick)="onRemove.emit()">
+        <span [textContent]="text.click_to_remove"></span>
+      </a>
+    </p>
+  </div>
 </div>

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.sass
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.sass
@@ -24,3 +24,8 @@
     flex: 1
     margin-bottom: 0
     margin-right: 0.25rem
+
+.notification-box
+  margin-top: 0
+  // Avoids having to hide the drag&drop handle of the list
+  z-index: 100

--- a/frontend/src/app/modules/boards/board/board.component.ts
+++ b/frontend/src/app/modules/boards/board/board.component.ts
@@ -1,10 +1,10 @@
 import {
-  AfterViewInit,
   Component,
   Injector,
   OnDestroy,
   OnInit,
-  QueryList, ViewChild,
+  QueryList,
+  ViewChild,
   ViewChildren,
   ViewEncapsulation
 } from "@angular/core";
@@ -15,7 +15,7 @@ import {BoardListsService} from "core-app/modules/boards/board/board-list/board-
 import {BoardCacheService} from "core-app/modules/boards/board/board-cache.service";
 import {BoardService} from "core-app/modules/boards/board/board.service";
 import {Board} from "core-app/modules/boards/board/board";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {componentDestroyed, untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {StateService} from "@uirouter/core";
 import {GridWidgetResource} from "core-app/modules/hal/resources/grid-widget-resource";
 import {CdkDragDrop, moveItemInArray} from "@angular/cdk/drag-drop";
@@ -26,7 +26,10 @@ import {DynamicCssService} from "core-app/modules/common/dynamic-css/dynamic-css
 import {BannersService} from "core-app/modules/common/enterprise/banners.service";
 import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-filter-instance-resource";
 import {ApiV3Filter} from "core-components/api/api-v3/api-v3-filter-builder";
+import {RequestSwitchmap} from "core-app/helpers/rxjs/request-switchmap";
+import {from} from "rxjs";
 import {BoardFilterComponent} from "core-app/modules/boards/board/board-filter/board-filter.component";
+import {delay} from "rxjs/operators";
 
 @Component({
   selector: 'board',
@@ -79,6 +82,22 @@ export class BoardComponent implements OnInit, OnDestroy {
     unnamed_list: this.I18n.t('js.boards.label_unnamed_list'),
   };
 
+  // We remember when we want to update the board
+  private boardSaver = new RequestSwitchmap(
+    (board:Board) => {
+      this.inFlight = true;
+      const promise = this.Boards
+        .save(board)
+        .then(board => {
+          this.inFlight = false;
+          return board;
+        })
+        .catch(() => this.inFlight = false);
+
+      return from(promise);
+    }
+  );
+
   trackByQueryId = (index:number, widget:GridWidgetResource) => widget.options.query_id;
 
   constructor(public readonly state:StateService,
@@ -100,6 +119,13 @@ export class BoardComponent implements OnInit, OnDestroy {
   ngOnInit():void {
     const id:string = this.state.params.board_id.toString();
     let initialized = false;
+
+    this.boardSaver
+      .observe(componentDestroyed(this))
+      .subscribe((board:Board) => {
+        this.BoardCache.update(board);
+        this.notifications.addSuccess(this.text.updateSuccessful);
+      });
 
     this.BoardCache
       .observe(id)
@@ -125,30 +151,25 @@ export class BoardComponent implements OnInit, OnDestroy {
   saveWithNameAndFilters(board:Board, newName:string) {
     board.name = newName;
     board.filters = this.filters;
-    return this.saveBoard(board, true);
+
+    let params = { isNew: false, query_props: null };
+    this.state.go('.', params, {custom: {notify: false}});
+
+    this.saveBoard(board);
   }
 
   showError(text = this.text.loadingError) {
     this.notifications.addError(text);
   }
 
-  saveBoard(board:Board, resetFilters = false) {
-    this.inFlight = true;
-    this.Boards
-      .save(board)
-      .then(board => {
-        this.BoardCache.update(board);
-        this.notifications.addSuccess(this.text.updateSuccessful);
-        this.inFlight = false;
-        let params = {isNew: false, query_props: (resetFilters ? null : this.state.params.query_props)};
-        this.state.go('.', params, {custom: {notify: false}});
-      });
+  saveBoard(board:Board):void {
+    this.boardSaver.request(board);
   }
 
   addList(board:Board):any {
     if (board.isFree) {
       return this.BoardList
-        .addFreeQuery(board, {name: this.text.unnamed_list})
+        .addFreeQuery(board, { name: this.text.unnamed_list})
         .then(board => this.Boards.save(board))
         .then(saved => {
           this.BoardCache.update(saved);
@@ -160,19 +181,19 @@ export class BoardComponent implements OnInit, OnDestroy {
       this.opModalService.show(
         AddListModalComponent,
         this.injector,
-        {board: board, queries: queries}
+        { board: board, queries: queries }
       );
     }
   }
 
   moveList(board:Board, event:CdkDragDrop<GridWidgetResource[]>) {
     moveItemInArray(board.queries, event.previousIndex, event.currentIndex);
-    return this.saveBoard(board);
+    this.saveBoard(board);
   }
 
   removeList(board:Board, query:GridWidgetResource) {
     board.removeQuery(query);
-    return this.saveBoard(board);
+    this.saveBoard(board);
   }
 
   public showBoardListView() {
@@ -183,7 +204,7 @@ export class BoardComponent implements OnInit, OnDestroy {
     return board.isFree ? 'boards#free' : 'boards#status';
   }
 
-  public updateFilters(filters:QueryFilterInstanceResource[]) {
+  public updateFilters(filters:ApiV3Filter[]) {
     this.filters = filters;
   }
 }

--- a/frontend/src/app/modules/boards/openproject-boards.module.ts
+++ b/frontend/src/app/modules/boards/openproject-boards.module.ts
@@ -60,7 +60,7 @@ export const BOARDS_ROUTES:Ng2StateDeclaration[] = [
     url: '/boards/?query_props',
     params: {
       // Use custom encoder/decoder that ensures validity of URL string
-      query_props: {type: 'opQueryString'}
+      query_props: { type: 'opQueryString', dynamic: true }
     },
     redirectTo: 'boards.list',
     component: BoardsRootComponent
@@ -77,8 +77,9 @@ export const BOARDS_ROUTES:Ng2StateDeclaration[] = [
     url: '{board_id}',
     params: {
       board_id: {type: 'int'},
-      isNew: {type: 'bool'}
+      isNew: {type: 'bool', dynamic: true}
     },
+    reloadOnSearch: false,
     component: BoardComponent,
     data: {
       parent: 'boards'

--- a/modules/boards/config/locales/js-en.yml
+++ b/modules/boards/config/locales/js-en.yml
@@ -9,6 +9,8 @@ en:
       new_board: 'New board'
       add_list: 'Add list'
       add_card: 'Add card'
+      error_loading_the_list: "Error loading the list: %{error_message}"
+      click_to_remove_list: "Click to remove this list"
       board_type:
         free: 'Free board'
         free_text: >


### PR DESCRIPTION
This ensures that only the latest board request will be saved, avoiding returning with an invalid list. In case a list was removed otherwise (faulty data, view deleted manually) an error is shown in the list and the list can be removed by the user.

https://community.openproject.com/wp/29913