### PR TITLE
[30005] Use schema and create form to check version writability

### DIFF
--- a/frontend/src/app/angular4-modules.ts
+++ b/frontend/src/app/angular4-modules.ts
@@ -85,6 +85,7 @@ import {MainMenuToggleComponent} from "core-components/main-menu/main-menu-toggl
 import {MainMenuNavigationService} from "core-components/main-menu/main-menu-navigation.service";
 import {StatusCacheService} from "core-components/statuses/status-cache.service";
 import {VersionCacheService} from "core-components/versions/version-cache.service";
+import {FormsCacheService} from "core-components/forms/forms-cache.service";
 
 @NgModule({
   imports: [
@@ -135,6 +136,7 @@ import {VersionCacheService} from "core-components/versions/version-cache.servic
     OpTitleService,
     UrlParamsHelperService,
     ProjectCacheService,
+    FormsCacheService,
     UserCacheService,
     StatusCacheService,
     VersionCacheService,

--- a/frontend/src/app/components/forms/forms-cache.service.ts
+++ b/frontend/src/app/components/forms/forms-cache.service.ts
@@ -1,0 +1,61 @@
+import {Injectable} from '@angular/core';
+import {SchemaResource} from 'core-app/modules/hal/resources/schema-resource';
+import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
+import {HalResourceService} from 'core-app/modules/hal/services/hal-resource.service';
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+import {input, InputState, multiInput, MultiInputState, State} from 'reactivestates';
+import {States} from '../states.service';
+import {FormResource} from "core-app/modules/hal/resources/form-resource";
+import {StateCacheService} from "core-components/states/state-cache.service";
+
+@Injectable()
+export class FormsCacheService extends StateCacheService<FormResource> {
+
+  private $formCache = multiInput<FormResource>();
+
+  constructor(private readonly halResourceService:HalResourceService) {
+    super();
+  }
+
+  protected load(href:string):Promise<FormResource> {
+    return this.halResourceService
+      .post<FormResource>(href, {})
+      .toPromise();
+  }
+
+  protected loadAll(ids:string[]):Promise<undefined> {
+    return Promise
+      .all(ids.map(id => this.load(id)))
+      .then(_ => undefined);
+  }
+
+  protected get multiState():MultiInputState<FormResource> {
+    return this.$formCache;
+  }
+}

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.html
@@ -13,7 +13,7 @@
        [attr.data-is-new]="wp.isNew || undefined"
        [attr.data-work-package-id]="wp.id"
        (doubleClickOrTap)="handleDblClick(wp)"
-       [ngClass]="{'-draggable': dragOutOf, '-new' : wp.isNew }">
+       [ngClass]="{'-draggable': canDragOutOf(wp), '-new' : wp.isNew }">
 
     <div class="wp-card--highlighting"
         [ngClass]="cardHighlightingClass(wp)">

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -40,8 +40,8 @@ import {RequestSwitchmap} from "core-app/helpers/rxjs/request-switchmap";
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class WorkPackageCardViewComponent  implements OnInit {
+  @Input('dragOutOfHandler') public canDragOutOf:(wp:WorkPackageResource) => boolean;
   @Input() public dragInto:boolean;
-  @Input() public dragOutOf:boolean;
   @Input() public highlightingMode:CardHighlightingMode;
   @Input() public workPackageAddedHandler:(wp:WorkPackageResource) => Promise<unknown>;
   @Input() public showStatusButton:boolean = true;
@@ -174,7 +174,12 @@ export class WorkPackageCardViewComponent  implements OnInit {
     this.dragService.register({
       dragContainer: this.container.nativeElement,
       scrollContainers: [this.container.nativeElement],
-      moves: (card:HTMLElement) => this.dragOutOf && !card.dataset.isNew,
+      moves: (card:HTMLElement) => {
+        const wpId:string = card.dataset.workPackageId!;
+        const workPackage = this.states.workPackages.get(wpId).value!;
+
+        return this.canDragOutOf(workPackage) && !card.dataset.isNew;
+      },
       accepts: () => this.dragInto,
       onMoved: (card:HTMLElement) => {
         const wpId:string = card.dataset.workPackageId!;

--- a/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
@@ -82,6 +82,7 @@ export class WorkPackageChangeset {
     return this.changes[attribute];
   }
 
+
   public clear() {
     this.changes = {};
     this.resetForm();
@@ -370,6 +371,22 @@ export class WorkPackageChangeset {
   public get schema():SchemaResource {
     return (this.form || this.workPackage).schema;
   }
+
+  /**
+   * Check whether the given attribute is writable.
+   * @param attribute
+   */
+  public isWritable(attribute:string):boolean {
+    const schemaName = this.getSchemaName(attribute);
+    const fieldSchema = this.schema[schemaName] as IFieldSchema;
+    return fieldSchema && fieldSchema.writable;
+  }
+
+  public humanName(attribute:string):string {
+    const fieldSchema = this.schema[attribute] as IFieldSchema;
+    return fieldSchema.name || attribute;
+  }
+
 
   public getSchemaName(attribute:string):string {
     if (this.schema.hasOwnProperty('date') && (attribute === 'startDate' || attribute === 'dueDate')) {

--- a/frontend/src/app/modules/boards/board/board-actions/board-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/board-action.service.ts
@@ -60,6 +60,12 @@ export interface BoardActionService {
   dragIntoAllowed(query:QueryResource, value:HalResource|undefined):boolean;
 
   /**
+   * Determine whether we can create new items for this action attribute
+   */
+  canAddToQuery(query:QueryResource):Promise<boolean>;
+
+
+  /**
    * Get the specific component for the autocompleter (e.g versionAutocompleter)
    * @returns {Component}
    */

--- a/frontend/src/app/modules/boards/board/board-actions/status/status-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/status/status-action.service.ts
@@ -56,6 +56,10 @@ export class BoardStatusActionService implements BoardActionService {
     }
   }
 
+  public canAddToQuery(query:QueryResource):Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
   public addActionQueries(board:Board):Promise<Board> {
     return this.getStatuses()
       .then((results) =>

--- a/frontend/src/app/modules/boards/board/board-actions/version/version-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/version/version-action.service.ts
@@ -15,9 +15,11 @@ import {OpContextMenuItem} from "core-components/op-context-menu/op-context-menu
 import {LinkHandling} from "core-app/modules/common/link-handling/link-handling";
 import {StateService} from "@uirouter/core";
 import {WorkPackageNotificationService} from "core-components/wp-edit/wp-notification.service";
-import {StatusResource} from "core-app/modules/hal/resources/status-resource";
 import {VersionCacheService} from "core-components/versions/version-cache.service";
 import {VersionBoardHeaderComponent} from "core-app/modules/boards/board/board-actions/version/version-board-header.component";
+import {FormResource} from "core-app/modules/hal/resources/form-resource";
+import {FormsCacheService} from "core-components/forms/forms-cache.service";
+import {CallableHalLink} from "core-app/modules/hal/hal-link/hal-link";
 
 @Injectable()
 export class BoardVersionActionService implements BoardActionService {
@@ -29,6 +31,7 @@ export class BoardVersionActionService implements BoardActionService {
               protected currentProject:CurrentProjectService,
               protected wpNotifications:WorkPackageNotificationService,
               protected state:StateService,
+              protected formCache:FormsCacheService,
               protected pathHelper:PathHelperService) {
   }
 
@@ -65,6 +68,18 @@ export class BoardVersionActionService implements BoardActionService {
     } else {
       return Promise.resolve(undefined);
     }
+  }
+
+  public canAddToQuery(query:QueryResource):Promise<boolean> {
+    const formLink = _.get(query, 'results.createWorkPackage.href', null) ;
+
+    if (!formLink) {
+      return Promise.resolve(false);
+    }
+
+    return this.formCache
+      .require(formLink)
+      .then((form:FormResource) => form.schema.version.writable);
   }
 
   public addActionQueries(board:Board):Promise<Board> {

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.html
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.html
@@ -50,7 +50,7 @@
         </button>
       </div>
 
-      <wp-card-view [dragOutOf]="canDragOutOf"
+      <wp-card-view [dragOutOfHandler]="canDragOutOfHandler"
                     [dragInto]="canDragInto"
                     [workPackageAddedHandler]="workPackageAddedHandler"
                     [cardsRemovable]="board.isFree && canDragOutOf"

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
@@ -44,6 +45,8 @@ import {WorkPackageNotificationService} from "core-components/wp-edit/wp-notific
 import {BoardActionsRegistryService} from "core-app/modules/boards/board/board-actions/board-actions-registry.service";
 import {BoardActionService} from "core-app/modules/boards/board/board-actions/board-action.service";
 import {ComponentType} from "@angular/cdk/portal";
+import {IFieldSchema} from "core-app/modules/fields/field.base";
+import {withLatestFrom} from "rxjs/operators";
 
 export interface DisabledButtonPlaceholder {
   text:string;
@@ -103,13 +106,16 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
   /** Are we allowed to remove and drag & drop elements ? */
   public canDragInto:boolean = false;
-  public canDragOutOf:boolean = false;
 
   /** Initially focus the list */
   public initiallyFocused:boolean = false;
 
   /** Editing handler to be passed into card component */
   public workPackageAddedHandler = (workPackage:WorkPackageResource) => this.addWorkPackage(workPackage);
+
+  /** Move check to be passed into card component */
+  public canDragOutOf:boolean = false;
+  public canDragOutOfHandler = (workPackage:WorkPackageResource) => this.canMove(workPackage);
 
   public buttonPlaceholder:DisabledButtonPlaceholder|undefined;
 
@@ -143,7 +149,9 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     this.authorisationService
       .observeUntil(componentDestroyed(this))
       .subscribe(() => {
-        this.showAddButton = this.canDragInto && (this.wpInlineCreate.canAdd || this.canReference);
+        if (!this.board.isAction) {
+          this.showAddButton = this.canDragInto && (this.wpInlineCreate.canAdd || this.canReference);
+        }
       });
 
     this.querySpace.query
@@ -174,6 +182,15 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
   public get errorMessage() {
     return this.I18n.t('js.boards.error_loading_the_list', { error_message: this.loadingError });
+  }
+
+  public canMove(workPackage:WorkPackageResource) {
+    if (this.board.isAction) {
+      const fieldSchema = workPackage.schema[this.board.actionAttribute!] as IFieldSchema;
+      return this.canDragOutOf && fieldSchema.writable;
+    } else {
+      return this.canDragOutOf;
+    }
   }
 
   public get canReference() {
@@ -265,13 +282,15 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     }
 
     // Load the resource
-    this.actionService.getLoadedFilterValue(query).then(resource => {
+    this.actionService.getLoadedFilterValue(query).then(async resource => {
       this.actionResource = resource;
       this.headerComponent = this.actionService.headerComponent();
       this.buttonPlaceholder = this.actionService.disabledAddButtonPlaceholder(resource);
       this.actionResourceClass = this.boardListActionColorClass(resource);
       this.canDragInto = this.actionService.dragIntoAllowed(query, resource);
-      this.showAddButton = this.canDragInto && (this.wpInlineCreate.canAdd || this.canReference);
+
+      const canWriteAttribute = await this.actionService.canAddToQuery(query);
+      this.showAddButton = this.canDragInto && this.wpInlineCreate.canAdd && canWriteAttribute;
     });
   }
 
@@ -289,8 +308,17 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
    */
   private addWorkPackage(workPackage:WorkPackageResource) {
     let query = this.querySpace.query.value!;
-
     const changeset = this.wpEditing.changesetFor(workPackage);
+
+    // Ensure attribute remains writable in the form
+    const actionAttribute = this.board.actionAttribute;
+    if (actionAttribute && !changeset.isWritable(actionAttribute)) {
+      throw this.I18n.t(
+        'js.boards.error_attribute_not_writable',
+        { attribute: changeset.humanName(actionAttribute)}
+      );
+    }
+
     const filter = new WorkPackageFilterValues(this.injector, changeset, query.filters);
     filter.applyDefaultsFromFilters();
 

--- a/modules/boards/config/locales/js-en.yml
+++ b/modules/boards/config/locales/js-en.yml
@@ -30,6 +30,7 @@ en:
       add_list: 'Add list'
       add_card: 'Add card'
       error_loading_the_list: "Error loading the list: %{error_message}"
+      error_attribute_not_writable: "Cannot move the work package, %{attribute} is not writable."
       click_to_remove_list: "Click to remove this list"
       board_type:
         free: 'Basic board'

--- a/modules/boards/spec/features/action_boards/version_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/version_board_spec.rb
@@ -266,6 +266,35 @@ describe 'Version action board', type: :feature, js: true do
     end
   end
 
+  context 'a user with edit_work_packages, but missing assign_versions permissions' do
+    let(:no_version_edit_user) do
+      FactoryBot.create(:user,
+                        member_in_projects: [project],
+                        member_through_role: no_version_edit_role)
+    end
+    let(:no_version_edit_role) { FactoryBot.create(:role, permissions: no_version_edit_permissions) }
+    let(:no_version_edit_permissions) do
+      %i[show_board_views manage_board_views add_work_packages manage_versions
+       edit_work_packages view_work_packages manage_public_queries]
+    end
+
+    it 'can not move cards or add cards' do
+      # Create version board first
+      login_as user
+      board_page = create_new_version_board
+
+      # Login in with restricted user
+      login_as no_version_edit_user
+
+      # Reload the page
+      board_page.visit!
+      board_page.expect_editable_board(true)
+      board_page.expect_editable_list(false)
+
+      expect(page).to have_no_selector('.wp-card.-draggable')
+    end
+  end
+
   context 'with limited permissions' do
     before do
       login_as(second_user)

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -252,8 +252,13 @@ module Pages
     end
 
     def expect_editable_list(editable)
-      # Add new / existing card
-      expect(page).to have_conditional_selector(editable, '.board-list--card-dropdown-button')
+      # Add list button
+      if action?
+        expect(page).to have_conditional_selector(!editable, '.board-list--add-button[disabled]')
+        expect(page).to have_conditional_selector(editable, '.board-list--add-button:not([disabled])')
+      else
+        expect(page).to have_conditional_selector(editable, '.board-list--card-dropdown-button')
+      end
     end
 
     def rename_board(new_name, through_dropdown: false)


### PR DESCRIPTION
- For board add button, the form is loaded and cached to ensure checking
whether the version is writable when creating work packages

- For cards, the `moves` function is extended to check whether the work
package under cursor is editable for the current action attribute, i.e.
whether the version is writable in the (now non-cached) schema.

https://community.openproject.com/wp/30005