### PR TITLE
Correct puma config for easier production usage

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,7 +8,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
@@ -27,7 +27,7 @@ workers ENV.fetch("WEB_CONCURRENCY") { 1 }
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-preload_app! if Rails.env.production?
+preload_app! if ENV["RAILS_ENV"] == 'production'
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
Because when starting the application with `puma -C config/puma.rb` leads to the Rails class not being defined, since it has not been loaded yet.
This solves our usage in production, since we dropped unicorn a long time ago.