### PR TITLE
[29994] First click on view in left menu often lost

### DIFF
--- a/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
+++ b/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
@@ -419,9 +419,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
     const currentId = _.toString(this.$state.params.query_id);
     let opts = {reload: false};
 
-    const isStaticItem = !!item.identifier;
     const isSameItem = params.query_id && params.query_id === currentId.toString();
-
 
     // Ensure we're reloading the query
     if (isSameItem) {

--- a/frontend/src/app/modules/router/openproject.routes.ts
+++ b/frontend/src/app/modules/router/openproject.routes.ts
@@ -150,7 +150,7 @@ export function initializeUiRouterListeners(injector:Injector) {
         // Only move to the URL if we're not coming from an initial URL load
         // (cases like /work_packages/invalid/activity which render a 403 without frontend,
         // but trigger the ui-router state)
-        if (!(transition.options().source === 'url' || firstRoute.isEmpty)) {
+        if (transition.options().source !== 'url' && transition.options().source !== 'redirect') {
           const target = stateService.href(toState, toParams);
           window.location.href = target;
           return false;

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -149,4 +149,16 @@ RSpec.feature 'Work package navigation', js: true, selenium: true do
     expect(page).to have_selector('.errorExplanation',
                                   text: I18n.t('notice_not_authorized'))
   end
+
+  # Regression #29994
+  scenario 'access the work package views directly from a non-angular view' do
+    visit project_path(project)
+
+    find('#main-menu-work-packages ~ .toggler').click
+    expect(page).to have_selector('.wp-query-menu--search-ul')
+    find('.wp-query-menu--item-link', text: query.name).click
+
+    expect(page).not_to have_selector('.title-container', text: 'Overview')
+    page.should have_field('editable-toolbar-title', with: query.name)
+  end
 end


### PR DESCRIPTION
When being in a non-angular context, switching the `state` is not sufficient to reload the content. That is why a complete page refresh is necessary. However in an angular context, switching the `state` is sufficient.


https://community.openproject.com/projects/openproject/work_packages/29994/activity