### PR TITLE
[29683] Fix order statements of CF list

### DIFF
--- a/app/models/custom_field/order_statements.rb
+++ b/app/models/custom_field/order_statements.rb
@@ -33,16 +33,17 @@ module CustomField::OrderStatements
   # Returns false, if the custom field can not be used for sorting.
   def order_statements
     case field_format
-    when 'string', 'text', 'list', 'date', 'bool'
+    when 'list'
+      if multi_value?
+        [select_custom_values_joined_options_as_group]
+      else
+        [select_custom_option_position]
+      end
+    when 'string', 'text', 'date', 'bool'
       if multi_value?
         [select_custom_values_as_group]
       else
-        # COALESCE is here to make sure that blank and NULL values are sorted equally
-        [
-          <<-SQL
-          COALESCE(#{select_custom_value_as_string}, '')
-          SQL
-        ]
+        coalesce_select_custom_value_as_string
       end
     when 'int', 'float'
       # Make the database cast values into numeric
@@ -60,7 +61,30 @@ module CustomField::OrderStatements
     end
   end
 
+  # Returns the grouping result
+  # which differ for multi-value select fields,
+  # because in this case we do want the primary CV values
+  def group_by_statements
+    return order_statements unless field_format == 'list'
+
+    if multi_value?
+      # We want to return the internal IDs in the case of grouping
+      [select_custom_values_as_group]
+    else
+      coalesce_select_custom_value_as_string
+    end
+  end
+
   private
+
+  def coalesce_select_custom_value_as_string
+    # COALESCE is here to make sure that blank and NULL values are sorted equally
+    [
+      <<-SQL
+          COALESCE(#{select_custom_value_as_string}, '')
+      SQL
+    ]
+  end
 
   def select_custom_value_as_string
     <<-SQL
@@ -68,6 +92,18 @@ module CustomField::OrderStatements
         WHERE cv_sort.customized_type='#{self.class.customized_class.name}'
         AND cv_sort.customized_id=#{self.class.customized_class.table_name}.id
         AND cv_sort.custom_field_id=#{id} LIMIT 1)
+    SQL
+  end
+
+  def select_custom_option_position
+    <<-SQL
+    (SELECT co_sort.position FROM #{CustomOption.table_name} co_sort
+        LEFT JOIN #{CustomValue.table_name} cv_sort
+        ON co_sort.id = CAST(cv_sort.value AS decimal(60,3))
+        WHERE cv_sort.custom_field_id=#{id}
+        AND cv_sort.customized_id=#{self.class.customized_class.table_name}.id
+        LIMIT 1
+    )
     SQL
   end
 
@@ -81,6 +117,25 @@ module CustomField::OrderStatements
 
     <<-SQL
       COALESCE((SELECT #{aggr_sql} FROM #{CustomValue.table_name} cv_sort
+        WHERE cv_sort.customized_type='#{self.class.customized_class.name}'
+          AND cv_sort.customized_id=#{self.class.customized_class.table_name}.id
+          AND cv_sort.custom_field_id=#{id}
+          AND cv_sort.value IS NOT NULL), '')
+    SQL
+  end
+
+  def select_custom_values_joined_options_as_group
+    aggr_sql =
+      if OpenProject::Database.mysql?
+        "GROUP_CONCAT(co_sort.value SEPARATOR '.')"
+      else
+        "string_agg(co_sort.value, '.' ORDER BY co_sort.position ASC)"
+      end
+
+    <<-SQL
+      COALESCE((SELECT #{aggr_sql} FROM #{CustomOption.table_name} co_sort
+        LEFT JOIN #{CustomValue.table_name} cv_sort
+        ON co_sort.id = CAST(cv_sort.value AS decimal(60,3))
         WHERE cv_sort.customized_type='#{self.class.customized_class.name}'
           AND cv_sort.customized_id=#{self.class.customized_class.table_name}.id
           AND cv_sort.custom_field_id=#{id}

--- a/app/models/queries/work_packages/columns/custom_field_column.rb
+++ b/app/models/queries/work_packages/columns/custom_field_column.rb
@@ -49,7 +49,7 @@ class Queries::WorkPackages::Columns::CustomFieldColumn < Queries::WorkPackages:
   end
 
   def set_groupable!(custom_field)
-    self.groupable = custom_field.order_statements if groupable_custom_field?(custom_field)
+    self.groupable = custom_field.group_by_statements if groupable_custom_field?(custom_field)
     self.groupable ||= false
   end
 

--- a/spec/features/custom_fields/multi_value_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_value_custom_field_spec.rb
@@ -1,15 +1,16 @@
 require "spec_helper"
 require "support/pages/work_packages/abstract_work_package"
 
-describe "multi select custom values", js: true do
+describe "multi select custom values", clear_cache: true, js: true do
   let(:type) { FactoryBot.create :type }
   let(:project) { FactoryBot.create :project, types: [type] }
+  let(:multi_value) { true }
 
   let(:custom_field) do
     FactoryBot.create(
       :list_wp_custom_field,
       name: "Ingredients",
-      multi_value: true,
+      multi_value: multi_value,
       types: [type],
       projects: [project],
       possible_values: ["ham", "onions", "pineapple", "mushrooms"]
@@ -20,31 +21,41 @@ describe "multi select custom values", js: true do
     custom_field.custom_options.find { |co| co.value == str }.try(:id)
   end
 
+  def table_edit_field(work_package)
+    field = wp_table.edit_field work_package, "customField#{custom_field.id}"
+    field.field_type = 'ng-select'
+    field
+  end
+
   let(:wp_page) { Pages::FullWorkPackage.new work_package }
   let(:wp_table) { Pages::WorkPackagesTable.new project }
   let(:hierarchy) { ::Components::WorkPackages::Hierarchies.new }
   let(:columns) { ::Components::WorkPackages::Columns.new }
   let(:group_by) { ::Components::WorkPackages::GroupBy.new }
+  let(:sort_by) { ::Components::WorkPackages::SortBy.new }
 
   let(:user) { FactoryBot.create :admin }
+  let(:cf_frontend) { "customField#{custom_field.id}"}
 
   context "with existing custom values" do
+    let(:work_package_options) { %w[ham pineapple onions] }
     let(:work_package) do
-      wp = FactoryBot.build :work_package, project: project, type: type
+      wp = FactoryBot.build :work_package, project: project, type: type, subject: 'First'
 
       wp.custom_field_values = {
-        custom_field.id => ["ham", "pineapple", "onions"].map { |s| custom_value_for(s) }
+        custom_field.id => work_package_options.map { |s| custom_value_for(s) }
       }
 
       wp.save
       wp
     end
 
+    let(:work_package2_options) { %w[ham] }
     let(:work_package2) do
-      wp = FactoryBot.build :work_package, project: project, type: type
+      wp = FactoryBot.build :work_package, project: project, type: type, subject: 'Second'
 
       wp.custom_field_values = {
-        custom_field.id => ["ham"].map { |s| custom_value_for(s) }
+        custom_field.id => work_package2_options.map { |s| custom_value_for(s) }
       }
 
       wp.save
@@ -90,11 +101,7 @@ describe "multi select custom values", js: true do
     end
 
     describe 'in the WP table' do
-      let(:table_edit_field) do
-        field = wp_table.edit_field work_package, "customField#{custom_field.id}"
-        field.field_type = 'ng-select'
-        field
-      end
+      let(:wp1_field) { table_edit_field(work_package) }
 
       before do
         work_package
@@ -127,12 +134,12 @@ describe "multi select custom values", js: true do
         expect(page).to have_selector('.group--value', text: 'ham, onions, pineapple (1)')
         expect(page).to have_selector('.group--value', text: 'ham (1)')
 
-        table_edit_field.activate!
+        wp1_field.activate!
 
-        table_edit_field.unset_value "pineapple", true
-        table_edit_field.unset_value "onions", true
+        wp1_field.unset_value "pineapple", true
+        wp1_field.unset_value "onions", true
 
-        table_edit_field.submit_by_dashboard
+        wp1_field.submit_by_dashboard
 
         # Expect changed groups
         expect(page).to have_selector('.group--value .count', count: 1)
@@ -148,7 +155,7 @@ describe "multi select custom values", js: true do
 
         # Expect none selected in split and table
         field.expect_state_text '-'
-        table_edit_field.expect_state_text '-'
+        wp1_field.expect_state_text '-'
 
         # Activate again
         field.activate!
@@ -160,7 +167,7 @@ describe "multi select custom values", js: true do
 
         expect(field.display_element).to have_text('ham')
         expect(field.display_element).to have_text('onions')
-        table_edit_field.expect_state_text 'ham, onions'
+        wp1_field.expect_state_text 'ham, onions'
 
         field.activate!
         field.set_value "pineapple"
@@ -172,7 +179,72 @@ describe "multi select custom values", js: true do
         expect(field.display_element).to have_text('pineapple')
         expect(field.display_element).to have_text('mushrooms')
 
-        table_edit_field.expect_state_text ", ...\n4"
+        wp1_field.expect_state_text ", ...\n4"
+      end
+    end
+
+    describe 'sorting in the table' do
+      let(:wp1_field) { table_edit_field(work_package) }
+      let(:wp2_field) { table_edit_field(work_package2) }
+      let!(:query) do
+        query = FactoryBot.build(:query, user: user, project: project)
+        query.column_names = ['id', 'type', 'subject', "cf_#{custom_field.id}"]
+        query.filters.clear
+        query.timeline_visible = false
+        query.sort_criteria = [["cf_#{custom_field.id}", 'asc']]
+
+        query.save!
+        query
+      end
+
+      before do
+        work_package
+        work_package2
+
+        login_as(user)
+
+        wp_table.visit_query query
+        wp_table.expect_work_package_listed(work_package)
+        wp_table.expect_work_package_listed(work_package2)
+      end
+
+      describe 'sorting by the multi select field' do
+        let(:multi_value) { true }
+
+        it 'sorts as expected asc and desc' do
+          expect(wp1_field.display_element).to have_text('ham')
+          expect(wp1_field.display_element).to have_text('pineapple')
+          expect(wp2_field.display_element).to have_text('ham')
+
+          wp_table.expect_work_package_order work_package2, work_package
+
+          # Reverse sort
+          sort_by.sort_via_header cf_frontend, descending: true, selector: cf_frontend
+
+          wp_table.expect_work_package_listed(work_package)
+          wp_table.expect_work_package_listed(work_package2)
+          wp_table.expect_work_package_order work_package, work_package2
+        end
+      end
+
+      describe 'sorting by the single select field' do
+        let(:multi_value) { false }
+        let(:work_package2_options) { %w[onions] } # position 2
+        let(:work_package_options) { %w[mushrooms] } # position 4
+
+        it 'sorts as expected asc and desc' do
+          expect(wp2_field.display_element).to have_text('onions')
+          expect(wp1_field.display_element).to have_text('mushrooms')
+
+          wp_table.expect_work_package_order work_package2, work_package
+
+          # Reverse sort
+          sort_by.sort_via_header cf_frontend, descending: true, selector: cf_frontend
+
+          wp_table.expect_work_package_listed(work_package)
+          wp_table.expect_work_package_listed(work_package2)
+          wp_table.expect_work_package_order work_package, work_package2
+        end
       end
     end
   end

--- a/spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb
@@ -41,6 +41,7 @@ describe 'Work Package table hierarchy parent below', js: true do
     let(:query) do
       query              = FactoryBot.build(:query, user: user, project: project)
       query.column_names = ['id', 'subject', 'type']
+      query.sort_criteria = [%w(id asc)]
       query.filters.clear
       query.add_filter('type_id', '=', [type_task.id])
       query.show_hierarchies = true
@@ -102,7 +103,7 @@ describe 'Work Package table hierarchy parent below', js: true do
     let(:query) do
       query              = FactoryBot.build(:query, user: user, project: project)
       query.column_names = %w(id subject)
-      query.sort_criteria = [%w(subject asc)]
+      query.sort_criteria = [%w(subject asc), %w(id asc)]
       query.show_hierarchies = true
 
       query.save!

--- a/spec/support/components/work_packages/sort_by.rb
+++ b/spec/support/components/work_packages/sort_by.rb
@@ -32,10 +32,10 @@ module Components
       include Capybara::DSL
       include RSpec::Matchers
 
-      def sort_via_header(name, descending: false)
+      def sort_via_header(name, selector: nil, descending: false)
         text = descending ? 'Sort descending' : 'Sort ascending'
 
-        open_table_column_context_menu(name)
+        open_table_column_context_menu(name, selector)
 
         within_column_context_menu do
           click_link text
@@ -104,8 +104,8 @@ module Components
         ['desc', 'descending'].include?(direction.to_s)
       end
 
-      def open_table_column_context_menu(name)
-        page.find(".generic-table--sort-header ##{name.downcase}").click
+      def open_table_column_context_menu(name, id = name.downcase)
+        page.find(".generic-table--sort-header ##{id}").click
       end
 
       def within_column_context_menu

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -83,9 +83,13 @@ module Pages
     end
 
     def expect_work_package_order(*ids)
-      rows = page.all '.wp-table--row'
-      ids = ids.map { |el| el.is_a?(WorkPackage) ? el.id.to_s : el.to_s }
-      expect(rows.map { |el| el['data-work-package-id'] }).to match_array(ids)
+      retry_block do
+        rows = page.all '.wp-table--row'
+        expected = ids.map { |el| el.is_a?(WorkPackage) ? el.id.to_s : el.to_s }
+        found = rows.map { |el| el['data-work-package-id'] }
+
+        raise "Order is incorrect: #{found.inspect} != #{expected.inspect}" unless found == expected
+      end
     end
 
     def expect_no_work_package_listed


### PR DESCRIPTION
Custom fields of type list have been refactored quite some time ago to contain a reference to a `custom_option` in their `custom_value.value`.

The sort statements still sort by the `custom_value.value` without joining properly, which results in sorting the internal IDs and not the correct positions.

For the multi-value case, the values are sorted by their text custom option instead of the position to provide a correct and reproducible which would be unfeasible over multiple position values.

https://community.openproject.com/wp/29683