### PR TITLE
[30197] Use separate ENV to trigger frontend angular recompilation

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -42,11 +42,23 @@ namespace :assets do
   end
 
   desc 'Prepare locales and angular assets'
-  task prepare_op: ['openproject:plugins:register_frontend', :angular, :export_locales]
+  task prepare_op: [:angular, :export_locales]
 
   desc 'Compile assets with webpack'
   task :angular do
+
+    # We skip angular compilation if backend was requested
+    # but frontend was not explicitly set
+    if ENV['RECOMPILE_RAILS_ASSETS'] == 'true' && ENV['RECOMPILE_ANGULAR_ASSETS'] != 'true'
+      warn "RECOMPILE_RAILS_ASSETS was set by installation, but RECOMPILE_ANGULAR_ASSETS is false. " \
+           "Skipping angular compilation. Set RECOMPILE_ANGULAR_ASSETS='true' if you need to force it."
+      next
+    end
+
     OpenProject::Assets.clear!
+
+    puts "Linking frontend plugins"
+    Rake::Task['openproject:plugins:register_frontend'].invoke
 
     puts "Building angular frontend"
     Dir.chdir Rails.root.join('frontend') do

--- a/lib/tasks/packager.rake
+++ b/lib/tasks/packager.rake
@@ -50,11 +50,14 @@ namespace :packager do
 
     # We need to precompile assets when either
     # 1. packager requested it
-    # 2. When a custom Gemfile is added
-    if ENV['MUST_REBUILD_ASSETS'] == 'true'
+    # 2. user requested frontend compilation with RECOMPILE_ANGULAR_ASSETS
+    if ENV['RECOMPILE_RAILS_ASSETS'] == 'true' || ENV['RECOMPILE_ANGULAR_ASSETS'] == 'true'
       Rake::Task['assets:precompile'].invoke
       FileUtils.chmod_R 'a+rx', "#{ENV['APP_HOME']}/public/assets/"
-      shell_setup(['config:set', 'MUST_REBUILD_ASSETS=""'])
+
+      # Unset rails request to recompile
+      # but keep RECOMPILE_ANGULAR_ASSETS as it's user defined
+      shell_setup(['config:set', 'RECOMPILE_RAILS_ASSETS=""'])
     end
 
     # Clear any caches


### PR DESCRIPTION
This PR introduces two env variables for packaged installations:

- RECOMPILE_RAILS_ASSETS will be set when a server prefix set and
backend assets need to be recompiled or when a custom gemfile is present

- RECOMPILE_ANGULAR_ASSETS will be undefined by default and will result
in skipping angular recompilation if `RECOMPILE_RAILS_ASSETS=true`. Can
be manually set by the user if frontend recompilation is needed (due to
a custom frontend plugin).

https://community.openproject.com/wp/30197

Requires https://github.com/opf/addon-openproject/pull/3
Requires https://github.com/pkgr/addon-apache2/pull/4