### PR TITLE
[30211] Missing status indicator on card in version board

### DIFF
--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.html
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.html
@@ -45,7 +45,7 @@
                     [workPackageAddedHandler]="workPackageAddedHandler"
                     [cardsRemovable]="board.isFree && canManage"
                     [highlightingMode]="board.highlightingMode"
-                    [showStatusButton]="board.isFree">
+                    [showStatusButton]="showCardStatusButton()">
       </wp-card-view>
     </div>
   </ng-container>

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -232,6 +232,10 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     return this.query && this.query.name;
   }
 
+  public showCardStatusButton() {
+    return this.board.showStatusButton();
+  }
+
   private updateQuery() {
     this.setQueryProps(this.filters);
     this.loadQuery();

--- a/frontend/src/app/modules/boards/board/board.ts
+++ b/frontend/src/app/modules/boards/board/board.ts
@@ -84,4 +84,8 @@ export class Board {
       return a.startColumn - b.startColumn;
     });
   }
+
+  public showStatusButton() {
+    return this.actionAttribute !== 'status';
+  }
 }


### PR DESCRIPTION
Hide status button in WP cards only in status boards.

https://community.openproject.com/projects/openproject/work_packages/30211/activity