### PR TITLE
[30426] User with :manage_boards but without :manage_public_queries can create faulty board columns

### DIFF
--- a/frontend/src/app/modules/boards/board/board.ts
+++ b/frontend/src/app/modules/boards/board/board.ts
@@ -3,7 +3,6 @@ import {GridResource} from "core-app/modules/hal/resources/grid-resource";
 import {CardHighlightingMode} from "core-components/wp-fast-table/builders/highlighting/highlighting-mode.const";
 import {ApiV3Filter} from "core-components/api/api-v3/api-v3-filter-builder";
 
-export type BoardDisplayMode = 'table'|'cards';
 export type BoardType = 'free'|'action';
 
 export class Board {
@@ -36,10 +35,6 @@ export class Board {
     }
 
     return this.grid.options.attribute as string;
-  }
-
-  public get displayMode():BoardDisplayMode {
-    return 'cards';
   }
 
   public set highlightingMode(val:CardHighlightingMode) {

--- a/modules/boards/config/locales/js-en.yml
+++ b/modules/boards/config/locales/js-en.yml
@@ -29,8 +29,9 @@ en:
       new_board: 'New board'
       add_list: 'Add list'
       add_card: 'Add card'
-      error_loading_the_list: "Error loading the list: %{error_message}"
       error_attribute_not_writable: "Cannot move the work package, %{attribute} is not writable."
+      error_loading_the_list: "Error loading the list: %{error_message}"
+      error_permission_missing: "The permission to create public queries is missing"
       click_to_remove_list: "Click to remove this list"
       board_type:
         free: 'Basic board'


### PR DESCRIPTION
When a user without `manage_public_queries` permission tries to create a new board list, a private query is created. This leads to errors for all others users. 

This happens because during the creation only those attributes are send within the payload, that are writable by the user. The `public` attribute is only changeable with the above named permission.

Since we only know with a given schema whether the user has the correct permission, this PR shows an error message when pressing "add list" and does not hide the button at all.

https://community.openproject.com/projects/openproject/work_packages/30426/activity