### PR TITLE
[Boards] Focus the autocompleter of the add-list-modal

### DIFF
--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -69,6 +69,10 @@ $modal-footer-height: $modal-header-height
     min-width: 75vw
     min-height: 40vh
 
+  &.-slim
+    min-width: 25vw
+    min-height: 20vh
+
 .op-modal--modal-header
   padding: 0
 

--- a/frontend/src/app/modules/boards/board/add-list-modal/add-list-modal.component.ts
+++ b/frontend/src/app/modules/boards/board/add-list-modal/add-list-modal.component.ts
@@ -41,12 +41,14 @@ import {BoardActionService} from "core-app/modules/boards/board/board-actions/bo
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {BoardListsService} from "core-app/modules/boards/board/board-list/board-lists.service";
 import {AngularTrackingHelpers} from "core-components/angular/tracking-functions";
+import {NgSelectComponent} from "@ng-select/ng-select/dist";
 
 @Component({
   templateUrl: './add-list-modal.html'
 })
 export class AddListModalComponent extends OpModalComponent implements OnInit {
-  @ViewChild('actionAttributeSelect') actionAttributeSelect:ElementRef;
+  @ViewChild('addActionAttributeSelect') addAutoCompleter:NgSelectComponent;
+  @ViewChild('actionAttributeSelect') autoCompleter:NgSelectComponent;
 
   public showClose:boolean;
 
@@ -119,7 +121,12 @@ export class AddListModalComponent extends OpModalComponent implements OnInit {
 
     this.actionService.canCreateNewActionElements().then((val) => {
       this.createAllowed = val;
+
+      setTimeout(() => {
+        this.createAllowed ? this.addAutoCompleter.focus() : this.autoCompleter.focus();
+      });
     });
+
   }
 
   onModelChange(element:HalResource) {

--- a/frontend/src/app/modules/boards/board/add-list-modal/add-list-modal.html
+++ b/frontend/src/app/modules/boards/board/add-list-modal/add-list-modal.html
@@ -1,5 +1,5 @@
 <div class="op-modal--portal confirm-form-submit--modal  ngdialog-theme-openproject">
-  <div class="op-modal--modal-container confirm-dialog--modal loading-indicator--location"
+  <div class="op-modal--modal-container confirm-dialog--modal loading-indicator--location -slim"
        data-indicator-name="modal"
        tabindex="0">
     <div class="op-modal--modal-header">
@@ -16,10 +16,10 @@
     <div class="ngdialog-body op-modal--modal-body">
         <div class="form--field">
           <div class="form--field-container">
-            <div class="form--select-container -slim">
+            <div class="form--select-container">
               <label class="form--label" for="new_list_action_select" [textContent]="actionService.localizedName"></label>
               <ng-select *ngIf="createAllowed"
-                         #actionAttributeSelect
+                         #addActionAttributeSelect
                          name="new_list_action_select"
                          class="new-list--action-select"
                          [items]="availableValues"

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -214,7 +214,7 @@ module Pages
       else
         expect(page).not_to have_selector('.ng-option-label', text: name)
       end
-      click_on 'Cancel'
+      find('body').send_keys [:escape]
     end
 
     def visit!
@@ -308,8 +308,6 @@ module Pages
 
     def open_and_fill_add_list_modal(name)
       page.find('.boards-list--add-item').click
-      page.find('.op-modal--modal-container .new-list--action-select').click
-
       page.find('.op-modal--modal-container .new-list--action-select input').set(name)
     end
   end


### PR DESCRIPTION
* Focus the input automatically when opening the modal. Thus the user can directly start typing.
* Increase the modal size.