### PR TITLE
[30291] Doubled files section in meeting agenda

### DIFF
--- a/modules/meeting/app/assets/javascripts/meeting/meeting.js
+++ b/modules/meeting/app/assets/javascripts/meeting/meeting.js
@@ -25,6 +25,8 @@ jQuery(function($) {
 
     jQuery('.button--edit-agenda').toggleClass('-active', edit);
     jQuery('.button--edit-agenda').attr('disabled', edit);
+
+    jQuery('.meeting_content ~ attachments').toggle(!edit);
   }
 
   $('.button--edit-agenda').click(function() {


### PR DESCRIPTION
Hide files section when the editor is open to avoid doubling with the attachment list of the ck editor.

https://community.openproject.com/projects/openproject/work_packages/30291/activity