### PR TITLE
Allow supervisorctl usage in docker container

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,6 +1,12 @@
 [supervisord]
 nodaemon=true
 
+[unix_http_server]
+file=/var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [program:web]
 priority=4
 user=app
@@ -79,4 +85,3 @@ stderr_logfile = /dev/stderr
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 stderr_logfile_maxbytes = 0
-


### PR DESCRIPTION
supervisorctl needs these entries in supervisord.conf,
otherwise it will fail with
`unix:///var/run/supervisor.sock no such file`.
See https://github.com/Supervisor/supervisor/issues/480 for more
details.