### PR TITLE
Explicitly forward private to_ary

### DIFF
--- a/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
+++ b/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
@@ -38,6 +38,13 @@ module API
           true
         end
 
+        ##
+        # Workaround against warnings in flatten
+        # delegator does not forward private method #to_ary
+        def to_ary
+          __getobj__.send(:to_ary)
+        end
+
         class << self
           def wrap(ids_in_order, current_user)
             work_packages = add_eager_loading(WorkPackage.where(id: ids_in_order), current_user).to_a


### PR DESCRIPTION
Avoids the repeated warnings of the kind

```
/home/oliver/openproject/dev/lib/api/caching/cached_representer.rb:194: warning: delegator does not forward private method #to_ary
/home/oliver/openproject/dev/lib/api/caching/cached_representer.rb:194: warning: delegator does not forward private method #to_ary
/home/oliver/openproject/dev/lib/api/caching/cached_representer.rb:194: warning: delegator does not forward private method #to_ary
/home/oliver/openproject/dev/lib/api/caching/cached_representer.rb:194: warning: delegator does not forward private method #to_ary
```