### PR TITLE
Fix/clamp without color

### DIFF
--- a/app/assets/stylesheets/content/work_packages/timelines/elements/_bar.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/elements/_bar.sass
@@ -5,9 +5,9 @@
   float: left
   z-index: 0
 
-  .timeline-element--bg
-    width: 100%
-    height: 100%
+.timeline-element--bg
+  width: 100%
+  height: 100%
 
   &:hover:not(.-clamp-style)
     .leftHandle, .rightHandle

--- a/frontend/src/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -79,12 +79,13 @@ export class TimelineCellRenderer {
 
     const placeholder = document.createElement('div');
     placeholder.style.pointerEvents = 'none';
-    placeholder.style.backgroundColor = '#DDDDDD';
     placeholder.style.position = 'absolute';
     placeholder.style.height = '1em';
     placeholder.style.width = '30px';
     placeholder.style.zIndex = '9999';
     placeholder.style.left = (days * renderInfo.viewParams.pixelPerDay) + 'px';
+
+    this.applyTypeColor(renderInfo, placeholder);
 
     return placeholder;
   }

--- a/frontend/src/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -402,10 +402,13 @@ export class TimelineCellRenderer {
    */
   checkForSpecialDisplaySituations(renderInfo:RenderInfo, bar:HTMLElement) {
     const wp = renderInfo.workPackage;
+    let selectionMode = renderInfo.viewParams.activeSelectionMode;
 
     // Cannot edit the work package if it has children
-    if (!wp.isLeaf) {
+    if (!wp.isLeaf && !selectionMode) {
       bar.classList.add('-readonly');
+    } else {
+      bar.classList.remove('-readonly');
     }
 
     // Display the parent as clamp-style when it has children in the table

--- a/frontend/src/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -374,15 +374,14 @@ export class TimelineCellRenderer {
 
     if (!type && !selectionMode) {
       bg.style.backgroundColor = this.fallbackColor;
+    } else {
+      bg.style.backgroundColor = '';
     }
 
-    bg.style.backgroundColor = '';
-
-    // Don't apply the class in selection mode
+    // Don't apply the class in selection mode or for parents (clamps)
     const id = type.id;
-    if (renderInfo.viewParams.activeSelectionMode) {
+    if (selectionMode || this.is_parent_with_displayed_children(wp)) {
       bg.classList.remove(Highlighting.backgroundClass('type', id!));
-      return;
     } else {
       bg.classList.add(Highlighting.backgroundClass('type', id!));
     }
@@ -403,23 +402,18 @@ export class TimelineCellRenderer {
   checkForSpecialDisplaySituations(renderInfo:RenderInfo, bar:HTMLElement) {
     const wp = renderInfo.workPackage;
 
-    // Cannot eddit the work package if it has children
+    // Cannot edit the work package if it has children
     if (!wp.isLeaf) {
       bar.classList.add('-readonly');
     }
 
     // Display the parent as clamp-style when it has children in the table
-    if (this.workPackageTimeline.inHierarchyMode &&
-      hasChildrenInTable(wp, this.workPackageTimeline.workPackageTable)) {
-      // this.applyTypeColor(wp, bar);
+    if (this.is_parent_with_displayed_children(wp)) {
       bar.classList.add('-clamp-style');
       bar.style.borderStyle = 'solid';
       bar.style.borderWidth = '2px';
       bar.style.borderBottom = 'none';
       bar.style.background = 'none';
-    } else {
-      // Apply the background color
-      this.applyTypeColor(renderInfo, bar);
     }
   }
 
@@ -475,5 +469,10 @@ export class TimelineCellRenderer {
     } else if (label) {
       label.classList.remove('not-empty');
     }
+  }
+
+  protected is_parent_with_displayed_children(wp:WorkPackageResource) {
+    return this.workPackageTimeline.inHierarchyMode &&
+      hasChildrenInTable(wp, this.workPackageTimeline.workPackageTable);
   }
 }

--- a/frontend/src/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
@@ -52,6 +52,8 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
     diamond.style.width = '1em';
     placeholder.appendChild(diamond);
 
+    this.applyTypeColor(renderInfo, diamond);
+
     return placeholder;
   }
 

--- a/spec/support/components/timelines/timeline_row.rb
+++ b/spec/support/components/timelines/timeline_row.rb
@@ -39,14 +39,7 @@ module Components
       end
 
       def hover!
-        # The timeline resizer overlays the timeline at the very right
-        # The hover implementation also seems to hover at the utmost right
-        # of an element.
-        # We therefore select an element in the row we assume to never be at the utmost right.
-        # TODO: As this is actually a usability issue, we should fix the
-        # timeline to always display as many days to the right as is needed to
-        # ensure that a timeline element is never blocked by the resizer bar.
-        @container.find('.rightHandle, .diamond').hover
+        @container.find('.timeline-element').hover
       end
 
       def expect_hovered_labels(left:, right:)


### PR DESCRIPTION
Started of by fixing the color background on parent/clamps:
https://community.openproject.com/projects/openproject/work_packages/30388

![image](https://user-images.githubusercontent.com/617519/59762931-a60c0280-9298-11e9-99c8-4afed8ce71ae.png)

It additionally:
* Adds colors to the placeholders displayed when hovering over a timeline row and no dates have been set yet
* fixes the readonly class styles so that the pointer on a parent no longer suggests the dates to be editable.