### PR TITLE
[30714] Cancel editing in before transition hook

### DIFF
--- a/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field-group.directive.ts
+++ b/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field-group.directive.ts
@@ -75,7 +75,7 @@ export class WorkPackageEditFieldGroupComponent implements OnInit, OnDestroy {
     const confirmText = I18n.t('js.work_packages.confirm_edit_cancel');
     const requiresConfirmation = ConfigurationService.warnOnLeavingUnsaved();
 
-    this.unregisterListener = $transitions.onStart({}, (transition:Transition) => {
+    this.unregisterListener = $transitions.onBefore({}, (transition:Transition) => {
       if (!this.editing) {
         return undefined;
       }

--- a/frontend/src/app/components/wp-fast-table/handlers/row/wp-state-links-handler.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/row/wp-state-links-handler.ts
@@ -60,8 +60,6 @@ export class WorkPackageStateLinksHandler implements TableEventHandler {
     let classIdentifier = row.data('classIdentifier');
     let [index, _] = table.findRenderedRow(classIdentifier);
 
-    this.wpTableFocus.updateFocus(workPackageId);
-
     // Update single selection if no modifier present
     this.wpTableSelection.setSelection(workPackageId, index);
 

--- a/spec/features/work_packages/cancel_editing_spec.rb
+++ b/spec/features/work_packages/cancel_editing_spec.rb
@@ -157,6 +157,29 @@ describe 'Cancel editing work package', js: true do
     expect(wp_page).not_to have_alert_dialog
   end
 
+  it 'correctly cancels setting the back route (Regression #30714)' do
+    wp_page = ::Pages::FullWorkPackage.new work_package
+    wp_page.visit!
+    wp_page.ensure_page_loaded
+
+    # Edit description in full view
+    description = wp_page.edit_field :description
+    description.activate!
+    description.click_and_type_slowly 'foobar'
+
+    # Try to move back to list, expect warning
+    find('.work-packages-back-button').click
+    wp_page.dismiss_alert_dialog!
+
+    # Now cancel the field
+    description.cancel_by_click
+
+    # Now we should be able to get back to list
+    find('.work-packages-back-button').click
+
+    wp_table.expect_work_package_listed(work_package, work_package2)
+  end
+
   context 'when user does not want to be warned' do
     before do
       FactoryBot.create(:user_preference, user: user, others: { warn_on_leaving_unsaved: false })


### PR DESCRIPTION
This avoids setting the back URL despite being cancelled

https://community.openproject.com/wp/30714