### PR TITLE
Styled scrollbars for Gantt and embedded tables

### DIFF
--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -63,7 +63,7 @@ $modal-footer-height: $modal-header-height
   max-width: 60vw
   overflow-y: auto
 
-  @include styled-scroll-bar-vertical
+  @include styled-scroll-bar
 
   &.-wide
     min-width: 75vw
@@ -81,7 +81,7 @@ $modal-footer-height: $modal-header-height
   padding: 0 1.5rem
   max-height: calc(100vh - #{$modal-header-height} - #{$modal-footer-height})
   overflow: auto
-  @include styled-scroll-bar-vertical
+  @include styled-scroll-bar
 
   &.-formattable
     p:last-of-type

--- a/app/assets/stylesheets/content/menus/_project_autocompletion.sass
+++ b/app/assets/stylesheets/content/menus/_project_autocompletion.sass
@@ -82,7 +82,7 @@
     // Borders to complete the menu look
     border-right: 1px solid $header-drop-down-border-color
     border-left: 1px solid $header-drop-down-border-color
-    @include styled-scroll-bar-vertical
+    @include styled-scroll-bar
 
   // Cut off result element width
   .ui-menu-item-wrapper

--- a/app/assets/stylesheets/layout/_main_menu.sass
+++ b/app/assets/stylesheets/layout/_main_menu.sass
@@ -50,7 +50,7 @@ $menu-item-line-height: 30px
     +allow-vertical-scrolling
     height: calc(100vh - #{$header-height})
     position: relative
-    @include styled-scroll-bar-vertical
+    @include styled-scroll-bar
 
     // Fixed heights to allow inner scrolling
     .menu_root.closed,
@@ -67,7 +67,7 @@ $menu-item-line-height: 30px
     .main-menu--children
       height: calc(100% - (#{$main-menu-item-height} + 10px)) // 10px spacing
       overflow: auto
-      @include styled-scroll-bar-vertical
+      @include styled-scroll-bar
 
   ul
     margin: 0
@@ -318,7 +318,7 @@ a.main-menu--parent-node
   padding-left: 7px
   padding-right: 7px
 
-  @include styled-scroll-bar-vertical
+  @include styled-scroll-bar
 
 .main-menu--segment-header
   @include varprop(color, main-menu-fieldset-header-color)

--- a/app/assets/stylesheets/layout/_top_menu.sass
+++ b/app/assets/stylesheets/layout/_top_menu.sass
@@ -107,7 +107,7 @@ $search-input-height: 30px
       overflow-y: auto
       overflow-x: hidden
 
-      @include styled-scroll-bar-vertical
+      @include styled-scroll-bar
 
       li
         float: none
@@ -244,7 +244,7 @@ $search-input-height: 30px
         @include varprop(color, header-search-field-font-color)
 
       .scroll-host
-        @include styled-scroll-bar-vertical
+        @include styled-scroll-bar
         max-height: 80vh
         height: auto
 

--- a/app/assets/stylesheets/layout/work_packages/_query_menu.sass
+++ b/app/assets/stylesheets/layout/work_packages/_query_menu.sass
@@ -15,7 +15,7 @@ $wp-query-menu-search-container-height: 35px
     background: none
     z-index: 0 // Prevent overlapping with project select dropdown (https://community.openproject.com/wp/28175)
 
-    @include styled-scroll-bar-vertical
+    @include styled-scroll-bar
 
 
   .wp-query-menu--results-container

--- a/app/assets/stylesheets/layout/work_packages/_table.sass
+++ b/app/assets/stylesheets/layout/work_packages/_table.sass
@@ -121,6 +121,7 @@
   flex: 1 1
   // Show scrollbars for inner content
   overflow: auto
+  @include styled-scroll-bar
   // relative for loading indicator
   position: relative
   // Hint browser that this will inner-scroll
@@ -142,6 +143,7 @@
   overflow-x: scroll
   // Show the vertical scrollbar when necessary
   overflow-y: auto
+  @include styled-scroll-bar
   // Hidden by default
   display: none
   // Hint browser that this will inner-scroll

--- a/app/assets/stylesheets/layout/work_packages/_table_embedded.sass
+++ b/app/assets/stylesheets/layout/work_packages/_table_embedded.sass
@@ -47,6 +47,7 @@ $table-timeline--compact-row-height: 28px
   // Allow scrolling in narrow views
   .work-packages-split-view--tabletimeline-content
     overflow: auto
+    @include styled-scroll-bar
 
   // Disable css containment since we have no inner elements
   .work-packages-tabletimeline--table-side,

--- a/app/assets/stylesheets/openproject/_mixins.sass
+++ b/app/assets/stylesheets/openproject/_mixins.sass
@@ -89,13 +89,14 @@
 $scrollbar-color: #DDDDDD
 $scrollbar-size: 10px
 
-@mixin styled-scroll-bar-vertical
+@mixin styled-scroll-bar
   // Firefox specific styles
   scrollbar-color: transparent transparent
   scrollbar-width: thin
 
   // Other browser styles
   &::-webkit-scrollbar
+    height: $scrollbar-size
     width: $scrollbar-size
 
   &::-webkit-scrollbar-track
@@ -109,23 +110,6 @@ $scrollbar-size: 10px
     scrollbar-color: $scrollbar-color transparent
     &::-webkit-scrollbar-thumb
       visibility: visible
-
-@mixin styled-scroll-bar-horizontal
-  // Firefox specific styles
-  scrollbar-color: $scrollbar-color transparent
-  scrollbar-width: thin
-
-  // Other browser styles
-  &::-webkit-scrollbar
-    height: $scrollbar-size
-
-  &::-webkit-scrollbar-track
-    background: transparent
-
-  // Should always be visible otherwise it would not be displayed on mobile or tablet
-  &::-webkit-scrollbar-thumb
-    background: $scrollbar-color
-    visibility: visible
 
 @mixin two-column-layout
   column-count: 2

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
@@ -11,7 +11,7 @@
   // We let the scrollbar be always there, so that we can align the button above with the card view
   // independently of whether we scroll or not.
   overflow-y: scroll
-  @include styled-scroll-bar-vertical
+  @include styled-scroll-bar
 
 .wp-card
   user-select: none


### PR DESCRIPTION
Apply styled scrollbars for Gantt chart and embedded tables. 

Further the two mixins were merged to one. We do not have to differentiate between horizontal and vertical scrollbars as the styles are only applied when the browser shows a scrollbar. The `height` value is then ignored for vertical bars and the `width` for horizontal bars. 


https://community.openproject.com/projects/openproject/work_packages/30175/activity