### PR TITLE
[30043] Disable events on touchend similar to mouseup

### DIFF
--- a/frontend/src/app/components/filters/filter-container/filter-container.directive.html
+++ b/frontend/src/app/components/filters/filter-container/filter-container.directive.html
@@ -6,8 +6,9 @@
   <span class="button--text" [textContent]="filterButtonText"></span>
 </button>
 
-<div class="work-packages--filters-optional-container" [hidden]="!visible">
-  <div id="query_form_content" class="hide-when-print">
+<div class="work-packages--filters-optional-container"
+     [ngClass]="{ '-loaded': loaded }">
+  <div id="query_form_content" class="hide-when-print" *ngIf="visible">
     <query-filters *ngIf="!!filters"
                    [filters]="filters"
                    [showCloseFilter]="true"

--- a/frontend/src/app/components/filters/filter-container/filter-container.directive.ts
+++ b/frontend/src/app/components/filters/filter-container/filter-container.directive.ts
@@ -44,6 +44,7 @@ export class WorkPackageFilterContainerComponent implements OnDestroy {
 
   public visible = false;
   public filters = this.wpTableFilters.current;
+  public loaded = false;
 
   constructor(readonly wpTableFilters:WorkPackageTableFiltersService,
               readonly wpFiltersService:WorkPackageFiltersService) {
@@ -51,6 +52,7 @@ export class WorkPackageFilterContainerComponent implements OnDestroy {
       .observeUntil(componentDestroyed(this))
       .subscribe(() => {
         this.filters = this.wpTableFilters.current;
+        this.loaded = true;
     });
 
     this.wpFiltersService

--- a/frontend/src/app/components/filters/query-filters/query-filters.component.ts
+++ b/frontend/src/app/components/filters/query-filters/query-filters.component.ts
@@ -28,7 +28,7 @@
 
 import {WorkPackageTableFiltersService} from '../../wp-fast-table/state/wp-table-filters.service';
 import {WorkPackageFiltersService} from "../../filters/wp-filters/wp-filters.service";
-import {Component, Input, OnChanges, OnDestroy, OnInit, Output} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, OnChanges, OnDestroy, OnInit, Output} from '@angular/core';
 import {QueryFilterInstanceResource} from 'core-app/modules/hal/resources/query-filter-instance-resource';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {componentDestroyed} from 'ng2-rx-componentdestroyed';

--- a/frontend/src/app/modules/common/drag-and-drop/dom-autoscroll.service.ts
+++ b/frontend/src/app/modules/common/drag-and-drop/dom-autoscroll.service.ts
@@ -14,9 +14,6 @@ export class DomAutoscrollService {
   public outerScrollContainer:HTMLElement;
   public point:any;
   public pointCB:any;
-  public onMoved:any;
-  public onMouseUp:any;
-  public onScroll:any;
 
   constructor(elements:Element[],
               params:any) {
@@ -33,21 +30,16 @@ export class DomAutoscrollService {
   }
 
   public init() {
-    this.onMoved =  this.onMove.bind(this);
-    this.onMouseUp =  this.onUp.bind(this);
-    this.onScroll =  this.setScroll.bind(this);
-
-    jQuery(window).on('mousemove touchmove', this.pointCB);
-    jQuery(window).on('mousemove touchmove', this.onMoved);
-    jQuery(window).on('mouseup', this.onMouseUp);
-    jQuery(window).on('scroll', this.onScroll);
+    jQuery(window).on('mousemove.domautoscroll touchmove.domautoscroll', (evt:any) => {
+      this.pointCB(evt);
+      this.onMove(evt);
+    });
+    jQuery(window).on('mouseup.domautoscroll touchend.domautoscroll', () => this.onUp());
+    jQuery(window).on('scroll.domautoscroll', (evt:any) => this.setScroll(evt));
   }
 
   public destroy() {
-    jQuery(window).off('mousemove touchmove', this.pointCB);
-    jQuery(window).off('mousemove touchmove', this.onMoved);
-    jQuery(window).off('mouseup', this.onMouseUp);
-    jQuery(window).off('scroll', this.onScroll);
+    jQuery(window).off('.domautoscroll');
 
     this.elements = [];
     this.cleanAnimation();
@@ -62,7 +54,7 @@ export class DomAutoscrollService {
     cancelAnimationFrame(this.windowAnimationFrame);
   }
 
-  public setScroll(e:Event) {
+  public setScroll(e:any) {
     for (let i = 0; i < this.elements.length; i++) {
       if (this.elements[i] === e.target) {
         this.scrolling = true;
@@ -112,10 +104,14 @@ export class DomAutoscrollService {
     return underPoint;
   }
 
-  public onMove(event:JQueryEventObject) {
-    if (!this.autoScroll()) { return };
+  public onMove(event:any) {
+    if (!this.autoScroll()) {
+      return;
+    }
 
-    if ((event as any).dispatched) { return; }
+    if (event.dispatched) {
+      return;
+    }
 
     let target = [] as HTMLElement[];
     if (event.target !== null) {

--- a/spec/features/accessibility/work_packages/work_package_query_spec.rb
+++ b/spec/features/accessibility/work_packages/work_package_query_spec.rb
@@ -39,9 +39,6 @@ describe 'Work package index accessibility', type: :feature, selenium: true do
 
   def visit_index_page
     work_packages_page.visit_index
-    # ensure the page is loaded before expecting anything
-    expect(page).to have_selector('#operators-status', visible: false),
-                    'Page was not fully loaded'
   end
 
   before do
@@ -51,15 +48,7 @@ describe 'Work package index accessibility', type: :feature, selenium: true do
   end
 
   after do
-    # Ensure that all requests have fired and are answered.  Otherwise one
-    # spec can interfere with the next when a request of the former is still
-    # running in the one process but the other process has already removed
-    # the data in the db to prepare for the next spec.
-    #
-    # Taking an element, that get's activated late in the page setup.
-    expect(page).to have_selector('.advanced-filters--filter label',
-                                  text: I18n.t(:label_status),
-                                  visible: false)
+    work_packages_page.ensure_loaded
   end
 
   describe 'Sort link', js: true do

--- a/spec/features/menu_items/query_menu_item_spec.rb
+++ b/spec/features/menu_items/query_menu_item_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature 'Query menu items', js: true do
     end
 
     after do
-      ensure_wp_table_loaded
+      work_packages_page.ensure_loaded
     end
   end
 
@@ -103,7 +103,7 @@ RSpec.feature 'Query menu items', js: true do
     end
 
     after do
-      ensure_wp_table_loaded
+      work_packages_page.ensure_loaded
     end
 
     it 'displaying a success message' do

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -71,7 +71,8 @@ describe 'work package export', type: :feature do
 
   before do
     work_packages_page.visit_index
-    work_packages_page.click_toolbar_button 'Activate Filter'
+    filters.expect_filter_count 1
+    filters.open
 
     # render the CSV as plain text so we can run expectations against the output
     expect_any_instance_of(WorkPackagesController)

--- a/spec/features/work_packages/select_query_spec.rb
+++ b/spec/features/work_packages/select_query_spec.rb
@@ -37,12 +37,9 @@ describe 'Query selection', type: :feature do
                               member_through_role: role
   end
 
-  let(:filter_1_name) { 'assignee' }
-  let(:filter_2_name) { 'percentageDone' }
-  let(:i18n_filter_1_name) { WorkPackage.human_attribute_name(:assigned_to) }
-  let(:i18n_filter_2_name) { WorkPackage.human_attribute_name(:done_ratio) }
   let(:default_status) { FactoryBot.create(:default_status) }
   let(:wp_page) { ::Pages::WorkPackagesTable.new project }
+  let(:filters) { ::Components::WorkPackages::Filters.new }
 
 
   let(:query) do
@@ -65,20 +62,12 @@ describe 'Query selection', type: :feature do
   context 'default view, without a query selected' do
     before do
       work_packages_page.visit_index
-      # ensure the page is loaded before expecting anything
-      find('.advanced-filters--filters select option', text: /\AAssignee\Z/,
-                                                       visible: false)
+      filters.open
     end
 
     it 'shows the default (status) filter', js: true do
-      work_packages_page.click_toolbar_button 'Activate Filter'
-      expect(work_packages_page.find_filter('status')).to have_content('Status')
-      expect(work_packages_page.find_filter('status'))
-        .to have_select('operators-status', selected: 'open')
-    end
-
-    it 'shows filter count within toggle button', js: true do
-      expect(find_button('Activate Filter')).to have_text /1$/
+      filters.expect_filter_count 1
+      filters.expect_filter_by 'Status', 'open', nil
     end
   end
 
@@ -90,9 +79,9 @@ describe 'Query selection', type: :feature do
     end
 
     it 'shows the saved filters', js: true do
-      work_packages_page.click_toolbar_button 'Activate Filter'
-      expect(work_packages_page.find_filter(filter_1_name)).to have_content(i18n_filter_1_name)
-      expect(work_packages_page.find_filter(filter_2_name)).to have_content(i18n_filter_2_name)
+      filters.open
+      filters.expect_filter_by 'Assignee', 'is',  ['me']
+      filters.expect_filter_by 'Progress (%)', '>=',  ['10'], 'percentageDone'
     end
 
     it 'shows filter count within toggle button', js: true do

--- a/spec/features/work_packages/shared_contexts.rb
+++ b/spec/features/work_packages/shared_contexts.rb
@@ -28,11 +28,6 @@
 
 # Ensure the page is completely loaded before the spec is run.
 # The status filter is loaded very late in the page setup.
-def ensure_wp_table_loaded
-  expect(page).to have_selector('.advanced-filters--filter', visible: false),
-                  'Work package table page was not loaded in time'
-end
-
 shared_context 'ensure wp details pane update done' do
   after do
     raise "Expect to have a let called 'update_user' defining which user \

--- a/spec/features/work_packages/work_packages_page.rb
+++ b/spec/features/work_packages/work_packages_page.rb
@@ -81,10 +81,6 @@ class WorkPackagesPage
     ensure_index_page_loaded
   end
 
-  def find_filter(filter_name)
-    find(".advanced-filters--filters #filter_#{filter_name}")
-  end
-
   def find_subject_field(text = nil)
     if text
       find('#inplace-edit--write-value--subject', text: text)
@@ -111,7 +107,7 @@ class WorkPackagesPage
 
   def ensure_index_page_loaded
     if Capybara.current_driver == Capybara.javascript_driver
-      expect(page).to have_selector('.advanced-filters--filter', visible: :all, wait: 20)
+      expect(page).to have_selector('.work-packages--filters-optional-container.-loaded', visible: :all, wait: 20)
     end
   end
 end


### PR DESCRIPTION
Also avoid heavy computation on filters for every event cycle which fixes / makes https://community.openproject.com/wp/30016 better

https://community.openproject.com/wp/30043
