### PR TITLE
[30246] Defer loading form for work package fields

### DIFF
--- a/frontend/src/app/components/work-packages/work-package-comment/work-package-comment-field-handler.ts
+++ b/frontend/src/app/components/work-packages/work-package-comment/work-package-comment-field-handler.ts
@@ -58,7 +58,7 @@ export abstract class WorkPackageCommentFieldHandler extends EditFieldHandler im
       required: false,
       type: '_comment',
       hasDefault: false
-    }
+    };
   }
 
   public get rawComment() {

--- a/frontend/src/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-edit-form.ts
@@ -111,7 +111,7 @@ export class WorkPackageEditForm {
    * @param noWarnings Ignore warnings if the field cannot be opened
    */
   public activate(fieldName:string, noWarnings:boolean = false):Promise<WorkPackageEditFieldHandler> {
-    return this.loadFieldSchema(fieldName)
+    return this.loadFieldSchema(fieldName, noWarnings)
       .then((schema:IFieldSchema) => {
         if (!schema.writable && !noWarnings) {
           this.wpNotificationsService.showEditingBlockedError(schema.name || fieldName);
@@ -278,22 +278,44 @@ export class WorkPackageEditForm {
    * values loaded.
    * @param fieldName
    */
-  private loadFieldSchema(fieldName:string):Promise<IFieldSchema> {
-    return this.changeset.getForm()
-      .then((form:FormResource) => {
-        const schemaName = this.changeset.getSchemaName(fieldName);
-        const fieldSchema:IFieldSchema = form.schema[schemaName];
+  private loadFieldSchema(fieldName:string, noWarnings:boolean = false):Promise<IFieldSchema> {
+    const schemaName = this.changeset.getSchemaName(fieldName);
 
-        if (!fieldSchema) {
-          throw new Error();
+    return new Promise((resolve, reject) => {
+      this.loadFormAndCheck(schemaName, noWarnings);
+      const fieldSchema:IFieldSchema = this.changeset.schema[schemaName];
+
+      if (!fieldSchema) {
+        throw new Error();
+      }
+
+      resolve(fieldSchema);
+    });
+  }
+
+  /**
+   * Ensure the form gets loaded and we show an error when the field cannot be opened
+   * @param schemaName
+   * @param noWarnings
+   */
+  private loadFormAndCheck(fieldName:string, noWarnings:boolean = false) {
+    const schemaName = this.changeset.getSchemaName(fieldName);
+
+    // Ensure the form is being loaded if necessary
+    this.changeset
+      .getForm()
+      .then((form) => {
+        // Look up whether we're actually editable
+        const fieldSchema = form.schema[schemaName];
+        if (!fieldSchema.writable && !noWarnings) {
+          this.wpNotificationsService.showEditingBlockedError(fieldSchema.name || fieldName);
+          this.closeEditFields([fieldName]);
         }
-
-        return fieldSchema;
       })
-      .catch((error) => {
+      .catch((error:any) => {
         console.error('Failed to build edit field: %o', error);
         this.wpNotificationsService.handleRawError(error, this.workPackage);
-        throw new Error();
+        this.closeEditFields([fieldName]);
       });
   }
 

--- a/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
@@ -139,6 +139,7 @@ export class CreateAutocompleterComponent implements AfterViewInit {
   }
 
   public closed() {
+    this.openDirectly = false;
     this.onClose.emit();
   }
 

--- a/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
@@ -92,7 +92,10 @@ export class CreateAutocompleterComponent implements AfterViewInit {
   @Input() public set createAllowed(val:boolean) {
     this._createAllowed = val;
     setTimeout(() => {
-      if (this.openDirectly) { this.openSelect(); }
+      if (this.openDirectly) {
+        this.openSelect();
+        this.openDirectly = false;
+      }
     });
   }
 

--- a/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
@@ -156,7 +156,7 @@ export class CreateAutocompleterComponent implements AfterViewInit {
 
   public set openDirectly(val:boolean) {
     this._openDirectly = val;
-    this.openSelect();
+    if (val) { this.openSelect(); }
   }
 
   public focusInputField() {

--- a/frontend/src/app/modules/common/set-click-position/set-click-position.ts
+++ b/frontend/src/app/modules/common/set-click-position/set-click-position.ts
@@ -22,8 +22,8 @@ export namespace ClickPositionMapper {
    * @param evt
    * @return {number}
    */
-  export function getPosition(evt:JQuery.Event):number {
-    const originalEvt = evt.originalEvent as any;
+  export function getPosition(evt:any):number {
+    const originalEvt = evt.originalEvent;
 
     try {
       if (document.caretRangeFromPoint) {

--- a/frontend/src/app/modules/common/set-click-position/set-click-position.ts
+++ b/frontend/src/app/modules/common/set-click-position/set-click-position.ts
@@ -22,10 +22,21 @@ export namespace ClickPositionMapper {
    * @param evt
    * @return {number}
    */
-  export function getPosition(evt:JQueryEventObject):number {
+  export function getPosition(evt:JQuery.Event):number {
+    const originalEvt = evt.originalEvent as any;
+
     try {
-      const range = document.caretRangeFromPoint(evt.clientX, evt.clientY);
-      return range.startOffset;
+      if (document.caretRangeFromPoint) {
+        return document
+          .caretRangeFromPoint(evt.clientX!, evt.clientY!)
+          .startOffset;
+      } else if (originalEvt.rangeParent) {
+        let range = document.createRange();
+        range.setStart(originalEvt.rangeParent, originalEvt.rangeOffset);
+        return range.startOffset;
+      }
+
+      return 0;
     } catch (e) {
       debugLog('Failed to get click position for edit field.', e);
       return 0;

--- a/frontend/src/app/modules/fields/edit/edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/edit-field.component.ts
@@ -71,7 +71,7 @@ export class EditFieldComponent extends Field implements OnInit, OnDestroy {
               readonly cdRef:ChangeDetectorRef,
               readonly injector:Injector) {
     super();
-    this.initialize();
+    this.schema = this.schema || this.changeset.schema[this.name];
 
     this.wpEditing.state(this.changeset.workPackage.id!)
       .values$()
@@ -79,16 +79,15 @@ export class EditFieldComponent extends Field implements OnInit, OnDestroy {
         untilComponentDestroyed(this)
       )
       .subscribe((changeset) => {
-
-        if (!this.changeset.empty && this.changeset.form) {
-          const fieldSchema = changeset.form!.schema[this.name];
+        if (this.changeset.form) {
+          const fieldSchema = changeset.schema[this.name];
 
           if (!fieldSchema) {
             return handler.deactivate(false);
           }
 
           this.changeset = changeset;
-          this.schema = fieldSchema;
+          this.schema = this.changeset.schema[this.name];
           this.initialize();
           this.cdRef.markForCheck();
         }
@@ -97,6 +96,7 @@ export class EditFieldComponent extends Field implements OnInit, OnDestroy {
 
   ngOnInit():void {
     this.$element = jQuery(this.elementRef.nativeElement);
+    this.initialize();
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
@@ -69,14 +69,17 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
   // Values used in template
   public isPreview:boolean = false;
   public previewHtml:string = '';
-  public text = {
-    attachmentLabel: this.I18n.t('js.label_formattable_attachment_hint'),
-    save: this.I18n.t('js.inplace.button_save', {attribute: this.schema.name}),
-    cancel: this.I18n.t('js.inplace.button_cancel', {attribute: this.schema.name})
-  };
+  public text:any = {};
 
   ngOnInit() {
+    super.ngOnInit();
+
     this.handler.registerOnSubmit(() => this.getCurrentValue());
+    this.text = {
+      attachmentLabel: this.I18n.t('js.label_formattable_attachment_hint'),
+      save: this.I18n.t('js.inplace.button_save', {attribute: this.schema.name}),
+      cancel: this.I18n.t('js.inplace.button_cancel', {attribute: this.schema.name})
+    };
   }
 
   public onCkeditorSetup(editor:ICKEditorInstance) {
@@ -131,7 +134,7 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
   }
 
   public reset() {
-    if (this.instance) {
+    if (this.instance && this.instance.initialized) {
       this.instance.content = this.rawValue;
     }
   }

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -58,18 +58,18 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   public currentValueInvalid:boolean = false;
   private nullOption:ValueOption;
   private _selectedOption:ValueOption[];
+  private requestFocus = false;
 
   ngOnInit() {
     this.nullOption = { name: this.text.placeholder, $href: null };
 
-    const loadingPromise = this.loadValues();
     this.handler
       .$onUserActivate
       .pipe(
         untilComponentDestroyed(this),
       )
       .subscribe(() => {
-        loadingPromise.then(() => this.openAutocompleteSelectField())
+        this.requestFocus = true;
       });
 
     super.ngOnInit();
@@ -159,6 +159,16 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
     });
     this._selectedOption = this.buildSelectedOption();
     this.checkCurrentValueValidity();
+
+    if (this.options.length > 0 && this.requestFocus) {
+      this.openAutocompleteSelectField();
+      this.requestFocus = false;
+    }
+  }
+
+  protected initialize() {
+    super.initialize();
+    this.loadValues();
   }
 
   private loadValues() {

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -43,7 +43,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   @ViewChild(NgSelectComponent) public ngSelectComponent:NgSelectComponent;
 
   readonly I18n:I18nService = this.injector.get(I18nService);
-  public options:any[];
+  public options:any[] = [];
   public valueOptions:ValueOption[];
   public text = {
     requiredPlaceholder: this.I18n.t('js.placeholders.selection'),

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -160,7 +160,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
       });
     }
 
-    this.options = availableValues;
+    this.options = availableValues || [];
     this.valueOptions = this.options.map(el => {
       return { name: el.name, $href: el.$href };
     });

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -58,6 +58,8 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   public currentValueInvalid:boolean = false;
   private nullOption:ValueOption;
   private _selectedOption:ValueOption[];
+
+  /** Since we need to wait for values to be loaded, remember if the user activated this field*/
   private requestFocus = false;
 
   ngOnInit() {
@@ -69,7 +71,12 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
         untilComponentDestroyed(this),
       )
       .subscribe(() => {
-        this.requestFocus = true;
+        this.requestFocus = this.options.length === 0;
+
+        // If we already have all values loaded, open now.
+        if (!this.requestFocus) {
+          this.openAutocompleteSelectField();
+        }
       });
 
     super.ngOnInit();

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -85,7 +85,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
       .subscribe(() => {
         loadingPromise.then(() => {
           this._autocompleterComponent.openDirectly = true;
-        })
+        });
       });
   }
 

--- a/spec/features/work_packages/attachments/attachment_upload_spec.rb
+++ b/spec/features/work_packages/attachments/attachment_upload_spec.rb
@@ -112,6 +112,8 @@ describe 'Upload attachment to work package', js: true do
         caption.click
         caption.base.send_keys('Some image caption')
 
+        sleep 2
+
         click_on 'Save'
 
         wp_page.expect_notification(

--- a/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
+++ b/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
@@ -105,11 +105,13 @@ describe 'custom field inplace editor', js: true do
                                 :"customField#{custom_field2.id}" => 'Y'
 
       field1.activate!
-      expect(field1.input_element.text).to include('bar')
+      expect(field1.input_element).to have_text 'bar'
+
       field1.cancel_by_escape
 
       field2.activate!
-      expect(field2.input_element.text).to include('Y')
+      expect(field2.input_element).to have_text 'Y'
+
       expect_update 'X',
                     message: I18n.t('js.notice_successful_update'),
                     field: field2

--- a/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
@@ -11,21 +11,21 @@ describe 'subject inplace editor', js: true, selenium: true do
 
   let!(:version) {
     FactoryBot.create(:version,
-                       status: 'open',
-                       sharing: 'tree',
-                       project: project)
+                      status: 'open',
+                      sharing: 'tree',
+                      project: project)
   }
   let!(:version2) {
     FactoryBot.create(:version,
-                       status: 'open',
-                       sharing: 'tree',
-                       project: subproject1)
+                      status: 'open',
+                      sharing: 'tree',
+                      project: subproject1)
   }
   let!(:version3) {
     FactoryBot.create(:version,
-                       status: 'open',
-                       sharing: 'tree',
-                       project: subproject2)
+                      status: 'open',
+                      sharing: 'tree',
+                      project: subproject2)
   }
 
   let(:property_name) { :version }
@@ -47,11 +47,12 @@ describe 'subject inplace editor', js: true, selenium: true do
       field = work_package_page.work_package_field(:version)
       field.activate!
 
-      options = field.all(".ng-option-label")
+      expect(page).to have_selector('.ng-option-label', text: '-')
+      expect(page).to have_selector('.ng-option-label', text: version3.name)
+      expect(page).to have_selector('.ng-option-label', text: version2.name)
+      expect(page).to have_selector('.ng-option-label', text: version.name)
 
-      expect(options.map(&:text)).to eq(['-', version3.name, version2.name, version.name])
-
-      options[1].select_option
+      page.find('.ng-option-label', text: version3.name).select_option
       field.expect_state_text(version3.name)
     end
 

--- a/spec/features/work_packages/tabs/activity_tab_spec.rb
+++ b/spec/features/work_packages/tabs/activity_tab_spec.rb
@@ -157,7 +157,7 @@ describe 'Activity tab', js: true, selenium: true do
                                            'comment',
                                            selector: '.work-packages--activity--add-comment'
 
-        expect(field.editing?).to be true
+        field.expect_active!
 
         # Add our comment
         quote = field.input_element.text


### PR DESCRIPTION
We don't have to load the form initially, we can just hope the user is allowed to edit this field and close it in case she don't (when children are set, e.g.,).

This significantly increases opening time of a field. In case of select fields, it will be re-initialized after the form is loaded.

https://community.openproject.com/wp/30246