### PR TITLE
[29663] Handle multi select fields with no value set

### DIFF
--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -78,7 +78,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
 
   public get value() {
     const val = this.changeset.value(this.name);
-    return val[0];
+    return val ? val[0] : val;
   }
 
   /**
@@ -88,7 +88,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
    */
   public buildSelectedOption() {
     const value:HalResource[] = this.changeset.value(this.name);
-    return value.map(val => this.findValueOption(val));
+    return value ? value.map(val => this.findValueOption(val)) : [];
   }
 
   public get selectedOption() {


### PR DESCRIPTION
### Problem
The error occurs only when switching types in a WP create form, and thus a new CF of type multi list appears. Since no value was set, the build of selected options failed. Thus the appending to the container was not executed. This resulted in the cut off dropdown list.

### Solution
The multi select field component can now handle it when no value is set (which is the basic case in a create form).