### PR TITLE
[30110] Avoid type bg classes applied to timeline bar

### DIFF
--- a/app/assets/stylesheets/content/work_packages/timelines/elements/_bar.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/elements/_bar.sass
@@ -5,8 +5,9 @@
   float: left
   z-index: 0
 
-  // Fallback color
-  background: #555
+  .timeline-element--bg
+    width: 100%
+    height: 100%
 
   &:hover:not(.-clamp-style)
     .leftHandle, .rightHandle

--- a/app/assets/stylesheets/content/work_packages/timelines/elements/_labels.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/elements/_labels.sass
@@ -22,6 +22,7 @@
     // Position container left of bar
     position: absolute
     left: 0px
+    top: 0px
     // Then translate by its own width + some margin
     transform: translateX(calc(-100% - 10px))
     font-size: 12px

--- a/frontend/src/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
@@ -2,7 +2,7 @@ import * as moment from 'moment';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {
   calculatePositionValueForDayCountingPx,
-  RenderInfo,
+  RenderInfo, timelineBackgroundElementClass,
   timelineElementCssClass
 } from '../wp-timeline';
 import {CellDateMovement, LabelPosition, TimelineCellRenderer} from './timeline-cell-renderer';
@@ -125,8 +125,8 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
 
     const diamond = jQuery('.diamond', element)[0];
 
-    element.style.width = 15 + 'px';
-    element.style.height = 15 + 'px';
+    diamond.style.width = 15 + 'px';
+    diamond.style.height = 15 + 'px';
     diamond.style.width = 15 + 'px';
     diamond.style.height = 15 + 'px';
     diamond.style.marginLeft = -(15 / 2) + (renderInfo.viewParams.pixelPerDay / 2) + 'px';

--- a/frontend/src/app/components/wp-table/timeline/wp-timeline.ts
+++ b/frontend/src/app/components/wp-table/timeline/wp-timeline.ts
@@ -34,6 +34,7 @@ import {RenderedRow} from '../../wp-fast-table/builders/primary-render-pass';
 import Moment = moment.Moment;
 
 export const timelineElementCssClass = 'timeline-element';
+export const timelineBackgroundElementClass = 'timeline-element--bg';
 export const timelineGridElementCssClass = 'wp-timeline--grid-element';
 export const timelineMarkerSelectionStartClass = 'selection-start';
 


### PR DESCRIPTION
The timeline element previously looked like this

```
div.timeline-element # Background applied here
  .labelLeft
  .labelRight
  // ....
```

Since the `__type_inl` classes were applied to the parent element, the
labels would also receive the overridden colors.

To avoid this, a new element is added into the timeline-element that
only draws the background diamond / bar type

https://community.openproject.com/wp/30110