### PR TITLE
Fix/reenable wp schema caching

### DIFF
--- a/lib/api/caching/cached_representer.rb
+++ b/lib/api/caching/cached_representer.rb
@@ -160,7 +160,7 @@ module API
         def delete_from_hash(hash, path, key)
           pathed_hash = path ? hash[path] : hash
 
-          pathed_hash.delete(key.to_s) if pathed_hash
+          pathed_hash&.delete(key.to_s)
         end
 
         def representable_map(*)

--- a/lib/api/caching/cached_representer.rb
+++ b/lib/api/caching/cached_representer.rb
@@ -207,7 +207,9 @@ module API
         def json_key_dependencies
           callable_dependencies = self.class.cached_representer_configuration[:dependencies]
 
-          callable_dependencies&.call
+          return unless callable_dependencies
+
+          instance_exec(&callable_dependencies)
         end
 
         def no_caching?

--- a/lib/api/caching/cached_representer.rb
+++ b/lib/api/caching/cached_representer.rb
@@ -186,12 +186,16 @@ module API
         end
 
         def json_key_representer_parts
-          cacheable = [represented]
+          cacheable = json_key_part_represented
           cacheable << json_key_custom_fields
           cacheable << json_key_parts_of_represented
           cacheable << json_key_dependencies
 
           OpenProject::Cache::CacheKey.expand(cacheable.flatten.compact)
+        end
+
+        def json_key_part_represented
+          [represented]
         end
 
         def json_key_parts_of_represented

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -33,14 +33,9 @@ module API
     module Users
       class UserRepresenter < ::API::V3::Principals::PrincipalRepresenter
         include AvatarHelper
-        ##
-        # Dependencies required to cache users with avatars
-        # Extended by plugin
-        def self.avatar_cache_dependencies
-          []
-        end
 
-        cached_representer key_parts: %i(auth_source), dependencies: ->(*) { avatar_cache_dependencies }
+        cached_representer key_parts: %i(auth_source),
+                           dependencies: ->(*) { avatar_cache_dependencies }
 
         def self.create(user, current_user:)
           new(user, current_user: current_user)
@@ -215,6 +210,15 @@ module API
 
         def current_user_can_delete_represented?
           current_user && ::Users::DeleteService.deletion_allowed?(represented, current_user)
+        end
+
+        private
+
+        ##
+        # Dependencies required to cache users with avatars
+        # Extended by plugin
+        def avatar_cache_dependencies
+          []
         end
       end
     end

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -40,7 +40,8 @@ module API
           include API::Caching::CachedRepresenter
           cached_representer key_parts: %i[project type],
                              dependencies: -> {
-                               Authorization.roles(User.current, represented.project).map(&:permissions).sort
+                               Authorization.roles(User.current, represented.project).map(&:permissions).sort +
+                                 [Setting.work_package_done_ratio]
                              }
 
           custom_field_injector type: :schema_representer

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -35,12 +35,10 @@ module API
     module WorkPackages
       module Schema
         class WorkPackageSchemaRepresenter < ::API::Decorators::SchemaRepresenter
-          # TODO: reenable caching after having ensured that the cache is
-          # user or at least roles in project specific.
-          # Otherwise, the writable information will not be correct and information
-          # cached e.g. in an embedded query (project name) is leaked to the user.
-          # include API::Caching::CachedRepresenter
           extend ::API::V3::Utilities::CustomFieldInjector::RepresenterClass
+
+          include API::Caching::CachedRepresenter
+          cached_representer key_parts: %i[project type]
 
           custom_field_injector type: :schema_representer
 
@@ -84,17 +82,6 @@ module API
             @base_schema_link = context.delete(:base_schema_link) || nil
             @show_lock_version = !context.delete(:hide_lock_version)
             super(schema, self_link, context)
-          end
-
-          def json_cache_key
-            parts = ['api/v3/work_packages/schemas',
-                     project_type_cache_key,
-                     I18n.locale,
-                     project_cache_key,
-                     type_cache_key,
-                     custom_field_cache_key]
-
-            OpenProject::Cache::CacheKey.key(parts)
           end
 
           link :baseSchema do
@@ -177,6 +164,8 @@ module API
 
           # TODO:
           # * create an available_work_package_parent resource
+          #   One can use a relatable filter with the 'parent' operator. Will however need to also
+          #   work without a value which is currently not supported.
           # * turn :parent into a schema_with_allowed_link
 
           schema :parent,
@@ -254,7 +243,7 @@ module API
                                          has_default: true
 
           def attribute_groups
-            (represented.type && represented.type.attribute_groups || []).map do |group|
+            (represented.type&.attribute_groups || []).map do |group|
               if group.is_a?(Type::QueryGroup)
                 ::API::V3::WorkPackages::Schema::FormConfigurations::QueryRepresenter
                   .new(group, current_user: current_user, embed_links: true)
@@ -269,6 +258,7 @@ module API
           # Return a map of attribute => group name
           def attribute_group_map(key)
             return nil if represented.type.nil?
+
             @attribute_group_map ||= begin
               represented.type.attribute_groups.each_with_object({}) do |group, hash|
                 Array(group.active_members(represented.project)).each { |prop| hash[prop] = group.translated_key }
@@ -279,26 +269,6 @@ module API
           end
 
           private
-
-          def custom_field_cache_key
-            custom_fields = represented.available_custom_fields
-            OpenProject::Cache::CacheKey.expand(custom_fields)
-          end
-
-          def project_type_cache_key
-            project_cache_key = represented.project ? represented.project.id : nil
-            type_cache_key = represented.type ? represented.type.id : nil
-
-            "#{project_cache_key}-#{type_cache_key}"
-          end
-
-          def type_cache_key
-            represented.type.try(:updated_at)
-          end
-
-          def project_cache_key
-            represented.project.updated_on
-          end
 
           def no_caching?
             represented.no_caching?

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -92,10 +92,14 @@ module API
             { href: @base_schema_link } if @base_schema_link
           end
 
+          # Needs to not be cached as the queries in the attribute
+          # groups might contain information (e.g. project names) whose
+          # visibility needs to be checked per user
           property :attribute_groups,
                    type: "[]String",
                    as: "_attributeGroups",
-                   exec_context: :decorator
+                   exec_context: :decorator,
+                   uncacheable: true
 
           schema :lock_version,
                  type: 'Integer',
@@ -276,6 +280,15 @@ module API
 
           def no_caching?
             represented.no_caching?
+          end
+
+          protected
+
+          # We do not want to make the represented a part of the cache key
+          # as they are currently dynamically created and thus will
+          # change their to_params value consistently
+          def json_key_part_represented
+            []
           end
         end
       end

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -38,7 +38,10 @@ module API
           extend ::API::V3::Utilities::CustomFieldInjector::RepresenterClass
 
           include API::Caching::CachedRepresenter
-          cached_representer key_parts: %i[project type]
+          cached_representer key_parts: %i[project type],
+                             dependencies: -> {
+                               Authorization.roles(User.current, represented.project).map(&:permissions).sort
+                             }
 
           custom_field_injector type: :schema_representer
 

--- a/modules/avatars/lib/open_project/avatars/patches/user_representer_patch.rb
+++ b/modules/avatars/lib/open_project/avatars/patches/user_representer_patch.rb
@@ -1,10 +1,8 @@
 module OpenProject::Avatars::Patches
   module UserRepresenterPatch
-    def self.included(base)
-      base.singleton_class.prepend ClassMethods
-    end
+    extend ActiveSupport::Concern
 
-    module ClassMethods
+    included do
       ##
       # Dependencies required to cache users with avatars
       # When the plugin is loaded, depend on its settings

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -875,11 +875,22 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
             .and_return([])
         end
       end
+
       it 'is based on the representer\'s cache_key' do
         expect(OpenProject::Cache)
           .to receive(:fetch)
           .with(representer.json_cache_key)
           .and_call_original
+
+        representer.to_json
+      end
+
+      it 'does not cache the attribute_groups' do
+        representer.to_json
+
+        expect(work_package.type)
+          .to receive(:attribute_groups)
+          .and_return([])
 
         representer.to_json
       end

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -955,6 +955,22 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         end
       end
 
+      context 'if the work_package_done_ratio setting changes' do
+        it_behaves_like 'changes' do
+          let(:setup) do
+            allow(Setting)
+              .to receive(:work_package_done_ratio)
+              .and_return('something')
+          end
+
+          let(:change) do
+            allow(Setting)
+              .to receive(:work_package_done_ratio)
+              .and_return('else')
+          end
+        end
+      end
+
       context 'if the users permissions change' do
         it_behaves_like 'changes' do
           let(:role1) { FactoryBot.build_stubbed(:role, permissions: permissions1) }

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -28,6 +28,8 @@
 
 require 'spec_helper'
 
+require 'api/v3/work_packages/schema/typed_work_package_schema'
+
 describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
   include API::V3::Utilities::PathHelper
 
@@ -841,58 +843,103 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
   end
 
-  describe '#json_cache_key' do
-    def joined_cache_key
-      representer.json_cache_key.join('/')
+  describe 'caching' do
+    context 'for a SpecificWorkPackageSchema' do
+      # do not interfere with the representer cache fetching
+      let(:attribute_groups) { [] }
+
+      it 'is disabled' do
+        expect(OpenProject::Cache)
+          .not_to receive(:fetch)
+
+        representer.to_json
+      end
     end
 
-    before do
-      allow(work_package.project)
-        .to receive(:all_work_package_custom_fields)
-        .and_return []
+    context 'for a TypedWorkPackageSchema' do
+      # do not interfere with the representer cache fetching
+      let(:attribute_groups) { [] }
 
-      original_cache_key
+      let(:embedded) { false }
+
+      let(:schema) do
+        ::API::V3::WorkPackages::Schema::TypedWorkPackageSchema
+          .new(type: work_package.type, project: project).tap do |schema|
+          allow(wp_type)
+            .to receive(:attribute_groups)
+            .and_return(attribute_groups)
+          allow(schema)
+            .to receive(:assignable_values)
+            .and_call_original
+          allow(schema)
+            .to receive(:assignable_values)
+            .with(:version, current_user)
+            .and_return([])
+        end
+      end
+      it 'is based on the representer\'s cache_key' do
+        expect(OpenProject::Cache)
+          .to receive(:fetch)
+          .with(representer.json_cache_key)
+          .and_call_original
+
+        representer.to_json
+      end
     end
 
-    let(:original_cache_key) { joined_cache_key }
+    describe '#json_cache_key' do
+      def joined_cache_key
+        representer.json_cache_key.join('/')
+      end
 
-    it 'changes when the project changes' do
-      work_package.project = FactoryBot.build_stubbed(:project)
+      before do
+        allow(work_package.project)
+          .to receive(:all_work_package_custom_fields)
+           .and_return []
 
-      expect(joined_cache_key).to_not eql(original_cache_key)
-    end
+        original_cache_key
+      end
 
-    it 'changes when the project updates' do
-      work_package.project.updated_on += 1.hour
+      let(:original_cache_key) { joined_cache_key }
 
-      expect(joined_cache_key).to_not eql(original_cache_key)
-    end
+      it 'changes when the project changes' do
+        work_package.project = FactoryBot.build_stubbed(:project)
 
-    it 'changes when the type updates' do
-      work_package.type.updated_at += 1.hour
+        expect(joined_cache_key).to_not eql(original_cache_key)
+      end
 
-      expect(joined_cache_key).to_not eql(original_cache_key)
-    end
+      it 'changes when the project updates' do
+        work_package.project.updated_on += 1.hour
 
-    it 'changes when the type changes' do
-      work_package.type = FactoryBot.build_stubbed(:type)
+        expect(joined_cache_key).to_not eql(original_cache_key)
+      end
 
-      expect(joined_cache_key).to_not eql(original_cache_key)
-    end
+      it 'changes when the type updates' do
+        work_package.type.updated_at += 1.hour
 
-    it 'changes when the locale changes' do
-      allow(I18n).to receive(:locale).and_return(:de)
-      work_package.type = FactoryBot.build_stubbed(:type)
+        expect(joined_cache_key).to_not eql(original_cache_key)
+      end
 
-      expect(joined_cache_key).to_not eql(original_cache_key)
-    end
+      it 'changes when the type changes' do
+        work_package.type = FactoryBot.build_stubbed(:type)
 
-    it 'changes when the custom_fields changes' do
-      allow(work_package)
-        .to receive(:available_custom_fields)
-        .and_return [FactoryBot.build_stubbed(:custom_field)]
+        expect(joined_cache_key).to_not eql(original_cache_key)
+      end
 
-      expect(joined_cache_key).to_not eql(original_cache_key)
+      it 'changes when the locale changes' do
+        allow(I18n).to receive(:locale).and_return(:de)
+        work_package.type = FactoryBot.build_stubbed(:type)
+
+        expect(joined_cache_key).to_not eql(original_cache_key)
+      end
+
+      it 'changes when the custom_fields changes' do
+        allow(work_package)
+          .to receive(:available_custom_fields)
+          .and_return [FactoryBot.build_stubbed(:custom_field)]
+
+        expect(joined_cache_key).to_not eql(original_cache_key)
+      end
     end
   end
 end

--- a/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
@@ -154,7 +154,7 @@ describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI, type: :request do
           self_link = api_v3_paths.work_package_schema(project.id, type.id)
           represented_schema = representer_class.create(schema,
                                                         self_link,
-                                                        current_user: nil)
+                                                        current_user: current_user)
 
           expect(OpenProject::Cache.fetch(represented_schema.json_cache_key)).to_not be_nil
         end

--- a/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
@@ -145,7 +145,7 @@ describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI, type: :request do
           expect(last_response.headers['ETag']).to match(/W\/\"\w+\"/)
         end
 
-        it 'caches the response', skip: true do
+        it 'caches the response' do
           schema_class = API::V3::WorkPackages::Schema::TypedWorkPackageSchema
           representer_class = API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter
 


### PR DESCRIPTION
Reenables the caching for work package schemas that where disabled to avoid leaking information:
https://community.openproject.com/projects/openproject/work_packages/30283
The attribute_groups part is no longer cached at all.

It also adjusts the caching to be specific to the user's permission set. This should strike a nice balance between wanting to ensure cache hits and actually reflecting the writability of attributes.
https://community.openproject.com/projects/openproject/work_packages/23216