### PR TITLE
[29509] Hide query groups when project filter is reduced to zero

### DIFF
--- a/app/services/api/v3/update_query_from_v3_params_service.rb
+++ b/app/services/api/v3/update_query_from_v3_params_service.rb
@@ -34,7 +34,7 @@ module API
         self.current_user = user
       end
 
-      def call(params)
+      def call(params, valid_subset: false)
         parsed = ::API::V3::ParseQueryParamsService
                  .new
                  .call(params)
@@ -42,7 +42,7 @@ module API
         if parsed.success?
           ::UpdateQueryFromParamsService
             .new(query, current_user)
-            .call(parsed.result)
+            .call(parsed.result, valid_subset: valid_subset)
         else
           parsed
         end

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -37,10 +37,10 @@ module API
         self.current_user = user
       end
 
-      def call(params = {})
+      def call(params = {}, valid_subset: false)
         update = UpdateQueryFromV3ParamsService
                  .new(query, current_user)
-                 .call(params)
+                 .call(params, valid_subset: valid_subset)
 
         if update.success?
           representer = results_to_representer(params)

--- a/app/services/update_query_from_params_service.rb
+++ b/app/services/update_query_from_params_service.rb
@@ -32,7 +32,7 @@ class UpdateQueryFromParamsService
     self.current_user = user
   end
 
-  def call(params)
+  def call(params, valid_subset: false)
     apply_group_by(params)
 
     apply_sort_by(params)
@@ -50,6 +50,10 @@ class UpdateQueryFromParamsService
     apply_highlighting(params)
 
     disable_hierarchy_when_only_grouped_by(params)
+
+    if valid_subset
+      query.valid_subset!
+    end
 
     if query.valid?
       ServiceResult.new(success: true,

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
@@ -47,6 +47,7 @@ import {HookService} from 'core-app/modules/plugins/hook-service';
 import {randomString} from "core-app/helpers/random-string";
 import {BrowserDetector} from "core-app/modules/common/browser/browser-detector.service";
 import {PortalCleanupService} from "core-app/modules/fields/display/display-portal/portal-cleanup.service";
+import {HalResourceService} from "core-app/modules/hal/services/hal-resource.service";
 
 export interface FieldDescriptor {
   name:string;
@@ -62,6 +63,7 @@ export interface GroupDescriptor {
   id:string;
   members:FieldDescriptor[];
   query?:QueryResource;
+  relationType?:string;
   isolated:boolean;
   type:string;
 }
@@ -129,6 +131,7 @@ export class WorkPackageSingleViewComponent implements OnInit, OnDestroy {
               protected states:States,
               protected dynamicCssService:DynamicCssService,
               @Inject(IWorkPackageEditingServiceToken) protected wpEditing:WorkPackageEditingService,
+              protected halResourceService:HalResourceService,
               protected displayFieldService:DisplayFieldService,
               protected wpCacheService:WorkPackageCacheService,
               protected hook:HookService,
@@ -283,7 +286,7 @@ export class WorkPackageSingleViewComponent implements OnInit, OnDestroy {
         return {
           name: group.name,
           id: groupId || randomString(16),
-          query: group._embedded.query,
+          query: this.halResourceService.createHalResourceOfClass(QueryResource, group._embedded.query),
           relationType: group.relationType,
           members: [group._embedded.query],
           type: group._type,

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
@@ -102,13 +102,6 @@
        [attr.data-overflowing-identifier]="'.__overflowing_' + group.id"
        class="attributes-group __overflowing_element_container">
 
-    <div class="attributes-group--header">
-      <div class="attributes-group--header-container">
-        <h3 class="attributes-group--header-text"
-            [textContent]="group.name"></h3>
-      </div>
-    </div>
-
     <ng-container wp-isolated-query-space *ngIf="group.isolated">
       <ndc-dynamic [ndcDynamicComponent]="attributeGroupComponent(group)"
                    [ndcDynamicInputs]="{ workPackage: workPackage,
@@ -118,6 +111,13 @@
     </ng-container>
 
     <ng-container *ngIf="!group.isolated">
+      <div class="attributes-group--header">
+        <div class="attributes-group--header-container">
+          <h3 class="attributes-group--header-text"
+              [textContent]="group.name"></h3>
+        </div>
+      </div>
+
       <ndc-dynamic [ndcDynamicComponent]="attributeGroupComponent(group)"
                    [ndcDynamicInjector]="injector"
                    [ndcDynamicInputs]="{ workPackage: workPackage, group: group }">

--- a/frontend/src/app/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/components/wp-query/url-params-helper.ts
@@ -243,7 +243,7 @@ export class UrlParamsHelperService {
     return queryData;
   }
 
-  public buildV3GetQueryFromQueryResource(query:QueryResource, additionalParams:any = {}) {
+  public buildV3GetQueryFromQueryResource(query:QueryResource, additionalParams:any = {}, contextual:any = {}) {
     var queryData:any = {};
 
     queryData["columns[]"] = this.buildV3GetColumnsFromQueryResource(query);
@@ -267,7 +267,7 @@ export class UrlParamsHelperService {
     queryData.groupBy = _.get(query.groupBy, 'id', '');
 
     // Filters
-    queryData.filters = this.buildV3GetFiltersAsJson(query.filters);
+    queryData.filters = this.buildV3GetFiltersAsJson(query.filters, contextual);
 
     // Sortation
     queryData.sortBy = this.buildV3GetSortByFromQuery(query);
@@ -295,7 +295,7 @@ export class UrlParamsHelperService {
 
   private buildV3GetColumnsFromQueryResource(query:QueryResource) {
     if (query.columns) {
-      return query.columns.map((column:any) => column.id);
+      return query.columns.map((column:any) => column.id || column.idFromLink);
     } else if (query._links.columns) {
       return query._links.columns.map((column:HalLink) => {
         let id = column.href!;
@@ -305,11 +305,17 @@ export class UrlParamsHelperService {
     }
   }
 
-  public buildV3GetFilters(filters:QueryFilterInstanceResource[]):ApiV3Filter[] {
+  public buildV3GetFilters(filters:QueryFilterInstanceResource[], replacements = {}):ApiV3Filter[] {
     let newFilters = filters.map((filter:QueryFilterInstanceResource) => {
       let id = this.buildV3GetFilterIdFromFilter(filter);
       let operator = this.buildV3GetOperatorIdFromFilter(filter);
-      let values = this.buildV3GetValuesFromFilter(filter);
+      let values = this.buildV3GetValuesFromFilter(filter).map(value => {
+        _.each(replacements, (val:string, key:string) => {
+          value = value.replace(`{${key}}`, val);
+        });
+
+        return value;
+      });
 
       const filterHash:ApiV3Filter = {};
       filterHash[id] = { operator: operator as FilterOperator, values: values };
@@ -320,8 +326,8 @@ export class UrlParamsHelperService {
     return newFilters;
   }
 
-  public buildV3GetFiltersAsJson(filter:QueryFilterInstanceResource[]) {
-    return JSON.stringify(this.buildV3GetFilters(filter));
+  public buildV3GetFiltersAsJson(filter:QueryFilterInstanceResource[], contextual = {}) {
+    return JSON.stringify(this.buildV3GetFilters(filter, contextual));
   }
 
   private buildV3GetFilterIdFromFilter(filter:QueryFilterInstanceResource) {

--- a/frontend/src/app/components/wp-relations/embedded/children/wp-children-query.component.ts
+++ b/frontend/src/app/components/wp-relations/embedded/children/wp-children-query.component.ts
@@ -40,6 +40,9 @@ import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {WorkPackageRelationQueryBase} from "core-components/wp-relations/embedded/wp-relation-query.base";
 import {WpChildrenInlineCreateService} from "core-components/wp-relations/embedded/children/wp-children-inline-create.service";
 import {WorkPackageCacheService} from "core-components/work-packages/work-package-cache.service";
+import {filter} from "rxjs/operators";
+import {QueryResource} from "core-app/modules/hal/resources/query-resource";
+import {GroupDescriptor} from "core-components/work-packages/wp-single-view/wp-single-view.component";
 
 @Component({
   selector: 'wp-children-query',
@@ -50,7 +53,10 @@ import {WorkPackageCacheService} from "core-components/work-packages/work-packag
 })
 export class WorkPackageChildrenQueryComponent extends WorkPackageRelationQueryBase implements OnInit, OnDestroy {
   @Input() public workPackage:WorkPackageResource;
-  @Input() public query:any;
+  @Input() public query:QueryResource;
+
+  /** An optional group descriptor if we're rendering on the single view */
+  @Input() public group?:GroupDescriptor;
   @Input() public addExistingChildEnabled:boolean = false;
   @ViewChild('childrenEmbeddedTable') private childrenEmbeddedTable:WorkPackageEmbeddedTableComponent;
 
@@ -79,12 +85,13 @@ export class WorkPackageChildrenQueryComponent extends WorkPackageRelationQueryB
     this.wpInlineCreate.referenceTarget = this.workPackage;
 
     // Set up the query props
-    this.buildQueryProps();
+    this.queryProps = this.buildQueryProps();
 
     // Refresh table when work package is refreshed
     this.wpCacheService
       .observe(this.workPackage.id!)
       .pipe(
+        filter(() => this.embeddedTable && this.embeddedTable.isInitialized),
         untilComponentDestroyed(this)
       )
       .subscribe(() => this.refreshTable());

--- a/frontend/src/app/components/wp-relations/embedded/wp-relation-query.base.ts
+++ b/frontend/src/app/components/wp-relations/embedded/wp-relation-query.base.ts
@@ -31,15 +31,21 @@ import {ViewChild} from "@angular/core";
 import {WorkPackageEmbeddedTableComponent} from "core-components/wp-table/embedded/wp-embedded-table.component";
 import {QueryResource} from "core-app/modules/hal/resources/query-resource";
 import {UrlParamsHelperService} from "core-components/wp-query/url-params-helper";
+import {ErrorResource} from "core-app/modules/hal/resources/error-resource";
+import {query} from "@angular/animations";
+import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 
 export abstract class WorkPackageRelationQueryBase {
   public workPackage:WorkPackageResource;
 
   /** Input is either a query resource, or directly query props */
-  public query:Object;
+  public query:QueryResource|Object;
 
   /** Query props are derived from the query resource, if any */
   public queryProps:Object;
+
+  /** Whether this section should be hidden completely (due to missing permissions e.g.) */
+  public hidden:boolean = false;
 
   /** Reference to the embedded table instance */
   @ViewChild('embeddedTable') protected embeddedTable:WorkPackageEmbeddedTableComponent;
@@ -55,30 +61,53 @@ export abstract class WorkPackageRelationQueryBase {
   }
 
   /**
-   * Create a contextualized copy of the query where all
-   * references to the templated value are replaced with the actual work package ID.
+   * Special handling for query loading when a project filter is involved.
+   *
+   * Ensure that at least one project was visible to the user or otherwise,
+   * hide the creation from them.
+   * cf. OP#30106
+   * @param query
    */
-  protected contextualizedQuery(query:QueryResource) {
-    let duppedQuery = _.cloneDeep(query);
+  public handleQueryLoaded(loaded:QueryResource) {
+    // We only handle loaded queries
+    if (!(this.query instanceof QueryResource)) {
+      return;
+    }
 
-    _.each(duppedQuery.filters, (filter) => {
-      if (filter._links.values[0] && filter._links.values[0].templated) {
-        filter._links.values[0].href = filter._links.values[0].href.replace('{id}', this.workPackage.id!);
-      }
-    });
+    const filtersLength = this.projectValuesCount(this.query);
+    const loadedFiltersLength = this.projectValuesCount(loaded);
 
-    return duppedQuery;
+    // Does the default have a project filter, but the other does not?
+    if (filtersLength !== null && loadedFiltersLength === null) {
+      this.hidden = true;
+    }
+
+    // Has a project filter been reduced to zero elements?
+    if (filtersLength && loadedFiltersLength && filtersLength > 0 && loadedFiltersLength === 0) {
+      this.hidden = true;
+    }
+  }
+
+  /**
+   * Get the filters of the query props
+   */
+  protected projectValuesCount(query:QueryResource):number|null {
+    const project = query.filters.find(f => f.id === 'project');
+    return project ? project.values.length : null;
   }
 
   /**
    * Set up the query props from input
    */
   protected buildQueryProps() {
-    if (this.query && (this.query as any)._type === 'Query') {
-      let query = this.contextualizedQuery(this.query as QueryResource);
-      this.queryProps = this.queryUrlParamsHelper.buildV3GetQueryFromQueryResource(query, {});
+    if (this.query instanceof QueryResource) {
+      return this.queryUrlParamsHelper.buildV3GetQueryFromQueryResource(
+        this.query,
+        { valid_subset: true },
+        { id: this.workPackage.id! }
+      );
     } else {
-      this.queryProps = this.query;
+      return this.query;
     }
   }
 }

--- a/frontend/src/app/components/wp-relations/embedded/wp-relation-query.html
+++ b/frontend/src/app/components/wp-relations/embedded/wp-relation-query.html
@@ -1,13 +1,23 @@
-<wp-embedded-table #embeddedTable
-                   [initialLoadingIndicator]="false"
-                   [queryProps]="queryProps"
-                   [tableActions]="tableActions"
-                   [configuration]="{ actionsColumnEnabled: true,
-                                      hierarchyToggleEnabled: false,
-                                      inlineCreateEnabled: true,
-                                      compactTableStyle: true,
-                                      columnMenuEnabled: false,
-                                      contextMenuEnabled: false,
-                                      projectIdentifier: workPackage.project.idFromLink,
-                                      projectContext: false }" >
-</wp-embedded-table>
+<ng-container *ngIf="!hidden">
+  <div *ngIf="group" class="attributes-group--header">
+    <div class="attributes-group--header-container">
+      <h3 class="attributes-group--header-text"
+          [textContent]="group.name"></h3>
+    </div>
+  </div>
+
+  <wp-embedded-table #embeddedTable
+                     (onQueryLoaded)="handleQueryLoaded($event)"
+                     [initialLoadingIndicator]="false"
+                     [queryProps]="queryProps"
+                     [tableActions]="tableActions"
+                     [configuration]="{ actionsColumnEnabled: true,
+                                        hierarchyToggleEnabled: false,
+                                        inlineCreateEnabled: true,
+                                        compactTableStyle: true,
+                                        columnMenuEnabled: false,
+                                        contextMenuEnabled: false,
+                                        projectIdentifier: workPackage.project.idFromLink,
+                                        projectContext: false }" >
+  </wp-embedded-table>
+</ng-container>

--- a/lib/api/v3/queries/helpers/query_representer_response.rb
+++ b/lib/api/v3/queries/helpers/query_representer_response.rb
@@ -31,10 +31,10 @@ module API
     module Queries
       module Helpers
         module QueryRepresenterResponse
-          def query_representer_response(query, params)
+          def query_representer_response(query, params, valid_subset = false)
             representer = ::API::V3::WorkPackageCollectionFromQueryService
                           .new(query, current_user)
-                          .call(params)
+                          .call(params, valid_subset: valid_subset)
 
             if representer.success?
               QueryRepresenter.new(query,

--- a/lib/api/v3/queries/queries_api.rb
+++ b/lib/api/v3/queries/queries_api.rb
@@ -82,13 +82,17 @@ module API
           end
 
           namespace 'default' do
+            params do
+              optional :valid_subset, type: Boolean
+            end
+
             get do
               @query = Query.new_default(name: 'default',
                                          user: current_user)
 
               authorize_by_policy(:show)
 
-              query_representer_response(@query, params)
+              query_representer_response(@query, params, params.delete(:valid_subset))
             end
           end
 
@@ -111,6 +115,10 @@ module API
               update_query @query, request_body, current_user
             end
 
+            params do
+              optional :valid_subset, type: Boolean
+            end
+
             get do
               # We try to ignore invalid aspects of the query as the user
               # might not even be able to fix them (public  query)
@@ -120,8 +128,9 @@ module API
               # Permissions are enforced nevertheless.
               @query.valid_subset!
 
-              # We do not ignore invalid params provided by the client.
-              query_representer_response(@query, params)
+              # We do not ignore invalid params provided by the client
+              # unless explicily required by valid_subset
+              query_representer_response(@query, params, params.delete(:valid_subset))
             end
 
             delete do

--- a/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
+++ b/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
@@ -32,7 +32,7 @@ describe 'Work package with relation query group', js: true, selenium: true do
   include_context 'ng-select-autocomplete helpers'
 
   let(:user) { FactoryBot.create :admin }
-  let(:project) { FactoryBot.create :project }
+  let(:project) { FactoryBot.create :project, types: [type] }
   let(:relation_type) { :parent }
   let(:relation_target) { work_package }
   let(:new_relation) do
@@ -64,7 +64,7 @@ describe 'Work package with relation query group', js: true, selenium: true do
   let(:relations_tab) { find('.tabrow li', text: 'RELATIONS') }
   let(:embedded_table) { Pages::EmbeddedWorkPackagesTable.new(first('wp-single-view .work-packages-embedded-view--container')) }
 
-  # let(:visit) { true }
+  let(:visit) { true }
 
   before do
     # inline create needs defaults
@@ -74,8 +74,11 @@ describe 'Work package with relation query group', js: true, selenium: true do
     priority.update_attribute :is_default, true
 
     login_as user
-    full_wp.visit!
-    full_wp.ensure_page_loaded
+
+    if visit
+      full_wp.visit!
+      full_wp.ensure_page_loaded
+    end
   end
 
   context 'children table' do
@@ -106,6 +109,82 @@ describe 'Work package with relation query group', js: true, selenium: true do
     end
   end
 
+  describe 'follower table with project filters', clear_cache: true do
+    let(:visit) { false }
+    let!(:project2) { FactoryBot.create(:project, types: [type]) }
+    let!(:project3) { FactoryBot.create(:project, types: [type]) }
+    let(:relation_type) { :follows }
+    let!(:related_work_package) do
+      FactoryBot.create :work_package,
+                        project: project2,
+                        type: type,
+                        follows: [work_package]
+    end
+
+    let(:type) do
+      FactoryBot.create :type_with_relation_query_group, relation_filter: relation_type
+    end
+    let(:query_text) { 'Embedded Table for follows'.upcase }
+
+    before do
+      query = type.attribute_groups.last.query
+      query.add_filter('project_id', '=', [project2.id, project3.id])
+      # User has no permission to save, avoid creating another user to allow it
+      query.save!(validate: false)
+      type.save!
+    end
+
+    context 'with a user who has permission in one project' do
+      let(:role) { FactoryBot.create(:role, permissions: permissions) }
+      let(:permissions) { [:view_work_packages, :add_work_packages, :manage_work_package_relations] }
+      let(:user) do
+        FactoryBot.create(:user,
+                          member_in_project: project,
+                          member_through_role: role)
+      end
+      let!(:project2_member) {
+        member = FactoryBot.build(:member, user: user, project: project2)
+        member.roles = [role]
+        member.save!
+      }
+
+      it 'can load the query and inline create' do
+        full_wp.visit!
+        full_wp.ensure_page_loaded
+
+        expect(page).to have_selector('.attributes-group--header-text', text: query_text, wait: 20)
+        embedded_table.expect_work_package_listed related_work_package
+        embedded_table.click_inline_create
+
+        subject_field = embedded_table.edit_field(nil, :subject)
+        subject_field.expect_active!
+        subject_field.set_value 'Another subject'
+        subject_field.save!
+
+        embedded_table.expect_work_package_subject 'Another subject'
+      end
+    end
+
+    context 'with a user who has no permission in any project' do
+      let(:role) { FactoryBot.create(:role, permissions: permissions) }
+      let(:permissions) { [:view_work_packages] }
+      let(:user) do
+        FactoryBot.create(:user,
+                          member_in_project: project,
+                          member_through_role: role)
+      end
+
+      it 'hides that group automatically without showing an error' do
+        full_wp.visit!
+        full_wp.ensure_page_loaded
+
+        # Will first try to load the query, and then hide it.
+        expect(page).to have_no_selector('.attributes-group--header-text', text: query_text, wait: 20)
+        expect(page).to have_no_selector('.work-packages-embedded-view--container .notification-box.-error')
+      end
+    end
+  end
+
   context 'follower table' do
     let(:relation_type) { :follows }
     let(:relation_target) { [work_package] }
@@ -123,6 +202,7 @@ describe 'Work package with relation query group', js: true, selenium: true do
     it 'creates and removes across all tables' do
       embedded_table.table_container.find('a', text: I18n.t('js.relation_buttons.create_new')).click
       subject_field = embedded_table.edit_field(nil, :subject)
+
       subject_field.expect_active!
       subject_field.set_value("Fresh WP\n")
 

--- a/spec/services/api/v3/update_query_from_v3_params_service_spec.rb
+++ b/spec/services/api/v3/update_query_from_v3_params_service_spec.rb
@@ -63,7 +63,7 @@ describe ::API::V3::UpdateQueryFromV3ParamsService,
 
     allow(mock)
       .to receive(:call)
-      .with(parsed_params)
+      .with(parsed_params, valid_subset: false)
       .and_return(mock_update_query_service_response)
 
     mock

--- a/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
+++ b/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
@@ -136,7 +136,7 @@ describe ::API::V3::WorkPackageCollectionFromQueryService,
 
     allow(mock)
       .to receive(:call)
-      .with(params)
+      .with(params, valid_subset: false)
       .and_return(mock_update_query_service_response)
 
     mock


### PR DESCRIPTION
Adds a `valid_subset` parameter to the default and :id query getter to ensure query_props can be reduced to their valid subset.

For embedded tables with a project filter present, the attribute group is removed when the results from that filter is zero (i.e., the user can see none of these filters), because he will never be able to see or create items in it.

https://community.openproject.com/wp/29509