### PR TITLE
Reduce number of rendered DOM elements in the WP table.

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -123,9 +123,8 @@ html:not(.-browser-mobile)
 .wp-table--cell .ui-datepicker
   margin-left: -38%
 
-.wp-table--cell-container
+.wp-table--cell-td
   @extend .ellipsis
-  display: block
   // Because of the display: block the elements now
   // take up the whole of the cell. This would block
   // the user from using click (to select) or double-click (to open full screen)
@@ -136,13 +135,18 @@ html:not(.-browser-mobile)
   pointer-events: none
 
   .inplace-edit
-    display: initial
     pointer-events: all
 
   &.id .inplace-edit
     pointer-events: none
     a
       pointer-events: all
+
+  edit-form-portal
+    display: flow-root
+
+  .wp-table--cell-span
+    display: inline
 
 // Some padding for the inner cells of the display fields
 .wp-table--cell-span

--- a/frontend/src/app/components/wp-edit-form/table-row-edit-context.ts
+++ b/frontend/src/app/components/wp-edit-form/table-row-edit-context.ts
@@ -63,7 +63,7 @@ export class TableRowEditContext implements WorkPackageEditContext {
   }
 
   public findContainer(fieldName:string):JQuery {
-    return this.rowContainer.find(`.${tdClassName}.${fieldName} .${editCellContainer}`).first();
+    return this.rowContainer.find(`.${tdClassName}.${fieldName}`).first();
   }
 
   public findCell(fieldName:string) {
@@ -94,15 +94,15 @@ export class TableRowEditContext implements WorkPackageEditContext {
   }
 
   public reset(workPackage:WorkPackageResource, fieldName:string, focus?:boolean) {
-    const cell = this.findContainer(fieldName);
+    const td = this.findContainer(fieldName);
 
-    if (cell.length) {
+    if (td.length) {
       this.findCell(fieldName).css('width', '');
       this.findCell(fieldName).css('max-width', '');
-      this.cellBuilder.refresh(cell[0], workPackage, fieldName);
+      let el = this.cellBuilder.refresh(td[0], workPackage, fieldName);
 
       if (focus) {
-        this.FocusHelper.focusElement(cell);
+        this.FocusHelper.focusElement(jQuery(el));
       }
     }
   }

--- a/frontend/src/app/components/wp-fast-table/builders/cell-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/cell-builder.ts
@@ -17,18 +17,15 @@ export class CellBuilder {
 
   public build(workPackage:WorkPackageResource, attribute:string) {
     const td = document.createElement('td');
-    td.classList.add(tdClassName, wpCellTdClassName, attribute);
+    td.classList.add(tdClassName, wpCellTdClassName, editFieldContainerClass, attribute);
 
     if (attribute === 'subject') {
       td.classList.add('-max');
     }
 
-    const container = document.createElement('span');
-    container.classList.add(editCellContainer, editFieldContainerClass, attribute);
     const displayElement = this.fieldRenderer.render(workPackage, attribute, null);
-
-    container.appendChild(displayElement);
-    td.appendChild(container);
+    displayElement.classList.add(editCellContainer);
+    td.appendChild(displayElement);
 
     return td;
   }
@@ -36,7 +33,7 @@ export class CellBuilder {
   public refresh(container:HTMLElement, workPackage:WorkPackageResource, attribute:string) {
     const displayElement = this.fieldRenderer.render(workPackage, attribute, null);
 
-    container.innerHTML = '';
     container.appendChild(displayElement);
+    return displayElement;
   }
 }

--- a/frontend/src/app/modules/fields/edit/editing-portal/wp-editing-portal-service.ts
+++ b/frontend/src/app/modules/fields/edit/editing-portal/wp-editing-portal-service.ts
@@ -50,8 +50,12 @@ export class WorkPackageEditingPortalService {
     // Create a portal for the edit-form/field
     const portal = new ComponentPortal(EditFormPortalComponent, null, localInjector);
 
-    // Clear the container
-    container.innerHTML = '';
+    // Remove the last child which is probably the display field
+    if (container.lastChild) {
+      container.removeChild(container.lastChild!);
+    } else {
+      container.innerHTML = '';
+    }
 
     // Attach the portal to the outlet
     const ref = outlet.attachComponentPortal(portal);


### PR DESCRIPTION
Remove the  container span of the display field. Thus the number of DOM elements to be rendered in the WP table shall be reduced.

When switching between display and edit field we can now not simply clear the container but have to replace the elements. This is due to additional elements as the hierarchy indicator which would vanish otherwise.