### PR TITLE
[30257] Redirect after deleting WPs from WP table leads to boards

### DIFF
--- a/frontend/src/app/components/modals/wp-destroy-modal/wp-destroy.modal.ts
+++ b/frontend/src/app/components/modals/wp-destroy-modal/wp-destroy.modal.ts
@@ -137,7 +137,15 @@ export class WpDestroyModal extends OpModalComponent implements OnInit {
         this.busy = false;
         this.closeMe($event);
         this.wpTableFocus.clear();
-        this.backRoutingService.goBack(true);
+
+        /**
+         * When we are in the list, we expect a refreshed list view.
+         * Otherwise we expect a redirect to where we came from,
+         * since the WP in view (split/full) does not exist any more.
+         */
+        if (this.$state.current.name !== 'work-packages.list') {
+          this.backRoutingService.goBack(true);
+        }
       })
       .catch(() => {
         this.busy = false;


### PR DESCRIPTION
Redirect to WP list when deleting a WP from there, otherwise redirect to where the user came from.

https://community.openproject.com/projects/openproject/work_packages/30257/activity