### PR TITLE
disable wp schema caching until it is turned save for it again

### DIFF
--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -35,7 +35,11 @@ module API
     module WorkPackages
       module Schema
         class WorkPackageSchemaRepresenter < ::API::Decorators::SchemaRepresenter
-          include API::Caching::CachedRepresenter
+          # TODO: reenable caching after having ensured that the cache is
+          # user or at least roles in project specific.
+          # Otherwise, the writable information will not be correct and information
+          # cached e.g. in an embedded query (project name) is leaked to the user.
+          # include API::Caching::CachedRepresenter
           extend ::API::V3::Utilities::CustomFieldInjector::RepresenterClass
 
           custom_field_injector type: :schema_representer

--- a/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
@@ -145,7 +145,7 @@ describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI, type: :request do
           expect(last_response.headers['ETag']).to match(/W\/\"\w+\"/)
         end
 
-        it 'caches the response' do
+        it 'caches the response', skip: true do
           schema_class = API::V3::WorkPackages::Schema::TypedWorkPackageSchema
           representer_class = API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter
 


### PR DESCRIPTION
Addresses https://community.openproject.com/projects/openproject/work_packages/30283 for now as it disables caching. 

Leaving caching enabled will also lead to faulty information regarding the writeability of an attribute.