### PR TITLE
Feature/cacheable descriptions

### DIFF
--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -61,8 +61,12 @@ module Type::Attributes
     #
     # @return [Hash{String => Hash}] Map from attribute names to options.
     def all_work_package_form_attributes(merge_date: false)
+      wp_cf_cache_parts = RequestStore.fetch(:wp_cf_max_updated_at_and_count) do
+        WorkPackageCustomField.pluck(Arel.sql('max(updated_at), count(id)')).flatten
+      end
+
       OpenProject::Cache.fetch('all_work_package_form_attributes',
-                               *WorkPackageCustomField.pluck(Arel.sql('max(updated_at), count(id)')).flatten,
+                               *wp_cf_cache_parts,
                                merge_date) do
         calculate_all_work_package_form_attributes(merge_date)
       end

--- a/app/models/user/project_role_cache.rb
+++ b/app/models/user/project_role_cache.rb
@@ -28,42 +28,34 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class User::ProjectAuthorizationCache
+class User::ProjectRoleCache
   attr_accessor :user
 
   def initialize(user)
     self.user = user
   end
 
-  def cache(actions)
-    cached_actions = if actions.is_a?(Array)
-                       actions
-                     else
-                       [actions]
-                     end
-
-    cached_actions.each do |action|
-      allowed_project_ids = Project.allowed_to(user, action).pluck(:id)
-
-      projects_by_actions[normalized_permission_name(action)] = allowed_project_ids
-    end
-  end
-
-  def cached?(action)
-    projects_by_actions[normalized_permission_name(action)]
-  end
-
-  def allowed?(action, project)
-    projects_by_actions[normalized_permission_name(action)].include? project.id
+  def fetch(project)
+    cache[project] ||= roles(project)
   end
 
   private
 
-  def normalized_permission_name(action)
-    OpenProject::AccessControl.permission(action)
+  def roles(project)
+    # No role on archived projects
+    return [] unless !project || project&.active?
+
+    # Return all roles if user is admin
+    return all_givable_roles if user.admin?
+
+    ::Authorization.roles(user, project).eager_load(:role_permissions)
   end
 
-  def projects_by_actions
-    @projects_by_actions ||= {}
+  def cache
+    @cache ||= {}
+  end
+
+  def all_givable_roles
+    @all_givable_roles ||= Role.givable.to_a
   end
 end

--- a/lib/api/v3/attachments/attachment_representer.rb
+++ b/lib/api/v3/attachments/attachment_representer.rb
@@ -104,8 +104,7 @@ module API
                  getter: ->(*) { filesize }
 
         formattable_property :description,
-                             plain: true,
-                             uncacheable: true
+                             plain: true
 
         property :content_type
         property :digest,

--- a/lib/api/v3/news/news_representer.rb
+++ b/lib/api/v3/news/news_representer.rb
@@ -49,8 +49,7 @@ module API
 
         property :summary
 
-        formattable_property :description,
-                             uncacheable: true
+        formattable_property :description
 
         date_time_property :created_on,
                            as: :createdAt

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -100,8 +100,7 @@ module API
         property :is_public,
                  as: :public
 
-        formattable_property :description,
-                             uncacheable: true
+        formattable_property :description
 
         date_time_property :created_on,
                            as: 'createdAt'

--- a/lib/api/v3/repositories/revision_representer.rb
+++ b/lib/api/v3/repositories/revision_representer.rb
@@ -68,8 +68,7 @@ module API
 
         formattable_property :comments,
                              as: :message,
-                             plain: true,
-                             uncacheable: true
+                             plain: true
 
         date_time_property :committed_on,
                            as: 'createdAt'

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -40,7 +40,7 @@ module API
           include API::Caching::CachedRepresenter
           cached_representer key_parts: %i[project type],
                              dependencies: -> {
-                               Authorization.roles(User.current, represented.project).map(&:permissions).sort +
+                               Authorization.roles(User.current, represented.project).eager_load(:role_permissions).map(&:permissions).sort +
                                  [Setting.work_package_done_ratio]
                              }
 

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -253,11 +254,9 @@ module API
           def attribute_groups
             (represented.type&.attribute_groups || []).map do |group|
               if group.is_a?(Type::QueryGroup)
-                ::API::V3::WorkPackages::Schema::FormConfigurations::QueryRepresenter
-                  .new(group, current_user: current_user, embed_links: true)
+                form_config_query_representation(group)
               else
-                ::API::V3::WorkPackages::Schema::FormConfigurations::AttributeRepresenter
-                  .new(group, current_user: current_user, project: represented.project, embed_links: true)
+                form_config_attribute_representation(group)
               end
             end
           end
@@ -289,6 +288,31 @@ module API
           # change their to_params value consistently
           def json_key_part_represented
             []
+          end
+
+          def form_config_query_representation(group)
+            # While we cannot cache the query group to be shared with other users (e.g. project names)
+            # we can cache it for the same user for this request so that when a collection of
+            # schemas is rendered, we can reuse that.
+            RequestStore.fetch("wp_schema_query_group/#{group.key}") do
+              ::JSON::parse(::API::V3::WorkPackages::Schema::FormConfigurations::QueryRepresenter
+                              .new(group, current_user: current_user, embed_links: true)
+                              .to_json)
+            end
+          end
+
+          def form_config_attribute_representation(group)
+            cache_keys = ['wp_schema_attribute_group', group.key,
+                          I18n.locale,
+                          represented.project,
+                          represented.type,
+                          represented.available_custom_fields]
+
+            OpenProject::Cache.fetch(OpenProject::Cache::CacheKey.expand(cache_keys.flatten.compact)) do
+              ::JSON::parse(::API::V3::WorkPackages::Schema::FormConfigurations::AttributeRepresenter
+                              .new(group, current_user: current_user, project: represented.project, embed_links: true)
+                              .to_json)
+            end
           end
         end
       end

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -40,7 +40,7 @@ module API
           include API::Caching::CachedRepresenter
           cached_representer key_parts: %i[project type],
                              dependencies: -> {
-                               Authorization.roles(User.current, represented.project).eager_load(:role_permissions).map(&:permissions).sort +
+                               User.current.roles_for_project(represented.project).map(&:permissions).sort +
                                  [Setting.work_package_done_ratio]
                              }
 

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -173,6 +173,10 @@ module API
 
         def schemas
           schemas = schema_pairs.map do |project, type, available_custom_fields|
+            # This hack preloads the custom fields for a project so that they do not have to be
+            # loaded again later on
+            project.instance_variable_set(:'@all_work_package_custom_fields', available_custom_fields)
+
             Schema::TypedWorkPackageSchema.new(project: project, type: type, custom_fields: available_custom_fields)
           end
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -328,8 +328,7 @@ module API
         property :subject,
                  render_nil: true
 
-        formattable_property :description,
-                             uncacheable: true
+        formattable_property :description
 
         date_property :start_date,
                       skip_render: ->(represented:, **) {

--- a/modules/documents/lib/api/v3/documents/document_representer.rb
+++ b/modules/documents/lib/api/v3/documents/document_representer.rb
@@ -48,8 +48,7 @@ module API
 
         property :title
 
-        formattable_property :description,
-                             uncacheable: true
+        formattable_property :description
 
         date_time_property :created_on,
                            as: 'createdAt'

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -988,12 +988,17 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:permissions1) { %i[blubs some more] }
           let(:role2) { FactoryBot.build_stubbed(:role, permissions: permissions2) }
           let(:permissions2) { %i[and other random permissions] }
+          let(:roles) { [role1, role2] }
 
           let(:setup) do
             allow(Authorization)
               .to receive(:roles)
               .with(current_user, project)
-              .and_return([role1, role2])
+              .and_return(roles)
+
+            allow(roles)
+              .to receive(:eager_load)
+              .and_return(roles)
           end
 
           let(:change) do

--- a/spec/models/attribute_help_text/work_package_spec.rb
+++ b/spec/models/attribute_help_text/work_package_spec.rb
@@ -50,14 +50,21 @@ describe AttributeHelpText::WorkPackage, type: :model do
     let(:role) { FactoryBot.create(:role, permissions: permissions) }
     let(:user) do
       FactoryBot.create(:user,
-                         member_in_project: project,
-                         member_through_role: role)
+                        member_in_project: project,
+                        member_through_role: role)
     end
     let(:permission) { [] }
     let(:static_instance) { FactoryBot.create :work_package_help_text, attribute_name: 'project' }
+
+    def create_cf_help_text(custom_field)
+      # Need to clear the request store after every creation as the available attributes are cached
+      RequestStore.clear!
+      FactoryBot.create(:work_package_help_text, attribute_name: "custom_field_#{custom_field.id}")
+    end
+
     let(:cf_instance) do
       custom_field = FactoryBot.create :text_wp_custom_field
-      FactoryBot.create :work_package_help_text, attribute_name: "custom_field_#{custom_field.id}"
+      create_cf_help_text(custom_field)
     end
 
     subject { FactoryBot.build :work_package_help_text }
@@ -67,8 +74,8 @@ describe AttributeHelpText::WorkPackage, type: :model do
       # Type.translated_work_package_form_attributes
       Rails.cache.clear
 
-      static_instance
       cf_instance
+      static_instance
     end
 
     subject { described_class.visible(user) }
@@ -105,7 +112,7 @@ describe AttributeHelpText::WorkPackage, type: :model do
         custom_field = FactoryBot.create(:text_wp_custom_field)
         project.work_package_custom_fields << custom_field
         type.custom_fields << custom_field
-        FactoryBot.create :work_package_help_text, attribute_name: "custom_field_#{custom_field.id}"
+        create_cf_help_text(custom_field)
       end
       let(:cf_instance_inactive) do
         cf_instance
@@ -113,16 +120,16 @@ describe AttributeHelpText::WorkPackage, type: :model do
       let(:cf_instance_inactive_no_type) do
         custom_field = FactoryBot.create(:text_wp_custom_field)
         project.work_package_custom_fields << custom_field
-        FactoryBot.create :work_package_help_text, attribute_name: "custom_field_#{custom_field.id}"
+        create_cf_help_text(custom_field)
       end
       let(:cf_instance_inactive_not_in_project) do
         custom_field = FactoryBot.create(:text_wp_custom_field)
         type.custom_fields << custom_field
-        FactoryBot.create :work_package_help_text, attribute_name: "custom_field_#{custom_field.id}"
+        create_cf_help_text(custom_field)
       end
       let(:cf_instance_for_all) do
         custom_field = FactoryBot.create(:text_wp_custom_field, is_for_all: true)
-        FactoryBot.create :work_package_help_text, attribute_name: "custom_field_#{custom_field.id}"
+        create_cf_help_text(custom_field)
       end
 
       before do

--- a/spec/models/custom_actions/conditions/role_spec.rb
+++ b/spec/models/custom_actions/conditions/role_spec.rb
@@ -48,27 +48,19 @@ describe CustomActions::Conditions::Role, type: :model do
     end
 
     describe '#fulfilled_by?' do
-      let(:work_package) { double('work_package', project_id: 1) }
-      let(:user) { double('user', id: 3) }
-
-      before do
-        role1 = double('role', id: 1)
-        role2 = double('role', id: 2)
-        roles = [role1, role2]
-
-        allow(Role)
-          .to receive(:joins)
-          .with(:members)
-          .and_return(roles)
-        allow(roles)
-          .to receive(:where)
-          .with(members: { project_id: [work_package.project_id],
-                           user_id: user.id })
-          .and_return(roles)
-        allow(roles)
-          .to receive(:select)
-          .and_return(roles)
+      let(:project) { double('project', id: 1) }
+      let(:work_package) { double('work_package', project: project, project_id: 1) }
+      let(:user) do
+        double('user', id: 3).tap do |user|
+          allow(user)
+            .to receive(:roles_for_project)
+            .with(project)
+            .and_return(roles)
+        end
       end
+      let(:role1) { double('role', id: 1) }
+      let(:role2) { double('role', id: 2) }
+      let(:roles) { [role1, role2] }
 
       it 'is true if values are empty' do
         instance.values = []

--- a/spec/services/authorization/user_allowed_service_spec.rb
+++ b/spec/services/authorization/user_allowed_service_spec.rb
@@ -36,7 +36,14 @@ describe Authorization::UserAllowedService do
   let(:project) { FactoryBot.build_stubbed(:project) }
   let(:other_project) { FactoryBot.build_stubbed(:project) }
   let(:role) { FactoryBot.build_stubbed(:role) }
-  let(:user_roles_in_project) { [role] }
+  let(:user_roles_in_project) do
+    array = [role]
+    allow(array)
+      .to receive(:eager_load)
+      .and_return(array)
+
+    array
+  end
   let(:role_grants_action) { true }
   let(:project_allows_to) { true }
 
@@ -272,7 +279,7 @@ describe Authorization::UserAllowedService do
           allow(Authorization)
             .to receive(:roles)
             .with(user, nil)
-            .and_return([role])
+            .and_return(user_roles_in_project)
 
           allow(role)
             .to receive(:allowed_to?)
@@ -294,7 +301,7 @@ describe Authorization::UserAllowedService do
           allow(Authorization)
             .to receive(:roles)
             .with(user, nil)
-            .and_return([role])
+            .and_return(user_roles_in_project)
 
           allow(role)
             .to receive(:allowed_to?)

--- a/spec_legacy/unit/group_spec.rb
+++ b/spec_legacy/unit/group_spec.rb
@@ -26,7 +26,7 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
-require 'legacy_spec_helper'
+require_relative '../legacy_spec_helper'
 
 describe Group, type: :model do
   before do


### PR DESCRIPTION
With the last of the macros remove in #7515, formattable fields can now be cached.

https://community.openproject.com/projects/openproject/work_packages/30712

The PR also includes additional performance optimizations:
* Recreates attribute groups caching for the form configuration embedded in the wp schema to a lesser degree than before. While we cannot cache the whole of the form configuration, we can cache the attribute groups as a whole and can cache query groups for the current request
* Centralizes accessing the roles of the current user and caches those more heavily for the request as they are in turn used as cache keys in several places. 