### PR TITLE
[30212] Add link to edit version in list options in boards view

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -53,6 +53,7 @@ en:
         check_out_link: 'Check out the Enterprise Edition.'
       lists:
         delete: 'Delete list'
+        edit_version: 'Edit version'
 
     card:
       add_new: 'Add new card'

--- a/frontend/src/app/modules/boards/board/board-actions/board-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/board-action.service.ts
@@ -32,4 +32,10 @@ export interface BoardActionService {
    * Get available values from the active queries
    */
   getAvailableValues(board:Board, queries:QueryResource[]):Promise<HalResource[]>;
+
+  /**
+   * Get action specific items that shall be shown in the list menu
+   * @returns {any[]}
+   */
+  getAdditionalListMenuItems(actionAttributeValue:HalResource):any[];
 }

--- a/frontend/src/app/modules/boards/board/board-actions/board-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/board-action.service.ts
@@ -37,5 +37,5 @@ export interface BoardActionService {
    * Get action specific items that shall be shown in the list menu
    * @returns {any[]}
    */
-  getAdditionalListMenuItems(actionAttributeValue:HalResource):any[];
+  getAdditionalListMenuItems(actionAttributeValue:HalResource):Promise<any>;
 }

--- a/frontend/src/app/modules/boards/board/board-actions/status-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/status-action.service.ts
@@ -1,6 +1,5 @@
 import {Injectable} from "@angular/core";
 import {BoardListsService} from "core-app/modules/boards/board/board-list/board-lists.service";
-import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 import {Board} from "core-app/modules/boards/board/board";
 import {StatusDmService} from "core-app/modules/hal/dm-services/status-dm.service";
 import {StatusResource} from "core-app/modules/hal/resources/status-resource";
@@ -13,8 +12,7 @@ import {FilterOperator} from "core-components/api/api-v3/api-v3-filter-builder";
 @Injectable()
 export class BoardStatusActionService implements BoardActionService {
 
-  constructor(protected pathHelper:PathHelperService,
-              protected boardListService:BoardListsService,
+  constructor(protected boardListsService:BoardListsService,
               protected I18n:I18nService,
               protected statusDm:StatusDmService) {
   }
@@ -66,7 +64,7 @@ export class BoardStatusActionService implements BoardActionService {
       values: [value.id]
     }};
 
-    return this.boardListService.addQuery(board, params, [filter]);
+    return this.boardListsService.addQuery(board, params, [filter]);
   }
 
   /**
@@ -91,5 +89,9 @@ export class BoardStatusActionService implements BoardActionService {
     return this.statusDm
       .list()
       .then(collection => collection.elements);
+  }
+
+  public getAdditionalListMenuItems(actionAttributeValue:HalResource) {
+    return [];
   }
 }

--- a/frontend/src/app/modules/boards/board/board-actions/status-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/status-action.service.ts
@@ -91,7 +91,7 @@ export class BoardStatusActionService implements BoardActionService {
       .then(collection => collection.elements);
   }
 
-  public getAdditionalListMenuItems(actionAttributeValue:HalResource) {
-    return [];
+  public getAdditionalListMenuItems(actionAttributeValue:HalResource):Promise<any> {
+    return Promise.resolve([]);
   }
 }

--- a/frontend/src/app/modules/boards/board/board-list/board-list-dropdown.directive.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list-dropdown.directive.ts
@@ -63,7 +63,6 @@ export class BoardListDropdownMenuDirective extends OpContextMenuTrigger {
 
     super(elementRef, opContextMenu);
     this.board = this.boardList.board;
-    this.actionService = this.boardActions.get(this.board.actionAttribute!);
   }
 
   protected open(evt:JQueryEventObject) {
@@ -100,20 +99,27 @@ export class BoardListDropdownMenuDirective extends OpContextMenuTrigger {
       }
     ];
 
-    this.querySpace.query.values$().subscribe((query) => {
-      const actionAttributeValue = this.BoardListService.getActionAttributeValue(this.board, query);
-      if (actionAttributeValue !== '') {
-        this.actionService.getAdditionalListMenuItems(actionAttributeValue).forEach((item) => {
-          this.items.push({
-            linkText: item.linkText,
-            onClick: () => {
-              item.externalAction();
-              return true;
-            }
+    // Add action specific menu entries
+    if (this.board.isAction) {
+      this.actionService = this.boardActions.get(this.board.actionAttribute!);
+      this.querySpace.query.values$().subscribe((query) => {
+        const actionAttributeValue = this.BoardListService.getActionAttributeValue(this.board, query);
+
+        if (actionAttributeValue !== '') {
+          this.actionService.getAdditionalListMenuItems(actionAttributeValue).then((items) => {
+            items.forEach((item:any) => {
+              this.items.push({
+                linkText: item.linkText,
+                onClick: () => {
+                  item.externalAction();
+                  return true;
+                }
+              });
+            });
           });
-        });
-      }
-    });
+        }
+      });
+    }
 
     return this.items;
   }

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -1,7 +1,9 @@
 import {
   Component,
   ElementRef,
-  EventEmitter, Inject, Injector,
+  EventEmitter,
+  Inject,
+  Injector,
   Input,
   OnChanges,
   OnDestroy,
@@ -30,17 +32,16 @@ import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {AuthorisationService} from "core-app/modules/common/model-auth/model-auth.service";
 import {Highlighting} from "core-components/wp-fast-table/builders/highlighting/highlighting.functions";
 import {WorkPackageCardViewComponent} from "core-components/wp-card-view/wp-card-view.component";
-import {GonService} from "core-app/modules/common/gon/gon.service";
 import {WorkPackageStatesInitializationService} from "core-components/wp-list/wp-states-initialization.service";
 import {ApiV3Filter} from "core-components/api/api-v3/api-v3-filter-builder";
 import {BoardService} from "app/modules/boards/board/board.service";
-import {BoardListsService} from "core-app/modules/boards/board/board-list/board-lists.service";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {WorkPackageFilterValues} from "core-components/wp-edit-form/work-package-filter-values";
 import {IWorkPackageEditingServiceToken} from "core-components/wp-edit-form/work-package-editing.service.interface";
 import {WorkPackageEditingService} from "core-components/wp-edit-form/work-package-editing-service";
 import {WorkPackageCacheService} from "core-components/work-packages/work-package-cache.service";
 import {WorkPackageNotificationService} from "core-components/wp-edit/wp-notification.service";
+import {BoardListService} from "core-app/modules/boards/board/board-list/board-list.service";
 
 @Component({
   selector: 'board-list',
@@ -103,7 +104,6 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
               private readonly boardCache:BoardCacheService,
               private readonly notifications:NotificationsService,
               private readonly querySpace:IsolatedQuerySpace,
-              private readonly Gon:GonService,
               private readonly wpNotificationService:WorkPackageNotificationService,
               private readonly wpStatesInitialization:WorkPackageStatesInitializationService,
               private readonly authorisationService:AuthorisationService,
@@ -113,7 +113,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
               private readonly loadingIndicator:LoadingIndicatorService,
               private readonly wpCacheService:WorkPackageCacheService,
               private readonly boardService:BoardService,
-              private readonly boardListService:BoardListsService) {
+              private readonly boardListService:BoardListService) {
     super(I18n);
   }
 
@@ -219,12 +219,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
   public boardListActionColorClass(query:QueryResource):string {
     const attribute = this.board.actionAttribute!;
-    const filter = _.find(query.filters, f => f.id === attribute);
-
-    if (!(filter && filter.values[0] instanceof HalResource)) {
-      return '';
-    }
-    const value = filter.values[0] as HalResource;
+    const value = this.boardListService.getActionAttributeValue(this.board, query);
     return Highlighting.backgroundClass(attribute, value.id!);
   }
 

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -219,7 +219,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
   public boardListActionColorClass(query:QueryResource):string {
     const attribute = this.board.actionAttribute!;
-    const value = this.boardListService.getActionAttributeValue(this.board, query);
+    const value = this.boardListService.getActionAttributeValue(this.board, query) as HalResource;
     return Highlighting.backgroundClass(attribute, value.id!);
   }
 

--- a/frontend/src/app/modules/boards/board/board-list/board-list.service.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.service.ts
@@ -1,0 +1,19 @@
+import {Injectable} from "@angular/core";
+import {Board} from "core-app/modules/boards/board/board";
+import {HalResource} from "core-app/modules/hal/resources/hal-resource";
+import {QueryResource} from "core-app/modules/hal/resources/query-resource";
+
+@Injectable()
+export class BoardListService {
+  public getActionAttributeValue(board:Board, query:QueryResource) {
+    const attribute = board.actionAttribute!;
+    const filter = _.find(query.filters, f => f.id === attribute);
+
+    if (!(filter && filter.values[0] instanceof HalResource)) {
+      return '';
+    }
+    const value = filter.values[0] as HalResource;
+    return value;
+  }
+}
+

--- a/frontend/src/app/modules/boards/openproject-boards.module.ts
+++ b/frontend/src/app/modules/boards/openproject-boards.module.ts
@@ -53,6 +53,7 @@ import {AddCardDropdownMenuDirective} from "core-app/modules/boards/board/add-ca
 import {BoardFilterComponent} from "core-app/modules/boards/board/board-filter/board-filter.component";
 import {DragScrollModule} from "cdk-drag-scroll";
 import {BoardListDropdownMenuDirective} from "core-app/modules/boards/board/board-list/board-list-dropdown.directive";
+import {BoardListService} from "core-app/modules/boards/board/board-list/board-list.service";
 
 export const BOARDS_ROUTES:Ng2StateDeclaration[] = [
   {
@@ -129,6 +130,7 @@ export function registerBoardsModule(injector:Injector) {
   providers: [
     BoardService,
     BoardDmService,
+    BoardListService,
     BoardListsService,
     BoardCacheService,
     BoardConfigurationService,

--- a/frontend/src/app/modules/common/path-helper/path-helper.service.ts
+++ b/frontend/src/app/modules/common/path-helper/path-helper.service.ts
@@ -164,6 +164,10 @@ export class PathHelperService {
     return this.staticBase + '/versions';
   }
 
+  public versionEditPath(id:string|number) {
+    return this.staticBase + '/versions/' + id + '/edit';
+  }
+
   public workPackagesPath() {
     return this.staticBase + '/work_packages';
   }


### PR DESCRIPTION
Let action services define „action“-specific menu items (e.g. edit version) in the board list

⚠️ Wait for https://github.com/opf/openproject/pull/7299 since there the API and the links in the resource are set. Without this, there will be no menu entry as the permission check fails.

https://community.openproject.com/projects/openproject/work_packages/30212/activity