### PR TITLE
[30352] Schedule attachment extraction jobs for faster migration

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -198,16 +198,26 @@ class Attachment < ActiveRecord::Base
 
   # Extract the fulltext of any attachments where fulltext is still nil.
   # This runs inline and not in a asynchronous worker.
-  def self.extract_fulltext_where_missing
+  def self.extract_fulltext_where_missing(run_now: true)
     return unless OpenProject::Database.allows_tsv?
-    Attachment.where(fulltext: nil).pluck(:id).each do |id|
+
+    Attachment
+      .where(fulltext: nil)
+      .pluck(:id)
+      .each do |id|
       job = ExtractFulltextJob.new(id)
-      job.perform
+
+      if run_now
+        job.perform
+      else
+        Delayed::Job.enqueue job, priority: ::ApplicationJob.priority_number(:low)
+      end
     end
   end
 
   def self.force_extract_fulltext
     return unless OpenProject::Database.allows_tsv?
+
     Attachment.pluck(:id).each do |id|
       job = ExtractFulltextJob.new(id)
       job.perform

--- a/docker/mysql-to-postgres/bin/migrate-mysql-to-postgres
+++ b/docker/mysql-to-postgres/bin/migrate-mysql-to-postgres
@@ -156,6 +156,15 @@ if migrate_status != 0
   puts "\nMigration failed. See above."
 end
 
+puts "\nRe-building DAG to create Postgres-specific indices"
+_, dag_status = run "bundle exec rake db:migrate:redo VERSION=20180105130053", record_output: false
+
+if dag_status != 0
+  puts "\nRebuild DAG migration failed. See above."
+
+  exit 1
+end
+
 if needs_fulltext_migration
   drop_version_cmd = "PGPASSWORD=#{db_password} psql -U #{db_user} -h #{db_host} -p #{db_port} -d #{db_name} -c \"delete from schema_migrations where version = '20180122135443'\""
   drop_version_output, drop_version_status = run drop_version_cmd, silent: true
@@ -177,22 +186,16 @@ if needs_fulltext_migration
     exit 1
   end
 
-  _, extract_status = run "bundle exec rake attachments:extract_fulltext_where_missing", record_output: false
+  _, extract_status = run "bundle exec rake attachments:schedule_fulltext_extraction_where_missing", record_output: false
 
-  if extract_status != 0
+  if extract_status == 0
+    puts "\nFull-text extraction for attachments have successfully been requested in background jobs."
+  else
     puts "\nFull-text extraction failed. See above."
 
     exit 1
   end
 end
 
-puts "\nRe-building DAG to create Postgres-specific indices"
-_, dag_status = run "bundle exec rake db:migrate:redo VERSION=20180105130053", record_output: false
-
-if dag_status != 0
-  puts "\nRebuild DAG migration failed. See above."
-
-  exit 1
-end
 
 puts "Migration from MySQL to Postgres completed successfully!"

--- a/lib/tasks/attachments.rake
+++ b/lib/tasks/attachments.rake
@@ -107,9 +107,14 @@ namespace :attachments do
     target_attachment.store_all! attachments
   end
 
-  desc 'Extract text content from attachment that were not extracted yet.'
+  desc 'Extract text content from attachment that were not extracted yet synchronously.'
   task extract_fulltext_where_missing: :environment do
-    Attachment.extract_fulltext_where_missing
+    Attachment.extract_fulltext_where_missing(run_now: true)
+  end
+
+  desc 'Extract text content from attachment that were not extracted yet.'
+  task schedule_fulltext_extraction_where_missing: :environment do
+    Attachment.extract_fulltext_where_missing(run_now: false)
   end
 
   desc 'Extracts fulltext of all attachments and provide it for attachment filter even if that attachment has been \


### PR DESCRIPTION
There are background jobs already for the text extraction, we can just make them async to ensure the initial migration runs as quickly as possible

https://community.openproject.com/wp/30352