### PR TITLE
automatically reverse relates relationship

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -36,7 +36,7 @@ class Relation < ActiveRecord::Base
 
   virtual_attribute :relation_type do
     types = ((TYPES.keys + [TYPE_HIERARCHY]) & Relation.column_names).select do |name|
-      send(name) > 0
+      send(name).positive?
     end
 
     case types.length
@@ -245,7 +245,7 @@ class Relation < ActiveRecord::Base
   end
 
   def canonical_type
-    self.class(relation_type)
+    self.class.canonical_type(relation_type)
   end
 
   def self.canonical_type(relation_type)
@@ -284,6 +284,7 @@ class Relation < ActiveRecord::Base
     end
 
     return unless relation_type
+
     new_column = self.class.relation_column(relation_type)
 
     send("#{new_column}=", 1) if new_column

--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relation-create.template.html
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relation-create.template.html
@@ -36,8 +36,8 @@
         <wp-relations-autocomplete
             [workPackage]="workPackage"
             (onReferenced)="onReferenced($event)"
-            appendToContainer=".work-packages-tab-view--overflow"
-            selectedRelationType="parent">
+            [appendToContainer]="'.work-packages-tab-view--overflow'"
+            [selectedRelationType]="selectedRelationType">
         </wp-relations-autocomplete>
       </div>
       <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">

--- a/lib/api/v3/work_packages/available_relation_candidates_helper.rb
+++ b/lib/api/v3/work_packages/available_relation_candidates_helper.rb
@@ -40,25 +40,30 @@ module API
         # @param from [WorkPackage] The work package in the `from` position of a relation.
         # @param limit [Integer] Maximum number of results to retrieve.
         def work_package_queried(query, from, type, limit)
-          canonical_type = Relation.canonical_type(type)
-
-          scope =
-            if type != 'parent' && canonical_type == type
-              WorkPackage.relateable_to(from)
-            else
-              WorkPackage.relateable_from(from)
-            end
-
           like_query = query
-            .downcase
-            .split(/\s+/)
-            .map { |substr| WorkPackage.connection.quote_string(substr) }
-            .join("%")
+                       .downcase
+                       .split(/\s+/)
+                       .map { |substr| WorkPackage.connection.quote_string(substr) }
+                       .join("%")
 
-          scope
+          work_package_scope(from, type)
             .where("work_packages.id = ? OR LOWER(work_packages.subject) LIKE ?",
                    query.to_i, "%#{like_query}%")
             .limit(limit)
+        end
+
+        private
+
+        def work_package_scope(from, type)
+          canonical_type = Relation.canonical_type(type)
+
+          if type == Relation::TYPE_RELATES
+            WorkPackage.relateable_to(from).or(WorkPackage.relateable_from(from))
+          elsif type != 'parent' && canonical_type == type
+            WorkPackage.relateable_to(from)
+          else
+            WorkPackage.relateable_from(from)
+          end
         end
       end
     end

--- a/spec/requests/api/v3/work_packages/available_relation_candidates_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_relation_candidates_spec.rb
@@ -127,7 +127,7 @@ describe ::API::V3::Relations::RelationRepresenter, type: :request do
     end
 
     describe "relation candidates for wp_2" do
-      let(:href) { "/api/v3/work_packages/#{wp_2.id}/available_relation_candidates?query=WP" }
+      let(:href) { "/api/v3/work_packages/#{wp_2.id}/available_relation_candidates?query=WP&type=follows" }
 
       it "should return WP 2.1 and 2.2, WP 1 and all WP 1.x" do
         expect(subjects).to match_array ["WP 1", "WP 1.1", "WP 1.2", "WP 1.2.1", "WP 2.1", "WP 2.2"]
@@ -142,8 +142,18 @@ describe ::API::V3::Relations::RelationRepresenter, type: :request do
           FactoryBot.create :relation, from: wp_1_1, to: wp_2, relation_type: "relates"
         end
 
-        it 'does not contain the work packages with which a relationship already exists' do
-          expect(subjects).to match_array ["WP 1.2", "WP 1.2.1", "WP 2.1"]
+        context 'for a follows relationship' do
+          it 'does not contain the work packages with which a relationship already exists' do
+            expect(subjects).to match_array ["WP 1.2", "WP 1.2.1", "WP 2.1"]
+          end
+        end
+
+        context 'for a relates relationship' do
+          let(:href) { "/api/v3/work_packages/#{wp_2.id}/available_relation_candidates?query=WP&type=relates" }
+
+          it 'does not contain the work packages with which a relationship already exists but the parent' do
+            expect(subjects).to match_array ["WP 1", "WP 1.2", "WP 1.2.1", "WP 2.1"]
+          end
         end
       end
     end

--- a/spec/services/relations/update_service_spec.rb
+++ b/spec/services/relations/update_service_spec.rb
@@ -41,13 +41,13 @@ describe Relations::UpdateService do
 
   let(:work_package1) do
     FactoryBot.build_stubbed(:work_package,
-                              due_date: work_package1_due_date,
-                              start_date: work_package1_start_date)
+                             due_date: work_package1_due_date,
+                             start_date: work_package1_start_date)
   end
   let(:work_package2) do
     FactoryBot.build_stubbed(:work_package,
-                              due_date: work_package2_due_date,
-                              start_date: work_package2_start_date)
+                             due_date: work_package2_due_date,
+                             start_date: work_package2_start_date)
   end
   let(:instance) do
     described_class.new(user: user, relation: relation)
@@ -73,6 +73,7 @@ describe Relations::UpdateService do
   let(:model_valid) { true }
   let(:contract_valid) { true }
   let(:contract) { double('contract') }
+  let(:symbols_for_base) { [] }
 
   subject do
     instance.call(attributes: attributes)
@@ -163,6 +164,10 @@ describe Relations::UpdateService do
       allow(contract)
         .to receive(:errors)
         .and_return(contract_errors)
+      allow(contract_errors)
+        .to receive(:symbols_for)
+        .with(:base)
+        .and_return(symbols_for_base)
     end
 
     it 'is unsuccessful' do
@@ -184,6 +189,10 @@ describe Relations::UpdateService do
       allow(relation)
         .to receive(:errors)
         .and_return(model_errors)
+      allow(model_errors)
+        .to receive(:symbols_for)
+        .with(:base)
+        .and_return(symbols_for_base)
     end
 
     it 'is unsuccessful' do


### PR DESCRIPTION
As described in https://community.openproject.com/projects/deutsche-bahn/work_packages/29512, this will automatically invert `from` and `to` on a 'relates' relation when a circular dependency is detected. All the magic happens without the user noticing. 