### PR TITLE
Add BCF snapshot as cover image to WP cards

### DIFF
--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.html
@@ -44,6 +44,8 @@
       </div>
     </wp-edit-field-group>
 
+    <img *ngIf="this.bcfSnapshotPath(wp)" [src]="this.bcfSnapshotPath(wp)" class="wp-card--cover-image">
+
     <div *ngIf="!wp.isNew"
          class="wp-card--content">
       <span [textContent]="wpTypeAttribute(wp)"

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
@@ -89,3 +89,9 @@ wp-edit-field
 
 .wp-inline-create--reference-container
   margin-bottom: 3rem
+
+.wp-card--cover-image
+  display: block
+  margin: -10px -10px 10px
+  width: calc(100% + 10px + 10px)
+  max-width: calc(100% + 10px + 10px)

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -31,6 +31,7 @@ import {AuthorisationService} from "core-app/modules/common/model-auth/model-aut
 import {StateService} from "@uirouter/core";
 import {States} from "core-components/states.service";
 import {RequestSwitchmap} from "core-app/helpers/rxjs/request-switchmap";
+import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 
 
 @Component({
@@ -93,7 +94,8 @@ export class WorkPackageCardViewComponent  implements OnInit {
               readonly dragService:DragAndDropService,
               readonly reorderService:ReorderQueryService,
               readonly authorisationService:AuthorisationService,
-              readonly cdRef:ChangeDetectorRef) {
+              readonly cdRef:ChangeDetectorRef,
+              readonly pathHelper:PathHelperService) {
   }
 
   ngOnInit() {
@@ -149,6 +151,15 @@ export class WorkPackageCardViewComponent  implements OnInit {
 
   public wpSubject(wp:WorkPackageResource) {
     return wp.subject;
+  }
+
+  public bcfSnapshotPath(wp:WorkPackageResource) {
+    let vp = _.get(wp, 'bcf.viewpoints[0]');
+    if (vp) {
+      return this.pathHelper.attachmentDownloadPath(vp.id, vp.file_name);
+    } else {
+      return null;
+    }
   }
 
   public cardHighlightingClass(wp:WorkPackageResource) {

--- a/modules/bcf/lib/open_project/bcf/engine.rb
+++ b/modules/bcf/lib/open_project/bcf/engine.rb
@@ -96,7 +96,7 @@ module OpenProject::Bcf
              type: 'BCF Thumbnail',
              required: false,
              writable: false,
-             show_if: ->(*) { represented&.project.module_enabled?(:bcf) }
+             show_if: ->(*) { represented&.project&.module_enabled?(:bcf) }
     end
 
     add_api_path :bcf_xml do |project_id|


### PR DESCRIPTION
This is a very tiny feature but enables teams working with BCF issues to use the Boards module effectively.