### PR TITLE
[Boards] Seeded board queries are not public

### DIFF
--- a/app/seeders/demo_data/work_package_board_seeder.rb
+++ b/app/seeders/demo_data/work_package_board_seeder.rb
@@ -89,8 +89,11 @@ module DemoData
 
       statuses.to_a.map do |status|
         Query.new_default(project: project, user: admin).tap do |query|
-          # Hide the query
+          # Hide the query in the main menu
           query.hidden = true
+
+          # Make it public so that new members can see it too
+          query.is_public = true
 
           query.name = status.name
           # Set filter by this status
@@ -139,8 +142,12 @@ module DemoData
 
       lists.map do |list|
         Query.new(project: project, user: admin).tap do |query|
-          # Hide the query
+          # Hide the query in the main menu
           query.hidden = true
+
+          # Make it public so that new members can see it too
+          query.is_public = true
+
           query.name = list[:name]
 
           # Set manual sort filter


### PR DESCRIPTION
Since the seeded queries were not public, new members of the project were not allowed to see them. 