### PR TITLE
Feature/project details widget on dashboard

### DIFF
--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -46,18 +46,10 @@ module Projects
 
     attribute_alias :is_public, :public
 
-    def validate_status_not_nil
-      errors.add(:status, :blank) if model.status.nil?
-    end
+    def validate
+      validate_user_allowed_to_manage
 
-    def validate_status_included
-      if model.status.present? && !assignable_statuses.include?(model.status)
-        errors.add(:status, :inclusion)
-      end
-    end
-
-    def validate_parent_visible
-      errors.add(:parent, :does_not_exist) if model.parent && model.parent_id_changed? && !model.parent.visible?
+      super
     end
 
     def assignable_parents
@@ -78,6 +70,30 @@ module Projects
       else
         model.available_custom_fields.select(&:visible?)
       end
+    end
+
+    private
+
+    def validate_status_not_nil
+      errors.add(:status, :blank) if model.status.nil?
+    end
+
+    def validate_status_included
+      if model.status.present? && !assignable_statuses.include?(model.status)
+        errors.add(:status, :inclusion)
+      end
+    end
+
+    def validate_parent_visible
+      errors.add(:parent, :does_not_exist) if model.parent && model.parent_id_changed? && !model.parent.visible?
+    end
+
+    def validate_user_allowed_to_manage
+      errors.add :base, :error_unauthorized unless user.allowed_to?(manage_permission, model)
+    end
+
+    def manage_permission
+      raise NotImplementedError
     end
   end
 end

--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -28,12 +28,56 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'model_contract'
-
 module Projects
   class BaseContract < ::ModelContract
-    def self.model
-      ::Project
+    include AssignableValuesContract
+
+    attribute :name
+    attribute :identifier
+    attribute :description
+    attribute :is_public
+    attribute :status do
+      validate_status_not_nil
+      validate_status_included
+    end
+    attribute :parent do
+      validate_parent_visible
+    end
+
+    attribute_alias :is_public, :public
+
+    def validate_status_not_nil
+      errors.add(:status, :blank) if model.status.nil?
+    end
+
+    def validate_status_included
+      if model.status.present? && !assignable_statuses.include?(model.status)
+        errors.add(:status, :inclusion)
+      end
+    end
+
+    def validate_parent_visible
+      errors.add(:parent, :does_not_exist) if model.parent && model.parent_id_changed? && !model.parent.visible?
+    end
+
+    def assignable_parents
+      Project.visible
+    end
+
+    def assignable_statuses
+      Project.statuses.keys
+    end
+
+    def assignable_custom_field_values(custom_field)
+      custom_field.possible_values
+    end
+
+    def available_custom_fields
+      if user.admin?
+        model.available_custom_fields
+      else
+        model.available_custom_fields.select(&:visible?)
+      end
     end
   end
 end

--- a/app/contracts/projects/create_contract.rb
+++ b/app/contracts/projects/create_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -23,31 +23,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# See docs/COPYRIGHT.rdoc for more details.
+# See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'spec_helper'
-
-describe ::API::Decorators::AggregationGroup do
-  let(:query) do
-    query = FactoryBot.build_stubbed(:query)
-    query.group_by = :assigned_to
-
-    query
-  end
-  let(:group_key) { OpenStruct.new name: 'ABC' }
-  let(:count) { 5 }
-  let(:current_user) { FactoryBot.build_stubbed(:user) }
-
-  subject { described_class.new(group_key, count, query: query, current_user: current_user).to_json }
-
-  context 'with an empty array key' do
-    let(:group_key) { [] }
-
-    it 'has an empty value' do
-      is_expected
-        .to be_json_eql(nil.to_json)
-        .at_path('value')
-    end
+module Projects
+  class CreateContract < BaseContract
   end
 end

--- a/app/contracts/projects/create_contract.rb
+++ b/app/contracts/projects/create_contract.rb
@@ -28,5 +28,10 @@
 
 module Projects
   class CreateContract < BaseContract
+    private
+
+    def manage_permission
+      :add_project
+    end
   end
 end

--- a/app/contracts/projects/update_contract.rb
+++ b/app/contracts/projects/update_contract.rb
@@ -1,6 +1,6 @@
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -23,31 +23,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# See docs/COPYRIGHT.rdoc for more details.
+# See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'spec_helper'
-
-describe ::API::Decorators::AggregationGroup do
-  let(:query) do
-    query = FactoryBot.build_stubbed(:query)
-    query.group_by = :assigned_to
-
-    query
-  end
-  let(:group_key) { OpenStruct.new name: 'ABC' }
-  let(:count) { 5 }
-  let(:current_user) { FactoryBot.build_stubbed(:user) }
-
-  subject { described_class.new(group_key, count, query: query, current_user: current_user).to_json }
-
-  context 'with an empty array key' do
-    let(:group_key) { [] }
-
-    it 'has an empty value' do
-      is_expected
-        .to be_json_eql(nil.to_json)
-        .at_path('value')
-    end
+module Projects
+  class UpdateContract < BaseContract
   end
 end

--- a/app/contracts/projects/update_contract.rb
+++ b/app/contracts/projects/update_contract.rb
@@ -28,5 +28,10 @@
 
 module Projects
   class UpdateContract < BaseContract
+    private
+
+    def manage_permission
+      :edit_project
+    end
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -135,8 +135,13 @@ class ProjectsController < ApplicationController
   def update
     @altered_project = Project.find(@project.id)
 
-    @altered_project.attributes = permitted_params.project
-    if validate_parent_id && @altered_project.save
+    # TODO: move the validation into the contract
+    #       move setting the allowed parents to the service
+    service = Projects::UpdateService
+              .new(user: current_user,
+                   model: @altered_project)
+
+    if validate_parent_id && service.call(permitted_params.project).success?
       if params['project'].has_key?('parent_id')
         @altered_project.set_allowed_parent!(params['project']['parent_id'])
       end

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -96,7 +96,7 @@ module API
                    format_query_sums results.all_sums_for_group(group)
                  end
 
-          ::API::Decorators::AggregationGroup.new(group, count, query: results.query, sums: sums)
+          ::API::Decorators::AggregationGroup.new(group, count, query: results.query, sums: sums, current_user: current_user)
         end
       end
 

--- a/app/services/projects/set_attributes_service.rb
+++ b/app/services/projects/set_attributes_service.rb
@@ -1,6 +1,8 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2019 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -23,24 +25,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# See docs/COPYRIGHT.rdoc for more details.
+# See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'spec_helper'
-require_relative './shared_contract_examples'
-
-describe Projects::CreateContract do
-  it_behaves_like 'project contract' do
-    let(:project) do
-      Project.new(name: project_name,
-                  identifier: project_identifier,
-                  description: project_description,
-                  status: project_status,
-                  is_public: project_public,
-                  parent: project_parent)
-    end
-    let(:permissions) { [:add_project] }
-
-    subject(:contract) { described_class.new(project, current_user) }
+module Projects
+  class SetAttributesService < ::BaseServices::SetAttributes
   end
 end

--- a/app/services/projects/update_service.rb
+++ b/app/services/projects/update_service.rb
@@ -1,6 +1,8 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
-# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+# Copyright (C) 2012-2019 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -23,24 +25,19 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# See docs/COPYRIGHT.rdoc for more details.
+# See doc/COPYRIGHT.rdoc for more details.
 #++
 
-require 'spec_helper'
-require_relative './shared_contract_examples'
+module Projects
+  class UpdateService < ::BaseServices::Update
+    private
 
-describe Projects::CreateContract do
-  it_behaves_like 'project contract' do
-    let(:project) do
-      Project.new(name: project_name,
-                  identifier: project_identifier,
-                  description: project_description,
-                  status: project_status,
-                  is_public: project_public,
-                  parent: project_parent)
+    def after_save
+      model.touch if only_custom_values_updated?
     end
-    let(:permissions) { [:add_project] }
 
-    subject(:contract) { described_class.new(project, current_user) }
+    def only_custom_values_updated?
+      model.saved_changes.empty? && model.custom_values.map(&:saved_changes).any?(&:present?)
+    end
   end
 end

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -226,6 +226,8 @@ en:
           no_results: 'Nothing new to report.'
         project_description:
           title: 'Project description'
+        project_details:
+          title: 'Project details'
         time_entries_current_user:
           title: 'Spent time (last 7 days)'
           no_results: 'No time entries for the last 7 days.'

--- a/docs/api/apiv3/endpoints/projects.apib
+++ b/docs/api/apiv3/endpoints/projects.apib
@@ -22,14 +22,16 @@ Depending on custom fields defined for projects, additional links might exist.
 
 ## Local Properties
 
-| Property    | Description                                   | Type        | Constraints | Supported operations |
-| :---------: | -------------                                 | ----        | ----------- | -------------------- |
-| id          | Projects's id                                 | Integer     | x > 0       | READ                 |
-| identifier  |                                               | String      |             | READ                 |
-| name        |                                               | String      |             | READ                 |
-| description |                                               | Formattable |             | READ                 |
-| createdAt   | Time of creation                              | DateTime    |             | READ                 |
-| updatedAt   | Time of the most recent change to the project | DateTime    |             | READ                 |
+| Property    | Description                                               | Type        | Constraints            | Supported operations |
+| :---------: | -------------                                             | ----        | -----------            | -------------------- |
+| id          | Projects's id                                             | Integer     | x > 0                  | READ                 |
+| identifier  |                                                           | String      |                        | READ                 |
+| name        |                                                           | String      |                        | READ                 |
+| status      | The project's status                                      | String      | 'active' or 'archived' | READ                 |
+| public      | Indicates whether the project is accessible for everybody | Boolean     |                        | READ                 |
+| description |                                                           | Formattable |                        | READ                 |
+| createdAt   | Time of creation                                          | DateTime    |                        | READ                 |
+| updatedAt   | Time of the most recent change to the project             | DateTime    |                        | READ                 |
 
 Depending on custom fields defined for projects, additional properties might exist.
 
@@ -76,6 +78,8 @@ Depending on custom fields defined for projects, additional properties might exi
                 "id": 1,
                 "identifier": "project_identifier",
                 "name": "Project example",
+                "status": active,
+                "public": false,
                 "description": {
                     "format": "markdown",
                     "raw": "Lorem **ipsum** dolor sit amet",
@@ -154,6 +158,8 @@ Depending on custom fields defined for projects, additional properties might exi
                     "id": 6,
                     "identifier": "a_project",
                     "name": "A project",
+                    "status": "active",
+                    "public": false,
                     "description": {
                         "format": "markdown",
                         "raw": "Lorem **ipsum** dolor sit amet",
@@ -188,6 +194,8 @@ Depending on custom fields defined for projects, additional properties might exi
                     "id": 14,
                     "identifier": "another_project",
                     "name": "Another project",
+                    "status": "archived",
+                    "public": true,
                     "description": {
                         "format": "markdown",
                         "raw": "",
@@ -215,6 +223,130 @@ Returns a collection of projects. The collection can be filtered via query param
 
     [Projects][]
 
+## Projects schema [/api/v3/projects/schemas]
+
++ Model
+    + Body
+
+            {
+                "_type": "Schema",
+                "_dependencies": [],
+                "id": {
+                    "type": "Integer",
+                    "name": "ID",
+                    "required": true,
+                    "hasDefault": false,
+                    "writable": false
+                },
+                "name": {
+                    "type": "String",
+                    "name": "Name",
+                    "required": true,
+                    "hasDefault": false,
+                    "writable": true,
+                    "minLength": 1,
+                    "maxLength": 255
+                },
+                "identifier": {
+                    "type": "String",
+                    "name": "Identifier",
+                    "required": true,
+                    "hasDefault": false,
+                    "writable": true,
+                    "minLength": 1,
+                    "maxLength": 100
+                },
+                "description": {
+                    "type": "Formattable",
+                    "name": "Description",
+                    "required": false,
+                    "hasDefault": false,
+                    "writable": true
+                },
+                "public": {
+                    "type": "Boolean",
+                    "name": "Public",
+                    "required": true,
+                    "hasDefault": false,
+                    "writable": true
+                },
+                "status": {
+                    "type": "String",
+                    "name": "Status",
+                    "required": true,
+                    "hasDefault": false,
+                    "writable": true,
+                    "visibility": "default",
+                    "_links": {}
+                },
+                "createdAt": {
+                    "type": "DateTime",
+                    "name": "Created on",
+                    "required": true,
+                    "hasDefault": false,
+                    "writable": false
+                },
+                "updatedAt": {
+                    "type": "DateTime",
+                    "name": "Updated on",
+                    "required": true,
+                    "hasDefault": false,
+                    "writable": false
+                },
+                "customField30": {
+                    "type": "Integer",
+                    "name": "Integer project custom field",
+                    "required": false,
+                    "hasDefault": false,
+                    "writable": true,
+                    "visibility": "default"
+                },
+                "customField31": {
+                    "type": "CustomOption",
+                    "name": "List project custom field",
+                    "required": false,
+                    "hasDefault": false,
+                    "writable": true,
+                    "visibility": "default",
+                    "_links": {}
+                },
+                "customField32": {
+                    "type": "Version",
+                    "name": "Version project custom field",
+                    "required": false,
+                    "hasDefault": false,
+                    "writable": true,
+                    "visibility": "default",
+                    "_links": {}
+                },
+                "customField34": {
+                    "type": "Boolean",
+                    "name": "Boolean project custom field",
+                    "required": false,
+                    "hasDefault": false,
+                    "writable": true,
+                    "visibility": "default"
+                },
+                "customField35": {
+                    "type": "String",
+                    "name": "Text project custom field",
+                    "required": true,
+                    "hasDefault": false,
+                    "writable": true,
+                    "visibility": "default"
+                },
+                "_links": {
+                    "self": {
+                        "href": "/api/v3/projects/schema"
+                    }
+                }
+            }
+
+## View project schema [GET]
+
++ Response 200 (application/hal+json)
+
+    [Projects schema][]
 
 ## Projects by version [/api/v3/versions/{id}/projects]
 

--- a/frontend/src/app/components/wp-edit-form/display-field-renderer.ts
+++ b/frontend/src/app/components/wp-edit-form/display-field-renderer.ts
@@ -24,7 +24,7 @@ export class DisplayFieldRenderer {
   readonly I18n:I18nService = this.injector.get(I18nService);
 
   /** We cache the previously used fields to avoid reinitialization */
-  private fieldCache:{ [key:string]: DisplayField } = {};
+  private fieldCache:{ [key:string]:DisplayField } = {};
 
   constructor(public readonly injector:Injector,
               public readonly container:'table' | 'single-view' | 'timeline',

--- a/frontend/src/app/modules/common/path-helper/apiv3/projects/apiv3-projects-paths.ts
+++ b/frontend/src/app/modules/common/path-helper/apiv3/projects/apiv3-projects-paths.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {SimpleResourceCollection} from 'core-app/modules/common/path-helper/apiv3/path-resources';
+import {SimpleResource, SimpleResourceCollection} from 'core-app/modules/common/path-helper/apiv3/path-resources';
 import {Apiv3ProjectPaths} from 'core-app/modules/common/path-helper/apiv3/projects/apiv3-project-paths';
 
 export class Apiv3ProjectsPaths extends SimpleResourceCollection<Apiv3ProjectPaths> {
@@ -38,4 +38,7 @@ export class Apiv3ProjectsPaths extends SimpleResourceCollection<Apiv3ProjectPat
   public id(projectIdentifier:string|number):Apiv3ProjectPaths {
     return new Apiv3ProjectPaths(this.path, projectIdentifier);
   }
+
+  // /api/v3/projects/schema
+  public readonly schema = this.path + '/schema';
 }

--- a/frontend/src/app/modules/grids/openproject-grids.module.ts
+++ b/frontend/src/app/modules/grids/openproject-grids.module.ts
@@ -61,6 +61,7 @@ import {WidgetHeaderComponent} from "core-app/modules/grids/widgets/header/heade
 import {WidgetWpOverviewComponent} from "core-app/modules/grids/widgets/wp-overview/wp-overview.component";
 import {WidgetCustomTextComponent} from "core-app/modules/grids/widgets/custom-text/custom-text.component";
 import {OpenprojectFieldsModule} from "core-app/modules/fields/openproject-fields.module";
+import {WidgetProjectDetailsComponent} from "core-app/modules/grids/widgets/project-details/project-details.component";
 
 export const GRID_ROUTES:Ng2StateDeclaration[] = [
   {
@@ -95,6 +96,7 @@ export const GRID_ROUTES:Ng2StateDeclaration[] = [
                                   WidgetWpCalendarComponent,
                                   WidgetWpOverviewComponent,
                                   WidgetProjectDescriptionComponent,
+                                  WidgetProjectDetailsComponent,
                                   WidgetTimeEntriesCurrentUserComponent]),
 
     // Support for inline editig fields
@@ -126,6 +128,7 @@ export const GRID_ROUTES:Ng2StateDeclaration[] = [
     WidgetWpTableQuerySpaceComponent,
     WidgetWpGraphComponent,
     WidgetProjectDescriptionComponent,
+    WidgetProjectDetailsComponent,
     WidgetTimeEntriesCurrentUserComponent,
 
     // Widget menus
@@ -303,6 +306,14 @@ export function registerWidgets(injector:Injector) {
             text: {
               raw: ''
             }
+          }
+        },
+        {
+          identifier: 'project_details',
+          component: WidgetProjectDetailsComponent,
+          title: i18n.t(`js.grid.widgets.project_details.title`),
+          properties: {
+            name: i18n.t('js.grid.widgets.project_details.title')
           }
         }
       ];

--- a/frontend/src/app/modules/grids/widgets/project-details/project-details.component.html
+++ b/frontend/src/app/modules/grids/widgets/project-details/project-details.component.html
@@ -1,0 +1,13 @@
+<widget-header
+    [name]="widgetName"
+    [icon]="'flag'"
+    (onRenamed)="renameWidget($event)">
+
+  <widget-menu
+      [resource]="resource">
+  </widget-menu>
+</widget-header>
+
+<div class="grid--widget-content"
+     #contentContainer>
+</div>

--- a/frontend/src/app/modules/grids/widgets/project-details/project-details.component.ts
+++ b/frontend/src/app/modules/grids/widgets/project-details/project-details.component.ts
@@ -1,0 +1,170 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef, Injector, ViewChild, ElementRef} from '@angular/core';
+import {AbstractWidgetComponent} from "app/modules/grids/widgets/abstract-widget.component";
+import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {ProjectDmService} from "core-app/modules/hal/dm-services/project-dm.service";
+import {CurrentProjectService} from "core-components/projects/current-project.service";
+import {SchemaResource} from "core-app/modules/hal/resources/schema-resource";
+import {DisplayFieldContext, DisplayFieldService} from "core-app/modules/fields/display/display-field.service";
+import {ProjectResource} from "core-app/modules/hal/resources/project-resource";
+import {PortalCleanupService} from 'core-app/modules/fields/display/display-portal/portal-cleanup.service';
+import {DisplayField} from "core-app/modules/fields/display/display-field.module";
+import {WorkPackageTableHighlightingService} from "core-components/wp-fast-table/state/wp-table-highlighting.service";
+import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
+
+export const emptyPlaceholder = '-';
+
+@Component({
+  templateUrl: './project-details.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    // required by the displayField service to render the fields
+    PortalCleanupService,
+    WorkPackageTableHighlightingService,
+    IsolatedQuerySpace
+  ]
+})
+export class WidgetProjectDetailsComponent extends AbstractWidgetComponent implements OnInit {
+  public customFieldsMap:Array<DisplayField> = [];
+
+  @ViewChild('contentContainer', { static: true }) readonly contentContainer:ElementRef;
+
+  constructor(protected readonly i18n:I18nService,
+              protected readonly injector:Injector,
+              protected readonly projectDm:ProjectDmService,
+              protected readonly currentProject:CurrentProjectService,
+              protected readonly displayField:DisplayFieldService,
+              protected readonly cdr:ChangeDetectorRef) {
+    super(i18n, injector);
+  }
+
+  ngOnInit() {
+    this.loadAndRender();
+  }
+
+  private loadAndRender() {
+    Promise.all(
+        [this.loadCurrentProject(),
+        this.loadProjectSchema()]
+      )
+      .then(([project, schema]) => {
+        this.renderCFs(project, schema as SchemaResource);
+
+        this.redraw();
+      });
+  }
+
+  private loadCurrentProject() {
+    return this.projectDm.load(this.currentProject.id as string);
+  }
+
+  private loadProjectSchema() {
+    return this.projectDm.schema();
+  }
+
+  private renderCFs(project:ProjectResource, schema:SchemaResource) {
+    const cfFields = this.collectFieldsForCfs(project, schema);
+
+    this.sortFieldsLexicographically(cfFields);
+    this.renderFields(cfFields);
+  }
+
+  private collectFieldsForCfs(project:ProjectResource, schema:SchemaResource) {
+    let displayFields:Array<DisplayField> = [];
+    // passing an arbitrary context to displayField.getField only to satisfy the interface
+    let context:DisplayFieldContext = {injector: this.injector, container: 'table', options: []};
+
+    Object.entries(schema).forEach(([key, keySchema]) => {
+      if (key.match(/customField\d+/)) {
+        let field = this.displayField.getField(project, key, keySchema, context);
+
+        displayFields.push(field);
+      }
+    });
+
+    return displayFields;
+  }
+
+  private sortFieldsLexicographically(fields:Array<DisplayField>) {
+    fields.sort((a, b) => { return a.label.localeCompare(b.label); });
+  }
+
+  private renderFields(fields:Array<DisplayField>) {
+    this.contentContainer.nativeElement.innerHTML = '';
+
+    fields.forEach(field => {
+      this.contentContainer.nativeElement.appendChild(this.displayKeyValue(field));
+    });
+  }
+
+  private displayKeyValue(field:DisplayField) {
+    const container = this.containerElement();
+
+    container.appendChild(this.labelElement(field));
+    container.appendChild(this.valueElement(field));
+
+    return container;
+  }
+
+  private containerElement() {
+    const container = document.createElement('div');
+    container.classList.add('attributes-key-value');
+
+    return container;
+  }
+
+  private labelElement(field:DisplayField) {
+    const label = document.createElement('div');
+    label.classList.add('attributes-key-value--key');
+    label.innerText = field.label;
+
+    return label;
+  }
+
+  private valueElement(field:DisplayField) {
+    const value = document.createElement('div');
+    value.classList.add('attributes-key-value--value-container');
+    field.render(value, this.getText(field));
+
+    return value;
+  }
+
+  private getText(field:DisplayField):string {
+    if (field.isEmpty()) {
+      return emptyPlaceholder;
+    } else {
+      return field.valueString;
+    }
+  }
+
+  private redraw() {
+    this.cdr.detectChanges();
+  }
+}

--- a/frontend/src/app/modules/hal/dm-services/project-dm.service.ts
+++ b/frontend/src/app/modules/hal/dm-services/project-dm.service.ts
@@ -30,6 +30,8 @@ import {HalResourceService} from 'core-app/modules/hal/services/hal-resource.ser
 import {Inject, Injectable} from '@angular/core';
 import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
 import {ProjectResource} from 'core-app/modules/hal/resources/project-resource';
+import {SchemaResource} from "core-app/modules/hal/resources/schema-resource";
+import {Apiv3ProjectsPaths} from "core-app/modules/common/path-helper/apiv3/projects/apiv3-projects-paths";
 
 @Injectable()
 export class ProjectDmService {
@@ -39,7 +41,17 @@ export class ProjectDmService {
 
   public load(id:string|number):Promise<ProjectResource> {
     return this.halResourceService
-      .get<ProjectResource>(this.pathHelper.api.v3.projects.id(id).toString())
+      .get<ProjectResource>(this.projectsPath.id(id).toString())
       .toPromise();
+  }
+
+  public schema():Promise<SchemaResource> {
+    return this.halResourceService
+      .get<SchemaResource>(this.projectsPath.schema)
+      .toPromise();
+  }
+
+  private get projectsPath():Apiv3ProjectsPaths {
+    return this.pathHelper.api.v3.projects;
   }
 }

--- a/lib/api/decorators/aggregation_group.rb
+++ b/lib/api/decorators/aggregation_group.rb
@@ -31,7 +31,7 @@
 module API
   module Decorators
     class AggregationGroup < Single
-      def initialize(group_key, count, query:, sums: nil)
+      def initialize(group_key, count, query:, sums: nil, current_user:)
         @count = count
         @sums = sums
         @query = query
@@ -42,7 +42,7 @@ module API
 
         @link = ::API::V3::Utilities::ResourceLinkGenerator.make_link(group_key)
 
-        super(group_key, current_user: nil)
+        super(group_key, current_user: current_user)
       end
 
       links :valueLink do
@@ -76,7 +76,7 @@ module API
       property :sums,
                exec_context: :decorator,
                getter: ->(*) {
-                 ::API::V3::WorkPackages::WorkPackageSumsRepresenter.create(sums) if sums
+                 ::API::V3::WorkPackages::WorkPackageSumsRepresenter.create(sums, current_user) if sums
                },
                render_nil: false
 

--- a/lib/api/utilities/payload_representer.rb
+++ b/lib/api/utilities/payload_representer.rb
@@ -105,8 +105,8 @@ module API
       end
 
       module ClassMethods
-        def create_class(work_package)
-          new_class = super
+        def create_class(*args)
+          new_class = super(*args)
 
           new_class.send(:include, ::API::Utilities::PayloadRepresenter)
 

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -93,10 +93,13 @@ module API
           { href: api_v3_paths.types_by_project(represented.id) }
         end
 
-        property :id, render_nil: true
-        property :identifier,   render_nil: true
+        property :id
+        property :identifier
+        property :name
+        property :status
+        property :is_public,
+                 as: :public
 
-        property :name,         render_nil: true
         formattable_property :description,
                              uncacheable: true
 

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -37,10 +37,11 @@ module API
                                                           scope: -> { Project.visible(User.current).includes(:enabled_modules) })
                                                      .mount
 
+          mount ::API::V3::Projects::Schemas::ProjectSchemaAPI
+
           params do
             requires :id, desc: 'Project id'
           end
-
           route_param :id do
             after_validation do
               @project = Project.find(params[:id])

--- a/lib/api/v3/projects/schemas/project_schema_api.rb
+++ b/lib/api/v3/projects/schemas/project_schema_api.rb
@@ -26,28 +26,16 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-require 'spec_helper'
-
-describe ::API::Decorators::AggregationGroup do
-  let(:query) do
-    query = FactoryBot.build_stubbed(:query)
-    query.group_by = :assigned_to
-
-    query
-  end
-  let(:group_key) { OpenStruct.new name: 'ABC' }
-  let(:count) { 5 }
-  let(:current_user) { FactoryBot.build_stubbed(:user) }
-
-  subject { described_class.new(group_key, count, query: query, current_user: current_user).to_json }
-
-  context 'with an empty array key' do
-    let(:group_key) { [] }
-
-    it 'has an empty value' do
-      is_expected
-        .to be_json_eql(nil.to_json)
-        .at_path('value')
+module API
+  module V3
+    module Projects
+      module Schemas
+        class ProjectSchemaAPI < ::API::OpenProjectAPI
+          resources :schema do
+            get &::API::V3::Utilities::Endpoints::Schema.new(model: Project).mount
+          end
+        end
+      end
     end
   end
 end

--- a/lib/api/v3/projects/schemas/project_schema_representer.rb
+++ b/lib/api/v3/projects/schemas/project_schema_representer.rb
@@ -1,0 +1,83 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module Projects
+      module Schemas
+        class ProjectSchemaRepresenter < ::API::Decorators::SchemaRepresenter
+          extend ::API::V3::Utilities::CustomFieldInjector::RepresenterClass
+          custom_field_injector type: :schema_representer
+
+          schema :id,
+                 type: 'Integer',
+                 visibility: false
+
+          schema :name,
+                 type: 'String',
+                 visibility: false,
+                 min_length: 1,
+                 max_length: 255
+
+          schema :identifier,
+                 type: 'String',
+                 visibility: false,
+                 min_length: 1,
+                 max_length: 100
+
+          schema :description,
+                 type: 'Formattable',
+                 visibility: false,
+                 required: false
+
+          schema :is_public,
+                 as: :public,
+                 type: 'Boolean',
+                 visibility: false
+
+          schema_with_allowed_string_collection :status,
+                                                type: 'String'
+
+          schema :created_at,
+                 type: 'DateTime',
+                 visibility: false
+
+          schema :updated_at,
+                 type: 'DateTime',
+                 visibility: false
+
+          def self.represented_class
+            ::Project
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/schemas/schema_collection_representer.rb
+++ b/lib/api/v3/schemas/schema_collection_representer.rb
@@ -32,7 +32,6 @@ module API
     module Schemas
       class SchemaCollectionRepresenter <
         ::API::Decorators::UnpaginatedCollection
-
         def initialize(represented, self_link, current_user:, form_embedded: false)
           self.form_embedded = form_embedded
 

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -353,12 +353,18 @@ module API
                                                 injector_class: ::API::V3::Utilities::CustomFieldInjector }
           end
 
-          def create_class(represented)
-            custom_field_class(represented.available_custom_fields)
+          def create_class(represented, current_user)
+            custom_fields = if current_user.admin?
+                              represented.available_custom_fields
+                            else
+                              represented.available_custom_fields.select(&:visible?)
+                            end
+
+            custom_field_class(custom_fields)
           end
 
           def create(*args)
-            create_class(args.first)
+            create_class(args.first, args.last[:current_user])
               .new(*args)
           end
 

--- a/lib/api/v3/utilities/endpoints/schema.rb
+++ b/lib/api/v3/utilities/endpoints/schema.rb
@@ -65,9 +65,9 @@ module API
             contract_instance = contract.new(instance, User.current)
 
             representer
-              .new(contract_instance,
-                   self_path,
-                   current_user: User.current)
+              .create(contract_instance,
+                      self_path,
+                      current_user: User.current)
           end
 
           def self_path

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -211,6 +211,7 @@ module API
 
           index :project
           show :project
+          schema :project
 
           resources :query
 

--- a/lib/api/v3/work_packages/form_representer.rb
+++ b/lib/api/v3/work_packages/form_representer.rb
@@ -42,7 +42,7 @@ module API
 
         def payload_representer
           WorkPackagePayloadRepresenter
-            .create_class(represented)
+            .create_class(represented, current_user)
             .new(represented, current_user: current_user)
         end
 

--- a/lib/api/v3/work_packages/parse_params_service.rb
+++ b/lib/api/v3/work_packages/parse_params_service.rb
@@ -39,7 +39,7 @@ module API
 
         def parse_attributes(request_body)
           ::API::V3::WorkPackages::WorkPackagePayloadRepresenter
-            .create_class(struct)
+            .create_class(struct, current_user)
             .new(struct, current_user: current_user)
             .from_hash(Hash(request_body))
             .to_h

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -83,7 +83,7 @@ module API
 
               WorkPackageSchemaCollectionRepresenter.new(schemas,
                                                          schemas_path_with_filters_params,
-                                                         current_user: nil)
+                                                         current_user: current_user)
             end
 
             # The schema identifier is an artificial identifier that is composed of a work package's
@@ -114,7 +114,7 @@ module API
                 self_link = api_v3_paths.work_package_schema(@project.id, @type.id)
                 represented_schema = WorkPackageSchemaRepresenter.create(schema,
                                                                          self_link,
-                                                                         current_user: nil)
+                                                                         current_user: current_user)
 
                 with_etag! represented_schema.json_cache_key
 

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -158,7 +158,7 @@ module API
                  exec_context: :decorator,
                  getter: ->(*) {
                    if total_sums
-                     ::API::V3::WorkPackages::WorkPackageSumsRepresenter.create(total_sums)
+                     ::API::V3::WorkPackages::WorkPackageSumsRepresenter.create(total_sums, current_user)
                    end
                  },
                  render_nil: false

--- a/lib/api/v3/work_packages/work_package_sums_representer.rb
+++ b/lib/api/v3/work_packages/work_package_sums_representer.rb
@@ -13,8 +13,8 @@ module API
           super(sums, current_user: nil)
         end
 
-        def self.create(sums)
-          create_class(Schema::WorkPackageSumsSchema.new).new(sums)
+        def self.create(sums, current_user)
+          create_class(Schema::WorkPackageSumsSchema.new, current_user).new(sums)
         end
 
         property :estimated_time,

--- a/modules/backlogs/spec/api/work_packages/schema/work_package_sums_schema_representer_spec.rb
+++ b/modules/backlogs/spec/api/work_packages/schema/work_package_sums_schema_representer_spec.rb
@@ -29,9 +29,9 @@
 require 'spec_helper'
 
 describe ::API::V3::WorkPackages::Schema::WorkPackageSumsSchemaRepresenter do
-  let(:current_user) {
+  let(:current_user) do
     FactoryBot.build_stubbed(:user)
-  }
+  end
 
   let(:schema) { ::API::V3::WorkPackages::Schema::WorkPackageSumsSchema.new }
 

--- a/modules/backlogs/spec/api/work_packages/work_package_sums_representer_spec.rb
+++ b/modules/backlogs/spec/api/work_packages/work_package_sums_representer_spec.rb
@@ -31,8 +31,9 @@ require 'spec_helper'
 describe ::API::V3::WorkPackages::WorkPackageSumsRepresenter do
   let(:sums) { double 'sums', story_points: 5, remaining_hours: 10 }
   let(:schema) { double 'schema', available_custom_fields: [] }
+  let(:user) { FactoryBot.build_stubbed(:user) }
   let(:representer) {
-    described_class.create_class(schema).new(sums)
+    described_class.create_class(schema, user).new(sums)
   }
   let(:summable_columns) { [] }
 

--- a/modules/costs/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
+++ b/modules/costs/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
@@ -31,8 +31,9 @@ require 'spec_helper'
 describe ::API::V3::WorkPackages::WorkPackageSumsRepresenter do
   let(:sums) { double 'sums', material_costs: 5, labor_costs: 10, overall_costs: 15 }
   let(:schema) { double 'schema', available_custom_fields: [] }
+  let(:user) { FactoryBot.build_stubbed(:user) }
   let(:representer) {
-    described_class.create_class(schema).new(sums)
+    described_class.create_class(schema, user).new(sums)
   }
   let(:summable_columns) { [] }
 

--- a/modules/dashboards/lib/dashboards/grid_registration.rb
+++ b/modules/dashboards/lib/dashboards/grid_registration.rb
@@ -6,6 +6,7 @@ module Dashboards
     widgets 'work_packages_table',
             'work_packages_graph',
             'project_description',
+            'project_details',
             'work_packages_calendar',
             'work_packages_overview',
             'custom_text'

--- a/modules/dashboards/spec/features/project_details_spec.rb
+++ b/modules/dashboards/spec/features/project_details_spec.rb
@@ -1,0 +1,118 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+require_relative '../support/pages/dashboard'
+
+describe 'Project details widget on dashboard', type: :feature, js: true do
+  let!(:version_cf) { FactoryBot.create(:version_project_custom_field) }
+  let!(:bool_cf) { FactoryBot.create(:bool_project_custom_field) }
+  let!(:user_cf) { FactoryBot.create(:user_project_custom_field) }
+  let!(:int_cf) { FactoryBot.create(:int_project_custom_field) }
+  let!(:float_cf) { FactoryBot.create(:float_project_custom_field) }
+  let!(:text_cf) { FactoryBot.create(:text_project_custom_field) }
+  let!(:string_cf) { FactoryBot.create(:string_project_custom_field) }
+  let!(:date_cf) { FactoryBot.create(:date_project_custom_field) }
+
+  let(:system_version) { FactoryBot.create(:version, sharing: 'system') }
+
+  let!(:project) do
+    FactoryBot.create(:project).tap do |p|
+      p.add_member(other_user, [role])
+
+      p.send(:"custom_field_#{int_cf.id}=", 5)
+      p.send(:"custom_field_#{bool_cf.id}=", true)
+      p.send(:"custom_field_#{version_cf.id}=", system_version)
+      p.send(:"custom_field_#{float_cf.id}=", 4.5)
+      p.send(:"custom_field_#{text_cf.id}=", 'Some **long** text')
+      p.send(:"custom_field_#{string_cf.id}=", 'Some small text')
+      p.send(:"custom_field_#{date_cf.id}=", Date.today)
+      p.send(:"custom_field_#{user_cf.id}=", other_user)
+
+      p.save!(validate: false)
+    end
+  end
+
+  let(:permissions) do
+    %i[view_dashboards
+       manage_dashboards]
+  end
+
+  let(:role) do
+    FactoryBot.create(:role, permissions: permissions)
+  end
+
+  let(:user) do
+    FactoryBot.create(:user, member_in_project: project, member_through_role: role)
+  end
+  let(:other_user) do
+    FactoryBot.create(:user)
+  end
+  let(:dashboard_page) do
+    Pages::Dashboard.new(project)
+  end
+
+  before do
+    login_as user
+
+    dashboard_page.visit!
+  end
+
+  it 'can add the widget and see the description in it' do
+    dashboard_page.add_column(3, before_or_after: :before)
+
+    dashboard_page.add_widget(2, 3, "Project details")
+
+    sleep(0.1)
+
+    # As the user lacks the manage_public_queries and save_queries permission, no other widget is present
+    details_widget = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(1)')
+    details_widget.resize_to(6, 5)
+    details_widget.expect_to_span(2, 3, 7, 6)
+
+    within(details_widget.area) do
+      expect(page)
+        .to have_content("#{int_cf.name}\n5")
+      expect(page)
+        .to have_content("#{bool_cf.name}\nyes")
+      expect(page)
+        .to have_content("#{version_cf.name}\n#{system_version.name}")
+      expect(page)
+        .to have_content("#{float_cf.name}\n4.5")
+      expect(page)
+        .to have_content("#{text_cf.name}\nSome long text")
+      expect(page)
+        .to have_content("#{string_cf.name}\nSome small text")
+      expect(page)
+        .to have_content("#{date_cf.name}\n#{Date.today.strftime('%m/%d/%Y')}")
+      expect(page)
+        .to have_content("#{user_cf.name}\n#{user.name.split.map(&:first).join}#{user.name}")
+    end
+  end
+end

--- a/spec/contracts/projects/create_contract_spec.rb
+++ b/spec/contracts/projects/create_contract_spec.rb
@@ -27,27 +27,19 @@
 #++
 
 require 'spec_helper'
+require_relative './shared_contract_examples'
 
-describe ::API::Decorators::AggregationGroup do
-  let(:query) do
-    query = FactoryBot.build_stubbed(:query)
-    query.group_by = :assigned_to
-
-    query
-  end
-  let(:group_key) { OpenStruct.new name: 'ABC' }
-  let(:count) { 5 }
-  let(:current_user) { FactoryBot.build_stubbed(:user) }
-
-  subject { described_class.new(group_key, count, query: query, current_user: current_user).to_json }
-
-  context 'with an empty array key' do
-    let(:group_key) { [] }
-
-    it 'has an empty value' do
-      is_expected
-        .to be_json_eql(nil.to_json)
-        .at_path('value')
+describe Projects::CreateContract do
+  it_behaves_like 'project contract' do
+    let(:project) do
+      Project.new(name: project_name,
+                  identifier: project_identifier,
+                  description: project_description,
+                  status: project_status,
+                  is_public: project_public,
+                  parent: project_parent)
     end
+
+    subject(:contract) { described_class.new(project, current_user) }
   end
 end

--- a/spec/contracts/projects/shared_contract_examples.rb
+++ b/spec/contracts/projects/shared_contract_examples.rb
@@ -1,0 +1,171 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+shared_examples_for 'project contract' do
+  let(:current_user) do
+    FactoryBot.build_stubbed(:user)
+  end
+  let(:project_name) { 'Project name' }
+  let(:project_identifier) { 'project_identifier' }
+  let(:project_description) { 'Project description' }
+  let(:project_status) { Project::STATUS_ACTIVE }
+  let(:project_public) { true }
+  let(:project_parent) do
+    FactoryBot.build_stubbed(:project).tap do |p|
+      allow(p)
+        .to receive(:visible?)
+        .and_return(parent_visible)
+    end
+  end
+  let(:parent_visible) { true }
+
+  def expect_valid(valid, symbols = {})
+    expect(contract.validate).to eq(valid)
+
+    symbols.each do |key, arr|
+      expect(contract.errors.symbols_for(key)).to match_array arr
+    end
+  end
+
+  shared_examples 'is valid' do
+    it 'is valid' do
+      expect_valid(true)
+    end
+  end
+
+  it_behaves_like 'is valid'
+
+  context 'if the name is nil' do
+    let(:project_name) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, name: %i(blank))
+    end
+  end
+
+  context 'if the identifier is nil' do
+    let(:project_identifier) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, identifier: %i(blank too_short))
+    end
+  end
+
+  context 'if the description is nil' do
+    let(:project_description) { nil }
+
+    it_behaves_like 'is valid'
+  end
+
+  context 'if the parent is nil' do
+    let(:project_parent) { nil }
+
+    it_behaves_like 'is valid'
+  end
+
+  context 'if the parent is invisible to the user' do
+    let(:parent_visible) { false }
+
+    it 'is invalid' do
+      expect_valid(false, parent: %i(does_not_exist))
+    end
+  end
+
+  context 'if the status is nil' do
+    let(:project_status) { nil }
+
+    it 'is invalid' do
+      expect_valid(false, status: %i(blank))
+    end
+  end
+
+  describe 'assignable_values' do
+    context 'for project' do
+      let(:visible_projects) { double('visible projects') }
+      before do
+        allow(Project)
+          .to receive(:visible)
+          .and_return(visible_projects)
+      end
+
+      it 'is the list of visible projects' do
+        expect(subject.assignable_values(:parent, current_user))
+          .to eql visible_projects
+      end
+    end
+
+    context 'for status' do
+      it 'is a list of all available status' do
+        expect(subject.assignable_values(:status, current_user))
+          .to eql Project.statuses.keys
+      end
+    end
+
+    context 'for a custom field' do
+      let(:custom_field) { FactoryBot.build_stubbed(:list_project_custom_field) }
+
+      it 'is the list of custom field values' do
+        expect(subject.assignable_custom_field_values(custom_field))
+          .to eql custom_field.possible_values
+      end
+    end
+  end
+
+  describe 'available_custom_fields' do
+    let(:visible_custom_field) { FactoryBot.build_stubbed(:int_project_custom_field, visible: true) }
+    let(:invisible_custom_field) { FactoryBot.build_stubbed(:int_project_custom_field, visible: false) }
+
+    before do
+      allow(project)
+        .to receive(:available_custom_fields)
+        .and_return([visible_custom_field, invisible_custom_field])
+    end
+
+    context 'if the user is admin' do
+      before do
+        allow(current_user)
+          .to receive(:admin?)
+          .and_return(true)
+      end
+
+      it 'returns all available_custom_fields of the project' do
+        expect(subject.available_custom_fields)
+          .to match_array([visible_custom_field, invisible_custom_field])
+      end
+    end
+
+    context 'if the user is no admin' do
+      it 'returns all visible and available_custom_fields of the project' do
+        expect(subject.available_custom_fields)
+          .to match_array([visible_custom_field])
+      end
+    end
+  end
+end

--- a/spec/contracts/projects/shared_contract_examples.rb
+++ b/spec/contracts/projects/shared_contract_examples.rb
@@ -30,7 +30,12 @@ require 'spec_helper'
 
 shared_examples_for 'project contract' do
   let(:current_user) do
-    FactoryBot.build_stubbed(:user)
+    FactoryBot.build_stubbed(:user) do |user|
+      allow(user)
+        .to receive(:allowed_to?) do |permission, permission_project|
+        permissions.include?(permission) && project == permission_project
+      end
+    end
   end
   let(:project_name) { 'Project name' }
   let(:project_identifier) { 'project_identifier' }
@@ -103,6 +108,14 @@ shared_examples_for 'project contract' do
 
     it 'is invalid' do
       expect_valid(false, status: %i(blank))
+    end
+  end
+
+  context 'if the user lacks permission' do
+    let(:permissions) { [] }
+
+    it 'is invalid' do
+      expect_valid(false, base: %i(error_unauthorized))
     end
   end
 

--- a/spec/contracts/projects/update_contract_spec.rb
+++ b/spec/contracts/projects/update_contract_spec.rb
@@ -27,27 +27,21 @@
 #++
 
 require 'spec_helper'
+require_relative './shared_contract_examples'
 
-describe ::API::Decorators::AggregationGroup do
-  let(:query) do
-    query = FactoryBot.build_stubbed(:query)
-    query.group_by = :assigned_to
-
-    query
-  end
-  let(:group_key) { OpenStruct.new name: 'ABC' }
-  let(:count) { 5 }
-  let(:current_user) { FactoryBot.build_stubbed(:user) }
-
-  subject { described_class.new(group_key, count, query: query, current_user: current_user).to_json }
-
-  context 'with an empty array key' do
-    let(:group_key) { [] }
-
-    it 'has an empty value' do
-      is_expected
-        .to be_json_eql(nil.to_json)
-        .at_path('value')
+describe Projects::UpdateContract do
+  it_behaves_like 'project contract' do
+    let(:project) do
+      FactoryBot.build_stubbed(:project,
+                               identifier: project_identifier,
+                               status: project_status,
+                               is_public: project_public).tap do |p|
+        # in order to actually have something changed
+        p.name = project_name
+        p.parent = project_parent
+      end
     end
+
+    subject(:contract) { described_class.new(project, current_user) }
   end
 end

--- a/spec/contracts/projects/update_contract_spec.rb
+++ b/spec/contracts/projects/update_contract_spec.rb
@@ -41,6 +41,7 @@ describe Projects::UpdateContract do
         p.parent = project_parent
       end
     end
+    let(:permissions) { [:edit_project] }
 
     subject(:contract) { described_class.new(project, current_user) }
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -162,10 +162,10 @@ describe ProjectsController, type: :controller do
   end
 
   describe 'index.html' do
-    let(:project_a) { FactoryBot.create(:project, name: 'Project A', is_public: false, status: true) }
-    let(:project_b) { FactoryBot.create(:project, name: 'Project B', is_public: false, status: true) }
-    let(:project_c) { FactoryBot.create(:project, name: 'Project C', is_public: true, status: true)  }
-    let(:project_d) { FactoryBot.create(:project, name: 'Project D', is_public: true, status: false) }
+    let(:project_a) { FactoryBot.create(:project, name: 'Project A', is_public: false, status: :active) }
+    let(:project_b) { FactoryBot.create(:project, name: 'Project B', is_public: false, status: :active) }
+    let(:project_c) { FactoryBot.create(:project, name: 'Project C', is_public: true, status: :active)  }
+    let(:project_d) { FactoryBot.create(:project, name: 'Project D', is_public: true, status: :archived) }
 
     let(:projects) { [project_a, project_b, project_c, project_d] }
 

--- a/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
+++ b/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
@@ -1,0 +1,233 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
+  include API::V3::Utilities::PathHelper
+
+  let(:current_user) { FactoryBot.build_stubbed(:user) }
+
+  let(:self_link) { '/a/self/link' }
+  let(:embedded) { true }
+  let(:new_record) { true }
+  let(:custom_field) do
+    FactoryBot.build_stubbed(:int_project_custom_field)
+  end
+  let(:allowed_status) { ['some status'] }
+  let(:contract) do
+    contract = double('contract')
+
+    allow(contract)
+      .to receive(:writable?) do |attribute|
+      writable = %w(name identifier description is_public status)
+
+      writable.include?(attribute.to_s)
+    end
+
+    allow(contract)
+      .to receive(:available_custom_fields)
+      .and_return([custom_field])
+
+    allow(contract)
+      .to receive(:assignable_values)
+      .with(:status, current_user)
+      .and_return(allowed_status)
+
+    contract
+  end
+  let(:representer) do
+    described_class.create(contract,
+                           self_link,
+                           form_embedded: embedded,
+                           current_user: current_user)
+  end
+
+  context 'generation' do
+    subject(:generated) { representer.to_json }
+
+    describe '_type' do
+      it 'is indicated as Schema' do
+        is_expected.to be_json_eql('Schema'.to_json).at_path('_type')
+      end
+    end
+
+    describe 'id' do
+      let(:path) { 'id' }
+
+      it_behaves_like 'has basic schema properties' do
+        let(:type) { 'Integer' }
+        let(:name) { I18n.t('attributes.id') }
+        let(:required) { true }
+        let(:writable) { false }
+      end
+
+      it_behaves_like 'has no visibility property'
+    end
+
+    describe 'name' do
+      let(:path) { 'name' }
+
+      it_behaves_like 'has basic schema properties' do
+        let(:type) { 'String' }
+        let(:name) { I18n.t('attributes.name') }
+        let(:required) { true }
+        let(:writable) { true }
+      end
+
+      it_behaves_like 'indicates length requirements' do
+        let(:min_length) { 1 }
+        let(:max_length) { 255 }
+      end
+
+      it_behaves_like 'has no visibility property'
+    end
+
+    describe 'identifier' do
+      let(:path) { 'identifier' }
+
+      it_behaves_like 'has basic schema properties' do
+        let(:type) { 'String' }
+        let(:name) { I18n.t('activerecord.attributes.project.identifier') }
+        let(:required) { true }
+        let(:writable) { true }
+      end
+
+      it_behaves_like 'indicates length requirements' do
+        let(:min_length) { 1 }
+        let(:max_length) { 100 }
+      end
+
+      it_behaves_like 'has no visibility property'
+    end
+
+    describe 'description' do
+      let(:path) { 'description' }
+
+      it_behaves_like 'has basic schema properties' do
+        let(:type) { 'Formattable' }
+        let(:name) { I18n.t('attributes.description') }
+        let(:required) { false }
+        let(:writable) { true }
+      end
+
+      it_behaves_like 'has no visibility property'
+    end
+
+    describe 'public' do
+      let(:path) { 'public' }
+
+      it_behaves_like 'has basic schema properties' do
+        let(:type) { 'Boolean' }
+        let(:name) { I18n.t('attributes.is_public') }
+        let(:required) { true }
+        let(:writable) { true }
+      end
+
+      it_behaves_like 'has no visibility property'
+    end
+
+    describe 'status' do
+      let(:path) { 'status' }
+
+      it_behaves_like 'has basic schema properties' do
+        let(:type) { 'String' }
+        let(:name) { I18n.t('attributes.status') }
+        let(:required) { true }
+        let(:writable) { true }
+      end
+
+      it 'contains no link to the allowed values' do
+        is_expected
+          .not_to have_json_path("#{path}/_links/allowedValues")
+      end
+
+      it 'embeds the allowed values' do
+        allowed_path = "#{path}/_embedded/allowedValues"
+
+        is_expected
+          .to be_json_eql(allowed_status.to_json)
+          .at_path(allowed_path)
+      end
+    end
+
+    describe 'createdAt' do
+      let(:path) { 'createdAt' }
+
+      it_behaves_like 'has basic schema properties' do
+        let(:type) { 'DateTime' }
+        let(:name) { I18n.t('attributes.created_at') }
+        let(:required) { true }
+        let(:writable) { false }
+      end
+
+      it_behaves_like 'has no visibility property'
+    end
+
+    describe 'updatedAt' do
+      let(:path) { 'updatedAt' }
+
+      it_behaves_like 'has basic schema properties' do
+        let(:type) { 'DateTime' }
+        let(:name) { I18n.t('attributes.updated_at') }
+        let(:required) { true }
+        let(:writable) { false }
+      end
+
+      it_behaves_like 'has no visibility property'
+    end
+
+    describe 'int custom field' do
+      let(:path) { "customField#{custom_field.id}" }
+
+      it_behaves_like 'has basic schema properties' do
+        let(:type) { 'Integer' }
+        let(:name) { custom_field.name }
+        let(:required) { false }
+        let(:writable) { true }
+      end
+    end
+
+    context '_links' do
+      describe 'self link' do
+        it_behaves_like 'has an untitled link' do
+          let(:link) { 'self' }
+          let(:href) { self_link }
+        end
+
+        context 'embedded in a form' do
+          let(:self_link) { nil }
+
+          it_behaves_like 'has no link' do
+            let(:link) { 'self' }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -240,6 +240,7 @@ describe ::API::V3::Utilities::PathHelper do
   describe 'projects paths' do
     it_behaves_like 'index', :project
     it_behaves_like 'show', :project
+    it_behaves_like 'schema', :project
   end
 
   describe 'query paths' do

--- a/spec/lib/api/v3/work_packages/schema/work_package_sums_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_sums_schema_representer_spec.rb
@@ -33,7 +33,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSumsSchemaRepresenter do
 
   let(:available_custom_fields) { [] }
   let(:schema) { double('wp_schema', available_custom_fields: available_custom_fields) }
-  let(:current_user) { double('user') }
+  let(:current_user) { double('user', admin?: false) }
 
   let(:representer) do
     described_class.create(schema, current_user: current_user)

--- a/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
@@ -32,8 +32,9 @@ describe ::API::V3::WorkPackages::WorkPackageSumsRepresenter do
   let(:available_custom_fields) { [] }
   let(:sums) { double 'sums', estimated_hours: 5 }
   let(:schema) { double 'schema', available_custom_fields: available_custom_fields }
+  let(:current_user) { FactoryBot.build_stubbed(:user) }
   let(:representer) do
-    described_class.create_class(schema).new(sums)
+    described_class.create_class(schema, current_user).new(sums)
   end
   let(:summable_columns) { [] }
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -44,18 +44,13 @@ describe Project, type: :model do
   end
 
   describe '#active?' do
-    before do
-      # stub out the actual value of the constant
-      stub_const('Project::STATUS_ACTIVE', 42)
-    end
-
     it 'is active when :status equals STATUS_ACTIVE' do
-      project = FactoryBot.build :project, status: 42
+      project = FactoryBot.build :project, status: :active
       expect(project).to be_active
     end
 
     it "is not active when :status doesn't equal STATUS_ACTIVE" do
-      project = FactoryBot.build :project, status: 99
+      project = FactoryBot.build :project, status: :archived
       expect(project).not_to be_active
     end
   end
@@ -85,23 +80,23 @@ describe Project, type: :model do
     let(:role_copy_projects) { FactoryBot.create(:role, permissions: [:edit_project, :copy_projects, :add_project]) }
     let(:parent_project) { FactoryBot.create(:project) }
     let(:project) { FactoryBot.create(:project, parent: parent_project) }
-    let!(:subproject_member) {
+    let!(:subproject_member) do
       FactoryBot.create(:member,
                          user: user,
                          project: project,
                          roles: [role_copy_projects])
-    }
+    end
     before do
       login_as(user)
     end
 
     context 'with permission to add subprojects' do
-      let!(:member_add_subproject) {
+      let!(:member_add_subproject) do
         FactoryBot.create(:member,
                            user: user,
                            project: parent_project,
                            roles: [role_add_subproject])
-      }
+      end
 
       it 'should allow copy' do
         expect(project.copy_allowed?).to eq(true)
@@ -119,18 +114,18 @@ describe Project, type: :model do
     let(:user) { FactoryBot.create(:user) }
     let(:group) { FactoryBot.create(:group) }
     let(:role) { FactoryBot.create(:role) }
-    let!(:user_member) {
+    let!(:user_member) do
       FactoryBot.create(:member,
-                         principal: user,
-                         project: project,
-                         roles: [role])
-    }
-    let!(:group_member) {
+                        principal: user,
+                        project: project,
+                        roles: [role])
+    end
+    let!(:group_member) do
       FactoryBot.create(:member,
-                         principal: group,
-                         project: project,
-                         roles: [role])
-    }
+                        principal: group,
+                        project: project,
+                        roles: [role])
+    end
 
     shared_examples_for 'respecting group assignment settings' do
       context 'with group assignment' do

--- a/spec/requests/api/v3/projects/schemas/project_schema_resource_spec.rb
+++ b/spec/requests/api/v3/projects/schemas/project_schema_resource_spec.rb
@@ -27,27 +27,42 @@
 #++
 
 require 'spec_helper'
+require 'rack/test'
 
-describe ::API::Decorators::AggregationGroup do
-  let(:query) do
-    query = FactoryBot.build_stubbed(:query)
-    query.group_by = :assigned_to
+describe 'API v3 Projects schema resource', type: :request, content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
 
-    query
+  shared_let(:current_user) do
+    FactoryBot.create(:user)
   end
-  let(:group_key) { OpenStruct.new name: 'ABC' }
-  let(:count) { 5 }
-  let(:current_user) { FactoryBot.build_stubbed(:user) }
 
-  subject { described_class.new(group_key, count, query: query, current_user: current_user).to_json }
+  let(:path) { api_v3_paths.project_schema }
 
-  context 'with an empty array key' do
-    let(:group_key) { [] }
+  before do
+    login_as(current_user)
+  end
 
-    it 'has an empty value' do
-      is_expected
-        .to be_json_eql(nil.to_json)
-        .at_path('value')
+  subject(:response) { last_response }
+
+  describe '#GET /projects/schema' do
+    before do
+      get path
     end
+
+    it 'responds with 200 OK' do
+      expect(subject.status).to eq(200)
+    end
+
+    it 'returns a schema' do
+      expect(subject.body)
+        .to be_json_eql('Schema'.to_json)
+        .at_path '_type'
+    end
+
+    #it 'does not embed' do
+    #  expect(subject.body)
+    #    .not_to have_json_path('page/_links/allowedValues')
+    #end
   end
 end

--- a/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
+++ b/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
@@ -115,16 +115,19 @@ describe ::API::V3::WorkPackageCollectionFromQueryService,
     Struct.new(:group,
                :count,
                :query,
-               :sums) do
+               :sums,
+               :current_user) do
 
       def initialize(group,
                      count,
                      query:,
-                     sums:)
+                     sums:,
+                     current_user:)
         super(group,
               count,
               query,
-              sums)
+              sums,
+              current_user)
       end
     end
   end

--- a/spec/services/projects/update_service_intergration_spec.rb
+++ b/spec/services/projects/update_service_intergration_spec.rb
@@ -27,20 +27,46 @@
 #++
 
 require 'spec_helper'
-require_relative './shared_contract_examples'
 
-describe Projects::CreateContract do
-  it_behaves_like 'project contract' do
-    let(:project) do
-      Project.new(name: project_name,
-                  identifier: project_identifier,
-                  description: project_description,
-                  status: project_status,
-                  is_public: project_public,
-                  parent: project_parent)
+describe Projects::UpdateService, 'integration', type: :model do
+  let(:user) do
+    FactoryBot.create(:user,
+                      member_in_project: project,
+                      member_through_role: role)
+  end
+  let(:role) do
+    FactoryBot.create(:role,
+                      permissions: permissions)
+  end
+  let(:permissions) do
+    %i(edit_project)
+  end
+
+  let!(:project) { FactoryBot.create(:project, "custom_field_#{custom_field.id}" => 1) }
+  let(:instance) { described_class.new(user: user, model: project) }
+  let(:custom_field) { FactoryBot.create(:int_project_custom_field) }
+  let(:attributes) { {} }
+  let(:service_result) do
+    instance
+      .call(attributes)
+  end
+
+  describe '#call' do
+    context 'if only a custom field is updated' do
+      let(:attributes) do
+        { "custom_field_#{custom_field.id}" => 8 }
+      end
+
+      it 'touches the project after saving' do
+        former_updated_at = Project.pluck(:updated_on).first
+
+        service_result
+
+        later_updated_at = Project.pluck(:updated_on).first
+
+        expect(former_updated_at)
+          .not_to eql later_updated_at
+      end
     end
-    let(:permissions) { [:add_project] }
-
-    subject(:contract) { described_class.new(project, current_user) }
   end
 end

--- a/spec_legacy/unit/project_spec.rb
+++ b/spec_legacy/unit/project_spec.rb
@@ -654,7 +654,7 @@ describe Project, type: :model do
     assert_equal source_project.types, copied_project.types
 
     # Default attributes
-    assert_equal 1, copied_project.status
+    assert_equal "active", copied_project.status
   end
 
   it 'should activities should use the system activities' do
@@ -757,11 +757,11 @@ describe Project, type: :model do
 
     it 'should copy work units' do
       work_package = FactoryBot.create(:work_package,
-                                        status: Status.find_by_name('Closed'),
-                                        subject: 'copy issue status',
-                                        type_id: 1,
-                                        assigned_to_id: 2,
-                                        project_id: @source_project.id)
+                                       status: Status.find_by_name('Closed'),
+                                       subject: 'copy issue status',
+                                       type_id: 1,
+                                       assigned_to_id: 2,
+                                       project_id: @source_project.id)
 
       @source_project.work_packages << work_package
       assert @project.valid?

--- a/spec_legacy/unit/user_spec.rb
+++ b/spec_legacy/unit/user_spec.rb
@@ -26,7 +26,7 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
-require 'legacy_spec_helper'
+require_relative '../legacy_spec_helper'
 
 describe User, type: :model do
   include MiniTest::Assertions # refute
@@ -386,7 +386,7 @@ describe User, type: :model do
     context 'with a unique project' do
       it 'should return false if project is archived' do
         project = Project.find(1)
-        allow_any_instance_of(Project).to receive(:status).and_return(Project::STATUS_ARCHIVED)
+        allow_any_instance_of(Project).to receive(:active?).and_return(false)
         assert ! @admin.allowed_to?(:view_work_packages, Project.find(1))
       end
 


### PR DESCRIPTION
Adds the project details widget (displaying a project's custom fields) to the dashboard (https://community.openproject.com/projects/openproject/work_packages/29368). 

In order to display the names of the custom fields, the PR also adds a project schema end point to the API (https://community.openproject.com/projects/openproject/work_packages/18809). As a schema end point relies on contracts, those are added as well although they are not yet used when modifying projects.  

Now also contains a fix for https://community.openproject.com/projects/openproject/work_packages/30683