### PR TITLE
[30590] Fix switching into closed status with closed version assigned

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -38,7 +38,9 @@ module WorkPackages
     attribute :description
     attribute :status_id,
               writeable: ->(*) {
-                !model.closed_version_and_status?
+                # If we did not change into the status,
+                # mark unwritable if status and version is closed
+                model.status_id_change || !model.closed_version_and_status?
               }
     attribute :type_id
     attribute :priority_id

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -669,6 +669,7 @@ en:
       message_successful_show_in_fullscreen: "Click here to open this work package in fullscreen view."
       message_view_spent_time: "Show spent time for this work package"
       message_work_package_read_only: "Work package is locked in this status. No attribute other than status can be altered."
+      message_work_package_status_blocked: "Work package status is not writable due to closed status and closed version being assigned."
       no_value: "No value"
       placeholder_filter_by_text: "Subject, description, comments, ..."
       inline_create:

--- a/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
@@ -39,6 +39,7 @@ import {CollectionResource} from 'core-app/modules/hal/resources/collection-reso
 import {IWorkPackageEditingServiceToken} from "../../wp-edit-form/work-package-editing.service.interface";
 import {Highlighting} from "core-components/wp-fast-table/builders/highlighting/highlighting.functions";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
 
 @Directive({
   selector: '[wpStatusDropdown]'
@@ -50,6 +51,7 @@ export class WorkPackageStatusDropdownDirective extends OpContextMenuTrigger {
               readonly opContextMenu:OPContextMenuService,
               readonly $state:StateService,
               protected wpNotificationsService:WorkPackageNotificationService,
+              protected notificationService:NotificationsService,
               @Inject(IWorkPackageEditingServiceToken) protected wpEditing:WorkPackageEditingService,
               protected I18n:I18nService,
               protected wpTableRefresh:WorkPackageTableRefreshService) {
@@ -63,7 +65,13 @@ export class WorkPackageStatusDropdownDirective extends OpContextMenuTrigger {
     changeset.getForm().then((form:any) => {
       const statuses = form.schema.status.allowedValues;
       this.buildItems(statuses);
-      this.opContextMenu.show(this, evt);
+
+      const writable = changeset.isWritable('status');
+      if (!writable) {
+        this.notificationService.addError(this.I18n.t('js.work_packages.message_work_package_status_blocked'));
+      } else {
+        this.opContextMenu.show(this, evt);
+      }
     });
   }
 

--- a/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.component.ts
@@ -48,14 +48,14 @@ export class WorkPackageStatusButtonComponent implements OnInit, OnDestroy {
 
   public text = {
     explanation: this.I18n.t('js.label_edit_status'),
-    workPackageReadOnly: this.I18n.t('js.work_packages.message_work_package_read_only')
+    workPackageReadOnly: this.I18n.t('js.work_packages.message_work_package_read_only'),
+    workPackageStatusBlocked: this.I18n.t('js.work_packages.message_work_package_status_blocked')
   };
 
   constructor(readonly I18n:I18nService,
               readonly cdRef:ChangeDetectorRef,
               readonly wpCacheService:WorkPackageCacheService,
               readonly schemaCacheService:SchemaCacheService,
-              readonly changeDetectorRef:ChangeDetectorRef,
               @Inject(IWorkPackageEditingServiceToken) protected wpEditing:WorkPackageEditingService) {
   }
 
@@ -77,9 +77,9 @@ export class WorkPackageStatusButtonComponent implements OnInit, OnDestroy {
       .pipe(
         untilComponentDestroyed(this)
       )
-      .subscribe((wp) => {
+      .subscribe(() => {
         // we have to explicitly force the component to update
-        this.changeDetectorRef.detectChanges();
+        this.cdRef.detectChanges();
       });
   }
 
@@ -90,6 +90,8 @@ export class WorkPackageStatusButtonComponent implements OnInit, OnDestroy {
   public get buttonTitle() {
     if (this.workPackage.isReadonly) {
       return this.text.workPackageReadOnly;
+    } else if (this.workPackage.isEditable && this.isDisabled) {
+      return this.text.workPackageStatusBlocked;
     } else {
       return '';
     }
@@ -97,12 +99,16 @@ export class WorkPackageStatusButtonComponent implements OnInit, OnDestroy {
 
   public get statusHighlightClass() {
     let status = this.status;
-    if (!status) { return; }
+    if (!status) {
+      return;
+    }
     return Highlighting.backgroundClass('status', status.id!);
   }
 
   public get status():HalResource|undefined {
-    if (!this.wpEditing) { return; }
+    if (!this.wpEditing) {
+      return;
+    }
 
     return this.changeset.value('status');
   }

--- a/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.html
+++ b/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.html
@@ -1,12 +1,11 @@
 <div class="wp-status-button"
      [ngClass]="containerClass"
+     [attr.title]="buttonTitle"
      *ngIf="status">
   <button class="button"
           [ngClass]="statusHighlightClass"
           [disabled]="isDisabled"
-          [attr.title]="buttonTitle"
           [attr.aria-label]="text.explanation"
-
           wpStatusDropdown
           [wpStatusDropdown-workPackage]="workPackage">
 

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -169,6 +169,18 @@ describe WorkPackages::BaseContract do
       it 'is not writable' do
         expect(contract.writable?(:status)).to be_falsey
       end
+
+      context 'if we only switched into that status now' do
+        before do
+          allow(work_package)
+            .to receive(:status_id_change)
+            .and_return [1,2]
+        end
+
+        it 'is writable' do
+          expect(contract.writable?(:status)).to be_truthy
+        end
+      end
     end
   end
 

--- a/spec/features/work_packages/details/closed_status_and_version_spec.rb
+++ b/spec/features/work_packages/details/closed_status_and_version_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'Closed status and version in full view', js: true do
+  let(:type) { FactoryBot.create(:type) }
+  let(:status) { FactoryBot.create(:closed_status) }
+
+  let(:project) { FactoryBot.create(:project, types: [type]) }
+
+  let(:version) { FactoryBot.create :version, status: 'closed', project: project }
+  let(:work_package) { FactoryBot.create :work_package, project: project, status: status, fixed_version: version }
+  let(:wp_page) { ::Pages::FullWorkPackage.new(work_package, project) }
+
+  let(:user) { FactoryBot.create :admin }
+
+  before do
+    login_as(user)
+    wp_page.visit!
+  end
+
+  it 'shows a warning when trying to edit status' do
+    # Should be initially editable (due to non specific schema)
+    status = page.find('.wp-status-button button:not([disabled])')
+    status.click
+
+    wp_page.expect_and_dismiss_notification type: :error,
+                                            message: I18n.t('js.work_packages.message_work_package_status_blocked')
+
+
+    expect(page).to have_selector('.wp-status-button button[disabled]')
+  end
+end


### PR DESCRIPTION
https://community.openproject.com/wp/30396 introduced a blocking of status editing when the version and version is closed. But this blocking also happens when trying to move a status INTO a closed state.

https://community.openproject.com/wp/30590