### PR TITLE
[30421] Disable drag and drop for relational sub rows

### DIFF
--- a/frontend/src/app/components/wp-fast-table/builders/drag-and-drop/drag-drop-handle-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/drag-and-drop/drag-drop-handle-builder.ts
@@ -1,6 +1,5 @@
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {wpCellTdClassName} from "core-components/wp-fast-table/builders/cell-builder";
-import {OpTableActionsService} from "core-components/wp-table/table-actions/table-actions.service";
 import {Injector} from "@angular/core";
 import {TableDragActionsRegistryService} from "core-components/wp-table/drag-and-drop/actions/table-drag-actions-registry.service";
 import {TableDragActionService} from "core-components/wp-table/drag-and-drop/actions/table-drag-action.service";

--- a/frontend/src/app/components/wp-fast-table/builders/drag-and-drop/drag-drop-handle-render-pass.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/drag-and-drop/drag-drop-handle-render-pass.ts
@@ -1,0 +1,34 @@
+import {Injector} from '@angular/core';
+import {WorkPackageTableColumnsService} from '../../state/wp-table-columns.service';
+import {PrimaryRenderPass, RowRenderInfo} from '../primary-render-pass';
+import {DragDropHandleBuilder} from "core-components/wp-fast-table/builders/drag-and-drop/drag-drop-handle-builder";
+import {WorkPackageTable} from "core-components/wp-fast-table/wp-fast-table";
+
+export class DragDropHandleRenderPass {
+
+  public wpTableColumns = this.injector.get(WorkPackageTableColumnsService);
+
+  // Drag & Drop handle builder
+  protected dragDropHandleBuilder = new DragDropHandleBuilder(this.injector);
+
+  constructor(public readonly injector:Injector,
+              private table:WorkPackageTable,
+              private tablePass:PrimaryRenderPass) {
+  }
+
+  public render() {
+    this.tablePass.renderedOrder.forEach((row:RowRenderInfo, position:number) => {
+      // We only care for rows that are natural work packages and are not relation sub-rows
+      if (!row.workPackage || row.renderType ===  'relations') {
+        return;
+      }
+
+      const handle = this.dragDropHandleBuilder.build(row.workPackage);
+
+      if (handle) {
+        const element:HTMLElement = this.tablePass.tableBody.children[position] as HTMLElement;
+        element.replaceChild(handle, element.firstElementChild!);
+      }
+    });
+  }
+}

--- a/frontend/src/app/components/wp-fast-table/builders/primary-render-pass.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/primary-render-pass.ts
@@ -12,6 +12,7 @@ import {
   IWorkPackageEditingServiceToken
 } from "../../wp-edit-form/work-package-editing.service.interface";
 import {HighlightingRenderPass} from "core-components/wp-fast-table/builders/highlighting/row-highlight-render-pass";
+import {DragDropHandleRenderPass} from "core-components/wp-fast-table/builders/drag-and-drop/drag-drop-handle-render-pass";
 
 export type RenderedRowType = 'primary' | 'relations';
 
@@ -53,6 +54,9 @@ export abstract class PrimaryRenderPass {
   /** Additional render pass that handles table relation rendering */
   public relations:RelationsRenderPass;
 
+  /** Additional render pass that handles drag'n'drop handle rendering */
+  public dragDropHandle:DragDropHandleRenderPass;
+
   /** Additional render pass that handles highlighting of rows */
   public highlighting:HighlightingRenderPass;
 
@@ -86,6 +90,10 @@ export abstract class PrimaryRenderPass {
 
     timeOutput('Relations render pass', () => {
       this.relations.render();
+    });
+
+    timeOutput('Drag handle render pass', () => {
+      this.dragDropHandle.render();
     });
 
     // Synchronize the rows to timeline
@@ -150,6 +158,7 @@ export abstract class PrimaryRenderPass {
   protected prepare() {
     this.timeline = new TimelineRenderPass(this.injector, this.workPackageTable, this);
     this.relations = new RelationsRenderPass(this.injector, this.workPackageTable, this);
+    this.dragDropHandle = new DragDropHandleRenderPass(this.injector, this.workPackageTable, this);
     this.highlighting = new HighlightingRenderPass(this.injector, this.workPackageTable, this);
     this.tableBody = document.createDocumentFragment();
     this.renderedOrder = [];

--- a/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
@@ -11,7 +11,6 @@ import {CellBuilder, wpCellTdClassName} from '../cell-builder';
 import {RelationCellbuilder} from '../relation-cell-builder';
 import {checkedClassName} from '../ui-state-link-builder';
 import {TableActionRenderer} from 'core-components/wp-fast-table/builders/table-action-renderer';
-import {DragDropHandleBuilder} from "core-components/wp-fast-table/builders/drag-and-drop/drag-drop-handle-builder";
 
 // Work package table row entries
 export const tableRowClassName = 'wp-table--row';
@@ -40,9 +39,6 @@ export class SingleRowBuilder {
 
   // Details Link builder
   protected contextLinkBuilder = new TableActionRenderer(this.injector);
-
-  // Drag & Drop handle builder
-  protected dragDropHandleBuilder = new DragDropHandleBuilder(this.injector);
 
   // Build the augmented columns set to render with
   protected readonly augmentedColumns:QueryColumn[] = this.buildAugmentedColumns();
@@ -80,8 +76,6 @@ export class SingleRowBuilder {
 
     // Handle property types
     switch (column.id) {
-      case internalSortColumn.id:
-        return this.dragDropHandleBuilder.build(workPackage);
       case internalContextMenuColumn.id:
         if (this.workPackageTable.configuration.actionsColumnEnabled) {
           return this.contextLinkBuilder.build(workPackage);


### PR DESCRIPTION
When having a relational column, there can be subelements displayed in the table. These are currently not sortable. 

Therefore this PR adds a separate render pass for the drag and drop handle. Thereby the drag and drop for relation sub rows is disabled.

https://community.openproject.com/projects/openproject/work_packages/30421/activity