### PR TITLE
[29873] Fix parsing of form query params in project context

### DIFF
--- a/frontend/src/app/modules/hal/dm-services/query-form-dm.service.ts
+++ b/frontend/src/app/modules/hal/dm-services/query-form-dm.service.ts
@@ -69,7 +69,7 @@ export class QueryFormDmService {
    * @param projectIdentifier
    * @param payload
    */
-  public loadWithParams(params:{}, queryId:string|undefined, projectIdentifier:string|undefined|null, payload:any = {}):Promise<QueryFormResource> {
+  public loadWithParams(params:{[key:string]:unknown}, queryId:string|undefined, projectIdentifier:string|undefined|null, payload:any = {}):Promise<QueryFormResource> {
     // We need a valid payload so that we
     // can check whether form saving is possible.
     // The query needs a name to be valid.
@@ -82,6 +82,7 @@ export class QueryFormDmService {
       payload._links.project = {
         'href': this.pathHelper.api.v3.projects.id(projectIdentifier).toString()
       };
+
     }
 
     let href:string = this.pathHelper.api.v3.queries.optionalId(queryId).form.toString();

--- a/lib/api/v3/queries/create_form_api.rb
+++ b/lib/api/v3/queries/create_form_api.rb
@@ -37,9 +37,7 @@ module API
           helpers ::API::V3::Queries::QueryHelper
 
           post do
-            query = query_from_params request, current_user: current_user
-
-            create_or_update_query_form query, ::Queries::CreateContract, CreateFormRepresenter
+            create_or_update_query_form Query.new_default, ::Queries::CreateContract, CreateFormRepresenter
           end
         end
       end

--- a/lib/api/v3/queries/filters/query_filter_instance_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_instance_representer.rb
@@ -56,6 +56,8 @@ module API
 
           resource_link :operator,
                         getter: ->(*) {
+                          next if represented.operator.nil?
+
                           hash = {
                             href: api_v3_paths.query_operator(CGI.escape(represented.operator))
                           }


### PR DESCRIPTION
The query params passed to a form were parsed without a project context being present. If we parse them the other way around (payload first, upgrading query string later), the project context is set and e.g.,
project-context CF filters are present.

https://community.openproject.com/wp/29873