### PR TITLE
[30370] Fix not allowed scope for relative URL root

### DIFF
--- a/lib/open_project/static_routing.rb
+++ b/lib/open_project/static_routing.rb
@@ -72,5 +72,24 @@ module OpenProject
     class StaticUrlHelpers
       include StaticRouting::UrlHelpers
     end
+
+
+    ##
+    # Try to recognize a route entry for the given path
+    # but strips the relative URL root information away beforehand.
+    #
+    # Returns nil if it could not be processed.
+    def self.recognize_route(path)
+      return nil unless path.present?
+
+      # Remove relative URL root
+      if relative_url = OpenProject::Configuration.rails_relative_url_root
+        path = path.gsub relative_url, ''
+      end
+
+      Rails.application.routes.recognize_path(path)
+    rescue ActionController::RoutingError
+      nil
+    end
   end
 end

--- a/modules/boards/lib/open_project/boards/grid_registration.rb
+++ b/modules/boards/lib/open_project/boards/grid_registration.rb
@@ -14,13 +14,12 @@ module OpenProject
 
       class << self
         def from_scope(scope)
-          recognized = Rails.application.routes.recognize_path(scope)
+          recognized = ::OpenProject::StaticRouting.recognize_route(scope)
+          return if recognized.nil?
 
           if recognized[:controller] == 'boards/boards'
             recognized.slice(:project_id, :id, :user_id)&.merge(class: ::Boards::Grid)
           end
-        rescue ActionController::RoutingError
-          nil
         end
 
         def writable_scopes

--- a/modules/boards/spec/lib/open_project/boards/grid_registration_spec.rb
+++ b/modules/boards/spec/lib/open_project/boards/grid_registration_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe OpenProject::Boards::GridRegistration do
   let(:project) { FactoryBot.create(:project) }
   let(:permissions) { [:show_board_views] }
@@ -6,6 +8,17 @@ describe OpenProject::Boards::GridRegistration do
     FactoryBot.create(:user,
                       member_in_project: project,
                       member_with_permissions: permissions)
+  end
+
+  describe 'from_scope' do
+    subject { described_class.from_scope '/foobar/projects/bla/boards' }
+
+    context 'with a relative URL root', with_config: { rails_relative_url_root: '/foobar' } do
+      it 'maps that correctly' do
+        expect(subject).to be_present
+        expect(subject[:class]).to eq(::Boards::Grid)
+      end
+    end
   end
 
   describe '.visible' do

--- a/spec/lib/open_project/static_routing_spec.rb
+++ b/spec/lib/open_project/static_routing_spec.rb
@@ -1,0 +1,53 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe OpenProject::StaticRouting do
+  describe '.recognize_route' do
+    subject { described_class.recognize_route path }
+
+    context 'with no relative URL root', with_config: { rails_relative_url_root: nil } do
+      let(:path) { '/projects/foo' }
+
+      it 'detects the route' do
+        expect(subject).to be_present
+        expect(subject[:controller]).to be_present
+      end
+    end
+
+    context 'with a relative URL root', with_config: { rails_relative_url_root: '/foobar' } do
+      let(:path) { '/foobar/projects/foo' }
+
+      it 'detects the route' do
+        expect(subject).to be_present
+        expect(subject[:controller]).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
If a relative URL root was set, no scope for boards was every writable.

https://community.openproject.com/wp/30370