### PR TITLE
[30293] User avatar is cut off in WP table (MS Edge)

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -148,12 +148,7 @@ html:not(.-browser-mobile)
 .wp-table--cell-span
   padding: 2px
 
-// On edge, pointer-events only work on
-// block or inline-block elements
 body.-browser-edge
-  .wp-table--cell-span
-    display: inline-block !important
-
   // Ensure height is set in table
   .work-package-table .wp-table--cell-span
     height: 22px !important

--- a/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
@@ -9,11 +9,6 @@
   &:hover
     text-decoration: none
 
-  // On edge, pointer-events only work on
-  // block or inline-block elements
-  html.-browser-edge &
-    display: inline-block !important
-
 // Toggle the indicator accessibility texts
 // accordingly
 .wp-table--hierarchy-indicator-collapsed


### PR DESCRIPTION
Remove Edge specific styles that are unnecessary with Edge 18 and caused overflowing issues https://community.openproject.com/projects/openproject/work_packages/30293/activity