### PR TITLE
[30677] Replace legacy user autocompleter to be able to assign group members again

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -69,6 +69,8 @@ class GroupsController < ApplicationController
   # GET /groups/1/edit
   def edit
     @group = Group.includes(:members, :users).find(params[:id])
+
+    set_filters_for_user_autocompleter
   end
 
   # POST /groups
@@ -176,6 +178,12 @@ class GroupsController < ApplicationController
 
   def find_group
     @group = Group.find(params[:id])
+  end
+
+  def set_filters_for_user_autocompleter
+    @autocompleter_filters = []
+    @autocompleter_filters.push({ selector: 'status', operator: '=', values: ['active'] })
+    @autocompleter_filters.push({ selector: 'group', operator: '!', values: [@group.id] })
   end
 
   def default_breadcrumb

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -31,7 +31,7 @@ class GroupsController < ApplicationController
   layout 'admin'
 
   before_action :require_admin
-  before_action :find_group, only: [:destroy, :autocomplete_for_user,
+  before_action :find_group, only: [:destroy,
                                     :show, :create_memberships, :destroy_membership,
                                     :edit_membership]
 
@@ -134,11 +134,6 @@ class GroupsController < ApplicationController
 
     I18n.t :notice_successful_update
     redirect_to controller: '/groups', action: 'edit', id: @group, tab: 'users'
-  end
-
-  def autocomplete_for_user
-    @users = User.active.not_in_group(@group).like(params[:q]).limit(100)
-    render layout: false
   end
 
   def create_memberships

--- a/app/models/queries/filters/shared/group_filter.rb
+++ b/app/models/queries/filters/shared/group_filter.rb
@@ -53,13 +53,29 @@ module Queries::Filters::Shared::GroupFilter
       I18n.t('query_fields.member_of_group')
     end
 
-    def joins
-      :groups
+    def where
+      case operator
+      when '='
+        "users.id IN (#{group_subselect})"
+      when '!'
+        "users.id NOT IN (#{group_subselect})"
+      when '*'
+        "users.id IN (#{any_group_subselect})"
+      when '!*'
+        "users.id NOT IN (#{any_group_subselect})"
+      end
     end
 
-    def where
-      operator_strategy.sql_for_field(values, 'groups_users', 'id')
+    private
+
+    def group_subselect
+      User.in_group(values).select(:id).to_sql
     end
+
+    def any_group_subselect
+      User.within_group([]).select(:id).to_sql
+    end
+
   end
 
   module ClassMethods

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,13 +140,25 @@ class User < Principal
   before_destroy :reassign_associated
 
   scope :in_group, ->(group) {
-    group_id = group.is_a?(Group) ? group.id : group.to_i
-    where(["#{User.table_name}.id IN (SELECT gu.user_id FROM #{table_name_prefix}group_users#{table_name_suffix} gu WHERE gu.group_id = ?)", group_id])
+    within_group(group)
   }
   scope :not_in_group, ->(group) {
-    group_id = group.is_a?(Group) ? group.id : group.to_i
-    where(["#{User.table_name}.id NOT IN (SELECT gu.user_id FROM #{table_name_prefix}group_users#{table_name_suffix} gu WHERE gu.group_id = ?)", group_id])
+    within_group(group, false)
   }
+  scope :within_group, ->(group, positive = true) {
+    group_id = group.is_a?(Group) ? [group.id] : Array(group).map(&:to_i)
+
+    sql_condition = group_id.any? ? 'WHERE gu.group_id IN (?)' : ''
+    sql_not = positive ? '' : 'NOT'
+
+    sql_query = ["#{User.table_name}.id #{sql_not} IN (SELECT gu.user_id FROM #{table_name_prefix}group_users#{table_name_suffix} gu #{sql_condition})"]
+    if group_id.any?
+      sql_query.push group_id
+    end
+
+    where(sql_query)
+  }
+
   scope :admin, -> { where(admin: true) }
 
   scope :newest, -> { not_builtin.order(created_on: :desc) }

--- a/app/views/groups/_users.html.erb
+++ b/app/views/groups/_users.html.erb
@@ -28,44 +28,41 @@ See docs/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%= activate_angular_js do %>
-<div class="grid-block">
-  <div class="grid-content">
-    <% if @group.users.any? %>
-      <div class="generic-table--container">
-        <div id="group_users_table" class="generic-table--results-container">
+  <div class="grid-block -visible-overflow">
+    <div class="grid-content medium-6">
+      <% if @group.users.any? %>
+        <div class="generic-table--container">
+          <div id="group_users_table" class="generic-table--results-container">
             <%= render partial: 'groups/users_table' %>
+          </div>
         </div>
-      </div>
-    <% else %>
-      <%= no_results_box %>
-    <% end %>
-  </div>
-  <div class="grid-content">
-    <% users = User
-               .not_builtin
-               .active
-               .not_in_group(@group)
-               .limit(1) %>
-    <% if users.any? %>
-      <%= styled_form_tag(members_of_group_path(@group), method: :post) do %>
-        <fieldset class="form--fieldset">
-          <legend class="form--fieldset-legend"><%=l(:label_user_new)%></legend>
-          <div class="form--field -vertical">
-            <% user_ids = [] %>
-            <% @group.users.each do |user| %>
-              <% user_ids.push(user.id) %>
-            <% end %>
-
-            <%= hidden_field_tag :user_ids, user_ids  %>
-            <user-autocompleter data-update-input="user_ids"></user-autocompleter>
-          </div>
-          <div>
-            <%= styled_button_tag l(:button_add),
-                                  class: '-highlight -with-icon icon-checkmark' %>
-          </div>
-        </fieldset>
+      <% else %>
+        <%= no_results_box %>
       <% end %>
-    <% end %>
+    </div>
+    <div class="grid-content medium-6 -visible-overflow">
+      <% users = User
+        .not_builtin
+        .active
+        .not_in_group(@group)
+        .limit(1) %>
+      <% if users.any? %>
+        <%= styled_form_tag(members_of_group_path(@group), method: :post) do %>
+          <fieldset class="form--fieldset">
+            <legend class="form--fieldset-legend"><%=l(:label_user_new)%></legend>
+            <div class="form--field -vertical">
+              <%= hidden_field_tag :user_ids, nil  %>
+              <user-autocompleter data-update-input="user_ids"
+                                  data-additional-filter="<%= @autocompleter_filters&.to_json %>">
+              </user-autocompleter>
+            </div>
+            <div>
+              <%= styled_button_tag l(:button_add),
+                                    class: '-highlight -with-icon icon-checkmark' %>
+            </div>
+          </fieldset>
+        <% end %>
+      <% end %>
+    </div>
   </div>
-</div>
 <% end %>

--- a/app/views/groups/_users.html.erb
+++ b/app/views/groups/_users.html.erb
@@ -53,7 +53,8 @@ See docs/COPYRIGHT.rdoc for more details.
             <div class="form--field -vertical">
               <%= hidden_field_tag :user_ids, nil  %>
               <user-autocompleter data-update-input="user_ids"
-                                  data-additional-filter="<%= @autocompleter_filters&.to_json %>">
+                                  data-additional-filter="<%= @autocompleter_filters&.to_json %>"
+                                  class="new-group-members--autocomplete">
               </user-autocompleter>
             </div>
             <div>

--- a/app/views/groups/_users.html.erb
+++ b/app/views/groups/_users.html.erb
@@ -45,32 +45,25 @@ See docs/COPYRIGHT.rdoc for more details.
                .not_builtin
                .active
                .not_in_group(@group)
-               .limit(100) %>
+               .limit(1) %>
     <% if users.any? %>
-      <%= styled_form_tag(members_of_group_path(@group), method: :post) do |f| %>
-        <remote-field-updater url="<%= url_for(controller: '/groups', action: 'autocomplete_for_user', id: @group)%>">
-          <fieldset class="form--fieldset">
-            <legend class="form--fieldset-legend"><%=l(:label_user_new)%></legend>
-              <div class="form--field -vertical">
-                <%= styled_label_tag "user_search", l(:label_user_search) %>
-                <div class="form--field-container">
-                  <%= styled_text_field_tag 'user_search',
-                                            nil,
-                                            class: 'remote-field--input',
-                                            data: { :'remote-field-key' =>'q' } %>
-                </div>
-              </div>
-              <div class="form--field -vertical">
-                <div id="users" class="remote-field--target form--field-container -vertical">
-                  <%= principals_check_box_tags 'user_ids[]', users %>
-                </div>
-              </div>
-          </fieldset>
-        </remote-field-updater>
-        <div>
-          <%= styled_button_tag l(:button_add),
-                                class: '-highlight -with-icon icon-checkmark' %>
-        </div>
+      <%= styled_form_tag(members_of_group_path(@group), method: :post) do %>
+        <fieldset class="form--fieldset">
+          <legend class="form--fieldset-legend"><%=l(:label_user_new)%></legend>
+          <div class="form--field -vertical">
+            <% user_ids = [] %>
+            <% @group.users.each do |user| %>
+              <% user_ids.push(user.id) %>
+            <% end %>
+
+            <%= hidden_field_tag :user_ids, user_ids  %>
+            <user-autocompleter data-update-input="user_ids"></user-autocompleter>
+          </div>
+          <div>
+            <%= styled_button_tag l(:button_add),
+                                  class: '-highlight -with-icon icon-checkmark' %>
+          </div>
+        </fieldset>
       <% end %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -357,7 +357,6 @@ OpenProject::Application.routes.draw do
 
     resources :groups do
       member do
-        get :autocomplete_for_user
         # this should be put into it's own resource
         match '/members' => 'groups#add_users', via: :post, as: 'members_of'
         match '/members/:user_id' => 'groups#remove_user', via: :delete, as: 'member_of'

--- a/spec/features/groups/membership_spec.rb
+++ b/spec/features/groups/membership_spec.rb
@@ -110,7 +110,7 @@ feature 'group memberships through project members page', type: :feature do
       allow(User).to receive(:current).and_return admin
     end
 
-    scenario 'adding members to that group adds them to the project too' do
+    scenario 'adding members to that group adds them to the project too', js: true do
       members_page.visit!
 
       expect(members_page).not_to have_user('Alice Wonderland') # Alice not in the project yet

--- a/spec/models/queries/members/filters/group_filter_spec.rb
+++ b/spec/models/queries/members/filters/group_filter_spec.rb
@@ -55,10 +55,8 @@ describe Queries::Members::Filters::GroupFilter, type: :model do
     end
   end
 
-  it_behaves_like 'list_optional query filter' do
-    let(:attribute) { :id }
+  it_behaves_like 'list_optional group query filter' do
     let(:model) { Member.joins(:principal).merge(User.joins(:groups)) }
     let(:valid_values) { [group1.id.to_s] }
-    let(:expected_table_name) { 'groups_users' }
   end
 end

--- a/spec/models/queries/users/filters/group_filter_spec.rb
+++ b/spec/models/queries/users/filters/group_filter_spec.rb
@@ -55,11 +55,8 @@ describe Queries::Users::Filters::GroupFilter, type: :model do
     end
   end
 
-  it_behaves_like 'list_optional query filter' do
-    let(:attribute) { :id }
+  it_behaves_like 'list_optional group query filter' do
     let(:model) { User }
-    let(:joins) { :groups }
     let(:valid_values) { [group1.id.to_s] }
-    let(:expected_table_name) { 'groups_users' }
   end
 end

--- a/spec/models/queries/users/user_query_spec.rb
+++ b/spec/models/queries/users/user_query_spec.rb
@@ -114,9 +114,8 @@ describe Queries::Users::UserQuery, type: :model do
     describe '#results' do
       it 'is the same as handwriting the query' do
         expected = base_scope
-                   .merge(User
-                          .joins(:groups)
-                          .where("groups_users.id IN ('#{group_1.id}')"))
+                     .merge(User
+                              .where(["users.id IN (#{User.in_group([group_1.id.to_s]).select(:id).to_sql})"]))
 
         expect(instance.results.to_sql).to eql expected.to_sql
       end

--- a/spec/routing/groups_spec.rb
+++ b/spec/routing/groups_spec.rb
@@ -69,12 +69,6 @@ describe 'groups routes', type: :routing do
   }
 
   it {
-    is_expected.to route(:get, '/admin/groups/4/autocomplete_for_user').to(controller: 'groups',
-                                                                           action: 'autocomplete_for_user',
-                                                                           id: '4')
-  }
-
-  it {
     is_expected.to route(:post, '/admin/groups/4/members').to(controller: 'groups',
                                                               action: 'add_users',
                                                               id: '4')

--- a/spec/support/pages/groups.rb
+++ b/spec/support/pages/groups.rb
@@ -64,6 +64,7 @@ module Pages
   end
 
   class Group < Pages::Page
+    include ::Components::NgSelectAutocompleteHelpers
     attr_reader :id
 
     def initialize(id)
@@ -108,7 +109,10 @@ module Pages
 
     def add_user!(user_name)
       open_users_tab!
-      check user_name
+
+      container = page.find('.new-group-members--autocomplete')
+      select_autocomplete container,
+                          query: user_name
       click_on 'Add'
     end
 

--- a/spec/support/queries/filters/shared_filter_examples.rb
+++ b/spec/support/queries/filters/shared_filter_examples.rb
@@ -220,6 +220,73 @@ shared_examples_for 'list_optional query filter' do
     end
   end
 end
+shared_examples_for 'list_optional group query filter' do
+  include_context 'filter tests'
+  describe '#scope' do
+    let(:values) { valid_values }
+
+    context 'for "="' do
+      let(:operator) { '=' }
+
+      it 'is the same as handwriting the query' do
+        expected = model.where(["users.id IN (#{User.in_group(values).select(:id).to_sql})"])
+        expect(instance.scope.to_sql).to eql expected.to_sql
+      end
+    end
+
+    context 'for "!"' do
+      let(:operator) { '!' }
+
+      it 'is the same as handwriting the query' do
+        expected = model.where(["users.id NOT IN (#{User.in_group(values).select(:id).to_sql})"])
+        expect(instance.scope.to_sql).to eql expected.to_sql
+      end
+    end
+
+    context 'for "*"' do
+      let(:operator) { '*' }
+
+      it 'is the same as handwriting the query' do
+        expected = model.where(["users.id IN (#{User.within_group([]).select(:id).to_sql})"])
+        expect(instance.scope.to_sql).to eql expected.to_sql
+      end
+    end
+
+    context 'for "!*"' do
+      let(:operator) { '!*' }
+
+      it 'is the same as handwriting the query' do
+        expected = model.where(["users.id NOT IN (#{User.within_group([]).select(:id).to_sql})"])
+        expect(instance.scope.to_sql).to eql expected.to_sql
+      end
+    end
+  end
+
+  describe '#valid?' do
+    let(:operator) { '=' }
+    let(:values) { valid_values }
+
+    it 'is valid' do
+      expect(instance).to be_valid
+    end
+
+    context 'for an invalid operator' do
+      let(:operator) { '~' }
+
+      it 'is invalid' do
+        expect(instance).to be_invalid
+      end
+    end
+
+    context 'for an invalid value' do
+      let(:values) { ['inexistent'] }
+
+      it 'is invalid' do
+        expect(instance).to be_invalid
+      end
+    end
+  end
+end
 
 shared_examples_for 'list_all query filter' do
   include_context 'filter tests'

--- a/spec_legacy/functional/groups_controller_spec.rb
+++ b/spec_legacy/functional/groups_controller_spec.rb
@@ -110,13 +110,4 @@ describe GroupsController, type: :controller do
       delete :destroy_membership, params: { id: 10, membership_id: 6 }
     end
   end
-
-  it 'should autocomplete for user' do
-    get :autocomplete_for_user, params: { id: 10, q: 'mis' }
-    assert_response :success
-    users = assigns(:users)
-    refute_nil users
-    assert users.any?
-    assert !users.include?(Group.find(10).users.first)
-  end
 end


### PR DESCRIPTION
Currently it is not possible to assign new members to a group.
Since the user selector used in the admin area is outdated, this PR replaces it with the new autocompleter component. Thereby I noticed that the groupFilter does not work as expected. This is fixed here, too.

- [x] Use userAutocompleter instead of RemoteFiledUpdater
  - [x] Use correct url (only those users shall be selectable, who are active and not yet in the group)
  - [x] Remove all unnecessary code 
- [x] Correct GroupFilter
- [x] Write test
