### PR TITLE
[29832] Split whitespace in like query

### DIFF
--- a/app/models/queries/operators/contains.rb
+++ b/app/models/queries/operators/contains.rb
@@ -33,8 +33,13 @@ module Queries::Operators
     set_symbol '~'
 
     def self.sql_for_field(values, db_table, db_field)
+      like_query =
+        values.first.split(/\s+/)
+        .map { |substr| connection.quote_string(substr.downcase) }
+        .join("%")
+
       "COALESCE(LOWER(#{db_table}.#{db_field}), '') LIKE " +
-        "'%#{connection.quote_string(values.first.to_s.downcase)}%'"
+        "'%#{like_query}%'"
     end
   end
 end

--- a/spec/models/queries/work_packages/filter/search_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/search_filter_spec.rb
@@ -69,6 +69,28 @@ describe Queries::WorkPackages::Filter::SearchFilter, type: :model do
     end
   end
 
+  describe 'partial (not fuzzy) match of string in subject (#29832)' do
+    subject { WorkPackage.joins(instance.joins).where(instance.where) }
+    let!(:work_package) { FactoryBot.create(:work_package, subject: "big old cat") }
+
+    it 'finds in subject' do
+      instance.values = ['big cat']
+      is_expected
+        .to match_array [work_package]
+    end
+  end
+
+  describe 'partial match of string in subject and description (#29832)' do
+    subject { WorkPackage.joins(instance.joins).where(instance.where) }
+    let!(:work_package) { FactoryBot.create(:work_package, subject: "big", description: "cat") }
+
+    it 'does not match a partial result currently' do
+      instance.values = ['big cat']
+      is_expected
+        .to match_array []
+    end
+  end
+
   if OpenProject::Database.allows_tsv?
     context 'DB allows tsv' do
       context 'with EE' do


### PR DESCRIPTION
Implements the first requirement of
https://community.openproject.com/wp/29832

- Searching for `big cat` matches a subject of `big old cat`. I believe this is the most pressing missing match
- Searching for `big cat` does NOT match a subject of `big` and a description of `cat`.

A spec has been added to test both cases