### PR TITLE
Add UI to administrate OpenID Connect providers (azure, google)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,8 +26,8 @@ GIT
 
 GIT
   remote: https://github.com/finnlabs/omniauth-openid_connect-providers.git
-  revision: 552205c402b921689552532b4591737dc030625b
-  ref: 552205c402b921689552532b4591737dc030625b
+  revision: 1d65afd2cbb0ff9cd294a764a4387e0fb36c92f4
+  ref: 1d65afd2cbb0ff9cd294a764a4387e0fb36c92f4
   specs:
     omniauth-openid_connect-providers (0.1.1)
       omniauth-openid-connect (>= 0.2.1)

--- a/Gemfile.modules
+++ b/Gemfile.modules
@@ -10,7 +10,7 @@ end
 
 gem 'omniauth-openid_connect-providers',
 		git: 'https://github.com/finnlabs/omniauth-openid_connect-providers.git',
-		ref: '552205c402b921689552532b4591737dc030625b'
+		ref: '1d65afd2cbb0ff9cd294a764a4387e0fb36c92f4'
 
 gem 'omniauth-openid-connect',
 		git: 'https://github.com/finnlabs/omniauth-openid-connect.git',

--- a/app/controllers/concerns/omniauth_login.rb
+++ b/app/controllers/concerns/omniauth_login.rb
@@ -54,16 +54,17 @@ module Concerns::OmniauthLogin
     # Set back url to page the omniauth login link was clicked on
     params[:back_url] = request.env['omniauth.origin']
 
+    user_attributes = omniauth_hash_to_user_attributes(auth_hash)
     user =
       if session.include? :invitation_token
         tok = Token::Invitation.find_by value: session[:invitation_token]
         u = tok.user
-        u.identity_url = identity_url_from_omniauth(auth_hash)
+        u.identity_url = user_attributes[:identity_url]
         tok.destroy
         session.delete :invitation_token
         u
       else
-        User.find_or_initialize_by identity_url: identity_url_from_omniauth(auth_hash)
+        find_or_initialize_user_with(user_attributes)
       end
 
     decision = OpenProject::OmniAuth::Authorization.authorized? auth_hash
@@ -71,6 +72,31 @@ module Concerns::OmniauthLogin
       authorization_successful user, auth_hash
     else
       authorization_failed user, decision.message
+    end
+  end
+
+  def find_or_initialize_user_with(user_attributes = {})
+    user = User.find_by(identity_url: user_attributes[:identity_url])
+    return user unless user.nil?
+
+    if Setting.oauth_allow_remapping_of_existing_users?
+      # Allow to map existing users with an Omniauth source if the login
+      # already exists, and no existing auth source or omniauth provider is
+      # linked
+      user = User.find_by(
+        login: user_attributes[:login],
+        identity_url: nil,
+        auth_source_id: nil
+      )
+    end
+
+    if user.nil?
+      User.new(identity_url: user_attributes[:identity_url])
+    else
+      # We might want to update all the attributes from the provider, but for
+      # backwards-compatibility only the identity_url is updated here
+      user.update_attribute :identity_url, user_attributes[:identity_url]
+      user
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -366,3 +366,6 @@ security_badge_displayed:
   default: true
 installation_uuid:
   default: null
+oauth_allow_remapping_of_existing_users:
+  default: false
+  format: boolean

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -273,7 +273,7 @@ class TabularFormBuilder < ActionView::Helpers::FormBuilder
       l(label)
     elsif label
       label
-    elsif @object.is_a?(ActiveRecord::Base)
+    elsif @object.class.respond_to?(:human_attribute_name)
       @object.class.human_attribute_name(field)
     else
       l(field)

--- a/modules/openid_connect/app/cells/openid_connect/providers/row_cell.rb
+++ b/modules/openid_connect/app/cells/openid_connect/providers/row_cell.rb
@@ -1,0 +1,49 @@
+module OpenIDConnect
+  module Providers
+    class RowCell < ::RowCell
+      include ::IconsHelper
+
+      def provider
+        model
+      end
+
+      def name
+        link_to(
+          provider.display_name || provider.name,
+          url_for(action: :edit, id: provider.id)
+        )
+      end
+
+      def row_css_class
+        [
+          'openid-connect--provider-row',
+          "openid-connect--provider-row-#{model.id}"
+        ].join(' ')
+      end
+
+      ###
+
+      def button_links
+        [edit_link, delete_link]
+      end
+
+      def edit_link
+        link_to(
+          op_icon('icon icon-edit button--link'),
+          url_for(action: :edit, id: provider.id),
+          title: t(:button_edit)
+        )
+      end
+
+      def delete_link
+        link_to(
+          op_icon('icon icon-delete button--link'),
+          url_for(action: :destroy, id: provider.id),
+          method: :delete,
+          data: { confirm: I18n.t(:text_are_you_sure) },
+          title: t(:button_delete)
+        )
+      end
+    end
+  end
+end

--- a/modules/openid_connect/app/cells/openid_connect/providers/table_cell.rb
+++ b/modules/openid_connect/app/cells/openid_connect/providers/table_cell.rb
@@ -1,0 +1,25 @@
+module OpenIDConnect
+  module Providers
+    class TableCell < ::TableCell
+      columns :name
+
+      def initial_sort
+        [:id, :asc]
+      end
+
+      def sortable?
+        false
+      end
+
+      def empty_row_message
+        I18n.t 'openid_connect.providers.no_results_table'
+      end
+
+      def headers
+        [
+          ['name', caption: I18n.t('attributes.name')],
+        ]
+      end
+    end
+  end
+end

--- a/modules/openid_connect/app/cells/openid_connect/providers/table_cell.rb
+++ b/modules/openid_connect/app/cells/openid_connect/providers/table_cell.rb
@@ -17,7 +17,7 @@ module OpenIDConnect
 
       def headers
         [
-          ['name', caption: I18n.t('attributes.name')],
+          ['name', caption: I18n.t('attributes.name')]
         ]
       end
     end

--- a/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
+++ b/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
@@ -6,8 +6,7 @@ module OpenIDConnect
     before_action :require_admin
     before_action :find_provider, only: [:edit, :update, :destroy]
 
-    def index
-    end
+    def index; end
 
     def new
       if openid_connect_providers_available_for_configure.none?
@@ -28,8 +27,7 @@ module OpenIDConnect
       end
     end
 
-    def edit
-    end
+    def edit; end
 
     def update
       @provider = ::OpenIDConnect::Provider.initialize_with(
@@ -54,29 +52,30 @@ module OpenIDConnect
     end
 
     private
-      def create_params
-        params.require(:openid_connect_provider).permit(:name, :display_name, :identifier, :secret)
-      end
 
-      def update_params
-        params.require(:openid_connect_provider).permit(:display_name, :identifier, :secret)
-      end
+    def create_params
+      params.require(:openid_connect_provider).permit(:name, :display_name, :identifier, :secret)
+    end
 
-      def find_provider
-        @provider = providers.find{|provider| provider.id.to_s == params[:id].to_s}
-        if @provider.nil?
-          render_404
-        end
-      end
+    def update_params
+      params.require(:openid_connect_provider).permit(:display_name, :identifier, :secret)
+    end
 
-      def providers
-        @providers ||= OpenProject::OpenIDConnect.providers
+    def find_provider
+      @provider = providers.find { |provider| provider.id.to_s == params[:id].to_s }
+      if @provider.nil?
+        render_404
       end
-      helper_method :providers
+    end
 
-      def openid_connect_providers_available_for_configure
-        Provider::ALLOWED_TYPES.dup - providers.map(&:name)
-      end
-      helper_method :openid_connect_providers_available_for_configure
+    def providers
+      @providers ||= OpenProject::OpenIDConnect.providers
+    end
+    helper_method :providers
+
+    def openid_connect_providers_available_for_configure
+      Provider::ALLOWED_TYPES.dup - providers.map(&:name)
+    end
+    helper_method :openid_connect_providers_available_for_configure
   end
 end

--- a/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
+++ b/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
@@ -1,0 +1,82 @@
+module OpenIDConnect
+  class ProvidersController < ::ApplicationController
+    layout 'admin'
+    menu_item :plugin_openid_connect
+
+    before_action :require_admin
+    before_action :find_provider, only: [:edit, :update, :destroy]
+
+    def index
+    end
+
+    def new
+      if openid_connect_providers_available_for_configure.none?
+        redirect_to action: :index
+      else
+        @provider = ::OpenIDConnect::Provider.initialize_with({})
+      end
+    end
+
+    def create
+      @provider = ::OpenIDConnect::Provider.initialize_with(create_params)
+
+      if @provider.save
+        flash[:notice] = I18n.t(:notice_successful_create)
+        redirect_to action: :index
+      else
+        render action: :new
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      @provider = ::OpenIDConnect::Provider.initialize_with(
+        update_params.merge("name" => params[:id])
+      )
+      if @provider.save
+        flash[:notice] = I18n.t(:notice_successful_update)
+        redirect_to action: :index
+      else
+        render action: :edit
+      end
+    end
+
+    def destroy
+      if @provider.destroy
+        flash[:notice] = I18n.t(:notice_successful_delete)
+      else
+        flash[:error] = I18n.t(:error_failed_to_delete_entry)
+      end
+
+      redirect_to action: :index
+    end
+
+    private
+      def create_params
+        params.require(:openid_connect_provider).permit(:name, :display_name, :identifier, :secret)
+      end
+
+      def update_params
+        params.require(:openid_connect_provider).permit(:display_name, :identifier, :secret)
+      end
+
+      def find_provider
+        @provider = providers.find{|provider| provider.id.to_s == params[:id].to_s}
+        if @provider.nil?
+          render_404
+        end
+      end
+
+      def providers
+        @providers ||= OpenProject::OpenIDConnect.providers
+      end
+      helper_method :providers
+
+      def openid_connect_providers_available_for_configure
+        Provider::ALLOWED_TYPES.dup - providers.map(&:name)
+      end
+      helper_method :openid_connect_providers_available_for_configure
+  end
+end

--- a/modules/openid_connect/app/models/openid_connect/provider.rb
+++ b/modules/openid_connect/app/models/openid_connect/provider.rb
@@ -4,7 +4,7 @@ module OpenIDConnect
 
     class NewProvider < OpenStruct
       def to_h
-        @table.dup.delete_if{|k,v| v.blank?}
+        @table.dup.delete_if { |_k, v| v.blank? }
       end
     end
 
@@ -27,7 +27,7 @@ module OpenIDConnect
     end
 
     def self.initialize_with(params)
-      self.new(NewProvider.new(params))
+      new(NewProvider.new(params))
     end
 
     def new_record?
@@ -35,7 +35,7 @@ module OpenIDConnect
     end
 
     def persisted?
-      omniauth_provider.kind_of?(OmniAuth::OpenIDConnect::Provider)
+      omniauth_provider.is_a?(OmniAuth::OpenIDConnect::Provider)
     end
 
     def id

--- a/modules/openid_connect/app/models/openid_connect/provider.rb
+++ b/modules/openid_connect/app/models/openid_connect/provider.rb
@@ -1,0 +1,75 @@
+module OpenIDConnect
+  class Provider
+    ALLOWED_TYPES = ["azure", "google"].freeze
+
+    class NewProvider < OpenStruct
+      def to_h
+        @table.dup.delete_if{|k,v| v.blank?}
+      end
+    end
+
+    extend ActiveModel::Naming
+    include ActiveModel::Conversion
+    extend ActiveModel::Translation
+    attr_reader :errors, :omniauth_provider
+
+    attr_accessor :display_name
+    delegate :name, to: :omniauth_provider, allow_nil: true
+    delegate :identifier, to: :omniauth_provider, allow_nil: true
+    delegate :secret, to: :omniauth_provider, allow_nil: true
+    delegate :scope, to: :omniauth_provider, allow_nil: true
+    delegate :to_h, to: :omniauth_provider, allow_nil: false
+
+    def initialize(omniauth_provider)
+      @omniauth_provider = omniauth_provider
+      @errors = ActiveModel::Errors.new(self)
+      @display_name = omniauth_provider.to_h[:display_name]
+    end
+
+    def self.initialize_with(params)
+      self.new(NewProvider.new(params))
+    end
+
+    def new_record?
+      !persisted?
+    end
+
+    def persisted?
+      omniauth_provider.kind_of?(OmniAuth::OpenIDConnect::Provider)
+    end
+
+    def id
+      return nil unless persisted?
+      name
+    end
+
+    def valid?
+      @errors.add(:name, :invalid) unless ALLOWED_TYPES.include?(name)
+      @errors.add(:identifier, :blank) if identifier.blank?
+      @errors.add(:secret, :blank) if secret.blank?
+      @errors.none?
+    end
+
+    def save
+      return false unless valid?
+      config = Setting.plugin_openproject_openid_connect || Hash.new
+      config["providers"] ||= Hash.new
+      config["providers"][name] = omniauth_provider.to_h.stringify_keys
+      Setting.plugin_openproject_openid_connect = config
+      true
+    end
+
+    def destroy
+      config = Setting.plugin_openproject_openid_connect
+      config["providers"] ||= {}
+      config["providers"].delete(name)
+      Setting.plugin_openproject_openid_connect = config
+      true
+    end
+
+    # https://api.rubyonrails.org/classes/ActiveModel/Errors.html
+    def read_attribute_for_validation(attr)
+      send(attr)
+    end
+  end
+end

--- a/modules/openid_connect/app/views/openid_connect/providers/_form.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/_form.html.erb
@@ -1,0 +1,25 @@
+<fieldset class="form--fieldset">
+  <% unless f.object.persisted? -%>
+    <div class="form--field -required">
+      <%= f.collection_select :name,
+        openid_connect_providers_available_for_configure,
+        :to_s,
+        :capitalize,
+        required: true,
+        container_class: '-middle'
+      %>
+    </div>
+  <% end -%>
+
+  <div class="form--field">
+    <%= f.text_field :display_name, required: false, container_class: '-middle' %>
+  </div>
+
+  <div class="form--field -required">
+    <%= f.text_field :identifier, required: true, container_class: '-middle' %>
+  </div>
+
+  <div class="form--field -required">
+    <%= f.text_field :secret, required: true, container_class: '-middle' %>
+  </div>
+</fieldset>

--- a/modules/openid_connect/app/views/openid_connect/providers/edit.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/edit.html.erb
@@ -1,0 +1,19 @@
+<% page_title = t('openid_connect.providers.label_edit', name: @provider.name) %>
+<% html_title(t(:label_administration), page_title) -%>
+<% local_assigns[:additional_breadcrumb] = [
+  link_to(t('openid_connect.providers.plural'), url_for(action: :index)),
+  page_title
+] %>
+
+<%= toolbar title: page_title %>
+
+<%= error_messages_for @provider %>
+
+<%= labelled_tabular_form_for @provider,
+                              html: { class: 'form', autocomplete: 'off' } do |f| %>
+  <%= render partial: "form", locals: { f: f } %>
+  <p>
+    <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
+    <%= link_to t(:button_cancel), { action: :index }, class: 'button' %>
+  </p>
+<% end %>

--- a/modules/openid_connect/app/views/openid_connect/providers/index.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/index.html.erb
@@ -1,0 +1,16 @@
+<% html_title(t(:label_administration), t('openid_connect.providers.plural')) -%>
+<% local_assigns[:additional_breadcrumb] = t('openid_connect.providers.plural') %>
+
+<%= toolbar title: t('openid_connect.providers.plural') do %>
+  <li class="toolbar-item">
+    <%= link_to new_openid_connect_provider_path,
+          { class: 'button -alt-highlight',
+            aria: {label: t('openid_connect.providers.label_add_new')},
+            title: t('openid_connect.providers.label_add_new')} do %>
+      <%= op_icon('button--icon icon-add') %>
+      <span class="button--text"><%= t('openid_connect.providers.singular') %></span>
+    <% end if openid_connect_providers_available_for_configure.any? %>
+  </li>
+<% end %>
+
+<%= cell ::OpenIDConnect::Providers::TableCell, providers %>

--- a/modules/openid_connect/app/views/openid_connect/providers/new.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/new.html.erb
@@ -1,0 +1,19 @@
+<% html_title(t(:label_administration), t('openid_connect.providers.label_add_new')) -%>
+<% local_assigns[:additional_breadcrumb] = [
+  link_to(t('openid_connect.providers.plural'), openid_connect_providers_path),
+  t('openid_connect.providers.label_add_new')
+  ]
+%>
+
+<%= toolbar title: t('openid_connect.providers.label_add_new') %>
+
+<%= error_messages_for @provider %>
+
+<%= labelled_tabular_form_for @provider,
+                              html: { class: 'form', autocomplete: 'off' } do |f| %>
+  <%= render partial: "form", locals: { f: f } %>
+  <p>
+    <%= styled_button_tag l(:button_create), class: '-highlight -with-icon icon-checkmark' %>
+    <%= link_to t(:button_cancel), { action: :index }, class: 'button' %>
+  </p>
+<% end %>

--- a/modules/openid_connect/config/locales/en.yml
+++ b/modules/openid_connect/config/locales/en.yml
@@ -2,3 +2,19 @@ en:
   logout_warning: >
     You have been logged out. The contents of any form you submit may be lost.
     Please [log in].
+  activemodel:
+    attributes:
+      openid_connect/provider:
+        name: Name
+        display_name: Display name
+        identifier: Identifier
+        secret: Secret
+        scope: Scope
+  openid_connect:
+    menu_title: OpenID providers
+    providers:
+      label_add_new: Add a new OpenID provider
+      label_edit: Edit OpenID provider %{name}
+      no_results_table: No providers have been defined yet.
+      plural: OpenID providers
+      singular: OpenID provider

--- a/modules/openid_connect/config/routes.rb
+++ b/modules/openid_connect/config/routes.rb
@@ -1,3 +1,9 @@
 Rails.application.routes.draw do
   get '/session/logout_warning', to: 'session#logout_warning'
+
+  scope :admin do
+    namespace :openid_connect do
+      resources :providers, only: [:index, :new, :create, :edit, :update, :destroy]
+    end
+  end
 end

--- a/modules/openid_connect/lib/open_project/openid_connect.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect.rb
@@ -1,5 +1,29 @@
 module OpenProject
   module OpenIDConnect
+    require 'omniauth/openid_connect/providers'
     require 'open_project/openid_connect/engine'
+
+
+    def providers
+      # update base redirect URI in case settings changed
+      ::OmniAuth::OpenIDConnect::Providers.configure(
+        base_redirect_uri: "#{Setting.protocol}://#{Setting.host_name}#{OpenProject::Configuration['rails_relative_url_root']}"
+      )
+      ::OmniAuth::OpenIDConnect::Providers.load(configuration).map do |omniauth_provider|
+        ::OpenIDConnect::Provider.new(omniauth_provider)
+      end
+    end
+    module_function :providers
+
+    def configuration
+      from_settings = if Setting.plugin_openproject_openid_connect.is_a? Hash
+        Hash(Setting.plugin_openproject_openid_connect["providers"])
+      else
+        {}
+      end
+      # Settings override configuration.yml
+      Hash(OpenProject::Configuration["openid_connect"]).deep_merge(from_settings)
+    end
+    module_function :configuration
   end
 end

--- a/modules/openid_connect/lib/open_project/openid_connect.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect.rb
@@ -3,7 +3,6 @@ module OpenProject
     require 'omniauth/openid_connect/providers'
     require 'open_project/openid_connect/engine'
 
-
     def providers
       # update base redirect URI in case settings changed
       ::OmniAuth::OpenIDConnect::Providers.configure(
@@ -17,10 +16,10 @@ module OpenProject
 
     def configuration
       from_settings = if Setting.plugin_openproject_openid_connect.is_a? Hash
-        Hash(Setting.plugin_openproject_openid_connect["providers"])
-      else
-        {}
-      end
+                        Hash(Setting.plugin_openproject_openid_connect["providers"])
+                      else
+                        {}
+                      end
       # Settings override configuration.yml
       Hash(OpenProject::Configuration["openid_connect"]).deep_merge(from_settings)
     end

--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -10,7 +10,14 @@ module OpenProject::OpenIDConnect
     register 'openproject-openid_connect',
              author_url: 'http://finn.de',
              bundled: true,
-             settings: { 'default' => { 'providers' => {} } }
+             settings: { 'default' => { 'providers' => {} } } do
+      menu :admin_menu,
+        :plugin_openid_connect,
+        :openid_connect_providers_path,
+        after: :ldap_authentication,
+        caption: ->(*) { I18n.t('openid_connect.menu_title') },
+        icon: 'icon2 icon-relations'
+    end
 
     assets %w(
       openid_connect/auth_provider-azure.png
@@ -19,39 +26,22 @@ module OpenProject::OpenIDConnect
     )
 
     register_auth_providers do
-      require 'omniauth/openid_connect/providers'
-
-      Providers = OmniAuth::OpenIDConnect::Providers
-
       # Use OpenSSL default certificate store instead of HTTPClient's.
       # It's outdated and it's unclear how it's managed.
       OpenIDConnect.http_config do |config|
         config.ssl_config.set_default_paths
       end
 
-      def configuration
-        from_settings = if Setting.plugin_openproject_openid_connect.is_a? Hash
-          Hash(Setting.plugin_openproject_openid_connect["providers"])
-        else
-          {}
-        end
-        # Settings override configuration.yml
-        Hash(OpenProject::Configuration["openid_connect"]).deep_merge(from_settings)
-      end
-
-      Providers.configure custom_options: [
+      OmniAuth::OpenIDConnect::Providers.configure custom_options: [
         :display_name?, :icon?, :sso?, :issuer?,
         :check_session_iframe?, :end_session_endpoint?
       ]
 
       strategy :openid_connect do
-        # update base redirect URI in case settings changed
-        Providers.configure base_redirect_uri: "#{Setting.protocol}://#{Setting.host_name}#{OpenProject::Configuration['rails_relative_url_root']}"
-        Providers.load(configuration).map(&:to_h)
+        OpenProject::OpenIDConnect.providers.map(&:to_h)
       end
     end
 
-    #config.to_prepare do
     initializer 'openid_connect.form_post_method' do
       # If response_mode 'form_post' is chosen,
       # the IP sends a POST to the callback. Only if

--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -12,11 +12,11 @@ module OpenProject::OpenIDConnect
              bundled: true,
              settings: { 'default' => { 'providers' => {} } } do
       menu :admin_menu,
-        :plugin_openid_connect,
-        :openid_connect_providers_path,
-        after: :ldap_authentication,
-        caption: ->(*) { I18n.t('openid_connect.menu_title') },
-        icon: 'icon2 icon-relations'
+           :plugin_openid_connect,
+           :openid_connect_providers_path,
+           after: :ldap_authentication,
+           caption: ->(*) { I18n.t('openid_connect.menu_title') },
+           icon: 'icon2 icon-relations'
     end
 
     assets %w(
@@ -32,9 +32,9 @@ module OpenProject::OpenIDConnect
         config.ssl_config.set_default_paths
       end
 
-      OmniAuth::OpenIDConnect::Providers.configure custom_options: [
-        :display_name?, :icon?, :sso?, :issuer?,
-        :check_session_iframe?, :end_session_endpoint?
+      OmniAuth::OpenIDConnect::Providers.configure custom_options: %i[
+        display_name? icon? sso? issuer?
+        check_session_iframe? end_session_endpoint?
       ]
 
       strategy :openid_connect do
@@ -46,8 +46,7 @@ module OpenProject::OpenIDConnect
       # If response_mode 'form_post' is chosen,
       # the IP sends a POST to the callback. Only if
       # the sameSite flag is not set on the session cookie, is the cookie send along with the request.
-      if OpenProject::Configuration['openid_connect'] &&
-        OpenProject::Configuration['openid_connect'].any? { |_, v| v['response_mode']&.to_s == 'form_post' }
+      if OpenProject::Configuration['openid_connect']&.any? { |_, v| v['response_mode']&.to_s == 'form_post' }
         SecureHeaders::Configuration.default.cookies[:samesite][:lax] = false
         # Need to reload the secure_headers config to
         # avoid having set defaults (e.g. https) when changing the cookie values
@@ -68,7 +67,7 @@ module OpenProject::OpenIDConnect
           # put it into a cookie
           if context && access_token
             context.send(:cookies)[:_open_project_session_access_token] = {
-              value:  access_token,
+              value: access_token,
               secure: secure_cookie
             }
           end

--- a/modules/openid_connect/spec/controllers/providers_controller_spec.rb
+++ b/modules/openid_connect/spec/controllers/providers_controller_spec.rb
@@ -1,0 +1,146 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.md for more details.
+#++
+
+require 'spec_helper'
+
+describe ::OpenIDConnect::ProvidersController, type: :controller do
+  let(:user) { FactoryBot.build_stubbed :admin }
+
+  let(:valid_params) do
+    {
+      name: 'azure',
+      identifier: "IDENTIFIER",
+      secret: "SECRET",
+    }
+  end
+
+  before do
+    login_as user
+  end
+
+  context 'when not admin' do
+    let(:user) { FactoryBot.build_stubbed :user }
+
+    it 'renders 403' do
+      get :index
+      expect(response.status).to eq 403
+    end
+  end
+
+  context 'when not logged in' do
+    let(:user) { User.anonymous }
+
+    it 'renders 403' do
+      get :index
+      expect(response.status).to redirect_to(signin_url(back_url: openid_connect_providers_url))
+    end
+  end
+
+  describe '#index' do
+    it 'renders the index page' do
+      get :index
+      expect(response).to be_successful
+      expect(response).to render_template 'index'
+    end
+  end
+
+  describe '#new' do
+    it 'renders the new page' do
+      get :new
+      expect(response).to be_successful
+      expect(assigns[:provider]).to be_new_record
+      expect(response).to render_template 'new'
+    end
+
+    it 'redirects to the index page if no provider available', with_settings: {
+      plugin_openproject_openid_connect: {
+        "providers" => OpenIDConnect::Provider::ALLOWED_TYPES.inject({}) do |accu, name|
+          accu.merge(name => { "identifier" => "IDENTIFIER", "secret" => "SECRET" })
+        end
+      }
+    } do
+      get :new
+      expect(response).to be_redirect
+    end
+  end
+
+  describe '#create' do
+    it 'is successful if valid params' do
+      post :create, params: {openid_connect_provider: valid_params}
+      expect(flash[:notice]).to eq(I18n.t(:notice_successful_create))
+      expect(Setting.plugin_openproject_openid_connect["providers"]).to have_key("azure")
+      expect(response).to be_redirect
+    end
+
+    it 'renders an error if invalid params' do
+      post :create, params: {openid_connect_provider: valid_params.merge(identifier: "")}
+      expect(response).to render_template 'new'
+    end
+  end
+
+  describe '#edit' do
+    context 'when found', with_settings: {
+      plugin_openproject_openid_connect: {
+        "providers" => { "azure" => { "identifier" => "IDENTIFIER", "secret" => "SECRET" } }
+      }
+    } do
+      it 'renders the edit page' do
+        get :edit, params: { id: 'azure' }
+        expect(response).to be_successful
+        expect(assigns[:provider]).to be_present
+        expect(response).to render_template 'edit'
+      end
+    end
+
+    context 'when not found' do
+      it 'renders 404' do
+        get :edit, params: { id: 'doesnoexist' }
+        expect(response).not_to be_successful
+        expect(response.status).to eq 404
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'when found', with_settings: {
+      plugin_openproject_openid_connect: {
+        "providers" => { "azure" => { "identifier" => "IDENTIFIER", "secret" => "SECRET" } }
+      }
+    } do
+      it 'successfully updates the provider configuration' do
+        put :update, params: {id: "azure", openid_connect_provider: valid_params.merge(secret: "NEWSECRET")}
+        expect(response).to be_redirect
+        expect(flash[:notice]).to be_present
+        provider = OpenProject::OpenIDConnect.providers.find{|provider| provider.name == "azure"}
+        expect(provider.secret).to eq("NEWSECRET")
+      end
+    end
+  end
+
+  describe '#destroy' do
+    context 'when found', with_settings: {
+      plugin_openproject_openid_connect: {
+        "providers" => { "azure" => { "identifier" => "IDENTIFIER", "secret" => "SECRET" } }
+      }
+    } do
+
+      it 'removes the provider' do
+        delete :destroy, params: {id: "azure"}
+        expect(response).to be_redirect
+        expect(flash[:notice]).to be_present
+        expect(OpenProject::OpenIDConnect.providers).to be_empty
+      end
+    end
+  end
+end

--- a/modules/openid_connect/spec/controllers/providers_controller_spec.rb
+++ b/modules/openid_connect/spec/controllers/providers_controller_spec.rb
@@ -21,7 +21,7 @@ describe ::OpenIDConnect::ProvidersController, type: :controller do
     {
       name: 'azure',
       identifier: "IDENTIFIER",
-      secret: "SECRET",
+      secret: "SECRET"
     }
   end
 
@@ -77,14 +77,14 @@ describe ::OpenIDConnect::ProvidersController, type: :controller do
 
   describe '#create' do
     it 'is successful if valid params' do
-      post :create, params: {openid_connect_provider: valid_params}
+      post :create, params: { openid_connect_provider: valid_params }
       expect(flash[:notice]).to eq(I18n.t(:notice_successful_create))
       expect(Setting.plugin_openproject_openid_connect["providers"]).to have_key("azure")
       expect(response).to be_redirect
     end
 
     it 'renders an error if invalid params' do
-      post :create, params: {openid_connect_provider: valid_params.merge(identifier: "")}
+      post :create, params: { openid_connect_provider: valid_params.merge(identifier: "") }
       expect(response).to render_template 'new'
     end
   end
@@ -119,10 +119,10 @@ describe ::OpenIDConnect::ProvidersController, type: :controller do
       }
     } do
       it 'successfully updates the provider configuration' do
-        put :update, params: {id: "azure", openid_connect_provider: valid_params.merge(secret: "NEWSECRET")}
+        put :update, params: { id: "azure", openid_connect_provider: valid_params.merge(secret: "NEWSECRET") }
         expect(response).to be_redirect
         expect(flash[:notice]).to be_present
-        provider = OpenProject::OpenIDConnect.providers.find{|provider| provider.name == "azure"}
+        provider = OpenProject::OpenIDConnect.providers.find { |item| item.name == "azure" }
         expect(provider.secret).to eq("NEWSECRET")
       end
     end
@@ -136,7 +136,7 @@ describe ::OpenIDConnect::ProvidersController, type: :controller do
     } do
 
       it 'removes the provider' do
-        delete :destroy, params: {id: "azure"}
+        delete :destroy, params: { id: "azure" }
         expect(response).to be_redirect
         expect(flash[:notice]).to be_present
         expect(OpenProject::OpenIDConnect.providers).to be_empty

--- a/modules/openid_connect/spec/requests/openid_connect_spec.rb
+++ b/modules/openid_connect/spec/requests/openid_connect_spec.rb
@@ -145,6 +145,10 @@ describe 'OpenID Connect', type: :rails_request do
             'google' => {
               'identifier' => 'does not',
               'secret' => 'matter'
+            },
+            'azure' => {
+              'identifier' => 'IDENTIFIER',
+              'secret' => 'SECRET'
             }
           }
 
@@ -152,6 +156,7 @@ describe 'OpenID Connect', type: :rails_request do
 
       get '/login'
       expect(response.body).to match /Google/i
+      expect(response.body).to match /Azure/i
 
       expect { click_on_signin('google') }.not_to raise_error
       expect(response.status).to be 302

--- a/modules/openid_connect/spec/requests/openid_connect_spec.rb
+++ b/modules/openid_connect/spec/requests/openid_connect_spec.rb
@@ -56,7 +56,8 @@ describe 'OpenID Connect', type: :rails_request do
     # provider to retrieve user information such as name and email address.
     # Since the test is not supposed to make an actual call it is be stubbed too.
     allow_any_instance_of(OpenIDConnect::AccessToken).to receive(:userinfo!).and_return(
-      OpenIDConnect::ResponseObject::UserInfo.new(user_info))
+      OpenIDConnect::ResponseObject::UserInfo.new(user_info)
+    )
 
     # enable storing the access token in a cookie
     OpenProject::Configuration['omniauth_store_access_token_in_cookie'] = true
@@ -65,14 +66,12 @@ describe 'OpenID Connect', type: :rails_request do
   describe 'sign-up and login' do
     before do
       allow(Setting).to receive(:plugin_openproject_openid_connect).and_return(
-
-          'providers' => {
-            'heroku' => {
-              'identifier' => 'does not',
-              'secret' => 'matter'
-            }
+        'providers' => {
+          'heroku' => {
+            'identifier' => 'does not',
+            'secret' => 'matter'
           }
-
+        }
       )
     end
 
@@ -140,18 +139,16 @@ describe 'OpenID Connect', type: :rails_request do
   context 'provider configuration through the settings' do
     it 'should make providers that have been configured through settings available without requiring a restart' do
       allow(Setting).to receive(:plugin_openproject_openid_connect).and_return(
-
-          'providers' => {
-            'google' => {
-              'identifier' => 'does not',
-              'secret' => 'matter'
-            },
-            'azure' => {
-              'identifier' => 'IDENTIFIER',
-              'secret' => 'SECRET'
-            }
+        'providers' => {
+          'google' => {
+            'identifier' => 'does not',
+            'secret' => 'matter'
+          },
+          'azure' => {
+            'identifier' => 'IDENTIFIER',
+            'secret' => 'SECRET'
           }
-
+        }
       )
 
       get '/login'

--- a/modules/openid_connect/spec/routing/openid_connect/providers_controller_spec.rb
+++ b/modules/openid_connect/spec/routing/openid_connect/providers_controller_spec.rb
@@ -1,13 +1,12 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
 #
 # OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
-# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2006-2013 Jean-Philippe Lang
 # Copyright (C) 2010-2013 the ChiliProject Team
 #
 # This program is free software; you can redistribute it and/or
@@ -24,23 +23,37 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# See docs/COPYRIGHT.rdoc for more details.
+# See doc/COPYRIGHT.rdoc for more details.
 #++
 
-# Be sure to restart your server when you modify this file.
+require 'spec_helper'
 
-# Add new inflection rules using the following format. Inflections
-# are locale specific, and you may define rules for as many different
-# locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
+describe 'OpenIDConnect Providers', type: :routing do
+  it 'routes to index' do
+    expect(get('/admin/openid_connect/providers')).to route_to('openid_connect/providers#index')
+  end
 
-# These inflection rules are supported but not enabled by default:
-ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.acronym 'OAuth'
-  inflect.acronym 'OpenID'
+  it 'routes to new' do
+    expect(get('/admin/openid_connect/providers/new')).to route_to('openid_connect/providers#new')
+  end
+
+  it 'routes to edit' do
+    expect(get('/admin/openid_connect/providers/azure/edit')).to(
+      route_to(
+        controller: 'openid_connect/providers',
+        action: 'edit',
+        id: 'azure'
+      )
+    )
+  end
+
+  it 'routes to destroy' do
+    expect(delete('/admin/openid_connect/providers/azure')).to(
+      route_to(
+        controller: 'openid_connect/providers',
+        action: 'destroy',
+        id: 'azure'
+      )
+    )
+  end
 end


### PR DESCRIPTION
This first attempt will allow users to configure their OpenID providers through the admin UI. For now the UI is only limited to add the built-in providers (Azure, Google), with the minimal number of configuration options required (identifier & secret).

I believe this is enough for the majority of the cases, and we can then build upon this first PR to add an advanced mode where admins can tweak other settings. This would likely require reorganizing a bit the relationship between omniauth-openid_connect-providers and the core, and promoting OpenID providers to first-class objects in the system.

Feel free to give advice/reviews already, before I finish this on May 9th.

TODO:
- [x] tests
- [x] verify impacts with SaaS