### PR TITLE
reduce db hits for wp schemas

### DIFF
--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -61,8 +61,12 @@ module Type::Attributes
     #
     # @return [Hash{String => Hash}] Map from attribute names to options.
     def all_work_package_form_attributes(merge_date: false)
+      wp_cf_cache_parts = RequestStore.fetch(:wp_cf_max_updated_at_and_count) do
+                            WorkPackageCustomField.pluck(Arel.sql('max(updated_at), count(id)')).flatten
+                          end
+
       OpenProject::Cache.fetch('all_work_package_form_attributes',
-                               *WorkPackageCustomField.pluck(Arel.sql('max(updated_at), count(id)')).flatten,
+                               *wp_cf_cache_parts,
                                merge_date) do
         calculate_all_work_package_form_attributes(merge_date)
       end

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -40,7 +40,7 @@ module API
           include API::Caching::CachedRepresenter
           cached_representer key_parts: %i[project type],
                              dependencies: -> {
-                               Authorization.roles(User.current, represented.project).map(&:permissions).sort +
+                               Authorization.roles(User.current, represented.project).eager_load(:role_permissions).map(&:permissions).sort +
                                  [Setting.work_package_done_ratio]
                              }
 


### PR DESCRIPTION
Reduces some of the n+1 queries occurring when rendering a set of work package schemas.