### PR TITLE
[30589] Allow inline-create only with edit_work_packages permission

### DIFF
--- a/frontend/src/app/components/wp-inline-create/wp-inline-create.service.ts
+++ b/frontend/src/app/components/wp-inline-create/wp-inline-create.service.ts
@@ -69,7 +69,8 @@ export class WorkPackageInlineCreateService implements OnDestroy {
   }
 
   public get canCreateWorkPackages() {
-    return this.authorisationService.can('work_packages', 'createWorkPackage');
+    return this.authorisationService.can('work_packages', 'createWorkPackage') &&
+      this.authorisationService.can('work_packages', 'editWorkPackage');
   }
 
   /** Allow callbacks to happen on newly created inline work packages */

--- a/frontend/src/app/modules/boards/board/board-list/board-inline-create.service.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-inline-create.service.ts
@@ -59,7 +59,7 @@ export class BoardInlineCreateService extends WorkPackageInlineCreateService imp
   public referenceTarget:WorkPackageResource|null = null;
 
   public get canAdd() {
-    return this.canCreateWorkPackages;
+    return this.authorisationService.can('work_packages', 'createWorkPackage');
   }
 
   public get canReference() {

--- a/modules/my_page/spec/features/my/assigned_to_me_spec.rb
+++ b/modules/my_page/spec/features/my/assigned_to_me_spec.rb
@@ -61,7 +61,7 @@ describe 'Assigned to me embedded query on my page', type: :feature, js: true do
     FactoryBot.create(:user)
   end
 
-  let(:role) { FactoryBot.create(:role, permissions: %i[view_work_packages add_work_packages]) }
+  let(:role) { FactoryBot.create(:role, permissions: %i[view_work_packages add_work_packages edit_work_packages]) }
 
   let(:user) do
     FactoryBot.create(:user,

--- a/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
+++ b/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
@@ -135,7 +135,7 @@ describe 'Work package with relation query group', js: true, selenium: true do
 
     context 'with a user who has permission in one project' do
       let(:role) { FactoryBot.create(:role, permissions: permissions) }
-      let(:permissions) { [:view_work_packages, :add_work_packages, :manage_work_package_relations] }
+      let(:permissions) { %i[view_work_packages add_work_packages edit_work_packages manage_work_package_relations] }
       let(:user) do
         FactoryBot.create(:user,
                           member_in_project: project,

--- a/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
+++ b/spec/features/work_packages/table/inline_create/create_work_packages_spec.rb
@@ -4,7 +4,7 @@ describe 'inline create work package', js: true do
   let(:type) { FactoryBot.create(:type) }
   let(:types) { [type] }
 
-  let(:permissions) { %i(view_work_packages add_work_packages)}
+  let(:permissions) { %i(view_work_packages add_work_packages edit_work_packages) }
   let(:role) { FactoryBot.create :role, permissions: permissions }
   let(:user) do
     FactoryBot.create :user,

--- a/spec/features/work_packages/table/inline_create/parallel_creation_spec.rb
+++ b/spec/features/work_packages/table/inline_create/parallel_creation_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Parallel work package creation spec', js: true do
   let(:type) { project.types.first }
 
-  let(:permissions) { %i(view_work_packages add_work_packages) }
+  let(:permissions) { %i(view_work_packages add_work_packages edit_work_packages) }
   let(:role) { FactoryBot.create :role, permissions: permissions }
   let(:user) do
     FactoryBot.create :user,


### PR DESCRIPTION
Since inline create saves very quickly, it does not make sense to use when not having the edit work packages permission

https://community.openproject.com/wp/30589