### PR TITLE
Update postgresql-migration.md

### DIFF
--- a/docs/operations/migrating/packaged/postgresql-migration.md
+++ b/docs/operations/migrating/packaged/postgresql-migration.md
@@ -95,7 +95,7 @@ Once installed, switch to the PostgreSQL system user.
 Then, as the PostgreSQL user, create the system user for OpenProject. This will prompt you for a password. We are going to assume in the following guide that password were 'openproject'. Of course, please choose a strong password and replace the values in the following guide with it!
 
 ```bash
-[postgres@host] createuser -W openproject
+[postgres@host] createuser -P -d openproject
 ```
 
 Next, create the database owned by the new user


### PR DESCRIPTION
Correct the createuser command to prompt for a password for the new user. Allow the new user to create databases; this is required by the current migration script which drops the target database if it exists and attempts to create a new database.