### PR TITLE
Separate pristine and update states in the work package table

### DIFF
--- a/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
+++ b/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
@@ -26,14 +26,13 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, Input, OnDestroy, OnInit, Output} from '@angular/core';
+import {Component, OnDestroy, Output} from '@angular/core';
 import {I18nService} from "app/modules/common/i18n/i18n.service";
 import {WorkPackageTableFiltersService} from "app/components/wp-fast-table/state/wp-table-filters.service";
-import {QueryFilterResource} from "app/modules/hal/resources/query-filter-resource";
 import {componentDestroyed, untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {WorkPackageCacheService} from "app/components/work-packages/work-package-cache.service";
-import {Subject} from "rxjs";
-import {debounceTime, distinctUntilChanged} from "rxjs/operators";
+import {merge, Observable, Subject} from "rxjs";
+import {debounceTime, distinctUntilChanged, map, startWith} from "rxjs/operators";
 import {DebouncedEventEmitter} from "core-components/angular/debounced-event-emitter";
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-filter-instance-resource";
@@ -43,7 +42,7 @@ import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-
   templateUrl: './quick-filter-by-text-input.html'
 })
 
-export class WorkPackageFilterByTextInputComponent implements OnInit, OnDestroy {
+export class WorkPackageFilterByTextInputComponent implements OnDestroy {
   @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource[]>(componentDestroyed(this));
 
   public text = {
@@ -53,30 +52,47 @@ export class WorkPackageFilterByTextInputComponent implements OnInit, OnDestroy 
     placeholder: this.I18n.t('js.work_packages.placeholder_filter_by_text')
   };
 
-  public searchTerm:string;
-  private searchTermChanged:Subject<string> = new Subject<string>();
+  /** Observable to the current search filter term */
+  public searchTerm$:Observable<string>;
+
+  /** Input for search requests */
+  public searchTermChanged:Subject<string> = new Subject<string>();
 
   constructor(readonly I18n:I18nService,
               readonly querySpace:IsolatedQuerySpace,
               readonly wpTableFilters:WorkPackageTableFiltersService,
               readonly wpCacheService:WorkPackageCacheService) {
+
+    this.searchTerm$ = merge(
+      this.wpTableFilters
+        .pristine$()
+        .pipe(
+          untilComponentDestroyed(this),
+          map(() => {
+            const currentSearchFilter = this.wpTableFilters.find('search');
+            return currentSearchFilter ? (currentSearchFilter.values[0] as string) : '';
+          }),
+          startWith(''),
+        ),
+      this.searchTermChanged
+    );
+
     this.searchTermChanged
       .pipe(
         untilComponentDestroyed(this),
-        debounceTime(250),
-        distinctUntilChanged()
+        distinctUntilChanged(),
+        debounceTime(500),
       )
       .subscribe(term => {
-        this.searchTerm = term;
         let filters = this.wpTableFilters.current;
 
         // Remove the current filter
         _.remove(filters, f => f.id === 'search');
 
-        if (this.searchTerm.length > 0) {
+        if (term.length > 0) {
           let searchFilter = this.wpTableFilters.instantiate('search');
           searchFilter.operator = searchFilter.findOperator('**')!;
-          searchFilter.values = [this.searchTerm];
+          searchFilter.values = [term];
           filters.push(searchFilter);
         }
 
@@ -84,28 +100,7 @@ export class WorkPackageFilterByTextInputComponent implements OnInit, OnDestroy 
       });
   }
 
-  public ngOnInit() {
-    let self:WorkPackageFilterByTextInputComponent = this;
-
-    this.wpTableFilters
-      .observeUntil(
-        componentDestroyed(this)
-      )
-      .subscribe(() => {
-        const currentSearchFilter = this.wpTableFilters.find('search');
-        if (currentSearchFilter) {
-          this.searchTerm = currentSearchFilter.values[0] as string;
-        } else {
-          this.searchTerm = '';
-        }
-      });
-  }
-
   public ngOnDestroy() {
     // Nothing to do
-  }
-
-  public valueChange(term:string) {
-    this.searchTermChanged.next(term);
   }
 }

--- a/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.html
+++ b/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.html
@@ -1,5 +1,5 @@
 <input id="filter-by-text-input"
        type="text"
        placeholder="{{text.placeholder}}"
-       [ngModel]="searchTerm"
-       (ngModelChange)="valueChange($event)">
+       [ngModel]="searchTerm$ | async"
+       (ngModelChange)="searchTermChanged.next($event)">

--- a/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.html
+++ b/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.html
@@ -1,5 +1,5 @@
 <input id="filter-by-text-input"
        type="text"
        placeholder="{{text.placeholder}}"
-       [ngModel]="searchTerm$ | async"
+       [ngModel]="searchTerm.values$() | async"
        (ngModelChange)="searchTermChanged.next($event)">

--- a/frontend/src/app/components/op-context-menu/handlers/op-columns-context-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/op-columns-context-menu.directive.ts
@@ -159,6 +159,9 @@ export class OpColumnsContextMenu extends OpContextMenuTrigger {
         linkText: this.I18n.t('js.work_packages.query.group'),
         icon: 'icon-group-by',
         onClick: () => {
+          if (this.wpTableHierarchies.isEnabled) {
+            this.wpTableHierarchies.setEnabled(false);
+          }
           this.wpTableGroupBy.setBy(c);
           return true;
         }

--- a/frontend/src/app/components/wp-buttons/wp-filter-button/wp-filter-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-filter-button/wp-filter-button.component.ts
@@ -31,7 +31,7 @@ import {AbstractWorkPackageButtonComponent} from 'core-components/wp-buttons/wp-
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
 import {WorkPackageFiltersService} from 'core-components/filters/wp-filters/wp-filters.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
+import {componentDestroyed, untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 
 @Component({
   selector: 'wp-filter-button',
@@ -86,7 +86,10 @@ export class WorkPackageFilterButtonComponent extends AbstractWorkPackageButtonC
 
   private setupObserver() {
     this.wpTableFilters
-      .observeUntil(componentDestroyed(this))
+      .live$()
+      .pipe(
+        untilComponentDestroyed(this)
+      )
       .subscribe(() => {
       this.count = this.wpTableFilters.currentlyVisibleFilters.length;
       this.initialized = true;

--- a/frontend/src/app/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component.ts
@@ -76,7 +76,10 @@ export class WorkPackageTimelineButtonComponent extends AbstractWorkPackageButto
 
   ngOnInit():void {
     this.wpTableTimeline
-      .observeUntil(componentDestroyed(this))
+      .live$()
+      .pipe(
+        untilComponentDestroyed(this)
+      )
       .subscribe(() => {
         this.isAutoZoom = this.wpTableTimeline.isAutoZoom();
         this.isActive = this.wpTableTimeline.isVisible;

--- a/frontend/src/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
@@ -71,7 +71,7 @@ export class SingleHierarchyRowBuilder extends SingleRowBuilder {
    * @param workPackage
    */
   public ancestorRowData(workPackage:WorkPackageResource):[string[], boolean] {
-    const state = this.wpTableHierarchies.currentState;
+    const state = this.wpTableHierarchies.current;
     const rowClasses:string[] = [];
     let hidden = false;
 

--- a/frontend/src/app/components/wp-fast-table/builders/primary-render-pass.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/primary-render-pass.ts
@@ -38,9 +38,9 @@ export type RenderedRow = { classIdentifier:string, workPackageId:string | null,
 
 export abstract class PrimaryRenderPass {
 
-  public wpEditing:WorkPackageEditingService = this.injector.get<WorkPackageEditingService>(IWorkPackageEditingServiceToken);
-  public states:States = this.injector.get(States);
-  public I18n:I18nService = this.injector.get(I18nService);
+  protected readonly wpEditing:WorkPackageEditingService = this.injector.get<WorkPackageEditingService>(IWorkPackageEditingServiceToken);
+  protected readonly states:States = this.injector.get(States);
+  protected readonly I18n:I18nService = this.injector.get(I18nService);
 
   /** The rendered order of rows of work package IDs or <null>, if not a work package row */
   public renderedOrder:RowRenderInfo[];

--- a/frontend/src/app/components/wp-fast-table/handlers/state/columns-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/columns-transformer.ts
@@ -1,9 +1,9 @@
 import {Injector} from '@angular/core';
-import {filter, takeUntil} from 'rxjs/operators';
 import {debugLog} from '../../../../helpers/debug_output';
 import {WorkPackageTableColumnsService} from '../../state/wp-table-columns.service';
 import {WorkPackageTable} from '../../wp-fast-table';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
+import {takeUntil} from "rxjs/operators";
 
 export class ColumnsTransformer {
 
@@ -13,8 +13,8 @@ export class ColumnsTransformer {
   constructor(public readonly injector:Injector,
               public table:WorkPackageTable) {
 
-    this.querySpace.updates.columnsUpdates
-      .values$('Refreshing columns on user request')
+    this.wpTableColumns
+      .updates$()
       .pipe(
         takeUntil(this.querySpace.stopAllSubscriptions)
       )

--- a/frontend/src/app/components/wp-fast-table/handlers/state/hierarchy-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/hierarchy-transformer.ts
@@ -1,12 +1,13 @@
 import {Injector} from '@angular/core';
 import {scrollTableRowIntoView} from 'core-components/wp-fast-table/helpers/wp-table-row-helpers';
-import {distinctUntilChanged, filter, map, takeUntil, withLatestFrom} from 'rxjs/operators';
+import {distinctUntilChanged, filter, map, takeUntil} from 'rxjs/operators';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {WorkPackageTableHierarchiesService} from "core-components/wp-fast-table/state/wp-table-hierarchy.service";
 import {WorkPackageTable} from "core-components/wp-fast-table/wp-fast-table";
 import {WorkPackageTableHierarchies} from "core-components/wp-fast-table/wp-table-hierarchies";
 import {
-  collapsedGroupClass, hierarchyGroupClass,
+  collapsedGroupClass,
+  hierarchyGroupClass,
   hierarchyRootClass
 } from "core-components/wp-fast-table/helpers/wp-table-hierarchy-helpers";
 import {indicatorCollapsedClass} from "core-components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder";
@@ -19,8 +20,9 @@ export class HierarchyTransformer {
 
   constructor(public readonly injector:Injector,
               table:WorkPackageTable) {
-    this.querySpace.updates.hierarchyUpdates
-      .values$('Refreshing hierarchies on user request')
+
+    this.wpTableHierarchies
+      .updates$()
       .pipe(
         takeUntil(this.querySpace.stopAllSubscriptions),
         map((state) => state.isVisible),
@@ -36,8 +38,9 @@ export class HierarchyTransformer {
     let lastValue = this.wpTableHierarchies.isEnabled;
 
     this.wpTableHierarchies
-      .observeUntil(this.querySpace.stopAllSubscriptions)
+      .updates$()
       .pipe(
+        takeUntil(this.querySpace.stopAllSubscriptions),
         filter(() => this.querySpace.rendered.hasValue())
       )
       .subscribe((state:WorkPackageTableHierarchies) => {

--- a/frontend/src/app/components/wp-fast-table/handlers/state/highlighting-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/highlighting-transformer.ts
@@ -11,8 +11,8 @@ export class HighlightingTransformer {
 
   constructor(public readonly injector:Injector,
               table:WorkPackageTable) {
-    this.querySpace.highlighting
-      .values$('Refreshing highlights on user request')
+    this.wpTableHighlighting
+      .live$()
       .pipe(
         takeUntil(this.querySpace.stopAllSubscriptions),
         distinctUntilChanged()

--- a/frontend/src/app/components/wp-fast-table/handlers/state/relations-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/relations-transformer.ts
@@ -1,8 +1,9 @@
 import {Injector} from '@angular/core';
 import {WorkPackageTableRelationColumnsService} from '../../state/wp-table-relation-columns.service';
 import {WorkPackageTable} from '../../wp-fast-table';
-import {WorkPackageTableRelationColumns} from '../../wp-table-relation-columns';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
+import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {takeUntil} from "rxjs/operators";
 
 export class RelationsTransformer {
 
@@ -12,9 +13,12 @@ export class RelationsTransformer {
   constructor(public readonly injector:Injector,
               table:WorkPackageTable) {
 
-    this.querySpace.updates.relationUpdates
-      .values$('Refreshing expanded relations on user request')
-      .subscribe((state:WorkPackageTableRelationColumns) => {
+    this.wpTableRelationColumns
+      .updates$()
+      .pipe(
+        takeUntil(this.querySpace.stopAllSubscriptions)
+      )
+      .subscribe(() => {
         table.redrawTableAndTimeline();
       });
   }

--- a/frontend/src/app/components/wp-fast-table/handlers/state/selection-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/selection-transformer.ts
@@ -40,7 +40,7 @@ export class SelectionTransformer {
 
 
     // Update selection state
-    this.wpTableSelection.selectionState.values$()
+    this.wpTableSelection.selection$()
       .pipe(
         takeUntil(this.querySpace.stopAllSubscriptions)
       )

--- a/frontend/src/app/components/wp-fast-table/handlers/state/timeline-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/timeline-transformer.ts
@@ -3,15 +3,19 @@ import {takeUntil} from 'rxjs/operators';
 import {WorkPackageTable} from '../../wp-fast-table';
 import {WorkPackageTableTimelineState} from '../../wp-table-timeline';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
+import {WorkPackageTableTimelineService} from "core-components/wp-fast-table/state/wp-table-timeline.service";
+import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 
 export class TimelineTransformer {
 
   public querySpace:IsolatedQuerySpace = this.injector.get(IsolatedQuerySpace);
+  public wpTableTimeline = this.injector.get(WorkPackageTableTimelineService);
 
   constructor(private readonly injector:Injector,
               private readonly table:WorkPackageTable) {
 
-   this.querySpace.timeline.values$()
+    this.wpTableTimeline
+      .live$()
       .pipe(
         takeUntil(this.querySpace.stopAllSubscriptions)
       )

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-columns.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-columns.service.ts
@@ -42,10 +42,6 @@ export class WorkPackageTableColumnsService extends WorkPackageQueryStateService
     super(querySpace);
   }
 
-  public get state():InputState<QueryColumn[]> {
-    return this.querySpace.columns;
-  }
-
   public valueFromQuery(query:QueryResource):QueryColumn[] {
     return [...query.columns];
   }
@@ -89,8 +85,8 @@ export class WorkPackageTableColumnsService extends WorkPackageQueryStateService
    * Retrieve the QueryColumn objects for the selected columns.
    * Returns a shallow copy with the original column objects.
    */
-  public getColumns():any[] {
-    return [ ...this.currentState ];
+  public getColumns():QueryColumn[] {
+    return [ ...this.current ];
   }
 
   /**
@@ -159,7 +155,7 @@ export class WorkPackageTableColumnsService extends WorkPackageQueryStateService
       return;
     }
 
-    this.current = columns;
+    this.update(columns);
   }
 
   public setColumnsById(columnIds:string[]) {
@@ -239,8 +235,8 @@ export class WorkPackageTableColumnsService extends WorkPackageQueryStateService
   }
 
   // only exists to cast the state
-  protected get currentState() {
-    return this.state.getValueOr([]);
+  protected get current() {
+    return this.lastUpdatedState.getValueOr([]);
   }
 
   // Get the available state

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-filters.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-filters.service.ts
@@ -67,10 +67,6 @@ export class WorkPackageTableFiltersService extends WorkPackageQueryStateService
     super(querySpace);
   }
 
-  protected get state():InputState<QueryFilterInstanceResource[]> {
-    return this.querySpace.filters;
-  }
-
   /**
    * Load all schemas for the current filters and fill respective states
    * @param query
@@ -81,7 +77,7 @@ export class WorkPackageTableFiltersService extends WorkPackageQueryStateService
 
     this.loadCurrentFiltersSchemas(filters).then(() => {
       this.availableState.putValue(schema.filtersSchemas.elements);
-      this.update(filters);
+      this.pristineState.putValue(filters);
     });
   }
 
@@ -89,7 +85,7 @@ export class WorkPackageTableFiltersService extends WorkPackageQueryStateService
    * Return whether rth
    */
   public get isEmpty() {
-    const value = this.state.value;
+    const value = this.lastUpdatedState.value;
     return !value || value.length === 0;
   }
 
@@ -103,7 +99,7 @@ export class WorkPackageTableFiltersService extends WorkPackageQueryStateService
    * @param filter
    */
   public add(filter:QueryFilterInstanceResource) {
-    this.state.doModify(filters => [...filters, filter]);
+    this.updatesState.putValue([...this.rawFilters, filter]);
   }
 
   /**
@@ -112,19 +108,17 @@ export class WorkPackageTableFiltersService extends WorkPackageQueryStateService
   public replace(id:string, modifier:(filter:QueryFilterInstanceResource) => void):void {
     let filter:QueryFilterInstanceResource = this.instantiate(id);
 
-    this.state.doModify(filters => {
-      let newFilters = [...filters];
-      modifier(filter);
+    let newFilters = [...this.rawFilters];
+    modifier(filter);
 
-      const index = this.findIndex(id);
-      if (index === -1) {
-        newFilters.push(filter);
-      } else {
-        newFilters.splice(index, 1, filter);
-      }
+    const index = this.findIndex(id);
+    if (index === -1) {
+      newFilters.push(filter);
+    } else {
+      newFilters.splice(index, 1, filter);
+    }
 
-      return newFilters;
-    });
+    this.update(newFilters);
   }
 
   /**
@@ -140,10 +134,9 @@ export class WorkPackageTableFiltersService extends WorkPackageQueryStateService
       return false;
     }
 
-    this.state.doModify(filters => {
-      modifier(filters[index]!);
-      return filters;
-    });
+    let filters = [...this.rawFilters];
+    modifier(filters[index]!);
+    this.update(filters);
 
     return true;
   }
@@ -170,9 +163,10 @@ export class WorkPackageTableFiltersService extends WorkPackageQueryStateService
   public remove(...filters:(QueryFilterInstanceResource|string)[]) {
     let mapper = (f:QueryFilterInstanceResource|string) => (f instanceof QueryFilterInstanceResource) ? f.id : f;
     let set = new Set<string>(filters.map(mapper));
-    this.state.doModify(value => {
-      return value.filter(f => !set.has(mapper(f)));
-    });
+
+    this.update(
+      this.rawFilters.filter(f => !set.has(mapper(f)))
+    );
   }
 
   /**
@@ -195,16 +189,6 @@ export class WorkPackageTableFiltersService extends WorkPackageQueryStateService
 
   private get availableSchemas():QueryFilterInstanceSchemaResource[] {
     return this.availableState.getValueOr([]);
-  }
-
-  /**
-   * Find an available filter by its ID. Can be used to instantiate or add
-   * with +get+ or +add+ methods on this service.
-   *
-   * @param id Internal identifier string of the filter
-   */
-  public findAvailableFilter(id:string):QueryFilterResource|undefined {
-    return _.find(this.availableFilters, f => f.id === id);
   }
 
   /**
@@ -282,7 +266,7 @@ export class WorkPackageTableFiltersService extends WorkPackageQueryStateService
    * without modification.
    */
   protected get rawFilters():QueryFilterInstanceResource[] {
-    return this.state.getValueOr([]);
+    return this.lastUpdatedState.value || [];
   }
 
   public get currentlyVisibleFilters() {
@@ -309,7 +293,7 @@ export class WorkPackageTableFiltersService extends WorkPackageQueryStateService
    * Filters service depends on two states
    */
   public onReady() {
-    return combine(this.state, this.availableState)
+    return combine(this.pristineState, this.availableState)
       .values$()
       .pipe(
         take(1),

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-group-by.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-group-by.service.ts
@@ -45,10 +45,6 @@ export class WorkPackageTableGroupByService extends WorkPackageQueryStateService
     super(querySpace);
   }
 
-  public get state():InputState<QueryGroupByResource|null> {
-    return this.querySpace.groupBy;
-  }
-
   valueFromQuery(query:QueryResource) {
     return query.groupBy || null;
   }
@@ -72,14 +68,8 @@ export class WorkPackageTableGroupByService extends WorkPackageQueryStateService
     return !!_.find(this.available, candidate => candidate.id === column.id);
   }
 
-  public update(groupBy:QueryGroupByResource|null) {
-    // hierarchies and group by are mutually exclusive
-    if (groupBy !== null) {
-      let hierarchy = this.querySpace.hierarchies.value!;
-      this.querySpace.hierarchies.putValue({ ...hierarchy, isVisible: false });
-    }
-
-    super.update(groupBy);
+  public disable() {
+    this.update(null);
   }
 
   public setBy(column:QueryColumn) {
@@ -91,7 +81,7 @@ export class WorkPackageTableGroupByService extends WorkPackageQueryStateService
   }
 
   public get current():QueryGroupByResource|null {
-    return this.state.getValueOr(null);
+    return this.lastUpdatedState.getValueOr(null);
   }
 
   protected get availableState() {
@@ -107,6 +97,7 @@ export class WorkPackageTableGroupByService extends WorkPackageQueryStateService
   }
 
   public isCurrentlyGroupedBy(column:QueryColumn):boolean {
-    return !!(this.current && this.current.id === column.id);
+    let cur = this.current;
+    return !!(cur && cur.id === column.id);
   }
 }

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-pagination.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-pagination.service.ts
@@ -50,10 +50,6 @@ export class WorkPackageTablePaginationService extends WorkPackageTableBaseServi
     super(querySpace);
   }
 
-  public get state():InputState<WorkPackageTablePagination> {
-    return this.querySpace.pagination;
-  }
-
   public get paginationObject():PaginationObject {
     if (this.current) {
       return {
@@ -86,7 +82,7 @@ export class WorkPackageTablePaginationService extends WorkPackageTableBaseServi
       currentState.total = object.total;
     }
 
-    this.state.putValue(currentState);
+    this.updatesState.putValue(currentState);
   }
 
   public updateFromResults(results:WorkPackageCollectionResource) {
@@ -101,6 +97,6 @@ export class WorkPackageTablePaginationService extends WorkPackageTableBaseServi
   }
 
   public get current():WorkPackageTablePagination {
-    return this.state.value!;
+    return this.lastUpdatedState.value!;
   }
 }

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-relation-columns.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-relation-columns.service.ts
@@ -61,10 +61,6 @@ export class WorkPackageTableRelationColumnsService extends WorkPackageTableBase
     super(querySpace);
   }
 
-  public get state():InputState<WorkPackageTableRelationColumns> {
-    return this.querySpace.relationColumns;
-  }
-
   public valueFromQuery(query:QueryResource):WorkPackageTableRelationColumns {
     // Take over current expanded values
     // which are not yet saved
@@ -81,7 +77,7 @@ export class WorkPackageTableRelationColumnsService extends WorkPackageTableBase
                               relations:RelationsStateValue|undefined,
                               eachCallback:(relation:RelationResource, column:QueryColumn, type:RelationColumnType) => void) {
     // Only if any relation columns or stored expansion state exist
-    if (!this.wpTableColumns.hasRelationColumns() || this.state.isPristine()) {
+    if (!(this.wpTableColumns.hasRelationColumns() && this.lastUpdatedState.hasValue())) {
       return;
     }
 
@@ -159,24 +155,21 @@ export class WorkPackageTableRelationColumnsService extends WorkPackageTableBase
   }
 
   public setExpandFor(workPackageId:string, columnId:string) {
-    this.state.doModify((value) => {
-      const update = { ...value };
-      update[workPackageId] = columnId;
-      return update;
-    });
+    const nextState = { ...this.current };
+    nextState[workPackageId] = columnId;
+
+    this.update(nextState);
   }
 
   public collapse(workPackageId:string) {
-    this.state.doModify((value:WorkPackageTableRelationColumns) => {
-      let update = {...value};
-      delete update[workPackageId];
+    const nextState = { ...this.current };
+    delete nextState[workPackageId];
 
-      return update;
-    });
+    this.update(nextState);
   }
 
   public get current():WorkPackageTableRelationColumns {
-    return this.state.getValueOr({});
+    return this.lastUpdatedState.getValueOr({});
   }
 }
 

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-selection.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-selection.service.ts
@@ -1,6 +1,6 @@
 import {WPTableRowSelectionState} from '../wp-table.interfaces';
 import {RenderedRow} from '../builders/primary-render-pass';
-import {InputState} from 'reactivestates';
+import {input} from 'reactivestates';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {WorkPackageCacheService} from 'core-components/work-packages/work-package-cache.service';
 import {Injectable} from '@angular/core';
@@ -10,17 +10,15 @@ import {States} from 'core-components/states.service';
 @Injectable()
 export class WorkPackageTableSelection {
 
-  public selectionState:InputState<WPTableRowSelectionState>;
+  private selectionState = input<WPTableRowSelectionState>();
 
   public constructor(readonly querySpace:IsolatedQuerySpace,
                      readonly states:States,
                      readonly wpCacheService:WorkPackageCacheService) {
-    this.selectionState = querySpace.selection;
 
-    if (this.selectionState.isPristine()) {
-      this.reset();
-    }
+    this.reset();
   }
+
 
   public isSelected(workPackageId:string) {
     return this.currentState.selected[workPackageId];
@@ -66,6 +64,13 @@ export class WorkPackageTableSelection {
    */
   public reset() {
     this.selectionState.putValue(this._emptyState);
+  }
+
+  /**
+   * Observe selection state
+   */
+  public selection$() {
+    return this.selectionState.values$();
   }
 
   /**

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-sort-by.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-sort-by.service.ts
@@ -47,17 +47,12 @@ export class WorkPackageTableSortByService extends WorkPackageQueryStateService<
     super(querySpace);
   }
 
-
-  public get state():InputState<QuerySortByResource[]> {
-    return this.querySpace.sortBy;
-  }
-
   public valueFromQuery(query:QueryResource) {
     return [...query.sortBy];
   }
 
   public onReadyWithAvailable():Observable<null> {
-    return combine(this.state, this.states.queries.sortBy)
+    return combine(this.pristineState, this.states.queries.sortBy)
       .values$()
       .pipe(
         mapTo(null)
@@ -97,9 +92,7 @@ export class WorkPackageTableSortByService extends WorkPackageQueryStateService<
     let available:QuerySortByResource = this.findAvailableDirection(column, criteria)!;
 
     if (available) {
-      this.state.doModify(() => {
-       return [available];
-      });
+      this.update([available]);
     }
   }
 
@@ -112,14 +105,11 @@ export class WorkPackageTableSortByService extends WorkPackageQueryStateService<
   }
 
   public add(sortBy:QuerySortByResource) {
-    this.state.doModify((current:QuerySortByResource[]) => {
-      let newValue = [sortBy, ...current];
-      return _
-        .uniqBy(newValue, sortBy => sortBy.column.$href)
-        .slice(0, 3);
+    let newValue = _
+      .uniqBy([sortBy, ...this.current], sortBy => sortBy.column.$href)
+      .slice(0, 3);
 
-      return current.concat(sortBy);
-    });
+    this.update(newValue);
   }
 
   public get isManualSortingMode():boolean {
@@ -140,7 +130,7 @@ export class WorkPackageTableSortByService extends WorkPackageQueryStateService<
   }
 
   public get current():QuerySortByResource[] {
-    return this.state.getValueOr([]);
+    return this.lastUpdatedState.getValueOr([]);
   }
 
   private get availableState() {

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-sum.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-sum.service.ts
@@ -39,16 +39,12 @@ export class WorkPackageTableSumService extends WorkPackageQueryStateService<boo
     super(querySpace);
   }
 
-  public get state():InputState<boolean> {
-    return this.querySpace.sum;
-  }
-
   public valueFromQuery(query:QueryResource) {
     return !!query.sums;
   }
 
   public initialize(query:QueryResource) {
-    this.state.putValue(!!query.sums);
+    this.pristineState.putValue(!!query.sums);
   }
 
   public hasChanged(query:QueryResource) {
@@ -61,11 +57,11 @@ export class WorkPackageTableSumService extends WorkPackageQueryStateService<boo
   }
 
   public toggle() {
-    this.state.putValue(!this.current);
+    this.updatesState.putValue(!this.current);
   }
 
   public setEnabled(value:boolean) {
-    this.state.putValue(value);
+    this.updatesState.putValue(value);
   }
 
   public get isEnabled() {
@@ -73,6 +69,6 @@ export class WorkPackageTableSumService extends WorkPackageQueryStateService<boo
   }
 
   public get current():boolean {
-    return this.state.getValueOr(false);
+    return this.lastUpdatedState.getValueOr(false);
   }
 }

--- a/frontend/src/app/components/wp-fast-table/state/wp-table-timeline.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-table-timeline.service.ts
@@ -46,10 +46,6 @@ export class WorkPackageTableTimelineService extends WorkPackageQueryStateServic
     super(querySpace);
   }
 
-  public get state():InputState<WorkPackageTableTimelineState> {
-    return this.querySpace.timeline;
-  }
-
   public valueFromQuery(query:QueryResource) {
     return {
       ...this.defaultState,
@@ -89,7 +85,7 @@ export class WorkPackageTableTimelineService extends WorkPackageQueryStateServic
   }
 
   public setVisible(value:boolean) {
-    this.state.putValue({...this.current, visible: value});
+    this.updatesState.putValue({...this.current, visible: value});
   }
 
   public get isVisible() {
@@ -141,9 +137,10 @@ export class WorkPackageTableTimelineService extends WorkPackageQueryStateServic
       return this.applyZoomLevel(level, delta);
     }
 
-    if (this.appliedZoomLevel && this.appliedZoomLevel !== 'auto') {
+    const applied = this.appliedZoomLevel;
+    if (applied && applied !== 'auto') {
       // When we have a real zoom value, use delta on that one
-      this.applyZoomLevel(this.appliedZoomLevel, delta);
+      this.applyZoomLevel(applied, delta);
     } else {
       // Use the maximum zoom value
       const target = delta < 0 ? 'days' : 'years';
@@ -160,7 +157,7 @@ export class WorkPackageTableTimelineService extends WorkPackageQueryStateServic
   }
 
   public get current():WorkPackageTableTimelineState {
-    return this.state.getValueOr(this.defaultState);
+    return this.lastUpdatedState.getValueOr(this.defaultState);
   }
 
   /**
@@ -168,7 +165,7 @@ export class WorkPackageTableTimelineService extends WorkPackageQueryStateServic
    * @param update
    */
   private modify(update:Partial<WorkPackageTableTimelineState>) {
-    this.update({ ...this.current, ...update });
+    this.update({ ...this.current, ...update } as WorkPackageTableTimelineState);
   }
 
   /**

--- a/frontend/src/app/components/wp-fast-table/wp-table-highlight.ts
+++ b/frontend/src/app/components/wp-fast-table/wp-table-highlight.ts
@@ -31,5 +31,5 @@ import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 
 export interface WorkPackageTableHighlight {
   mode:HighlightingMode;
-  selectedAttributes?:HalResource[];
+  selectedAttributes?:HalResource[]|undefined;
 }

--- a/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
@@ -158,8 +158,8 @@ export class WorkPackageInlineCreateComponent implements OnInit, AfterViewInit, 
    * we need to manually ensure the inline create row gets refreshed as well.
    */
   private refreshOnColumnChanges() {
-    this.querySpace.columns
-      .values$()
+    this.wpTableColumns
+      .updates$()
       .pipe(
         filter(() => this.isActive), // Take only when row is inserted
         untilComponentDestroyed(this),

--- a/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
@@ -20,6 +20,8 @@ import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/iso
 import {Injectable} from '@angular/core';
 import {QuerySchemaResource} from 'core-app/modules/hal/resources/query-schema-resource';
 import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
+import {combineLatest, Observable} from "rxjs";
+import {take} from "rxjs/operators";
 
 @Injectable()
 export class WorkPackageStatesInitializationService {
@@ -109,6 +111,11 @@ export class WorkPackageStatesInitializationService {
     this.wpTableRelationColumns.initialize(query, results);
 
     this.wpTableAdditionalElements.initialize(results.elements);
+
+    this.querySpace.additionalRequiredWorkPackages
+      .values$()
+      .pipe(take(1))
+      .subscribe(() => this.querySpace.initialized.putValue(null));
   }
 
   public updateChecksum(query:QueryResource, results:WorkPackageCollectionResource) {
@@ -146,20 +153,20 @@ export class WorkPackageStatesInitializationService {
     const reason = 'Clearing states before re-initialization.';
 
     // Clear immediate input states
+    this.querySpace.initialized.clear(reason);
     this.querySpace.query.clear(reason);
     this.querySpace.rows.clear(reason);
-    this.querySpace.columns.clear(reason);
-    this.querySpace.sortBy.clear(reason);
-    this.querySpace.groupBy.clear(reason);
-    this.querySpace.sum.clear(reason);
     this.querySpace.results.clear(reason);
     this.querySpace.groups.clear(reason);
     this.querySpace.additionalRequiredWorkPackages.clear(reason);
 
+    this.wpTableFilters.clear(reason);
+    this.wpTableColumns.clear(reason);
+    this.wpTableSortBy.clear(reason);
+    this.wpTableGroupBy.clear(reason);
+    this.wpTableSum.clear(reason);
+
     // Clear rendered state
     this.querySpace.rendered.clear(reason);
-
-    // Needed for reinitialization of WpSetComponent
-    this.querySpace.query.clear();
   }
 }

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/sort-by-tab.component.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/sort-by-tab.component.ts
@@ -74,11 +74,8 @@ export class WpTableConfigurationSortByTab implements TabComponent {
 
   ngOnInit() {
     this.wpTableSortBy
-      .state
-      .values$()
-      .pipe(take(1))
-      .toPromise()
-      .then(() => {
+      .onReadyWithAvailable()
+      .subscribe(() => {
         let allColumns:SortColumn[] = this.wpTableSortBy.available.filter(
           (sort:QuerySortByResource) => {
             return !sort.column.$href!.endsWith('/parent');

--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/timelines-tab.component.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/timelines-tab.component.ts
@@ -56,11 +56,12 @@ export class WpTableConfigurationTimelinesTab implements TabComponent {
   }
 
   public onSave() {
-    let current = this.wpTableTimeline.current;
-    current.visible = this.timelineVisible;
-    current.labels = this.labels;
-    current.zoomLevel = this.zoomLevel;
-    this.wpTableTimeline.state.putValue(current);
+    this.wpTableTimeline.update({
+      ...this.wpTableTimeline.current,
+      visible: this.timelineVisible,
+      labels: this.labels,
+      zoomLevel: this.zoomLevel
+    });
   }
 
   public updateLabels(key:keyof TimelineLabels, value:string|null) {

--- a/frontend/src/app/components/wp-table/table-pagination/wp-table-pagination.component.ts
+++ b/frontend/src/app/components/wp-table/table-pagination/wp-table-pagination.component.ts
@@ -29,7 +29,7 @@
 import {WorkPackageTablePaginationService} from '../../wp-fast-table/state/wp-table-pagination.service';
 import {WorkPackageTablePagination} from '../../wp-fast-table/wp-table-pagination';
 import {TablePaginationComponent} from 'core-components/table-pagination/table-pagination.component';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
+import {componentDestroyed, untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {PaginationService} from 'core-components/table-pagination/pagination-service';
@@ -50,7 +50,10 @@ export class WorkPackageTablePaginationComponent extends TablePaginationComponen
 
   public newPagination() {
     this.wpTablePagination
-      .observeUntil(componentDestroyed(this))
+      .live$()
+      .pipe(
+        untilComponentDestroyed(this)
+      )
       .subscribe((wpPagination:WorkPackageTablePagination) => {
         this.pagination = wpPagination.current;
         this.update();

--- a/frontend/src/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
+++ b/frontend/src/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
@@ -41,6 +41,7 @@ import {WorkPackageTimelineCell} from '../cells/wp-timeline-cell';
 import {WorkPackageTimelineTableController} from '../container/wp-timeline-container.directive';
 import {timelineElementCssClass, TimelineViewParameters} from '../wp-timeline';
 import {TimelineRelationElement, workPackagePrefix} from './timeline-relation-element';
+import {WorkPackageTableTimelineService} from "core-components/wp-fast-table/state/wp-table-timeline.service";
 
 const DEBUG_DRAW_RELATION_LINES_WITH_COLOR = false;
 
@@ -91,6 +92,7 @@ export class WorkPackageTableTimelineRelations implements OnInit, OnDestroy {
               public elementRef:ElementRef,
               public states:States,
               public workPackageTimelineTableController:WorkPackageTimelineTableController,
+              public wpTableTimeline:WorkPackageTableTimelineService,
               public wpRelations:WorkPackageRelationsService) {
 
   }
@@ -121,12 +123,12 @@ export class WorkPackageTableTimelineRelations implements OnInit, OnDestroy {
    */
   private setupRelationSubscription() {
     // for all visible WorkPackage rows...
-    combineLatest(
+    combineLatest([
       this.querySpace.renderedWorkPackages.values$(),
-      this.querySpace.timeline.values$()
-    )
+      this.wpTableTimeline.live$()
+    ])
       .pipe(
-        filter(([rendered, timeline]) => timeline.visible),
+        filter(([_, timeline]) => timeline.visible),
         takeUntil(componentDestroyed(this)),
         map(([rendered, _]) => rendered)
       )
@@ -154,7 +156,7 @@ export class WorkPackageTableTimelineRelations implements OnInit, OnDestroy {
     this.states.workPackages.observeChange()
       .pipe(
         takeUntil(componentDestroyed(this)),
-        filter(() => this.querySpace.timeline.mapOr(v => v.visible, false))
+        filter(() => this.wpTableTimeline.isVisible)
       )
       .subscribe(([workPackageId]) => {
         this.renderWorkPackagesRelations([workPackageId]);

--- a/frontend/src/app/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/components/wp-table/wp-table.directive.html
@@ -1,4 +1,4 @@
-<div class="work-packages-split-view--tabletimeline-content">
+<div class="work-packages-split-view--tabletimeline-content" *ngIf="query">
   <div class="work-packages-tabletimeline--table-side work-package-table--container __hidden_overflow_container">
     <table class="keyboard-accessible-list generic-table work-package-table">
       <colgroup>
@@ -18,7 +18,7 @@
               <op-icon *ngIf="manualSortEnabled" icon-classes="icon-sort-by"></op-icon>
             </div>
           </th>
-          <th *ngFor="let column of columns"
+          <th *ngFor="let column of columns; trackBy:trackByHref"
               class="wp-table--table-header">
             <sortHeader [headerColumn]="column"
                         [locale]="column.custom_field && column.custom_field.name_locale || locale"

--- a/frontend/src/app/modules/boards/board/board-filter/board-filter.component.ts
+++ b/frontend/src/app/modules/boards/board/board-filter/board-filter.component.ts
@@ -8,7 +8,7 @@ import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/iso
 import {QueryResource} from "core-app/modules/hal/resources/query-resource";
 import {HalResourceService} from "core-app/modules/hal/services/hal-resource.service";
 import {WorkPackageTableFiltersService} from "core-components/wp-fast-table/state/wp-table-filters.service";
-import {componentDestroyed} from "ng2-rx-componentdestroyed";
+import {componentDestroyed, untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-filter-instance-resource";
 import {UrlParamsHelperService} from "core-components/wp-query/url-params-helper";
 import {StateService} from "@uirouter/core";
@@ -78,8 +78,11 @@ export class BoardFilterComponent implements OnDestroy {
 
   private updateChecksumOnFilterChanges() {
     this.wpTableFilters
-      .observeUntil(componentDestroyed(this))
-      .pipe(skip(1))
+      .live$()
+      .pipe(
+        untilComponentDestroyed(this),
+        skip(1)
+      )
       .subscribe(() => {
 
         const filters:QueryFilterInstanceResource[] = this.wpTableFilters.current;

--- a/frontend/src/app/modules/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/modules/calendar/wp-calendar/wp-calendar.component.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, Input, OnDestroy, OnInit, ViewChild, SecurityContext} from "@angular/core";
+import {Component, ElementRef, Input, OnDestroy, OnInit, SecurityContext, ViewChild} from "@angular/core";
 import {CalendarComponent} from 'ng-fullcalendar';
 import {Options} from 'fullcalendar';
 import {States} from "core-components/states.service";
@@ -7,16 +7,15 @@ import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {WorkPackageCollectionResource} from "core-app/modules/hal/resources/wp-collection-resource";
 import {WorkPackageTableFiltersService} from "core-components/wp-fast-table/state/wp-table-filters.service";
+import * as moment from "moment";
 import {Moment} from "moment";
 import {WorkPackagesListService} from "core-components/wp-list/wp-list.service";
 import {StateService} from "@uirouter/core";
 import {UrlParamsHelperService} from "core-components/wp-query/url-params-helper";
-import * as moment from "moment";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
 import {DomSanitizer} from "@angular/platform-browser";
 import {WorkPackagesListChecksumService} from "core-components/wp-list/wp-list-checksum.service";
-import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-filter-instance-resource";
 import {OpTitleService} from "core-components/html/op-title.service";
 
 @Component({

--- a/frontend/src/app/modules/hal/hal-link/hal-link.ts
+++ b/frontend/src/app/modules/hal/hal-link/hal-link.ts
@@ -27,10 +27,7 @@
 //++
 
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
-import {
-  HTTPSupportedMethods
-} from 'core-app/modules/hal/services/hal-resource.service';
-import {HalResourceService} from 'core-app/modules/hal/services/hal-resource.service';
+import {HalResourceService, HTTPSupportedMethods} from 'core-app/modules/hal/services/hal-resource.service';
 
 export interface HalLinkInterface {
   href:string | null;

--- a/frontend/src/app/modules/work_packages/query-space/isolated-query-space.ts
+++ b/frontend/src/app/modules/work_packages/query-space/isolated-query-space.ts
@@ -1,24 +1,14 @@
 import {RenderedRow} from 'app/components/wp-fast-table/builders/primary-render-pass';
-import {WorkPackageTableHierarchies} from 'app/components/wp-fast-table/wp-table-hierarchies';
-import {WorkPackageTablePagination} from 'app/components/wp-fast-table/wp-table-pagination';
-import {WorkPackageTableRelationColumns} from 'app/components/wp-fast-table/wp-table-relation-columns';
-import {WorkPackageTableTimelineState} from 'app/components/wp-fast-table/wp-table-timeline';
-import {WPTableRowSelectionState} from 'app/components/wp-fast-table/wp-table.interfaces';
-import {combine, derive, DerivedState, input, InputState, State, StatesGroup} from 'reactivestates';
+import {derive, input, InputState, State, StatesGroup} from 'reactivestates';
 import {Subject} from 'rxjs';
 import {Injectable} from '@angular/core';
-import {SwitchState} from 'core-components/states/switch-state';
-import {map, mapTo} from 'rxjs/operators';
+import {map} from 'rxjs/operators';
 import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
 import {GroupObject, WorkPackageCollectionResource} from 'core-app/modules/hal/resources/wp-collection-resource';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
-import {WorkPackageTableHighlight} from "core-components/wp-fast-table/wp-table-highlight";
 import {QueryFormResource} from "core-app/modules/hal/resources/query-form-resource";
 import {WPFocusState} from "core-components/wp-fast-table/state/wp-table-focus.service";
 import {QueryColumn} from "core-components/wp-query/query-column";
-import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-filter-instance-resource";
-import {QueryGroupByResource} from "core-app/modules/hal/resources/query-group-by-resource";
-import {QuerySortByResource} from "core-app/modules/hal/resources/query-sort-by-resource";
 import {WorkPackageTableRefreshRequest} from "core-components/wp-table/wp-table-refresh-request.service";
 
 @Injectable()
@@ -45,24 +35,8 @@ export class IsolatedQuerySpace extends StatesGroup {
   // Set of columns in strict order of appearance
   columns = input<QueryColumn[]>();
 
-  // Set of filters
-  filters = input<QueryFilterInstanceResource[]>();
-  // Active and available sort by
-  sortBy = input<QuerySortByResource[]>();
-  // Active and available group by
-  groupBy = input<QueryGroupByResource|null>();
-  // is query summed
-  sum = input<boolean>();
-  // pagination information
-  pagination = input<WorkPackageTablePagination>();
-  // Table row selection state
-  selection = input<WPTableRowSelectionState>();
   // Current state of collapsed groups (if any)
   collapsedGroups = input<{ [identifier:string]:boolean }>();
-  // Hierarchies of table
-  hierarchies = input<WorkPackageTableHierarchies>();
-  // Highlighting mode
-  highlighting = input<WorkPackageTableHighlight>();
   // State to be updated when the table is up to date
   rendered = input<RenderedRow[]>();
 
@@ -73,58 +47,14 @@ export class IsolatedQuerySpace extends StatesGroup {
   // Current focused work package (e.g, row preselected for details button)
   focusedWorkPackage:InputState<WPFocusState> = input<WPFocusState>();
 
-  // State to determine timeline visibility
-  timeline = input<WorkPackageTableTimelineState>();
-
   // Subject used to unregister all listeners of states above.
   stopAllSubscriptions = new Subject();
   // Fire when table refresh is required
   refreshRequired = input<WorkPackageTableRefreshRequest>();
 
-  // Expanded relation columns
-  relationColumns = input<WorkPackageTableRelationColumns>();
-
   // Required work packages to be rendered by hierarchy mode + relation columns
   additionalRequiredWorkPackages = input<null>();
 
-  tableRendering = new TableRenderingStates(this);
-
-  // Current context of table loading
-  ready = new SwitchState<'Query loaded'>();
-
-  // Updater states on user input
-  updates = new UserUpdaterStates(this);
-}
-
-export class TableRenderingStates {
-  constructor(private querySpace:IsolatedQuerySpace) {
-  }
-
-  // State when all required input states for the current query are ready
-  private combinedquerySpaces = combine(
-    this.querySpace.rows,
-    this.querySpace.columns,
-    this.querySpace.sum,
-    this.querySpace.sortBy,
-    this.querySpace.groupBy,
-    this.querySpace.additionalRequiredWorkPackages
-  );
-
-  onQueryUpdated:DerivedState<unknown[], [undefined], null, undefined> =
-    derive(this.combinedquerySpaces, ($, ) => $.pipe(mapTo(null)));
-}
-
-export class UserUpdaterStates {
-
-  constructor(private querySpace:IsolatedQuerySpace) {
-  }
-
-  columnsUpdates = this.querySpace.ready.fireOnStateChange(this.querySpace.columns,
-    'Query loaded');
-
-  hierarchyUpdates = this.querySpace.ready.fireOnStateChange(this.querySpace.hierarchies,
-    'Query loaded');
-
-  relationUpdates = this.querySpace.ready.fireOnStateChange(this.querySpace.relationColumns,
-    'Query loaded');
+  // Input state that emits whenever table services have initialized
+  initialized = input<unknown>();
 }

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -197,11 +197,11 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
   }
 
   protected setupInformationLoadedListener() {
-    this.querySpace.tableRendering.onQueryUpdated
+    this
+      .querySpace
+      .initialized
       .values$()
-      .pipe(
-        take(1)
-      )
+      .pipe(take(1))
       .subscribe(() => {
         this.tableInformationLoaded = true;
         this.cdRef.detectChanges();

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
@@ -31,7 +31,7 @@ import {StateService, TransitionService} from '@uirouter/core';
 import {AuthorisationService} from 'core-app/modules/common/model-auth/model-auth.service';
 import {WorkPackageCollectionResource} from 'core-app/modules/hal/resources/wp-collection-resource';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
-import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
+import {componentDestroyed, untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {auditTime, filter, take, withLatestFrom} from 'rxjs/operators';
 import {LoadingIndicatorService} from "core-app/modules/common/loading-indicator/loading-indicator.service";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
@@ -99,23 +99,17 @@ export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
   }
 
   private setupQueryObservers() {
-    this
-      .querySpace
-      .ready
-      .fireOnStateChange(
-        this.wpTablePagination.state,
-      'Query loaded'
-      )
-      .values$()
+    this.wpTablePagination
+      .updates$()
       .pipe(
         untilComponentDestroyed(this),
         withLatestFrom(this.querySpace.query.values$())
       ).subscribe(([pagination, query]) => {
-        if (this.wpListChecksumService.isQueryOutdated(query, pagination)) {
-          this.wpListChecksumService.update(query, pagination);
-          this.refresh(true, false);
-        }
-      });
+      if (this.wpListChecksumService.isQueryOutdated(query, pagination)) {
+        this.wpListChecksumService.update(query, pagination);
+        this.refresh(true, false);
+      }
+    });
 
     this.setupChangeObserver(this.wpTableFilters, true);
     this.setupChangeObserver(this.wpTableGroupBy);
@@ -137,28 +131,28 @@ export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
   protected setupChangeObserver(service:WorkPackageQueryStateService<unknown>, firstPage:boolean = false) {
     const queryState = this.querySpace.query;
 
-    this.querySpace.ready
-      .fireOnStateChange(service.readonlyState, 'Query loaded')
-      .values$()
+    service
+      .updates$()
       .pipe(
         untilComponentDestroyed(this),
         filter(() => queryState.hasValue() && service.hasChanged(queryState.value!))
-      ).subscribe(() => {
-      const newQuery = queryState.value!;
-      const triggerUpdate = service.applyToQuery(newQuery);
-      this.querySpace.query.putValue(newQuery);
+      )
+      .subscribe(() => {
+        const newQuery = queryState.value!;
+        const triggerUpdate = service.applyToQuery(newQuery);
+        this.querySpace.query.putValue(newQuery);
 
-      // Update the current checksum
-      this.wpListChecksumService.updateIfDifferent(newQuery, this.wpTablePagination.current);
+        // Update the current checksum
+        this.wpListChecksumService.updateIfDifferent(newQuery, this.wpTablePagination.current);
 
-      // Update the page, if the change requires it
-      if (triggerUpdate) {
-        this.wpTableRefresh.request(
-          'Query updated by user',
-          { visible: true, firstPage: firstPage }
-        );
-      }
-    });
+        // Update the page, if the change requires it
+        if (triggerUpdate) {
+          this.wpTableRefresh.request(
+            'Query updated by user',
+            { visible: true, firstPage: firstPage }
+          );
+        }
+      });
   }
 
   /**

--- a/spec/features/calendars/calendars_spec.rb
+++ b/spec/features/calendars/calendars_spec.rb
@@ -88,10 +88,11 @@ describe 'Work package calendars', type: :feature, js: true do
     expect(page)
       .to have_no_selector '.fc-event-container', text: another_future_work_package.subject
 
+    filters.expect_filter_count 1
+
     filters.open
     # The filter for the time frame added implicitly should not be visible
     filters.expect_no_filter_by('Dates interval', 'datesInterval')
-    filters.expect_filter_count 1
 
     # The user can filter by e.g. the subject filter
     filters.add_filter_by 'Subject', 'contains', ['Another']


### PR DESCRIPTION
Separates the data flow of wp table services into two streams:

The `pristine` state, which can be retrieved individually through the `pristine$` observable, represents the state from the last update

The `updates` state, which can be retrieved individually through the `updates$` observable, represents only values that were changed in services

The `live$` observable, which returns the most recent value of either