### PR TITLE
spike to evaluate postgresql based json rendering

### DIFF
--- a/lib/api/v3/projects/project_collection_representer.rb
+++ b/lib/api/v3/projects/project_collection_representer.rb
@@ -38,6 +38,72 @@ module API
       class ProjectCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
         element_decorator ::API::V3::Projects::ProjectRepresenter
 
+        property :elements,
+                   getter: ->(*) {
+                     ids = represented.pluck(:id)
+
+
+                     sql = <<SQL
+SELECT array_to_json(array_agg(row_to_json(t))) 
+                       FROM (
+                        Select 
+                          'Project' as _type,
+                          projects.id, 
+                          identifier, 
+                          projects.name, 
+                          description,
+                          created_on as createdAt,
+                          updated_on as updatedAt,
+                          json_object_agg(links.name, json_build_object('href', href)) as _links
+                        
+                        FROM projects
+						LEFT OUTER JOIN (SELECT name, href, id, present FROM
+(SELECT
+  blubs.name,
+  CASE blubs.name
+    WHEN 'work_packages' THEN '/api/v3/projects/' || projects.id || '/work_packages'
+    WHEN 'createWorkPackage' THEN '/api/v3/projects/' || projects.id || '/work_packages/form'
+    WHEN 'createWorkPackageImmediate' THEN '/api/v3/projects/' || projects.id || '/work_packages'
+    WHEN 'categories' THEN '/api/v3/projects/' || projects.id || '/categories'
+    WHEN 'versions' THEN '/api/v3/projects/' || projects.id || '/versions'
+    WHEN 'types' THEN '/api/v3/projects/' || projects.id || '/types'
+    ELSE ''
+  END as href,
+    CASE blubs.name
+    WHEN 'work_packages' THEN view_work_packages.id IS NOT NULL
+    WHEN 'createWorkPackage' THEN add_work_packages.id IS NOT NULL
+    WHEN 'createWorkPackageImmediate' THEN add_work_packages.id IS NOT NULL
+    WHEN 'versions' THEN manage_versions.id IS NOT NULL OR view_work_packages.id IS NOT NULL
+    WHEN 'types' THEN manage_types.id IS NOT NULL OR view_work_packages.id IS NOT NULL
+    ELSE true
+  END AS present,
+  projects.id
+FROM
+(SELECT 'work_packages' as name
+UNION SELECT 'createWorkPackage'
+UNION SELECT 'createWorkPackageImmediate'
+UNION SELECT 'categories'
+UNION SELECT 'versions'
+UNION SELECT 'types'
+) blubs
+LEFT OUTER JOIN projects ON 1 = 1
+LEFT OUTER JOIN (#{Project.allowed_to(User.current, :view_work_packages).select(:id).to_sql}) view_work_packages ON view_work_packages.id = projects.id
+LEFT OUTER JOIN (#{Project.allowed_to(User.current, :view_work_packages).select(:id).to_sql}) add_work_packages ON add_work_packages.id = projects.id
+LEFT OUTER JOIN (#{Project.allowed_to(User.current, :manage_versions).select(:id).to_sql}) manage_versions ON manage_versions.id = projects.id
+LEFT OUTER JOIN (#{Project.allowed_to(User.current, :manage_types).select(:id).to_sql}) manage_types ON manage_types.id = projects.id
+) blubs2) links ON links.id = projects.id  AND present = true
+						   GROUP BY projects.id, projects.identifier, projects.name, description, created_on, updated_on
+                       ) t
+SQL
+
+                     json = ActiveRecord::Base.connection
+                       .select_one(sql)['array_to_json']
+
+                     ::JSON::parse(json)
+                   },
+                   exec_context: :decorator,
+                   embedded: true
+
         self.to_eager_load = ::API::V3::Projects::ProjectRepresenter.to_eager_load
         self.checked_permissions = ::API::V3::Projects::ProjectRepresenter.checked_permissions
       end


### PR DESCRIPTION
🛑:warning: not intended to be merged :warning:  

Implements, rather hacky, postgresql based json rendering for the projects collection end point. The intend is to evaluate the pros and cons of such an approach.

Custom fields are not yet supported but I do not expect them to make a difference performancewise.

### Findings
* By far outperforms rails based rendering. On a community dump, rendering 80 projects takes about 450-500 ms when done by our current stack while it takes only 90 - 100 ms when done in postgresql. As community does not have custom fields, the comparison is adequate even though custom fields have not been implemented.
* The collection rendering part of the response itself takes below 5 ms which is promising as it suggests being able to render larger sets of collections with more properties. That also suggests that every request by the api will take 80+ ms which is something we should look into.
* Adding additional properties to the response in most cases does not seem to have a measurable effect. 
* The impact on readability is not as bad as I expected. With a DSL developed for it, it will be even less.
* More complicated conditions might be harder to formulate in sql though.
* The sql based permissions play into our hands here as they can be made part of the rendering sql query. It might make sense to optimize them though so that more than one permission can be evaluated.
* Rendering formattable fields, e.g. work package description or text custom fields will not work within sql and would currently require postprocessing which would then, given the performance boost, be considered even more expensive. Rendering completely in postgresql will require for those fields to be user independent.
* Some representers, e.g. query schema might be too complicated to render in postgresql.  