### PR TITLE
[30631] Reduce sum label to avoid enlarged first column

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -324,6 +324,7 @@ en:
     label_star_query: "Favored"
     label_press_enter_to_save: "Press enter to save."
     label_public_query: "Public"
+    label_sum: "Sum"
     label_sum_for: "Sum for"
     label_subject: "Subject"
     label_this_week: "this week"

--- a/frontend/src/app/components/wp-table/wp-table-sums-row/wp-table-sums-row.directive.ts
+++ b/frontend/src/app/components/wp-table/wp-table-sums-row/wp-table-sums-row.directive.ts
@@ -43,7 +43,7 @@ import {QueryColumn} from "core-components/wp-query/query-column";
 })
 export class WorkPackageTableSumsRowController implements AfterViewInit {
 
-  private text:{ sumFor:string, allWorkPackages:string };
+  private text:{ sum:string };
 
   private $element:JQuery;
 
@@ -55,8 +55,7 @@ export class WorkPackageTableSumsRowController implements AfterViewInit {
               readonly I18n:I18nService) {
 
     this.text = {
-      sumFor: I18n.t('js.label_sum_for'),
-      allWorkPackages: I18n.t('js.label_all_work_packages')
+      sum: I18n.t('js.label_sum')
     };
   }
 
@@ -137,7 +136,7 @@ export class WorkPackageTableSumsRowController implements AfterViewInit {
 
   private appendFirstLabel(div:HTMLElement) {
     const span = document.createElement('span');
-    span.textContent = `${this.text.sumFor} ${this.text.allWorkPackages}`;
+    span.textContent = `${this.text.sum}`;
     jQuery(div).prepend(span);
   }
 }

--- a/spec/features/work_packages/index_sums_spec.rb
+++ b/spec/features/work_packages/index_sums_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature 'Work package index sums', js: true do
     wp_table.expect_work_package_listed work_package_1, work_package_2
 
     within('.sum.group.all') do
-      expect(page).to have_content('Sum for all work packages')
+      expect(page).to have_content('Sum')
       expect(page).to have_content('25')
     end
 
@@ -74,7 +74,7 @@ RSpec.feature 'Work package index sums', js: true do
     edit_field.update '20'
 
     within('.sum.group.all') do
-      expect(page).to have_content('Sum for all work packages')
+      expect(page).to have_content('Sum')
       expect(page).to have_content('35')
     end
   end


### PR DESCRIPTION
Remove unnecessary text content to avoid a super large first column when sums are displayed.

https://community.openproject.com/projects/openproject/work_packages/30631/activity