### PR TITLE
prevent useless edits to wp status

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -36,7 +36,10 @@ module WorkPackages
 
     attribute :subject
     attribute :description
-    attribute :status_id
+    attribute :status_id,
+              writeable: ->(*) {
+                !model.closed_version_and_status?
+              }
     attribute :type_id
     attribute :priority_id
     attribute :category_id

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -31,12 +31,12 @@
 class Status < ActiveRecord::Base
   extend Pagination::Model
 
-  default_scope { order('position ASC') }
+  default_scope { order_by_position }
   before_destroy :check_integrity
   has_many :workflows, foreign_key: 'old_status_id'
   acts_as_list
 
-  belongs_to :color, class_name:  'Color', foreign_key: 'color_id'
+  belongs_to :color, class_name: 'Color', foreign_key: 'color_id'
 
   before_destroy :delete_workflows
 
@@ -57,7 +57,7 @@ class Status < ActiveRecord::Base
   end
 
   def self.where_default
-    where(['is_default=?', true])
+    where(is_default: true)
   end
 
   # Update all the +Issues+ setting their done_ratio to the value of their +Status+
@@ -107,6 +107,7 @@ class Status < ActiveRecord::Base
 
   def is_readonly
     return false unless can_readonly?
+
     super
   end
   alias :is_readonly? :is_readonly

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -279,13 +279,17 @@ class WorkPackage < ActiveRecord::Base
     status.present? && status.is_readonly?
   end
 
+  def closed_version_and_status?
+    fixed_version&.closed? && status.is_closed?
+  end
+
   # Returns true if the work_package is overdue
   def overdue?
     !due_date.nil? && (due_date < Date.today) && !closed?
   end
 
   def milestone?
-    type && type.is_milestone?
+    type&.is_milestone?
   end
   alias_method :is_milestone?, :milestone?
 
@@ -295,10 +299,12 @@ class WorkPackage < ActiveRecord::Base
 
     current_status = Status.where(id: status_id)
 
+    return current_status if closed_version_and_status?
+
     statuses = new_statuses_allowed_by_workflow_to(user)
                .or(current_status)
 
-    statuses = statuses.or(Status.where(id: Status.default.id)) if include_default
+    statuses = statuses.or(Status.where_default) if include_default
     statuses = statuses.where(is_closed: false) if blocked?
 
     statuses.order_by_position

--- a/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
@@ -78,7 +78,7 @@ export class WorkPackageStatusDropdownDirective extends OpContextMenuTrigger {
     const changeset = this.wpEditing.changesetFor(this.workPackage);
     changeset.setValue('status', status);
 
-    if(!this.workPackage.isNew) {
+    if (!this.workPackage.isNew) {
       changeset.save().then(() => {
         this.wpNotificationsService.showSave(this.workPackage);
         this.wpTableRefresh.request('Altered work package status via button');

--- a/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.html
+++ b/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.html
@@ -3,7 +3,7 @@
      *ngIf="status">
   <button class="button"
           [ngClass]="statusHighlightClass"
-          [disabled]="isDisabled()"
+          [disabled]="isDisabled"
           [attr.title]="buttonTitle"
           [attr.aria-label]="text.explanation"
 

--- a/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
@@ -167,6 +167,9 @@ export class WorkPackageChangeset {
         .update(payload)
         .then((form:FormResource) => {
           this.form = form;
+          if (!this.workPackage.isNew) {
+            this.schemaCacheService.state(this.workPackage).putValue(form.schema);
+          }
 
           this.rebuildDefaults(form.payload);
 

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -146,13 +146,29 @@ describe WorkPackages::BaseContract do
     end
   end
 
-  describe 'locked status' do
-    before do
-      allow(work_package).to receive(:readonly_status?).and_return true
+  describe 'status' do
+    context 'on a readonly status' do
+      before do
+        allow(work_package)
+          .to receive(:readonly_status?)
+          .and_return true
+      end
+
+      it 'only sets status to allowed' do
+        expect(contract.writable_attributes).to eq(%w[status status_id])
+      end
     end
 
-    it 'only sets status to allowed' do
-      expect(contract.writable_attributes).to eq(%w[status status_id])
+    context 'work_package has a closed version and status' do
+      before do
+        allow(work_package)
+          .to receive(:closed_version_and_status?)
+          .and_return true
+      end
+
+      it 'is not writable' do
+        expect(contract.writable?(:status)).to be_falsey
+      end
     end
   end
 

--- a/spec/support/work_packages/work_package_status_field.rb
+++ b/spec/support/work_packages/work_package_status_field.rb
@@ -1,7 +1,6 @@
 require_relative './work_package_field'
 
 class WorkPackageStatusField < WorkPackageField
-
   def initialize(context)
     @context = context
     @selector = ".wp-status-button"


### PR DESCRIPTION
In case the fixed version and the status of a work package are both closed, the status of a work package cannot be altered any more. Attempting it will result in an error.

Before the fix, the possible status calculation would not factor in that situation and the status would be marked as writable regardless as well. Therefore, the frontend would display a list of statuses even though selecting one would do nothing at all.

Now, the status property is marked as non writable in such a situation and the status list will only contain the current status. As we only fetch the form after a click on the edit field, we can only disable the field after that which is a bit weird.

https://community.openproject.com/projects/openproject/work_packages/30396