### PR TITLE
[30096] Bright colours for WP Types cannot be seen

### DIFF
--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -77,6 +77,7 @@ module ColorsHelper
 
       if name === 'type'
         concat ".__hl_inline_#{name}_#{entry.id} { color: #{color.hexcode} !important;}"
+        concat ".__hl_inline_#{name}_#{entry.id} { -webkit-text-stroke: 0.5px grey;}" if color.super_bright?
       else
         concat ".__hl_inline_#{name}_#{entry.id}::before { #{background_style}; border-color: #{border_color}; }\n"
       end

--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -32,7 +32,7 @@ module ColorsHelper
   def options_for_colors(colored_thing, allow_bright_colors)
     colors = []
     Color.find_each do |c|
-      next if !allow_bright_colors && c.bright?
+      next if !allow_bright_colors && c.super_bright?
 
       options = {}
       options[:name] = c.name
@@ -47,6 +47,10 @@ module ColorsHelper
       colors.push(options)
     end
     colors.to_json
+  end
+
+  def selected_color(colored_thing)
+    colored_thing.color_id
   end
 
   def darken_color(hex_color, amount = 0.4)
@@ -64,15 +68,21 @@ module ColorsHelper
     content_tag(:span, color.hexcode, class: 'color--text-preview', style: style)
   end
 
+  #
+  # Styles to display colors itself (e.g. for the colors autocompleter)
+  ##
   def color_css
     Color.find_each do |color|
       concat ".__hl_inline_color_#{color.id}_dot::before { background-color: #{color.hexcode} !important;}"
       concat ".__hl_inline_color_#{color.id}_dot::before { border: 1px solid #555555 !important;}" if color.bright?
       concat ".__hl_inline_color_#{color.id}_text { color: #{color.hexcode} !important;}"
-      concat ".__hl_inline_color_#{color.id}_text { -webkit-text-stroke: 0.5px grey;}" if color.super_bright?
+      concat ".__hl_inline_color_#{color.id}_text { -webkit-text-stroke: 0.5px grey; text-stroke: 0.5px grey;}" if color.super_bright?
     end
   end
 
+  #
+  # Styles to display the color of attributes (type, status etc.) for example in the WP view
+  ##
   def resource_color_css(name, scope)
     scope.includes(:color).find_each do |entry|
       color = entry.color

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -72,6 +72,13 @@ class Color < ActiveRecord::Base
   end
 
   ##
+  # Returns whether the color is very bright according to
+  # YIQ lightness.
+  def super_bright?
+    brightness_yiq >= 200
+  end
+
+  ##
   # Sum the color values of each channel
   # Same as in frontend color-contrast.functions.ts
   def brightness_yiq

--- a/app/views/colors/_color_autocomplete_field.html.erb
+++ b/app/views/colors/_color_autocomplete_field.html.erb
@@ -6,10 +6,14 @@
     <%= t('activerecord.attributes.color') %>
   </label>
   <div class="form--field-container">
+    <%= form.hidden_field :color_id %>
     <%= content_tag('colors-autocompleter',
                     '',
                     class: "colors-autocomplete form--select-container " + "#{container_class.present? ? container_class : '-middle'}",
-                    data: { colors: options_for_colors(object, allow_bright_colors), highlightTextInline: highlight_text_inline }) %>
+                    data: { colors: options_for_colors(object, allow_bright_colors),
+                            selected_color: selected_color(object),
+                            highlight_text_inline: highlight_text_inline,
+                            update_input: type + '[color_id]'}) %>
   </div>
   <div class="form--field-instructions"><%= label %></div>
 </div>

--- a/app/views/colors/_color_autocomplete_field.html.erb
+++ b/app/views/colors/_color_autocomplete_field.html.erb
@@ -1,12 +1,15 @@
 <% form_field_class = form_field_class || '' %>
 <% container_class  = container_class  || '' %>
-<div class="form--field <%= form_field_class %>">
-  <%= form.select :color_id,
-                  options_for_colors(object),
-                  {},
-                  container_class: container_class.present? ? container_class : '-middle',
-                  class: 'colors-autocomplete' %>
-
+<% highlight_text_inline  = highlight_text_inline  || false %>
+<div class="form--field <%= form_field_class %>"<%=  %>>
+  <label class="form--label">
+    <%= t('activerecord.attributes.color') %>
+  </label>
+  <div class="form--field-container">
+    <%= content_tag('colors-autocompleter',
+                    '',
+                    class: "colors-autocomplete form--select-container " + "#{container_class.present? ? container_class : '-middle'}",
+                    data: { colors: options_for_colors(object, allow_bright_colors), highlightTextInline: highlight_text_inline }) %>
+  </div>
   <div class="form--field-instructions"><%= label %></div>
-  <colors-autocompleter></colors-autocompleter>
 </div>

--- a/app/views/enumerations/_form.html.erb
+++ b/app/views/enumerations/_form.html.erb
@@ -44,6 +44,7 @@ See docs/COPYRIGHT.rdoc for more details.
                locals: {
                    form: f,
                    object: @enumeration,
+                   type: 'enumeration',
                    allow_bright_colors: true,
                    label: @enumeration.color_label
                }  %>

--- a/app/views/enumerations/_form.html.erb
+++ b/app/views/enumerations/_form.html.erb
@@ -44,6 +44,7 @@ See docs/COPYRIGHT.rdoc for more details.
                locals: {
                    form: f,
                    object: @enumeration,
+                   allow_bright_colors: true,
                    label: @enumeration.color_label
                }  %>
   <% end %>

--- a/app/views/highlighting/styles.css.erb
+++ b/app/views/highlighting/styles.css.erb
@@ -2,6 +2,7 @@
 <%= resource_color_css('status', ::Status) %>
 <%= resource_color_css('priority', ::IssuePriority) %>
 <%= resource_color_css('type', ::Type) %>
+<%= color_css() %>
 
 <%# Overdue tasks %>
 .__hl_date_due_today { color: #F76707 !important; }

--- a/app/views/statuses/_form.html.erb
+++ b/app/views/statuses/_form.html.erb
@@ -57,6 +57,7 @@ See docs/COPYRIGHT.rdoc for more details.
              locals: {
                form: f,
                object: @status,
+               allow_bright_colors: true,
                label: t('statuses.edit.status_color_text')
             } %>
 

--- a/app/views/statuses/_form.html.erb
+++ b/app/views/statuses/_form.html.erb
@@ -57,6 +57,7 @@ See docs/COPYRIGHT.rdoc for more details.
              locals: {
                form: f,
                object: @status,
+               type: 'status',
                allow_bright_colors: true,
                label: t('statuses.edit.status_color_text')
             } %>

--- a/app/views/types/form/_settings.html.erb
+++ b/app/views/types/form/_settings.html.erb
@@ -36,6 +36,7 @@ See docs/COPYRIGHT.rdoc for more details.
                locals: {
                    form: f,
                    object: @type,
+                   type: 'type',
                    allow_bright_colors: false,
                    highlight_text_inline: true,
                    label: t('types.edit.type_color_text'),

--- a/app/views/types/form/_settings.html.erb
+++ b/app/views/types/form/_settings.html.erb
@@ -36,6 +36,8 @@ See docs/COPYRIGHT.rdoc for more details.
                locals: {
                    form: f,
                    object: @type,
+                   allow_bright_colors: false,
+                   highlight_text_inline: true,
                    label: t('types.edit.type_color_text'),
                    form_field_class: '-wide-label',
                    container_class: '-slim'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -252,7 +252,7 @@ en:
       reset: "Reset to defaults"
       type_color_text: |
         Click to assign or change the color of this type. The selected color distinguishes work packages
-        in Gantt charts.
+        in Gantt charts. It is therefore recommended to use a strong color.
 
   versions:
     overview:

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -285,6 +285,7 @@ en:
     label_more_than_ago: "more than days ago"
     label_my_page: "My page"
     label_next: "Next"
+    label_no_color: "No color"
     label_no_data: "No data to display"
     label_no_due_date: "no end date"
     label_no_start_date: "no start date"

--- a/frontend/src/app/components/wp-fast-table/builders/highlighting/highlighting.functions.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/highlighting/highlighting.functions.ts
@@ -7,6 +7,14 @@ export namespace Highlighting {
     return `__hl_inline_${property}_${id}`;
   }
 
+  export function colorClass(highlightColorTextInline:boolean, id:string|number) {
+    if (highlightColorTextInline) {
+      return `__hl_inline_color_${id}_text`;
+    } else {
+      return `__hl_inline_color_${id}_dot`;
+    }
+  }
+
   /**
    * Given the difference from today (negative = n days in the past),
    * output the fixed overdue classes


### PR DESCRIPTION
With the new WP Type highlighting, bright colours are problematic as they are hard to read. To avoid this, the PR does two things

- [x] Disable bright colours in the autocompleter in the admin section for types
  - [x] Show empty input when a color is selected that is now forbidden
- [x] For types that have already a bright color, a `text-stroke` is shown. 
- [x] Replace colors autocompleter with ngSelect
  - [x] Take care that everything works (create, update, delete)
