### PR TITLE
[30575] Include Cards View into work packages module

### DIFF
--- a/app/contracts/queries/base_contract.rb
+++ b/app/contracts/queries/base_contract.rb
@@ -44,6 +44,7 @@ module Queries
     attribute :highlighting_mode
     attribute :highlighted_attributes
     attribute :show_hierarchies
+    attribute :display_representation
 
     attribute :column_names # => columns
     attribute :filters

--- a/app/services/api/v3/parse_query_params_service.rb
+++ b/app/services/api/v3/parse_query_params_service.rb
@@ -56,6 +56,8 @@ module API
 
         parsed_params[:highlighted_attributes] = highlighted_attributes_from_params(params)
 
+        parsed_params[:display_representation] = params[:displayRepresentation]
+
         parsed_params[:show_hierarchies] = boolearize(params[:showHierarchies])
 
         allow_empty = params.keys + skip_empty

--- a/app/services/update_query_from_params_service.rb
+++ b/app/services/update_query_from_params_service.rb
@@ -49,6 +49,8 @@ class UpdateQueryFromParamsService
 
     apply_highlighting(params)
 
+    apply_display_representation(params)
+
     disable_hierarchy_when_only_grouped_by(params)
 
     if valid_subset
@@ -104,6 +106,10 @@ class UpdateQueryFromParamsService
   def apply_highlighting(params)
     query.highlighting_mode = params[:highlighting_mode] if params.key?(:highlighting_mode)
     query.highlighted_attributes = params[:highlighted_attributes] if params.key?(:highlighted_attributes)
+  end
+
+  def apply_display_representation(params)
+    query.display_representation = params[:display_representation] if params.key?(:display_representation)
   end
 
   def disable_hierarchy_when_only_grouped_by(params)

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -84,6 +84,8 @@ en:
     button_open_details: "Open details view"
     button_close_details: "Close details view"
     button_open_fullscreen: "Open fullscreen view"
+    button_show_cards: "Show card view"
+    button_show_list: "Show list view"
     button_quote: "Quote"
     button_save: "Save"
     button_settings: "Settings"

--- a/db/migrate/20190716071941_add_display_representation_to_query.rb
+++ b/db/migrate/20190716071941_add_display_representation_to_query.rb
@@ -1,0 +1,5 @@
+class AddDisplayRepresentationToQuery < ActiveRecord::Migration[5.2]
+  def change
+    add_column :queries, :display_representation, :text
+  end
+end

--- a/frontend/src/app/components/wp-buttons/wp-details-view-button/wp-details-view-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-details-view-button/wp-details-view-button.component.ts
@@ -30,15 +30,20 @@ import {KeepTabService} from '../../wp-single-view-tabs/keep-tab/keep-tab.servic
 import {States} from '../../states.service';
 import {WorkPackageTableFocusService} from 'core-components/wp-fast-table/state/wp-table-focus.service';
 import {StateService} from '@uirouter/core';
-import {Component} from '@angular/core';
+import {ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
 import {AbstractWorkPackageButtonComponent} from 'core-components/wp-buttons/wp-buttons.module';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {
+  WorkPackageDisplayRepresentationService,
+  wpDisplayCardRepresentation
+} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 @Component({
   templateUrl: '../wp-button.template.html',
   selector: 'wp-details-view-button',
 })
-export class WorkPackageDetailsViewButtonComponent extends AbstractWorkPackageButtonComponent {
+export class WorkPackageDetailsViewButtonComponent extends AbstractWorkPackageButtonComponent implements OnInit, OnDestroy {
   public projectIdentifier:string;
   public accessKey:number = 8;
   public activeState:string = 'work-packages.list.details';
@@ -55,12 +60,29 @@ export class WorkPackageDetailsViewButtonComponent extends AbstractWorkPackageBu
     readonly I18n:I18nService,
     public states:States,
     public wpTableFocus:WorkPackageTableFocusService,
-    public keepTab:KeepTabService) {
+    public keepTab:KeepTabService,
+    public wpDisplayRepresentationService:WorkPackageDisplayRepresentationService,
+    public cdRef:ChangeDetectorRef) {
 
     super(I18n);
 
     this.activateLabel = I18n.t('js.button_open_details');
     this.deactivateLabel = I18n.t('js.button_close_details');
+  }
+
+  public ngOnInit() {
+    this.wpDisplayRepresentationService.state.values$()
+      .pipe(
+        untilComponentDestroyed(this)
+      )
+      .subscribe(() => {
+        this.disabled = this.wpDisplayRepresentationService.current === wpDisplayCardRepresentation;
+        this.cdRef.detectChanges();
+      });
+  }
+
+  public ngOnDestroy() {
+    // Nothing to do
   }
 
   public get label():string {

--- a/frontend/src/app/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component.ts
@@ -32,6 +32,10 @@ import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {TimelineZoomLevel} from 'core-app/modules/hal/resources/query-resource';
 import {componentDestroyed, untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {
+  WorkPackageDisplayRepresentationService,
+  wpDisplayCardRepresentation
+} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 export interface TimelineButtonText extends ButtonControllerText {
   zoomOut:string;
@@ -64,7 +68,8 @@ export class WorkPackageTimelineButtonComponent extends AbstractWorkPackageButto
 
   constructor(readonly I18n:I18nService,
               readonly cdRef:ChangeDetectorRef,
-              public wpTableTimeline:WorkPackageTableTimelineService) {
+              public wpTableTimeline:WorkPackageTableTimelineService,
+              public wpDisplayRepresentationService:WorkPackageDisplayRepresentationService) {
     super(I18n);
 
     this.activateLabel = I18n.t('js.timelines.button_activate');
@@ -93,6 +98,15 @@ export class WorkPackageTimelineButtonComponent extends AbstractWorkPackageButto
       .subscribe((current) => {
         this.isMaxLevel = current === this.maxZoomLevel;
         this.isMinLevel = current === this.minZoomLevel;
+        this.cdRef.detectChanges();
+      });
+
+    this.wpDisplayRepresentationService.state.values$()
+      .pipe(
+        untilComponentDestroyed(this)
+      )
+      .subscribe(() => {
+        this.disabled = this.wpDisplayRepresentationService.current === wpDisplayCardRepresentation;
         this.cdRef.detectChanges();
       });
   }

--- a/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
@@ -1,0 +1,91 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {AbstractWorkPackageButtonComponent} from '../wp-buttons.module';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component} from '@angular/core';
+import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
+import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
+import {StateService} from "@uirouter/core";
+import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
+
+
+@Component({
+  templateUrl: '../wp-button.template.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'wp-view-toggle-button',
+})
+export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonComponent {
+  public buttonId:string = 'work-packages-view-toggle-button';
+  public buttonClass:string = 'toolbar-icon';
+  public iconClass:string = 'icon-view-fullscreen';
+
+  public inListView:boolean = true;
+
+  public activateLabel:string;
+  public deactivateLabel:string;
+
+  constructor(readonly $state:StateService,
+              readonly I18n:I18nService,
+              readonly cdRef:ChangeDetectorRef,
+              readonly wpDisplayRepresentationService:WpDisplayRepresentationService) {
+    super(I18n);
+
+    this.activateLabel = I18n.t('js.button_card_list');
+    this.deactivateLabel = I18n.t('js.button_show_list');
+  }
+
+  public performAction(evt:Event):false {
+    if (this.inListView) {
+      this.activateCardView();
+    } else {
+      this.activateListView();
+    }
+
+    evt.preventDefault();
+    return false;
+  }
+
+  private activateCardView() {
+    this.iconClass = 'icon-view-list';
+    this.inListView = false;
+
+    this.wpDisplayRepresentationService.setDisplayRepresentation('card');
+    this.cdRef.detectChanges();
+  }
+
+  private activateListView() {
+    this.iconClass = 'icon-view-fullscreen';
+    this.inListView = true;
+
+    this.wpDisplayRepresentationService.setDisplayRepresentation('');
+    this.cdRef.detectChanges();
+  }
+
+}
+
+DynamicBootstrapper.register({ selector: 'wp-view-toggle-button', cls: WorkPackageViewToggleButton });

--- a/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
@@ -27,11 +27,15 @@
 // ++
 
 import {AbstractWorkPackageButtonComponent} from '../wp-buttons.module';
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
 import {StateService} from "@uirouter/core";
-import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
+import {
+  WorkPackageDisplayRepresentationService, wpDisplayCardRepresentation,
+  wpDisplayListRepresentation
+} from "core-components/wp-fast-table/state/work-package-display-representation.service";
+import {WorkPackagesListService} from "core-components/wp-list/wp-list.service";
 
 
 @Component({
@@ -39,10 +43,13 @@ import {WpDisplayRepresentationService} from "core-components/wp-fast-table/stat
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'wp-view-toggle-button',
 })
-export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonComponent {
+export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonComponent implements OnInit {
+  private iconListView:string = 'icon-view-list';
+  private iconCardView:string = 'icon-image2';
+
   public buttonId:string = 'work-packages-view-toggle-button';
   public buttonClass:string = 'toolbar-icon';
-  public iconClass:string = 'icon-view-fullscreen';
+  public iconClass:string = this.iconCardView;
 
   public inListView:boolean = true;
 
@@ -52,11 +59,17 @@ export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonCompon
   constructor(readonly $state:StateService,
               readonly I18n:I18nService,
               readonly cdRef:ChangeDetectorRef,
-              readonly wpDisplayRepresentationService:WpDisplayRepresentationService) {
+              readonly wpDisplayRepresentationService:WorkPackageDisplayRepresentationService,
+              readonly wpListService:WorkPackagesListService) {
     super(I18n);
 
     this.activateLabel = I18n.t('js.button_card_list');
     this.deactivateLabel = I18n.t('js.button_show_list');
+  }
+
+  ngOnInit() {
+    this.inListView = this.wpDisplayRepresentationService.valueFromQuery(this.wpListService.currentQuery) === wpDisplayListRepresentation;
+    this.iconClass = this.inListView ? this.iconCardView : this.iconListView;
   }
 
   public performAction(evt:Event):false {
@@ -71,18 +84,18 @@ export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonCompon
   }
 
   private activateCardView() {
-    this.iconClass = 'icon-view-list';
+    this.iconClass = this.iconListView;
     this.inListView = false;
 
-    this.wpDisplayRepresentationService.setDisplayRepresentation('card');
+    this.wpDisplayRepresentationService.setDisplayRepresentation(wpDisplayCardRepresentation);
     this.cdRef.detectChanges();
   }
 
   private activateListView() {
-    this.iconClass = 'icon-view-fullscreen';
+    this.iconClass = this.iconCardView;
     this.inListView = true;
 
-    this.wpDisplayRepresentationService.setDisplayRepresentation('');
+    this.wpDisplayRepresentationService.setDisplayRepresentation(wpDisplayListRepresentation);
     this.cdRef.detectChanges();
   }
 

--- a/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
@@ -93,7 +93,7 @@ export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonCompon
         untilComponentDestroyed(this)
       )
       .subscribe(() => {
-        this.inListView = this.wpDisplayRepresentationService.current === wpDisplayListRepresentation;
+        this.inListView = this.wpDisplayRepresentationService.current !== wpDisplayCardRepresentation;
         this.cdRef.detectChanges();
       });
   }

--- a/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
@@ -35,7 +35,6 @@ import {
   WorkPackageDisplayRepresentationService, wpDisplayCardRepresentation,
   wpDisplayListRepresentation
 } from "core-components/wp-fast-table/state/work-package-display-representation.service";
-import {WorkPackagesListService} from "core-components/wp-list/wp-list.service";
 import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 
 
@@ -47,8 +46,8 @@ import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
             type="button"
             [ngClass]="{ '-active': inListView }"
             [disabled]="inListView"
-            [attr.id]="buttonId"
-            [attr.title]="label"
+            id="wp-view-toggle-button--list"
+            [attr.title]="listLabel"
             [attr.accesskey]="accessKey"
             (accessibleClick)="performAction($event)">
       <op-icon icon-classes="{{ iconListView }} button--icon"></op-icon>
@@ -57,8 +56,8 @@ import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
   <li>
     <button class="button"
             [ngClass]="{ '-active': !inListView }"
-            [attr.id]="buttonId"
-            [attr.title]="label"
+            id="wp-view-toggle-button--card"
+            [attr.title]="cardLabel"
             [disabled]="!inListView"
             (click)="performAction($event)">
       <op-icon icon-classes="{{ iconCardView }} button--icon"></op-icon>
@@ -73,38 +72,38 @@ export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonCompon
   public iconListView:string = 'icon-view-list';
   public iconCardView:string = 'icon-image2';
 
-  public buttonId:string = 'work-packages-view-toggle-button';
-
   public inListView:boolean = true;
 
-  public activateLabel:string;
-  public deactivateLabel:string;
+  public cardLabel:string;
+  public listLabel:string;
 
   constructor(readonly $state:StateService,
               readonly I18n:I18nService,
               readonly cdRef:ChangeDetectorRef,
-              readonly wpDisplayRepresentationService:WorkPackageDisplayRepresentationService,
-              readonly wpListService:WorkPackagesListService) {
+              readonly wpDisplayRepresentationService:WorkPackageDisplayRepresentationService) {
     super(I18n);
 
-    this.activateLabel = I18n.t('js.button_card_list');
-    this.deactivateLabel = I18n.t('js.button_show_list');
+    this.cardLabel = I18n.t('js.button_card_list');
+    this.listLabel = I18n.t('js.button_show_list');
   }
 
   ngOnInit() {
-    this.wpDisplayRepresentationService
-      .live$()
+    this.wpDisplayRepresentationService.state.values$()
       .pipe(
         untilComponentDestroyed(this)
       )
       .subscribe(() => {
-        this.inListView = this.wpDisplayRepresentationService.valueFromQuery(this.wpListService.currentQuery) === wpDisplayListRepresentation;
+        this.inListView = this.wpDisplayRepresentationService.current === wpDisplayListRepresentation;
         this.cdRef.detectChanges();
       });
   }
 
   ngOnDestroy() {
     //
+  }
+
+  public isActive():boolean {
+    return false;
   }
 
   public performAction(evt:Event):false {

--- a/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
@@ -70,8 +70,8 @@ import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
   selector: 'wp-view-toggle-button',
 })
 export class WorkPackageViewToggleButton extends AbstractWorkPackageButtonComponent implements OnInit, OnDestroy {
-  private iconListView:string = 'icon-view-list';
-  private iconCardView:string = 'icon-image2';
+  public iconListView:string = 'icon-view-list';
+  public iconCardView:string = 'icon-image2';
 
   public buttonId:string = 'work-packages-view-toggle-button';
 

--- a/frontend/src/app/components/wp-card-view/wp-card-view-horizontal.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view-horizontal.sass
@@ -2,5 +2,3 @@
   display: grid
   grid-template-columns: repeat(auto-fit, minmax(100px, 300px))
   grid-column-gap: 10px
-  grid-template-rows: repeat(1, 180px)
-  grid-auto-rows: 180px

--- a/frontend/src/app/components/wp-card-view/wp-card-view-horizontal.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view-horizontal.sass
@@ -1,0 +1,6 @@
+.wp-cards-container.-horizontal
+  display: grid
+  grid-template-columns: repeat(auto-fit, minmax(100px, 300px))
+  grid-column-gap: 10px
+  grid-template-rows: repeat(1, 180px)
+  grid-auto-rows: 180px

--- a/frontend/src/app/components/wp-card-view/wp-card-view-vertical.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view-vertical.sass
@@ -1,0 +1,19 @@
+@import 'helpers'
+
+.wp-cards-container.-vertical
+  display: flex
+  flex-direction: column
+  // Ensure 100% height for drag & drop area
+  height: 100%
+  // Some minor left/right padding
+  padding: 0 15px
+  border-radius: 2px
+  // We let the scrollbar be always there, so that we can align the button above with the card view
+  // independently of whether we scroll or not.
+  overflow-y: scroll
+  @include styled-scroll-bar
+
+  .wp-card
+    // Take care that the shadow of the last element is still visible
+    &:last-of-type
+      margin-bottom: 3px

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.html
@@ -1,5 +1,5 @@
 <div #container
-     class="wp-cards-container">
+     [ngClass]="'wp-cards-container -' + orientation">
   <div *ngIf="inReference"
        class="wp-inline-create--reference-container">
     <ndc-dynamic [ndcDynamicComponent]="referenceClass"

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
@@ -1,18 +1,5 @@
 @import 'helpers'
 
-.wp-cards-container
-  display: flex
-  flex-direction: column
-  // Ensure 100% height for drag & drop area
-  height: 100%
-  // Some minor left/right padding
-  padding: 0 15px
-  border-radius: 2px
-  // We let the scrollbar be always there, so that we can align the button above with the card view
-  // independently of whether we scroll or not.
-  overflow-y: scroll
-  @include styled-scroll-bar
-
 .wp-card
   user-select: none
   width: 100%
@@ -31,17 +18,14 @@
   &.-new
     padding-right: 25px
 
-  // Take care that the shadow of the last element is still visible
-  &:last-of-type
-    margin-bottom: 3px
-
 .wp-card--content:not(.-new)
   display: grid
   grid-template-columns: auto 1fr auto
-  grid-template-rows: auto auto auto
+  grid-template-rows: auto 1fr auto
   grid-row-gap: 10px
   grid-template-areas: "type type type" "subject subject subject" "attributeTag avatar idlink"
   overflow: hidden
+  height: 100%
 
   .wp-card--type
     grid-area: type

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
@@ -79,3 +79,5 @@ wp-edit-field
   margin: -10px -10px 10px
   width: calc(100% + 10px + 10px)
   max-width: calc(100% + 10px + 10px)
+  height: 200px
+  object-fit: cover

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.sass
@@ -1,6 +1,8 @@
 @import 'helpers'
 
 .wp-card
+  display: flex
+  flex-direction: column
   user-select: none
   width: 100%
   border: 1px solid var(--widget-box-block-border-color)
@@ -25,7 +27,7 @@
   grid-row-gap: 10px
   grid-template-areas: "type type type" "subject subject subject" "attributeTag avatar idlink"
   overflow: hidden
-  height: 100%
+  flex-grow: 1
 
   .wp-card--type
     grid-area: type
@@ -79,5 +81,6 @@ wp-edit-field
   margin: -10px -10px 10px
   width: calc(100% + 10px + 10px)
   max-width: calc(100% + 10px + 10px)
-  height: 200px
+
+  flex-basis: 200px
   object-fit: cover

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -37,6 +37,8 @@ import {PathHelperService} from "core-app/modules/common/path-helper/path-helper
 import {filter} from 'rxjs/operators';
 import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
 
+export type CardViewOrientation = 'horizontal'|'vertical';
+
 @Component({
   selector: 'wp-card-view',
   styleUrls: ['./wp-card-view.component.sass', './wp-card-view-horizontal.sass', './wp-card-view-vertical.sass'],
@@ -49,7 +51,14 @@ export class WorkPackageCardViewComponent  implements OnInit {
   @Input() public highlightingMode:CardHighlightingMode;
   @Input() public workPackageAddedHandler:(wp:WorkPackageResource) => Promise<unknown>;
   @Input() public showStatusButton:boolean = true;
-  @Input() public orientation:'horizontal'|'vertical' = 'vertical';
+  @Input() public orientation:CardViewOrientation = 'vertical';
+  /** Whether cards are removable */
+  @Input() public cardsRemovable:boolean = false;
+
+  /** Container reference */
+  @ViewChild('container') public container:ElementRef;
+
+  @Output() onMoved = new EventEmitter<void>();
 
   public trackByHref = AngularTrackingHelpers.trackByHref;
   public query:QueryResource;
@@ -71,12 +80,6 @@ export class WorkPackageCardViewComponent  implements OnInit {
     onCancel: () => this.setReferenceMode(false),
     onReferenced: (wp:WorkPackageResource) => this.addWorkPackageToQuery(wp, 0)
   };
-
-  /** Whether cards are removable */
-  @Input() public cardsRemovable:boolean = false;
-
-  /** Container reference */
-  @ViewChild('container') public container:ElementRef;
 
   /** Whether the card view has an active inline created wp */
   public activeInlineCreateWp?:WorkPackageResource;
@@ -210,6 +213,8 @@ export class WorkPackageCardViewComponent  implements OnInit {
 
         const newOrder = this.reorderService.move(this.currentOrder, wpId, toIndex);
         this.updateOrder(newOrder);
+
+        this.onMoved.emit();
       },
       onRemoved: (card:HTMLElement) => {
         const wpId:string = card.dataset.workPackageId!;

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -39,7 +39,7 @@ import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates
 
 @Component({
   selector: 'wp-card-view',
-  styleUrls: ['./wp-card-view.component.sass'],
+  styleUrls: ['./wp-card-view.component.sass', './wp-card-view-horizontal.sass', './wp-card-view-vertical.sass'],
   templateUrl: './wp-card-view.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -49,6 +49,7 @@ export class WorkPackageCardViewComponent  implements OnInit {
   @Input() public highlightingMode:CardHighlightingMode;
   @Input() public workPackageAddedHandler:(wp:WorkPackageResource) => Promise<unknown>;
   @Input() public showStatusButton:boolean = true;
+  @Input() public orientation:'horizontal'|'vertical' = 'vertical';
 
   public trackByHref = AngularTrackingHelpers.trackByHref;
   public query:QueryResource;

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -60,7 +60,7 @@ export class WorkPackageCardViewComponent  implements OnInit {
 
   @Output() onMoved = new EventEmitter<void>();
 
-  public trackByHref = AngularTrackingHelpers.trackByHref;
+  public trackByHref = AngularTrackingHelpers.trackByHrefAndProperty('lockVersion');
   public query:QueryResource;
   private _workPackages:WorkPackageResource[];
   public columns:QueryColumn[];

--- a/frontend/src/app/components/wp-fast-table/builders/highlighting/highlighting-mode.const.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/highlighting/highlighting-mode.const.ts
@@ -1,3 +1,3 @@
 export type HighlightingMode = 'status'|'priority'|'type'|'inline'|'none';
 
-export type CardHighlightingMode =  'priority'|'type'|'none'|'entire-card';
+export type CardHighlightingMode =  'priority'|'type'|'none'|'inline';

--- a/frontend/src/app/components/wp-fast-table/state/work-package-display-representation.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/work-package-display-representation.service.ts
@@ -32,19 +32,20 @@ import {States} from 'core-components/states.service';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {Injectable} from '@angular/core';
 import {InputState} from "reactivestates";
-import {QuerySortByResource} from "core-app/modules/hal/resources/query-sort-by-resource";
+
 
 export const wpDisplayListRepresentation:string = 'list';
 export const wpDisplayCardRepresentation:string = 'card';
+export type wpDisplayRepresentation = 'list'|'card';
 
 @Injectable()
-export class WorkPackageDisplayRepresentationService extends WorkPackageQueryStateService<string> {
+export class WorkPackageDisplayRepresentationService extends WorkPackageQueryStateService<string|null> {
   public constructor(readonly states:States,
                      readonly querySpace:IsolatedQuerySpace) {
     super(querySpace);
   }
 
-  public get state():InputState<string> {
+  public get state():InputState<string|null> {
     return this.querySpace.displayRepresentation;
   }
 
@@ -53,16 +54,17 @@ export class WorkPackageDisplayRepresentationService extends WorkPackageQuerySta
   }
 
   valueFromQuery(query:QueryResource) {
-    return query.displayRepresentation || wpDisplayListRepresentation;
+    return query.displayRepresentation || null;
   }
 
   public applyToQuery(query:QueryResource) {
-    query.displayRepresentation = this.current;
+    const current = this.current;
+    query.displayRepresentation = current === null ? undefined : current;
     return true;
   }
 
-  public get current():string {
-    return this.state.getValueOr(wpDisplayListRepresentation);
+  public get current():string|null {
+    return this.state.getValueOr(null);
   }
 
   public setDisplayRepresentation(representation:string) {

--- a/frontend/src/app/components/wp-fast-table/state/work-package-display-representation.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/work-package-display-representation.service.ts
@@ -32,8 +32,11 @@ import {States} from 'core-components/states.service';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {Injectable} from '@angular/core';
 
+export const wpDisplayListRepresentation:string = 'list';
+export const wpDisplayCardRepresentation:string = 'card';
+
 @Injectable()
-export class WpDisplayRepresentationService extends WorkPackageQueryStateService<string> {
+export class WorkPackageDisplayRepresentationService extends WorkPackageQueryStateService<string> {
   public constructor(readonly states:States,
                      readonly querySpace:IsolatedQuerySpace) {
     super(querySpace);
@@ -44,7 +47,7 @@ export class WpDisplayRepresentationService extends WorkPackageQueryStateService
   }
 
   valueFromQuery(query:QueryResource) {
-    return query.displayRepresentation || '';
+    return query.displayRepresentation || wpDisplayListRepresentation;
   }
 
   public applyToQuery(query:QueryResource) {
@@ -53,7 +56,7 @@ export class WpDisplayRepresentationService extends WorkPackageQueryStateService
   }
 
   public get current():string {
-    return this.lastUpdatedState.getValueOr('');
+    return this.lastUpdatedState.getValueOr(wpDisplayListRepresentation);
   }
 
   public setDisplayRepresentation(representation:string) {

--- a/frontend/src/app/components/wp-fast-table/state/work-package-display-representation.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/work-package-display-representation.service.ts
@@ -31,6 +31,8 @@ import {WorkPackageQueryStateService} from './wp-table-base.service';
 import {States} from 'core-components/states.service';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {Injectable} from '@angular/core';
+import {InputState} from "reactivestates";
+import {QuerySortByResource} from "core-app/modules/hal/resources/query-sort-by-resource";
 
 export const wpDisplayListRepresentation:string = 'list';
 export const wpDisplayCardRepresentation:string = 'card';
@@ -40,6 +42,10 @@ export class WorkPackageDisplayRepresentationService extends WorkPackageQuerySta
   public constructor(readonly states:States,
                      readonly querySpace:IsolatedQuerySpace) {
     super(querySpace);
+  }
+
+  public get state():InputState<string> {
+    return this.querySpace.displayRepresentation;
   }
 
   public hasChanged(query:QueryResource) {
@@ -56,7 +62,7 @@ export class WorkPackageDisplayRepresentationService extends WorkPackageQuerySta
   }
 
   public get current():string {
-    return this.lastUpdatedState.getValueOr(wpDisplayListRepresentation);
+    return this.state.getValueOr(wpDisplayListRepresentation);
   }
 
   public setDisplayRepresentation(representation:string) {

--- a/frontend/src/app/components/wp-fast-table/state/wp-display-representation.service.ts
+++ b/frontend/src/app/components/wp-fast-table/state/wp-display-representation.service.ts
@@ -1,0 +1,62 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
+import {WorkPackageQueryStateService} from './wp-table-base.service';
+import {States} from 'core-components/states.service';
+import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
+import {Injectable} from '@angular/core';
+
+@Injectable()
+export class WpDisplayRepresentationService extends WorkPackageQueryStateService<string> {
+  public constructor(readonly states:States,
+                     readonly querySpace:IsolatedQuerySpace) {
+    super(querySpace);
+  }
+
+  public hasChanged(query:QueryResource) {
+    return this.current !== query.displayRepresentation;
+  }
+
+  valueFromQuery(query:QueryResource) {
+    return query.displayRepresentation || '';
+  }
+
+  public applyToQuery(query:QueryResource) {
+    query.displayRepresentation = this.current;
+    return true;
+  }
+
+  public get current():string {
+    return this.lastUpdatedState.getValueOr('');
+  }
+
+  public setDisplayRepresentation(representation:string) {
+    this.update(representation);
+  }
+}

--- a/frontend/src/app/components/wp-grid/wp-grid.component.ts
+++ b/frontend/src/app/components/wp-grid/wp-grid.component.ts
@@ -26,12 +26,13 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from "@angular/core";
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit} from "@angular/core";
 import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
 import {CardViewOrientation} from "core-components/wp-card-view/wp-card-view.component";
 import {takeUntil} from "rxjs/operators";
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {HighlightingMode} from "core-components/wp-fast-table/builders/highlighting/highlighting-mode.const";
+import {componentDestroyed, untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 
 @Component({
   selector: 'wp-grid',
@@ -46,7 +47,7 @@ import {HighlightingMode} from "core-components/wp-fast-table/builders/highlight
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class WorkPackagesGridComponent implements OnInit {
+export class WorkPackagesGridComponent implements OnInit, OnDestroy {
   public canDragOutOf = () => { return false; };
   public gridOrientation:CardViewOrientation = 'horizontal';
   public highlightingMode:HighlightingMode = 'none';
@@ -59,11 +60,15 @@ export class WorkPackagesGridComponent implements OnInit {
   ngOnInit() {
     this.querySpace.highlighting.values$()
       .pipe(
-        takeUntil(this.querySpace.stopAllSubscriptions)
+        takeUntil(this.querySpace.stopAllSubscriptions),
+        untilComponentDestroyed(this)
       )
       .subscribe(() => {
         this.highlightingMode = this.wpTableHighlight.current.mode;
         this.cdRef.detectChanges();
       });
+  }
+
+  ngOnDestroy():void {
   }
 }

--- a/frontend/src/app/components/wp-grid/wp-grid.component.ts
+++ b/frontend/src/app/components/wp-grid/wp-grid.component.ts
@@ -29,32 +29,25 @@
 import {ChangeDetectionStrategy, Component} from "@angular/core";
 import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
 import {CardViewOrientation} from "core-components/wp-card-view/wp-card-view.component";
-import {WorkPackageTableSortByService} from "core-components/wp-fast-table/state/wp-table-sort-by.service";
 
 @Component({
   selector: 'wp-grid',
   template: `
     <wp-card-view [dragOutOfHandler]="canDragOutOf"
-                  [dragInto]="true"
+                  [dragInto]="false"
                   [cardsRemovable]="false"
                   [highlightingMode]="highlightingMode()"
                   [showStatusButton]="false"
-                  [orientation]="gridOrientation"
-                  (onMoved)="switchToManualSorting()">
+                  [orientation]="gridOrientation">
     </wp-card-view>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WorkPackagesGridComponent {
-  public canDragOutOf = () => { return true };
+  public canDragOutOf = () => { return false };
   public gridOrientation:CardViewOrientation = 'horizontal';
 
-  constructor(readonly wpTableHighlight:WorkPackageTableHighlightingService,
-              readonly wpTableSortBy:WorkPackageTableSortByService) {
-  }
-
-  public switchToManualSorting() {
-    this.wpTableSortBy.switchToManualSorting();
+  constructor(readonly wpTableHighlight:WorkPackageTableHighlightingService) {
   }
 
   public highlightingMode() {

--- a/frontend/src/app/components/wp-grid/wp-grid.component.ts
+++ b/frontend/src/app/components/wp-grid/wp-grid.component.ts
@@ -1,0 +1,63 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {ChangeDetectionStrategy, Component} from "@angular/core";
+import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
+import {CardViewOrientation} from "core-components/wp-card-view/wp-card-view.component";
+import {WorkPackageTableSortByService} from "core-components/wp-fast-table/state/wp-table-sort-by.service";
+
+@Component({
+  selector: 'wp-grid',
+  template: `
+    <wp-card-view [dragOutOfHandler]="canDragOutOf"
+                  [dragInto]="true"
+                  [cardsRemovable]="false"
+                  [highlightingMode]="highlightingMode()"
+                  [showStatusButton]="false"
+                  [orientation]="gridOrientation"
+                  (onMoved)="switchToManualSorting()">
+    </wp-card-view>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class WorkPackagesGridComponent {
+  public canDragOutOf = () => { return true };
+  public gridOrientation:CardViewOrientation = 'horizontal';
+
+  constructor(readonly wpTableHighlight:WorkPackageTableHighlightingService,
+              readonly wpTableSortBy:WorkPackageTableSortByService) {
+  }
+
+  public switchToManualSorting() {
+    this.wpTableSortBy.switchToManualSorting();
+  }
+
+  public highlightingMode() {
+    return this.wpTableHighlight.current.mode;
+  }
+}

--- a/frontend/src/app/components/wp-grid/wp-grid.component.ts
+++ b/frontend/src/app/components/wp-grid/wp-grid.component.ts
@@ -40,7 +40,7 @@ import {HighlightingMode} from "core-components/wp-fast-table/builders/highlight
                   [dragInto]="false"
                   [cardsRemovable]="false"
                   [highlightingMode]="highlightingMode"
-                  [showStatusButton]="false"
+                  [showStatusButton]="true"
                   [orientation]="gridOrientation">
     </wp-card-view>
   `,

--- a/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
@@ -94,6 +94,12 @@ export class WorkPackageStatesInitializationService {
         this.states.schemas.get(schema.href as string).putValue(schema);
       });
     }
+
+    // Ensure we're setting the current results to the query
+    // This is due to 9.X still loading results from /api/v3/work_packages
+    // for a previously loaded query.
+    query.results = results;
+
     this.querySpace.query.putValue(query);
 
     this.querySpace.rows.putValue(results.elements);

--- a/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
@@ -20,6 +20,7 @@ import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/iso
 import {Injectable} from '@angular/core';
 import {QuerySchemaResource} from 'core-app/modules/hal/resources/query-schema-resource';
 import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
+import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
 
 @Injectable()
 export class WorkPackageStatesInitializationService {
@@ -38,7 +39,8 @@ export class WorkPackageStatesInitializationService {
               protected wpTableAdditionalElements:WorkPackageTableAdditionalElementsService,
               protected wpCacheService:WorkPackageCacheService,
               protected wpListChecksumService:WorkPackagesListChecksumService,
-              protected authorisationService:AuthorisationService) {
+              protected authorisationService:AuthorisationService,
+              protected wpDisplayRepresentation:WpDisplayRepresentationService) {
   }
 
   /**
@@ -140,6 +142,7 @@ export class WorkPackageStatesInitializationService {
     this.wpTableTimeline.applyToQuery(query);
     this.wpTableHighlighting.applyToQuery(query);
     this.wpTableHierarchies.applyToQuery(query);
+    this.wpDisplayRepresentation.applyToQuery(query);
   }
 
   public clearStates() {

--- a/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
@@ -128,6 +128,7 @@ export class WorkPackageStatesInitializationService {
     this.wpTableTimeline.initialize(query, results);
     this.wpTableHierarchies.initialize(query, results);
     this.wpTableHighlighting.initialize(query, results);
+    this.wpDisplayRepresentation.initialize(query, results);
 
     this.authorisationService.initModelAuth('query', query.$links);
     this.authorisationService.initModelAuth('work_packages', results.$links);

--- a/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
@@ -20,7 +20,7 @@ import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/iso
 import {Injectable} from '@angular/core';
 import {QuerySchemaResource} from 'core-app/modules/hal/resources/query-schema-resource';
 import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
-import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
+import {WorkPackageDisplayRepresentationService} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 @Injectable()
 export class WorkPackageStatesInitializationService {
@@ -40,7 +40,7 @@ export class WorkPackageStatesInitializationService {
               protected wpCacheService:WorkPackageCacheService,
               protected wpListChecksumService:WorkPackagesListChecksumService,
               protected authorisationService:AuthorisationService,
-              protected wpDisplayRepresentation:WpDisplayRepresentationService) {
+              protected wpDisplayRepresentation:WorkPackageDisplayRepresentationService) {
   }
 
   /**

--- a/frontend/src/app/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/components/wp-query/url-params-helper.ts
@@ -263,6 +263,10 @@ export class UrlParamsHelperService {
       queryData.highlightedAttributes = query.highlightedAttributes.map(el => el.href);
     }
 
+    if (query.displayRepresentation) {
+      queryData.displayRepresentation = query.displayRepresentation;
+    }
+
     queryData.showHierarchies = !!query.showHierarchies;
     queryData.groupBy = _.get(query.groupBy, 'id', '');
 

--- a/frontend/src/app/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/components/wp-query/url-params-helper.ts
@@ -77,6 +77,7 @@ export class UrlParamsHelperService {
     paramsData = this.encodeFilters(paramsData, query.filters);
     paramsData.pa = additional.page;
     paramsData.pp = additional.perPage;
+    paramsData.dr = query.displayRepresentation;
 
     return JSON.stringify(paramsData);
   }
@@ -185,6 +186,10 @@ export class UrlParamsHelperService {
       if (properties.tzl) {
         queryData.timelineZoomLevel = properties.tzl;
       }
+    }
+
+    if (properties.dr) {
+      queryData.displayRepresentation = properties.dr;
     }
 
     if (properties.hl) {

--- a/frontend/src/app/modules/boards/board/configuration-modal/tabs/highlighting-tab.component.html
+++ b/frontend/src/app/modules/boards/board/configuration-modal/tabs/highlighting-tab.component.html
@@ -7,7 +7,7 @@
         <label class="option-label">
           <input type="radio"
                  [(ngModel)]="entireCardMode"
-                 (change)="updateMode('entire-card')"
+                 (change)="updateMode('inline')"
                  [value]="true"
                  name="entire_card_switch">
           <span [textContent]="text.highlighting_mode.entire_card_by"></span>

--- a/frontend/src/app/modules/boards/board/configuration-modal/tabs/highlighting-tab.component.ts
+++ b/frontend/src/app/modules/boards/board/configuration-modal/tabs/highlighting-tab.component.ts
@@ -46,7 +46,7 @@ export class BoardHighlightingTabComponent implements TabComponent {
   }
 
   public updateMode(mode:CardHighlightingMode) {
-    if (mode === 'entire-card') {
+    if (mode === 'inline') {
       this.highlightingMode = this.lastEntireCardAttribute;
     } else {
       this.highlightingMode = mode;

--- a/frontend/src/app/modules/hal/resources/query-resource.ts
+++ b/frontend/src/app/modules/hal/resources/query-resource.ts
@@ -66,6 +66,7 @@ export class QueryResource extends HalResource {
   public timelineZoomLevel:TimelineZoomLevel;
   public highlightingMode:HighlightingMode;
   public highlightedAttributes:HalResource[]|undefined;
+  public displayRepresentation:string|undefined;
   public timelineLabels:TimelineLabels;
   public showHierarchies:boolean;
   public public:boolean;

--- a/frontend/src/app/modules/hal/resources/query-resource.ts
+++ b/frontend/src/app/modules/hal/resources/query-resource.ts
@@ -66,7 +66,7 @@ export class QueryResource extends HalResource {
   public timelineZoomLevel:TimelineZoomLevel;
   public highlightingMode:HighlightingMode;
   public highlightedAttributes:HalResource[]|undefined;
-  public displayRepresentation:string|undefined;
+  public displayRepresentation:string;
   public timelineLabels:TimelineLabels;
   public showHierarchies:boolean;
   public public:boolean;

--- a/frontend/src/app/modules/hal/resources/query-resource.ts
+++ b/frontend/src/app/modules/hal/resources/query-resource.ts
@@ -66,7 +66,7 @@ export class QueryResource extends HalResource {
   public timelineZoomLevel:TimelineZoomLevel;
   public highlightingMode:HighlightingMode;
   public highlightedAttributes:HalResource[]|undefined;
-  public displayRepresentation:string;
+  public displayRepresentation:string|undefined;
   public timelineLabels:TimelineLabels;
   public showHierarchies:boolean;
   public public:boolean;

--- a/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
@@ -157,6 +157,7 @@ import {WorkPackageRelationsService} from "core-components/wp-relations/wp-relat
 import {OpenprojectBcfModule} from "core-app/modules/bcf/openproject-bcf.module";
 import {WorkPackageRelationsAutocomplete} from "core-components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component";
 import {WorkPackageViewToggleButton} from "core-components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component";
+import {WorkPackagesGridComponent} from "core-components/wp-grid/wp-grid.component";
 
 
 @NgModule({
@@ -238,6 +239,8 @@ import {WorkPackageViewToggleButton} from "core-components/wp-buttons/wp-view-to
     // Inline create
     WorkPackageInlineCreateComponent,
     WpRelationInlineAddExistingComponent,
+
+    WorkPackagesGridComponent,
 
     WorkPackagesTableController,
     WorkPackageTablePaginationComponent,
@@ -383,8 +386,12 @@ import {WorkPackageViewToggleButton} from "core-components/wp-buttons/wp-view-to
 
     // Inline create
     WpRelationInlineAddExistingComponent,
+
+    // View representations
     WorkPackagesBaseComponent,
     WorkPackagesListComponent,
+
+    WorkPackagesGridComponent,
 
     // WP new
     WorkPackageNewFullViewComponent,

--- a/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
@@ -156,6 +156,8 @@ import {WorkPackageDmService} from "core-app/modules/hal/dm-services/work-packag
 import {WorkPackageRelationsService} from "core-components/wp-relations/wp-relations.service";
 import {OpenprojectBcfModule} from "core-app/modules/bcf/openproject-bcf.module";
 import {WorkPackageRelationsAutocomplete} from "core-components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component";
+import {WorkPackageViewToggleButton} from "core-components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component";
+
 
 @NgModule({
   imports: [
@@ -361,6 +363,7 @@ import {WorkPackageRelationsAutocomplete} from "core-components/wp-relations/wp-
 
     // Card view
     WorkPackageCardViewComponent,
+    WorkPackageViewToggleButton,
   ],
   entryComponents: [
     // Split view

--- a/frontend/src/app/modules/work_packages/query-space/isolated-query-space.ts
+++ b/frontend/src/app/modules/work_packages/query-space/isolated-query-space.ts
@@ -20,6 +20,7 @@ import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-
 import {QueryGroupByResource} from "core-app/modules/hal/resources/query-group-by-resource";
 import {QuerySortByResource} from "core-app/modules/hal/resources/query-sort-by-resource";
 import {WorkPackageTableRefreshRequest} from "core-components/wp-table/wp-table-refresh-request.service";
+import {WorkPackageDisplayRepresentationService} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 @Injectable()
 export class IsolatedQuerySpace extends StatesGroup {
@@ -63,6 +64,8 @@ export class IsolatedQuerySpace extends StatesGroup {
   hierarchies = input<WorkPackageTableHierarchies>();
   // Highlighting mode
   highlighting = input<WorkPackageTableHighlight>();
+  // Display of the WP results
+  displayRepresentation = input<string>();
   // State to be updated when the table is up to date
   rendered = input<RenderedRow[]>();
 

--- a/frontend/src/app/modules/work_packages/query-space/isolated-query-space.ts
+++ b/frontend/src/app/modules/work_packages/query-space/isolated-query-space.ts
@@ -20,7 +20,7 @@ import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-
 import {QueryGroupByResource} from "core-app/modules/hal/resources/query-group-by-resource";
 import {QuerySortByResource} from "core-app/modules/hal/resources/query-sort-by-resource";
 import {WorkPackageTableRefreshRequest} from "core-components/wp-table/wp-table-refresh-request.service";
-import {WorkPackageDisplayRepresentationService} from "core-components/wp-fast-table/state/work-package-display-representation.service";
+import {wpDisplayRepresentation} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 @Injectable()
 export class IsolatedQuerySpace extends StatesGroup {
@@ -65,7 +65,7 @@ export class IsolatedQuerySpace extends StatesGroup {
   // Highlighting mode
   highlighting = input<WorkPackageTableHighlight>();
   // Display of the WP results
-  displayRepresentation = input<string>();
+  displayRepresentation = input<wpDisplayRepresentation|null>();
   // State to be updated when the table is up to date
   rendered = input<RenderedRow[]>();
 

--- a/frontend/src/app/modules/work_packages/query-space/wp-isolated-query-space.directive.ts
+++ b/frontend/src/app/modules/work_packages/query-space/wp-isolated-query-space.directive.ts
@@ -60,6 +60,7 @@ import {WpRelationInlineCreateService} from "core-components/wp-relations/embedd
 import {WorkPackagesListChecksumService} from "core-components/wp-list/wp-list-checksum.service";
 import {debugLog} from "core-app/helpers/debug_output";
 import {PortalCleanupService} from "core-app/modules/fields/display/display-portal/portal-cleanup.service";
+import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
 
 /**
  * Directive to open a work package query 'space', an isolated injector hierarchy
@@ -93,6 +94,7 @@ import {PortalCleanupService} from "core-app/modules/fields/display/display-port
     WorkPackageTableAdditionalElementsService,
     WorkPackageTableFocusService,
     WorkPackageTableHighlightingService,
+    WpDisplayRepresentationService,
     WorkPackageService,
     WorkPackageRelationsHierarchyService,
     WorkPackageFiltersService,

--- a/frontend/src/app/modules/work_packages/query-space/wp-isolated-query-space.directive.ts
+++ b/frontend/src/app/modules/work_packages/query-space/wp-isolated-query-space.directive.ts
@@ -60,7 +60,7 @@ import {WpRelationInlineCreateService} from "core-components/wp-relations/embedd
 import {WorkPackagesListChecksumService} from "core-components/wp-list/wp-list-checksum.service";
 import {debugLog} from "core-app/helpers/debug_output";
 import {PortalCleanupService} from "core-app/modules/fields/display/display-portal/portal-cleanup.service";
-import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
+import {WorkPackageDisplayRepresentationService} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 /**
  * Directive to open a work package query 'space', an isolated injector hierarchy
@@ -94,7 +94,7 @@ import {WpDisplayRepresentationService} from "core-components/wp-fast-table/stat
     WorkPackageTableAdditionalElementsService,
     WorkPackageTableFocusService,
     WorkPackageTableHighlightingService,
-    WpDisplayRepresentationService,
+    WorkPackageDisplayRepresentationService,
     WorkPackageService,
     WorkPackageRelationsHierarchyService,
     WorkPackageFiltersService,

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
@@ -7,3 +7,5 @@
 
 .work-packages--card-view-container
   width: 100%
+  overflow: auto
+  @include styled-scroll-bar

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
@@ -4,3 +4,6 @@
   @include overlay-background
   background-color: #FFFFFF
   opacity: 0.5
+
+.work-packages--card-view-container
+  width: 100%

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
@@ -8,4 +8,5 @@
 .work-packages--card-view-container
   width: 100%
   overflow: auto
+  padding-bottom: 5px
   @include styled-scroll-bar

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -34,7 +34,6 @@ import {WorkPackagesViewBase} from "core-app/modules/work_packages/routing/wp-vi
 import {take} from "rxjs/operators";
 import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and-drop.service";
 import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
-import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {wpDisplayCardRepresentation} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 @Component({
@@ -75,9 +74,6 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
 
   /** An overlay over the table shown for example when the filters are invalid */
   showResultOverlay = false;
-
-  // TODO: REPLACE WITH REAL IMPLEMENTATION
-  public test = (workPackage:WorkPackageResource) => { return true };
 
   /** Switch between list and card view */
   private _showListView:boolean = true;

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {ChangeDetectionStrategy, Component, OnDestroy} from "@angular/core";
+import {Component, OnDestroy} from "@angular/core";
 import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
 import {OpTitleService} from "core-components/html/op-title.service";
@@ -40,7 +40,6 @@ import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-r
   selector: 'wp-list',
   templateUrl: './wp.list.component.html',
   styleUrls: ['./wp-list.component.sass'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     DragAndDropService,
     CausedUpdatesService,
@@ -77,7 +76,7 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
   showResultOverlay = false;
 
   /** Switch between list and card view */
-  showListView:boolean = false;
+  private _showListView:boolean = false;
 
 
   // TODO: REPLACE WITH REAL IMPLEMENTATION
@@ -111,6 +110,7 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
     ).subscribe((query) => {
       this.updateTitle(query);
       this.currentQuery = query;
+      this.showListView = !this.wpDisplayRepresentation.valueFromQuery(query);
     });
   }
 
@@ -178,6 +178,14 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
 
   public updateResultVisibility(completed:boolean) {
     this.showResultOverlay = !completed;
+  }
+
+  public set showListView(val:boolean) {
+    this._showListView = val;
+  }
+
+  public get showListView():boolean {
+    return this._showListView;
   }
 
   protected updateQueryOnParamsChanges() {

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -35,10 +35,7 @@ import {take} from "rxjs/operators";
 import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and-drop.service";
 import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
-import {
-  wpDisplayCardRepresentation,
-  wpDisplayListRepresentation
-} from "core-components/wp-fast-table/state/work-package-display-representation.service";
+import {wpDisplayCardRepresentation} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 @Component({
   selector: 'wp-list',

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -76,12 +76,11 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
   /** An overlay over the table shown for example when the filters are invalid */
   showResultOverlay = false;
 
-  /** Switch between list and card view */
-  private _showListView:boolean = true;
-
-
   // TODO: REPLACE WITH REAL IMPLEMENTATION
   public test = (workPackage:WorkPackageResource) => { return true };
+
+  /** Switch between list and card view */
+  private _showListView:boolean = true;
 
   private readonly titleService:OpTitleService = this.injector.get(OpTitleService);
 
@@ -105,12 +104,14 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
       }
     });
 
-    // Update the title whenever the query changes
     this.querySpace.query.values$().pipe(
       untilComponentDestroyed(this)
     ).subscribe((query) => {
+      // Update the title whenever the query changes
       this.updateTitle(query);
       this.currentQuery = query;
+      
+      // Update the visible representation
       if (this.wpDisplayRepresentation.valueFromQuery(query) === wpDisplayCardRepresentation) {
         this.showListView = false;
       } else {
@@ -231,6 +232,8 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
     return this.loadingIndicator =
       this.wpListService
         .loadCurrentQueryFromParams(this.projectIdentifier)
-        .then(() => this.querySpace.rendered.valuesPromise());
+        .then(() => {
+          this.querySpace.rendered.valuesPromise();
+        });
   }
 }

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -26,17 +26,25 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, OnDestroy} from "@angular/core";
+import {ChangeDetectionStrategy, Component, OnDestroy} from "@angular/core";
 import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
 import {OpTitleService} from "core-components/html/op-title.service";
 import {WorkPackagesViewBase} from "core-app/modules/work_packages/routing/wp-view-base/work-packages-view.base";
 import {take} from "rxjs/operators";
+import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and-drop.service";
+import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
+import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 
 @Component({
   selector: 'wp-list',
   templateUrl: './wp.list.component.html',
-  styleUrls: ['./wp-list.component.sass']
+  styleUrls: ['./wp-list.component.sass'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    DragAndDropService,
+    CausedUpdatesService,
+  ]
 })
 export class WorkPackagesListComponent extends WorkPackagesViewBase implements OnDestroy {
   text = {
@@ -67,6 +75,13 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
 
   /** An overlay over the table shown for example when the filters are invalid */
   showResultOverlay = false;
+
+  /** Switch between list and card view */
+  showListView:boolean = false;
+
+
+  // TODO: REPLACE WITH REAL IMPLEMENTATION
+  public test = (workPackage:WorkPackageResource) => { return true };
 
   private readonly titleService:OpTitleService = this.injector.get(OpTitleService);
 

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -32,7 +32,7 @@ import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
 import {OpTitleService} from "core-components/html/op-title.service";
 import {WorkPackagesViewBase} from "core-app/modules/work_packages/routing/wp-view-base/work-packages-view.base";
 import {take} from "rxjs/operators";
-import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and-drop.service";
+import {DragAndDropService} from "core-app/modules/boards/drag-and-drop/drag-and-drop.service";
 import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
 import {wpDisplayCardRepresentation} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -35,6 +35,10 @@ import {take} from "rxjs/operators";
 import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and-drop.service";
 import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
+import {
+  wpDisplayCardRepresentation,
+  wpDisplayListRepresentation
+} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 @Component({
   selector: 'wp-list',
@@ -76,7 +80,7 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
   showResultOverlay = false;
 
   /** Switch between list and card view */
-  private _showListView:boolean = false;
+  private _showListView:boolean = true;
 
 
   // TODO: REPLACE WITH REAL IMPLEMENTATION
@@ -110,7 +114,11 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
     ).subscribe((query) => {
       this.updateTitle(query);
       this.currentQuery = query;
-      this.showListView = !this.wpDisplayRepresentation.valueFromQuery(query);
+      if (this.wpDisplayRepresentation.valueFromQuery(query) === wpDisplayCardRepresentation) {
+        this.showListView = false;
+      } else {
+        this.showListView = true;
+      }
     });
   }
 

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -63,16 +63,27 @@
   <div class="work-packages-split-view">
 
     <!-- (TABLE + TIMELINE) and FOOTER vertical split-->
-    <div *ngIf="showListView"
-         class="work-packages-split-view--tabletimeline-side loading-indicator--location"
+    <div class="work-packages-split-view--tabletimeline-side loading-indicator--location"
          data-indicator-name="table">
       <div class="result-overlay"
-           *ngIf="showResultOverlay"></div>
+           *ngIf="showResultOverlay && showListView"></div>
 
       <!-- TABLE + TIMELINE horizontal split -->
-      <wp-table *ngIf="tableInformationLoaded"
+      <wp-table *ngIf="tableInformationLoaded && showListView"
                 [projectIdentifier]="projectIdentifier"
                 class="work-packages-split-view--tabletimeline-content"></wp-table>
+
+      <!-- CARD representation of the WP -->
+      <div *ngIf="!showListView"
+           class="work-packages--card-view-container">
+        <wp-card-view [dragOutOfHandler]="test"
+                      [dragInto]="true"
+                      [cardsRemovable]="false"
+                      [highlightingMode]="wpTableHighlighting.current.mode"
+                      [showStatusButton]="false"
+                      [orientation]="'horizontal'">
+        </wp-card-view>
+      </div>
 
       <!-- Footer -->
       <div class="work-packages-split-view--tabletimeline-footer hide-when-print"
@@ -83,19 +94,5 @@
 
     <!-- Details view -->
     <div class="work-packages-split-view--details-side" ui-view></div>
-
-    <!-- Card representation of the WP -->
-    <div *ngIf="!showListView"
-         class="work-packages--card-view-container loading-indicator--location"
-         data-indicator-name="table">
-      <wp-card-view *ngIf="!showListView"
-                    [dragOutOfHandler]="test"
-                    [dragInto]="true"
-                    [cardsRemovable]="false"
-                    [highlightingMode]="wpTableHighlighting.current.mode"
-                    [showStatusButton]="false"
-                    [orientation]="'horizontal'">
-      </wp-card-view>
-    </div>
   </div>
 </div>

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -73,16 +73,10 @@
                 [projectIdentifier]="projectIdentifier"
                 class="work-packages-split-view--tabletimeline-content"></wp-table>
 
-      <!-- CARD representation of the WP -->
+      <!-- GRID representation of the WP -->
       <div *ngIf="!showListView"
            class="work-packages--card-view-container">
-        <wp-card-view [dragOutOfHandler]="test"
-                      [dragInto]="true"
-                      [cardsRemovable]="false"
-                      [highlightingMode]="wpTableHighlighting.current.mode"
-                      [showStatusButton]="false"
-                      [orientation]="'horizontal'">
-        </wp-card-view>
+        <wp-grid></wp-grid>
       </div>
 
       <!-- Footer -->

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -30,6 +30,10 @@
           </wp-timeline-toggle-button>
         </li>
         <li class="toolbar-item hidden-for-mobile">
+          <wp-view-toggle-button>
+          </wp-view-toggle-button>
+        </li>
+        <li class="toolbar-item hidden-for-mobile">
           <zen-mode-toggle-button>
           </zen-mode-toggle-button>
         </li>

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -26,12 +26,12 @@
           </wp-details-view-button>
         </li>
         <li class="toolbar-item hidden-for-mobile">
-          <wp-timeline-toggle-button>
-          </wp-timeline-toggle-button>
-        </li>
-        <li class="toolbar-item hidden-for-mobile">
           <wp-view-toggle-button>
           </wp-view-toggle-button>
+        </li>
+        <li class="toolbar-item hidden-for-mobile">
+          <wp-timeline-toggle-button>
+          </wp-timeline-toggle-button>
         </li>
         <li class="toolbar-item hidden-for-mobile">
           <zen-mode-toggle-button>

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -59,7 +59,8 @@
   <div class="work-packages-split-view">
 
     <!-- (TABLE + TIMELINE) and FOOTER vertical split-->
-    <div class="work-packages-split-view--tabletimeline-side loading-indicator--location"
+    <div *ngIf="showListView"
+         class="work-packages-split-view--tabletimeline-side loading-indicator--location"
          data-indicator-name="table">
       <div class="result-overlay"
            *ngIf="showResultOverlay"></div>
@@ -78,5 +79,19 @@
 
     <!-- Details view -->
     <div class="work-packages-split-view--details-side" ui-view></div>
+
+    <!-- Card representation of the WP -->
+    <div *ngIf="!showListView"
+         class="work-packages--card-view-container loading-indicator--location"
+         data-indicator-name="table">
+      <wp-card-view *ngIf="!showListView"
+                    [dragOutOfHandler]="test"
+                    [dragInto]="true"
+                    [cardsRemovable]="false"
+                    [highlightingMode]="wpTableHighlighting.current.mode"
+                    [showStatusButton]="false"
+                    [orientation]="'horizontal'">
+      </wp-card-view>
+    </div>
   </div>
 </div>

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
@@ -56,7 +56,7 @@ import {WorkPackageQueryStateService} from "core-components/wp-fast-table/state/
 import {debugLog} from "core-app/helpers/debug_output";
 import {QueryDmService} from "core-app/modules/hal/dm-services/query-dm.service";
 import {WorkPackageStatesInitializationService} from "core-components/wp-list/wp-states-initialization.service";
-import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
+import {WorkPackageDisplayRepresentationService} from "core-components/wp-fast-table/state/work-package-display-representation.service";
 
 export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
 
@@ -82,7 +82,7 @@ export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
   readonly wpStaticQueries:WorkPackageStaticQueriesService = this.injector.get(WorkPackageStaticQueriesService);
   readonly QueryDm:QueryDmService = this.injector.get(QueryDmService);
   readonly wpStatesInitialization:WorkPackageStatesInitializationService = this.injector.get(WorkPackageStatesInitializationService);
-  readonly wpDisplayRepresentation:WpDisplayRepresentationService = this.injector.get(WpDisplayRepresentationService);
+  readonly wpDisplayRepresentation:WorkPackageDisplayRepresentationService = this.injector.get(WorkPackageDisplayRepresentationService);
 
   constructor(protected injector:Injector) {
   }

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
@@ -56,6 +56,7 @@ import {WorkPackageQueryStateService} from "core-components/wp-fast-table/state/
 import {debugLog} from "core-app/helpers/debug_output";
 import {QueryDmService} from "core-app/modules/hal/dm-services/query-dm.service";
 import {WorkPackageStatesInitializationService} from "core-components/wp-list/wp-states-initialization.service";
+import {WpDisplayRepresentationService} from "core-components/wp-fast-table/state/wp-display-representation.service";
 
 export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
 
@@ -81,6 +82,7 @@ export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
   readonly wpStaticQueries:WorkPackageStaticQueriesService = this.injector.get(WorkPackageStaticQueriesService);
   readonly QueryDm:QueryDmService = this.injector.get(QueryDmService);
   readonly wpStatesInitialization:WorkPackageStatesInitializationService = this.injector.get(WorkPackageStatesInitializationService);
+  readonly wpDisplayRepresentation:WpDisplayRepresentationService = this.injector.get(WpDisplayRepresentationService);
 
   constructor(protected injector:Injector) {
   }
@@ -124,6 +126,7 @@ export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
     this.setupChangeObserver(this.wpTableHierarchies);
     this.setupChangeObserver(this.wpTableColumns);
     this.setupChangeObserver(this.wpTableHighlighting);
+    this.setupChangeObserver(this.wpDisplayRepresentation);
   }
 
   /**

--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -300,6 +300,9 @@ module API
 
         property :timeline_labels
 
+        # Visible representation of the results
+        property :display_representation
+
         # Highlighting properties
         property :highlighting_mode,
                  render_nil: false

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -138,6 +138,13 @@ module API
                  has_default: true,
                  visibility: false
 
+          schema :display_representation,
+                 type: 'String',
+                 required: false,
+                 writable: true,
+                 has_default: true,
+                 visibility: false
+
           schema :show_hierarchies,
                  type: 'Boolean',
                  required: false,

--- a/modules/boards/spec/features/board_highlighting_spec.rb
+++ b/modules/boards/spec/features/board_highlighting_spec.rb
@@ -87,12 +87,12 @@ describe 'Work Package boards spec', type: :feature, js: true do
     expect(page).to have_selector('.__hl_inline_type_' + type2.id.to_s)
 
     # Highlight whole card by priority
-    board_page.change_board_highlighting 'entire-card', 'Priority'
+    board_page.change_board_highlighting 'inline', 'Priority'
     expect(page).to have_selector('.__hl_background_priority_' + priority.id.to_s)
     expect(page).to have_selector('.__hl_background_priority_' + priority2.id.to_s)
 
     # Highlight whole card by type
-    board_page.change_board_highlighting 'entire-card', 'Type'
+    board_page.change_board_highlighting 'inline', 'Type'
     expect(page).to have_selector('.__hl_background_type_' + type.id.to_s)
     expect(page).to have_selector('.__hl_background_type_' + type2.id.to_s)
 

--- a/spec/features/work_packages/display_representations/switch_display_representations_spec.rb
+++ b/spec/features/work_packages/display_representations/switch_display_representations_spec.rb
@@ -1,0 +1,109 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Work package timeline navigation',
+         with_ee: %i[conditional_highlighting],
+         js: true do
+  let(:user) { FactoryBot.create(:admin) }
+  let(:project) { FactoryBot.create(:project) }
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  let(:highlighting) { ::Components::WorkPackages::Highlighting.new }
+  let(:display_representation) { ::Components::WorkPackages::DisplayRepresentation.new }
+
+  let(:priority1) { FactoryBot.create :issue_priority, color: FactoryBot.create(:color, hexcode: '#123456') }
+  let(:priority2) { FactoryBot.create :issue_priority, color: FactoryBot.create(:color, hexcode: '#332211') }
+  let(:status) { FactoryBot.create :status, color: FactoryBot.create(:color, hexcode: '#654321') }
+
+  let(:wp_1) do
+    FactoryBot.create :work_package,
+                      project: project,
+                      priority: priority1,
+                      status: status
+  end
+  let(:wp_2) do
+    FactoryBot.create :work_package,
+                      project: project,
+                      priority: priority2,
+                      status: status
+  end
+
+  before do
+    wp_1
+    wp_2
+    allow(EnterpriseToken).to receive(:show_banners?).and_return(false)
+
+    login_as(user)
+    wp_table.visit!
+    wp_table.expect_work_package_listed wp_1, wp_2
+
+    # Enable card representation
+    display_representation.switch_to_card_layout
+    expect(page).to have_selector(".wp-card[data-work-package-id='#{wp_1.id}']")
+    expect(page).to have_selector(".wp-card[data-work-package-id='#{wp_2.id}']")
+  end
+
+  it 'can switch the representations and keep the configuration settings' do
+    # Enable highlighting
+    highlighting.switch_entire_row_highlight "Priority"
+    within ".wp-card[data-work-package-id='#{wp_1.id}']" do
+      expect(page).to have_selector(".wp-card--highlighting.__hl_background_priority_#{priority1.id}")
+    end
+    within ".wp-card[data-work-package-id='#{wp_2.id}']" do
+      expect(page).to have_selector(".wp-card--highlighting.__hl_background_priority_#{priority2.id}")
+    end
+
+    # Switch back to list representation & Highlighting is kept
+    display_representation.switch_to_list_layout
+    wp_table.expect_work_package_listed wp_1, wp_2
+    expect(page).to have_selector("#{wp_table.row_selector(wp_1)}.__hl_background_priority_#{priority1.id}")
+    expect(page).to have_selector("#{wp_table.row_selector(wp_2)}.__hl_background_priority_#{priority2.id}")
+
+    # Change attribute
+    highlighting.switch_entire_row_highlight "Status"
+    expect(page).to have_selector("#{wp_table.row_selector(wp_1)}.__hl_background_status_#{status.id}")
+    expect(page).to have_selector("#{wp_table.row_selector(wp_2)}.__hl_background_status_#{status.id}")
+
+    # Switch back to card representation & Highlighting is kept, too
+    display_representation.switch_to_card_layout
+    within ".wp-card[data-work-package-id='#{wp_1.id}']" do
+      expect(page).to have_selector(".wp-card--highlighting.__hl_background_status_#{status.id}")
+    end
+    within ".wp-card[data-work-package-id='#{wp_2.id}']" do
+      expect(page).to have_selector(".wp-card--highlighting.__hl_background_status_#{status.id}")
+    end
+  end
+
+  it 'saves the representation in the query' do
+    # After refresh the WP are still disaplyed as cards
+    page.driver.browser.navigate.refresh
+    expect(page).to have_selector(".wp-card[data-work-package-id='#{wp_1.id}']")
+    expect(page).to have_selector(".wp-card[data-work-package-id='#{wp_2.id}']")
+  end
+end

--- a/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
@@ -336,6 +336,20 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
         it_behaves_like 'has no visibility property'
       end
 
+      describe 'display_representation' do
+        let(:path) { 'displayRepresentation' }
+
+        it_behaves_like 'has basic schema properties' do
+          let(:type) { 'String' }
+          let(:name) { Query.human_attribute_name('display_representation') }
+          let(:required) { false }
+          let(:writable) { true }
+          let(:has_default) { true }
+        end
+
+        it_behaves_like 'has no visibility property'
+      end
+
       describe 'columns' do
         let(:path) { 'columns' }
 

--- a/spec/services/api/v3/parse_query_params_service_spec.rb
+++ b/spec/services/api/v3/parse_query_params_service_spec.rb
@@ -142,6 +142,20 @@ describe ::API::V3::ParseQueryParamsService,
       end
     end
 
+    context 'with display_representation' do
+      it_behaves_like 'transforms' do
+        let(:params) { { displayRepresentation: 'cards' } }
+        let(:expected) { { display_representation:'cards' } }
+      end
+    end
+
+    context 'without display_representation' do
+      it_behaves_like 'transforms' do
+        let(:params) { { displayRepresentation: nil } }
+        let(:expected) { {} }
+      end
+    end
+
     context 'with sort' do
       context 'as sortBy in comma separated value' do
         it_behaves_like 'transforms' do

--- a/spec/services/update_query_from_params_service_spec.rb
+++ b/spec/services/update_query_from_params_service_spec.rb
@@ -112,6 +112,19 @@ describe UpdateQueryFromParamsService,
       end
     end
 
+    context 'display representation' do
+      let(:params) do
+        { display_representation: 'list' }
+      end
+
+      it 'sets the display_representation' do
+        subject
+
+        expect(query.display_representation)
+          .to eq('list')
+      end
+    end
+
     context 'highlighting mode', with_ee: %i[conditional_highlighting] do
       let(:params) do
         { highlighting_mode: 'status' }

--- a/spec/support/components/work_packages/display_representation.rb
+++ b/spec/support/components/work_packages/display_representation.rb
@@ -28,71 +28,22 @@
 
 module Components
   module WorkPackages
-    class Highlighting
+    class DisplayRepresentation
       include Capybara::DSL
       include RSpec::Matchers
 
       def initialize; end
 
-      def switch_highlighting_mode(label)
-        modal_open? or open_modal
-        choose label
-
-        apply
+      def switch_to_card_layout
+        expect(page).to have_button('wp-view-toggle-button--card', disabled: false)
+        expect(page).to have_button('wp-view-toggle-button--list', disabled: true)
+        page.find('#wp-view-toggle-button--card').click
       end
 
-      def switch_entire_row_highlight(label)
-        modal_open? or open_modal
-        choose "Entire row by"
-        page.all(".form--field")[1].select label
-        apply
-      end
-
-      def switch_inline_attribute_highlight(*labels)
-        modal_open? or open_modal
-        choose "Highlighted attribute(s)"
-        within(page.all(".form--field")[0]) do
-          if labels.size == 1
-            select labels.first
-          elsif labels.size > 1
-            find('[class*="--toggle-multiselect"]').click
-            labels.each do |label|
-              select label
-            end
-          end
-        end
-        apply
-      end
-
-      def apply
-        @opened = false
-
-        click_button('Apply')
-      end
-
-      def open_modal
-        @opened = true
-        ::Components::WorkPackages::SettingsMenu.new.open_and_choose 'Configure view'
-
-        retry_block do
-          find(".tab-show", text: 'Highlighting', wait: 10).click
-        end
-      end
-
-      def assume_opened
-        @opened = true
-      end
-
-      private
-
-      def within_modal
-        page.within('.wp-table--configuration-modal') do
-          yield
-        end
-      end
-
-      def modal_open?
-        !!@opened
+      def switch_to_list_layout
+        expect(page).to have_button('wp-view-toggle-button--card', disabled: true)
+        expect(page).to have_button('wp-view-toggle-button--list', disabled: false)
+        page.find('#wp-view-toggle-button--list').click
       end
     end
   end


### PR DESCRIPTION
This PR aims to create a different representation of the WP list in form of cards. The cards itself shall look similar to the board, but the layout is horizontal.

### ToDo
- [x] Add a card-based representation of the WP table
- [x] Add a button to switch between the layouts
- [x] The state shall be stored in the query, so that it is persisted when the page is reloaded
- [x] The following actions that are possible on the table, shall be possible, too:
  - [x] Apply the defined highlighting as far as possible (for attributes that are visible)
- [x] Tests

### Out of Scope for this PR
* Changing the order via drag'n'drop (as the targeted branch is release/9.1)
* Grouping the results
* Moving cards between groups should change the according attribute.
* Adding the card representation to the BIM module