### PR TITLE
[30103] Remove the internal setting with 500 max entries

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -225,7 +225,11 @@ class Setting < ActiveRecord::Base
 
   # Helper that returns an array based on per_page_options setting
   def self.per_page_options_array
-    per_page_options.split(%r{[\s,]}).map(&:to_i).select { |n| n > 0 }.sort
+    per_page_options
+      .split(%r{[\s,]})
+      .map(&:to_i)
+      .select(&:positive?)
+      .sort
   end
 
   def self.clear_cache(key = cache_key)

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -30,7 +30,7 @@ module API
   module V3
     class WorkPackageCollectionFromQueryService
       include Utilities::PathHelper
-      include ::API::Utilities::ParamsHelper
+      include ::API::Utilities::PageSizeHelper
 
       def initialize(query, user)
         self.query = query

--- a/lib/api/decorators/offset_paginated_collection.rb
+++ b/lib/api/decorators/offset_paginated_collection.rb
@@ -30,20 +30,17 @@
 module API
   module Decorators
     class OffsetPaginatedCollection < ::API::Decorators::Collection
+      include ::API::Utilities::PageSizeHelper
+
       def self.per_page_default(relation)
         relation.base_class.per_page
-      end
-
-      def self.per_page_maximum
-        Setting.api_max_page_size.to_i
       end
 
       def initialize(models, self_link, query: {}, page: nil, per_page: nil, current_user:)
         @self_link_base = self_link
         @query = query
         @page = page || 1
-        @per_page = [per_page || self.class.per_page_default(models),
-                     self.class.per_page_maximum].min
+        @per_page = [per_page || self.class.per_page_default(models), maximum_page_size].min
 
         full_self_link = make_page_link(page: @page, page_size: @per_page)
         paged = paged_models(models)

--- a/lib/api/utilities/page_size_helper.rb
+++ b/lib/api/utilities/page_size_helper.rb
@@ -30,15 +30,37 @@
 
 module API
   module Utilities
-    module ParamsHelper
+    module PageSizeHelper
+
+      # Set a default max size to ensure backwards compatibility
+      # with the previous private setting `maximum_page_size`.
+      # The actual value is taken from
+      # max(Setting.per_page_options)
+      DEFAULT_API_MAX_SIZE ||= 500
+
+      ##
+      # Determine set page_size from string
       def resolve_page_size(string)
         resolved_value = to_i_or_nil(string)
         # a page size of 0 is a magic number for the maximum page size value
-        if resolved_value == 0 || resolved_value.to_i > Setting.api_max_page_size.to_i
-          resolved_value = Setting.api_max_page_size.to_i
+        if resolved_value == 0 || resolved_value.to_i > maximum_page_size
+          resolved_value = maximum_page_size
         end
         resolved_value
       end
+
+      ##
+      # Get the maximum allowed page size from
+      # the largest option of per_page size,
+      # or the magic fallback value 500.
+      def maximum_page_size
+        [
+          DEFAULT_API_MAX_SIZE,
+          Setting.per_page_options_array.max
+        ].max
+      end
+
+      private
 
       def to_i_or_nil(string)
         string ? string.to_i : nil

--- a/lib/api/v3/groups/groups_api.rb
+++ b/lib/api/v3/groups/groups_api.rb
@@ -30,7 +30,7 @@ module API
   module V3
     module Groups
       class GroupsAPI < ::API::OpenProjectAPI
-        helpers ::API::Utilities::ParamsHelper
+        helpers ::API::Utilities::PageSizeHelper
 
         resources :groups do
           params do

--- a/lib/api/v3/news/news_api.rb
+++ b/lib/api/v3/news/news_api.rb
@@ -30,7 +30,7 @@ module API
   module V3
     module News
       class NewsAPI < ::API::OpenProjectAPI
-        helpers ::API::Utilities::ParamsHelper
+        helpers ::API::Utilities::PageSizeHelper
 
         resources :news do
           get do

--- a/lib/api/v3/time_entries/time_entries_api.rb
+++ b/lib/api/v3/time_entries/time_entries_api.rb
@@ -30,7 +30,7 @@ module API
   module V3
     module TimeEntries
       class TimeEntriesAPI < ::API::OpenProjectAPI
-        helpers ::API::Utilities::ParamsHelper
+        helpers ::API::Utilities::PageSizeHelper
 
         resources :time_entries do
           get do

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -33,7 +33,7 @@ module API
   module V3
     module Users
       class UsersAPI < ::API::OpenProjectAPI
-        helpers ::API::Utilities::ParamsHelper
+        helpers ::API::Utilities::PageSizeHelper
 
         helpers do
           def user_transition(allowed)

--- a/lib/api/v3/work_packages/watchers_api.rb
+++ b/lib/api/v3/work_packages/watchers_api.rb
@@ -32,7 +32,7 @@ module API
   module V3
     module WorkPackages
       class WatchersAPI < ::API::OpenProjectAPI
-        helpers ::API::Utilities::ParamsHelper
+        helpers ::API::Utilities::PageSizeHelper
 
         get '/available_watchers' do
           authorize(:add_work_package_watchers, context: @work_package.project)

--- a/modules/documents/lib/api/v3/documents/documents_api.rb
+++ b/modules/documents/lib/api/v3/documents/documents_api.rb
@@ -33,7 +33,7 @@ module API
   module V3
     module Documents
       class DocumentsAPI < ::API::OpenProjectAPI
-        helpers ::API::Utilities::ParamsHelper
+        helpers ::API::Utilities::PageSizeHelper
 
         resources :documents do
           get do

--- a/modules/grids/app/controllers/api/v3/grids/grids_api.rb
+++ b/modules/grids/app/controllers/api/v3/grids/grids_api.rb
@@ -32,7 +32,7 @@ module API
       class GridsAPI < ::API::OpenProjectAPI
         resources :grids do
           helpers do
-            include API::Utilities::ParamsHelper
+            include API::Utilities::PageSizeHelper
           end
 
           get do


### PR DESCRIPTION
Instead, use the maximum allowed page size for the maximum number. This will match what the users have selected and be reasonable without adding another user-visible setting.

https://community.openproject.com/wp/30103