### PR TITLE
[30298] Remove type row highlighting

### DIFF
--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.html
@@ -45,9 +45,6 @@
             <option [textContent]="text.highlighting_mode.status"
                     [selected]="lastEntireRowAttribute === 'status'"
                     value="status"></option>
-            <option [textContent]="text.highlighting_mode.type"
-                    [selected]="lastEntireRowAttribute === 'type'"
-                    value="type"></option>
             <option [textContent]="text.highlighting_mode.priority"
                     [selected]="lastEntireRowAttribute === 'priority'"
                     value="priority"></option>


### PR DESCRIPTION
No additional care is taken to remove saved type highlights, as I don't think it's worth the effort. People can just choose another mode.

https://community.openproject.com/wp/30298