### PR TITLE
replace acts_as_silent_list by acts_as_list touch_on_update: false

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ PATH
   remote: modules/backlogs
   specs:
     openproject-backlogs (1.0.0)
-      acts_as_silent_list (~> 3.0.0)
+      acts_as_list (~> 0.9.18)
       openproject-pdf_export
 
 PATH
@@ -293,9 +293,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    acts_as_list (0.9.11)
+    acts_as_list (0.9.19)
       activerecord (>= 3.0)
-    acts_as_silent_list (3.0.0)
     acts_as_tree (2.8.0)
       activerecord (>= 3.0.0)
     addressable (2.6.0)

--- a/app/models/custom_action.rb
+++ b/app/models/custom_action.rb
@@ -53,7 +53,7 @@ class CustomAction < ActiveRecord::Base
     ret
   end
 
-  def reload
+  def reload(*args)
     @conditions = nil
 
     super
@@ -113,11 +113,7 @@ class CustomAction < ActiveRecord::Base
     availables.map do |available|
       existing = actual.detect { |a| a.key == available.key }
 
-      if existing
-        existing
-      else
-        available.new
-      end
+      existing || available.new
     end
   end
 

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -246,11 +246,14 @@ class WorkPackage < ActiveRecord::Base
   end
 
   # Users/groups the work_package can be assigned to
-  extend Forwardable
-  def_delegator :project, :possible_assignees, :assignable_assignees
+  def assignable_assignees
+    project.possible_assignees
+  end
 
   # Users the work_package can be assigned to
-  def_delegator :project, :possible_responsibles, :assignable_responsibles
+  def assignable_responsibles
+    project.possible_responsibles
+  end
 
   # Versions that the work_package can be assigned to
   # A work_package can be assigned to:

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -35,9 +35,6 @@
 
 require 'open_project/plugins'
 
-
-require 'acts_as_silent_list'
-
 module OpenProject::Backlogs
   class Engine < ::Rails::Engine
     engine_name :openproject_backlogs

--- a/modules/backlogs/lib/open_project/backlogs/patches/version_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/version_patch.rb
@@ -63,7 +63,7 @@ module OpenProject::Backlogs::Patches::VersionPatch
                                          .order(Arel.sql('COALESCE(position, 0), id'))
 
         (stories_w_position + stories_wo_position).each_with_index do |story, index|
-          story.send(:update_attribute_silently, 'position', index + 1)
+          story.update_column(:position, index + 1)
         end
       end
 

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
@@ -36,30 +36,30 @@
 require_dependency 'work_package'
 
 module OpenProject::Backlogs::Patches::WorkPackagePatch
-  def self.included(base)
-    base.class_eval do
-      prepend InstanceMethods
-      extend ClassMethods
+  extend ActiveSupport::Concern
 
-      before_validation :backlogs_before_validation, if: lambda { backlogs_enabled? }
+  included do
+    prepend InstanceMethods
+    extend ClassMethods
 
-      register_on_journal_formatter(:fraction, 'remaining_hours')
-      register_on_journal_formatter(:decimal, 'story_points')
-      register_on_journal_formatter(:decimal, 'position')
+    before_validation :backlogs_before_validation, if: lambda { backlogs_enabled? }
 
-      validates_numericality_of :story_points, only_integer:             true,
-                                               allow_nil:                true,
-                                               greater_than_or_equal_to: 0,
-                                               less_than:                10_000,
-                                               if: lambda { backlogs_enabled? }
+    register_on_journal_formatter(:fraction, 'remaining_hours')
+    register_on_journal_formatter(:decimal, 'story_points')
+    register_on_journal_formatter(:decimal, 'position')
 
-      validates_numericality_of :remaining_hours, only_integer: false,
-                                                  allow_nil: true,
-                                                  greater_than_or_equal_to: 0,
-                                                  if: lambda { backlogs_enabled? }
+    validates_numericality_of :story_points, only_integer:             true,
+                                             allow_nil:                true,
+                                             greater_than_or_equal_to: 0,
+                                             less_than:                10_000,
+                                             if: lambda { backlogs_enabled? }
 
-      include OpenProject::Backlogs::List
-    end
+    validates_numericality_of :remaining_hours, only_integer: false,
+                                                allow_nil: true,
+                                                greater_than_or_equal_to: 0,
+                                                if: lambda { backlogs_enabled? }
+
+    include OpenProject::Backlogs::List
   end
 
   module ClassMethods

--- a/modules/backlogs/openproject-backlogs.gemspec
+++ b/modules/backlogs/openproject-backlogs.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,doc}/**/*', 'README.md']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'acts_as_silent_list', '~> 3.0.0'
+  s.add_dependency 'acts_as_list', '~> 0.9.18'
 
   s.add_dependency 'openproject-pdf_export'
 

--- a/modules/backlogs/spec/models/version_spec.rb
+++ b/modules/backlogs/spec/models/version_spec.rb
@@ -143,11 +143,11 @@ describe Version, type: :model do
       [e1, s2, s3, s4, s5].each(&:move_to_bottom)
 
       # Messing around with positions
-      s3.send :assume_not_in_list
-      s4.send :assume_not_in_list
+      s3.update_column(:position, nil)
+      s4.update_column(:position, nil)
 
-      t3.send(:update_attribute_silently, :position, 3)
-      o9.send(:update_attribute_silently, :position, 9)
+      t3.update_column(:position, 3)
+      o9.update_column(:position, 9)
 
       version.rebuild_positions(project)
 


### PR DESCRIPTION
Since v0.9.18, acts_as_list has the `touch_on_update: false` option which results in acts_as_list doing the same as acts_as_silent_list did.

As acts_as_list is actually maintained, replacing acts_as_silent_list with it is reasonable.