### PR TITLE
[30591] Use username for login form

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -361,7 +361,7 @@ en:
         account: "Account"
         attr_firstname: "Firstname attribute"
         attr_lastname: "Lastname attribute"
-        attr_login: "Login attribute"
+        attr_login: "Username attribute"
         attr_mail: "Email attribute"
         base_dn: "Base DN"
         host: "Host"
@@ -742,7 +742,7 @@ en:
     # kept for backwards compatibility
     issue: "Work package"
     lastname: "Last name"
-    login: "Login"
+    login: "Username"
     mail: "Email"
     name: "Name"
     password: "Password"

--- a/modules/reporting/spec/features/permissions_spec.rb
+++ b/modules/reporting/spec/features/permissions_spec.rb
@@ -55,7 +55,7 @@ describe 'Cost report calculations', type: :feature, js: true do
   context 'as anonymous' do
     let(:current_user) { User.anonymous }
     it 'is redirect to login' do
-      expect(page).to have_content 'Login'
+      expect(page).to have_content 'Username'
       expect(page).to have_content 'Password'
     end
   end

--- a/spec/controllers/concerns/auth_source_sso_spec.rb
+++ b/spec/controllers/concerns/auth_source_sso_spec.rb
@@ -64,7 +64,7 @@ describe MyController, type: :controller do
   end
 
   it "should log in given user" do
-    expect(response.body.squish).to have_content("Login   h.wurst")
+    expect(response.body.squish).to have_content("Username   h.wurst")
   end
 
   shared_examples "auth source sso failure" do

--- a/spec/features/auth/login_spec.rb
+++ b/spec/features/auth/login_spec.rb
@@ -47,7 +47,7 @@ describe 'Login', type: :feature do
 
   def expect_not_being_logged_in
     expect(page)
-      .to have_field('Login')
+      .to have_field('Username')
   end
 
   context 'sign in user' do
@@ -113,7 +113,7 @@ describe 'Login', type: :feature do
       visit my_page_path
 
       expect(page)
-        .to have_field('Login')
+        .to have_field('Username')
 
       login_with(user.login, user_password)
 

--- a/spec/features/auth/logout_spec.rb
+++ b/spec/features/auth/logout_spec.rb
@@ -57,6 +57,6 @@ describe 'Logout', type: :feature, js: true do
     visit my_page_path
 
     expect(page)
-      .to have_field('Login')
+      .to have_field('Username')
   end
 end

--- a/spec/features/users/brute_force_spec.rb
+++ b/spec/features/users/brute_force_spec.rb
@@ -42,7 +42,7 @@ describe 'Loggin (with brute force protection)', type: :feature do
   def new_login_attempt(login_attempt, password_attempt)
     # The login name already provided is retained
     expect(page)
-      .to have_field 'Login', with: login_attempt
+      .to have_field 'Username', with: login_attempt
 
     login_with(login_attempt, password_attempt)
   end

--- a/spec/features/users/self_registration_spec.rb
+++ b/spec/features/users/self_registration_spec.rb
@@ -45,7 +45,7 @@ describe 'user self registration', type: :feature, js: true do
       click_link 'Create a new account'
       # deliberately inserting a wrong password confirmation
       within '.registration-modal' do
-        fill_in 'Login', with: 'heidi'
+        fill_in 'Username', with: 'heidi'
         fill_in 'First name', with: 'Heidi'
         fill_in 'Last name', with: 'Switzerland'
         fill_in 'Email', with: 'heidi@heidiland.com'
@@ -74,7 +74,7 @@ describe 'user self registration', type: :feature, js: true do
 
       # deliberately inserting a wrong password confirmation
       within '.registration-modal' do
-        fill_in 'Login', with: 'heidi'
+        fill_in 'Username', with: 'heidi'
         fill_in 'First name', with: 'Heidi'
         fill_in 'Last name', with: 'Switzerland'
         fill_in 'Email', with: 'heidi@heidiland.com'

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -63,7 +63,7 @@ describe MailHandler, type: :model do
       email = ActionMailer::Base.deliveries.first
       expect(email).not_to be_nil
       expect(email.subject).to eq(I18n.t('mail_subject_register', value: Setting.app_title))
-      login = email.body.encoded.match(/\* Login: (\S+)\s?$/)[1]
+      login = email.body.encoded.match(/\* Username: (\S+)\s?$/)[1]
       password = email.body.encoded.match(/\* Password: (\S+)\s?$/)[1]
 
       # Can't log in here since randomly assigned password must be changed

--- a/spec/support/pages/new_user.rb
+++ b/spec/support/pages/new_user.rb
@@ -44,7 +44,7 @@ module Pages
       form.fill! 'Email', :email
 
       form.select! 'Authentication mode', :auth_source
-      form.fill! 'Login', :login
+      form.fill! 'Username', :login
 
       form.set_checked! 'Administrator', :admin
     end

--- a/spec/views/layouts/base.html.erb_spec.rb
+++ b/spec/views/layouts/base.html.erb_spec.rb
@@ -108,7 +108,7 @@ describe 'layouts/base', type: :view do
       end
 
       it 'shows a login form' do
-        expect(rendered).to include 'Login'
+        expect(rendered).to include 'Username'
         expect(rendered).to include 'Password'
       end
     end
@@ -120,7 +120,7 @@ describe 'layouts/base', type: :view do
       end
 
       it 'shows no password login form' do
-        expect(rendered).not_to include 'Login'
+        expect(rendered).not_to include 'Username'
         expect(rendered).not_to include 'Password'
       end
     end


### PR DESCRIPTION
Use username instead of 'login' https://community.openproject.com/wp/30591