### PR TITLE
Ensure quick filter does not get overridden during debounce

### DIFF
--- a/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
+++ b/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
@@ -26,14 +26,13 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, Input, OnDestroy, OnInit, Output} from '@angular/core';
+import {Component, OnDestroy, Output} from '@angular/core';
 import {I18nService} from "app/modules/common/i18n/i18n.service";
 import {WorkPackageTableFiltersService} from "app/components/wp-fast-table/state/wp-table-filters.service";
-import {QueryFilterResource} from "app/modules/hal/resources/query-filter-resource";
 import {componentDestroyed, untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {WorkPackageCacheService} from "app/components/work-packages/work-package-cache.service";
-import {Subject} from "rxjs";
-import {debounceTime, distinctUntilChanged} from "rxjs/operators";
+import {merge, Observable, Subject} from "rxjs";
+import {debounceTime, distinctUntilChanged, map, startWith} from "rxjs/operators";
 import {DebouncedEventEmitter} from "core-components/angular/debounced-event-emitter";
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-filter-instance-resource";
@@ -43,7 +42,7 @@ import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-
   templateUrl: './quick-filter-by-text-input.html'
 })
 
-export class WorkPackageFilterByTextInputComponent implements OnInit, OnDestroy {
+export class WorkPackageFilterByTextInputComponent implements OnDestroy {
   @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource[]>(componentDestroyed(this));
 
   public text = {
@@ -53,30 +52,48 @@ export class WorkPackageFilterByTextInputComponent implements OnInit, OnDestroy 
     placeholder: this.I18n.t('js.work_packages.placeholder_filter_by_text')
   };
 
-  public searchTerm:string;
-  private searchTermChanged:Subject<string> = new Subject<string>();
+  /** Observable to the current search filter term */
+  public searchTerm$:Observable<string>;
+
+  /** Input for search requests */
+  public searchTermChanged:Subject<string> = new Subject<string>();
 
   constructor(readonly I18n:I18nService,
               readonly querySpace:IsolatedQuerySpace,
               readonly wpTableFilters:WorkPackageTableFiltersService,
               readonly wpCacheService:WorkPackageCacheService) {
+
+    this.searchTerm$ = merge(
+      this.wpTableFilters
+        .observeUntil(
+          componentDestroyed(this)
+        )
+        .pipe(
+          map(() => {
+            const currentSearchFilter = this.wpTableFilters.find('search');
+            return currentSearchFilter ? (currentSearchFilter.values[0] as string) : '';
+          }),
+          startWith(''),
+        ),
+      this.searchTermChanged
+    );
+
     this.searchTermChanged
       .pipe(
         untilComponentDestroyed(this),
-        debounceTime(250),
-        distinctUntilChanged()
+        distinctUntilChanged(),
+        debounceTime(500),
       )
       .subscribe(term => {
-        this.searchTerm = term;
         let filters = this.wpTableFilters.current;
 
         // Remove the current filter
         _.remove(filters, f => f.id === 'search');
 
-        if (this.searchTerm.length > 0) {
+        if (term.length > 0) {
           let searchFilter = this.wpTableFilters.instantiate('search');
           searchFilter.operator = searchFilter.findOperator('**')!;
-          searchFilter.values = [this.searchTerm];
+          searchFilter.values = [term];
           filters.push(searchFilter);
         }
 
@@ -84,28 +101,7 @@ export class WorkPackageFilterByTextInputComponent implements OnInit, OnDestroy 
       });
   }
 
-  public ngOnInit() {
-    let self:WorkPackageFilterByTextInputComponent = this;
-
-    this.wpTableFilters
-      .observeUntil(
-        componentDestroyed(this)
-      )
-      .subscribe(() => {
-        const currentSearchFilter = this.wpTableFilters.find('search');
-        if (currentSearchFilter) {
-          this.searchTerm = currentSearchFilter.values[0] as string;
-        } else {
-          this.searchTerm = '';
-        }
-      });
-  }
-
   public ngOnDestroy() {
     // Nothing to do
-  }
-
-  public valueChange(term:string) {
-    this.searchTermChanged.next(term);
   }
 }

--- a/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.html
+++ b/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.html
@@ -1,5 +1,5 @@
 <input id="filter-by-text-input"
        type="text"
        placeholder="{{text.placeholder}}"
-       [ngModel]="searchTerm"
-       (ngModelChange)="valueChange($event)">
+       [ngModel]="searchTerm$ | async"
+       (ngModelChange)="searchTermChanged.next($event)">

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-filters.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-filters.service.ts
@@ -198,16 +198,6 @@ export class WorkPackageTableFiltersService extends WorkPackageQueryStateService
   }
 
   /**
-   * Find an available filter by its ID. Can be used to instantiate or add
-   * with +get+ or +add+ methods on this service.
-   *
-   * @param id Internal identifier string of the filter
-   */
-  public findAvailableFilter(id:string):QueryFilterResource|undefined {
-    return _.find(this.availableFilters, f => f.id === id);
-  }
-
-  /**
    * Determine whether all given filters are completely defined.
    * @param filters
    */


### PR DESCRIPTION
The search filter can be updated from two places

- The search input, which is debounced
- The filter updates, which happens every time after the filter has been updated + another time when the form was loaded with it

When typing during the request, the debounced input will be replaced by the filter value. With the current wiring of states, there is no way to distinguish between a filter update from an initialization (which is the _only_ case where we want to override the current search term) and subsequent update. But we can still reduce flickering by cancelling updates in this fashion when the user is still typing.