### PR TITLE
[30202] Visualise that empty filter values are not allowed for multiSelect Fields

### DIFF
--- a/app/assets/stylesheets/content/_context_menu.sass
+++ b/app/assets/stylesheets/content/_context_menu.sass
@@ -71,11 +71,7 @@
 
 
 .op-context-menu--overlay
-  position: absolute
-  top: 0
-  left: 0
-  width: 100%
-  height: 100%
+  @include overlay-background
   display: none
 
   // Disable pointer events on this element

--- a/app/assets/stylesheets/content/_loading_indicator.sass
+++ b/app/assets/stylesheets/content/_loading_indicator.sass
@@ -1,4 +1,3 @@
-
 // Based on spinkit by Tobias Ahlin.
 //
 // The MIT License (MIT)
@@ -22,14 +21,9 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 .loading-indicator--background
-  position: absolute
-  top: 0
-  left: 0
-  right: 0
-  bottom: 0
+  @include overlay-background
   @include varprop(background, loading-indicator-bg-color)
   @include varprop(opacity, loading-indicator-bg-opacity)
-  z-index: 900
 
 // Ensure loading indicator is rendered correctly in each location
 .loading-indicator--location

--- a/app/assets/stylesheets/openproject/_generic.sass
+++ b/app/assets/stylesheets/openproject/_generic.sass
@@ -90,3 +90,5 @@
 .drop-zone.-dragged-over
   background-color: #eaeaea60
 
+.-required-highlighting
+  border: 1px solid red

--- a/app/assets/stylesheets/openproject/_mixins.sass
+++ b/app/assets/stylesheets/openproject/_mixins.sass
@@ -140,3 +140,11 @@ $scrollbar-color: #DDDDDD
     // as if it would result in showing the backside of this element.
     // This leads to input and select elements not showing their values.
     backface-visibility: visible
+
+@mixin overlay-background
+  position: absolute
+  top: 0
+  left: 0
+  right: 0
+  bottom: 0
+  z-index: 900

--- a/frontend/src/app/components/filters/filter-container/filter-container.directive.ts
+++ b/frontend/src/app/components/filters/filter-container/filter-container.directive.ts
@@ -41,6 +41,7 @@ export class WorkPackageFilterContainerComponent implements OnDestroy {
   @Input('showFilterButton') showFilterButton:boolean = false;
   @Input('filterButtonText') filterButtonText:string = I18n.t('js.button_filter');
   @Output() public filtersChanged = new DebouncedEventEmitter<QueryFilterInstanceResource[]>(componentDestroyed(this));
+  @Output() public filtersCompleted = new DebouncedEventEmitter<boolean>(componentDestroyed(this));
 
   public visible = false;
   public filters = this.wpTableFilters.current;
@@ -67,7 +68,8 @@ export class WorkPackageFilterContainerComponent implements OnDestroy {
   }
 
   public replaceIfComplete(filters:QueryFilterInstanceResource[]) {
-    this.wpTableFilters.replaceIfComplete(filters);
+    let complete = this.wpTableFilters.replaceIfComplete(filters);
+    this.filtersCompleted.emit(complete);
     this.filtersChanged.emit(this.filters);
   }
 }

--- a/frontend/src/app/components/filters/filter-toggled-multiselect-value/filter-toggled-multiselect-value.component.html
+++ b/frontend/src/app/components/filters/filter-toggled-multiselect-value/filter-toggled-multiselect-value.component.html
@@ -8,6 +8,7 @@
              [compareWith]="compareByHrefOrString"
              [clearSearchOnAdd]="true"
              [placeholder]="text.placeholder"
+             [ngClass]="{'-required-highlighting' : isEmpty}"
              class="advanced-filters--ng-select -multi-select"
              [id]="'values-' + filter.id"
              [items]="availableOptions"

--- a/frontend/src/app/components/filters/filter-toggled-multiselect-value/filter-toggled-multiselect-value.component.ts
+++ b/frontend/src/app/components/filters/filter-toggled-multiselect-value/filter-toggled-multiselect-value.component.ts
@@ -53,6 +53,8 @@ export class FilterToggledMultiselectValueComponent implements OnInit {
   public _availableOptions:HalResource[] = [];
   public compareByHrefOrString = AngularTrackingHelpers.compareByHrefOrString;
 
+  private _isEmpty:boolean;
+
   readonly text = {
     placeholder: this.I18n.t('js.placeholders.selection'),
   };
@@ -83,6 +85,10 @@ export class FilterToggledMultiselectValueComponent implements OnInit {
 
   public set availableOptions(val:HalResource[]) {
     this._availableOptions = this.halSorting.sort(val);
+  }
+
+  public get isEmpty():boolean {
+    return this._isEmpty = this.value.length === 0;
   }
 
   public repositionDropdown() {

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-filters.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-filters.service.ts
@@ -299,6 +299,9 @@ export class WorkPackageTableFiltersService extends WorkPackageQueryStateService
   public replaceIfComplete(newState:QueryFilterInstanceResource[]) {
     if (this.isComplete(newState)) {
       this.update(newState);
+      return true;
+    } else {
+      return false;
     }
   }
 

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
@@ -1,0 +1,6 @@
+@import "helpers"
+
+.result-overlay
+  @include overlay-background
+  background-color: #FFFFFF
+  opacity: 0.5

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -35,7 +35,8 @@ import {take} from "rxjs/operators";
 
 @Component({
   selector: 'wp-list',
-  templateUrl: './wp.list.component.html'
+  templateUrl: './wp.list.component.html',
+  styleUrls: ['./wp-list.component.sass']
 })
 export class WorkPackagesListComponent extends WorkPackagesViewBase implements OnDestroy {
   text = {
@@ -63,6 +64,9 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
 
   /** Project identifier of the list */
   projectIdentifier = this.$state.params['projectPath'] || null;
+
+  /** An overlay over the table shown for example when the filters are invalid */
+  showResultOverlay = false;
 
   private readonly titleService:OpTitleService = this.injector.get(OpTitleService);
 
@@ -155,6 +159,10 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
     }
 
     return promise;
+  }
+
+  public updateResultVisibility(completed:boolean) {
+    this.showResultOverlay = !completed;
   }
 
   protected updateQueryOnParamsChanges() {

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -46,7 +46,7 @@
     </div>
   </div>
 
-  <filter-container></filter-container>
+  <filter-container (filtersCompleted)="updateResultVisibility($event)"></filter-container>
 
   <accessible-by-keyboard
     linkClass="hidden-for-sighted skip-navigation-link"
@@ -61,6 +61,8 @@
     <!-- (TABLE + TIMELINE) and FOOTER vertical split-->
     <div class="work-packages-split-view--tabletimeline-side loading-indicator--location"
          data-indicator-name="table">
+      <div class="result-overlay"
+           *ngIf="showResultOverlay"></div>
 
       <!-- TABLE + TIMELINE horizontal split -->
       <wp-table *ngIf="tableInformationLoaded"


### PR DESCRIPTION
When the last value of multiSelect Filters (e.g status) is removed, the result list not updated, as it is an invalid filter. To visualise this to the user, the (empty) field gets a red border and the list is greyed out.


https://community.openproject.com/projects/openproject/work_packages/30202/activity?query_id=1727