### PR TITLE
[30586] Subject fields in sync while creating 2 new board cards

### DIFF
--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -242,7 +242,16 @@ export class WorkPackageCardViewComponent  implements OnInit {
    */
   public set workPackages(workPackages:WorkPackageResource[]) {
     if (this.activeInlineCreateWp) {
-      this._workPackages = [this.activeInlineCreateWp, ...workPackages];
+      let existingNewWp = this._workPackages.find(o => o.isNew);
+
+      // If there is already a card for a new WP,
+      // we have to replace this one by the new activeInlineCreateWp
+      if (existingNewWp) {
+        let index = this._workPackages.indexOf(existingNewWp);
+        this._workPackages[index] = this.activeInlineCreateWp;
+      } else {
+        this._workPackages = [this.activeInlineCreateWp, ...workPackages];
+      }
     } else {
       this._workPackages = [...workPackages];
     }


### PR DESCRIPTION
Replace activeInlineCreateWP in board instead of just adding it to the array. Thus we avoid that there can be more than one "New WP card".


https://community.openproject.com/projects/openproject/work_packages/30586/activity