### PR TITLE
[30070] Change the representation of the WP type

### DIFF
--- a/app/assets/stylesheets/content/_tables.sass
+++ b/app/assets/stylesheets/content/_tables.sass
@@ -164,10 +164,9 @@ th.hidden
   display: none
 
 tr.context-menu-selection,
-tr.-checked,
-tr.-checked.-bright-row
+tr.-checked
   background-color: $table-row-highlighting-color !important
-  &[class*=__hl_row]
+  &[class*=__hl_background]
     outline: $table-row-highlighting-outline-color solid 2px
 
   td

--- a/app/assets/stylesheets/layout/_colors.sass
+++ b/app/assets/stylesheets/layout/_colors.sass
@@ -87,6 +87,13 @@
   a.-dark
     color: white
 
+[class^='__hl_dot_type'],
+[class*=' __hl_dot_type']
+  text-transform: uppercase
+  font-weight: bold
+  &:before
+    display: none !important
+
 [class^='__hl_dot_'],
 [class*=' __hl_dot_']
   &::before

--- a/app/assets/stylesheets/layout/_colors.sass
+++ b/app/assets/stylesheets/layout/_colors.sass
@@ -87,15 +87,17 @@
   a.-dark
     color: white
 
-[class^='__hl_dot_type'],
-[class*=' __hl_dot_type']
+
+// -------------------------- Highlighting colors -----------------------------
+// Inline: type
+[class^='__hl_inline_type'],
+[class*=' __hl_inline_type']
   text-transform: uppercase
   font-weight: bold
-  &:before
-    display: none !important
 
-[class^='__hl_dot_'],
-[class*=' __hl_dot_']
+// Inline: all except type
+[class^='__hl_inline_']:not([class^='__hl_inline_type']),
+[class*=' __hl_inline_']:not([class*='__hl_inline_type'])
   &::before
     content: ''
     display: inline-block
@@ -110,8 +112,8 @@
       height: 10px
 
 @mixin dot_border_width_style
-  [class^='__hl_dot_'],
-  [class*=' __hl_dot_']
+  [class^='__hl_inline_'],
+  [class*=' __hl_inline_']
     &::before
       border-width: 1px
       border-style: solid

--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -206,16 +206,9 @@
     padding-bottom: 3px
     margin-top: 2px
 
-    .work-packages--type-selector:not(.wp-new-top-row--element)
-      [class*='__hl_dot_']::before
-        vertical-align: 1px
-        margin-right: 6px
-
 .work-packages--type-selector:not(.wp-new-top-row--element)
   .wp-table--cell-span
     padding-right: 5px !important
-    &:after
-      content: ':'
 
   // Remove left padding from type
   .wp-edit-field--display-field

--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -66,25 +66,22 @@ module ColorsHelper
       color = entry.color
 
       if color.nil?
-        concat ".__hl_dot_#{name}_#{entry.id}::before { display: none }\n"
+        concat ".__hl_inline_#{name}_#{entry.id}::before { display: none }\n"
         next
       end
 
       styles = color.color_styles
 
-      inline_style = styles.map { |k,v| "#{k}:#{v} !important"}.join(';')
-      row_style = "background-color: #{color.hexcode} !important;"
-
+      background_style = styles.map { |k,v| "#{k}:#{v} !important"}.join(';')
       border_color = color.bright? ? '#555555' : color.hexcode
 
-      concat ".__hl_inl_#{name}_#{entry.id} { #{inline_style}; }\n"
-      binding.pry
       if name === 'type'
-        concat ".__hl_dot_#{name}_#{entry.id} { color: #{color.hexcode} !important;}"
+        concat ".__hl_inline_#{name}_#{entry.id} { color: #{color.hexcode} !important;}"
       else
-        concat ".__hl_dot_#{name}_#{entry.id}::before { #{inline_style}; border-color: #{border_color}; }\n"
+        concat ".__hl_inline_#{name}_#{entry.id}::before { #{background_style}; border-color: #{border_color}; }\n"
       end
-      concat ".__hl_row_#{name}_#{entry.id} { #{row_style}; }\n"
+
+      concat ".__hl_background_#{name}_#{entry.id} { #{background_style}; }\n"
 
       # Mark color as bright through CSS variable
       # so it can be used to add a separate -bright class

--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -78,7 +78,12 @@ module ColorsHelper
       border_color = color.bright? ? '#555555' : color.hexcode
 
       concat ".__hl_inl_#{name}_#{entry.id} { #{inline_style}; }\n"
-      concat ".__hl_dot_#{name}_#{entry.id}::before { #{inline_style}; border-color: #{border_color}; }\n"
+      binding.pry
+      if name === 'type'
+        concat ".__hl_dot_#{name}_#{entry.id} { color: #{color.hexcode} !important;}"
+      else
+        concat ".__hl_dot_#{name}_#{entry.id}::before { #{inline_style}; border-color: #{border_color}; }\n"
+      end
       concat ".__hl_row_#{name}_#{entry.id} { #{row_style}; }\n"
 
       # Mark color as bright through CSS variable

--- a/frontend/src/app/components/op-context-menu/handlers/op-types-context-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/op-types-context-menu.directive.ts
@@ -92,7 +92,7 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger {
         linkText: type.name,
         href: this.$state.href(this.stateName, { type: type.id! }),
         ariaLabel: type.name,
-        class: Highlighting.dotClass('type', type.id!),
+        class: Highlighting.inlineClass('type', type.id!),
         onClick: ($event:JQueryEventObject) => {
           if (LinkHandling.isClickedWithModifier($event)) {
             return false;

--- a/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
@@ -93,7 +93,7 @@ export class WorkPackageStatusDropdownDirective extends OpContextMenuTrigger {
         linkText: status.name,
         postIcon: status.isReadonly ? 'icon-locked' : null,
         postIconTitle: this.I18n.t('js.work_packages.message_work_package_read_only'),
-        class: Highlighting.dotClass('status', status.id!),
+        class: Highlighting.inlineClass('status', status.id!),
         onClick: () => {
           this.updateStatus(status);
           return true;

--- a/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.component.ts
@@ -89,7 +89,7 @@ export class WorkPackageStatusButtonComponent implements OnInit, OnDestroy {
   public get statusHighlightClass() {
     let status = this.status;
     if (!status) { return }
-    return Highlighting.inlineClass('status', status.id!);
+    return Highlighting.backgroundClass('status', status.id!);
   }
 
   public get status():HalResource|undefined {

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -149,7 +149,7 @@ export class WorkPackageCardViewComponent  implements OnInit {
   }
 
   public wpTypeAttribute(wp:WorkPackageResource) {
-    return wp.type.name + ':';
+    return wp.type.name;
   }
 
   public wpSubject(wp:WorkPackageResource) {

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -161,19 +161,19 @@ export class WorkPackageCardViewComponent  implements OnInit {
   }
 
   public typeHighlightingClass(wp:WorkPackageResource) {
-    return this.attributeDotHighlighting('type', wp);
+    return this.attributeHighlighting('type', wp);
   }
 
   private cardHighlighting(wp:WorkPackageResource) {
     if (['status', 'priority', 'type'].includes(this.highlightingMode)) {
-      return Highlighting.rowClass(this.highlightingMode, wp[this.highlightingMode].id);
+      return Highlighting.backgroundClass(this.highlightingMode, wp[this.highlightingMode].id);
     }
     return '';
   }
 
-  private attributeDotHighlighting(type:string, wp:WorkPackageResource) {
+  private attributeHighlighting(type:string, wp:WorkPackageResource) {
     if (this.highlightingMode === 'inline') {
-      return Highlighting.dotClass(type, wp.type.id!);
+      return Highlighting.inlineClass(type, wp.type.id!);
     }
     return '';
   }

--- a/frontend/src/app/components/wp-fast-table/builders/highlighting/highlighting.functions.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/highlighting/highlighting.functions.ts
@@ -1,14 +1,10 @@
 export namespace Highlighting {
-  export function rowClass(property:string, id:string|number) {
-    return `__hl_row_${property}_${id}`;
+  export function backgroundClass(property:string, id:string|number) {
+    return `__hl_background_${property}_${id}`;
   }
 
   export function inlineClass(property:string, id:string|number) {
-    return `__hl_inl_${property}_${id}`;
-  }
-
-  export function dotClass(property:string, id:string|number) {
-    return `__hl_dot_${property}_${id}`;
+    return `__hl_inline_${property}_${id}`;
   }
 
   /**

--- a/frontend/src/app/components/wp-fast-table/builders/highlighting/row-highlight-render-pass.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/highlighting/row-highlight-render-pass.ts
@@ -46,12 +46,7 @@ export class HighlightingRenderPass {
 
       const id = property.id!;
       const element:HTMLElement = this.tablePass.tableBody.children[position] as HTMLElement;
-      element.classList.add(Highlighting.rowClass(highlightAttribute, id));
-
-      // If the applied color is bright, also apply the '-bright-row' class
-      if (Highlighting.isBright(styles, highlightAttribute, id)) {
-        element.classList.add('-bright-row');
-      }
+      element.classList.add(Highlighting.backgroundClass(highlightAttribute, id));
     });
   }
 

--- a/frontend/src/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -370,7 +370,7 @@ export class TimelineCellRenderer {
     }
 
     const id = type.id;
-    element.classList.add(Highlighting.rowClass('type', id!));
+    element.classList.add(Highlighting.backgroundClass('type', id!));
   }
 
   protected assignDate(changeset:WorkPackageChangeset, attributeName:string, value:moment.Moment) {

--- a/frontend/src/app/components/wp-table/wp-table.styles.sass
+++ b/frontend/src/app/components/wp-table/wp-table.styles.sass
@@ -1,14 +1,3 @@
-// Fix colors for bright rows
-.wp-table--row
-  &.-bright-row
-    color: #FFF
-
-    a
-      color: #FFF
-
-    i.icon:before
-      color: #FFF
-
 .wp-table--drag-and-drop-handle
   &:hover
     cursor: move

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -225,7 +225,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
       return '';
     }
     const value = filter.values[0] as HalResource;
-    return Highlighting.rowClass(attribute, value.id!);
+    return Highlighting.backgroundClass(attribute, value.id!);
   }
 
   public get listName() {

--- a/frontend/src/app/modules/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/modules/calendar/wp-calendar/wp-calendar.component.ts
@@ -168,7 +168,7 @@ export class WorkPackagesCalendarController implements OnInit, OnDestroy {
         title: workPackage.subject,
         start: startDate,
         end: endDate,
-        className: `__hl_row_type_${workPackage.type.id}`,
+        className: `__hl_background_type_${workPackage.type.id}`,
         workPackage: workPackage
       };
     });

--- a/frontend/src/app/modules/fields/display/field-types/wp-display-highlighted-resource-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-display-highlighted-resource-field.module.ts
@@ -51,7 +51,7 @@ export class HighlightedResourceDisplayField extends HighlightableDisplayField {
 
   private addHighlight(element:HTMLElement):void {
     if (this.attribute instanceof HalResource) {
-      const hlClass = Highlighting.dotClass(this.name, this.attribute.id!);
+      const hlClass = Highlighting.inlineClass(this.name, this.attribute.id!);
       element.classList.add(hlClass);
     }
   }

--- a/frontend/src/app/modules/global_search/global-search-input.component.html
+++ b/frontend/src/app/modules/global_search/global-search-input.component.html
@@ -47,7 +47,10 @@
           <ng-template #workPackageItemTemplate>
             <div tabindex="-1" class="global-search--option">
               <div class="global-search--option-wrapper" tabindex="-1">
-                <span class="global-search--wp-id __hl_dot_status_{{item.statusId}}" title="{{item.status}}" [ngOptionHighlight]="currentValue"> #{{item.id}} </span>
+                <span class="global-search--wp-id"
+                      title="{{item.status}}"
+                      [ngOptionHighlight]="currentValue"
+                      [ngClass]="statusHighlighting(item.statusId)"> #{{item.id}} </span>
                 <span class="global-search--wp-subject" [ngOptionHighlight]="currentValue"> {{item.subject}} </span>
               </div>
             </div>

--- a/frontend/src/app/modules/global_search/global-search-input.component.ts
+++ b/frontend/src/app/modules/global_search/global-search-input.component.ts
@@ -50,6 +50,7 @@ import {NgSelectComponent} from "@ng-select/ng-select";
 import {debounceTime, distinctUntilChanged} from "rxjs/operators";
 import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {Subject} from "rxjs";
+import {Highlighting} from "core-components/wp-fast-table/builders/highlighting/highlighting.functions";
 
 export const globalSearchSelector = 'global-search-input';
 
@@ -202,6 +203,10 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
     if (this.noResults) {
       this.searchInScope(this.currentScope);
     }
+  }
+
+  public statusHighlighting(statusId:string) {
+    return Highlighting.inlineClass('status', statusId);
   }
 
   // get work packages result list and append it to suggestions

--- a/modules/bcf/app/views/bcf/issues/index.html.erb
+++ b/modules/bcf/app/views/bcf/issues/index.html.erb
@@ -30,7 +30,7 @@
   <div class="bcf--issues">
     <% @issues.each do |issue| %>
       <% status_id = issue.work_package&.status_id %>
-      <% hl_classname = status_id.present? ? "__hl_row_status_#{status_id}" : '' %>
+      <% hl_classname = status_id.present? ? "__hl_background_status_#{status_id}" : '' %>
       <div class="<%= hl_classname %>">
         <p>
         <strong><%= issue.title %></strong>

--- a/modules/boards/spec/features/board_highlighting_spec.rb
+++ b/modules/boards/spec/features/board_highlighting_spec.rb
@@ -84,22 +84,22 @@ describe 'Work Package boards spec', type: :feature, js: true do
 
     # Highlight inline
     board_page.change_board_highlighting 'inline'
-    expect(page).to have_selector('.__hl_dot_type_' + type.id.to_s)
-    expect(page).to have_selector('.__hl_dot_type_' + type2.id.to_s)
+    expect(page).to have_selector('.__hl_inline_type_' + type.id.to_s)
+    expect(page).to have_selector('.__hl_inline_type_' + type2.id.to_s)
 
     # Highlight whole card by priority
     board_page.change_board_highlighting 'entire-card', 'Priority'
-    expect(page).to have_selector('.__hl_row_priority_' + priority.id.to_s)
-    expect(page).to have_selector('.__hl_row_priority_' + priority2.id.to_s)
+    expect(page).to have_selector('.__hl_background_priority_' + priority.id.to_s)
+    expect(page).to have_selector('.__hl_background_priority_' + priority2.id.to_s)
 
     # Highlight whole card by type
     board_page.change_board_highlighting 'entire-card', 'Type'
-    expect(page).to have_selector('.__hl_row_type_' + type.id.to_s)
-    expect(page).to have_selector('.__hl_row_type_' + type2.id.to_s)
+    expect(page).to have_selector('.__hl_background_type_' + type.id.to_s)
+    expect(page).to have_selector('.__hl_background_type_' + type2.id.to_s)
 
     # Disable highlighting
     board_page.change_board_highlighting 'none'
-    expect(page).not_to have_selector('.__hl_row_priority_' + priority.id.to_s)
-    expect(page).not_to have_selector('.__hl_row_priority_' + priority2.id.to_s)
+    expect(page).not_to have_selector('.__hl_background_priority_' + priority.id.to_s)
+    expect(page).not_to have_selector('.__hl_background_priority_' + priority2.id.to_s)
   end
 end

--- a/modules/costs/spec/features/costs_edit_fields_spec.rb
+++ b/modules/costs/spec/features/costs_edit_fields_spec.rb
@@ -41,7 +41,7 @@ describe 'Work Package cost fields', type: :feature, js: true do
     wp_table.visit!
     wp_table.expect_no_work_package_listed
 
-    split_create.click_create_wp_button type_task.name
+    split_create.click_create_wp_button type_task
     split_create.expect_fully_loaded
 
     expect(page).to have_selector('.wp-edit-field--container.costObject')

--- a/spec/features/work_package_show_spec.rb
+++ b/spec/features/work_package_show_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'Work package show page', selenium: true do
 
     wp_page.visit!
 
-    wp_page.expect_attributes type: work_package.type.name,
+    wp_page.expect_attributes type: work_package.type.name.upcase,
                               status: work_package.status.name,
                               priority: work_package.priority.name,
                               assignee: work_package.assigned_to.name,

--- a/spec/features/work_packages/custom_actions_spec.rb
+++ b/spec/features/work_packages/custom_actions_spec.rb
@@ -424,7 +424,7 @@ describe 'Custom actions', type: :feature, js: true do
 
     wp_page.expect_attributes assignee: '-',
                               status: rejected_status.name,
-                              type: other_type.name,
+                              type: other_type.name.upcase,
                               "customField#{date_custom_field.id}" => (Date.today + 5.days).strftime('%m/%d/%Y')
     expect(page)
       .to have_content(I18n.t('js.project.work_package_belongs_to', projectname: other_project.name))

--- a/spec/features/work_packages/details/milestones_spec.rb
+++ b/spec/features/work_packages/details/milestones_spec.rb
@@ -32,7 +32,7 @@ describe 'Milestones full screen v iew', js: true do
       expect(button['disabled']).to be_falsey
 
       button.click
-      expect(page).to have_selector('.menu-item', text: type.name)
+      expect(page).to have_selector('.menu-item', text: type.name.upcase)
     end
   end
 

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -122,7 +122,7 @@ describe 'edit work package', js: true do
                               status: status2.name,
                               description: 'a new description'
 
-    wp_page.expect_attributes type: type2.name,
+    wp_page.expect_attributes type: type2.name.upcase,
                               responsible: manager.name,
                               assignee: manager.name,
                               startDate: '03/04/2013',

--- a/spec/features/work_packages/highlighting_spec.rb
+++ b/spec/features/work_packages/highlighting_spec.rb
@@ -132,8 +132,8 @@ describe 'Work Package highlighting fields',
     expect(query.highlighting_mode).to eq(:status)
 
     ## This disables any inline styles
-    expect(page).to have_no_selector('[class*="__hl_inlinestatus"]')
-    expect(page).to have_no_selector('[class*="__hl_inlinepriority"]')
+    expect(page).to have_no_selector('[class*="__hl_inline_status"]')
+    expect(page).to have_no_selector('[class*="__hl_inline_priority"]')
     expect(page).to have_no_selector('[class*="__hl_date"]')
 
     # Highlight entire row by priority
@@ -156,15 +156,15 @@ describe 'Work Package highlighting fields',
     expect(query.highlighting_mode).to eq(:priority)
 
     ## This disables any inline styles
-    expect(page).to have_no_selector('[class*="__hl_inlinestatus"]')
-    expect(page).to have_no_selector('[class*="__hl_inlinepriority"]')
+    expect(page).to have_no_selector('[class*="__hl_inline_status"]')
+    expect(page).to have_no_selector('[class*="__hl_inline_priority"]')
     expect(page).to have_no_selector('[class*="__hl_date"]')
 
     # No highlighting
     highlighting.switch_highlighting_mode 'No highlighting'
     expect(page).to have_no_selector('[class*="__hl_background"]')
-    expect(page).to have_no_selector('[class*="__hl_inlinestatus"]')
-    expect(page).to have_no_selector('[class*="__hl_inlinepriority"]')
+    expect(page).to have_no_selector('[class*="__hl_background_status"]')
+    expect(page).to have_no_selector('[class*="__hl_background_priority"]')
     expect(page).to have_no_selector('[class*="__hl_date"]')
 
     # Save query
@@ -175,7 +175,7 @@ describe 'Work Package highlighting fields',
 
     # Expect highlighted fields in single view even when table disabled
     wp_table.open_full_screen_by_doubleclick wp_1
-    expect(page).to have_selector(".wp-status-button .__hl_inlinestatus_#{status1.id}")
+    expect(page).to have_selector(".wp-status-button .__hl_background_status_#{status1.id}")
     expect(page).to have_selector(".__hl_inline_priority_#{priority1.id}")
   end
 end

--- a/spec/features/work_packages/highlighting_spec.rb
+++ b/spec/features/work_packages/highlighting_spec.rb
@@ -59,21 +59,21 @@ describe 'Work Package highlighting fields',
 
     ## Status
     expect(SelectorHelpers.get_pseudo_class_property(page,
-                                                     wp1_row.find('[class^="__hl_dot_status_"]'),
+                                                     wp1_row.find('[class^="__hl_inline_status_"]'),
                                                      ':before',
                                                      "background-color")).to eq('rgb(255, 0, 0)')
     expect(SelectorHelpers.get_pseudo_class_property(page,
-                                                     wp2_row.find('[class^="__hl_dot_status_"]'),
+                                                     wp2_row.find('[class^="__hl_inline_status_"]'),
                                                      ':before',
                                                      "background-color")).to eq('rgb(240, 240, 240)')
 
     ## Priority
     expect(SelectorHelpers.get_pseudo_class_property(page,
-                                                     wp1_row.find('[class^="__hl_dot_priority_"]'),
+                                                     wp1_row.find('[class^="__hl_inline_priority_"]'),
                                                      ':before',
                                                      "background-color")).to eq('rgb(18, 52, 86)')
     expect(SelectorHelpers.get_pseudo_class_property(page,
-                                                     wp2_row.find('[class^="__hl_dot_priority_"]'),
+                                                     wp2_row.find('[class^="__hl_inline_priority_"]'),
                                                      ':before',
                                                      "background-color")).to eq('rgba(0, 0, 0, 0)')
 
@@ -89,33 +89,33 @@ describe 'Work Package highlighting fields',
 
     ## Priority should have a dot
     expect(SelectorHelpers.get_pseudo_class_property(page,
-                                                     wp1_row.find('[class^="__hl_dot_priority_"]'),
+                                                     wp1_row.find('[class^="__hl_inline_priority_"]'),
                                                      ':before',
                                                      "background-color")).to eq('rgb(18, 52, 86)')
     expect(SelectorHelpers.get_pseudo_class_property(page,
-                                                     wp2_row.find('[class^="__hl_dot_priority_"]'),
+                                                     wp2_row.find('[class^="__hl_inline_priority_"]'),
                                                      ':before',
                                                      "background-color")).to eq('rgba(0, 0, 0, 0)')
 
     ## Status should not have a dot
-    expect(wp1_row).not_to have_selector('.status [class^="__hl_dot_"]')
+    expect(wp1_row).not_to have_selector('.status [class^="__hl_inline_"]')
 
     # Highlight multiple attributes
     highlighting.switch_inline_attribute_highlight "Priority", "Status"
     wp1_row = wp_table.row(wp_1)
     expect(SelectorHelpers.get_pseudo_class_property(page,
-                                                     wp1_row.find('[class^="__hl_dot_priority_"]'),
+                                                     wp1_row.find('[class^="__hl_inline_priority_"]'),
                                                      ':before',
                                                      "background-color")).to eq('rgb(18, 52, 86)')
     expect(SelectorHelpers.get_pseudo_class_property(page,
-                                                     wp1_row.find('[class^="__hl_dot_status_"]'),
+                                                     wp1_row.find('[class^="__hl_inline_status_"]'),
                                                      ':before',
                                                      "background-color")).to eq('rgb(255, 0, 0)')
 
     # Highlight entire row by status
     highlighting.switch_entire_row_highlight 'Status'
-    expect(page).to have_selector("#{wp_table.row_selector(wp_1)}.__hl_row_status_#{status1.id}")
-    expect(page).to have_selector("#{wp_table.row_selector(wp_2)}.__hl_row_status_#{status2.id}")
+    expect(page).to have_selector("#{wp_table.row_selector(wp_1)}.__hl_background_status_#{status1.id}")
+    expect(page).to have_selector("#{wp_table.row_selector(wp_2)}.__hl_background_status_#{status2.id}")
 
     # Unselect all rows to ensure we get the correct background
     find('body').send_keys [:control, 'd']
@@ -132,14 +132,14 @@ describe 'Work Package highlighting fields',
     expect(query.highlighting_mode).to eq(:status)
 
     ## This disables any inline styles
-    expect(page).to have_no_selector('[class*="__hl_inl_status"]')
-    expect(page).to have_no_selector('[class*="__hl_inl_priority"]')
+    expect(page).to have_no_selector('[class*="__hl_inlinestatus"]')
+    expect(page).to have_no_selector('[class*="__hl_inlinepriority"]')
     expect(page).to have_no_selector('[class*="__hl_date"]')
 
     # Highlight entire row by priority
     highlighting.switch_entire_row_highlight 'Priority'
-    expect(page).to have_selector("#{wp_table.row_selector(wp_1)}.__hl_row_priority_#{priority1.id}")
-    expect(page).to have_selector("#{wp_table.row_selector(wp_2)}.__hl_row_priority_#{priority_no_color.id}")
+    expect(page).to have_selector("#{wp_table.row_selector(wp_1)}.__hl_background_priority_#{priority1.id}")
+    expect(page).to have_selector("#{wp_table.row_selector(wp_2)}.__hl_background_priority_#{priority_no_color.id}")
 
     # Remove selection from table row
     find('body').send_keys [:control, 'd']
@@ -156,15 +156,15 @@ describe 'Work Package highlighting fields',
     expect(query.highlighting_mode).to eq(:priority)
 
     ## This disables any inline styles
-    expect(page).to have_no_selector('[class*="__hl_inl_status"]')
-    expect(page).to have_no_selector('[class*="__hl_inl_priority"]')
+    expect(page).to have_no_selector('[class*="__hl_inlinestatus"]')
+    expect(page).to have_no_selector('[class*="__hl_inlinepriority"]')
     expect(page).to have_no_selector('[class*="__hl_date"]')
 
     # No highlighting
     highlighting.switch_highlighting_mode 'No highlighting'
-    expect(page).to have_no_selector('[class*="__hl_row"]')
-    expect(page).to have_no_selector('[class*="__hl_inl_status"]')
-    expect(page).to have_no_selector('[class*="__hl_inl_priority"]')
+    expect(page).to have_no_selector('[class*="__hl_background"]')
+    expect(page).to have_no_selector('[class*="__hl_inlinestatus"]')
+    expect(page).to have_no_selector('[class*="__hl_inlinepriority"]')
     expect(page).to have_no_selector('[class*="__hl_date"]')
 
     # Save query
@@ -175,7 +175,7 @@ describe 'Work Package highlighting fields',
 
     # Expect highlighted fields in single view even when table disabled
     wp_table.open_full_screen_by_doubleclick wp_1
-    expect(page).to have_selector(".wp-status-button .__hl_inl_status_#{status1.id}")
-    expect(page).to have_selector(".__hl_dot_priority_#{priority1.id}")
+    expect(page).to have_selector(".wp-status-button .__hl_inlinestatus_#{status1.id}")
+    expect(page).to have_selector(".__hl_inline_priority_#{priority1.id}")
   end
 end

--- a/spec/features/work_packages/new/attributes_from_filter_spec.rb
+++ b/spec/features/work_packages/new/attributes_from_filter_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature 'Work package create uses attributes from filters', js: true, sele
     end
 
     it 'allows to save with a single value (Regression test #27833)' do
-      split_page = wp_table.create_wp_split_screen type_task.name
+      split_page = wp_table.create_wp_split_screen type_task
 
       subject = split_page.edit_field(:subject)
       subject.expect_active!

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -72,7 +72,7 @@ describe 'new work package', js: true do
 
   shared_examples 'work package creation workflow' do
     before do
-      create_method.call('Task', project.name)
+      create_method.call(type_task, project.name)
 
       expect(page).to have_selector(safeguard_selector, wait: 10)
     end
@@ -89,10 +89,10 @@ describe 'new work package', js: true do
 
       subject_field.expect_state_text(subject)
 
-      create_method.call('Bug', project.name)
+      create_method.call(type_bug, project.name)
       expect(page).to have_selector(safeguard_selector, wait: 10)
 
-      type_field.expect_state_text 'Bug'
+      type_field.expect_state_text type_bug.name
     end
 
     it 'saves the work package with enter' do
@@ -142,12 +142,12 @@ describe 'new work package', js: true do
         wp_page.subject_field.set(subject)
         type_field.activate!
         type_field.openSelectField
-        type_field.set_value 'Bug'
+        type_field.set_value type_bug.name
 
         save_work_package!
 
         wp_page.expect_attributes subject: subject
-        wp_page.expect_attributes type: 'Bug'
+        wp_page.expect_attributes type: type_bug.name.upcase
       end
 
       context 'custom fields' do
@@ -217,7 +217,7 @@ describe 'new work package', js: true do
     it 'reloads the table and selects the new work package' do
       expect(page).to have_no_selector('.wp--row')
 
-      create_work_package('Task', project.name)
+      create_work_package(type_task, project.name)
       expect(page).to have_selector(safeguard_selector, wait: 10)
 
       wp_page.subject_field.set('new work package')

--- a/spec/features/work_packages/table/inline_create/parallel_creation_spec.rb
+++ b/spec/features/work_packages/table/inline_create/parallel_creation_spec.rb
@@ -36,7 +36,7 @@ describe 'Parallel work package creation spec', js: true do
     subject_field.set_value subject
 
     # Create in split screen
-    split = wp_table.create_wp_split_screen type.name
+    split = wp_table.create_wp_split_screen type
     description_field = WorkPackageEditorField.new split, 'description'
     description_field.expect_active!
     description_field.set_value description

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -242,7 +242,7 @@ describe 'Switching types in work package table', js: true do
     end
 
     it 'can switch to the bug type without errors' do
-      type_field.expect_state_text type_task.name
+      type_field.expect_state_text type_task.name.upcase
       type_field.update type_bug.name
 
       # safegurards
@@ -250,7 +250,7 @@ describe 'Switching types in work package table', js: true do
       wp_page.dismiss_notification!
       wp_page.expect_no_notification message: 'Successful update.'
 
-      type_field.expect_state_text type_bug.name
+      type_field.expect_state_text type_bug.name.upcase
 
       work_package.reload
       expect(work_package.type_id).to eq(type_bug.id)

--- a/spec/features/work_packages/timeline/timeline_labels_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_labels_spec.rb
@@ -120,13 +120,13 @@ RSpec.feature 'Work package timeline labels',
     # Check overriden labels
     row = wp_timeline.timeline_row work_package.id
     row.expect_labels left: user.name,
-                      right: type.name,
+                      right: type.name.upcase,
                       farRight: work_package.status.name
 
     # Check default labels (milestone)
     row = wp_timeline.timeline_row milestone_work_package.id
     row.expect_labels left: '-',
-                      right: milestone_type.name,
+                      right: milestone_type.name.upcase,
                       farRight: milestone_work_package.status.name
 
     # Save the query
@@ -147,13 +147,13 @@ RSpec.feature 'Work package timeline labels',
     # Check overridden labels
     row = wp_timeline.timeline_row work_package.id
     row.expect_labels left: user.name,
-                      right: type.name,
+                      right: type.name.upcase,
                       farRight: work_package.status.name
 
     # Check overridden labels (milestone)
     row = wp_timeline.timeline_row milestone_work_package.id
     row.expect_labels left: '-',
-                      right: milestone_type.name,
+                      right: milestone_type.name.upcase,
                       farRight: milestone_work_package.status.name
 
     # Set labels to start|due|subject

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -264,11 +264,11 @@ module Pages
     def click_create_wp_button(type)
       find('.add-work-package:not([disabled])', text: 'Create').click
 
-      find('#types-context-menu .menu-item', text: type, wait: 10).click
+      find('#types-context-menu .menu-item', text: type.name.upcase, wait: 10).click
     end
 
     def select_type(type)
-      find(@type_field_selector + ' option', text: type).select_option
+      find(@type_field_selector + ' option', text: type.name.upcase).select_option
     end
 
     def subject_field

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -124,7 +124,7 @@ module Pages
     def create_wp_split_screen(type)
       click_wp_create_button
 
-      find('#types-context-menu .menu-item', text: type, wait: 10).click
+      find('#types-context-menu .menu-item', text: type.name.upcase, wait: 10).click
 
       SplitWorkPackageCreate.new(project: project)
     end
@@ -137,14 +137,14 @@ module Pages
       click_wp_create_button
 
       expect(page)
-        .to have_selector('#types-context-menu .menu-item', text: type.name)
+        .to have_selector('#types-context-menu .menu-item', text: type.name.upcase)
     end
 
     def expect_type_not_available_for_create(type)
       click_wp_create_button
 
       expect(page)
-        .to have_no_selector('#types-context-menu .menu-item', text: type.name)
+        .to have_no_selector('#types-context-menu .menu-item', text: type.name.upcase)
     end
 
     def open_split_view(work_package)


### PR DESCRIPTION
Apply new highlighting style for WP type.

Thereby the number of highlighting possibilities was reduced to `inline` (previously `dot`) and `background` (previously `inline` and `row` which were basically the same). 

https://community.openproject.com/projects/openproject/work_packages/30070/activity