### PR TITLE
Avoid before blocks and raw params access for IDs

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2626,6 +2626,7 @@ en:
     attributes:
       lock_version: "Lock Version"
     errors:
+      code_400: "Bad request: %{message}"
       code_401: "You need to be authenticated to access this resource."
       code_401_wrong_credentials: "You did not provide the correct credentials."
       code_403: "You are not authorized to access this resource."

--- a/lib/api/errors/bad_request.rb
+++ b/lib/api/errors/bad_request.rb
@@ -1,3 +1,4 @@
+#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -26,25 +27,13 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-require 'api/v3/users/user_collection_representer'
-
 module API
-  module V3
-    module Projects
-      class AvailableResponsiblesAPI < ::API::OpenProjectAPI
-        resource :available_responsibles do
-          after_validation do
-            authorize(:view_work_packages, global: true, user: current_user)
-          end
+  module Errors
+    class BadRequest < ErrorBase
+      identifier 'urn:openproject-org:api:v3:errors:BadRequest'
 
-          get do
-            available_responsibles = @project.possible_responsibles.includes(:preference)
-            self_link = api_v3_paths.available_responsibles(@project.id)
-            Users::UserCollectionRepresenter.new(available_responsibles,
-                                                 self_link,
-                                                 current_user: current_user)
-          end
-        end
+      def initialize(e)
+        super 400, I18n.t('api_v3.errors.code_400', message: e.message)
       end
     end
   end

--- a/lib/api/errors/bad_request.rb
+++ b/lib/api/errors/bad_request.rb
@@ -31,9 +31,10 @@ module API
   module Errors
     class BadRequest < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:BadRequest'
+      code 400
 
-      def initialize(e)
-        super 400, I18n.t('api_v3.errors.code_400', message: e.message)
+      def initialize(message)
+        super I18n.t('api_v3.errors.code_400', message: message)
       end
     end
   end

--- a/lib/api/errors/conflict.rb
+++ b/lib/api/errors/conflict.rb
@@ -31,9 +31,10 @@ module API
   module Errors
     class Conflict < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:UpdateConflict'
+      code 409
 
-      def initialize
-        super 409, I18n.t('api_v3.errors.code_409')
+      def initialize(*)
+        super I18n.t('api_v3.errors.code_409')
       end
     end
   end

--- a/lib/api/errors/error_base.rb
+++ b/lib/api/errors/error_base.rb
@@ -30,7 +30,8 @@
 module API
   module Errors
     class ErrorBase < Grape::Exceptions::Base
-      attr_reader :code, :message, :details, :errors, :property
+      attr_reader :message, :details, :errors, :property
+      delegate :code, to: :class
 
       class << self
         ##
@@ -70,6 +71,15 @@ module API
           @identifier
         end
 
+        ##
+        # Allows defining this error class's http code
+        # Used to read it otherwise.
+        def code(status = nil)
+          @code = status if status
+
+          @code
+        end
+
         private
 
         def convert_ar_to_api_errors(errors)
@@ -90,8 +100,7 @@ module API
         end
       end
 
-      def initialize(code, message)
-        @code = code
+      def initialize(message)
         @message = message
         @errors = []
       end

--- a/lib/api/errors/internal_error.rb
+++ b/lib/api/errors/internal_error.rb
@@ -31,9 +31,16 @@ module API
   module Errors
     class InternalError < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:InternalServerError'
+      code 500
 
-      def initialize(message = I18n.t('api_v3.errors.code_500'))
-        super 500, message
+      def initialize(error_message = nil)
+        error = I18n.t('api_v3.errors.code_500')
+
+        if message
+          error += " #{error_message}"
+        end
+
+        super error
       end
     end
   end

--- a/lib/api/errors/invalid_query.rb
+++ b/lib/api/errors/invalid_query.rb
@@ -31,10 +31,7 @@ module API
   module Errors
     class InvalidQuery < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:InvalidQuery'
-
-      def initialize(message)
-        super 400, message
-      end
+      code 400
     end
   end
 end

--- a/lib/api/errors/invalid_render_context.rb
+++ b/lib/api/errors/invalid_render_context.rb
@@ -31,10 +31,7 @@ module API
   module Errors
     class InvalidRenderContext < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:InvalidRenderContext'
-
-      def initialize(message)
-        super 400, message
-      end
+      code 400
     end
   end
 end

--- a/lib/api/errors/invalid_request_body.rb
+++ b/lib/api/errors/invalid_request_body.rb
@@ -31,10 +31,7 @@ module API
   module Errors
     class InvalidRequestBody < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:InvalidRequestBody'
-
-      def initialize(message)
-        super 400, message
-      end
+      code 400
     end
   end
 end

--- a/lib/api/errors/invalid_resource_link.rb
+++ b/lib/api/errors/invalid_resource_link.rb
@@ -31,6 +31,7 @@ module API
   module Errors
     class InvalidResourceLink < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:ResourceTypeMismatch'
+      code 422
 
       def initialize(property_name, expected_link, actual_link)
         expected_i18n = Array(expected_link).join("' #{I18n.t('concatenation.single')} '")
@@ -40,7 +41,7 @@ module API
                          expected: expected_i18n,
                          actual: actual_link)
 
-        super(422, message)
+        super message
       end
     end
   end

--- a/lib/api/errors/invalid_user_status_transition.rb
+++ b/lib/api/errors/invalid_user_status_transition.rb
@@ -31,9 +31,10 @@ module API
   module Errors
     class InvalidUserStatusTransition < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:InvalidUserStatusTransition'
+      code 400
 
-      def initialize
-        super 400, I18n.t('api_v3.errors.invalid_user_status_transition')
+      def initialize(*)
+        super I18n.t('api_v3.errors.invalid_user_status_transition')
       end
     end
   end

--- a/lib/api/errors/multiple_errors.rb
+++ b/lib/api/errors/multiple_errors.rb
@@ -31,6 +31,7 @@ module API
   module Errors
     class MultipleErrors < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:MultipleErrors'
+      code 422
 
       def self.create_if_many(errors)
         raise ArgumentError, 'expected at least one error' unless errors.any?
@@ -40,7 +41,7 @@ module API
       end
 
       def initialize(errors)
-        super 422, I18n.t('api_v3.errors.multiple_errors')
+        super I18n.t('api_v3.errors.multiple_errors')
 
         @errors = errors
       end

--- a/lib/api/errors/not_found.rb
+++ b/lib/api/errors/not_found.rb
@@ -32,8 +32,8 @@ module API
     class NotFound < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:NotFound'
 
-      def initialize(message = I18n.t('api_v3.errors.code_404'))
-        super 404, message
+      def initialize(*)
+        super 404, I18n.t('api_v3.errors.code_404')
       end
     end
   end

--- a/lib/api/errors/not_found.rb
+++ b/lib/api/errors/not_found.rb
@@ -31,9 +31,10 @@ module API
   module Errors
     class NotFound < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:NotFound'
+      code 404
 
       def initialize(*)
-        super 404, I18n.t('api_v3.errors.code_404')
+        super I18n.t('api_v3.errors.code_404')
       end
     end
   end

--- a/lib/api/errors/parse_error.rb
+++ b/lib/api/errors/parse_error.rb
@@ -31,9 +31,10 @@ module API
   module Errors
     class ParseError < InvalidRequestBody
       identifier InvalidRequestBody.identifier
+      code 400
 
-      def initialize(message: I18n.t('api_v3.errors.invalid_json'), details: nil)
-        super(message)
+      def initialize(message = nil, details: nil)
+        super I18n.t('api_v3.errors.invalid_json')
 
         if details
           @details = { parseError: clean_parse_error(details) }

--- a/lib/api/errors/property_format_error.rb
+++ b/lib/api/errors/property_format_error.rb
@@ -31,6 +31,7 @@ module API
   module Errors
     class PropertyFormatError < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:PropertyFormatError'
+      code 422
 
       attr_accessor :property
 
@@ -41,7 +42,7 @@ module API
                          property: property,
                          expected_format: expected_format,
                          actual: actual_value)
-        super 422, message
+        super message
       end
 
       def details

--- a/lib/api/errors/unauthenticated.rb
+++ b/lib/api/errors/unauthenticated.rb
@@ -31,9 +31,10 @@ module API
   module Errors
     class Unauthenticated < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:Unauthenticated'
+      code 401
 
       def initialize(message = I18n.t('api_v3.errors.code_401'))
-        super 401, message
+        super message
       end
     end
   end

--- a/lib/api/errors/unauthorized.rb
+++ b/lib/api/errors/unauthorized.rb
@@ -31,9 +31,10 @@ module API
   module Errors
     class Unauthorized < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:MissingPermission'
+      code 403
 
-      def initialize
-        super 403, I18n.t('api_v3.errors.code_403')
+      def initialize(*)
+        super I18n.t('api_v3.errors.code_403')
       end
     end
   end

--- a/lib/api/errors/unsupported_media_type.rb
+++ b/lib/api/errors/unsupported_media_type.rb
@@ -31,9 +31,10 @@ module API
   module Errors
     class UnsupportedMediaType < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:TypeNotSupported'
+      code 415
 
       def initialize(message)
-        super 415, message
+        super message
       end
     end
   end

--- a/lib/api/errors/unwritable_property.rb
+++ b/lib/api/errors/unwritable_property.rb
@@ -31,9 +31,10 @@ module API
   module Errors
     class UnwritableProperty < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:PropertyIsReadOnly'
+      code 422
 
       def initialize(property)
-        super 422, I18n.t('api_v3.errors.writing_read_only_attributes')
+        super I18n.t('api_v3.errors.writing_read_only_attributes')
 
         @property = property
         @details = { attribute: property }

--- a/lib/api/errors/validation.rb
+++ b/lib/api/errors/validation.rb
@@ -31,9 +31,10 @@ module API
   module Errors
     class Validation < ErrorBase
       identifier 'urn:openproject-org:api:v3:errors:PropertyConstraintViolation'
+      code 422
 
       def initialize(property, full_message)
-        super 422, full_message
+        super full_message
 
         @property = property
         @details = { attribute: property }

--- a/lib/api/utilities/grape_helper.rb
+++ b/lib/api/utilities/grape_helper.rb
@@ -56,7 +56,7 @@ module API
           if error.nil?
             error_response_lambda
           else
-            lambda { instance_exec error.new, &error_response_lambda }
+            lambda { |e| instance_exec error.new(e), &error_response_lambda }
           end
 
         # We do this lambda business because #rescue_from behaves differently

--- a/lib/api/utilities/grape_helper.rb
+++ b/lib/api/utilities/grape_helper.rb
@@ -56,7 +56,7 @@ module API
           if error.nil?
             error_response_lambda
           else
-            lambda { |e| instance_exec error.new(e), &error_response_lambda }
+            lambda { |e| instance_exec error.new(e.message), &error_response_lambda }
           end
 
         # We do this lambda business because #rescue_from behaves differently

--- a/lib/api/v3/activities/activities_api.rb
+++ b/lib/api/v3/activities/activities_api.rb
@@ -33,12 +33,9 @@ module API
     module Activities
       class ActivitiesAPI < ::API::OpenProjectAPI
         resources :activities do
-          params do
-            requires :id, type: Integer, desc: 'Activity id'
-          end
-          route_param :id do
-            before do
-              @activity = Journal::AggregatedJournal.with_notes_id(params[:id])
+          route_param :id, type: Integer, desc: 'Activity ID' do
+            after_validation do
+              @activity = Journal::AggregatedJournal.with_notes_id(declared_params[:id])
               raise API::Errors::NotFound unless @activity
 
               authorize(:view_project, context: @activity.journable.project)
@@ -68,7 +65,7 @@ module API
             patch do
               editable_activity = Journal.find(@activity.notes_id)
               authorize_edit_own(editable_activity)
-              editable_activity.notes = params[:comment]
+              editable_activity.notes = declared_params[:comment]
               save_activity(editable_activity)
 
               ActivityRepresenter.new(@activity.reloaded, current_user: current_user)

--- a/lib/api/v3/attachments/attachments_api.rb
+++ b/lib/api/v3/attachments/attachments_api.rb
@@ -48,11 +48,8 @@ module API
                                                               current_user: current_user)
           end
 
-          params do
-            requires :id, desc: 'Attachment id'
-          end
-          route_param :id do
-            before do
+          route_param :id, type: Integer, desc: 'Attachment ID' do
+            after_validation do
               @attachment = Attachment.find(params[:id])
 
               raise ::API::Errors::NotFound.new unless @attachment.visible?(current_user)

--- a/lib/api/v3/categories/categories_api.rb
+++ b/lib/api/v3/categories/categories_api.rb
@@ -34,8 +34,8 @@ module API
     module Categories
       class CategoriesAPI < ::API::OpenProjectAPI
         resources :categories do
-          route_param :id do
-            before do
+          route_param :id, type: Integer, desc: 'Category ID' do
+            after_validation do
               @category = Category.find(params[:id])
               authorize(:view_project, context: @category.project) do
                 raise API::Errors::NotFound.new

--- a/lib/api/v3/categories/categories_by_project_api.rb
+++ b/lib/api/v3/categories/categories_by_project_api.rb
@@ -34,7 +34,7 @@ module API
     module Categories
       class CategoriesByProjectAPI < ::API::OpenProjectAPI
         resources :categories do
-          before do
+          after_validation do
             @categories = @project.categories
           end
 

--- a/lib/api/v3/custom_actions/custom_actions_api.rb
+++ b/lib/api/v3/custom_actions/custom_actions_api.rb
@@ -31,10 +31,7 @@ module API
     module CustomActions
       class CustomActionsAPI < ::API::OpenProjectAPI
         resources :custom_actions do
-          params do
-            requires :id, desc: 'Custom action id', type: Integer
-          end
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Custom action ID' do
             helpers do
               def custom_action
                 @custom_action ||= CustomAction.find(params[:id])
@@ -43,7 +40,7 @@ module API
 
             helpers ::API::V3::WorkPackages::WorkPackagesSharedHelpers
 
-            before do
+            after_validation do
               authorize(:edit_work_packages, global: true)
             end
 
@@ -65,7 +62,7 @@ module API
                 end
               end
 
-              before do
+              after_validation do
                 contract = ::CustomActions::ExecuteContract.new(parsed_params)
 
                 unless contract.valid?

--- a/lib/api/v3/groups/groups_api.rb
+++ b/lib/api/v3/groups/groups_api.rb
@@ -33,10 +33,7 @@ module API
         helpers ::API::Utilities::PageSizeHelper
 
         resources :groups do
-          params do
-            requires :id, desc: 'Group\'s id'
-          end
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Group ID' do
             helpers do
               def group_scope
                 if current_user.allowed_to_globally?(:manage_members)

--- a/lib/api/v3/help_texts/help_texts_api.rb
+++ b/lib/api/v3/help_texts/help_texts_api.rb
@@ -39,11 +39,8 @@ module API
             HelpTextCollectionRepresenter.new(@entries, api_v3_paths.help_texts, current_user: current_user)
           end
 
-          params do
-            requires :id, type: Integer, desc: 'Help text id'
-          end
-          route_param :id do
-            before do
+          route_param :id, type: Integer, desc: 'Help text ID' do
+            after_validation do
               @help_text = AttributeHelpText.visible(current_user).find(params[:id])
             end
 

--- a/lib/api/v3/news/news_api.rb
+++ b/lib/api/v3/news/news_api.rb
@@ -49,8 +49,8 @@ module API
             end
           end
 
-          route_param :id do
-            before do
+          route_param :id, type: Integer, desc: 'News ID' do
+            after_validation do
               @time_entry = ::News
                             .visible
                             .find(params[:id])

--- a/lib/api/v3/posts/posts_api.rb
+++ b/lib/api/v3/posts/posts_api.rb
@@ -37,7 +37,7 @@ module API
             end
           end
 
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Message ID' do
             get do
               ::API::V3::Posts::PostRepresenter.new(post,
                                                     current_user: current_user,

--- a/lib/api/v3/priorities/priorities_api.rb
+++ b/lib/api/v3/priorities/priorities_api.rb
@@ -35,7 +35,7 @@ module API
     module Priorities
       class PrioritiesAPI < ::API::OpenProjectAPI
         resources :priorities do
-          before do
+          after_validation do
             authorize(:view_work_packages, global: true)
 
             @priorities = IssuePriority.all
@@ -47,8 +47,8 @@ module API
                                               current_user: current_user)
           end
 
-          route_param :id do
-            before do
+          route_param :id, type: Integer, desc: 'Priority ID' do
+            after_validation do
               @priority = IssuePriority.find(params[:id])
             end
 

--- a/lib/api/v3/projects/available_assignees_api.rb
+++ b/lib/api/v3/projects/available_assignees_api.rb
@@ -33,7 +33,7 @@ module API
     module Projects
       class AvailableAssigneesAPI < ::API::OpenProjectAPI
         resource :available_assignees do
-          before do
+          after_validation do
             authorize(:view_work_packages, global: true, user: current_user)
           end
 

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -44,7 +44,7 @@ module API
           end
 
           route_param :id do
-            before do
+            after_validation do
               @project = Project.find(params[:id])
 
               authorize(:view_project, context: @project) do

--- a/lib/api/v3/queries/columns/query_columns_api.rb
+++ b/lib/api/v3/queries/columns/query_columns_api.rb
@@ -38,15 +38,11 @@ module API
               end
             end
 
-            params do
-              requires :id, desc: 'Column id'
-            end
-
-            before do
+            after_validation do
               authorize(:view_work_packages, global: true, user: current_user)
             end
 
-            route_param :id do
+            route_param :id, type: String, regexp: /\A\w+\z/, desc: 'Column ID' do
               get do
                 ar_id = convert_to_ar(params[:id]).to_sym
                 column = Query.available_columns.detect { |candidate| candidate.name == ar_id }

--- a/lib/api/v3/queries/filters/query_filters_api.rb
+++ b/lib/api/v3/queries/filters/query_filters_api.rb
@@ -39,15 +39,11 @@ module API
               end
             end
 
-            params do
-              requires :id, desc: 'Filter id'
-            end
-
-            before do
+            after_validation do
               authorize(:view_work_packages, global: true, user: current_user)
             end
 
-            route_param :id do
+            route_param :id, type: String, regexp: /\A\w+\z/, desc: 'Filter ID' do
               get do
                 ar_id = convert_to_ar(params[:id])
                 filter_class = Query.find_registered_filter(ar_id)

--- a/lib/api/v3/queries/group_bys/query_group_bys_api.rb
+++ b/lib/api/v3/queries/group_bys/query_group_bys_api.rb
@@ -38,15 +38,11 @@ module API
               end
             end
 
-            params do
-              requires :id, desc: 'Group by id'
-            end
-
-            before do
+            after_validation do
               authorize(:view_work_packages, global: true, user: current_user)
             end
 
-            route_param :id do
+            route_param :id, type: String, regexp: /\A\w+\z/, desc: 'Group by ID' do
               get do
                 ar_id = convert_to_ar(params[:id]).to_sym
                 column = Query.groupable_columns.detect { |candidate| candidate.name == ar_id }

--- a/lib/api/v3/queries/operators/query_operators_api.rb
+++ b/lib/api/v3/queries/operators/query_operators_api.rb
@@ -32,15 +32,11 @@ module API
       module Operators
         class QueryOperatorsAPI < ::API::OpenProjectAPI
           resource :operators do
-            params do
-              requires :id, desc: 'Operator id'
-            end
-
-            before do
+            after_validation do
               authorize(:view_work_packages, global: true, user: current_user)
             end
 
-            route_param :id do
+            route_param :id, type: String, regexp: /\A\w+\z/, desc: 'Operator ID' do
               get do
                 operator = ::Queries::Operators::OPERATORS[params[:id]]
 

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -67,7 +67,7 @@ module API
           end
 
           namespace 'available_projects' do
-            before do
+            after_validation do
               authorize(:view_work_packages, global: true, user: current_user)
             end
 
@@ -96,11 +96,8 @@ module API
             create_query request_body, current_user
           end
 
-          params do
-            requires :id, desc: 'Query id'
-          end
-          route_param :id do
-            before do
+          route_param :id, type: Integer, desc: 'Query ID' do
+            after_validation do
               @query = Query.find(params[:id])
 
               authorize_by_policy(:show) do

--- a/lib/api/v3/queries/queries_by_project_api.rb
+++ b/lib/api/v3/queries/queries_by_project_api.rb
@@ -33,7 +33,7 @@ module API
         namespace :queries do
           helpers ::API::V3::Queries::Helpers::QueryRepresenterResponse
 
-          before do
+          after_validation do
             authorize(:view_work_packages, context: @project, user: current_user)
           end
 

--- a/lib/api/v3/queries/schemas/query_filter_instance_schema_api.rb
+++ b/lib/api/v3/queries/schemas/query_filter_instance_schema_api.rb
@@ -42,7 +42,7 @@ module API
               end
             end
 
-            before do
+            after_validation do
               authorize(:view_work_packages, global: true, user: current_user)
             end
 
@@ -54,11 +54,7 @@ module API
                                          current_user: current_user)
             end
 
-            params do
-              requires :id, desc: 'Filter instance schema id'
-            end
-
-            route_param :id do
+            route_param :id, type: String, regexp: /\A\w+\z/, desc: 'Filter schema ID' do
               get do
                 ar_name = ::API::Utilities::QueryFiltersNameConverter
                           .to_ar_name(params[:id], refer_to_ids: true)

--- a/lib/api/v3/queries/schemas/query_schema_api.rb
+++ b/lib/api/v3/queries/schemas/query_schema_api.rb
@@ -38,7 +38,7 @@ module API
               end
             end
 
-            before do
+            after_validation do
               authorize(:view_work_packages, global: true, user: current_user)
             end
 

--- a/lib/api/v3/queries/sort_bys/query_sort_bys_api.rb
+++ b/lib/api/v3/queries/sort_bys/query_sort_bys_api.rb
@@ -51,7 +51,7 @@ module API
               requires :direction, desc: 'Direction of sorting'
             end
 
-            before do
+            after_validation do
               authorize(:view_work_packages, global: true, user: current_user)
             end
 

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -49,10 +49,7 @@ module API
                                                                     params)
           end
 
-          params do
-            requires :id, type: Integer, desc: 'Relation id'
-          end
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Relation ID' do
             get do
               representer.new(
                 Relation.find_by_id!(params[:id]),

--- a/lib/api/v3/render/render_api.rb
+++ b/lib/api/v3/render/render_api.rb
@@ -115,7 +115,7 @@ module API
           end
 
           route_param :render_format do
-            before do
+            after_validation do
               @format = params[:render_format]
             end
 

--- a/lib/api/v3/repositories/revisions_api.rb
+++ b/lib/api/v3/repositories/revisions_api.rb
@@ -30,10 +30,7 @@ module API
     module Repositories
       class RevisionsAPI < ::API::OpenProjectAPI
         resources :revisions do
-          params do
-            requires :id, desc: 'Revision id'
-          end
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Revision ID' do
             helpers do
               attr_reader :revision
 
@@ -42,7 +39,7 @@ module API
               end
             end
 
-            before do
+            after_validation do
               @revision = Changeset.find(params[:id])
 
               authorize(:view_changesets, context: revision.project) do

--- a/lib/api/v3/repositories/revisions_by_work_package_api.rb
+++ b/lib/api/v3/repositories/revisions_by_work_package_api.rb
@@ -33,7 +33,7 @@ module API
     module Repositories
       class RevisionsByWorkPackageAPI < ::API::OpenProjectAPI
         resources :revisions do
-          before do
+          after_validation do
             authorize(:view_work_packages, context: work_package.project)
           end
 

--- a/lib/api/v3/roles/roles_api.rb
+++ b/lib/api/v3/roles/roles_api.rb
@@ -41,7 +41,7 @@ module API
                                           current_user: current_user)
           end
 
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Role ID' do
             get do
               role = Role.find(params[:id])
 

--- a/lib/api/v3/statuses/statuses_api.rb
+++ b/lib/api/v3/statuses/statuses_api.rb
@@ -35,7 +35,7 @@ module API
     module Statuses
       class StatusesAPI < ::API::OpenProjectAPI
         resources :statuses do
-          before do
+          after_validation do
             authorize(:view_work_packages, global: true)
           end
 
@@ -45,7 +45,7 @@ module API
                                             current_user: current_user)
           end
 
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Status ID' do
             helpers do
               # Note that naming the method #status or having
               # a variable named @status colides with grape.

--- a/lib/api/v3/time_entries/time_entries_activity_api.rb
+++ b/lib/api/v3/time_entries/time_entries_activity_api.rb
@@ -31,12 +31,9 @@ module API
     module TimeEntries
       class TimeEntriesActivityAPI < ::API::OpenProjectAPI
         resources :activities do
-          params do
-            requires :id, desc: 'Time entries activity\'s id'
-          end
 
-          route_param :id do
-            before do
+          route_param :id, type: Integer, desc: 'Time entry activity ID' do
+            after_validation do
               authorize_any(%i(log_time
                                view_time_entries
                                edit_time_entries

--- a/lib/api/v3/time_entries/time_entries_api.rb
+++ b/lib/api/v3/time_entries/time_entries_api.rb
@@ -51,12 +51,8 @@ module API
 
           post &::API::V3::Utilities::Endpoints::Create.new(model: TimeEntry).mount
 
-          params do
-            requires :id, desc: 'Time entry\'s id'
-          end
-
-          route_param :id do
-            before do
+          route_param :id, type: Integer, desc: 'Time entry ID' do
+            after_validation do
               @time_entry = TimeEntry
                             .visible
                             .find(params[:id])

--- a/lib/api/v3/types/types_api.rb
+++ b/lib/api/v3/types/types_api.rb
@@ -35,7 +35,7 @@ module API
     module Types
       class TypesAPI < ::API::OpenProjectAPI
         resources :types do
-          before do
+          after_validation do
             authorize_any([:view_work_packages, :manage_types], global: true)
           end
 
@@ -45,7 +45,7 @@ module API
           end
 
           namespace ':id' do
-            before do
+            after_validation do
               type = Type.find(params[:id])
               @representer = TypeRepresenter.new(type, current_user: current_user)
             end

--- a/lib/api/v3/types/types_api.rb
+++ b/lib/api/v3/types/types_api.rb
@@ -44,7 +44,7 @@ module API
             TypeCollectionRepresenter.new(types, api_v3_paths.types, current_user: current_user)
           end
 
-          namespace ':id' do
+          route_param :id, type: Integer, desc: 'Type ID' do
             after_validation do
               type = Type.find(params[:id])
               @representer = TypeRepresenter.new(type, current_user: current_user)

--- a/lib/api/v3/types/types_by_project_api.rb
+++ b/lib/api/v3/types/types_by_project_api.rb
@@ -34,7 +34,7 @@ module API
     module Types
       class TypesByProjectAPI < ::API::OpenProjectAPI
         resources :types do
-          before do
+          after_validation do
             authorize_any [:view_work_packages, :manage_types], projects: @project
           end
 

--- a/lib/api/v3/user_preferences/user_preferences_api.rb
+++ b/lib/api/v3/user_preferences/user_preferences_api.rb
@@ -39,7 +39,7 @@ module API
             end
           end
 
-          before do
+          after_validation do
             fail ::API::Errors::Unauthenticated unless current_user.logged?
             @preferences = current_user.pref
           end

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -77,10 +77,10 @@ module API
           params do
             requires :id, desc: 'User\'s id'
           end
-          route_param :id do
+          route_param :id  do
             helpers ::API::V3::Users::UpdateUser
 
-            before do
+            after_validation do
               @user =
                 if params[:id] == 'me'
                   User.current
@@ -108,7 +108,7 @@ module API
 
             namespace :lock do
               # Authenticate lock transitions
-              before do
+              after_validation do
                 authorize_admin
               end
 

--- a/lib/api/v3/versions/projects_by_version_api.rb
+++ b/lib/api/v3/versions/projects_by_version_api.rb
@@ -34,7 +34,7 @@ module API
     module Versions
       class ProjectsByVersionAPI < ::API::OpenProjectAPI
         resources :projects do
-          before do
+          after_validation do
             @projects = @version.projects.visible(current_user)
 
             # Authorization for accessing the version is done in the versions

--- a/lib/api/v3/versions/update_form_api.rb
+++ b/lib/api/v3/versions/update_form_api.rb
@@ -31,7 +31,7 @@ module API
     module Versions
       class UpdateFormAPI < ::API::OpenProjectAPI
         resource :form do
-          before do
+          after_validation do
             authorize :manage_versions, global: true
           end
 

--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -47,8 +47,8 @@ module API
           mount ::API::V3::Versions::Schemas::VersionSchemaAPI
           mount ::API::V3::Versions::CreateFormAPI
 
-          route_param :id do
-            before do
+          route_param :id, type: Integer, desc: 'Version ID' do
+            after_validation do
               @version = Version.find(params[:id])
 
               authorized_for_version?(@version)

--- a/lib/api/v3/versions/versions_by_project_api.rb
+++ b/lib/api/v3/versions/versions_by_project_api.rb
@@ -35,7 +35,7 @@ module API
     module Versions
       class VersionsByProjectAPI < ::API::OpenProjectAPI
         resources :versions do
-          before do
+          after_validation do
             @versions = @project.shared_versions
 
             authorize_any %i(view_work_packages manage_versions), projects: @project

--- a/lib/api/v3/wiki_pages/wiki_pages_api.rb
+++ b/lib/api/v3/wiki_pages/wiki_pages_api.rb
@@ -37,7 +37,7 @@ module API
             end
           end
 
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Wiki page ID' do
             get do
               ::API::V3::WikiPages::WikiPageRepresenter.new(wiki_page,
                                                             current_user: current_user,

--- a/lib/api/v3/work_packages/available_projects_on_create_api.rb
+++ b/lib/api/v3/work_packages/available_projects_on_create_api.rb
@@ -33,7 +33,7 @@ module API
     module WorkPackages
       class AvailableProjectsOnCreateAPI < ::API::OpenProjectAPI
         resource :available_projects do
-          before do
+          after_validation do
             authorize(:add_work_packages, global: true)
           end
 

--- a/lib/api/v3/work_packages/available_projects_on_edit_api.rb
+++ b/lib/api/v3/work_packages/available_projects_on_edit_api.rb
@@ -33,7 +33,7 @@ module API
     module WorkPackages
       class AvailableProjectsOnEditAPI < ::API::OpenProjectAPI
         resource :available_projects do
-          before do
+          after_validation do
             authorize(:edit_work_packages, context: @work_package.project)
           end
 

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -96,7 +96,7 @@ module API
               requires :type, desc: 'Work package schema id'
             end
             namespace ':project-:type' do
-              before do
+              after_validation do
                 begin
                   @project = Project.find(params[:project])
                   @type = Type.find(params[:type])

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -66,18 +66,15 @@ module API
                                                             })
                                                        .mount
 
-          params do
-            requires :id, desc: 'Work package id', type: Integer
-          end
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Work package ID' do
             helpers WorkPackagesSharedHelpers
 
             helpers do
               attr_reader :work_package
             end
 
-            before do
-              @work_package = WorkPackage.find(params[:id])
+            after_validation do
+              @work_package = WorkPackage.find(declared_params[:id])
 
               authorize(:view_work_packages, context: @work_package.project) do
                 raise API::Errors::NotFound.new

--- a/modules/costs/lib/api/v3/budgets/budgets_api.rb
+++ b/modules/costs/lib/api/v3/budgets/budgets_api.rb
@@ -32,7 +32,7 @@ module API
     module Budgets
       class BudgetsAPI < ::API::OpenProjectAPI
         resources :budgets do
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Budget ID' do
             before do
               @budget = CostObject.find(params[:id])
 

--- a/modules/costs/lib/api/v3/budgets/budgets_api.rb
+++ b/modules/costs/lib/api/v3/budgets/budgets_api.rb
@@ -33,7 +33,7 @@ module API
       class BudgetsAPI < ::API::OpenProjectAPI
         resources :budgets do
           route_param :id, type: Integer, desc: 'Budget ID' do
-            before do
+            after_validation do
               @budget = CostObject.find(params[:id])
 
               authorize_any([:view_work_packages, :view_budgets], projects: @budget.project)

--- a/modules/costs/lib/api/v3/budgets/budgets_by_project_api.rb
+++ b/modules/costs/lib/api/v3/budgets/budgets_by_project_api.rb
@@ -32,7 +32,7 @@ module API
     module Budgets
       class BudgetsByProjectAPI < ::API::OpenProjectAPI
         resources :budgets do
-          before do
+          after_validation do
             authorize_any([:view_work_packages, :view_budgets], projects: @project)
             @budgets = @project.cost_objects
           end

--- a/modules/costs/lib/api/v3/cost_entries/cost_entries_api.rb
+++ b/modules/costs/lib/api/v3/cost_entries/cost_entries_api.rb
@@ -34,7 +34,7 @@ module API
     module CostEntries
       class CostEntriesAPI < ::API::OpenProjectAPI
         resources :cost_entries do
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Cost entry ID' do
             before do
               @cost_entry = CostEntry.find(params[:id])
 

--- a/modules/costs/lib/api/v3/cost_entries/cost_entries_api.rb
+++ b/modules/costs/lib/api/v3/cost_entries/cost_entries_api.rb
@@ -35,7 +35,7 @@ module API
       class CostEntriesAPI < ::API::OpenProjectAPI
         resources :cost_entries do
           route_param :id, type: Integer, desc: 'Cost entry ID' do
-            before do
+            after_validation do
               @cost_entry = CostEntry.find(params[:id])
 
               authorize(:view_cost_entries, context: @cost_entry.project) do

--- a/modules/costs/lib/api/v3/cost_entries/cost_entries_by_work_package_api.rb
+++ b/modules/costs/lib/api/v3/cost_entries/cost_entries_by_work_package_api.rb
@@ -33,7 +33,7 @@ module API
   module V3
     module CostEntries
       class CostEntriesByWorkPackageAPI < ::API::OpenProjectAPI
-        before do
+        after_validation do
           authorize_any([:view_cost_entries, :view_own_cost_entries],
                         projects: @work_package.project)
           @cost_helper = ::OpenProject::Costs::AttributesHelper.new(@work_package, current_user)

--- a/modules/costs/lib/api/v3/cost_types/cost_types_api.rb
+++ b/modules/costs/lib/api/v3/cost_types/cost_types_api.rb
@@ -40,7 +40,7 @@ module API
                           user: current_user)
           end
 
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Cost type ID' do
             before do
               @cost_type = CostType.active.find(params[:id])
             end

--- a/modules/costs/lib/api/v3/cost_types/cost_types_api.rb
+++ b/modules/costs/lib/api/v3/cost_types/cost_types_api.rb
@@ -34,14 +34,14 @@ module API
     module CostTypes
       class CostTypesAPI < ::API::OpenProjectAPI
         resources :cost_types do
-          before do
+          after_validation do
             authorize_any([:view_cost_entries, :view_own_cost_entries],
                           global: true,
                           user: current_user)
           end
 
           route_param :id, type: Integer, desc: 'Cost type ID' do
-            before do
+            after_validation do
               @cost_type = CostType.active.find(params[:id])
             end
 

--- a/modules/costs/spec/requests/api/budgets/budget_resource_spec.rb
+++ b/modules/costs/spec/requests/api/budgets/budget_resource_spec.rb
@@ -63,7 +63,7 @@ describe 'API v3 Budget resource' do
       context 'invalid id' do
         let(:get_path) { api_v3_paths.budget 'bogus' }
 
-        it_behaves_like 'not found' do
+        it_behaves_like 'param validation error' do
           let(:id) { 'bogus' }
         end
       end

--- a/modules/costs/spec/requests/api/cost_entries/cost_entry_resource_spec.rb
+++ b/modules/costs/spec/requests/api/cost_entries/cost_entry_resource_spec.rb
@@ -63,7 +63,7 @@ describe 'API v3 Cost Entry resource' do
       context 'invalid id' do
         let(:get_path) { api_v3_paths.cost_type 'bogus' }
 
-        it_behaves_like 'not found' do
+        it_behaves_like 'param validation error' do
           let(:id) { 'bogus' }
         end
       end

--- a/modules/costs/spec/requests/api/cost_types/cost_type_resource_spec.rb
+++ b/modules/costs/spec/requests/api/cost_types/cost_type_resource_spec.rb
@@ -69,7 +69,7 @@ describe 'API v3 Cost Type resource' do
       context 'invalid id' do
         let(:get_path) { api_v3_paths.cost_type 'bogus' }
 
-        it_behaves_like 'not found' do
+        it_behaves_like 'param validation error' do
           let(:id) { 'bogus' }
         end
       end

--- a/modules/documents/lib/api/v3/documents/documents_api.rb
+++ b/modules/documents/lib/api/v3/documents/documents_api.rb
@@ -52,7 +52,7 @@ module API
             end
           end
 
-          route_param :id do
+          route_param :id, type: Integer, desc: 'Document ID' do
             helpers do
               def document
                 Document.visible.find(params[:id])

--- a/modules/grids/app/controllers/api/v3/grids/grids_api.rb
+++ b/modules/grids/app/controllers/api/v3/grids/grids_api.rb
@@ -57,8 +57,8 @@ module API
           mount CreateFormAPI
           mount ::API::V3::Grids::Schemas::GridSchemaAPI
 
-          route_param :id do
-            before do
+          route_param :id, type: Integer, desc: 'Grid ID' do
+            after_validation do
               @grid = ::Grids::Query
                       .new(user: current_user)
                       .results

--- a/modules/grids/app/controllers/api/v3/grids/grids_api.rb
+++ b/modules/grids/app/controllers/api/v3/grids/grids_api.rb
@@ -73,7 +73,7 @@ module API
             # Hack to be able to use the Default* mount while having the permission check
             # not affecting the GET request
             namespace do
-              before do
+              after_validation do
                 unless ::Grids::UpdateContract.new(@grid, current_user).edit_allowed?
                   raise ActiveRecord::RecordNotFound
                 end

--- a/spec/requests/api/v3/category_resource_spec.rb
+++ b/spec/requests/api/v3/category_resource_spec.rb
@@ -100,7 +100,7 @@ describe 'API v3 Category resource' do
 
       context 'invalid priority id' do
         let(:get_path) { api_v3_paths.category 'bogus' }
-        it_behaves_like 'not found' do
+        it_behaves_like 'param validation error' do
           let(:id) { 'bogus' }
           let(:type) { 'Category' }
         end
@@ -115,7 +115,7 @@ describe 'API v3 Category resource' do
         get get_path
       end
 
-      it_behaves_like 'not found' do
+      it_behaves_like 'param validation error' do
         let(:id) { 'bogus' }
         let(:type) { 'Category' }
       end

--- a/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
+++ b/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
@@ -93,7 +93,7 @@ describe 'API v3 Help texts resource' do
         context 'invalid type id' do
           let(:get_path) { api_v3_paths.type 'bogus' }
 
-          it_behaves_like 'not found' do
+          it_behaves_like 'param validation error' do
             let(:id) { 'bogus' }
             let(:type) { 'HelpText' }
           end

--- a/spec/requests/api/v3/priority_resource_spec.rb
+++ b/spec/requests/api/v3/priority_resource_spec.rb
@@ -91,7 +91,7 @@ describe 'API v3 Priority resource' do
       context 'invalid priority id' do
         let(:get_path) { api_v3_paths.priority 'bogus' }
 
-        it_behaves_like 'not found' do
+        it_behaves_like 'param validation error' do
           let(:id) { 'bogus' }
           let(:type) { 'IssuePriority' }
         end

--- a/spec/requests/api/v3/status_resource_spec.rb
+++ b/spec/requests/api/v3/status_resource_spec.rb
@@ -92,7 +92,7 @@ describe 'API v3 Status resource' do
         context 'invalid status id' do
           let(:get_path) { api_v3_paths.status 'bogus' }
 
-          it_behaves_like 'not found' do
+          it_behaves_like 'param validation error' do
             let(:id) { 'bogus' }
             let(:type) { 'Status' }
           end

--- a/spec/requests/api/v3/support/response_examples.rb
+++ b/spec/requests/api/v3/support/response_examples.rb
@@ -120,6 +120,16 @@ shared_examples_for 'not found' do
   end
 end
 
+shared_examples_for 'param validation error' do
+  subject { JSON.parse(last_response.body) }
+
+  it 'results in a validation error' do
+    expect(last_response.status).to eq(400)
+    expect(subject['errorIdentifier']).to eq("urn:openproject-org:api:v3:errors:BadRequest")
+    expect(subject['message']).to match /Bad request: .+? is invalid/
+  end
+end
+
 shared_examples_for 'update conflict' do
   it_behaves_like 'error response',
                   409,

--- a/spec/requests/api/v3/types/type_resource_spec.rb
+++ b/spec/requests/api/v3/types/type_resource_spec.rb
@@ -92,7 +92,7 @@ describe 'API v3 Type resource' do
         context 'invalid type id' do
           let(:get_path) { api_v3_paths.type 'bogus' }
 
-          it_behaves_like 'not found' do
+          it_behaves_like 'param validation error' do
             let(:id) { 'bogus' }
             let(:type) { 'Type' }
           end

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -76,7 +76,7 @@ describe 'API v3 Work package form resource', type: :request do
 
         include_context 'post request'
 
-        it_behaves_like 'not found' do
+        it_behaves_like 'param validation error' do
           let(:id) { 'eeek' }
           let(:type) { 'WorkPackage' }
         end


### PR DESCRIPTION
Grape's validation runs after a `before` block so we should avoid using
raw params there and instead using `after_validate` which ensures the given validations have finished before acessing `params`, or even better access them only through `declared(params)[:id]` returns only
the validated whitelisted params, much like a permitted params hash.