### PR TITLE
[29755] Load I18n.js number/date locales to allow formatNumber to be used

### DIFF
--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -1,4 +1,4 @@
 fallbacks: :en
 translations:
   - file: "app/assets/javascripts/locales/%{locale}.js"
-    only: '*.js'
+    only: ['*.js', '*.number.*', '*.time.*', '*.date.*']

--- a/frontend/src/app/angular4-modules.ts
+++ b/frontend/src/app/angular4-modules.ts
@@ -83,6 +83,7 @@ import {DeviceService} from "core-app/modules/common/browser/device.service";
 import {MainMenuToggleService} from "core-components/main-menu/main-menu-toggle.service";
 import {MainMenuToggleComponent} from "core-components/main-menu/main-menu-toggle.component";
 import {MainMenuNavigationService} from "core-components/main-menu/main-menu-navigation.service";
+import {registerLocaleData} from "@angular/common";
 
 @NgModule({
   imports: [
@@ -226,5 +227,20 @@ export function initializeServices(injector:Injector) {
     // Setup query configuration listener
     ExternalQueryConfiguration.setupListener();
     ExternalRelationQueryConfiguration.setupListener();
+
+    // Dynamically load the current locale for Angular
+    const localeId = I18n.locale;
+    try {
+      import(
+        /* webpackInclude: /(zh-TW|af|es|fa|no|ko|nl|zh|hr|he|th|pl|it|cs|pt|bg|vi|pt-BR|tr|de|fil|ar|az|ca|ru|ro|lol|hi|fr|et|ja|el|lt|hu|lv|sv-SE|id|ne-NP|da|uk|fi|sk)\.js$/ */
+        `@angular/common/locales/${localeId}.js`
+      )
+        .then((locale) => {
+          console.log("Got locale for " + localeId);
+          registerLocaleData(locale.default);
+        });
+    } catch (e) {
+      console.error("Failed to get matching locale data for " + localeId);
+    }
   };
 }

--- a/frontend/src/app/modules/common/i18n/i18n.service.ts
+++ b/frontend/src/app/modules/common/i18n/i18n.service.ts
@@ -5,18 +5,47 @@ import {Injectable} from "@angular/core";
  */
 export interface GlobalI18n {
   t(translateId:string, parameters?:any):string;
-  lookup(translateId:string):boolean | undefined;
+
+  lookup(translateId:string):boolean|undefined;
+
+  toNumber(num:number, options?:ToNumberOptions):string;
+
+  toPercentage(num:number, options?:ToPercentageOptions):string;
+
+  toCurrency(num:number, options?:ToCurrencyOptions):string;
+
+  strftime(date:Date, format:string):string;
+
+  toHumanSize(num:number, options?:ToHumanSizeOptions):string;
+
   locale:string;
   firstDayOfWeek:number;
+
 }
+
+interface ToNumberOptions {
+  precision?:number;
+  separator?:string;
+  delimiter?:string;
+  strip_insignificant_zeros?:boolean;
+}
+
+type ToPercentageOptions = ToNumberOptions;
+
+interface ToCurrencyOptions extends ToNumberOptions {
+  format?:string;
+  unit?:string;
+  sign_first?:boolean;
+}
+
+interface ToHumanSizeOptions extends ToNumberOptions {
+  format?:string;
+}
+
 
 @Injectable()
 export class I18nService {
-  private _i18n:GlobalI18n;
-
-  constructor() {
-    this._i18n = (window as any).I18n;
-  }
+  private _i18n:GlobalI18n = (window as any).I18n;
 
   public get locale():string {
     return this._i18n.locale;
@@ -29,5 +58,11 @@ export class I18nService {
   public lookup(translateId:string):boolean|undefined {
     return this._i18n.lookup(translateId);
   }
+
+  public toNumber = this._i18n.toNumber.bind(this._i18n);
+  public toPercentage = this._i18n.toPercentage.bind(this._i18n);
+  public toCurrency = this._i18n.toCurrency.bind(this._i18n);
+  public strftime = this._i18n.strftime.bind(this._i18n);
+  public toHumanSize = this._i18n.toHumanSize.bind(this._i18n);
 
 }

--- a/frontend/src/app/modules/grids/widgets/time-entries-current-user/time-entries-current-user.component.html
+++ b/frontend/src/app/modules/grids/widgets/time-entries-current-user/time-entries-current-user.component.html
@@ -78,7 +78,7 @@
           </td>
           <td class="hours"
               *ngIf="item.sum">
-            <em [textContent]="item.sum  | number : '1.2-2'"></em>
+            <em [textContent]="item.sum"></em>
           </td>
           <td class="buttons">
             <a [href]="editPath(item.entry)"

--- a/frontend/src/app/modules/grids/widgets/time-entries-current-user/time-entries-current-user.component.ts
+++ b/frontend/src/app/modules/grids/widgets/time-entries-current-user/time-entries-current-user.component.ts
@@ -153,12 +153,7 @@ export class WidgetTimeEntriesCurrentUserComponent extends AbstractWidgetCompone
   }
 
   private formatNumber(value:number):string {
-    try {
-      return formatNumber(value, this.i18n.locale, '1.2-2');
-    } catch(e) {
-      console.error("Failed to format number with Angular (missing locale?): " + e);
-      return value.toLocaleString();
-    }
+    return this.i18n.toNumber(value, { precision: 2 });
   }
 
   public get noEntries() {

--- a/frontend/src/test/i18n-shim.ts
+++ b/frontend/src/test/i18n-shim.ts
@@ -16,5 +16,12 @@ export class I18nShim implements GlobalI18n {
   lookup(translateId:string):boolean {
     return false;
   }
+
+  // Return the input for these helpers
+  public toNumber = _.identity;
+  public toPercentage = _.identity;
+  public toCurrency = _.identity;
+  public strftime = _.identity;
+  public toHumanSize = _.identity;
 }
 


### PR DESCRIPTION
This dynamically loads the current locale data for angular upon page load. This allows pipes such as the decimal pipie or the `formatNumber` as in spent-time widget to be used.

If this locale data is not present, the `formatNumber` helper will throw an error with the locale not present.

~~:warning: This adds quite a number of chunks to the build and one request for the current angular locale per page load.~~

https://community.openproject.com/wp/29755