### PR TITLE
[30218] Restrict inline editing for basic boards

### DIFF
--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -181,7 +181,9 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
   }
 
   public get canRename() {
-    return this.canManage && !!this.query.updateImmediately;
+    return this.canManage &&
+           !!this.query.updateImmediately &&
+           this.board.isFree;
   }
 
   public addReferenceCard() {

--- a/frontend/src/app/modules/boards/board/board.component.sass
+++ b/frontend/src/app/modules/boards/board/board.component.sass
@@ -37,13 +37,13 @@ $board-list-max-width: 300px
   position: absolute
   font-size: 14px
   left: 0
-  top: 20px
+  top: 18px
   z-index: 100
   opacity: 0
   cursor: grab
 
   .board--container.-free &
-    top: 14px
+    top: 13px
 
   &:before
     padding: 0
@@ -74,5 +74,5 @@ $board-list-max-width: 300px
   flex-direction: column
   height: 100%
 
-.boards-filters-container .work-packages--filters-optional-container
+.boards-filters-container .advanced-filters--container
   margin-bottom: 1rem

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.sass
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.sass
@@ -4,9 +4,11 @@
 
 .editable-toolbar-title--fixed
   padding: 0
+  cursor: default
 
   &.-small
     font-size: 1.2rem
+    line-height: 32px
 
 .editable-toolbar-title--save
   span:before

--- a/modules/boards/spec/features/board_highlighting_spec.rb
+++ b/modules/boards/spec/features/board_highlighting_spec.rb
@@ -78,7 +78,7 @@ describe 'Work Package boards spec', type: :feature, js: true do
     board_page = board_index.create_board action: :Status
 
     # See the work packages
-    board_page.expect_query 'Open', editable: true
+    board_page.expect_query 'Open', editable: false
     board_page.expect_card 'Open', wp.subject
     board_page.expect_card 'Open', wp2.subject
 

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -174,11 +174,11 @@ module Pages
     end
 
     def expect_list(name)
-      expect(page).to have_field('editable-toolbar-title', with: name)
+      expect(page).to have_selector('editable-toolbar-title', text: name)
     end
 
     def expect_no_list(name)
-      expect(page).not_to have_field('editable-toolbar-title', with: name)
+      expect(page).not_to have_selector('editable-toolbar-title', text: name)
     end
 
     def expect_empty


### PR DESCRIPTION
To avoid confusion as to whether changing the list header leads to a change in the attribute, it will be disabled for now.

https://community.openproject.com/projects/openproject/work_packages/30218/activity