### PR TITLE
Spike to show reduced ghost row as a border only

### DIFF
--- a/app/assets/stylesheets/vendor/_dragula.sass
+++ b/app/assets/stylesheets/vendor/_dragula.sass
@@ -15,6 +15,17 @@
 
 .gu-transit
   opacity: 0.2
+  height: 1px !important
+  padding: 0 !important
+
+  td
+    border-top: 1px solid black !important
+    height: 1px !important
+    padding: 0 !important
+    line-height: 1px !important
+
+  span
+    display: none !important
 
 .dragula-handle
   cursor: pointer


### PR DESCRIPTION
:no_entry_sign: Do not merge