### PR TITLE
Create option of version autocompleter is not readable in WP table

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -55,7 +55,7 @@
 
   // Avoid that the select field gets too small
   .wp-inline-edit--field.ng-select
-    min-width: 110px
+    min-width: 140px
 
 // Styles for inline editable attributes
 .work-package-table--container td.-editable

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -243,7 +243,7 @@ en:
     label_board_locked: "Locked"
     label_board_plural: "Boards"
     label_board_sticky: "Sticky"
-    label_create_new: "Create new"
+    label_create: "Create"
     label_create_work_package: "Create new work package"
     label_created_by: "Created by"
     label_date: "Date"

--- a/frontend/src/app/components/wp-edit-form/table-row-edit-context.ts
+++ b/frontend/src/app/components/wp-edit-form/table-row-edit-context.ts
@@ -78,7 +78,7 @@ export class TableRowEditContext implements WorkPackageEditContext {
         // be given more width. Thereby preserve a minimum width of 120.
         const td = this.findCell(fieldName);
         var width = td.css('width');
-        width = parseInt(width) > 120 ? width : '120px';
+        width = parseInt(width) > 150 ? width : '150px';
         td.css('max-width', width);
         td.css('width', width);
 

--- a/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
@@ -108,7 +108,7 @@ export class CreateAutocompleterComponent implements AfterViewInit {
   @Output() public onAfterViewInit = new EventEmitter<CreateAutocompleterComponent>();
 
   public text:any = {
-    add_new_action: this.I18n.t('js.label_create_new'),
+    add_new_action: this.I18n.t('js.label_create'),
   };
 
   private _createAllowed:boolean = false;

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -164,7 +164,7 @@ module Pages
     def add_list_with_new_value(name)
       open_and_fill_add_list_modal name
 
-      page.find('.ng-option', text: 'Create new: ' + name).click
+      page.find('.ng-option', text: 'Create: ' + name).click
     end
 
     def save

--- a/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
@@ -84,7 +84,7 @@ describe 'subject inplace editor', js: true, selenium: true do
       field.activate!
 
       field.input_element.find('input').set 'Version that does not exist'
-      expect(page).not_to have_selector('.ng-option', text: 'Create new: Version that does not exist')
+      expect(page).not_to have_selector('.ng-option', text: 'Create: Version that does not exist')
     end
   end
 end

--- a/spec/support/work_packages/work_package_field.rb
+++ b/spec/support/work_packages/work_package_field.rb
@@ -151,7 +151,7 @@ class WorkPackageField
     scroll_to_element(input_element)
     input_element.find('input').set content
 
-    page.find('.ng-option', text: 'Create new: ' + content).click
+    page.find('.ng-option', text: 'Create: ' + content).click
   end
 
   def type(text)


### PR DESCRIPTION
Increase available space for autocompleter in table and reduce label to save space

![image](https://user-images.githubusercontent.com/7457313/58803913-da34c180-8610-11e9-91be-e748d52e706e.png)
