### PR TITLE
Enable debian 10

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -9,6 +9,8 @@ targets:
       - unrtf
       - tesseract-ocr
       - catdoc
+  debian-10:
+    <<: *debian9
   ubuntu-14.04:
     <<: *debian9
   ubuntu-16.04:


### PR DESCRIPTION
Enables debian 10 packaging on Packager.io. Packages build [fine](https://packager.io/gh/opf/openproject/refs/feature/debian-10), but I need a few more days to test the resulting package.