### PR TITLE
use default filter behaviour for wps available for relations

### DIFF
--- a/app/models/queries/operators.rb
+++ b/app/models/queries/operators.rb
@@ -47,7 +47,20 @@ module Queries::Operators
     Queries::Operators::Ago,
     Queries::Operators::OnDate,
     Queries::Operators::BetweenDate,
-    Queries::Operators::Everywhere
+    Queries::Operators::Everywhere,
+    Queries::Operators::Relates,
+    Queries::Operators::Duplicates,
+    Queries::Operators::Duplicated,
+    Queries::Operators::Blocks,
+    Queries::Operators::Blocked,
+    Queries::Operators::Follows,
+    Queries::Operators::Precedes,
+    Queries::Operators::Includes,
+    Queries::Operators::PartOf,
+    Queries::Operators::Requires,
+    Queries::Operators::Required,
+    Queries::Operators::Parent,
+    Queries::Operators::Children
   ]
 
   OPERATORS = Hash[*(operators.map { |o| [o.symbol.to_s, o] }).flatten].freeze

--- a/app/models/queries/operators/blocked.rb
+++ b/app/models/queries/operators/blocked.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -27,54 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::NotExistingFilter < Queries::Filters::Base
-  def available?
-    false
-  end
-
-  def type
-    :inexistent
-  end
-
-  def self.key
-    :not_existent
-  end
-
-  def human_name
-    name.to_s.blank? ? type : name.to_s
-  end
-
-  validate :always_false
-
-  def always_false
-    errors.add :base, I18n.t(:'activerecord.errors.messages.does_not_exist')
-  end
-
-  # deactivating superclass validation
-  def validate_inclusion_of_operator; end
-
-  def to_hash
-    {
-      non_existent_filter: {
-        operator: operator,
-        values: values
-      }
-    }
-  end
-
-  def scope
-    # TODO: remove switch once the WP query is a
-    # subclass of Queries::Base
-    model = if context.respond_to?(:model)
-              context.model
-            else
-              WorkPackage
-            end
-
-    model.unscoped
-  end
-
-  def attributes_hash
-    nil
+module Queries::Operators
+  class Blocked < Base
+    label ::Relation::TYPE_BLOCKED
+    set_symbol ::Relation::TYPE_BLOCKED
   end
 end

--- a/app/models/queries/operators/blocks.rb
+++ b/app/models/queries/operators/blocks.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -27,54 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::NotExistingFilter < Queries::Filters::Base
-  def available?
-    false
-  end
-
-  def type
-    :inexistent
-  end
-
-  def self.key
-    :not_existent
-  end
-
-  def human_name
-    name.to_s.blank? ? type : name.to_s
-  end
-
-  validate :always_false
-
-  def always_false
-    errors.add :base, I18n.t(:'activerecord.errors.messages.does_not_exist')
-  end
-
-  # deactivating superclass validation
-  def validate_inclusion_of_operator; end
-
-  def to_hash
-    {
-      non_existent_filter: {
-        operator: operator,
-        values: values
-      }
-    }
-  end
-
-  def scope
-    # TODO: remove switch once the WP query is a
-    # subclass of Queries::Base
-    model = if context.respond_to?(:model)
-              context.model
-            else
-              WorkPackage
-            end
-
-    model.unscoped
-  end
-
-  def attributes_hash
-    nil
+module Queries::Operators
+  class Blocks < Base
+    label ::Relation::TYPE_BLOCKS
+    set_symbol ::Relation::TYPE_BLOCKS
   end
 end

--- a/app/models/queries/operators/children.rb
+++ b/app/models/queries/operators/children.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -27,54 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::NotExistingFilter < Queries::Filters::Base
-  def available?
-    false
-  end
-
-  def type
-    :inexistent
-  end
-
-  def self.key
-    :not_existent
-  end
-
-  def human_name
-    name.to_s.blank? ? type : name.to_s
-  end
-
-  validate :always_false
-
-  def always_false
-    errors.add :base, I18n.t(:'activerecord.errors.messages.does_not_exist')
-  end
-
-  # deactivating superclass validation
-  def validate_inclusion_of_operator; end
-
-  def to_hash
-    {
-      non_existent_filter: {
-        operator: operator,
-        values: values
-      }
-    }
-  end
-
-  def scope
-    # TODO: remove switch once the WP query is a
-    # subclass of Queries::Base
-    model = if context.respond_to?(:model)
-              context.model
-            else
-              WorkPackage
-            end
-
-    model.unscoped
-  end
-
-  def attributes_hash
-    nil
+module Queries::Operators
+  class Children < Base
+    label 'children'
+    set_symbol 'children'
   end
 end

--- a/app/models/queries/operators/duplicated.rb
+++ b/app/models/queries/operators/duplicated.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -27,54 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::NotExistingFilter < Queries::Filters::Base
-  def available?
-    false
-  end
-
-  def type
-    :inexistent
-  end
-
-  def self.key
-    :not_existent
-  end
-
-  def human_name
-    name.to_s.blank? ? type : name.to_s
-  end
-
-  validate :always_false
-
-  def always_false
-    errors.add :base, I18n.t(:'activerecord.errors.messages.does_not_exist')
-  end
-
-  # deactivating superclass validation
-  def validate_inclusion_of_operator; end
-
-  def to_hash
-    {
-      non_existent_filter: {
-        operator: operator,
-        values: values
-      }
-    }
-  end
-
-  def scope
-    # TODO: remove switch once the WP query is a
-    # subclass of Queries::Base
-    model = if context.respond_to?(:model)
-              context.model
-            else
-              WorkPackage
-            end
-
-    model.unscoped
-  end
-
-  def attributes_hash
-    nil
+module Queries::Operators
+  class Duplicated < Base
+    label ::Relation::TYPE_DUPLICATED
+    set_symbol ::Relation::TYPE_DUPLICATED
   end
 end

--- a/app/models/queries/operators/duplicates.rb
+++ b/app/models/queries/operators/duplicates.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -27,54 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::NotExistingFilter < Queries::Filters::Base
-  def available?
-    false
-  end
-
-  def type
-    :inexistent
-  end
-
-  def self.key
-    :not_existent
-  end
-
-  def human_name
-    name.to_s.blank? ? type : name.to_s
-  end
-
-  validate :always_false
-
-  def always_false
-    errors.add :base, I18n.t(:'activerecord.errors.messages.does_not_exist')
-  end
-
-  # deactivating superclass validation
-  def validate_inclusion_of_operator; end
-
-  def to_hash
-    {
-      non_existent_filter: {
-        operator: operator,
-        values: values
-      }
-    }
-  end
-
-  def scope
-    # TODO: remove switch once the WP query is a
-    # subclass of Queries::Base
-    model = if context.respond_to?(:model)
-              context.model
-            else
-              WorkPackage
-            end
-
-    model.unscoped
-  end
-
-  def attributes_hash
-    nil
+module Queries::Operators
+  class Duplicates < Base
+    label ::Relation::TYPE_DUPLICATES
+    set_symbol ::Relation::TYPE_DUPLICATES
   end
 end

--- a/app/models/queries/operators/follows.rb
+++ b/app/models/queries/operators/follows.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -26,24 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module WorkPackages
-      module AvailableRelationCandidatesHelper
-        include API::V3::Utilities::PathHelper
-
-        def work_package_scope(from, type)
-          canonical_type = Relation.canonical_type(type)
-
-          if type == Relation::TYPE_RELATES
-            WorkPackage.relateable_to(from).or(WorkPackage.relateable_from(from))
-          elsif type != 'parent' && canonical_type == type
-            WorkPackage.relateable_to(from)
-          else
-            WorkPackage.relateable_from(from)
-          end
-        end
-      end
-    end
+module Queries::Operators
+  class Follows < Base
+    label 'follows'
+    set_symbol ::Relation::TYPE_FOLLOWS
   end
 end

--- a/app/models/queries/operators/includes.rb
+++ b/app/models/queries/operators/includes.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -27,54 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::NotExistingFilter < Queries::Filters::Base
-  def available?
-    false
-  end
-
-  def type
-    :inexistent
-  end
-
-  def self.key
-    :not_existent
-  end
-
-  def human_name
-    name.to_s.blank? ? type : name.to_s
-  end
-
-  validate :always_false
-
-  def always_false
-    errors.add :base, I18n.t(:'activerecord.errors.messages.does_not_exist')
-  end
-
-  # deactivating superclass validation
-  def validate_inclusion_of_operator; end
-
-  def to_hash
-    {
-      non_existent_filter: {
-        operator: operator,
-        values: values
-      }
-    }
-  end
-
-  def scope
-    # TODO: remove switch once the WP query is a
-    # subclass of Queries::Base
-    model = if context.respond_to?(:model)
-              context.model
-            else
-              WorkPackage
-            end
-
-    model.unscoped
-  end
-
-  def attributes_hash
-    nil
+module Queries::Operators
+  class Includes < Base
+    label ::Relation::TYPE_INCLUDES
+    set_symbol ::Relation::TYPE_INCLUDES
   end
 end

--- a/app/models/queries/operators/parent.rb
+++ b/app/models/queries/operators/parent.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -27,54 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::NotExistingFilter < Queries::Filters::Base
-  def available?
-    false
-  end
-
-  def type
-    :inexistent
-  end
-
-  def self.key
-    :not_existent
-  end
-
-  def human_name
-    name.to_s.blank? ? type : name.to_s
-  end
-
-  validate :always_false
-
-  def always_false
-    errors.add :base, I18n.t(:'activerecord.errors.messages.does_not_exist')
-  end
-
-  # deactivating superclass validation
-  def validate_inclusion_of_operator; end
-
-  def to_hash
-    {
-      non_existent_filter: {
-        operator: operator,
-        values: values
-      }
-    }
-  end
-
-  def scope
-    # TODO: remove switch once the WP query is a
-    # subclass of Queries::Base
-    model = if context.respond_to?(:model)
-              context.model
-            else
-              WorkPackage
-            end
-
-    model.unscoped
-  end
-
-  def attributes_hash
-    nil
+module Queries::Operators
+  class Parent < Base
+    label 'parent'
+    set_symbol 'parent'
   end
 end

--- a/app/models/queries/operators/part_of.rb
+++ b/app/models/queries/operators/part_of.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -27,54 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::NotExistingFilter < Queries::Filters::Base
-  def available?
-    false
-  end
-
-  def type
-    :inexistent
-  end
-
-  def self.key
-    :not_existent
-  end
-
-  def human_name
-    name.to_s.blank? ? type : name.to_s
-  end
-
-  validate :always_false
-
-  def always_false
-    errors.add :base, I18n.t(:'activerecord.errors.messages.does_not_exist')
-  end
-
-  # deactivating superclass validation
-  def validate_inclusion_of_operator; end
-
-  def to_hash
-    {
-      non_existent_filter: {
-        operator: operator,
-        values: values
-      }
-    }
-  end
-
-  def scope
-    # TODO: remove switch once the WP query is a
-    # subclass of Queries::Base
-    model = if context.respond_to?(:model)
-              context.model
-            else
-              WorkPackage
-            end
-
-    model.unscoped
-  end
-
-  def attributes_hash
-    nil
+module Queries::Operators
+  class PartOf < Base
+    label ::Relation::TYPE_PARTOF
+    set_symbol ::Relation::TYPE_PARTOF
   end
 end

--- a/app/models/queries/operators/precedes.rb
+++ b/app/models/queries/operators/precedes.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -27,54 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::NotExistingFilter < Queries::Filters::Base
-  def available?
-    false
-  end
-
-  def type
-    :inexistent
-  end
-
-  def self.key
-    :not_existent
-  end
-
-  def human_name
-    name.to_s.blank? ? type : name.to_s
-  end
-
-  validate :always_false
-
-  def always_false
-    errors.add :base, I18n.t(:'activerecord.errors.messages.does_not_exist')
-  end
-
-  # deactivating superclass validation
-  def validate_inclusion_of_operator; end
-
-  def to_hash
-    {
-      non_existent_filter: {
-        operator: operator,
-        values: values
-      }
-    }
-  end
-
-  def scope
-    # TODO: remove switch once the WP query is a
-    # subclass of Queries::Base
-    model = if context.respond_to?(:model)
-              context.model
-            else
-              WorkPackage
-            end
-
-    model.unscoped
-  end
-
-  def attributes_hash
-    nil
+module Queries::Operators
+  class Precedes < Base
+    label ::Relation::TYPE_PRECEDES
+    set_symbol ::Relation::TYPE_PRECEDES
   end
 end

--- a/app/models/queries/operators/relates.rb
+++ b/app/models/queries/operators/relates.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -27,54 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::NotExistingFilter < Queries::Filters::Base
-  def available?
-    false
-  end
-
-  def type
-    :inexistent
-  end
-
-  def self.key
-    :not_existent
-  end
-
-  def human_name
-    name.to_s.blank? ? type : name.to_s
-  end
-
-  validate :always_false
-
-  def always_false
-    errors.add :base, I18n.t(:'activerecord.errors.messages.does_not_exist')
-  end
-
-  # deactivating superclass validation
-  def validate_inclusion_of_operator; end
-
-  def to_hash
-    {
-      non_existent_filter: {
-        operator: operator,
-        values: values
-      }
-    }
-  end
-
-  def scope
-    # TODO: remove switch once the WP query is a
-    # subclass of Queries::Base
-    model = if context.respond_to?(:model)
-              context.model
-            else
-              WorkPackage
-            end
-
-    model.unscoped
-  end
-
-  def attributes_hash
-    nil
+module Queries::Operators
+  class Relates < Base
+    label 'relates'
+    set_symbol ::Relation::TYPE_RELATES
   end
 end

--- a/app/models/queries/operators/required.rb
+++ b/app/models/queries/operators/required.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -27,54 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::NotExistingFilter < Queries::Filters::Base
-  def available?
-    false
-  end
-
-  def type
-    :inexistent
-  end
-
-  def self.key
-    :not_existent
-  end
-
-  def human_name
-    name.to_s.blank? ? type : name.to_s
-  end
-
-  validate :always_false
-
-  def always_false
-    errors.add :base, I18n.t(:'activerecord.errors.messages.does_not_exist')
-  end
-
-  # deactivating superclass validation
-  def validate_inclusion_of_operator; end
-
-  def to_hash
-    {
-      non_existent_filter: {
-        operator: operator,
-        values: values
-      }
-    }
-  end
-
-  def scope
-    # TODO: remove switch once the WP query is a
-    # subclass of Queries::Base
-    model = if context.respond_to?(:model)
-              context.model
-            else
-              WorkPackage
-            end
-
-    model.unscoped
-  end
-
-  def attributes_hash
-    nil
+module Queries::Operators
+  class Required < Base
+    label ::Relation::TYPE_REQUIRED
+    set_symbol ::Relation::TYPE_REQUIRED
   end
 end

--- a/app/models/queries/operators/requires.rb
+++ b/app/models/queries/operators/requires.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -27,54 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::NotExistingFilter < Queries::Filters::Base
-  def available?
-    false
-  end
-
-  def type
-    :inexistent
-  end
-
-  def self.key
-    :not_existent
-  end
-
-  def human_name
-    name.to_s.blank? ? type : name.to_s
-  end
-
-  validate :always_false
-
-  def always_false
-    errors.add :base, I18n.t(:'activerecord.errors.messages.does_not_exist')
-  end
-
-  # deactivating superclass validation
-  def validate_inclusion_of_operator; end
-
-  def to_hash
-    {
-      non_existent_filter: {
-        operator: operator,
-        values: values
-      }
-    }
-  end
-
-  def scope
-    # TODO: remove switch once the WP query is a
-    # subclass of Queries::Base
-    model = if context.respond_to?(:model)
-              context.model
-            else
-              WorkPackage
-            end
-
-    model.unscoped
-  end
-
-  def attributes_hash
-    nil
+module Queries::Operators
+  class Requires < Base
+    label ::Relation::TYPE_REQUIRES
+    set_symbol ::Relation::TYPE_REQUIRES
   end
 end

--- a/app/models/queries/work_packages.rb
+++ b/app/models/queries/work_packages.rb
@@ -75,6 +75,7 @@ module Queries::WorkPackages
   register.filter Query, filters_module::CommentFilter
   register.filter Query, filters_module::SubjectOrIdFilter
   register.filter Query, filters_module::ManualSortFilter
+  register.filter Query, filters_module::RelatableFilter
 
   columns_module = Queries::WorkPackages::Columns
 

--- a/app/models/queries/work_packages/filter/filter_for_wp_mixin.rb
+++ b/app/models/queries/work_packages/filter/filter_for_wp_mixin.rb
@@ -38,7 +38,7 @@ module Queries::WorkPackages::Filter::FilterForWpMixin
   end
 
   def value_objects
-    objects = scope.find(no_templated_values)
+    objects = visible_scope.find(no_templated_values)
 
     if has_templated_value?
       objects << ::Queries::Filters::TemplatedValue.new(WorkPackage)
@@ -52,7 +52,7 @@ module Queries::WorkPackages::Filter::FilterForWpMixin
   end
 
   def available?
-    scope.exists?
+    visible_scope.exists?
   end
 
   def ar_object_filter?
@@ -60,7 +60,7 @@ module Queries::WorkPackages::Filter::FilterForWpMixin
   end
 
   def allowed_values_subset
-    id_values = scope.where(id: no_templated_values).pluck(:id).map(&:to_s)
+    id_values = visible_scope.where(id: no_templated_values).pluck(:id).map(&:to_s)
 
     if has_templated_value?
       id_values + templated_value_keys
@@ -71,7 +71,7 @@ module Queries::WorkPackages::Filter::FilterForWpMixin
 
   private
 
-  def scope
+  def visible_scope
     if context.project
       WorkPackage
         .visible

--- a/app/models/queries/work_packages/filter/project_filter.rb
+++ b/app/models/queries/work_packages/filter/project_filter.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)

--- a/app/models/queries/work_packages/filter/relates_filter.rb
+++ b/app/models/queries/work_packages/filter/relates_filter.rb
@@ -32,7 +32,6 @@
 
 class Queries::WorkPackages::Filter::RelatesFilter <
   Queries::WorkPackages::Filter::WorkPackageFilter
-
   include ::Queries::WorkPackages::Filter::FilterOnUndirectedRelationsMixin
 
   def relation_type

--- a/app/models/queries/work_packages/filter/subject_or_id_filter.rb
+++ b/app/models/queries/work_packages/filter/subject_or_id_filter.rb
@@ -30,7 +30,6 @@
 
 class Queries::WorkPackages::Filter::SubjectOrIdFilter <
   Queries::WorkPackages::Filter::WorkPackageFilter
-
   include Queries::WorkPackages::Filter::OrFilterForWpMixin
 
   CONTAINS_OPERATOR = '~'.freeze

--- a/app/models/queries/work_packages/filter/work_package_filter.rb
+++ b/app/models/queries/work_packages/filter/work_package_filter.rb
@@ -44,4 +44,12 @@ class Queries::WorkPackages::Filter::WorkPackageFilter < ::Queries::Filters::Bas
   def includes
     nil
   end
+
+  def scope
+    # We only return the WorkPackage base scope for now as most of the filters
+    # (this one's subclasses) currently do not follow the base filter approach of using the scope.
+    # The intend is to have more and more wp filters use the scope method just like the
+    # rest of the queries (e.g. project)
+    WorkPackage.unscoped
+  end
 end

--- a/app/services/update_query_from_params_service.rb
+++ b/app/services/update_query_from_params_service.rb
@@ -75,6 +75,7 @@ class UpdateQueryFromParamsService
 
   def apply_filters(params)
     return unless params[:filters]
+
     query.filters = []
 
     params[:filters].each do |filter|

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -257,7 +257,10 @@ module API
           end
 
           def filters_schemas
-            filters = represented.available_filters
+            # TODO: The RelatableFilter is not supported by the schema depdendencies yet
+            filters = represented
+                      .available_filters
+                      .reject { |f| f.is_a?(::Queries::WorkPackages::Filter::RelatableFilter) }
 
             QueryFilterInstanceSchemaCollectionRepresenter.new(filters,
                                                                filter_instance_schemas_href,

--- a/spec_legacy/unit/mail_handler_spec.rb
+++ b/spec_legacy/unit/mail_handler_spec.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)


### PR DESCRIPTION
That way, we can treat the end point as just another wp endpoint with
filter capabilities. Currently, there is a couple of custom logic still
present but that is only due to wanting to not break the public API.

In the long run, the whole end point could be removed as the same
filtering is now available using /api/v3/work_packages with an
appropriate filter.

It fixes:
* adding page size so that the performance is adequate
* also finding closed work packages

It also moves the work package query more into the direction of the rest of the queries by merging the `#scope`-method into the result scope.  

https://community.openproject.com/projects/openproject/work_packages/30287