### PR TITLE
write logs to files (/var/log/openproject) outside of docker

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,6 +15,17 @@ port ENV.fetch("PORT") { 3000 }
 #
 environment ENV.fetch("RAILS_ENV") { "development" }
 
+# HEROKU is set to true in the Dockerfile. In the Dockerfile we do just want to
+# log to STDOUT. In any other case (i.e. packager) we want to log to files
+# so that users can inspect the logs if necessary.
+if ENV["HEROKU"] != "true"
+  directory = "/var/log/openproject"
+  directory = "." unless File.directory? directory
+
+  stdout_redirect "#{directory}/stdout.log",
+                  "#{directory}/stderr.log"
+end
+
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together
 # the concurrency of the application would be max `threads` * `workers`.

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -30,6 +30,17 @@ worker_processes Integer(ENV['WEB_CONCURRENCY'] || 4)
 timeout Integer(ENV['WEB_TIMEOUT'] || 300)
 preload_app true
 
+# HEROKU is set to true in the Dockerfile. In the Dockerfile we do just want to
+# log to STDOUT. In any other case (i.e. packager) we want to log to files
+# so that users can inspect the logs if necessary.
+if ENV["HEROKU"] != "true"
+  directory = "/var/log/openproject"
+  directory = "." unless File.directory? directory
+
+  stdout_path "#{directory}/stdout.log"
+  stderr_path "#{directory}/stderr.log"
+end
+
 # Preloading the unicorn server to have all workers spawn the application
 # automatically.
 #


### PR DESCRIPTION
Currently package-based installations do not write any logs which makes debugging issues difficult.