### PR TITLE
Remove with_advisory_lock for MySQL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,8 +133,6 @@ gem 'lograge', '~> 0.10.0'
 # don't require by default, instead load on-demand when actually configured
 gem 'airbrake', '~> 8.0.1', require: false
 
-gem 'with_advisory_lock'
-
 gem 'prawn', '~> 2.2'
 gem 'prawn-table', '~> 0.2.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -891,8 +891,6 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
     will_paginate (3.1.6)
-    with_advisory_lock (4.0.0)
-      activerecord (>= 4.2)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -1056,7 +1054,6 @@ DEPENDENCIES
   warden-basic_auth (~> 0.2.1)
   webmock (~> 3.5.0)
   will_paginate (~> 3.1.0)
-  with_advisory_lock
 
 RUBY VERSION
    ruby 2.6.1p33


### PR DESCRIPTION
Remove the rewritten journal version locking for MySQL. Now that PostgreSQL doesn't require locking, we can remove the gem dependency.