### PR TITLE
[30288] Styling and wording issues in autocompleter below embedded tables

### DIFF
--- a/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
+++ b/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
@@ -146,6 +146,7 @@
 
   .wp-relations-input-section
     margin-right: 10px
+    flex: 1
 
 .detail-panel--relations
   .panel-toggler .icon-small

--- a/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
+++ b/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
@@ -80,9 +80,6 @@
 .wp-relations-controls-section
   text-align: right
   flex-shrink: 1
-  .force-right
-    position: absolute
-    right: 0
 
   a:hover
     text-decoration: none
@@ -144,10 +141,11 @@
   .icon-button
     cursor: not-allowed
 
-// Disable overflow in grid-content of create form
-// To allow results indicator to overflow it
-.wp-relations-create--form .grid-content
-  overflow-y: visible
+.wp-relations-create--form
+  display: flex
+
+  .wp-relations-input-section
+    margin-right: 10px
 
 .detail-panel--relations
   .panel-toggler .icon-small

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -519,7 +519,7 @@ en:
       abort: "Abort"
 
     relations_autocomplete:
-      placeholder: "Enter the related work package id"
+      placeholder: "Type to search"
       parent_placeholder: "Choose new parent or press escape to cancel."
 
     repositories:

--- a/frontend/src/app/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.html
+++ b/frontend/src/app/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.html
@@ -1,7 +1,7 @@
 <div class="loading-indicator--location"
      data-indicator-name="relationAddChild">
-  <div class="v-align wp-relations-create--form wp-relations--add-form">
-    <div class="grid-content medium-10">
+  <div class="wp-relations-create--form wp-relations--add-form">
+    <div class="wp-relations-input-section">
       <wp-relations-autocomplete
           [workPackage]="workPackage"
           (onReferenced)="onReferenced($event)"
@@ -9,7 +9,7 @@
           [filterCandidatesFor]="relationType">
       </wp-relations-autocomplete>
     </div>
-    <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
+    <div class="wp-relations-controls-section relation-row">
       <accessible-by-keyboard
           linkClass="wp-create-relation--save"
           [isDisabled]="isDisabled"

--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component.ts
@@ -106,7 +106,6 @@ export class WorkPackageRelationsAutocomplete implements AfterContentInit {
     if (!this.ngSelectComponent) {
       return;
     }
-    this.ngSelectComponent.open();
 
     setTimeout(() => {
       this.ngSelectComponent.focus();

--- a/spec/features/work_packages/new/work_package_default_description_spec.rb
+++ b/spec/features/work_packages/new/work_package_default_description_spec.rb
@@ -36,7 +36,7 @@ describe 'new work package', js: true do
 
     type_field.openSelectField
     type_field.set_value type_task
-    expect(page).not_to have_selector('.wp-edit-field.description h1', text: 'New Task template')
+    expect(page).to have_no_selector('.wp-edit-field.description h1', text: 'New Task template', wait: 5)
 
     description_field.set_value ''
 

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -171,7 +171,7 @@ module Components
           find('.wp-inline-create--reference-link', text: I18n.t('js.relation_buttons.add_existing_child')).click
 
           # Security check to be sure that the autocompleter has finished loading
-          page.find '.ng-dropdown-panel-items'
+          sleep 3
         end
       end
 

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -168,10 +168,11 @@ module Components
 
       def openChildrenAutocompleter
         retry_block do
+          next if page.has_selector?('.wp-relations--children .ng-input input')
           find('.wp-inline-create--reference-link', text: I18n.t('js.relation_buttons.add_existing_child')).click
 
           # Security check to be sure that the autocompleter has finished loading
-          sleep 3
+          page.find '.wp-relations--children .ng-input input'
         end
       end
 


### PR DESCRIPTION
Remove unnecessary foundation grid for „add existing“ line in embedded tables.

https://community.openproject.com/projects/openproject/work_packages/30288/activity