### PR TITLE
[30389][DnD] Changing a WP changes the sort order 

### DIFF
--- a/frontend/src/app/components/wp-fast-table/handlers/state/drag-and-drop-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/drag-and-drop-transformer.ts
@@ -50,7 +50,7 @@ export class DragAndDropTransformer {
       .observe(this.querySpace.stopAllSubscriptions.pipe(take(1)))
       .subscribe({
         next: () =>  {
-          if (this.wpTableTimeline.isVisible ) {
+          if (this.wpTableTimeline.isVisible) {
             this.table.originalRows = this.currentRenderedOrder.map((e) => e.workPackageId!);
             this.table.redrawTableAndTimeline();
           }

--- a/frontend/src/app/components/wp-list/wp-list.service.ts
+++ b/frontend/src/app/components/wp-list/wp-list.service.ts
@@ -195,17 +195,6 @@ export class WorkPackagesListService {
   }
 
   /**
-   * Reload the first page of work packages for the current query
-   */
-  public loadCurrentResultsListFirstPage():Promise<WorkPackageCollectionResource> {
-    let pagination = this.getPaginationInfo();
-    pagination.offset = 1;
-    let query = this.currentQuery;
-
-    return this.loadResultsList(query, pagination);
-  }
-
-  /**
    * Load the query from the given state params
    */
   public loadCurrentQueryFromParams(projectIdentifier?:string) {
@@ -336,14 +325,14 @@ export class WorkPackagesListService {
   }
 
   private updateStatesFromWPListOnPromise(query:QueryResource, promise:Promise<WorkPackageCollectionResource>):Promise<WorkPackageCollectionResource> {
-    return promise.then((results) => {
+    return promise.then((result) => {
       this.querySpace.ready.doAndTransition('Query loaded', () => {
-        this.wpStatesInitialization.updateQuerySpace(query, results);
-        this.wpStatesInitialization.updateChecksum(query, results);
+        this.wpStatesInitialization.updateQuerySpace(query, result.results);
+        this.wpStatesInitialization.updateChecksum(query, result.results);
         return this.querySpace.tableRendering.onQueryUpdated.valuesPromise();
       });
 
-      return results;
+      return result.results;
     });
   }
 

--- a/frontend/src/app/modules/hal/dm-services/query-dm.service.ts
+++ b/frontend/src/app/modules/hal/dm-services/query-dm.service.ts
@@ -95,7 +95,7 @@ export class QueryDmService {
 
     var queryData = this.UrlParamsHelper.buildV3GetQueryFromQueryResource(query, pagination);
 
-    var url = URI(query.results.href!).path();
+    var url = URI(query.href!).path();
 
     return this.halResourceService
       .get<WorkPackageCollectionResource>(url, queryData)

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -158,7 +158,7 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
     let promise:Promise<unknown>;
 
     if (firstPage) {
-      promise = this.wpListService.loadCurrentResultsListFirstPage();
+      promise = this.loadCurrentQuery();
     } else {
       promise = this.wpListService.reloadCurrentResultsList();
     }


### PR DESCRIPTION
Load the query instead of just the WorkPackages without reference to the query. This will avoid that manual sorting is lost, when the table is refreshed.

https://community.openproject.com/projects/openproject/work_packages/30389/activity