### PR TITLE
[30269] Creating a new version from within the WP create form does nothing

### DIFF
--- a/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
@@ -96,9 +96,7 @@ export class CreateAutocompleterComponent implements AfterViewInit {
         this.openSelect();
         this.openDirectly = false;
       }
-      if (val) {
-        this.focusInputField();
-      }
+      this.ngAfterViewInit();
     });
   }
 

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -138,6 +138,11 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
     return Promise.resolve();
   }
 
+  private addValue(val:HalResource) {
+    this.options.push(val);
+    this.valueOptions.push({name: val.name, $href: val.$href});
+  }
+
   public get currentValueInvalid():boolean {
     return !!(
       (this.value && !_.some(this.options, (option:HalResource) => (option.$href === this.value.$href)))
@@ -147,7 +152,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   }
 
   public onCreate(newElement:HalResource) {
-    this.options.push(newElement);
+    this.addValue(newElement);
     this.selectedOption = { name: newElement.name, $href: newElement.$href };
     this.handler.handleUserSubmit();
   }


### PR DESCRIPTION
Add newly created versions to list of available options. Thus it is shown correctly in create forms, where the input field does not close after creating a new version.
Further the focus handling is deferred to the component that calls the autocompleter. Thus we can better differentiate when the input shall be focused (and when not).

https://community.openproject.com/projects/openproject/work_packages/30269/activity