### PR TITLE
[30245] Restore indentation of table of contents

### DIFF
--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -72,6 +72,10 @@ div.wiki
     margin-left: 0
     display: table
     font-size: $wiki-toc-ul-font-size
+
+    .section-nav
+      margin-bottom: 0
+      margin-left: 12px
     &.right
       float: right
       margin-left: 12px
@@ -107,8 +111,10 @@ div.wiki
 
 a.wiki-anchor
   display: none
-  margin-left: 6px
   text-decoration: none
+  font-size: 16px
+  vertical-align: middle
+  padding-right: 2px
 
   &:hover
     color: #aaa !important

--- a/app/views/wiki/_content.html.erb
+++ b/app/views/wiki/_content.html.erb
@@ -28,5 +28,9 @@ See docs/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <div class="wiki wiki-content highlight">
-  <%= format_text content, :text, attachments: content.page.attachments %>
+  <% if @formatted_text %>
+    <%= @formatted_text %>
+  <% else %>
+    <%= format_text content, :text, attachments: content.page.attachments %>
+  <% end %>
 </div>

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -36,7 +36,8 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <%# Set meta tags %>
 <% title "#{t(:project_module_wiki)} | #{title}" %>
-<% description strip_tags(format_text(@content, :text)) %>
+<% @formatted_text = format_text @page.content, :text, attachments: @page.attachments  %>
+<% description strip_tags(@formatted_text) %>
 
 <%= toolbar title: title, html: {class: '-with-dropdown'} do %>
   <% if @editable %>

--- a/frontend/src/app/globals/global-listeners.ts
+++ b/frontend/src/app/globals/global-listeners.ts
@@ -34,7 +34,6 @@ import {augmentedDatePicker} from "./global-listeners/augmented-date-picker";
  */
 (function($:JQueryStatic) {
 
-
   $(function() {
     $(document.documentElement!)
       .on('click', (evt:JQueryEventObject) => {
@@ -49,6 +48,13 @@ import {augmentedDatePicker} from "./global-listeners/augmented-date-picker";
 
         return true;
       });
+
+    // Jump to the element given by location.hash, if present
+    const hash = window.location.hash;
+    if (hash && hash.startsWith('#')) {
+      const el = document.querySelector(hash);
+      el && el.scrollIntoView();
+    }
 
     // Disable global drag & drop handling, which results in the browser loading the image and losing the page
     $(document.documentElement!)

--- a/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
+++ b/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
@@ -1,0 +1,128 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject::TextFormatting
+  module Filters
+    class TableOfContentsFilter < HTML::Pipeline::TableOfContentsFilter
+      include ActionView::Context
+      include ActionView::Helpers::TagHelper
+
+      attr_reader :headings, :ids
+
+      def initialize(doc, context = nil, result = nil)
+        super(doc, context, result)
+        @headings ||= doc.css('h1, h2, h3, h4, h5, h6')
+        @ids = Set.new
+      end
+
+      def add_header_link(node, id)
+        link = content_tag(:a,
+                           '',
+                           class: 'wiki-anchor icon-paragraph',
+                           'aria-hidden': true,
+                           href: "##{id}")
+        node['id'] = id
+        node.prepend_child(link)
+      end
+
+      ##
+      # Build a unique id used for anchoring
+      def get_unique_id(text)
+        # Build id from text
+        id = ascii_downcase(text)
+        id.gsub!(PUNCTUATION_REGEXP, '') # remove punctuation
+        id.tr!(' ', '-') # replace spaces with dash
+
+        while ids.add?(id).nil?
+          id += SecureRandom.hex(4)
+        end
+
+        id
+      end
+
+      ##
+      # Appends the header link and returns
+      # a toc item.
+      def process_item(node)
+        text = node.text
+        return ''.html_safe unless text.present?
+
+        id = get_unique_id(node.text)
+        add_header_link(node, id)
+
+        content_tag(:li) do
+          content_tag(:a, node.text, href: "##{id}")
+        end
+      end
+
+      def render_nested(current_level)
+        result = ''.html_safe
+
+        while headings.length > 0
+          node = headings.first
+          level = node.name[1,].to_i
+
+          # Initialize first level
+          current_level = level if current_level.nil?
+
+          # Cancel our loop and let parent render this one
+          break if level < current_level
+
+          # We will render this node
+          node = headings.shift
+
+          if level == current_level
+            result << process_item(node)
+            result << render_nested(current_level)
+          elsif level > current_level
+            result << (content_tag(:ul, class: 'section-nav') do
+              process_item(node) + render_nested(level)
+            end)
+          end
+        end
+
+        result
+      end
+
+      def call
+        process!
+        doc
+      end
+
+      def process!
+        return if headings.empty?
+
+        result[:toc] = content_tag(:ul, render_nested(nil), class: 'toc')
+      rescue StandardError => e
+        Rails.logger.error { "Failed to render table of contents: #{e} #{e.message}" }
+      end
+    end
+  end
+end

--- a/lib/open_project/text_formatting/formats/markdown/formatter.rb
+++ b/lib/open_project/text_formatting/formats/markdown/formatter.rb
@@ -53,7 +53,7 @@ module OpenProject::TextFormatting::Formats::Markdown
       [
         :markdown,
         :sanitization,
-        HTML::Pipeline::TableOfContentsFilter,
+        :table_of_contents,
         :macro,
         :pattern_matcher,
         :syntax_highlight,

--- a/spec/lib/open_project/macros/include_wiki_page_macro_spec.rb
+++ b/spec/lib/open_project/macros/include_wiki_page_macro_spec.rb
@@ -114,9 +114,8 @@ describe 'OpenProject include wiki page macro' do
       is_expected.to be_html_eql('
         <p>
         <section class="macros--included-wiki-page" data-page-name="included">
-          <h1>
-            <a id="included-from-same-project" class="anchor" href="#included-from-same-project" aria-hidden="true">
-              <span aria-hidden="true" class="octicon octicon-link"></span>
+          <h1 id="included-from-same-project">
+            <a class="wiki-anchor icon-paragraph" href="#included-from-same-project" aria-hidden="true">
             </a>
             included from same project
           </h1>
@@ -177,9 +176,8 @@ describe 'OpenProject include wiki page macro' do
         is_expected.to be_html_eql('
         <p>
           <section class="macros--included-wiki-page" data-page-name="other-project:include-test">
-          <h1>
-            <a id="included-from-other-project" class="anchor" href="#included-from-other-project" aria-hidden="true">
-              <span aria-hidden="true" class="octicon octicon-link"></span>
+          <h1 id="included-from-other-project">
+            <a class="wiki-anchor icon-paragraph" href="#included-from-other-project" aria-hidden="true">
             </a>
             Included from other project
           </h1>

--- a/spec/lib/open_project/text_formatting/markdown/markdown_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/markdown_formatting_spec.rb
@@ -58,9 +58,8 @@ describe OpenProject::TextFormatting::Formats::Markdown::Formatter do
 
   it 'should use of backslashes followed by numbers in headers' do
     html = <<-HTML.strip_heredoc
-      <h1>
-        <a id="20090209" class="anchor" href="#20090209" aria-hidden="true">
-          <span aria-hidden="true" class="octicon octicon-link"></span>
+      <h1 id="20090209">
+        <a class="wiki-anchor icon-paragraph" href="#20090209" aria-hidden="true">
         </a>
         2009\\02\\09
       </h1>
@@ -279,51 +278,49 @@ describe OpenProject::TextFormatting::Formats::Markdown::Formatter do
     html = <<-HTML.strip_heredoc
       <p>
         <h1>Table of contents</h1>
-        <ul class="section-nav">
+        <ul class="toc">
           <li><a href="#the-first-h1-heading">The first h1 heading</a></li>
-          <li><a href="#the-first-h2-heading">The first h2 heading</a></li>
-          <li><a href="#the-first-h3-heading">The first h3 heading</a></li>
+          <ul class="section-nav">
+            <li><a href="#the-first-h2-heading">The first h2 heading</a></li>
+            <ul class="section-nav"><li><a href="#the-first-h3-heading">The first h3 heading</a></li></ul>
+          </ul>
           <li><a href="#the-second-h1-heading">The second h1 heading</a></li>
-          <li><a href="#the-second-h2-heading">The second h2 heading</a></li>
-          <li><a href="#the-second-h3-heading">The second h3 heading</a></li>
+          <ul class="section-nav">
+            <li><a href="#the-second-h2-heading">The second h2 heading</a></li>
+            <ul class="section-nav"><li><a href="#the-second-h3-heading">The second h3 heading</a></li></ul>
+          </ul>
         </ul>
       </p>
-      <h1>
-        <a id="the-first-h1-heading" class="anchor" href="#the-first-h1-heading" aria-hidden="true">
-          <span aria-hidden="true" class="octicon octicon-link"></span>
+      <h1 id="the-first-h1-heading">
+        <a class="wiki-anchor icon-paragraph" href="#the-first-h1-heading" aria-hidden="true">
         </a>
         The first h1 heading
       </h1>
       <p>Some text after the first h1 heading</p>
-      <h2>
-        <a id="the-first-h2-heading" class="anchor" href="#the-first-h2-heading" aria-hidden="true">
-          <span aria-hidden="true" class="octicon octicon-link"></span>
+      <h2 id="the-first-h2-heading">
+        <a class="wiki-anchor icon-paragraph" href="#the-first-h2-heading" aria-hidden="true">
         </a>
         The first h2 heading
       </h2>
       <p>Some text after the first h2 heading</p>
-      <h3>
-        <a id="the-first-h3-heading" class="anchor" href="#the-first-h3-heading" aria-hidden="true">
-          <span aria-hidden="true" class="octicon octicon-link"></span>
+      <h3 id="the-first-h3-heading">
+        <a class="wiki-anchor icon-paragraph" href="#the-first-h3-heading" aria-hidden="true">
         </a>
         The first h3 heading
       </h3>
       <p>Some text after the first h3 heading</p>
-      <h1>
-        <a id="the-second-h1-heading" class="anchor" href="#the-second-h1-heading" aria-hidden="true">
-          <span aria-hidden="true" class="octicon octicon-link"></span>
+      <h1 id="the-second-h1-heading">
+        <a class="wiki-anchor icon-paragraph" href="#the-second-h1-heading" aria-hidden="true">
         </a>The second h1 heading
       </h1>
       <p>Some text after the second h1 heading</p>
-      <h2>
-        <a id="the-second-h2-heading" class="anchor" href="#the-second-h2-heading" aria-hidden="true">
-          <span aria-hidden="true" class="octicon octicon-link"></span>
+      <h2 id="the-second-h2-heading">
+        <a class="wiki-anchor icon-paragraph" href="#the-second-h2-heading" aria-hidden="true">
         </a>The second h2 heading
       </h2>
       <p>Some text after the second h2 heading</p>
-      <h3>
-        <a id="the-second-h3-heading" class="anchor" href="#the-second-h3-heading" aria-hidden="true">
-          <span aria-hidden="true" class="octicon octicon-link"></span>
+      <h3 id="the-second-h3-heading">
+        <a class="wiki-anchor icon-paragraph" href="#the-second-h3-heading" aria-hidden="true">
         </a>The second h3 heading
       </h3>
       <p>Some text after the second h3 heading</p>


### PR DESCRIPTION
This got lost with the migration to markdown

https://community.openproject.com/wp/30245