### PR TITLE
[30217] WP table highlighting not kept after reloading

### DIFF
--- a/frontend/src/app/components/wp-fast-table/state/wp-table-highlighting.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-highlighting.service.ts
@@ -65,7 +65,7 @@ export class WorkPackageTableHighlightingService extends WorkPackageQueryStateSe
   }
 
   public valueFromQuery(query:QueryResource):WorkPackageTableHighlight {
-    const highlight = { mode: query.highlightingMode || 'inline', highlightedAttributes: query.highlightedAttributes };
+    const highlight = { mode: query.highlightingMode || 'inline', selectedAttributes: query.highlightedAttributes };
     return this.filteredValue(highlight);
   }
 

--- a/spec/features/work_packages/highlighting_spec.rb
+++ b/spec/features/work_packages/highlighting_spec.rb
@@ -149,6 +149,14 @@ describe 'Work Package highlighting fields',
     expect(wp1_row.native.css_value('background-color')).to eq('rgba(18, 52, 86, 1)')
     expect(wp2_row.native.css_value('background-color')).to eq('rgba(0, 0, 0, 0)')
 
+    # Highlighting is kept even after a hard reload (Regression #30217)
+    page.driver.refresh
+    expect(page).to have_selector("#{wp_table.row_selector(wp_1)}.__hl_background_priority_#{priority1.id}")
+    expect(page).to have_selector("#{wp_table.row_selector(wp_2)}.__hl_background_priority_#{priority_no_color.id}")
+    expect(page).to have_no_selector('[class*="__hl_inline_status"]')
+    expect(page).to have_no_selector('[class*="__hl_inline_priority"]')
+    expect(page).to have_no_selector('[class*="__hl_date"]')
+
     # Save query
     wp_table.save
     wp_table.expect_and_dismiss_notification message: 'Successful update.'


### PR DESCRIPTION
Use correct attribute to set highlighting according to query params

https://community.openproject.com/projects/openproject/work_packages/30217/activity

