### PR TITLE
[30609] Extend seeder to handle groups

### DIFF
--- a/app/seeders/demo_data/group_seeder.rb
+++ b/app/seeders/demo_data/group_seeder.rb
@@ -44,6 +44,23 @@ module DemoData
       puts
     end
 
+    def add_projects_to_groups
+      groups = demo_data_for('groups')
+      groups.each do |group_attr|
+        group = Group.find_by(lastname: group_attr[:name])
+        group_attr[:projects].each do |project_attr|
+          project = Project.find(project_attr[:name])
+          role = Role.find_by(name: project_attr[:role])
+
+          Member.create!(
+            project: project,
+            principal: group,
+            roles: [role]
+          )
+        end
+      end
+    end
+
     private
 
     def seed_groups
@@ -54,7 +71,6 @@ module DemoData
         group = create_group group_attr[:name]
 
         add_user_to_group group
-        add_projects_to_group group, group_attr[:projects]
       end
     end
 
@@ -64,19 +80,6 @@ module DemoData
 
     def add_user_to_group(group)
       group.users << user
-    end
-
-    def add_projects_to_group(group, projects)
-      projects.each do |project_attr|
-        project = Project.find(project_attr[:name])
-        role = Role.find_by(name: project_attr[:role])
-
-        Member.create!(
-          project: project,
-          principal: group,
-          roles: [role]
-        )
-      end
     end
   end
 end

--- a/app/seeders/demo_data/group_seeder.rb
+++ b/app/seeders/demo_data/group_seeder.rb
@@ -1,5 +1,7 @@
 #-- encoding: UTF-8
+
 #-- copyright
+
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 #
@@ -25,15 +27,41 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See doc/COPYRIGHT.rdoc for more details.
-class DemoDataSeeder < CompositeSeeder
-  def data_seeder_classes
-    [
-      DemoData::GroupSeeder,
-      DemoData::ProjectSeeder
-    ]
-  end
+module DemoData
+  class GroupSeeder < Seeder
+    attr_accessor :user
+    include ::DemoData::References
 
-  def namespace
-    'DemoData'
+    def initialize
+      self.user = User.admin.first
+    end
+
+    def seed_data!
+      print '    ↳ Creating groups'
+
+      seed_groups
+
+      puts
+    end
+
+    private
+
+    def seed_groups
+      groups = demo_data_for('groups')
+
+      groups.each do |group_attr|
+        print '.'
+        group = create_group group_attr[:name]
+        add_user_to_group group
+      end
+    end
+
+    def create_group(name)
+      Group.create lastname: name
+    end
+
+    def add_user_to_group(group)
+      group.users << user
+    end
   end
 end

--- a/app/seeders/demo_data/group_seeder.rb
+++ b/app/seeders/demo_data/group_seeder.rb
@@ -52,7 +52,9 @@ module DemoData
       groups.each do |group_attr|
         print '.'
         group = create_group group_attr[:name]
+
         add_user_to_group group
+        add_projects_to_group group, group_attr[:projects]
       end
     end
 
@@ -62,6 +64,19 @@ module DemoData
 
     def add_user_to_group(group)
       group.users << user
+    end
+
+    def add_projects_to_group(group, projects)
+      projects.each do |project_attr|
+        project = Project.find(project_attr[:name])
+        role = Role.find_by(name: project_attr[:role])
+
+        Member.create!(
+          project: project,
+          principal: group,
+          roles: [role]
+        )
+      end
     end
   end
 end

--- a/app/seeders/demo_data/group_seeder.rb
+++ b/app/seeders/demo_data/group_seeder.rb
@@ -46,17 +46,19 @@ module DemoData
 
     def add_projects_to_groups
       groups = demo_data_for('groups')
-      groups.each do |group_attr|
-        group = Group.find_by(lastname: group_attr[:name])
-        group_attr[:projects].each do |project_attr|
-          project = Project.find(project_attr[:name])
-          role = Role.find_by(name: project_attr[:role])
+      if groups.present?
+        groups.each do |group_attr|
+          group = Group.find_by(lastname: group_attr[:name])
+          group_attr[:projects].each do |project_attr|
+            project = Project.find(project_attr[:name])
+            role = Role.find_by(name: project_attr[:role])
 
-          Member.create!(
-            project: project,
-            principal: group,
-            roles: [role]
-          )
+            Member.create!(
+              project: project,
+              principal: group,
+              roles: [role]
+            )
+          end
         end
       end
     end
@@ -65,21 +67,16 @@ module DemoData
 
     def seed_groups
       groups = demo_data_for('groups')
-
-      groups.each do |group_attr|
-        print '.'
-        group = create_group group_attr[:name]
-
-        add_user_to_group group
+      if groups.present?
+        groups.each do |group_attr|
+          print '.'
+          create_group group_attr[:name]
+        end
       end
     end
 
     def create_group(name)
       Group.create lastname: name
-    end
-
-    def add_user_to_group(group)
-      group.users << user
     end
   end
 end

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -66,6 +66,9 @@ module DemoData
         Setting.demo_projects_available = 'true'
       end
 
+      puts ' ↳ Assign groups to projects'
+      set_groups
+
       puts ' ↳ Updating settings'
       seed_settings
     end
@@ -119,6 +122,10 @@ module DemoData
         principal: user,
         roles: [role]
       )
+    end
+
+    def set_groups
+      DemoData::GroupSeeder.new.add_projects_to_groups
     end
 
     def set_types(project, key)

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -98,13 +98,22 @@ module DemoData
       {
         project:       project,
         author:        user,
-        assigned_to:   user,
+        assigned_to:   find_assignee(attributes),
         subject:       attributes[:subject],
         description:   attributes[:description],
         status:        find_status(attributes),
         type:          find_type(attributes),
         priority:      find_priority(attributes) || IssuePriority.default
       }
+    end
+
+    def find_assignee(attributes)
+      if attributes[:assignee]
+        group_assignee =  Group.find_by(lastname: attributes[:assignee])
+        return group_assignee unless group_assignee.nil?
+      end
+
+      user
     end
 
     def find_priority(attributes)

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -66,6 +66,7 @@ module DemoData
       wp_attr = base_work_package_attributes attributes
 
       set_version! wp_attr, attributes
+      set_accountable! wp_attr, attributes
       set_time_tracking_attributes! wp_attr, attributes
       set_backlogs_attributes! wp_attr, attributes
 
@@ -98,7 +99,7 @@ module DemoData
       {
         project:       project,
         author:        user,
-        assigned_to:   find_assignee(attributes),
+        assigned_to:   find_principal(attributes[:assignee]),
         subject:       attributes[:subject],
         description:   attributes[:description],
         status:        find_status(attributes),
@@ -107,9 +108,9 @@ module DemoData
       }
     end
 
-    def find_assignee(attributes)
-      if attributes[:assignee]
-        group_assignee =  Group.find_by(lastname: attributes[:assignee])
+    def find_principal(name)
+      if name
+        group_assignee =  Group.find_by(lastname: name)
         return group_assignee unless group_assignee.nil?
       end
 
@@ -131,6 +132,12 @@ module DemoData
     def set_version!(wp_attr, attributes)
       if attributes[:version]
         wp_attr[:fixed_version] = Version.find_by!(name: attributes[:version])
+      end
+    end
+
+    def set_accountable!(wp_attr, attributes)
+      if attributes[:accountable]
+        wp_attr[:responsible] = find_principal(attributes[:accountable])
       end
     end
 

--- a/app/seeders/demo_data_seeder.rb
+++ b/app/seeders/demo_data_seeder.rb
@@ -28,8 +28,8 @@
 class DemoDataSeeder < CompositeSeeder
   def data_seeder_classes
     [
-      DemoData::GroupSeeder,
-      DemoData::ProjectSeeder
+      DemoData::ProjectSeeder,
+      DemoData::GroupSeeder
     ]
   end
 

--- a/app/seeders/demo_data_seeder.rb
+++ b/app/seeders/demo_data_seeder.rb
@@ -28,8 +28,8 @@
 class DemoDataSeeder < CompositeSeeder
   def data_seeder_classes
     [
-      DemoData::ProjectSeeder,
-      DemoData::GroupSeeder
+      DemoData::GroupSeeder,
+      DemoData::ProjectSeeder
     ]
   end
 

--- a/config/locales/en.seeders.standard.yml
+++ b/config/locales/en.seeders.standard.yml
@@ -29,13 +29,6 @@ en:
   seeders:
     standard:
       demo_data:
-        groups:
-          - name: 'Project Admins'
-            projects:
-              - name: 'demo-project'
-                role: 'Project admin'
-              - name: 'your-scrum-project'
-                role: 'Project admin'
         welcome:
           title: "Welcome to OpenProject!"
           text: |
@@ -187,7 +180,6 @@ en:
                     attachments:
                       - project_overview.jpg
                   - subject: Activate further modules
-                    assignee: 'Project Admins'
                     description: |
                       Please activate further [Modules](%{base_url}/projects/demo-project/settings/modules) in the Project settings in order to have more features in your project.
 
@@ -614,7 +606,6 @@ en:
                 start: 23
                 duration: 0
               - subject: Choose a content management system
-                assignee: 'Project Admins'
                 status: :default_status_specified
                 type: :default_type_user_story
                 version: Product Backlog

--- a/config/locales/en.seeders.standard.yml
+++ b/config/locales/en.seeders.standard.yml
@@ -29,6 +29,13 @@ en:
   seeders:
     standard:
       demo_data:
+        groups:
+          - name: 'Project Admins'
+            projects:
+              - name: 'demo-project'
+                role: 'Project admin'
+              - name: 'your-scrum-project'
+                role: 'Project admin'
         welcome:
           title: "Welcome to OpenProject!"
           text: |
@@ -180,6 +187,7 @@ en:
                     attachments:
                       - project_overview.jpg
                   - subject: Activate further modules
+                    assignee: 'Project Admins'
                     description: |
                       Please activate further [Modules](%{base_url}/projects/demo-project/settings/modules) in the Project settings in order to have more features in your project.
 
@@ -606,6 +614,7 @@ en:
                 start: 23
                 duration: 0
               - subject: Choose a content management system
+                assignee: 'Project Admins'
                 status: :default_status_specified
                 type: :default_type_user_story
                 version: Product Backlog

--- a/config/locales/en.seeders.standard.yml.example
+++ b/config/locales/en.seeders.standard.yml.example
@@ -1,0 +1,124 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+en:
+  seeders:
+    standard:
+      demo_data:
+        groups:
+          - name: 'Project Admins'
+            projects:
+              - name: 'demo-project'
+                role: 'Project admin'
+        welcome:
+          title: "Welcome to OpenProject!"
+          text: |
+            Select one of the demo projects to get started with some demo data we have prepared for you.
+        projects:
+          demo-project:
+            name: Demo project
+            identifier: demo-project
+            description: >
+              **This is a demo project**. You can edit the description in
+              the [Project settings -> Description](%{base_url}/projects/demo-project/settings).
+            timeline:
+              name: Timeline
+            modules:
+              - work_package_tracking
+              - news
+              - wiki
+              - board_view
+            news:
+              - title: Welcome to your demo project
+                summary: >
+                  We are glad you joined.
+                  In this module you can communicate project news to your team members.
+                description: The actual news
+            types:
+              - :default_type_task
+              - :default_type_milestone
+            categories:
+              - Category 1 (to be changed in Project settings)
+            queries:
+              - name: Milestones
+                status: open
+                type: :default_type_milestone
+                timeline: true
+                columns:
+                  - id
+                  - type
+                  - status
+                  - subject
+                  - start_date
+                  - due_date
+                sort_by: id
+            boards:
+              kanban:
+                name: 'Kanban board'
+            work_packages:
+              - subject: Project planning
+                description: |
+                  Please execute the related tasks:
+
+                  * ##child:1
+                status: :default_status_new
+                type: :default_type_task
+                priority: :default_priority_high
+                estimated_hours: 8
+                start: 0
+                duration: 3
+                assignee: 'Project Admins'
+                children:
+                  - subject: Create a new project
+                    description: |
+                      Please [create a new project](%{base_url}/projects/new) from the project drop down menu in the left hand header navigation.
+                    status: :default_status_in_progress
+                    type: :default_type_task
+                    start: 0
+                    duration: 0
+                    attachments:
+                      - new_project.jpg
+              - subject: Develop v1.0
+                status: :default_status_scheduled
+                type: :default_type_phase
+                start: 7
+                duration: 17
+                accountable: 'Project Admins'
+                relations:
+                  - to: Project planning
+                    type: follows
+            wiki:
+              - title: Wiki
+                content: |
+                  In this wiki you can collaboratively create and edit pages and sub-pages to create a project wiki.
+                children:
+                  - title: Project documentation
+                    content: |
+                      This is a sub-page of the wiki. You can change this by editing the Parent page (Click the _EDIT_ button and see bottom of the page).
+                    children:
+                      - title: Project manual
+                        content: ''


### PR DESCRIPTION
This PR aims to extend the current seeding mechanism to seed groups.

### ToDo
- [x] Possibility to seed groups
  - [x] A group is created, the user assigned as member.
  - [x] It is possible to enable groups for projects
  - [x] It is possible to set a group as an assignee. 

https://community.openproject.com/projects/openproject/work_packages/30617/activity