### PR TITLE
Allow at max 250 elements to be rendered with manual sorting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV RAILS_CACHE_STORE memcache
 ENV OPENPROJECT_INSTALLATION__TYPE docker
 ENV NEW_RELIC_AGENT_ENABLED false
 ENV ATTACHMENTS_STORAGE_PATH $APP_DATA_PATH/files
+ENV BUNDLE_PATH__SYSTEM=false
 
 ENV PGLOADER_DEPENDENCIES "libsqlite3-dev make curl gawk freetds-dev libzip-dev"
 
@@ -69,7 +70,7 @@ COPY modules ./modules
 # OpenProject::Version is required by module versions in gemspecs
 RUN mkdir -p lib/open_project
 COPY lib/open_project/version.rb ./lib/open_project/
-RUN bundle install --deployment --with="docker opf_plugins" --without="test development" --jobs=8 --retry=3
+RUN bundle install --deployment --path vendor/bundle --with="docker opf_plugins" --without="test development" --jobs=8 --retry=3
 
 # Finally, copy over the whole thing
 COPY . $APP_PATH

--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -162,3 +162,8 @@ body.-browser-edge
 
 .wp-table--cell-td img.thumbnail
   height: 40px
+
+.work-package--limited-results
+  td
+    height: 40px
+    text-align: center !important

--- a/app/models/query/manual_sorting.rb
+++ b/app/models/query/manual_sorting.rb
@@ -42,6 +42,10 @@ module Query::ManualSorting
         .pluck(:work_package_id)
     end
 
+    def manually_sorted?
+      sort_criteria_columns.any? { |clz, _| clz.is_a?(::Queries::WorkPackages::Columns::ManualSortingColumn) }
+    end
+
     private
 
     def self.manual_sorting_column

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -69,8 +69,15 @@ module API
       end
 
       def calculate_resulting_params(provided_params)
-        calculate_default_params
-          .merge(provided_params.slice('offset', 'pageSize').symbolize_keys)
+        calculate_default_params.merge(provided_params.slice('offset', 'pageSize').symbolize_keys).tap do |params|
+          if query.manually_sorted?
+            params[:offset] = 1
+            params[:pageSize] = Setting.forced_single_page_size
+          else
+            params[:offset] = to_i_or_nil(params[:offset])
+            params[:pageSize] = to_i_or_nil(params[:pageSize])
+          end
+        end
       end
 
       def calculate_default_params
@@ -127,8 +134,8 @@ module API
           self_link(project),
           project: project,
           query: resulting_params,
-          page: to_i_or_nil(resulting_params[:offset]),
-          per_page: to_i_or_nil(resulting_params[:pageSize]),
+          page: resulting_params[:offset],
+          per_page: resulting_params[:pageSize],
           groups: groups,
           total_sums: sums,
           embed_schemas: true,

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -728,6 +728,9 @@ en:
       no_results:
         title: No work packages to display.
         description: Either none have been created or all work packages are filtered out.
+      limited_results: >
+        There are %{total} total work packages, but only %{count} can be shown in manual sorting mode.
+        Please reduce the results by filtering.
       property_groups:
         details: "Details"
         people: "People"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -138,6 +138,8 @@ activity_days_default:
   default: 30
 per_page_options:
   default: '20, 100'
+forced_single_page_size:
+  default: 250
 mail_from:
   default: openproject@example.net
 bcc_recipients:

--- a/frontend/src/app/components/main-menu/main-menu-toggle.component.ts
+++ b/frontend/src/app/components/main-menu/main-menu-toggle.component.ts
@@ -26,18 +26,17 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-import {ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnDestroy, OnInit} from '@angular/core';
 import {MainMenuToggleService} from './main-menu-toggle.service';
 import {distinctUntilChanged} from 'rxjs/operators';
 import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
-import {MainMenuResizerComponent} from "core-components/resizer/main-menu-resizer.component";
 import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {DeviceService} from "app/modules/common/browser/device.service";
-import {Injector} from "@angular/core";
 
 @Component({
   selector: 'main-menu-toggle',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div *ngIf="this.currentProject.id !== null || this.deviceService.isMobile" id="main-menu-toggle"
         aria-haspopup="true"

--- a/frontend/src/app/components/routing/my-page/my-page.component.html
+++ b/frontend/src/app/components/routing/my-page/my-page.component.html
@@ -1,3 +1,5 @@
 <h2 [textContent]="text.title"></h2>
 
-<grid *ngIf="grid" [grid]="grid"></grid>
+<ng-container *ngIf="(grid$ | async) as grid">
+  <grid [grid]="grid"></grid>
+</ng-container>

--- a/frontend/src/app/components/routing/my-page/my-page.component.ts
+++ b/frontend/src/app/components/routing/my-page/my-page.component.ts
@@ -13,21 +13,19 @@ export class MyPageComponent implements OnInit {
   public text = { title: this.i18n.t('js.label_my_page'),
                   html_title: this.i18n.t('js.label_my_page') };
 
+  public grid$:Promise<GridResource>;
+
   constructor(readonly gridInitialization:GridInitializationService,
               readonly pathHelper:PathHelperService,
               readonly halResourceService:HalResourceService,
               readonly i18n:I18nService,
               readonly title:Title) {}
 
-  public grid:GridResource;
 
   ngOnInit() {
-    this
+    this.grid$ = this
       .gridInitialization
-      .initialize(this.pathHelper.myPagePath())
-      .then((grid) => {
-        this.grid = grid;
-      });
+      .initialize(this.pathHelper.myPagePath());
 
     this.setHtmlTitle();
   }

--- a/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
@@ -90,6 +90,7 @@ export class WorkPackageStatesInitializationService {
   public updateQuerySpace(query:QueryResource, results:WorkPackageCollectionResource) {
     // Clear table required data states
     this.querySpace.additionalRequiredWorkPackages.clear('Clearing additional WPs before updating rows');
+    this.querySpace.rendered.clear('Clearing rendered data before upgrading query space');
 
     if (results.schemas) {
       _.each(results.schemas.elements, (schema:SchemaResource) => {

--- a/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
+++ b/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
@@ -141,6 +141,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
 
     // Register click handler on results
     this.addClickHandler();
+    this.cdRef.detach();
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/components/wp-table/embedded/wp-embedded-base.component.ts
+++ b/frontend/src/app/components/wp-table/embedded/wp-embedded-base.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Input, SimpleChanges} from '@angular/core';
+import {AfterViewInit, ChangeDetectorRef, Input, SimpleChanges} from '@angular/core';
 import {CurrentProjectService} from '../../projects/current-project.service';
 import {WorkPackageStatesInitializationService} from '../../wp-list/wp-states-initialization.service';
 import {
@@ -32,6 +32,7 @@ export abstract class WorkPackageEmbeddedBaseComponent extends WorkPackagesViewB
   readonly loadingIndicatorService:LoadingIndicatorService = this.injector.get(LoadingIndicatorService);
   readonly wpStatesInitialization:WorkPackageStatesInitializationService = this.injector.get(WorkPackageStatesInitializationService);
   readonly currentProject:CurrentProjectService = this.injector.get(CurrentProjectService);
+  readonly cdRef = this.injector.get(ChangeDetectorRef);
 
   ngOnInit() {
     super.ngOnInit();
@@ -78,6 +79,7 @@ export abstract class WorkPackageEmbeddedBaseComponent extends WorkPackagesViewB
 
   protected setLoaded() {
     this.renderTable = this.configuration.tableVisible;
+    this.cdRef.detectChanges();
   }
 
   public refresh(visible:boolean = true, firstPage:boolean = false):Promise<any> {

--- a/frontend/src/app/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/components/wp-table/wp-table.directive.html
@@ -38,9 +38,9 @@
           </th>
         </tr>
       </thead>
-      <tbody class="work-package--empty-tbody" *ngIf="!isEmbedded && query && rowcount === 0">
+      <tbody class="work-package--empty-tbody" *ngIf="!isEmbedded && query && results.count === 0">
       <tr id="empty-row-notification">
-        <td [attr.colspan]="columns.length + 1">
+        <td [attr.colspan]="columns.length + 2">
           <span>
             <op-icon icon-classes="icon-info1 icon-context"></op-icon>
             <span>
@@ -57,6 +57,18 @@
              [wp-inline-create--table]="workPackageTable"
              [wp-inline-create--project-identifier]="projectIdentifier"
       >
+      </tbody>
+      <tbody class="work-package--limited-results" *ngIf="limitedResults">
+        <tr>
+          <td [attr.colspan]="columns.length + 2">
+            <span>
+              <op-icon icon-classes="icon-info1 icon-context"></op-icon>
+              <span>
+                {{text.limitedResults(results.count, results.total)}}
+              </span>
+            </span>
+          </td>
+        </tr>
       </tbody>
       <tfoot>
       <tr wpTableSumsRow></tr>

--- a/frontend/src/app/modules/boards/board/board-list/board-lists.service.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-lists.service.ts
@@ -94,7 +94,10 @@ export class BoardListsService {
       hidden: true,
       public: true,
       "_links": {
-        "sortBy": [{"href": this.v3.resource("/queries/sort_bys/manualSorting-asc")}]
+        "sortBy": [
+          {"href": this.v3.resource("/queries/sort_bys/manualSorting-asc")},
+          {"href": this.v3.resource("/queries/sort_bys/id-asc")},
+        ]
       },
       ...params
     };

--- a/frontend/src/app/modules/common/notifications/notification.component.ts
+++ b/frontend/src/app/modules/common/notifications/notification.component.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, Inject, Input, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {
   INotification,
@@ -36,6 +36,7 @@ import {
 
 @Component({
   templateUrl: './notification.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'notification'
 })
 export class NotificationComponent implements OnInit {

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -63,6 +63,9 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
   /** Do we currently have query props ? */
   hasQueryProps:boolean;
 
+  /** Should we show the pagination ? */
+  showPagination = true;
+
   /** Listener callbacks */
   unRegisterTitleListener:Function;
   removeTransitionSubscription:Function;
@@ -106,6 +109,7 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
     ).subscribe((query) => {
       this.updateTitle(query);
       this.currentQuery = query;
+      this.showPagination = !this.wpTableSortBy.isManualSortingMode;
       this.cdRef.detectChanges();
     });
   }

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -71,7 +71,7 @@
 
       <!-- Footer -->
       <div class="work-packages-split-view--tabletimeline-footer hide-when-print"
-           *ngIf="tableInformationLoaded">
+           *ngIf="tableInformationLoaded && showPagination">
         <wp-table-pagination></wp-table-pagination>
       </div>
     </div>


### PR DESCRIPTION
This hides the pagination and always returns a single page of at max 250 work packages for manual sorting. It's a hack to demonstrate its functions and limitations:

- No matter what the previous pagesize was, the user will receive a potentially larger number of results
- It's no longer possible to see or select from the subsequent pages without switching back to automatic sorting