### PR TITLE
Lookup visible children in table beforehand

### DIFF
--- a/frontend/src/app/components/projects/project-menu-autocomplete/project-menu-autocomplete.component.ts
+++ b/frontend/src/app/components/projects/project-menu-autocomplete/project-menu-autocomplete.component.ts
@@ -35,7 +35,7 @@ import {keyCodes} from 'core-app/modules/common/keyCodes.enum';
 import {LinkHandling} from 'core-app/modules/common/link-handling/link-handling';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {HttpClient} from "@angular/common/http";
-import {ChangeDetectorRef, Component, ElementRef, OnInit} from "@angular/core";
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit} from "@angular/core";
 import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 
@@ -51,6 +51,7 @@ export type ProjectAutocompleteItem = IAutocompleteItem<IProjectMenuEntry>;
 
 @Component({
   templateUrl: './project-menu-autocomplete.template.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'project-menu-autocomplete'
 })
 export class ProjectMenuAutocompleteComponent extends ILazyAutocompleterBridge<IProjectMenuEntry> implements OnInit {

--- a/frontend/src/app/components/wp-fast-table/builders/cell-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/cell-builder.ts
@@ -10,7 +10,7 @@ export const wpCellTdClassName = 'wp-table--cell-td';
 
 export class CellBuilder {
 
-  private fieldRenderer = new DisplayFieldRenderer(this.injector, 'table');
+  public fieldRenderer = new DisplayFieldRenderer(this.injector, 'table');
 
   constructor(public injector:Injector) {
   }

--- a/frontend/src/app/components/wp-fast-table/builders/drag-and-drop/drag-drop-handle-render-pass.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/drag-and-drop/drag-drop-handle-render-pass.ts
@@ -23,11 +23,10 @@ export class DragDropHandleRenderPass {
         return;
       }
 
-      const handle = this.dragDropHandleBuilder.build(row.workPackage);
+      const handle = this.dragDropHandleBuilder.build(row.workPackage!);
 
       if (handle) {
-        const element:HTMLElement = this.tablePass.tableBody.children[position] as HTMLElement;
-        element.replaceChild(handle, element.firstElementChild!);
+        row.element.replaceChild(handle, row.element.firstElementChild!);
       }
     });
   }

--- a/frontend/src/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -19,13 +19,13 @@ export class HierarchyRenderPass extends PrimaryRenderPass {
   protected readonly wpTableHierarchies = this.injector.get(WorkPackageTableHierarchiesService);
 
   // Remember which rows were already rendered
-  public rendered:{ [workPackageId:string]:boolean } = {};
+  private rendered:{ [workPackageId:string]:boolean } = {};
 
   // Remember additional parents inserted that are not part of the results table
-  public additionalParents:{ [workPackageId:string]:WorkPackageResource } = {};
+  private additionalParents:{ [workPackageId:string]:WorkPackageResource } = {};
 
   // Defer children to be rendered when their parent occurs later in the table
-  public deferred:{ [parentId:string]:WorkPackageResource[] } = {};
+  private deferred:{ [parentId:string]:WorkPackageResource[] } = {};
 
   // Collapsed state
   private hierarchies:WorkPackageTableHierarchies;
@@ -47,7 +47,7 @@ export class HierarchyRenderPass extends PrimaryRenderPass {
 
     _.each(this.workPackageTable.originalRowIndex, (row, ) => {
       row.object.ancestors.forEach((ancestor:WorkPackageResource) => {
-        this.parentsWithVisibleChildren[ancestor.id] = true;
+        this.parentsWithVisibleChildren[ancestor.id!] = true;
       });
     });
 

--- a/frontend/src/app/components/wp-fast-table/builders/primary-render-pass.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/primary-render-pass.ts
@@ -17,6 +17,8 @@ import {DragDropHandleRenderPass} from "core-components/wp-fast-table/builders/d
 export type RenderedRowType = 'primary' | 'relations';
 
 export interface RowRenderInfo {
+  // The rendered row
+  element:HTMLTableRowElement;
   // Unique class name as an identifier to uniquely identify the row in both table and timeline
   classIdentifier:string;
   // Additional classes to be added by any secondary render passes
@@ -186,7 +188,7 @@ export abstract class PrimaryRenderPass {
    * @param hidden whether the row was rendered hidden
    */
   protected appendRow(workPackage:WorkPackageResource,
-                      row:HTMLElement,
+                      row:HTMLTableRowElement,
                       additionalClasses:string[] = [],
                       hidden:boolean = false) {
 
@@ -197,6 +199,7 @@ export abstract class PrimaryRenderPass {
       additionalClasses: additionalClasses,
       workPackage: workPackage,
       renderType: 'primary',
+      element: row,
       hidden: hidden
     });
   }
@@ -207,7 +210,7 @@ export abstract class PrimaryRenderPass {
    * @param classIdentifer a unique identifier for the two rows (one each in table/timeline).
    * @param hidden whether the row was rendered hidden
    */
-  protected appendNonWorkPackageRow(row:HTMLElement,
+  protected appendNonWorkPackageRow(row:HTMLTableRowElement,
                                     classIdentifer:string,
                                     additionalClasses:string[] = [],
                                     hidden:boolean = false) {
@@ -215,6 +218,7 @@ export abstract class PrimaryRenderPass {
     this.tableBody.appendChild(row);
 
     this.renderedOrder.push({
+      element: row,
       classIdentifier: classIdentifer,
       additionalClasses: additionalClasses,
       workPackage: null,

--- a/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
@@ -94,7 +94,7 @@ export class SingleRowBuilder {
   /**
    * Build the columns on the given empty row
    */
-  public buildEmpty(workPackage:WorkPackageResource):[HTMLElement, boolean] {
+  public buildEmpty(workPackage:WorkPackageResource):[HTMLTableRowElement, boolean] {
     let row = this.createEmptyRow(workPackage);
     return this.buildEmptyRow(workPackage, row);
   }
@@ -177,7 +177,7 @@ export class SingleRowBuilder {
     return form && form.activeFields[column.id];
   }
 
-  protected buildEmptyRow(workPackage:WorkPackageResource, row:HTMLElement):[HTMLElement, boolean] {
+  protected buildEmptyRow(workPackage:WorkPackageResource, row:HTMLTableRowElement):[HTMLTableRowElement, boolean] {
     const changeset = this.workPackageTable.editing.changeset(workPackage.id!);
     let cells:{ [attribute:string]:JQuery } = {};
 

--- a/frontend/src/app/components/wp-fast-table/handlers/state/highlighting-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/highlighting-transformer.ts
@@ -12,7 +12,7 @@ export class HighlightingTransformer {
   constructor(public readonly injector:Injector,
               table:WorkPackageTable) {
     this.wpTableHighlighting
-      .live$()
+      .updates$()
       .pipe(
         takeUntil(this.querySpace.stopAllSubscriptions),
         distinctUntilChanged()

--- a/frontend/src/app/components/wp-fast-table/handlers/state/rows-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/rows-transformer.ts
@@ -8,15 +8,10 @@ import {WorkPackageStatesInitializationService} from "core-components/wp-list/wp
 export class RowsTransformer {
 
   public querySpace:IsolatedQuerySpace = this.injector.get(IsolatedQuerySpace);
-  public wpStatesInitialization = this.injector.get(WorkPackageStatesInitializationService);
   public states:States = this.injector.get(States);
 
   constructor(public readonly injector:Injector,
               public table:WorkPackageTable) {
-
-    // Initial setup
-    let rows = this.querySpace.rows.value!;
-    table.initialSetup(rows);
 
     // Redraw table if the current row state changed
     this.querySpace

--- a/frontend/src/app/components/wp-fast-table/helpers/wp-table-hierarchy-helpers.ts
+++ b/frontend/src/app/components/wp-fast-table/helpers/wp-table-hierarchy-helpers.ts
@@ -18,20 +18,3 @@ export function hierarchyRootClass(ancestorId:string):string {
 export function ancestorClassIdentifier(ancestorId:string) {
   return `wp-ancestor-row-${ancestorId}`;
 }
-
-/**
- * Returns whether any of the children of this work package
- * are visible in the table results.
- */
-export function hasChildrenInTable(workPackage:WorkPackageResource, table:WorkPackageTable) {
-  if (workPackage.isLeaf) {
-    return false; // Work Package has no children at all
-  }
-
-  // Return if this work package is in the ancestor chain of any of the work packages
-  return !!_.find(table.originalRows, (wpId:string) => {
-    const row = table.originalRowIndex[wpId].object;
-
-    return row.ancestorIds.indexOf(workPackage.id!) >= 0;
-  });
-}

--- a/frontend/src/app/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/src/app/components/wp-fast-table/wp-fast-table.ts
@@ -151,8 +151,10 @@ export class WorkPackageTable {
     const renderPass = this.lastRenderPass = this.rowBuilder.buildRows();
 
     // Insert table body
-    this.tbody.innerHTML = '';
-    this.tbody.appendChild(renderPass.tableBody);
+    requestAnimationFrame(() => {
+      this.tbody.innerHTML = '';
+      this.tbody.appendChild(renderPass.tableBody);
+    });
 
     return renderPass;
   }

--- a/frontend/src/app/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/src/app/components/wp-fast-table/wp-fast-table.ts
@@ -39,7 +39,7 @@ export class WorkPackageTable {
   ];
 
   // Last render pass used for refreshing single rows
-  private lastRenderPass:PrimaryRenderPass | null = null;
+  public lastRenderPass:PrimaryRenderPass|null = null;
 
   // Work package editing context handler in the table, which handles open forms
   // and their contexts
@@ -75,7 +75,7 @@ export class WorkPackageTable {
     this.originalRowIndex = {};
     this.originalRows = rows.map((wp:WorkPackageResource, i:number) => {
       let wpId = wp.id!;
-      this.originalRowIndex[wpId] = <WorkPackageTableRow> {object: wp, workPackageId: wpId, position: i};
+      this.originalRowIndex[wpId] = <WorkPackageTableRow>{object: wp, workPackageId: wpId, position: i};
       return wpId;
     });
   }
@@ -100,10 +100,12 @@ export class WorkPackageTable {
     const renderPass = this.performRenderPass();
 
     // Insert timeline body
-    this.timelineBody.innerHTML = '';
-    this.timelineBody.appendChild(renderPass.timeline.timelineBody);
+    requestAnimationFrame(() => {
+      this.timelineBody.innerHTML = '';
+      this.timelineBody.appendChild(renderPass.timeline.timelineBody);
 
-    this.querySpace.rendered.putValue(renderPass.result);
+      this.querySpace.rendered.putValue(renderPass.result);
+    });
   }
 
   /**

--- a/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
@@ -303,10 +303,12 @@ export class WorkPackageInlineCreateComponent implements OnInit, AfterViewInit, 
 
   public showRow() {
     this.mode = 'inactive';
+    this.cdRef.detectChanges();
   }
 
   public hideRow() {
     this.mode = 'create';
+    this.cdRef.detectChanges();
   }
 
   public get colspan():number {

--- a/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
+++ b/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
@@ -29,7 +29,15 @@
 import {CollectionResource} from 'core-app/modules/hal/resources/collection-resource';
 import {States} from '../states.service';
 import {StateService, TransitionService} from '@uirouter/core';
-import {ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit, ViewChild} from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  ViewChild
+} from "@angular/core";
 import {QueryDmService} from 'core-app/modules/hal/dm-services/query-dm.service';
 import {LoadingIndicatorService} from "core-app/modules/common/loading-indicator/loading-indicator.service";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
@@ -70,6 +78,7 @@ interface IQueryAutocompleteJQuery extends JQuery {
 
 @Component({
   selector: 'wp-query-select',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './wp-query-select.template.html',
 })
 export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestroy {
@@ -116,7 +125,8 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
               readonly pathHelper:PathHelperService,
               readonly wpStaticQueries:WorkPackageStaticQueriesService,
               readonly mainMenuService:MainMenuNavigationService,
-              readonly toggleService:MainMenuToggleService) {
+              readonly toggleService:MainMenuToggleService,
+              readonly cdRef:ChangeDetectorRef) {
   }
 
   public ngOnInit() {
@@ -239,8 +249,14 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
   private set loadingPromise(promise:Promise<any>) {
     this.loading = true;
     promise
-      .then(() => this.loading = false)
-      .catch(() => this.loading = false);
+      .then(() => {
+        this.loading = false;
+        this.cdRef.detectChanges();
+      })
+      .catch(() => {
+        this.loading = false;
+        this.cdRef.detectChanges();
+      });
   }
 
   private setupAutoCompletion(input:IQueryAutocompleteJQuery) {

--- a/frontend/src/app/modules/fields/display/display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/display-field.module.ts
@@ -40,11 +40,18 @@ export class DisplayField extends Field {
 
   protected I18n:I18nService = this.$injector.get(I18nService);
 
-  constructor(public resource:any,
-              public name:string,
-              public schema:IFieldSchema,
-              public context:DisplayFieldContext) {
+  constructor(public name:string, public context:DisplayFieldContext) {
     super();
+  }
+
+  /**
+   * Apply the display field to the given resource and schema
+   * @param resource
+   * @param schema
+   */
+  public apply(resource:any, schema:IFieldSchema) {
+    this.resource = resource;
+    this.schema = schema;
   }
 
   public texts = {

--- a/frontend/src/app/modules/fields/display/display-field.service.ts
+++ b/frontend/src/app/modules/fields/display/display-field.service.ts
@@ -66,6 +66,8 @@ export class DisplayFieldService extends AbstractFieldService<DisplayField, IDis
    */
   public getField(resource:any, fieldName:string, schema:IFieldSchema, context:DisplayFieldContext):DisplayField {
     const fieldClass = this.getClassFor(fieldName, schema.type);
-    return new fieldClass(resource, fieldName, schema, context);
+    let instance = new fieldClass(fieldName, context);
+    instance.apply(resource, schema);
+    return instance;
   }
 }

--- a/modules/costs/frontend/module/wp-display/wp-display-costs-by-type-field.module.ts
+++ b/modules/costs/frontend/module/wp-display/wp-display-costs-by-type-field.module.ts
@@ -29,7 +29,7 @@
 
 import {DisplayField} from "core-app/modules/fields/display/display-field.module";
 import {WorkPackageCacheService} from "core-components/work-packages/work-package-cache.service";
-import {DisplayFieldContext} from 'core-app/modules/fields/display/display-field.service';
+import {IFieldSchema} from "core-app/modules/fields/field.base";
 
 interface ICostsByType {
     costObjectId:string;
@@ -46,14 +46,9 @@ export class CostsByTypeDisplayField extends DisplayField {
 
     public wpCacheService:any;
 
-    constructor(public resource:any,
-                public name:string,
-                public schema:any,
-                public context:DisplayFieldContext) {
-        super(resource, name, schema, context);
-
+    public apply(resource:any, schema:IFieldSchema) {
+        super.apply(resource, schema);
         this.wpCacheService = this.$injector.get(WorkPackageCacheService);
-
         this.loadIfNecessary();
     }
 


### PR DESCRIPTION
Reduces rendering overhead from hierarchy table rendering to roughly half, since a lot time is spent in the ancestor lookup