### PR TITLE
use wp create from for type dropdown

### DIFF
--- a/frontend/src/app/components/op-context-menu/handlers/op-types-context-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/op-types-context-menu.directive.ts
@@ -29,13 +29,14 @@
 import {OpContextMenuItem} from 'core-components/op-context-menu/op-context-menu.types';
 import {StateService} from '@uirouter/core';
 import {OPContextMenuService} from "core-components/op-context-menu/op-context-menu.service";
-import {Directive, ElementRef, Input} from "@angular/core";
+import {Directive, ElementRef, Input, Inject} from "@angular/core";
 import {LinkHandling} from "core-app/modules/common/link-handling/link-handling";
 import {OpContextMenuTrigger} from "core-components/op-context-menu/handlers/op-context-menu-trigger.directive";
 import {TypeResource} from 'core-app/modules/hal/resources/type-resource';
-import {TypeDmService} from "core-app/modules/hal/dm-services/type-dm.service";
 import {Highlighting} from 'core-app/components/wp-fast-table/builders/highlighting/highlighting.functions';
 import {BrowserDetector} from "core-app/modules/common/browser/browser-detector.service";
+import {WorkPackageCreateService} from 'core-components/wp-new/wp-create.service';
+import {IWorkPackageCreateServiceToken} from 'core-components/wp-new/wp-create.service.interface';
 
 @Directive({
   selector: '[opTypesCreateDropdown]'
@@ -51,7 +52,7 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger {
               readonly opContextMenu:OPContextMenuService,
               readonly browserDetector:BrowserDetector,
               readonly $state:StateService,
-              readonly typeDmService:TypeDmService) {
+              @Inject(IWorkPackageCreateServiceToken) protected wpCreate:WorkPackageCreateService) {
     super(elementRef, opContextMenu);
   }
 
@@ -67,9 +68,12 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger {
       this.stateName = 'work-packages.new';
     }
 
-    this.loadingPromise = this.typeDmService
-      .loadAll(this.projectIdentifier)
-      .then(types => this.buildItems(types));
+    this.loadingPromise = this
+      .wpCreate
+      .getEmptyForm(this.projectIdentifier)
+      .then(form => {
+        return this.buildItems(form.schema.type.allowedValues);
+      })
   }
 
   protected open(evt:JQueryEventObject) {


### PR DESCRIPTION
That way, the front end has less knowledge and processes defined by OpenProject in the back end can be adhered to. It is e.g. possible to limit the types via a plugin.

It would be reasonable to reuse the response in a subsequent create form if the user chooses to do so but this change would be bigger and thus outside of the scope of this fix.