### PR TITLE
Feature/project description widget

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -220,6 +220,8 @@ en:
           title: 'News'
           at: 'at'
           no_results: 'Nothing new to report.'
+        project_description:
+          title: 'Project description'
         time_entries_current_user:
           title: 'Spent time (last 7 days)'
           no_results: 'No time entries for the last 7 days.'

--- a/docs/api/apiv3/endpoints/projects.apib
+++ b/docs/api/apiv3/endpoints/projects.apib
@@ -22,14 +22,14 @@ Depending on custom fields defined for projects, additional links might exist.
 
 ## Local Properties
 
-| Property    | Description                                   | Type     | Constraints | Supported operations |
-| :---------: | -------------                                 | ----     | ----------- | -------------------- |
-| id          | Projects's id                                 | Integer  | x > 0       | READ                 |
-| identifier  |                                               | String   |             | READ                 |
-| name        |                                               | String   |             | READ                 |
-| description |                                               | String   |             | READ                 |
-| createdAt   | Time of creation                              | DateTime |             | READ                 |
-| updatedAt   | Time of the most recent change to the project | DateTime |             | READ                 |
+| Property    | Description                                   | Type        | Constraints | Supported operations |
+| :---------: | -------------                                 | ----        | ----------- | -------------------- |
+| id          | Projects's id                                 | Integer     | x > 0       | READ                 |
+| identifier  |                                               | String      |             | READ                 |
+| name        |                                               | String      |             | READ                 |
+| description |                                               | Formattable |             | READ                 |
+| createdAt   | Time of creation                              | DateTime    |             | READ                 |
+| updatedAt   | Time of the most recent change to the project | DateTime    |             | READ                 |
 
 Depending on custom fields defined for projects, additional properties might exist.
 
@@ -76,7 +76,14 @@ Depending on custom fields defined for projects, additional properties might exi
                 "id": 1,
                 "identifier": "project_identifier",
                 "name": "Project example",
-                "description": "Lorem ipsum dolor sit amet",
+                "description": {
+                    "format": "markdown",
+                    "raw": "Lorem **ipsum** dolor sit amet",
+                    "html": "<p>Lorem <strong>ipsum</strong> dolor sit amet</p>"
+                },
+                "description": {
+                  "raw": "Lorem ipsum dolor sit amet",
+                  "markdown"gt
                 "createdAt": "2014-05-21T08:51:20Z",
                 "updatedAt": "2014-05-21T08:51:20Z",
                 "customField123": 123
@@ -150,7 +157,11 @@ Depending on custom fields defined for projects, additional properties might exi
                     "id": 6,
                     "identifier": "a_project",
                     "name": "A project",
-                    "description": "Eveniet molestias omnis quis aut qui eum adipisci.",
+                    "description": {
+                        "format": "markdown",
+                        "raw": "Lorem **ipsum** dolor sit amet",
+                        "html": "<p>Lorem <strong>ipsum</strong> dolor sit amet</p>"
+                    },
                     "createdAt": "2015-07-06T13:28:14+00:00",
                     "updatedAt": "2015-10-01T09:55:02+00:00",
                     "type": "Customer Project"
@@ -180,7 +191,11 @@ Depending on custom fields defined for projects, additional properties might exi
                     "id": 14,
                     "identifier": "another_project",
                     "name": "Another project",
-                    "description": "",
+                    "description": {
+                        "format": "markdown",
+                        "raw": "",
+                        "html": ""
+                    },
                     "createdAt": "2016-02-29T12:50:20+00:00",
                     "updatedAt": "2016-02-29T12:50:20+00:00",
                     "type": null
@@ -236,7 +251,11 @@ Returns a collection of projects. The collection can be filtered via query param
                             "id": 1,
                             "identifier": "project_identifier",
                             "name": "Project example",
-                            "description": "Lorem ipsum dolor sit amet",
+                            "description": {
+                                "format": "markdown",
+                                "raw": "Lorem **ipsum** dolor sit amet",
+                                "html": "<p>Lorem <strong>ipsum</strong> dolor sit amet</p>"
+                            },
                             "createdAt": "2014-05-21T08:51:20Z",
                             "updatedAt": "2014-05-21T08:51:20Z"
                         }

--- a/frontend/src/app/modules/grids/openproject-grids.module.ts
+++ b/frontend/src/app/modules/grids/openproject-grids.module.ts
@@ -57,6 +57,7 @@ import {OpenprojectWorkPackageGraphsModule} from "core-app/modules/work-package-
 import {ApiV3FilterBuilder} from "core-components/api/api-v3/api-v3-filter-builder";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {WidgetProjectDescriptionComponent} from "core-app/modules/grids/widgets/project-description/project-description.component";
+import {WidgetHeaderComponent} from "core-app/modules/grids/widgets/header/header.component";
 
 export const GRID_ROUTES:Ng2StateDeclaration[] = [
   {
@@ -122,6 +123,8 @@ export const GRID_ROUTES:Ng2StateDeclaration[] = [
 
     GridColumnContextMenu,
     GridRowContextMenu,
+
+    WidgetHeaderComponent,
 
     // MyPage
     MyPageComponent,

--- a/frontend/src/app/modules/grids/openproject-grids.module.ts
+++ b/frontend/src/app/modules/grids/openproject-grids.module.ts
@@ -56,6 +56,7 @@ import {WidgetWpTableQuerySpaceComponent} from "core-app/modules/grids/widgets/w
 import {OpenprojectWorkPackageGraphsModule} from "core-app/modules/work-package-graphs/openproject-work-package-graphs.module";
 import {ApiV3FilterBuilder} from "core-components/api/api-v3/api-v3-filter-builder";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {WidgetProjectDescriptionComponent} from "core-app/modules/grids/widgets/project-description/project-description.component";
 
 export const GRID_ROUTES:Ng2StateDeclaration[] = [
   {
@@ -86,6 +87,7 @@ export const GRID_ROUTES:Ng2StateDeclaration[] = [
                                   WidgetWpTableQuerySpaceComponent,
                                   WidgetWpGraphComponent,
                                   WidgetWpCalendarComponent,
+                                  WidgetProjectDescriptionComponent,
                                   WidgetTimeEntriesCurrentUserComponent]),
 
     // Routes for grid pages
@@ -109,6 +111,7 @@ export const GRID_ROUTES:Ng2StateDeclaration[] = [
     WidgetWpTableComponent,
     WidgetWpTableQuerySpaceComponent,
     WidgetWpGraphComponent,
+    WidgetProjectDescriptionComponent,
     WidgetTimeEntriesCurrentUserComponent,
 
     WidgetMenuComponent,
@@ -256,6 +259,14 @@ export function registerWidgets(injector:Injector) {
           title: i18n.t(`js.grid.widgets.news.title`),
           properties: {
             name: i18n.t('js.grid.widgets.news.title')
+          }
+        },
+        {
+          identifier: 'project_description',
+          component: WidgetProjectDescriptionComponent,
+          title: i18n.t(`js.grid.widgets.project_description.title`),
+          properties: {
+            name: i18n.t('js.grid.widgets.project_description.title')
           }
         }
       ];

--- a/frontend/src/app/modules/grids/widgets/documents/documents.component.html
+++ b/frontend/src/app/modules/grids/widgets/documents/documents.component.html
@@ -1,20 +1,12 @@
-<h3 class="widget-box--header" cdkDragHandle>
-  <span class="grid--area-drag-handle
-               icon
-               icon-drag-handle"
-        cdkDragHandle></span>
-
-  <i class="icon-context icon-notes" aria-hidden="true"></i>
-
-  <editable-toolbar-title [title]="widgetName"
-                          (onSave)="renameWidget($event)"
-                          class="widget-box--header-title">
-  </editable-toolbar-title>
+<widget-header
+    [name]="widgetName"
+    [icon]="'notes'"
+    (onRenamed)="renameWidget($event)">
 
   <widget-menu
       [resource]="resource">
   </widget-menu>
-</h3>
+</widget-header>
 
 <div class="grid--widget-content">
   <no-results *ngIf="noEntries"

--- a/frontend/src/app/modules/grids/widgets/documents/documents.component.ts
+++ b/frontend/src/app/modules/grids/widgets/documents/documents.component.ts
@@ -1,5 +1,5 @@
 import {AbstractWidgetComponent} from "core-app/modules/grids/widgets/abstract-widget.component";
-import {Component, OnInit, SecurityContext} from '@angular/core';
+import {Component, OnInit, SecurityContext, ChangeDetectionStrategy, ChangeDetectorRef} from '@angular/core';
 import {DocumentResource} from "../../../../../../../modules/documents/frontend/module/hal/resources/document-resource";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {CollectionResource} from "core-app/modules/hal/resources/collection-resource";
@@ -10,6 +10,7 @@ import {DomSanitizer} from '@angular/platform-browser';
 
 @Component({
   templateUrl: './documents.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class WidgetDocumentsComponent extends AbstractWidgetComponent implements OnInit {
   public text = {
@@ -23,7 +24,8 @@ export class WidgetDocumentsComponent extends AbstractWidgetComponent implements
               readonly pathHelper:PathHelperService,
               readonly i18n:I18nService,
               readonly timezone:TimezoneService,
-              readonly domSanitizer:DomSanitizer) {
+              readonly domSanitizer:DomSanitizer,
+              readonly cdr:ChangeDetectorRef) {
     super(i18n);
   }
 
@@ -38,6 +40,8 @@ export class WidgetDocumentsComponent extends AbstractWidgetComponent implements
       .then((collection) => {
         this.entries = collection.elements as DocumentResource[];
         this.entriesLoaded = true;
+
+        this.cdr.detectChanges();
       });
   }
 

--- a/frontend/src/app/modules/grids/widgets/header/header.component.html
+++ b/frontend/src/app/modules/grids/widgets/header/header.component.html
@@ -1,0 +1,17 @@
+<h3 class="widget-box--header">
+  <span class="grid--area-drag-handle
+               icon
+               icon-drag-handle"
+        cdkDragHandle></span>
+
+  <i class="icon-context"
+     aria-hidden="true"
+     [ngClass]="iconClass"></i>
+
+  <editable-toolbar-title [title]="name"
+                          (onSave)="renamed($event)"
+                          class="widget-box--header-title">
+  </editable-toolbar-title>
+
+  <ng-content></ng-content>
+</h3>

--- a/frontend/src/app/modules/grids/widgets/header/header.component.sass
+++ b/frontend/src/app/modules/grids/widgets/header/header.component.sass
@@ -1,0 +1,2 @@
+.icon-context
+  padding-top: 5px

--- a/frontend/src/app/modules/grids/widgets/header/header.component.ts
+++ b/frontend/src/app/modules/grids/widgets/header/header.component.ts
@@ -1,0 +1,49 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {Component, ChangeDetectionStrategy, Input, EventEmitter, Output} from '@angular/core';
+
+@Component({
+  selector: 'widget-header',
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.sass'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class WidgetHeaderComponent {
+  @Input() name:string;
+  @Input() icon:string;
+  @Output() onRenamed = new EventEmitter<string>();
+
+  public renamed(name:string) {
+    this.onRenamed.emit(name);
+  }
+
+  public get iconClass() {
+    return `icon-${this.icon}`;
+  }
+}

--- a/frontend/src/app/modules/grids/widgets/news/news.component.html
+++ b/frontend/src/app/modules/grids/widgets/news/news.component.html
@@ -1,20 +1,12 @@
-<h3 class="widget-box--header" cdkDragHandle>
-  <span class="grid--area-drag-handle
-               icon
-               icon-drag-handle"
-        cdkDragHandle></span>
-
-  <i class="icon-context icon-news" aria-hidden="true"></i>
-
-  <editable-toolbar-title [title]="widgetName"
-                          (onSave)="renameWidget($event)"
-                          class="widget-box--header-title">
-  </editable-toolbar-title>
+<widget-header
+    [name]="widgetName"
+    [icon]="'news'"
+    (onRenamed)="renameWidget($event)">
 
   <widget-menu
       [resource]="resource">
   </widget-menu>
-</h3>
+</widget-header>
 
 <div class="grid--widget-content">
   <no-results *ngIf="noEntries"

--- a/frontend/src/app/modules/grids/widgets/news/news.component.ts
+++ b/frontend/src/app/modules/grids/widgets/news/news.component.ts
@@ -1,5 +1,5 @@
 import {AbstractWidgetComponent} from "core-app/modules/grids/widgets/abstract-widget.component";
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, ChangeDetectorRef} from '@angular/core';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {HalResourceService} from "core-app/modules/hal/services/hal-resource.service";
 import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
@@ -27,7 +27,8 @@ export class WidgetNewsComponent extends AbstractWidgetComponent implements OnIn
               readonly i18n:I18nService,
               readonly timezone:TimezoneService,
               readonly userCache:UserCacheService,
-              readonly newsDm:NewsDmService) {
+              readonly newsDm:NewsDmService,
+              readonly cdr:ChangeDetectorRef) {
     super(i18n);
   }
 
@@ -38,17 +39,10 @@ export class WidgetNewsComponent extends AbstractWidgetComponent implements OnIn
         this.entries = collection.elements as NewsResource[];
         this.entriesLoaded = true;
 
-        this.entries.forEach((entry) => {
-          if (!entry.author) {
-            return;
-          }
+        const users_loaded = this.setAuthors();
 
-          this.userCache
-            .require(entry.author.idFromLink)
-            .then((user:UserResource) => {
-              entry.author = user;
-            });
-        });
+        Promise.all(users_loaded)
+          .then(() => this.cdr.detectChanges());
       });
   }
 
@@ -82,5 +76,19 @@ export class WidgetNewsComponent extends AbstractWidgetComponent implements OnIn
 
   public get noEntries() {
     return !this.entries.length && this.entriesLoaded;
+  }
+
+  public setAuthors() {
+    return this.entries.map((entry) => {
+      if (!entry.author) {
+        return Promise.resolve();
+      }
+
+      return this.userCache
+        .require(entry.author.idFromLink)
+        .then((user:UserResource) => {
+          entry.author = user;
+        });
+    });
   }
 }

--- a/frontend/src/app/modules/grids/widgets/project-description/project-description.component.html
+++ b/frontend/src/app/modules/grids/widgets/project-description/project-description.component.html
@@ -1,0 +1,20 @@
+<h3 class="widget-box--header">
+  <span class="grid--area-drag-handle
+               icon
+               icon-drag-handle"
+        cdkDragHandle></span>
+
+  <i class="icon-context icon-calendar" aria-hidden="true"></i>
+
+  <editable-toolbar-title [title]="widgetName"
+                          (onSave)="renameWidget($event)"
+                          class="widget-box--header-title">
+  </editable-toolbar-title>
+
+  <widget-menu
+      [resource]="resource">
+  </widget-menu>
+</h3>
+
+<div class="grid--widget-content"
+     [innerHTML]="description" ></div>

--- a/frontend/src/app/modules/grids/widgets/project-description/project-description.component.html
+++ b/frontend/src/app/modules/grids/widgets/project-description/project-description.component.html
@@ -1,20 +1,12 @@
-<h3 class="widget-box--header">
-  <span class="grid--area-drag-handle
-               icon
-               icon-drag-handle"
-        cdkDragHandle></span>
-
-  <i class="icon-context icon-calendar" aria-hidden="true"></i>
-
-  <editable-toolbar-title [title]="widgetName"
-                          (onSave)="renameWidget($event)"
-                          class="widget-box--header-title">
-  </editable-toolbar-title>
+<widget-header
+  [name]="widgetName"
+  [icon]="'flag'"
+  (onRenamed)="renameWidget($event)">
 
   <widget-menu
       [resource]="resource">
   </widget-menu>
-</h3>
+</widget-header>
 
 <div class="grid--widget-content"
      [innerHTML]="description" ></div>

--- a/frontend/src/app/modules/grids/widgets/project-description/project-description.component.ts
+++ b/frontend/src/app/modules/grids/widgets/project-description/project-description.component.ts
@@ -1,0 +1,62 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {Component, OnInit} from '@angular/core';
+import {AbstractWidgetComponent} from "app/modules/grids/widgets/abstract-widget.component";
+import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {ProjectDmService} from "core-app/modules/hal/dm-services/project-dm.service";
+import {CurrentProjectService} from "core-components/projects/current-project.service";
+
+@Component({
+  templateUrl: './project-description.component.html',
+})
+export class WidgetProjectDescriptionComponent extends AbstractWidgetComponent implements OnInit {
+  public description:string;
+
+  constructor(protected i18n:I18nService,
+              protected projectDm:ProjectDmService,
+              protected currentProject:CurrentProjectService) {
+    super(i18n);
+  }
+
+  ngOnInit() {
+    this.setDescription();
+  }
+
+  private setDescription() {
+    this
+      .loadCurrentProject()
+      .then(project => {
+        this.description = project.description.html;
+      });
+  }
+
+  private loadCurrentProject() {
+    return this.projectDm.load(this.currentProject.id as string);
+  }
+}

--- a/frontend/src/app/modules/grids/widgets/project-description/project-description.component.ts
+++ b/frontend/src/app/modules/grids/widgets/project-description/project-description.component.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef} from '@angular/core';
 import {AbstractWidgetComponent} from "app/modules/grids/widgets/abstract-widget.component";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {ProjectDmService} from "core-app/modules/hal/dm-services/project-dm.service";
@@ -34,13 +34,15 @@ import {CurrentProjectService} from "core-components/projects/current-project.se
 
 @Component({
   templateUrl: './project-description.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class WidgetProjectDescriptionComponent extends AbstractWidgetComponent implements OnInit {
   public description:string;
 
-  constructor(protected i18n:I18nService,
-              protected projectDm:ProjectDmService,
-              protected currentProject:CurrentProjectService) {
+  constructor(protected readonly i18n:I18nService,
+              protected readonly projectDm:ProjectDmService,
+              protected readonly currentProject:CurrentProjectService,
+              protected readonly cdr:ChangeDetectorRef) {
     super(i18n);
   }
 
@@ -53,6 +55,7 @@ export class WidgetProjectDescriptionComponent extends AbstractWidgetComponent i
       .loadCurrentProject()
       .then(project => {
         this.description = project.description.html;
+        this.cdr.detectChanges();
       });
   }
 

--- a/frontend/src/app/modules/grids/widgets/time-entries-current-user/time-entries-current-user.component.html
+++ b/frontend/src/app/modules/grids/widgets/time-entries-current-user/time-entries-current-user.component.html
@@ -1,20 +1,12 @@
-<h3 class="widget-box--header" cdkDragHandle>
-  <span class="grid--area-drag-handle
-               icon
-               icon-drag-handle"
-        cdkDragHandle></span>
-
-  <i class="icon-context icon-time" aria-hidden="true"></i>
-
-  <editable-toolbar-title [title]="widgetName"
-                          (onSave)="renameWidget($event)"
-                          class="widget-box--header-title">
-  </editable-toolbar-title>
+<widget-header
+    [name]="widgetName"
+    [icon]="'time'"
+    (onRenamed)="renameWidget($event)">
 
   <widget-menu
       [resource]="resource">
   </widget-menu>
-</h3>
+</widget-header>
 
 <no-results *ngIf="noEntries"
             [title]="text.noResults">

--- a/frontend/src/app/modules/grids/widgets/time-entries-current-user/time-entries-current-user.component.ts
+++ b/frontend/src/app/modules/grids/widgets/time-entries-current-user/time-entries-current-user.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from "@angular/core";
+import {Component, OnInit, ChangeDetectorRef} from "@angular/core";
 import {AbstractWidgetComponent} from "app/modules/grids/widgets/abstract-widget.component";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {TimeEntryDmService} from "core-app/modules/hal/dm-services/time-entry-dm.service";
@@ -6,7 +6,6 @@ import {TimeEntryResource} from "core-app/modules/hal/resources/time-entry-resou
 import {TimezoneService} from "core-components/datetime/timezone.service";
 import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 import {ConfirmDialogService} from "core-components/modals/confirm-dialog/confirm-dialog.service";
-import {formatNumber} from "@angular/common";
 import {FilterOperator} from "core-components/api/api-v3/api-v3-filter-builder";
 
 @Component({
@@ -35,7 +34,8 @@ export class WidgetTimeEntriesCurrentUserComponent extends AbstractWidgetCompone
               readonly timezone:TimezoneService,
               readonly i18n:I18nService,
               readonly pathHelper:PathHelperService,
-              readonly confirmDialog:ConfirmDialogService) {
+              readonly confirmDialog:ConfirmDialogService,
+              protected readonly cdr:ChangeDetectorRef) {
     super(i18n);
   }
 
@@ -47,6 +47,8 @@ export class WidgetTimeEntriesCurrentUserComponent extends AbstractWidgetCompone
       .then((collection) => {
         this.buildEntries(collection.elements);
         this.entriesLoaded = true;
+
+        this.cdr.detectChanges();
       });
   }
 

--- a/frontend/src/app/modules/grids/widgets/wp-calendar/wp-calendar.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-calendar/wp-calendar.component.html
@@ -1,20 +1,12 @@
-<h3 class="widget-box--header" cdkDragHandle>
-  <span class="grid--area-drag-handle
-               icon
-               icon-drag-handle"
-        cdkDragHandle></span>
-
-  <i class="icon-context icon-calendar" aria-hidden="true"></i>
-
-  <editable-toolbar-title [title]="widgetName"
-                          (onSave)="renameWidget($event)"
-                          class="widget-box--header-title">
-  </editable-toolbar-title>
+<widget-header
+    [name]="widgetName"
+    [icon]="'calendar'"
+    (onRenamed)="renameWidget($event)">
 
   <widget-menu
       [resource]="resource">
   </widget-menu>
-</h3>
+</widget-header>
 
 <ng-container wp-isolated-query-space>
   <wp-calendar [static]="true"></wp-calendar>

--- a/frontend/src/app/modules/grids/widgets/wp-graph/wp-graph.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-graph/wp-graph.component.html
@@ -1,22 +1,13 @@
-<h3 class="widget-box--header"
-    *ngIf="datasets.length > 0"
-    cdkDragHandle>
-  <span class="grid--area-drag-handle
-               icon
-               icon-drag-handle"
-        cdkDragHandle></span>
-  <i class="icon-context icon-view-timeline" aria-hidden="true"></i>
-
-  <editable-toolbar-title [title]="widgetName"
-                          (onSave)="renameWidget($event)"
-                          class="widget-box--header-title">
-  </editable-toolbar-title>
+<widget-header
+    [name]="widgetName"
+    [icon]="'chart2'"
+    (onRenamed)="renameWidget($event)">
 
   <widget-wp-graph-menu
       [resource]="resource"
       (onConfigured)="updateGraph($event)">
   </widget-wp-graph-menu>
-</h3>
+</widget-header>
 
 <wp-embedded-graph [datasets]="datasets"
                    [chartType]="chartType"

--- a/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.html
@@ -1,21 +1,13 @@
-<h3 class="widget-box--header"
-    cdkDragHandle>
-  <span class="grid--area-drag-handle
-               icon
-               icon-drag-handle"
-        cdkDragHandle></span>
-  <i class="icon-context icon-view-timeline" aria-hidden="true"></i>
+<widget-header
+    [name]="widgetName"
+    [icon]="'view-timeline'"
+    (onRenamed)="renameWidget($event)">
 
-  <editable-toolbar-title [title]="widgetName"
-                          [inFlight]="inFlight"
-                          (onSave)="renameWidget($event)"
-                          class="widget-box--header-title">
-  </editable-toolbar-title>
 
   <widget-wp-table-menu
       [resource]="resource">
   </widget-wp-table-menu>
-</h3>
+</widget-header>
 
 <wp-embedded-table [queryId]="queryId"
                    [configuration]="configuration"

--- a/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.sass
+++ b/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.sass
@@ -2,6 +2,3 @@ wp-embedded-table
   display: flex
   flex: 1 1 auto
   overflow: hidden
-
-.widget-box--header .icon-context
-  padding-top: 5px

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -36,6 +36,7 @@ module API
       class ProjectRepresenter < ::API::Decorators::Single
         include API::Decorators::DateProperty
         include ::API::Caching::CachedRepresenter
+        include API::Decorators::FormattableProperty
         extend ::API::V3::Utilities::CustomFieldInjector::RepresenterClass
 
         self_link
@@ -96,7 +97,8 @@ module API
         property :identifier,   render_nil: true
 
         property :name,         render_nil: true
-        property :description,  render_nil: true
+        formattable_property :description,
+                             uncacheable: true
 
         date_time_property :created_on,
                            as: 'createdAt'

--- a/modules/dashboards/lib/dashboards/grid_registration.rb
+++ b/modules/dashboards/lib/dashboards/grid_registration.rb
@@ -4,7 +4,8 @@ module Dashboards
     to_scope :project_dashboards_path
 
     widgets 'work_packages_table',
-            'work_packages_graph'
+            'work_packages_graph',
+            'project_description'
 
     widget_strategy 'work_packages_table' do
       after_destroy -> { ::Query.find_by(id: options[:queryId])&.destroy }

--- a/modules/dashboards/spec/features/project_description_spec.rb
+++ b/modules/dashboards/spec/features/project_description_spec.rb
@@ -1,0 +1,82 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+require_relative '../support/pages/dashboard'
+
+describe 'Project description widget on dashboard', type: :feature, js: true do
+  let(:project_description) { "Some text I like to write" }
+  let!(:project) do
+    FactoryBot.create :project, description: project_description
+  end
+
+  let(:permissions) do
+    %i[view_dashboards
+       manage_dashboards]
+  end
+
+  let(:role) do
+    FactoryBot.create(:role, permissions: permissions)
+  end
+
+  let(:user) do
+    FactoryBot.create(:user, member_in_project: project, member_with_permissions: permissions)
+  end
+  let(:dashboard_page) do
+    Pages::Dashboard.new(project)
+  end
+
+  before do
+    login_as user
+
+    dashboard_page.visit!
+  end
+
+  it 'can add the widget and see the description in it' do
+    dashboard_page.add_column(3, before_or_after: :before)
+
+    dashboard_page.add_widget(2, 3, "Project description")
+
+    sleep(1)
+
+    # As the user lacks the manage_public_queries and save_queries permission, no other widget is present
+    description_widget = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(1)')
+
+    description_widget.expect_to_span(2, 3, 5, 5)
+    description_widget.resize_to(6, 5)
+
+    description_widget.expect_to_span(2, 3, 7, 6)
+    ## enlarging the table area will have moved the created area down
+
+    within(description_widget.area) do
+      expect(page)
+        .to have_content(project_description)
+    end
+  end
+end

--- a/spec/lib/api/v3/projects/project_representer_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_spec.rb
@@ -32,7 +32,8 @@ describe ::API::V3::Projects::ProjectRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) do
-    FactoryBot.build_stubbed(:project).tap do |p|
+    FactoryBot.build_stubbed(:project,
+                             description: 'some description').tap do |p|
       allow(p)
         .to receive(:available_custom_fields)
         .and_return([int_custom_field, version_custom_field])
@@ -100,7 +101,7 @@ describe ::API::V3::Projects::ProjectRepresenter do
         let(:value) { project.name }
       end
 
-      it_behaves_like 'property', :description do
+      it_behaves_like 'formattable property', :description do
         let(:value) { project.description }
       end
 


### PR DESCRIPTION
Implements the project description widget: https://community.openproject.com/projects/openproject/work_packages/29367

It omits adding a button to the widget like it used to exist on the my project page's widget as I expect the description to become inline editable once the project API supports edit operations.

This PR also:
* Adds OnPush to the trivial components
* Alters the description property of the project resource to a formattable which it is.
* Adds a default header component for widgets