### PR TITLE
[30278] Enable automatic scrolling in lists again

### DIFF
--- a/app/assets/stylesheets/openproject/_mixins.sass
+++ b/app/assets/stylesheets/openproject/_mixins.sass
@@ -87,6 +87,7 @@
 
 
 $scrollbar-color: #DDDDDD
+$scrollbar-size: 10px
 
 @mixin styled-scroll-bar-vertical
   // Firefox specific styles
@@ -95,8 +96,7 @@ $scrollbar-color: #DDDDDD
 
   // Other browser styles
   &::-webkit-scrollbar
-    width: 8px
-    height: 12px
+    width: $scrollbar-size
 
   &::-webkit-scrollbar-track
     background: transparent
@@ -117,8 +117,7 @@ $scrollbar-color: #DDDDDD
 
   // Other browser styles
   &::-webkit-scrollbar
-    width: 12px
-    height: 8px
+    height: $scrollbar-size
 
   &::-webkit-scrollbar-track
     background: transparent

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
@@ -3,12 +3,15 @@
 .wp-cards-container
   display: flex
   flex-direction: column
-  overflow: auto
   // Ensure 100% height for drag & drop area
   height: 100%
   // Some minor left/right padding
   padding: 0 15px
   border-radius: 2px
+  // We let the scrollbar be always there, so that we can align the button above with the card view
+  // independently of whether we scroll or not.
+  overflow-y: scroll
+  @include styled-scroll-bar-vertical
 
 .wp-card
   user-select: none

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.sass
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.sass
@@ -5,15 +5,15 @@ $board-list-max-width: 300px
 .board-list--query-container
   // 100% - board header height
   max-width: inherit
-  overflow: auto
+  overflow: hidden
   height: 100%
-
-  @include styled-scroll-bar-vertical
 
   // Ensure grid is only applied if button is visible
   &.-with-create-button
     display: grid
-    grid-template: 34px 1fr / 1fr
+    // In order to enable automatic scrolling within the card view,
+    // it is important that second container is limited in the height, so that it is scrollable.
+    grid-template: 34px minmax(0, 1fr) / 1fr
 
 // Make the button sticky so that it does not scroll,
 // Unfortunately we cannot let the card container scroll because there seem to be a Chrome bug,
@@ -58,7 +58,7 @@ $board-list-max-width: 300px
 
 .board-list--add-button
   background-color: var(--body-background)
-  width: calc(100% - 30px)
+  width: calc(100% - 30px - #{$scrollbar-size})
   margin: 0 15px
   box-shadow: 1px 1px 3px 0px lightgrey
 


### PR DESCRIPTION
Enable automatic scrolling in the board lists again. 
This was broken because the cards-container was not limited in the height. Thus for the code there was no need to scroll although it was out of viewport.


https://community.openproject.com/projects/openproject/work_packages/30278/activity