### PR TITLE
Fix: API error logs

### DIFF
--- a/lib/api/utilities/grape_helper.rb
+++ b/lib/api/utilities/grape_helper.rb
@@ -71,25 +71,7 @@ module API
           resp_headers = instance_exec &headers
           env['api.format'] = 'hal+json'
 
-          if log
-            message = <<-MESSAGE
-  Grape rescuing from error: #{e}
-
-  Original error: #{original_exception.inspect}
-
-  Stacktrace:
-            MESSAGE
-
-            OpenProject.logger.clean_backtrace(original_exception).each do |line|
-              message << "\n    #{line}"
-            end
-
-            OpenProject.logger.error(
-              message,
-              exception: original_exception,
-              reference: :APIv3
-            )
-          end
+          OpenProject.logger.error original_exception, reference: :APIv3 if log
 
           error_response status: e.code, message: representer.to_json, headers: resp_headers
         }


### PR DESCRIPTION
Wrapping the message with "Grape rescuing from error"
adds no useful information and makes the exceptions harder
to track in sentry and in general