### PR TITLE
[30279] No error when version cannot be inline-created

### DIFF
--- a/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
@@ -127,6 +127,10 @@ export class CreateAutocompleterComponent implements AfterViewInit {
     this.createAllowed ? this.addAutoCompleter.open() : this.autoCompleter.open();
   }
 
+  public closeSelect() {
+    this.createAllowed ? this.addAutoCompleter.close() : this.autoCompleter.close();
+  }
+
   public createNewElement(newElement:string) {
     this.create.emit(newElement);
   }

--- a/frontend/src/app/modules/common/autocomplete/version-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/version-autocompleter.component.ts
@@ -35,6 +35,7 @@ import {VersionResource} from "core-app/modules/hal/resources/version-resource";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {CreateAutocompleterComponent} from "core-app/modules/common/autocomplete/create-autocompleter.component";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {WorkPackageNotificationService} from "core-components/wp-edit/wp-notification.service";
 
 @Component({
   template: `
@@ -67,7 +68,8 @@ export class VersionAutocompleterComponent extends CreateAutocompleterComponent 
   constructor(readonly I18n:I18nService,
               readonly currentProject:CurrentProjectService,
               readonly pathHelper:PathHelperService,
-              readonly versionDm:VersionDmService) {
+              readonly versionDm:VersionDmService,
+              readonly wpNotifications:WorkPackageNotificationService) {
     super(I18n, currentProject, pathHelper);
   }
 
@@ -100,9 +102,14 @@ export class VersionAutocompleterComponent extends CreateAutocompleterComponent 
   }
 
   public createNewVersion(name:string) {
-    this.versionDm.createVersion(this.getVersionPayload(name)).then((version) => {
-      this.onCreate.emit(version);
-    });
+    this.versionDm.createVersion(this.getVersionPayload(name))
+      .then((version) => {
+        this.onCreate.emit(version);
+      })
+      .catch(error =>  {
+        this.createAutocompleter.closeSelect();
+        this.wpNotifications.handleRawError(error);
+      });
   }
   private getVersionPayload(name:string) {
     let payload:any = {};


### PR DESCRIPTION
Show an error message when the version could not be created and empty the select field.

https://community.openproject.com/projects/openproject/work_packages/30279/activity