### PR TITLE
[30348] Switching between manual and forced sorting in the sort by tab

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -223,6 +223,7 @@ thead.-sticky th
 .generic-table--empty-header
   padding:       0 6px
   height:        $generic-table--header-height
+  line-height:   $generic-table--header-height
   border-bottom: 1px solid $table-row-border-color
   z-index:       1
 

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -786,6 +786,10 @@ en:
           status: 'Status'
           priority: 'Priority'
           type: 'Type'
+        sorting_mode:
+          description: 'Chose the mode to sort your Work packages:'
+          automatic: 'Automatic'
+          manually: 'Manually'
         columns_help_text: "Use the input above to add or remove columns to your table view. You can drag and drop the columns to reorder them."
         upsale:
           attribute_highlighting: 'Need certain work packages to stand out from the mass?'

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/sort-by-tab.component.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/sort-by-tab.component.html
@@ -2,60 +2,88 @@
   <div id="modal-sorting"
        class="modal-content-container loading-indicator--location"
        data-indicator-name="sorting-modal">
-    <div class="form--row modal-sorting-row-{{index}}"
-         *ngFor="let sort of sortationObjects; let index = index">
-      <div class="form--field -full-width">
-        <label
-          for="modal-sorting-attribute-{{index}}"
-          [textContent]="text['sort_criteria_' + index]"
-          class="form--label hidden-for-sighted">
+
+    <p [textContent]="text.sorting_mode.description"></p>
+    <div class="form--field -full-width">
+      <div class="form--field-container">
+        <label class="option-label">
+          <input type="radio"
+                 [(ngModel)]="sortingMode"
+                 (change)="updateSortingMode($event.target.value)"
+                 name="sorting_mode_switch"
+                 value="manual">
+          {{ text.sorting_mode.manually }}
         </label>
-        <div class="form--field-container">
-          <div class="form--select-container">
-            <select
-              id="modal-sorting-attribute-{{index}}"
-              name="modal-sorting-attribute-{{index}}"
-              (change)="updateSelection(sort, $event.target.value)"
-              class="form--select">
-              <option *ngIf="!!sort.column.href"
-                      [textContent]="sort.column.name"
-                      [value]="sort.column.href"
-                      selected></option>
+      </div>
+    </div><div class="form--field -full-width">
+      <div class="form--field-container">
+        <label class="option-label">
+          <input type="radio"
+                 [(ngModel)]="sortingMode"
+                 (change)="updateSortingMode($event.target.value)"
+                 name="sorting_mode_switch"
+                 value="automatic">
+          {{ text.sorting_mode.automatic }}
+        </label>
+      </div>
+    </div>
 
-              <!--
-              TODO:
-              The option element below used this code:
-                [selected]="sort.column.href === null"
+    <ng-container *ngIf="sortingMode === 'automatic'">
+      <div class="form--row modal-sorting-row-{{index}}"
+           *ngFor="let sort of sortationObjects; let index = index">
+        <div class="form--field -full-width">
+          <label
+            for="modal-sorting-attribute-{{index}}"
+            [textContent]="text['sort_criteria_' + index]"
+            class="form--label hidden-for-sighted">
+          </label>
+          <div class="form--field-container">
+            <div class="form--select-container">
+              <select
+                id="modal-sorting-attribute-{{index}}"
+                name="modal-sorting-attribute-{{index}}"
+                (change)="updateSelection(sort, $event.target.value)"
+                class="form--select">
+                <option *ngIf="!!sort.column.href"
+                        [textContent]="sort.column.name"
+                        [value]="sort.column.href"
+                        selected></option>
 
-              However, the Angular template compiler wrongly complains about the comparison.
-              https://github.com/angular/angular/issues/18754
+                <!--
+                TODO:
+                The option element below used this code:
+                  [selected]="sort.column.href === null"
 
-              Since the explicit null comparision is safer than `!sort.column.href` the code
-              should be reverted to the old version once the bug is fixed.
-              -->
-              <option [textContent]="emptyColumn.name"
-                      [value]="emptyColumn.href"
-                      [selected]="!sort.column.href"></option>
+                However, the Angular template compiler wrongly complains about the comparison.
+                https://github.com/angular/angular/issues/18754
 
-              <option *ngFor="let column of availableColumns"
-                      [textContent]="column.name"
-                      [value]="column.href"></option>
-            </select>
+                Since the explicit null comparision is safer than `!sort.column.href` the code
+                should be reverted to the old version once the bug is fixed.
+                -->
+                <option [textContent]="emptyColumn.name"
+                        [value]="emptyColumn.href"
+                        [selected]="!sort.column.href"></option>
+
+                <option *ngFor="let column of availableColumns"
+                        [textContent]="column.name"
+                        [value]="column.href"></option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="form--field -full-width">
+          <div class="form--field-container">
+            <label class="option-label" *ngFor="let availableDirection of availableDirections">
+              <input type="radio"
+                     [(ngModel)]="sort.direction"
+                     [value]="availableDirection.$href"
+                     [textContent]="availableDirection.name"
+                     name="modal-sorting-attribute-{{index}}--sort-direction">
+              {{ availableDirection.name }}
+            </label>
           </div>
         </div>
       </div>
-      <div class="form--field -full-width">
-        <div class="form--field-container">
-          <label class="option-label" *ngFor="let availableDirection of availableDirections">
-            <input type="radio"
-                   [(ngModel)]="sort.direction"
-                   [value]="availableDirection.$href"
-                   [textContent]="availableDirection.name"
-                   name="modal-sorting-attribute-{{index}}--sort-direction">
-            {{ availableDirection.name }}
-          </label>
-        </div>
-      </div>
-    </div>
+    </ng-container>
   </div>
 </form>

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/sort-by-tab.component.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/sort-by-tab.component.ts
@@ -20,6 +20,8 @@ export interface SortColumn {
   href:string | null;
 }
 
+export type SortingMode = 'automatic'|'manual';
+
 @Component({
   templateUrl: './sort-by-tab.component.html'
 })
@@ -31,6 +33,11 @@ export class WpTableConfigurationSortByTab implements TabComponent {
     sort_criteria_1: this.I18n.t('js.filter.sorting.criteria.one'),
     sort_criteria_2: this.I18n.t('js.filter.sorting.criteria.two'),
     sort_criteria_3: this.I18n.t('js.filter.sorting.criteria.three'),
+    sorting_mode: {
+      description: this.I18n.t('js.work_packages.table_configuration.sorting_mode.description'),
+      automatic: this.I18n.t('js.work_packages.table_configuration.sorting_mode.automatic'),
+      manually: this.I18n.t('js.work_packages.table_configuration.sorting_mode.manually'),
+    },
   };
 
   readonly availableDirections = [
@@ -43,6 +50,9 @@ export class WpTableConfigurationSortByTab implements TabComponent {
   public sortationObjects:SortModalObject[] = [];
   public emptyColumn:SortColumn = {name: this.text.placeholder, href: null};
 
+  public sortingMode:SortingMode = 'automatic';
+  public manualSortColumn:SortColumn;
+
   constructor(readonly injector:Injector,
               readonly I18n:I18nService,
               readonly wpTableSortBy:WorkPackageTableSortByService) {
@@ -50,11 +60,14 @@ export class WpTableConfigurationSortByTab implements TabComponent {
   }
 
   public onSave() {
-    let sortElements =
-      this.sortationObjects
-        .filter(object => object.column !== null)
-        .map(object => this.getMatchingSort(object.column.href!, object.direction));
+    let sortElements;
+    if (this.sortingMode === 'automatic') {
+      sortElements = this.sortationObjects.filter(object => object.column !== null);
+    } else {
+      sortElements = [ new SortModalObject(this.manualSortColumn, QUERY_SORT_BY_ASC) ];
+    }
 
+    sortElements = sortElements.map(object => this.getMatchingSort(object.column.href!, object.direction));
     this.wpTableSortBy.update(_.compact(sortElements));
   }
 
@@ -79,12 +92,17 @@ export class WpTableConfigurationSortByTab implements TabComponent {
         // QuerySortByResources are doubled for each column (one for asc/desc direction)
         this.allColumns = _.uniqBy(allColumns, 'href');
 
+        this.getManualSortingOption();
+
         _.each(this.wpTableSortBy.current, sort => {
           if (!sort.column.$href!.endsWith('/parent')) {
             this.sortationObjects.push(
               new SortModalObject({name: sort.column.name, href: sort.column.$href},
                 sort.direction.$href!)
             );
+            if (sort.column.href === this.manualSortColumn.href) {
+              this.updateSortingMode('manual');
+            }
           }
         });
 
@@ -106,6 +124,10 @@ export class WpTableConfigurationSortByTab implements TabComponent {
     this.availableColumns = _.sortBy(_.differenceBy(this.allColumns, usedColumns, 'href'), 'name');
   }
 
+  public updateSortingMode(mode:SortingMode) {
+    this.sortingMode = mode;
+  }
+
   private getMatchingSort(column:string, direction:string) {
     return _.find(this.wpTableSortBy.available, sort => {
       return sort.column.$href === column && sort.direction.$href === direction;
@@ -116,5 +138,10 @@ export class WpTableConfigurationSortByTab implements TabComponent {
     while (this.sortationObjects.length < 3) {
       this.sortationObjects.push(new SortModalObject(this.emptyColumn, QUERY_SORT_BY_ASC));
     }
+  }
+
+  private getManualSortingOption() {
+    this.manualSortColumn = this.allColumns.find((e) => e.href!.endsWith('/manualSorting'))!;
+    this.allColumns.splice(this.allColumns.indexOf(this.manualSortColumn), 1);
   }
 }

--- a/frontend/src/app/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/components/wp-table/wp-table.directive.html
@@ -2,6 +2,7 @@
   <div class="work-packages-tabletimeline--table-side work-package-table--container __hidden_overflow_container">
     <table class="keyboard-accessible-list generic-table work-package-table">
       <colgroup>
+        <col *ngIf="configuration.dragAndDropEnabled">
         <!-- Generate col elements dynamically(!) for each requested column plus one for the action menu's column. -->
         <col highlight-col *ngFor="let column of [].constructor(columns.length + 1)">
       </colgroup>
@@ -12,7 +13,11 @@
       </caption>
       <thead class="-sticky">
         <tr>
-          <th *ngIf="configuration.dragAndDropEnabled" class="wp-table--manual-sort-th -short hide-when-print"></th>
+          <th *ngIf="configuration.dragAndDropEnabled" class="wp-table--manual-sort-th -short hide-when-print">
+            <div class="generic-table--empty-header">
+              <op-icon *ngIf="manualSortEnabled" icon-classes="icon-sort-by"></op-icon>
+            </div>
+          </th>
           <th *ngFor="let column of columns"
               class="wp-table--table-header">
             <sortHeader [headerColumn]="column"

--- a/frontend/src/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/src/app/components/wp-table/wp-table.directive.ts
@@ -60,6 +60,7 @@ import {
 import {QueryColumn} from 'core-components/wp-query/query-column';
 import {OpModalService} from 'core-components/op-modals/op-modal.service';
 import {WpTableConfigurationModalComponent} from 'core-components/wp-table/configuration-modal/wp-table-configuration.modal';
+import {WorkPackageTableSortByService} from "core-components/wp-fast-table/state/wp-table-sort-by.service";
 
 @Component({
   templateUrl: './wp-table.directive.html',
@@ -105,6 +106,8 @@ export class WorkPackagesTableController implements OnInit, OnDestroy {
 
   public timelineVisible:boolean;
 
+  public manualSortEnabled:boolean;
+
   constructor(readonly elementRef:ElementRef,
               readonly injector:Injector,
               readonly states:States,
@@ -115,7 +118,8 @@ export class WorkPackagesTableController implements OnInit, OnDestroy {
               readonly cdRef:ChangeDetectorRef,
               readonly wpTableGroupBy:WorkPackageTableGroupByService,
               readonly wpTableTimeline:WorkPackageTableTimelineService,
-              readonly wpTableColumns:WorkPackageTableColumnsService) {
+              readonly wpTableColumns:WorkPackageTableColumnsService,
+              readonly wpTableSortBy:WorkPackageTableSortByService) {
   }
 
   ngOnInit():void {
@@ -147,11 +151,12 @@ export class WorkPackagesTableController implements OnInit, OnDestroy {
       this.querySpace.results.values$(),
       this.wpTableGroupBy.state.values$(),
       this.wpTableColumns.state.values$(),
-      this.wpTableTimeline.state.values$());
+      this.wpTableTimeline.state.values$(),
+      this.wpTableSortBy.state.values$());
 
     statesCombined.pipe(
       untilComponentDestroyed(this)
-    ).subscribe(([results, groupBy, columns, timelines]) => {
+    ).subscribe(([results, groupBy, columns, timelines, sort]) => {
       this.query = this.querySpace.query.value!;
       this.rowcount = results.count;
 
@@ -164,6 +169,8 @@ export class WorkPackagesTableController implements OnInit, OnDestroy {
         this.scrollSyncUpdate(timelines.visible);
       }
       this.timelineVisible = timelines.visible;
+
+      this.manualSortEnabled = sort[0].column.href!.endsWith('/manualSorting');
     });
 
     // Locate table and timeline elements


### PR DESCRIPTION
In the sort-by tab add a switch to distinguish between manual and automatic mode.

In the table header show an icon when manual sort is enabled. 
