### PR TITLE
[29975] Add card view representation for the work packages list

### DIFF
--- a/app/contracts/queries/base_contract.rb
+++ b/app/contracts/queries/base_contract.rb
@@ -44,6 +44,7 @@ module Queries
     attribute :highlighting_mode
     attribute :highlighted_attributes
     attribute :show_hierarchies
+    attribute :display_representation
 
     attribute :column_names # => columns
     attribute :filters

--- a/app/services/api/v3/parse_query_params_service.rb
+++ b/app/services/api/v3/parse_query_params_service.rb
@@ -56,6 +56,8 @@ module API
 
         parsed_params[:highlighted_attributes] = highlighted_attributes_from_params(params)
 
+        parsed_params[:display_representation] = params[:displayRepresentation]
+
         parsed_params[:show_hierarchies] = boolearize(params[:showHierarchies])
 
         allow_empty = params.keys + skip_empty

--- a/app/services/update_query_from_params_service.rb
+++ b/app/services/update_query_from_params_service.rb
@@ -49,6 +49,8 @@ class UpdateQueryFromParamsService
 
     apply_highlighting(params)
 
+    apply_display_representation(params)
+
     disable_hierarchy_when_only_grouped_by(params)
 
     if valid_subset
@@ -104,6 +106,10 @@ class UpdateQueryFromParamsService
   def apply_highlighting(params)
     query.highlighting_mode = params[:highlighting_mode] if params.key?(:highlighting_mode)
     query.highlighted_attributes = params[:highlighted_attributes] if params.key?(:highlighted_attributes)
+  end
+
+  def apply_display_representation(params)
+    query.display_representation = params[:display_representation] if params.key?(:display_representation)
   end
 
   def disable_hierarchy_when_only_grouped_by(params)

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -73,6 +73,8 @@ en:
     button_open_details: "Open details view"
     button_close_details: "Close details view"
     button_open_fullscreen: "Open fullscreen view"
+    button_show_cards: "Show card view"
+    button_show_list: "Show list view"
     button_quote: "Quote"
     button_save: "Save"
     button_settings: "Settings"

--- a/db/migrate/20190716071941_add_display_representation_to_query.rb
+++ b/db/migrate/20190716071941_add_display_representation_to_query.rb
@@ -1,0 +1,5 @@
+class AddDisplayRepresentationToQuery < ActiveRecord::Migration[5.2]
+  def change
+    add_column :queries, :display_representation, :text
+  end
+end

--- a/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
@@ -1,0 +1,91 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {AbstractWorkPackageButtonComponent} from '../wp-buttons.module';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component} from '@angular/core';
+import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
+import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
+import {StateService} from "@uirouter/core";
+import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
+
+
+@Component({
+  templateUrl: '../wp-button.template.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'wp-view-toggle-button',
+})
+export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonComponent {
+  public buttonId:string = 'work-packages-view-toggle-button';
+  public buttonClass:string = 'toolbar-icon';
+  public iconClass:string = 'icon-view-fullscreen';
+
+  public inListView:boolean = true;
+
+  public activateLabel:string;
+  public deactivateLabel:string;
+
+  constructor(readonly $state:StateService,
+              readonly I18n:I18nService,
+              readonly cdRef:ChangeDetectorRef,
+              readonly wpDisplayRepresentationService:WpDisplayRepresentationService) {
+    super(I18n);
+
+    this.activateLabel = I18n.t('js.button_card_list');
+    this.deactivateLabel = I18n.t('js.button_show_list');
+  }
+
+  public performAction(evt:Event):false {
+    if (this.inListView) {
+      this.activateCardView();
+    } else {
+      this.activateListView();
+    }
+
+    evt.preventDefault();
+    return false;
+  }
+
+  private activateCardView() {
+    this.iconClass = 'icon-view-list';
+    this.inListView = false;
+
+    this.wpDisplayRepresentationService.setDisplayRepresentation('card');
+    this.cdRef.detectChanges();
+  }
+
+  private activateListView() {
+    this.iconClass = 'icon-view-fullscreen';
+    this.inListView = true;
+
+    this.wpDisplayRepresentationService.setDisplayRepresentation('');
+    this.cdRef.detectChanges();
+  }
+
+}
+
+DynamicBootstrapper.register({ selector: 'wp-view-toggle-button', cls: WorkPackageViewToggleButton });

--- a/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
@@ -27,11 +27,15 @@
 // ++
 
 import {AbstractWorkPackageButtonComponent} from '../wp-buttons.module';
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
 import {StateService} from "@uirouter/core";
-import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
+import {
+  WorkPackageDisplayRepresentationService, wpDisplayCardRepresentation,
+  wpDisplayListRepresentation
+} from "core-components/wp-fast-table/state/work-package-display-representation.service";
+import {WorkPackagesListService} from "core-components/wp-list/wp-list.service";
 
 
 @Component({
@@ -39,10 +43,13 @@ import {WpDisplayRepresentationService} from "core-components/wp-fast-table/stat
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'wp-view-toggle-button',
 })
-export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonComponent {
+export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonComponent implements OnInit {
+  private iconListView:string = 'icon-view-list';
+  private iconCardView:string = 'icon-image2';
+
   public buttonId:string = 'work-packages-view-toggle-button';
   public buttonClass:string = 'toolbar-icon';
-  public iconClass:string = 'icon-view-fullscreen';
+  public iconClass:string = this.iconCardView;
 
   public inListView:boolean = true;
 
@@ -52,11 +59,17 @@ export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonCompon
   constructor(readonly $state:StateService,
               readonly I18n:I18nService,
               readonly cdRef:ChangeDetectorRef,
-              readonly wpDisplayRepresentationService:WpDisplayRepresentationService) {
+              readonly wpDisplayRepresentationService:WorkPackageDisplayRepresentationService,
+              readonly wpListService:WorkPackagesListService) {
     super(I18n);
 
     this.activateLabel = I18n.t('js.button_card_list');
     this.deactivateLabel = I18n.t('js.button_show_list');
+  }
+
+  ngOnInit() {
+    this.inListView = this.wpDisplayRepresentationService.valueFromQuery(this.wpListService.currentQuery) === wpDisplayListRepresentation;
+    this.iconClass = this.inListView ? this.iconCardView : this.iconListView;
   }
 
   public performAction(evt:Event):false {
@@ -71,18 +84,18 @@ export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonCompon
   }
 
   private activateCardView() {
-    this.iconClass = 'icon-view-list';
+    this.iconClass = this.iconListView;
     this.inListView = false;
 
-    this.wpDisplayRepresentationService.setDisplayRepresentation('card');
+    this.wpDisplayRepresentationService.setDisplayRepresentation(wpDisplayCardRepresentation);
     this.cdRef.detectChanges();
   }
 
   private activateListView() {
-    this.iconClass = 'icon-view-fullscreen';
+    this.iconClass = this.iconCardView;
     this.inListView = true;
 
-    this.wpDisplayRepresentationService.setDisplayRepresentation('');
+    this.wpDisplayRepresentationService.setDisplayRepresentation(wpDisplayListRepresentation);
     this.cdRef.detectChanges();
   }
 

--- a/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
@@ -70,8 +70,8 @@ import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
   selector: 'wp-view-toggle-button',
 })
 export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonComponent implements OnInit, OnDestroy {
-  private iconListView:string = 'icon-view-list';
-  private iconCardView:string = 'icon-image2';
+  public iconListView:string = 'icon-view-list';
+  public iconCardView:string = 'icon-image2';
 
   public buttonId:string = 'work-packages-view-toggle-button';
 

--- a/frontend/src/app/components/wp-card-view/wp-card-view-horizontal.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view-horizontal.sass
@@ -2,5 +2,3 @@
   display: grid
   grid-template-columns: repeat(auto-fit, minmax(100px, 300px))
   grid-column-gap: 10px
-  grid-template-rows: repeat(1, 180px)
-  grid-auto-rows: 180px

--- a/frontend/src/app/components/wp-card-view/wp-card-view-horizontal.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view-horizontal.sass
@@ -1,0 +1,6 @@
+.wp-cards-container.-horizontal
+  display: grid
+  grid-template-columns: repeat(auto-fit, minmax(100px, 300px))
+  grid-column-gap: 10px
+  grid-template-rows: repeat(1, 180px)
+  grid-auto-rows: 180px

--- a/frontend/src/app/components/wp-card-view/wp-card-view-vertical.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view-vertical.sass
@@ -1,0 +1,19 @@
+@import 'helpers'
+
+.wp-cards-container.-vertical
+  display: flex
+  flex-direction: column
+  // Ensure 100% height for drag & drop area
+  height: 100%
+  // Some minor left/right padding
+  padding: 0 15px
+  border-radius: 2px
+  // We let the scrollbar be always there, so that we can align the button above with the card view
+  // independently of whether we scroll or not.
+  overflow-y: scroll
+  @include styled-scroll-bar
+
+  .wp-card
+    // Take care that the shadow of the last element is still visible
+    &:last-of-type
+      margin-bottom: 3px

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.html
@@ -1,5 +1,5 @@
 <div #container
-     class="wp-cards-container">
+     [ngClass]="'wp-cards-container -' + orientation">
   <div *ngIf="inReference"
        class="wp-inline-create--reference-container">
     <ndc-dynamic [ndcDynamicComponent]="referenceClass"

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
@@ -1,18 +1,5 @@
 @import 'helpers'
 
-.wp-cards-container
-  display: flex
-  flex-direction: column
-  // Ensure 100% height for drag & drop area
-  height: 100%
-  // Some minor left/right padding
-  padding: 0 15px
-  border-radius: 2px
-  // We let the scrollbar be always there, so that we can align the button above with the card view
-  // independently of whether we scroll or not.
-  overflow-y: scroll
-  @include styled-scroll-bar
-
 .wp-card
   user-select: none
   width: 100%
@@ -31,17 +18,14 @@
   &.-new
     padding-right: 25px
 
-  // Take care that the shadow of the last element is still visible
-  &:last-of-type
-    margin-bottom: 3px
-
 .wp-card--content:not(.-new)
   display: grid
   grid-template-columns: auto 1fr auto
-  grid-template-rows: auto auto auto
+  grid-template-rows: auto 1fr auto
   grid-row-gap: 10px
   grid-template-areas: "type type type" "subject subject subject" "attributeTag avatar idlink"
   overflow: hidden
+  height: 100%
 
   .wp-card--type
     grid-area: type

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -37,6 +37,7 @@ import {PathHelperService} from "core-app/modules/common/path-helper/path-helper
 import {filter} from 'rxjs/operators';
 import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
 
+export type CardViewOrientation = 'horizontal'|'vertical';
 
 @Component({
   selector: 'wp-card-view',
@@ -50,7 +51,14 @@ export class WorkPackageCardViewComponent  implements OnInit {
   @Input() public highlightingMode:CardHighlightingMode;
   @Input() public workPackageAddedHandler:(wp:WorkPackageResource) => Promise<unknown>;
   @Input() public showStatusButton:boolean = true;
-  @Input() public orientation:'horizontal'|'vertical' = 'vertical';
+  @Input() public orientation:CardViewOrientation = 'vertical';
+  /** Whether cards are removable */
+  @Input() public cardsRemovable:boolean = false;
+
+  /** Container reference */
+  @ViewChild('container', { static: true }) public container:ElementRef;
+
+  @Output() onMoved = new EventEmitter<void>();
 
   public trackByHref = AngularTrackingHelpers.trackByHref;
   public query:QueryResource;
@@ -72,12 +80,6 @@ export class WorkPackageCardViewComponent  implements OnInit {
     onCancel: () => this.setReferenceMode(false),
     onReferenced: (wp:WorkPackageResource) => this.addWorkPackageToQuery(wp, 0)
   };
-
-  /** Whether cards are removable */
-  @Input() public cardsRemovable:boolean = false;
-
-  /** Container reference */
-  @ViewChild('container', { static: true }) public container:ElementRef;
 
   /** Whether the card view has an active inline created wp */
   public activeInlineCreateWp?:WorkPackageResource;
@@ -211,6 +213,8 @@ export class WorkPackageCardViewComponent  implements OnInit {
 
         const newOrder = this.reorderService.move(this.currentOrder, wpId, toIndex);
         this.updateOrder(newOrder);
+
+        this.onMoved.emit();
       },
       onRemoved: (card:HTMLElement) => {
         const wpId:string = card.dataset.workPackageId!;

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -40,7 +40,7 @@ import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates
 
 @Component({
   selector: 'wp-card-view',
-  styleUrls: ['./wp-card-view.component.sass'],
+  styleUrls: ['./wp-card-view.component.sass', './wp-card-view-horizontal.sass', './wp-card-view-vertical.sass'],
   templateUrl: './wp-card-view.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -50,6 +50,7 @@ export class WorkPackageCardViewComponent  implements OnInit {
   @Input() public highlightingMode:CardHighlightingMode;
   @Input() public workPackageAddedHandler:(wp:WorkPackageResource) => Promise<unknown>;
   @Input() public showStatusButton:boolean = true;
+  @Input() public orientation:'horizontal'|'vertical' = 'vertical';
 
   public trackByHref = AngularTrackingHelpers.trackByHref;
   public query:QueryResource;

--- a/frontend/src/app/components/wp-fast-table/builders/highlighting/highlighting-mode.const.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/highlighting/highlighting-mode.const.ts
@@ -1,3 +1,3 @@
 export type HighlightingMode = 'status'|'priority'|'type'|'inline'|'none';
 
-export type CardHighlightingMode =  'priority'|'type'|'none'|'entire-card';
+export type CardHighlightingMode =  'priority'|'type'|'none'|'inline';

--- a/frontend/src/app/components/wp-fast-table/state/work-package-display-representation.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/work-package-display-representation.service.ts
@@ -32,8 +32,11 @@ import {States} from 'core-components/states.service';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {Injectable} from '@angular/core';
 
+export const wpDisplayListRepresentation:string = 'list';
+export const wpDisplayCardRepresentation:string = 'card';
+
 @Injectable()
-export class WpDisplayRepresentationService extends WorkPackageQueryStateService<string> {
+export class WorkPackageDisplayRepresentationService extends WorkPackageQueryStateService<string> {
   public constructor(readonly states:States,
                      readonly querySpace:IsolatedQuerySpace) {
     super(querySpace);
@@ -44,7 +47,7 @@ export class WpDisplayRepresentationService extends WorkPackageQueryStateService
   }
 
   valueFromQuery(query:QueryResource) {
-    return query.displayRepresentation || '';
+    return query.displayRepresentation || wpDisplayListRepresentation;
   }
 
   public applyToQuery(query:QueryResource) {
@@ -53,7 +56,7 @@ export class WpDisplayRepresentationService extends WorkPackageQueryStateService
   }
 
   public get current():string {
-    return this.lastUpdatedState.getValueOr('');
+    return this.lastUpdatedState.getValueOr(wpDisplayListRepresentation);
   }
 
   public setDisplayRepresentation(representation:string) {

--- a/frontend/src/app/components/wp-fast-table/state/wp-display-representation.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-display-representation.service.ts
@@ -1,0 +1,62 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
+import {WorkPackageQueryStateService} from './wp-table-base.service';
+import {States} from 'core-components/states.service';
+import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
+import {Injectable} from '@angular/core';
+
+@Injectable()
+export class WpDisplayRepresentationService extends WorkPackageQueryStateService<string> {
+  public constructor(readonly states:States,
+                     readonly querySpace:IsolatedQuerySpace) {
+    super(querySpace);
+  }
+
+  public hasChanged(query:QueryResource) {
+    return this.current !== query.displayRepresentation;
+  }
+
+  valueFromQuery(query:QueryResource) {
+    return query.displayRepresentation || '';
+  }
+
+  public applyToQuery(query:QueryResource) {
+    query.displayRepresentation = this.current;
+    return true;
+  }
+
+  public get current():string {
+    return this.lastUpdatedState.getValueOr('');
+  }
+
+  public setDisplayRepresentation(representation:string) {
+    this.update(representation);
+  }
+}

--- a/frontend/src/app/components/wp-grid/wp-grid.component.ts
+++ b/frontend/src/app/components/wp-grid/wp-grid.component.ts
@@ -1,0 +1,63 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {ChangeDetectionStrategy, Component} from "@angular/core";
+import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
+import {CardViewOrientation} from "core-components/wp-card-view/wp-card-view.component";
+import {WorkPackageTableSortByService} from "core-components/wp-fast-table/state/wp-table-sort-by.service";
+
+@Component({
+  selector: 'wp-grid',
+  template: `
+    <wp-card-view [dragOutOfHandler]="canDragOutOf"
+                  [dragInto]="true"
+                  [cardsRemovable]="false"
+                  [highlightingMode]="highlightingMode()"
+                  [showStatusButton]="false"
+                  [orientation]="gridOrientation"
+                  (onMoved)="switchToManualSorting()">
+    </wp-card-view>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class WorkPackagesGridComponent {
+  public canDragOutOf = () => { return true };
+  public gridOrientation:CardViewOrientation = 'horizontal';
+
+  constructor(readonly wpTableHighlight:WorkPackageTableHighlightingService,
+              readonly wpTableSortBy:WorkPackageTableSortByService) {
+  }
+
+  public switchToManualSorting() {
+    this.wpTableSortBy.switchToManualSorting();
+  }
+
+  public highlightingMode() {
+    return this.wpTableHighlight.current.mode;
+  }
+}

--- a/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
@@ -138,6 +138,7 @@ export class WorkPackageStatesInitializationService {
     this.wpTableTimeline.initialize(query, results);
     this.wpTableHierarchies.initialize(query, results);
     this.wpTableHighlighting.initialize(query, results);
+    this.wpDisplayRepresentation.initialize(query, results);
 
     this.authorisationService.initModelAuth('query', query.$links);
     this.authorisationService.initModelAuth('work_packages', results.$links);

--- a/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
@@ -23,7 +23,7 @@ import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table
 import {combineLatest, Observable} from "rxjs";
 import {take} from "rxjs/operators";
 import {WorkPackageTableOrderService} from "core-components/wp-fast-table/state/wp-table-order.service";
-import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
+import {WorkPackageDisplayRepresentationService} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 @Injectable()
 export class WorkPackageStatesInitializationService {
@@ -44,7 +44,7 @@ export class WorkPackageStatesInitializationService {
               protected wpCacheService:WorkPackageCacheService,
               protected wpListChecksumService:WorkPackagesListChecksumService,
               protected authorisationService:AuthorisationService,
-              protected wpDisplayRepresentation:WpDisplayRepresentationService) {
+              protected wpDisplayRepresentation:WorkPackageDisplayRepresentationService) {
   }
 
   /**

--- a/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
@@ -23,6 +23,7 @@ import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table
 import {combineLatest, Observable} from "rxjs";
 import {take} from "rxjs/operators";
 import {WorkPackageTableOrderService} from "core-components/wp-fast-table/state/wp-table-order.service";
+import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
 
 @Injectable()
 export class WorkPackageStatesInitializationService {
@@ -42,7 +43,8 @@ export class WorkPackageStatesInitializationService {
               protected wpTableAdditionalElements:WorkPackageTableAdditionalElementsService,
               protected wpCacheService:WorkPackageCacheService,
               protected wpListChecksumService:WorkPackagesListChecksumService,
-              protected authorisationService:AuthorisationService) {
+              protected authorisationService:AuthorisationService,
+              protected wpDisplayRepresentation:WpDisplayRepresentationService) {
   }
 
   /**
@@ -151,6 +153,7 @@ export class WorkPackageStatesInitializationService {
     this.wpTableHighlighting.applyToQuery(query);
     this.wpTableHierarchies.applyToQuery(query);
     this.wpTableOrder.applyToQuery(query);
+    this.wpDisplayRepresentation.applyToQuery(query);
   }
 
   public clearStates() {

--- a/frontend/src/app/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/components/wp-query/url-params-helper.ts
@@ -263,6 +263,10 @@ export class UrlParamsHelperService {
       queryData.highlightedAttributes = query.highlightedAttributes.map(el => el.href);
     }
 
+    if (query.displayRepresentation) {
+      queryData.displayRepresentation = query.displayRepresentation;
+    }
+
     queryData.showHierarchies = !!query.showHierarchies;
     queryData.groupBy = _.get(query.groupBy, 'id', '');
 

--- a/frontend/src/app/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/components/wp-query/url-params-helper.ts
@@ -77,6 +77,7 @@ export class UrlParamsHelperService {
     paramsData = this.encodeFilters(paramsData, query.filters);
     paramsData.pa = additional.page;
     paramsData.pp = additional.perPage;
+    paramsData.dr = query.displayRepresentation;
 
     return JSON.stringify(paramsData);
   }
@@ -185,6 +186,10 @@ export class UrlParamsHelperService {
       if (properties.tzl) {
         queryData.timelineZoomLevel = properties.tzl;
       }
+    }
+
+    if (properties.dr) {
+      queryData.displayRepresentation = properties.dr;
     }
 
     if (properties.hl) {

--- a/frontend/src/app/modules/boards/board/configuration-modal/tabs/highlighting-tab.component.html
+++ b/frontend/src/app/modules/boards/board/configuration-modal/tabs/highlighting-tab.component.html
@@ -7,7 +7,7 @@
         <label class="option-label">
           <input type="radio"
                  [(ngModel)]="entireCardMode"
-                 (change)="updateMode('entire-card')"
+                 (change)="updateMode('inline')"
                  [value]="true"
                  name="entire_card_switch">
           <span [textContent]="text.highlighting_mode.entire_card_by"></span>

--- a/frontend/src/app/modules/boards/board/configuration-modal/tabs/highlighting-tab.component.ts
+++ b/frontend/src/app/modules/boards/board/configuration-modal/tabs/highlighting-tab.component.ts
@@ -46,7 +46,7 @@ export class BoardHighlightingTabComponent implements TabComponent {
   }
 
   public updateMode(mode:CardHighlightingMode) {
-    if (mode === 'entire-card') {
+    if (mode === 'inline') {
       this.highlightingMode = this.lastEntireCardAttribute;
     } else {
       this.highlightingMode = mode;

--- a/frontend/src/app/modules/hal/resources/query-resource.ts
+++ b/frontend/src/app/modules/hal/resources/query-resource.ts
@@ -66,6 +66,7 @@ export class QueryResource extends HalResource {
   public timelineZoomLevel:TimelineZoomLevel;
   public highlightingMode:HighlightingMode;
   public highlightedAttributes:HalResource[]|undefined;
+  public displayRepresentation:string|undefined;
   public timelineLabels:TimelineLabels;
   public showHierarchies:boolean;
   public public:boolean;

--- a/frontend/src/app/modules/hal/resources/query-resource.ts
+++ b/frontend/src/app/modules/hal/resources/query-resource.ts
@@ -66,7 +66,7 @@ export class QueryResource extends HalResource {
   public timelineZoomLevel:TimelineZoomLevel;
   public highlightingMode:HighlightingMode;
   public highlightedAttributes:HalResource[]|undefined;
-  public displayRepresentation:string|undefined;
+  public displayRepresentation:string;
   public timelineLabels:TimelineLabels;
   public showHierarchies:boolean;
   public public:boolean;

--- a/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
@@ -157,6 +157,7 @@ import {CustomDateActionAdminComponent} from 'core-components/wp-custom-actions/
 import {WorkPackagesTableConfigMenu} from "core-components/wp-table/config-menu/config-menu.component";
 import {WorkPackageIsolatedGraphQuerySpaceDirective} from "core-app/modules/work_packages/query-space/wp-isolated-graph-query-space.directive";
 import {WorkPackageViewToggleButton} from "core-components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component";
+import {WorkPackagesGridComponent} from "core-components/wp-grid/wp-grid.component";
 
 @NgModule({
   imports: [
@@ -236,6 +237,8 @@ import {WorkPackageViewToggleButton} from "core-components/wp-buttons/wp-view-to
     // Inline create
     WorkPackageInlineCreateComponent,
     WpRelationInlineAddExistingComponent,
+
+    WorkPackagesGridComponent,
 
     WorkPackagesTableController,
     WorkPackagesTableConfigMenu,
@@ -378,8 +381,12 @@ import {WorkPackageViewToggleButton} from "core-components/wp-buttons/wp-view-to
 
     // Inline create
     WpRelationInlineAddExistingComponent,
+
+    // View representations
     WorkPackagesBaseComponent,
     WorkPackagesListComponent,
+
+    WorkPackagesGridComponent,
 
     // WP new
     WorkPackageNewFullViewComponent,

--- a/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
@@ -156,6 +156,7 @@ import {WorkPackageRelationsAutocomplete} from "core-components/wp-relations/wp-
 import {CustomDateActionAdminComponent} from 'core-components/wp-custom-actions/date-action/custom-date-action-admin.component';
 import {WorkPackagesTableConfigMenu} from "core-components/wp-table/config-menu/config-menu.component";
 import {WorkPackageIsolatedGraphQuerySpaceDirective} from "core-app/modules/work_packages/query-space/wp-isolated-graph-query-space.directive";
+import {WorkPackageViewToggleButton} from "core-components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component";
 
 @NgModule({
   imports: [
@@ -357,6 +358,7 @@ import {WorkPackageIsolatedGraphQuerySpaceDirective} from "core-app/modules/work
 
     // Card view
     WorkPackageCardViewComponent,
+    WorkPackageViewToggleButton,
   ],
   entryComponents: [
     // Split view

--- a/frontend/src/app/modules/work_packages/query-space/wp-isolated-query-space.directive.ts
+++ b/frontend/src/app/modules/work_packages/query-space/wp-isolated-query-space.directive.ts
@@ -62,6 +62,7 @@ import {PortalCleanupService} from "core-app/modules/fields/display/display-port
 import {TableDragActionsRegistryService} from "core-components/wp-table/drag-and-drop/actions/table-drag-actions-registry.service";
 import {ReorderQueryService} from "core-app/modules/common/drag-and-drop/reorder-query.service";
 import {WorkPackageTableOrderService} from "core-components/wp-fast-table/state/wp-table-order.service";
+import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
 
 /**
  * Directive to open a work package query 'space', an isolated injector hierarchy
@@ -96,6 +97,7 @@ import {WorkPackageTableOrderService} from "core-components/wp-fast-table/state/
   WorkPackageTableFocusService,
   WorkPackageTableHighlightingService,
   WorkPackageTableOrderService,
+  WpDisplayRepresentationService,
   WorkPackageService,
   WorkPackageRelationsHierarchyService,
   WorkPackageFiltersService,

--- a/frontend/src/app/modules/work_packages/query-space/wp-isolated-query-space.directive.ts
+++ b/frontend/src/app/modules/work_packages/query-space/wp-isolated-query-space.directive.ts
@@ -62,7 +62,7 @@ import {PortalCleanupService} from "core-app/modules/fields/display/display-port
 import {TableDragActionsRegistryService} from "core-components/wp-table/drag-and-drop/actions/table-drag-actions-registry.service";
 import {ReorderQueryService} from "core-app/modules/common/drag-and-drop/reorder-query.service";
 import {WorkPackageTableOrderService} from "core-components/wp-fast-table/state/wp-table-order.service";
-import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
+import {WorkPackageDisplayRepresentationService} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 /**
  * Directive to open a work package query 'space', an isolated injector hierarchy
@@ -97,7 +97,7 @@ import {WpDisplayRepresentationService} from "core-components/wp-fast-table/stat
   WorkPackageTableFocusService,
   WorkPackageTableHighlightingService,
   WorkPackageTableOrderService,
-  WpDisplayRepresentationService,
+  WorkPackageDisplayRepresentationService,
   WorkPackageService,
   WorkPackageRelationsHierarchyService,
   WorkPackageFiltersService,

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
@@ -7,3 +7,5 @@
 
 .work-packages--card-view-container
   width: 100%
+  overflow: auto
+  @include styled-scroll-bar

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
@@ -4,3 +4,6 @@
   @include overlay-background
   background-color: #FFFFFF
   opacity: 0.5
+
+.work-packages--card-view-container
+  width: 100%

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -83,7 +83,7 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
   showResultOverlay = false;
 
   /** Switch between list and card view */
-  showListView:boolean = false;
+  private _showListView:boolean = false;
 
 
   // TODO: REPLACE WITH REAL IMPLEMENTATION
@@ -120,6 +120,7 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
       this.updateTitle(query);
       this.currentQuery = query;
       this.showPagination = !this.wpTableSortBy.isManualSortingMode;
+      this.showListView = !this.wpDisplayRepresentation.valueFromQuery(query);
       this.cdRef.detectChanges();
     });
   }
@@ -199,6 +200,14 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
 
   public updateResultVisibility(completed:boolean) {
     this.showResultOverlay = !completed;
+  }
+
+  public set showListView(val:boolean) {
+    this._showListView = val;
+  }
+
+  public get showListView():boolean {
+    return this._showListView;
   }
 
   protected updateQueryOnParamsChanges() {

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -35,6 +35,10 @@ import {take} from "rxjs/operators";
 import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and-drop.service";
 import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
+import {
+  wpDisplayCardRepresentation,
+  wpDisplayListRepresentation
+} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 @Component({
   selector: 'wp-list',
@@ -83,7 +87,7 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
   showResultOverlay = false;
 
   /** Switch between list and card view */
-  private _showListView:boolean = false;
+  private _showListView:boolean = true;
 
 
   // TODO: REPLACE WITH REAL IMPLEMENTATION
@@ -120,7 +124,13 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
       this.updateTitle(query);
       this.currentQuery = query;
       this.showPagination = !this.wpTableSortBy.isManualSortingMode;
-      this.showListView = !this.wpDisplayRepresentation.valueFromQuery(query);
+
+      if (this.wpDisplayRepresentation.valueFromQuery(query) === wpDisplayCardRepresentation) {
+        this.showListView = false;
+      } else {
+        this.showListView = true;
+      }
+
       this.cdRef.detectChanges();
     });
   }

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -33,6 +33,8 @@ import {OpTitleService} from "core-components/html/op-title.service";
 import {WorkPackagesViewBase} from "core-app/modules/work_packages/routing/wp-view-base/work-packages-view.base";
 import {take} from "rxjs/operators";
 import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and-drop.service";
+import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
+import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 
 @Component({
   selector: 'wp-list',
@@ -40,7 +42,8 @@ import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and
   styleUrls: ['./wp-list.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
-    DragAndDropService
+    DragAndDropService,
+    CausedUpdatesService,
   ]
 })
 export class WorkPackagesListComponent extends WorkPackagesViewBase implements OnDestroy {
@@ -78,6 +81,13 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
 
   /** An overlay over the table shown for example when the filters are invalid */
   showResultOverlay = false;
+
+  /** Switch between list and card view */
+  showListView:boolean = false;
+
+
+  // TODO: REPLACE WITH REAL IMPLEMENTATION
+  public test = (workPackage:WorkPackageResource) => { return true };
 
   private readonly titleService:OpTitleService = this.injector.get(OpTitleService);
 

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -35,10 +35,7 @@ import {take} from "rxjs/operators";
 import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and-drop.service";
 import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
-import {
-  wpDisplayCardRepresentation,
-  wpDisplayListRepresentation
-} from "core-components/wp-fast-table/state/work-package-display-representation.service";
+import {wpDisplayCardRepresentation} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 @Component({
   selector: 'wp-list',

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -83,12 +83,11 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
   /** An overlay over the table shown for example when the filters are invalid */
   showResultOverlay = false;
 
-  /** Switch between list and card view */
-  private _showListView:boolean = true;
-
-
   // TODO: REPLACE WITH REAL IMPLEMENTATION
   public test = (workPackage:WorkPackageResource) => { return true };
+
+  /** Switch between list and card view */
+  private _showListView:boolean = true;
 
   private readonly titleService:OpTitleService = this.injector.get(OpTitleService);
 
@@ -114,12 +113,14 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
       }
     });
 
-    // Update the title whenever the query changes
     this.querySpace.query.values$().pipe(
       untilComponentDestroyed(this)
     ).subscribe((query) => {
+      // Update the title whenever the query changes
       this.updateTitle(query);
       this.currentQuery = query;
+
+      // Update the visible representation
       this.showPagination = !this.wpTableSortBy.isManualSortingMode;
 
       if (this.wpDisplayRepresentation.valueFromQuery(query) === wpDisplayCardRepresentation) {
@@ -261,6 +262,8 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
     return this.loadingIndicator =
       this.wpListService
         .loadCurrentQueryFromParams(this.projectIdentifier)
-        .then(() => this.querySpace.rendered.valuesPromise());
+        .then(() => {
+          this.querySpace.rendered.valuesPromise();
+        });
   }
 }

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -34,7 +34,6 @@ import {WorkPackagesViewBase} from "core-app/modules/work_packages/routing/wp-vi
 import {take} from "rxjs/operators";
 import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and-drop.service";
 import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
-import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {wpDisplayCardRepresentation} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 @Component({
@@ -82,9 +81,6 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
 
   /** An overlay over the table shown for example when the filters are invalid */
   showResultOverlay = false;
-
-  // TODO: REPLACE WITH REAL IMPLEMENTATION
-  public test = (workPackage:WorkPackageResource) => { return true };
 
   /** Switch between list and card view */
   private _showListView:boolean = true;

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -63,16 +63,27 @@
   <div class="work-packages-split-view">
 
     <!-- (TABLE + TIMELINE) and FOOTER vertical split-->
-    <div *ngIf="showListView"
-         class="work-packages-split-view--tabletimeline-side loading-indicator--location"
+    <div class="work-packages-split-view--tabletimeline-side loading-indicator--location"
          data-indicator-name="table">
       <div class="result-overlay"
-           *ngIf="showResultOverlay"></div>
+           *ngIf="showResultOverlay && showListView"></div>
 
       <!-- TABLE + TIMELINE horizontal split -->
-      <wp-table *ngIf="tableInformationLoaded"
+      <wp-table *ngIf="tableInformationLoaded && showListView"
                 [projectIdentifier]="projectIdentifier"
                 class="work-packages-split-view--tabletimeline-content"></wp-table>
+
+      <!-- CARD representation of the WP -->
+      <div *ngIf="!showListView"
+           class="work-packages--card-view-container">
+        <wp-card-view [dragOutOfHandler]="test"
+                      [dragInto]="true"
+                      [cardsRemovable]="false"
+                      [highlightingMode]="wpTableHighlighting.current.mode"
+                      [showStatusButton]="false"
+                      [orientation]="'horizontal'">
+        </wp-card-view>
+      </div>
 
       <!-- Footer -->
       <div class="work-packages-split-view--tabletimeline-footer hide-when-print"
@@ -83,19 +94,5 @@
 
     <!-- Details view -->
     <div class="work-packages-split-view--details-side" ui-view></div>
-
-    <!-- Card representation of the WP -->
-    <div *ngIf="!showListView"
-         class="work-packages--card-view-container loading-indicator--location"
-         data-indicator-name="table">
-      <wp-card-view *ngIf="!showListView"
-                    [dragOutOfHandler]="test"
-                    [dragInto]="true"
-                    [cardsRemovable]="false"
-                    [highlightingMode]="wpTableHighlighting.current.mode"
-                    [showStatusButton]="false"
-                    [orientation]="'horizontal'">
-      </wp-card-view>
-    </div>
   </div>
 </div>

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -73,16 +73,10 @@
                 [projectIdentifier]="projectIdentifier"
                 class="work-packages-split-view--tabletimeline-content"></wp-table>
 
-      <!-- CARD representation of the WP -->
+      <!-- GRID representation of the WP -->
       <div *ngIf="!showListView"
            class="work-packages--card-view-container">
-        <wp-card-view [dragOutOfHandler]="test"
-                      [dragInto]="true"
-                      [cardsRemovable]="false"
-                      [highlightingMode]="wpTableHighlighting.current.mode"
-                      [showStatusButton]="false"
-                      [orientation]="'horizontal'">
-        </wp-card-view>
+        <wp-grid></wp-grid>
       </div>
 
       <!-- Footer -->

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -30,6 +30,10 @@
           </wp-timeline-toggle-button>
         </li>
         <li class="toolbar-item hidden-for-mobile">
+          <wp-view-toggle-button>
+          </wp-view-toggle-button>
+        </li>
+        <li class="toolbar-item hidden-for-mobile">
           <zen-mode-toggle-button>
           </zen-mode-toggle-button>
         </li>

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -59,7 +59,8 @@
   <div class="work-packages-split-view">
 
     <!-- (TABLE + TIMELINE) and FOOTER vertical split-->
-    <div class="work-packages-split-view--tabletimeline-side loading-indicator--location"
+    <div *ngIf="showListView"
+         class="work-packages-split-view--tabletimeline-side loading-indicator--location"
          data-indicator-name="table">
       <div class="result-overlay"
            *ngIf="showResultOverlay"></div>
@@ -78,5 +79,19 @@
 
     <!-- Details view -->
     <div class="work-packages-split-view--details-side" ui-view></div>
+
+    <!-- Card representation of the WP -->
+    <div *ngIf="!showListView"
+         class="work-packages--card-view-container loading-indicator--location"
+         data-indicator-name="table">
+      <wp-card-view *ngIf="!showListView"
+                    [dragOutOfHandler]="test"
+                    [dragInto]="true"
+                    [cardsRemovable]="false"
+                    [highlightingMode]="wpTableHighlighting.current.mode"
+                    [showStatusButton]="false"
+                    [orientation]="'horizontal'">
+      </wp-card-view>
+    </div>
   </div>
 </div>

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
@@ -57,7 +57,7 @@ import {debugLog} from "core-app/helpers/debug_output";
 import {QueryDmService} from "core-app/modules/hal/dm-services/query-dm.service";
 import {WorkPackageStatesInitializationService} from "core-components/wp-list/wp-states-initialization.service";
 import {WorkPackageTableOrderService} from "core-components/wp-fast-table/state/wp-table-order.service";
-import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
+import {WorkPackageDisplayRepresentationService} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
 
@@ -85,7 +85,7 @@ export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
   readonly QueryDm:QueryDmService = this.injector.get(QueryDmService);
   readonly wpStatesInitialization:WorkPackageStatesInitializationService = this.injector.get(WorkPackageStatesInitializationService);
   readonly cdRef:ChangeDetectorRef = this.injector.get(ChangeDetectorRef);
-  readonly wpDisplayRepresentation:WpDisplayRepresentationService = this.injector.get(WpDisplayRepresentationService);
+  readonly wpDisplayRepresentation:WorkPackageDisplayRepresentationService = this.injector.get(WorkPackageDisplayRepresentationService);
 
   constructor(protected injector:Injector) {
   }

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
@@ -57,6 +57,7 @@ import {debugLog} from "core-app/helpers/debug_output";
 import {QueryDmService} from "core-app/modules/hal/dm-services/query-dm.service";
 import {WorkPackageStatesInitializationService} from "core-components/wp-list/wp-states-initialization.service";
 import {WorkPackageTableOrderService} from "core-components/wp-fast-table/state/wp-table-order.service";
+import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
 
 export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
 
@@ -84,6 +85,7 @@ export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
   readonly QueryDm:QueryDmService = this.injector.get(QueryDmService);
   readonly wpStatesInitialization:WorkPackageStatesInitializationService = this.injector.get(WorkPackageStatesInitializationService);
   readonly cdRef:ChangeDetectorRef = this.injector.get(ChangeDetectorRef);
+  readonly wpDisplayRepresentation:WpDisplayRepresentationService = this.injector.get(WpDisplayRepresentationService);
 
   constructor(protected injector:Injector) {
   }
@@ -122,6 +124,7 @@ export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
     this.setupChangeObserver(this.wpTableColumns);
     this.setupChangeObserver(this.wpTableHighlighting);
     this.setupChangeObserver(this.wpTableOrder);
+    this.setupChangeObserver(this.wpDisplayRepresentation);
   }
 
   /**

--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -300,6 +300,9 @@ module API
 
         property :timeline_labels
 
+        # Visible representation of the results
+        property :display_representation
+
         # Highlighting properties
         property :highlighting_mode,
                  render_nil: false

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -138,6 +138,13 @@ module API
                  has_default: true,
                  visibility: false
 
+          schema :display_representation,
+                 type: 'String',
+                 required: false,
+                 writable: true,
+                 has_default: true,
+                 visibility: false
+
           schema :show_hierarchies,
                  type: 'Boolean',
                  required: false,

--- a/modules/boards/spec/features/board_highlighting_spec.rb
+++ b/modules/boards/spec/features/board_highlighting_spec.rb
@@ -87,12 +87,12 @@ describe 'Work Package boards spec', type: :feature, js: true do
     expect(page).to have_selector('.__hl_inline_type_' + type2.id.to_s)
 
     # Highlight whole card by priority
-    board_page.change_board_highlighting 'entire-card', 'Priority'
+    board_page.change_board_highlighting 'inline', 'Priority'
     expect(page).to have_selector('.__hl_background_priority_' + priority.id.to_s)
     expect(page).to have_selector('.__hl_background_priority_' + priority2.id.to_s)
 
     # Highlight whole card by type
-    board_page.change_board_highlighting 'entire-card', 'Type'
+    board_page.change_board_highlighting 'inline', 'Type'
     expect(page).to have_selector('.__hl_background_type_' + type.id.to_s)
     expect(page).to have_selector('.__hl_background_type_' + type2.id.to_s)
 


### PR DESCRIPTION
This PR aims to create a different representation of the WP list in form of cards. The cards itself shall look similar to the board, but the layout is horizontal.

### ToDo
- [x] Add a card-based representation of the WP table
- [x] Add a button to switch between the layouts
- [x] The state shall be stored in the query, so that it is persisted when the page is reloaded
- [x] The following actions that are possible on the table, shall be possible, too:
  - [x] Apply the defined highlighting as far as possible (for attributes that are visible)
- [ ] Tests

### Out of Scope for this PR
* Changing the order via drag'n'drop (as the targeted branch is release/9.1)
* Grouping the results
* Moving cards between groups should change the according attribute.
* Adding the card representation to the BIM module