### PR TITLE
[30275] Allow global type select, restrict available projects

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -422,7 +422,9 @@ en:
       relation_description: 'Click to add description for this relation'
 
     project:
-      required_outside_context: 'You are not within a project context. Please choose the project context first in order to select type and status'
+      required_outside_context: >
+        Please choose a project to create the work package in to see all attributes.
+        You can only select projects which have the type above activated.
       context: 'Project context'
       work_package_belongs_to: 'This work package belongs to project %{projectname}.'
       click_to_switch_context: 'Open this work package in that project.'

--- a/frontend/src/app/components/op-context-menu/handlers/op-types-context-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/op-types-context-menu.directive.ts
@@ -42,7 +42,7 @@ import {IWorkPackageCreateServiceToken} from 'core-components/wp-new/wp-create.s
   selector: '[opTypesCreateDropdown]'
 })
 export class OpTypesContextMenuDirective extends OpContextMenuTrigger {
-  @Input('projectIdentifier') public projectIdentifier:string;
+  @Input('projectIdentifier') public projectIdentifier:string|null|undefined;
   @Input('stateName') public stateName:string;
   @Input('dropdownActive') active:boolean;
 
@@ -73,7 +73,7 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger {
       .getEmptyForm(this.projectIdentifier)
       .then(form => {
         return this.buildItems(form.schema.type.allowedValues);
-      })
+      });
   }
 
   protected open(evt:JQueryEventObject) {

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
@@ -82,7 +82,10 @@ export const overflowingContainerAttribute = 'overflowingIdentifier';
   ]
 })
 export class WorkPackageSingleViewComponent implements OnInit, OnDestroy {
-  @Input('workPackage') public workPackage:WorkPackageResource;
+  @Input() public workPackage:WorkPackageResource;
+
+  /** Should we show the project field */
+  @Input() public showProject:boolean = false;
 
   // Grouped fields returned from API
   public groupedFields:GroupDescriptor[] = [];
@@ -171,7 +174,7 @@ export class WorkPackageSingleViewComponent implements OnInit, OnDestroy {
           };
         }
 
-        if (isNew && !this.currentProject.inProjectContext) {
+        if (isNew && (!this.currentProject.inProjectContext || this.showProject)) {
           this.projectContext.field = this.getFields(resource, ['project']);
         }
 

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
@@ -36,11 +36,8 @@
   <div class="attributes-group -project-context __overflowing_element_container __overflowing_project_context"
        *ngIf="projectContext.field"
        data-overflowing-identifier=".__overflowing_project_context">
-    <div class="attributes-group--header">
-      <div class="attributes-group--header-container"></div>
-    </div>
     <div>
-      <p class="wp-project-context--warning" [hidden]="projectContext.href" [textContent]="text.project.required"></p>
+      <p class="wp-project-context--warning" [textContent]="text.project.required"></p>
       <div class="attributes-key-value"
            [ngClass]="{'-span-all-columns': descriptor.spanAll }"
            *ngFor="let descriptor of projectContext.field; trackBy:trackByName">

--- a/frontend/src/app/components/wp-buttons/wp-create-button/wp-create-button.html
+++ b/frontend/src/app/components/wp-buttons/wp-create-button/wp-create-button.html
@@ -1,6 +1,5 @@
 <div class="wp-create-button">
   <button class="button -alt-highlight add-work-package"
-          *ngIf="projectIdentifier"
           [disabled]="isDisabled()"
           [attr.aria-label]="text.explanation"
           opTypesCreateDropdown
@@ -12,16 +11,5 @@
           [textContent]="text.createWithDropdown"
           aria-hidden="true"></span>
     <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
-  </button>
-  <button class="button -alt-highlight add-work-package"
-          *ngIf="!projectIdentifier"
-          (click)="createWorkPackage()"
-          [disabled]="isDisabled()"
-          [attr.aria-label]="text.explanation">
-
-    <op-icon icon-classes="button--icon icon-add"></op-icon>
-    <span class="button--text"
-          [textContent]="text.createButton"
-          aria-hidden="true"></span>
   </button>
 </div>

--- a/frontend/src/app/components/wp-copy/wp-copy.controller.ts
+++ b/frontend/src/app/components/wp-copy/wp-copy.controller.ts
@@ -39,6 +39,9 @@ export class WorkPackageCopyController extends WorkPackageCreateController {
   private __initialized_at:Number;
   private copiedWorkPackageId:string;
 
+  /** Are we in the copying substates ? */
+  public copying = true;
+
   private wpRelations:WorkPackageRelationsService = this.injector.get(WorkPackageRelationsService);
   protected wpEditing:WorkPackageEditingService = this.injector.get<WorkPackageEditingService>(IWorkPackageEditingServiceToken);
 

--- a/frontend/src/app/components/wp-new/wp-create.controller.ts
+++ b/frontend/src/app/components/wp-new/wp-create.controller.ts
@@ -53,6 +53,9 @@ export class WorkPackageCreateController implements OnInit, OnDestroy {
   public parentWorkPackage:WorkPackageResource;
   public changeset:WorkPackageChangeset;
 
+  /** Are we in the copying substates ? */
+  public copying = false;
+
   public stateParams = this.$transition.params('to');
   public text = {
     button_settings: this.I18n.t('js.button_settings')

--- a/frontend/src/app/components/wp-new/wp-new-full-view.html
+++ b/frontend/src/app/components/wp-new/wp-new-full-view.html
@@ -23,7 +23,9 @@
       </ul>
     </div>
 
-    <wp-single-view [workPackage]="newWorkPackage"></wp-single-view>
+    <wp-single-view [workPackage]="newWorkPackage"
+                    [showProject]="copying">
+    </wp-single-view>
     <wp-edit-actions-bar (onCancel)="cancelAndBackToList()"></wp-edit-actions-bar>
   </wp-edit-field-group>
 </div>

--- a/frontend/src/app/components/wp-new/wp-new-split-view.html
+++ b/frontend/src/app/components/wp-new/wp-new-split-view.html
@@ -15,7 +15,9 @@
           </a>
         </div>
       </div>
-      <wp-single-view [workPackage]="newWorkPackage"></wp-single-view>
+      <wp-single-view [workPackage]="newWorkPackage"
+                      [showProject]="copying">
+      </wp-single-view>
     </div>
 
     <div class="work-packages--details-toolbar-container">

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -129,7 +129,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
     if (Array.isArray(allowedValues)) {
       this.setValues(allowedValues);
     } else if (allowedValues) {
-      return allowedValues.$load().then((values:CollectionResource) => {
+      return allowedValues.$load(false).then((values:CollectionResource) => {
         this.setValues(values.elements);
       });
     } else {

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -91,8 +91,12 @@ module API
             "#{work_package(work_package_id)}/available_projects"
           end
 
-          def self.available_projects_on_create
-            "#{work_packages}/available_projects"
+          def self.available_projects_on_create(type_id)
+            if type_id.to_i.zero?
+              "#{work_packages}/available_projects"
+            else
+              "#{work_packages}/available_projects?for_type=#{type_id}"
+            end
           end
 
           def self.available_relation_candidates(work_package_id)

--- a/lib/api/v3/work_packages/available_projects_on_create_api.rb
+++ b/lib/api/v3/work_packages/available_projects_on_create_api.rb
@@ -37,6 +37,10 @@ module API
             authorize(:add_work_packages, global: true)
           end
 
+          params do
+            optional :for_type, type: Integer
+          end
+
           get do
             checked_permissions = Projects::ProjectCollectionRepresenter.checked_permissions
             current_user.preload_projects_allowed_to(checked_permissions)
@@ -44,7 +48,14 @@ module API
             available_projects = WorkPackage
                                  .allowed_target_projects_on_create(current_user)
                                  .includes(Projects::ProjectCollectionRepresenter.to_eager_load)
-            self_link = api_v3_paths.available_projects_on_create
+
+            query = ::Queries::Projects::ProjectQuery.new(user: current_user)
+            if params[:for_type]
+              query.where('type_id', '=', params[:for_type])
+              available_projects = query.results.merge(available_projects)
+            end
+
+            self_link = api_v3_paths.available_projects_on_create(params[:for_type])
             Projects::ProjectCollectionRepresenter.new(available_projects,
                                                        self_link,
                                                        current_user: current_user)

--- a/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
@@ -51,7 +51,9 @@ module API
             when :status
               assignable_statuses_for(current_user)
             when :type
-              if project.respond_to?(:types)
+              if project.nil?
+                Type.includes(:color)
+              else
                 project.types.includes(:color)
               end
             when :version

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -163,8 +163,9 @@ module API
                                    type: 'Project',
                                    required: true,
                                    href_callback: ->(*) {
-                                     if represented.work_package&.new_record?
-                                       api_v3_paths.available_projects_on_create
+                                     work_package = represented.work_package
+                                     if work_package&.new_record?
+                                       api_v3_paths.available_projects_on_create(work_package.type_id)
                                      else
                                        api_v3_paths.available_projects_on_edit(represented.id)
                                      end

--- a/spec/features/work_packages/new/new_work_package_spec.rb
+++ b/spec/features/work_packages/new/new_work_package_spec.rb
@@ -52,7 +52,7 @@ describe 'new work package', js: true do
   def create_work_package_globally(type, project)
     loading_indicator_saveguard
 
-    wp_page.click_add_wp_button
+    wp_page.click_create_wp_button(type)
 
     loading_indicator_saveguard
     wp_page.subject_field.set(subject)
@@ -60,8 +60,6 @@ describe 'new work package', js: true do
     project_field.openSelectField
     project_field.set_value project
 
-    type_field.openSelectField
-    type_field.set_value type
     sleep 1
   end
 
@@ -284,16 +282,30 @@ describe 'new work package', js: true do
 
       click_on 'Cancel'
 
-      wp_page.click_add_wp_button
+      wp_page.click_create_wp_button type_bug
       expect(page).to have_no_selector('.ng-value', text: project.name)
 
       project_field.openSelectField
       project_field.set_value project.name
 
-      type_field.openSelectField
-      type_field.set_value type_bug
-
       click_on 'Cancel'
+    end
+
+    context 'with a project without type_bug' do
+      let!(:project_without_bug) do
+        FactoryBot.create(:project, name: 'Unrelated project', types: [type_task])
+      end
+
+      it 'will not show that value in the project drop down' do
+        create_work_package_globally(type_bug, project.name)
+
+        sleep 2
+
+        project_field.openSelectField
+
+        expect(page).to have_selector('.ng-dropdown-panel .ng-option', text: project.name)
+        expect(page).to have_no_selector('.ng-dropdown-panel .ng-option', text: project_without_bug.name)
+      end
     end
   end
 

--- a/spec/features/work_packages/new/work_package_default_description_spec.rb
+++ b/spec/features/work_packages/new/work_package_default_description_spec.rb
@@ -24,7 +24,7 @@ describe 'new work package', js: true do
 
   # Changing the type changes the description if it was empty or still the default.
   # Changes in the description shall not be overridden.
-  def change_type_and_expect_description
+  def change_type_and_expect_description(set_project: false)
     type_field.openSelectField
     type_field.set_value type_task
     expect(page).to have_selector('.wp-edit-field.description h1', text: 'New Task template')
@@ -45,6 +45,12 @@ describe 'new work package', js: true do
     type_field.set_value type_bug
     expect(page).to have_selector('.wp-edit-field.description h1', text: 'New Bug template')
 
+    if set_project
+      project_field.openSelectField
+      project_field.set_value project
+      sleep 1
+    end
+
     scroll_to_and_click find('#work-packages--edit-actions-save')
     wp_page.expect_notification message: 'Successful creation.'
 
@@ -61,15 +67,9 @@ describe 'new work package', js: true do
       visit '/work_packages/new'
       wp_page.expect_fully_loaded
 
-      project_field.openSelectField
-      project_field.set_value project
-
       subject_field.set_value 'Foobar!'
 
-      # Wait until project is set
-      expect(page).to have_no_selector('.wp-project-context--warning')
-
-      change_type_and_expect_description
+      change_type_and_expect_description set_project: true
     end
   end
 

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -129,9 +129,15 @@ describe ::API::V3::Utilities::PathHelper do
   end
 
   describe '#available_projects_on_create' do
-    subject { helper.available_projects_on_create }
+    subject { helper.available_projects_on_create(nil) }
 
     it_behaves_like 'api v3 path', '/work_packages/available_projects'
+  end
+
+  describe '#available_projects_on_create with type' do
+    subject { helper.available_projects_on_create(1) }
+
+    it_behaves_like 'api v3 path', '/work_packages/available_projects?for_type=1'
   end
 
   describe '#categories' do

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -583,7 +583,22 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
         it_behaves_like 'links to allowed values via collection link' do
           let(:path) { 'project' }
-          let(:href) { api_v3_paths.available_projects_on_create }
+          let(:href) { api_v3_paths.available_projects_on_create(wp_type.id) }
+        end
+      end
+
+      context 'when creating (new_record with empty type)' do
+        let(:work_package) do
+          FactoryBot.build(:stubbed_work_package, project: project, type: nil) do |wp|
+            allow(wp)
+              .to receive(:available_custom_fields)
+                    .and_return(available_custom_fields)
+          end
+        end
+
+        it_behaves_like 'links to allowed values via collection link' do
+          let(:path) { 'project' }
+          let(:href) { api_v3_paths.available_projects_on_create(nil) }
         end
       end
 

--- a/spec/models/queries/projects/filters/type_filter_spec.rb
+++ b/spec/models/queries/projects/filters/type_filter_spec.rb
@@ -28,23 +28,26 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Queries::Projects
-  register = ::Queries::Register
-  filters = ::Queries::Projects::Filters
-  orders = ::Queries::Projects::Orders
-  query = ::Queries::Projects::ProjectQuery
+require 'spec_helper'
 
-  register.filter query, filters::AncestorFilter
-  register.filter query, filters::TypeFilter
-  register.filter query, filters::ActiveOrArchivedFilter
-  register.filter query, filters::NameAndIdentifierFilter
-  register.filter query, filters::CustomFieldFilter
-  register.filter query, filters::CreatedOnFilter
-  register.filter query, filters::LatestActivityAtFilter
-  register.filter query, filters::PrincipalFilter
+describe Queries::Projects::Filters::TypeFilter, type: :model do
+  it_behaves_like 'basic query filter' do
+    let(:class_key) { :type_id }
+    let(:type) { :list }
+    let(:model) { Project }
+    let(:attribute) { :type_id }
+    let(:values) { ['3'] }
+    let(:admin) { FactoryBot.build_stubbed(:admin) }
+    let(:user) { FactoryBot.build_stubbed(:user) }
 
-  register.order query, orders::DefaultOrder
-  register.order query, orders::LatestActivityAtOrder
-  register.order query, orders::RequiredDiskSpaceOrder
-  register.order query, orders::CustomFieldOrder
+    before do
+      allow(Type).to receive(:pluck).with(:name, :id).and_return([['Foo', '1234']])
+    end
+
+    describe '#allowed_values' do
+      it 'is a list of the possible values' do
+        expect(instance.allowed_values).to match_array([['Foo', '1234']])
+      end
+    end
+  end
 end

--- a/spec/requests/api/v3/work_packages/available_projects_on_create_api_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_projects_on_create_api_spec.rb
@@ -38,30 +38,56 @@ describe API::V3::WorkPackages::AvailableProjectsOnCreateAPI, type: :request do
   let(:project) { FactoryBot.create(:project) }
   let(:user) do
     FactoryBot.create(:user,
-                       member_in_project: project,
-                       member_through_role: add_role)
+                      member_in_project: project,
+                      member_through_role: add_role)
   end
+  let(:type_id) { nil }
 
-  before do
-    project
+  context 'with a type filter present' do
+    let(:type) { FactoryBot.create :type }
+    let(:type_id) { type.id }
+    let(:project_with_type) { FactoryBot.create :project, types: [type] }
+    let(:member) do
+      FactoryBot.create(:member, principal: user, project: project_with_type, roles: [add_role])
+    end
 
-    allow(User).to receive(:current).and_return(user)
-    get api_v3_paths.available_projects_on_create
-  end
+    before do
+      project
+      project_with_type
+      member
 
-  context 'w/ the necessary permissions' do
-    it_behaves_like 'API V3 collection response', 1, 1, 'Project'
+      allow(User).to receive(:current).and_return(user)
+      get api_v3_paths.available_projects_on_create(type_id)
+    end
 
-    it 'has the project for which the add_work_packages permission exists' do
-      expect(last_response.body).to be_json_eql(project.id).at_path('_embedded/elements/0/id')
+    it 'returns only the filtered one' do
+      expect(last_response.body).to be_json_eql(1).at_path('total')
+      expect(last_response.body).to be_json_eql(project_with_type.id).at_path('_embedded/elements/0/id')
     end
   end
 
-  context 'w/o any add_work_packages permission' do
-    let(:add_role) do
-      FactoryBot.create(:role, permissions: [])
+  describe 'with a single project' do
+    before do
+      project
+
+      allow(User).to receive(:current).and_return(user)
+      get api_v3_paths.available_projects_on_create(type_id)
     end
 
-    it { expect(last_response.status).to eq(403) }
+    context 'w/ the necessary permissions' do
+      it_behaves_like 'API V3 collection response', 1, 1, 'Project'
+
+      it 'has the project for which the add_work_packages permission exists' do
+        expect(last_response.body).to be_json_eql(project.id).at_path('_embedded/elements/0/id')
+      end
+    end
+
+    context 'w/o any add_work_packages permission' do
+      let(:add_role) do
+        FactoryBot.create(:role, permissions: [])
+      end
+
+      it { expect(last_response.status).to eq(403) }
+    end
   end
 end

--- a/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
@@ -59,7 +59,7 @@ describe ::API::V3::WorkPackages::CreateProjectFormAPI do
 
   it 'has the available_projects link for creation in the schema' do
     expect(response.body)
-      .to be_json_eql(api_v3_paths.available_projects_on_create.to_json)
+      .to be_json_eql(api_v3_paths.available_projects_on_create(nil).to_json)
       .at_path('_embedded/schema/project/_links/allowedValues/href')
   end
 


### PR DESCRIPTION
This allows to select all available types globally, and restrict the projects to the ones that have the type available.

The same functionality applies to embedded tables, where a filter on a type will ensure that only the projects with the type selected will be returned.

https://community.openproject.com/wp/30275