### PR TITLE
Displaying WP from sub-projects in Backlogs module

### DIFF
--- a/modules/backlogs/app/controllers/rb_tasks_controller.rb
+++ b/modules/backlogs/app/controllers/rb_tasks_controller.rb
@@ -41,9 +41,10 @@ class RbTasksController < RbApplicationController
                       "estimated_hours", "status_id", "sprint_id"]
 
   def create
+    parent_task = Task.find(params[:parent_id])
     call = Tasks::CreateService
            .new(user: current_user)
-           .call(attributes: task_params.merge(project: @project), prev: params[:prev])
+           .call(attributes: task_params.merge(project: parent_task.project), prev: params[:prev])
 
     respond_with_task call
   end

--- a/modules/backlogs/app/models/story.rb
+++ b/modules/backlogs/app/models/story.rb
@@ -151,8 +151,8 @@ class Story < WorkPackage
   private
 
   def self.condition(project_id, sprint_ids, extras = [])
-    c = ['project_id = ? AND type_id in (?) AND fixed_version_id in (?)',
-         project_id, Story.types, sprint_ids]
+    c = ['type_id in (?) AND fixed_version_id in (?)',
+         Story.types, sprint_ids]
 
     if extras.size > 0
       c[0] += ' ' + extras.shift


### PR DESCRIPTION
I was stuck to manage multiple sub-projects and get a view on a shared version/sprint at the same time on the parent project.

Thanks to [Carsten Klein](https://community.openproject.com/users/42018) I found a bit of code on the [Feature proposal](https://community.openproject.com/projects/plugin-backlogs/work_packages/24038/activity#activity-2).

I know my code is too simple and could be improved : 

1. each sub-project get to view the work packages of all other sub-projects in the same version if it is shared accordingly. And there is no visibility checks ! A bit of help would be welcomed ;)
2. this behavior should be activated through an option of the backlog module