### PR TITLE
Use our packaged pgloader-ccl, as well as the migration script

### DIFF
--- a/docs/operations/migrating/packaged/postgresql-migration.md
+++ b/docs/operations/migrating/packaged/postgresql-migration.md
@@ -116,7 +116,7 @@ Lastly, exit the system user
 The following command saves the current MySQL `DATABASE_URL` as `MYSQL_DATABASE_URL` in the OpenProject configuration:
 
 ```bash
-openproject config:set MYSQL_DATABASE_URL=$(openproject config:get DATABASE_URL)
+openproject config:set MYSQL_DATABASE_URL="$(openproject config:get DATABASE_URL)"
 openproject config:get MYSQL_DATABASE_URL
 
 # Will output something of the kind

--- a/docs/operations/migrating/packaged/postgresql-migration.md
+++ b/docs/operations/migrating/packaged/postgresql-migration.md
@@ -116,7 +116,8 @@ Lastly, exit the system user
 Note down or copy the current MySQL `DATABASE_URL`. The following command exports it to the curent shell as `MYSQL_DATABASE_URL`:
 
 ```bash
-openproject config:get DATABASE_URL
+openproject config:set MYSQL_DATABASE_URL=$(openproject config:get DATABASE_URL)
+openproject config:get MYSQL_DATABASE_URL
 
 # Will output something of the kind
 # mysql2://user:password@localhost:3306/dbname
@@ -129,7 +130,6 @@ Form the `DATABASE_URL` string to match your entered password and pass it to the
 
 ```bash
 openproject config:set DATABASE_URL="postgresql://openproject:<PASSWORD>@localhost/openproject"
-export POSTGRES_DATABASE_URL="postgresql://openproject:<PASSWORD>@localhost/openproject"
 ```
 
 
@@ -141,7 +141,7 @@ export POSTGRES_DATABASE_URL="postgresql://openproject:<PASSWORD>@localhost/open
 You are now ready to migrate from MySQL to PostgreSQL. The OpenProject packages embed a migration script that can be launched as follows:
 
 ```
-sudo openproject run ./docker/mysql-to-postgres/bin/migrate-mysql-to-postgres MYSQL_DATABASE_URL="mysql2://user:password@localhost:3306/dbname"
+sudo openproject run ./docker/mysql-to-postgres/bin/migrate-mysql-to-postgres
 ```
 
 This might take a while depending on current installation size.
@@ -156,6 +156,7 @@ The following is an exemplary removal of an installed version MySQL 5.7.
 
 ```
 [root@host] apt-get remove mysql-server
+[root@host] openproject config:unset MYSQL_DATABASE_URL
 ```
 
 **Note:** OpenProject still depends on `mysql-common` and other dev libraries of MySQL to build the `mysql2` gem for talking to MySQL databases. Depending on what packages you try to uninstall, `openproject` will be listed as a dependent package to be uninstalled if trying to uninstall `mysql-common`. Be careful here with the confirmation of removal, because it might just remove openproject itself due to the apt dependency management.

--- a/docs/operations/migrating/packaged/postgresql-migration.md
+++ b/docs/operations/migrating/packaged/postgresql-migration.md
@@ -16,7 +16,6 @@ This guide should leave you with a set of archives that you should manually move
 - **Repositories**: svn- and git-&lt;timestamp&gt;.tar.gz
 
 
-
 ## Installation of pgloader
 
 We ship a custom version of pgloader (named `pgloader-ccl`), which embeds some memory optimizations useful when you are migrating from a large MySQL database. This also allows us to provide a unified migration experience for all installation types. This package is available for all the currently supported distributions at https://packager.io/gh/opf/pgloader-ccl.
@@ -124,11 +123,6 @@ openproject config:get DATABASE_URL
 ```
 
 
-
-**Please note:** Ensure that the URL starts with `mysql://` , not with ` mysql2://` !
-
-
-
 ## Configuring OpenProject to use the PostgreSQL database
 
 Form the `DATABASE_URL` string to match your entered password and pass it to the openproject configuration. The following command also exports it to the current shell as `POSTGRES_DATABASE_URL`
@@ -139,9 +133,7 @@ export POSTGRES_DATABASE_URL="postgresql://openproject:<PASSWORD>@localhost/open
 ```
 
 
-
 **Please note:**  Replace  `<PASSWORD>`  with the password you provided above. If you used any special characters, [check whether they need to be percent-encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding) for the database URL.
-
 
 
 ## Migrating the database

--- a/docs/operations/migrating/packaged/postgresql-migration.md
+++ b/docs/operations/migrating/packaged/postgresql-migration.md
@@ -172,8 +172,8 @@ openproject reconfigure
 ```
 
 
-In the database installation screen, select `skip` now.
-Keep all other values the same by simply confirming them by pressing  `enter` .
+In the database installation screen, make sure to select `skip`.
+Keep all other values the same by simply confirming them by pressing `enter` .
 
 
-After the configuration process has run through, your database will be running on PostgreSQL!
+After the configuration process has run through, your OpenProject installation will be running on PostgreSQL!

--- a/docs/operations/migrating/packaged/postgresql-migration.md
+++ b/docs/operations/migrating/packaged/postgresql-migration.md
@@ -8,7 +8,7 @@ This guide will migrate your packaged MySQL installation to a PostgreSQL install
 
 Before beginning the migration, please ensure you have created a backup of your current installation. Please follow our [backup and restore documentation](https://www.openproject.org/operations/backup/backup-guide-packaged-installation/) for our packaged installation.
 
-This guide should leave you with a set of archives that you should manually move to your new environment:
+This guide should leave you with a set of archives that you can use to restore, should the migration end up in an unstable state:
 
 - **Database**: mysql-dump-&lt;timestamp&gt;.sql.gz
 - **Attachments**: attachments-&lt;timestamp&gt;.tar.gz
@@ -111,9 +111,9 @@ Lastly, exit the system user
 # You will be root again now.
 ```
 
-## Remember the current database URL
+## Set the MYSQL_DATABASE_URL to migrate from
 
-Note down or copy the current MySQL `DATABASE_URL`. The following command exports it to the curent shell as `MYSQL_DATABASE_URL`:
+The following command saves the current MySQL `DATABASE_URL` as `MYSQL_DATABASE_URL` in the OpenProject configuration:
 
 ```bash
 openproject config:set MYSQL_DATABASE_URL=$(openproject config:get DATABASE_URL)
@@ -123,10 +123,11 @@ openproject config:get MYSQL_DATABASE_URL
 # mysql2://user:password@localhost:3306/dbname
 ```
 
+This will be used later by the migration script.
 
 ## Configuring OpenProject to use the PostgreSQL database
 
-Form the `DATABASE_URL` string to match your entered password and pass it to the openproject configuration. The following command also exports it to the current shell as `POSTGRES_DATABASE_URL`
+Form the `DATABASE_URL` string to match your selected password and add it to the openproject configuration:
 
 ```bash
 openproject config:set DATABASE_URL="postgresql://openproject:<PASSWORD>@localhost/openproject"


### PR DESCRIPTION
Note: another improvement would be to somehow use the embedded postgres addon to setup the postgres installation (i.e. `reconfigure, choose install postgres, which will setup a postgres database in the recommended way). Although this would required some more testing, and it might better to not be too magical for that migration.