### PR TITLE
Reinstate contain: strict for performance wins in the table

### DIFF
--- a/app/assets/stylesheets/layout/work_packages/_table.sass
+++ b/app/assets/stylesheets/layout/work_packages/_table.sass
@@ -127,7 +127,7 @@
   // Hint browser that this will inner-scroll
   will-change: transform
   // Hinter browser that the content of the flex is contained except for size
-  contain: layout style paint
+  contain: strict
 
   &.-timeline-visible
     // Show the horizontal scrollbar _always_ (same as timeline)
@@ -149,7 +149,7 @@
   // Hint browser that this will inner-scroll
   will-change: transform
   // Hinter browser that the content of the flex is contained except for size
-  contain: layout style paint
+  contain: strict
 
 .work-package--attachments--files
   margin-bottom: 1rem


### PR DESCRIPTION
This was removed in https://community.openproject.com/wp/29581 but this bug can no longer happen due to changes in the back button

This will ensure that sizing of the table is contained which no longer results in a reflow on table row hovers, drastically improving performance for > 200 work packages shown for Chrome