### PR TITLE
bump livingstyleguide and remove sass/sass-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -165,7 +165,6 @@ gem 'autoprefixer-rails', '~> 9.4.5'
 # use until proper release no longer requiring sass exists
 gem 'bourbon', git: 'https://github.com/sikachu/bourbon', ref: 'a12ca168e74d3468c80500b21b525a4e12a19ef9'
 gem 'i18n-js', '~> 3.2.0'
-gem 'sass-rails'
 gem 'sassc-rails', '~> 2.1.0'
 gem 'sprockets', '~> 3.7.0'
 
@@ -249,7 +248,7 @@ end
 group :development do
   gem 'faker'
   gem 'letter_opener'
-  gem 'livingstyleguide', '~> 2.0.1'
+  gem 'livingstyleguide', '~> 2.1.0'
 
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,7 +464,7 @@ GEM
     faker (1.9.1)
       i18n (>= 0.7)
     fastimage (2.1.5)
-    ffi (1.9.25)
+    ffi (1.10.0)
     flamegraph (0.9.5)
     fog-aws (3.3.0)
       fog-core (~> 2.1)
@@ -547,10 +547,10 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.7.0)
       launchy (~> 2.2)
-    livingstyleguide (2.0.3)
+    livingstyleguide (2.1.0)
       minisyntax (>= 0.2.5)
       redcarpet
-      sass
+      sassc
       thor
       tilt
     lobby_boy (0.1.3)
@@ -718,9 +718,6 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.0)
     rake (12.3.2)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     rbtree (0.4.2)
     rdoc (6.1.1)
     redcarpet (3.4.0)
@@ -799,19 +796,8 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
-    sass (3.7.3)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
-    sassc (2.0.0)
-      ffi (~> 1.9.6)
+    sassc (2.0.1)
+      ffi (~> 1.9)
       rake
     sassc-rails (2.1.0)
       railties (>= 4.0.0)
@@ -972,7 +958,7 @@ DEPENDENCIES
   ladle
   launchy (~> 2.4.3)
   letter_opener
-  livingstyleguide (~> 2.0.1)
+  livingstyleguide (~> 2.1.0)
   lograge (~> 0.10.0)
   meta-tags (~> 2.11.0)
   multi_json (~> 1.13.1)
@@ -1052,7 +1038,6 @@ DEPENDENCIES
   ruby-progressbar (~> 1.10.0)
   rubytree!
   sanitize (~> 5.0.0)
-  sass-rails
   sassc-rails (~> 2.1.0)
   secure_headers (~> 6.0.0)
   selenium-webdriver (~> 3.14)

--- a/app/assets/stylesheets/styleguide.html.lsg
+++ b/app/assets/stylesheets/styleguide.html.lsg
@@ -1,4 +1,4 @@
-@require sass
+@require sassc
 
 @sass ../stylesheets/openproject.sass
 @title "Living Style Guide for OpenProject"
@@ -9,59 +9,70 @@
 
 @default preprocessor: sass
 
-@sass
-  .livingstyleguide--header
-    @include grid-content
+@css
+  .livingstyleguide--header {
+    @include grid-content;
+  }
 
-  .livingstyleguide--footer
-    @include grid-content
+  .livingstyleguide--footer {
+    @include grid-content;
+  }
 
-  .livingstyleguide--intro
-    @include grid-content
+  .livingstyleguide--intro {
+    @include grid-content;
+  }
 
-  .styleguide-banner
-    height:  280px
-    padding: 200px 0 0
-    background: url('/assets/styleguide/logo_openproject.png')
-    background-position: top center
-    background-repeat: no-repeat
+  .styleguide-banner {
+    height:  280px;
+    padding: 200px 0 0;
+    background: url('/assets/styleguide/logo_openproject.png');
+    background-position: top center;
+    background-repeat: no-repeat;
+  }
 
-  .styleguide-banner--text
-    text-align: center
+  .styleguide-banner--text {
+    text-align: center;
+  }
 
-  .styleguide-nav--menu-items
-    @extend %menu-bar
-    @include menu-bar-layout
-    @include menu-bar-style(#eee)
+  .styleguide-nav--menu-items {
+    @extend %menu-bar;
+    @include menu-bar-layout;
+    @include menu-bar-style(#eee);
+  }
 
-  .livingstyleguide--code-block
-    max-height: 300px
+  .livingstyleguide--code-block {
+    max-height: 300px;
+  }
 
-  .livingstyleguide--example
-    overflow: visible
+  .livingstyleguide--example {
+    overflow: visible;
+  }
 
-  .lsg-search-box
-    width: 40%
-    margin: 0 auto
+  .lsg-search-box {
+    width: 40%;
+    margin: 0 auto;
+  }
 
-  .icon-list
-    display: flex
-    flex-flow: row wrap
-    width: 640px
-    margin: 0 auto
+  .icon-list {
+    display: flex;
+    flex-flow: row wrap;
+    width: 640px;
+    margin: 0 auto;
+  }
 
-    li
-      flex: 1
-      flex-basis: 15%
-      display: block
-      text-align: center
-      margin: 10px
-      font-size: 12px
+  .icon-list li {
+      flex: 1;
+      flex-basis: 15%;
+      display: block;
+      text-align: center;
+      margin: 10px;
+      font-size: 12px;
+  }
 
-    span
-      display: block
-      font-size: 30px
-
+  .icon-list .span {
+      display: block;
+      font-size: 30px;
+  }
 
 @header
   <header class="livingstyleguide--header">
@@ -91,7 +102,7 @@
 
 @footer
   <footer class="livingstyleguide--footer">
-    Copyright © 2015 OpenProject - All rights reserved.
+    Copyright © 2019 OpenProject - All rights reserved.
   </footer>
 
 @import ../stylesheets/**/_*.lsg


### PR DESCRIPTION
Removes the dependency on sass/sass-rails altogether by bumping
livingingstyleguide to the version relying on sassc/sassc-rails.

Because livingstyleguide does a poor job of being compatible to sassc, a
custom templte class is necessary and the `@sass style` directive can no
longer be used within the styleguide file.