### PR TITLE
Feature/attachments on dashboards

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -199,6 +199,7 @@ class Attachment < ActiveRecord::Base
 
   def extract_fulltext
     return unless OpenProject::Database.allows_tsv?
+
     job = ExtractFulltextJob.new(id)
     Delayed::Job.enqueue job, priority: ::ApplicationJob.priority_number(:low)
   end
@@ -259,7 +260,7 @@ class Attachment < ActiveRecord::Base
   end
 
   def allowed_or_author?(user)
-    containered? && yield ||
+    containered? && !(container.class.attachable_options[:only_user_allowed] && author_id != user.id) && yield ||
       !containered? && author_id == user.id
   end
 end

--- a/app/services/attachments/set_replacements.rb
+++ b/app/services/attachments/set_replacements.rb
@@ -28,12 +28,26 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Grids
-  class Dashboard < Grid
-    belongs_to :project
+module Attachments
+  module SetReplacements
+    extend ActiveSupport::Concern
 
-    set_acts_as_attachable_options view_permission: :view_dashboards,
-                                   delete_permission: :manage_dashboards,
-                                   add_permission: :manage_dashboards
+    included do
+      private
+
+      def set_attributes(attributes)
+        set_attachments_attributes(attributes)
+
+        super
+      end
+
+      def set_attachments_attributes(attributes)
+        attachment_ids = attributes.delete(:attachment_ids)
+
+        return unless attachment_ids
+
+        work_package.attachments_replacements = Attachment.where(id: attachment_ids)
+      end
+    end
   end
 end

--- a/app/services/projects/update_service.rb
+++ b/app/services/projects/update_service.rb
@@ -37,7 +37,7 @@ module Projects
     end
 
     def only_custom_values_updated?
-      model.saved_changes.empty? && model.custom_values.map(&:saved_changes).any?(&:present?)
+      !model.saved_changes? && model.custom_values.any?(&:saved_changes?)
     end
   end
 end

--- a/app/services/versions/update_service.rb
+++ b/app/services/versions/update_service.rb
@@ -46,7 +46,7 @@ module Versions
     end
 
     def only_custom_values_updated?
-      model.saved_changes.empty? && model.custom_values.map(&:saved_changes).any?(&:present?)
+      !model.saved_changes? && model.custom_values.any?(&:saved_changes?)
     end
 
     def no_valid_version_before_or_now?

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -29,6 +29,8 @@
 #++
 
 class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
+  include Attachments::SetReplacements
+
   private
 
   def set_attributes(attributes)
@@ -49,14 +51,8 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
     end
   end
 
-  def set_attachments_attributes(attributes)
-    return unless attributes.key?(:attachment_ids)
-
-    work_package.attachments_replacements = Attachment.where(id: attributes[:attachment_ids])
-  end
-
   def set_static_attributes(attributes)
-    assignable_attributes = attributes.except(:attachment_ids).select do |key, _|
+    assignable_attributes = attributes.select do |key, _|
       !CustomField.custom_field_attribute?(key) && work_package.respond_to?(key)
     end
 

--- a/config/constants/ar_to_api_conversions.rb
+++ b/config/constants/ar_to_api_conversions.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -28,12 +26,40 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Grids
-  class Dashboard < Grid
-    belongs_to :project
+module Constants
+  class ARToAPIConversions
+    WELL_KNOWN_CONVERSIONS = {
+      assigned_to: 'assignee',
+      fixed_version: 'version',
+      done_ratio: 'percentageDone',
+      estimated_hours: 'estimatedTime',
+      created_on: 'createdAt',
+      updated_on: 'updatedAt',
+      remaining_hours: 'remainingTime',
+      spent_hours: 'spentTime',
+      subproject: 'subprojectId',
+      relation_type: 'type',
+      mail: 'email',
+      column_names: 'columns',
+      is_public: 'public',
+      sort_criteria: 'sortBy',
+      message: 'post'
+    }.freeze
 
-    set_acts_as_attachable_options view_permission: :view_dashboards,
-                                   delete_permission: :manage_dashboards,
-                                   add_permission: :manage_dashboards
+    class << self
+      def add(map)
+        conversions.push(map)
+      end
+
+      def all
+        conversions.inject(:merge)
+      end
+
+      private
+
+      def conversions
+        @conversions ||= [WELL_KNOWN_CONVERSIONS]
+      end
+    end
   end
 end

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
@@ -218,7 +218,7 @@ export class WorkPackageSingleViewComponent implements OnInit, OnDestroy {
     // Is a query in a new screen
     const queryInNew = this.workPackage.isNew && !!group.query;
 
-    return isEmpty || queryInNew
+    return isEmpty || queryInNew;
   }
 
   /**

--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
@@ -125,7 +125,7 @@
 
 <div class="work-packages--attachments attributes-group"
      *ngIf="workPackage.canAddAttachments || workPackage.hasAttachments">
-  <div class="work-packages--atachments-container">
+  <div class="work-packages--attachments-container">
     <div class="attributes-group--header">
       <div class="attributes-group--header-container">
         <h3 class="attributes-group--header-text" [textContent]="text.attachments.label"></h3>

--- a/frontend/src/app/modules/attachments/attachments.component.ts
+++ b/frontend/src/app/modules/attachments/attachments.component.ts
@@ -42,6 +42,7 @@ import {filter, takeUntil} from 'rxjs/operators';
 })
 export class AttachmentsComponent implements OnInit, OnDestroy {
   @Input('resource') public resource:HalResource;
+  @Input() public selfDestroy:boolean = false;
 
   public $element:JQuery;
   public allowUploading:boolean;
@@ -117,6 +118,10 @@ export class AttachmentsComponent implements OnInit, OnDestroy {
   }
 
   private destroyRemovedAttachments() {
+    if (this.selfDestroy) {
+      return;
+    }
+
     let missingAttachments = _.differenceBy(this.initialAttachments,
       this.resource.attachments.elements,
       (attachment:HalResource) => attachment.id);

--- a/frontend/src/app/modules/attachments/attachments.html
+++ b/frontend/src/app/modules/attachments/attachments.html
@@ -3,8 +3,14 @@
     {{ text.attachments }}
   </legend>
   <div id="attachments_fields">
-    <attachment-list *ngIf="resource.attachments" [resource]="resource"></attachment-list>
-    <attachments-upload [resource]="resource" class="hide-when-print" *ngIf="allowUploading"></attachments-upload>
+    <attachment-list *ngIf="resource.attachments"
+                     [resource]="resource"
+                     [selfDestroy]="selfDestroy">
+    </attachment-list>
+    <attachments-upload [resource]="resource"
+                        class="hide-when-print"
+                        *ngIf="allowUploading">
+    </attachments-upload>
   </div>
 </fieldset>
 

--- a/frontend/src/app/modules/grids/grid/add-widget.service.ts
+++ b/frontend/src/app/modules/grids/grid/add-widget.service.ts
@@ -99,6 +99,8 @@ export class GridAddWidgetService {
 
         let resource = this.halResource.createHalResource(source) as GridWidgetResource;
 
+        resource.grid = this.layout.gridResource;
+
         resolve(resource);
       });
     });

--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -32,6 +32,10 @@ export class GridAreaService {
     this.buildAreas(false);
   }
 
+  public get gridResource() {
+    return this.resource;
+  }
+
   public setMousedOverArea(area:GridArea) {
     this.mousedOverArea = area;
   }

--- a/frontend/src/app/modules/grids/openproject-grids.module.ts
+++ b/frontend/src/app/modules/grids/openproject-grids.module.ts
@@ -64,6 +64,7 @@ import {OpenprojectFieldsModule} from "core-app/modules/fields/openproject-field
 import {WidgetProjectDetailsComponent} from "core-app/modules/grids/widgets/project-details/project-details.component";
 import {WidgetTimeEntriesProjectComponent} from "core-app/modules/grids/widgets/time-entries-current-user/project/time-entries-project.component";
 import {WidgetSubprojectsComponent} from "core-app/modules/grids/widgets/subprojects/subprojects.component";
+import {OpenprojectAttachmentsModule} from "core-app/modules/attachments/openproject-attachments.module";
 
 export const GRID_ROUTES:Ng2StateDeclaration[] = [
   {
@@ -88,6 +89,8 @@ export const GRID_ROUTES:Ng2StateDeclaration[] = [
     OpenprojectWorkPackagesModule,
     OpenprojectWorkPackageGraphsModule,
     OpenprojectCalendarModule,
+
+    OpenprojectAttachmentsModule,
 
     DynamicModule.withComponents([
                                   WidgetCustomTextComponent,

--- a/frontend/src/app/modules/grids/widgets/custom-text/custom-text-edit-field.service.ts
+++ b/frontend/src/app/modules/grids/widgets/custom-text/custom-text-edit-field.service.ts
@@ -4,6 +4,8 @@ import {IFieldSchema} from "core-app/modules/fields/field.base";
 import {BehaviorSubject} from "rxjs";
 import {GridWidgetResource} from "core-app/modules/hal/resources/grid-widget-resource";
 import {CustomTextChangeset} from "core-app/modules/grids/widgets/custom-text/custom-text-changeset";
+import {Attachable} from "core-app/modules/hal/resources/mixins/attachable-mixin";
+import {UploadFile} from "core-components/api/op-file-upload/op-file-upload.service";
 
 @Injectable()
 export class CustomTextEditFieldService extends EditFieldHandler {
@@ -28,12 +30,12 @@ export class CustomTextEditFieldService extends EditFieldHandler {
   }
 
   public initialize(value:GridWidgetResource) {
-    this.changeset = new CustomTextChangeset(this.injector, value.options);
+    this.changeset = new CustomTextChangeset(this.injector, this.newEditResource(value));
     this.valueChanged$ = new BehaviorSubject(value.options['text'] as string);
   }
 
   public reinitialize(value:GridWidgetResource) {
-    this.changeset = new CustomTextChangeset(this.injector, value.options);
+    this.changeset = new CustomTextChangeset(this.injector, this.newEditResource(value));
   }
 
   /**
@@ -114,5 +116,11 @@ export class CustomTextEditFieldService extends EditFieldHandler {
 
   stopPropagation(evt:JQueryEventObject):boolean {
     return false;
+  }
+
+  private newEditResource(value:GridWidgetResource) {
+    return { text: value.options.text,
+             canAddAttachments: value.grid.canAddAttachments,
+             uploadAttachments: (files:UploadFile[]) => value.grid.uploadAttachments(files) };
   }
 }

--- a/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.html
+++ b/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.html
@@ -15,6 +15,12 @@
                       [changesetInput]="changeset"
                       [editFieldHandler]="handler">
     </edit-form-portal>
+    <attachments *ngIf="active"
+                 [resource]="resource.grid"
+                 [selfDestroy]="true"
+                 data-allow-uploading="true">
+    </attachments>
+
     <div *ngIf="!active"
          class="inplace-edit--read">
       <accessible-by-keyboard

--- a/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.ts
+++ b/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.ts
@@ -52,6 +52,9 @@ export class WidgetCustomTextComponent extends AbstractWidgetComponent implement
   }
 
   public activate() {
+    // load the attachments so that they are displayed in the list;
+    this.resource.grid.updateAttachments();
+
     this.handler.activate();
   }
 

--- a/frontend/src/app/modules/hal/resources/grid-widget-resource.ts
+++ b/frontend/src/app/modules/hal/resources/grid-widget-resource.ts
@@ -27,6 +27,10 @@
 //++
 
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
+import {GridResource} from "core-app/modules/hal/resources/grid-resource";
+import {Attachable} from "core-app/modules/hal/resources/mixins/attachable-mixin";
+import {AttachmentCollectionResource} from "core-app/modules/hal/resources/attachment-collection-resource";
+import {UploadFile} from "core-components/api/op-file-upload/op-file-upload.service";
 
 export class GridWidgetResource extends HalResource {
   public identifier:string;
@@ -44,4 +48,6 @@ export class GridWidgetResource extends HalResource {
   public get width() {
     return this.endColumn - this.startColumn;
   }
+
+  public grid:GridResource;
 }

--- a/frontend/src/app/modules/hal/resources/mixins/attachable-mixin.ts
+++ b/frontend/src/app/modules/hal/resources/mixins/attachable-mixin.ts
@@ -115,7 +115,7 @@ export function Attachable<TBase extends Constructor<HalResource>>(Base:TBase) {
     public uploadAttachments(files:UploadFile[]):Promise<{ response:HalResource, uploadUrl:string }[]> {
       const { uploads, finished } = this.performUpload(files);
 
-      const message = I18n.t('js.label_upload_notification', this);
+      const message = I18n.t('js.label_upload_notification');
       const notification = this.NotificationsService.addAttachmentUpload(message, uploads);
 
       return finished

--- a/lib/api/utilities/property_name_converter.rb
+++ b/lib/api/utilities/property_name_converter.rb
@@ -46,25 +46,7 @@ module API
     # sense in different contexts.
     class PropertyNameConverter
       class << self
-        WELL_KNOWN_AR_TO_API_CONVERSIONS = {
-          assigned_to: 'assignee',
-          fixed_version: 'version',
-          done_ratio: 'percentageDone',
-          estimated_hours: 'estimatedTime',
-          created_on: 'createdAt',
-          updated_on: 'updatedAt',
-          remaining_hours: 'remainingTime',
-          spent_hours: 'spentTime',
-          subproject: 'subprojectId',
-          relation_type: 'type',
-          mail: 'email',
-          column_names: 'columns',
-          is_public: 'public',
-          sort_criteria: 'sortBy',
-          message: 'post'
-        }.freeze
-
-        # Converts the attribute name as refered to by ActiveRecord to a corresponding API-conform
+        # Converts the attribute name as referred to by ActiveRecord to a corresponding API-conform
         # attribute name:
         #  * camelCasing the attribute name
         #  * unifying :status and :status_id to 'status' (and other foo_id fields)
@@ -73,14 +55,14 @@ module API
           attribute = normalize_foreign_key_name attribute
           attribute = expand_custom_field_name attribute
 
-          special_conversion = WELL_KNOWN_AR_TO_API_CONVERSIONS[attribute.to_sym]
+          special_conversion = Constants::ARToAPIConversions.all[attribute.to_sym]
           return special_conversion if special_conversion
 
           # use the generic conversion rules if there is no special conversion
           attribute.camelize(:lower)
         end
 
-        # Converts the attribute name as refered to by the APIv3 to the source name of the attribute
+        # Converts the attribute name as referred to by the APIv3 to the source name of the attribute
         # in ActiveRecord. For that to work properly, an instance of the correct AR-class needs
         # to be passed as context.
         def to_ar_name(attribute, context:, refer_to_ids: false)
@@ -105,7 +87,7 @@ module API
         private
 
         def special_api_to_ar_conversions
-          @api_to_ar_conversions ||= WELL_KNOWN_AR_TO_API_CONVERSIONS.inject({}) do |result, (k, v)|
+          @api_to_ar_conversions ||= Constants::ARToAPIConversions.all.inject({}) do |result, (k, v)|
             result[v.underscore] = k.to_s
             result
           end

--- a/lib/api/v3/news/news_api.rb
+++ b/lib/api/v3/news/news_api.rb
@@ -51,13 +51,13 @@ module API
 
           route_param :id, type: Integer, desc: 'News ID' do
             after_validation do
-              @time_entry = ::News
-                            .visible
-                            .find(params[:id])
+              @news = ::News
+                      .visible
+                      .find(params[:id])
             end
 
             get do
-              NewsRepresenter.create(@time_entry,
+              NewsRepresenter.create(@news,
                                      current_user: current_user,
                                      embed_links: true)
             end

--- a/lib/api/v3/work_packages/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/work_package_payload_representer.rb
@@ -33,36 +33,12 @@ module API
     module WorkPackages
       class WorkPackagePayloadRepresenter < WorkPackageRepresenter
         include ::API::Utilities::PayloadRepresenter
+        include ::API::V3::Attachments::AttachablePayloadRepresenterMixin
 
         cached_representer disabled: true
 
         def writeable_attributes
-          super + %w[date attachments]
-        end
-
-        property :attachments,
-                 exec_context: :decorator,
-                 getter: ->(*) {},
-                 setter: ->(fragment:, **) do
-                   next unless fragment.is_a?(Array)
-
-                   ids = fragment.map do |link|
-                     ::API::Utilities::ResourceLinkParser.parse_id link['href'],
-                                                                   property: :attachment,
-                                                                   expected_version: '3',
-                                                                   expected_namespace: :attachments
-                   end
-
-                   represented.attachment_ids = ids
-                 end,
-                 skip_render: ->(*) { true },
-                 linked_resource: true,
-                 uncacheable: true
-
-        links :attachments do
-          represented.attachments.map do |attachment|
-            { href: api_v3_paths.attachment(attachment.id) }
-          end
+          super + %w[date]
         end
 
         def load_complete_model(model)

--- a/lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb
+++ b/lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb
@@ -61,6 +61,7 @@ module Redmine
             delete_permission: delete_permission(options),
             add_on_new_permission: add_on_new_permission(options),
             add_on_persisted_permission: add_on_persisted_permission(options),
+            only_user_allowed: only_user_allowed(options),
             modification_blocked: options[:modification_blocked]
           }
 
@@ -69,6 +70,7 @@ module Redmine
                           :add_on_new_permission,
                           :add_on_persisted_permission,
                           :add_permission,
+                          :only_user_allowed,
                           :modification_blocked)
         end
 
@@ -86,6 +88,10 @@ module Redmine
 
         def add_on_persisted_permission(options)
           options[:add_on_persisted_permission] || options[:add_permission] || edit_permission_default
+        end
+
+        def only_user_allowed(options)
+          options.fetch(:only_user_allowed, false)
         end
 
         def view_permission_default

--- a/modules/boards/app/models/boards/grid.rb
+++ b/modules/boards/app/models/boards/grid.rb
@@ -37,6 +37,10 @@ module Boards
 
     before_destroy :delete_queries
 
+    set_acts_as_attachable_options view_permission: :show_board_views,
+                                   delete_permission: :manage_board_views,
+                                   add_permission: :manage_board_views
+
     def user_deletable?
       true
     end

--- a/modules/boards/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
+++ b/modules/boards/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
@@ -80,6 +80,7 @@ describe "POST /api/v3/grids/form for Board Grids", type: :request, content_type
           "name": 'foo',
           "options": {},
           "_links": {
+            "attachments": [],
             "scope": {
               'href': project_work_package_boards_path(project),
               "type": "text/html"
@@ -147,6 +148,7 @@ describe "POST /api/v3/grids/form for Board Grids", type: :request, content_type
         {
           name: 'foo',
           "_links": {
+            "attachments": [],
             "scope": {
               'href': project_work_package_boards_path(project),
               "type": "text/html"

--- a/modules/boards/spec/requests/api/v3/grids/grids_update_form_resource_spec.rb
+++ b/modules/boards/spec/requests/api/v3/grids/grids_update_form_resource_spec.rb
@@ -89,6 +89,7 @@ describe "PATCH /api/v3/grids/:id/form for Board Grids", type: :request, content
         widgets: [],
         options: {},
         "_links": {
+          "attachments": [],
           "scope": {
             "href": project_work_package_boards_path(project),
             "type": "text/html"

--- a/modules/dashboards/lib/dashboards/engine.rb
+++ b/modules/dashboards/lib/dashboards/engine.rb
@@ -33,6 +33,12 @@ module Dashboards
       end
     end
 
+    initializer 'dashboards.conversion' do
+      require Rails.root.join('config', 'constants', 'ar_to_api_conversions')
+
+      Constants::ARToAPIConversions.add('grids/dashboard': 'grid')
+    end
+
     config.to_prepare do
       Dashboards::GridRegistration.register!
     end

--- a/modules/dashboards/spec/requests/api/v3/attachments/grid_spec.rb
+++ b/modules/dashboards/spec/requests/api/v3/attachments/grid_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -28,12 +26,19 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Grids
-  class Dashboard < Grid
-    belongs_to :project
+require 'spec_helper'
+require File.join(Rails.root, 'spec', 'requests', 'api', 'v3', 'attachments', 'attachment_resource_shared_examples')
 
-    set_acts_as_attachable_options view_permission: :view_dashboards,
-                                   delete_permission: :manage_dashboards,
-                                   add_permission: :manage_dashboards
+describe "grid attachments" do
+  it_behaves_like "an APIv3 attachment resource" do
+    let(:attachment_type) { :grid }
+
+    let(:create_permission) { :manage_dashboards }
+    let(:read_permission) { :view_dashboards }
+    let(:update_permission) { :manage_dashboards }
+
+    let(:grid) { FactoryBot.create(:dashboard, project: project) }
+
+    let(:missing_permissions_user) { FactoryBot.create(:user) }
   end
 end

--- a/modules/dashboards/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
+++ b/modules/dashboards/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
@@ -104,6 +104,7 @@ describe "POST /api/v3/grids/form for Dashboard Grids", type: :request, content_
           "name": 'foo',
           "options": {},
           "_links": {
+            "attachments": [],
             "scope": {
               'href': project_dashboards_path(project),
               "type": "text/html"
@@ -171,6 +172,7 @@ describe "POST /api/v3/grids/form for Dashboard Grids", type: :request, content_
         {
           name: 'foo',
           "_links": {
+            "attachments": [],
             "scope": {
               'href': project_dashboards_path(project)
             }
@@ -216,6 +218,7 @@ describe "POST /api/v3/grids/form for Dashboard Grids", type: :request, content_
           "name": 'foo',
           "options": {},
           "_links": {
+            "attachments": [],
             "scope": {
               'href': project_dashboards_path(project),
               "type": "text/html"

--- a/modules/grids/app/contracts/grids/base_contract.rb
+++ b/modules/grids/app/contracts/grids/base_contract.rb
@@ -34,6 +34,7 @@ module Grids
   class BaseContract < ::ModelContract
     include OpenProject::StaticRouting::UrlHelpers
     include AssignableValuesContract
+    include ::Attachments::ValidateReplacements
 
     attribute :row_count do
       validate_positive_integer(:row_count)

--- a/modules/grids/app/controllers/api/v3/attachments/attachments_by_grid_api.rb
+++ b/modules/grids/app/controllers/api/v3/attachments/attachments_by_grid_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -28,12 +26,27 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Grids
-  class Dashboard < Grid
-    belongs_to :project
+module API
+  module V3
+    module Attachments
+      class AttachmentsByGridAPI < ::API::OpenProjectAPI
+        resources :attachments do
+          helpers API::V3::Attachments::AttachmentsByContainerAPI::Helpers
 
-    set_acts_as_attachable_options view_permission: :view_dashboards,
-                                   delete_permission: :manage_dashboards,
-                                   add_permission: :manage_dashboards
+          helpers do
+            def container
+              @grid
+            end
+
+            def get_attachment_self_path
+              api_v3_paths.attachments_by_grid container.id
+            end
+          end
+
+          get &API::V3::Attachments::AttachmentsByContainerAPI.read
+          post &API::V3::Attachments::AttachmentsByContainerAPI.create
+        end
+      end
+    end
   end
 end

--- a/modules/grids/app/controllers/api/v3/grids/grids_api.rb
+++ b/modules/grids/app/controllers/api/v3/grids/grids_api.rb
@@ -42,7 +42,7 @@ module API
 
             if query.valid?
               GridCollectionRepresenter.new(query.results,
-                                            api_v3_paths.time_entries,
+                                            api_v3_paths.grids,
                                             grid_scope: query.filter_scope,
                                             page: to_i_or_nil(params[:offset]),
                                             per_page: resolve_page_size(params[:pageSize]),
@@ -69,6 +69,8 @@ module API
               GridRepresenter.new(@grid,
                                   current_user: current_user)
             end
+
+            mount ::API::V3::Attachments::AttachmentsByGridAPI
 
             # Hack to be able to use the Default* mount while having the permission check
             # not affecting the GET request

--- a/modules/grids/app/models/grids/grid.rb
+++ b/modules/grids/app/models/grids/grid.rb
@@ -42,5 +42,7 @@ module Grids
     def user_deletable?
       false
     end
+
+    acts_as_attachable
   end
 end

--- a/modules/grids/app/representers/api/v3/grids/grid_payload_representer.rb
+++ b/modules/grids/app/representers/api/v3/grids/grid_payload_representer.rb
@@ -33,6 +33,9 @@ module API
     module Grids
       class GridPayloadRepresenter < GridRepresenter
         include ::API::Utilities::PayloadRepresenter
+        include ::API::V3::Attachments::AttachablePayloadRepresenterMixin
+
+        cached_representer disabled: true
 
         def widget_representer_class
           Widgets::WidgetPayloadRepresenter

--- a/modules/grids/app/representers/api/v3/grids/grid_representer.rb
+++ b/modules/grids/app/representers/api/v3/grids/grid_representer.rb
@@ -32,6 +32,10 @@ module API
       class GridRepresenter < ::API::Decorators::Single
         include API::Decorators::LinkedResource
         include API::Decorators::DateProperty
+        include API::Caching::CachedRepresenter
+        include ::API::V3::Attachments::AttachableRepresenterMixin
+
+        cached_representer key_parts: %i(widgets)
 
         resource_link :scope,
                       getter: ->(*) {
@@ -52,6 +56,7 @@ module API
 
         link :updateImmediately do
           next unless write_allowed?
+
           {
             href: api_v3_paths.grid(represented.id),
             method: :patch
@@ -60,6 +65,7 @@ module API
 
         link :update do
           next unless write_allowed?
+
           {
             href: api_v3_paths.grid_form(represented.id),
             method: :post

--- a/modules/grids/app/representers/api/v3/grids/widgets/custom_text_options_representer.rb
+++ b/modules/grids/app/representers/api/v3/grids/widgets/custom_text_options_representer.rb
@@ -36,7 +36,7 @@ module API
           formattable_property :text,
                                getter: ->(*) do
                                  ::API::Decorators::Formattable.new(represented[:text],
-                                                                    object: represented,
+                                                                    object: represented[:grid],
                                                                     plain: false)
                                end
         end

--- a/modules/grids/app/services/grids/set_attributes_service.rb
+++ b/modules/grids/app/services/grids/set_attributes_service.rb
@@ -29,6 +29,8 @@
 #++
 
 class Grids::SetAttributesService < ::BaseServices::SetAttributes
+  include Attachments::SetReplacements
+
   private
 
   def set_attributes(attributes)

--- a/modules/grids/app/services/grids/update_service.rb
+++ b/modules/grids/app/services/grids/update_service.rb
@@ -37,6 +37,14 @@ class Grids::UpdateService < ::BaseServices::Update
     super
   end
 
+  def after_save
+    model.touch if only_widgets_updated?
+  end
+
+  def only_widgets_updated?
+    !model.saved_changes? && model.widgets.any?(&:saved_changes?)
+  end
+
   # Changing the scope/type after the grid has been created is prohibited.
   # But we set the value so that an error message can be displayed
   def set_type_for_error_message(scope)

--- a/modules/grids/lib/grids/engine.rb
+++ b/modules/grids/lib/grids/engine.rb
@@ -4,6 +4,10 @@ module Grids
 
     include OpenProject::Plugins::ActsAsOpEngine
 
+    add_api_path :attachments_by_grid do |id|
+      "#{root}/grids/#{id}/attachments"
+    end
+
     config.to_prepare do
       query = Grids::Query
 

--- a/modules/grids/spec/factories/grid_factory.rb
+++ b/modules/grids/spec/factories/grid_factory.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
   factory :grid, class: Grids::Grid do
+    row_count { 5 }
+    column_count { 5 }
   end
 end

--- a/modules/grids/spec/lib/api/v3/utilities/file_helper_spec.rb
+++ b/modules/grids/spec/lib/api/v3/utilities/file_helper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
@@ -28,12 +26,18 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Grids
-  class Dashboard < Grid
-    belongs_to :project
+require 'spec_helper'
 
-    set_acts_as_attachable_options view_permission: :view_dashboards,
-                                   delete_permission: :manage_dashboards,
-                                   add_permission: :manage_dashboards
+describe ::API::V3::Utilities::PathHelper do
+  let(:helper) { Class.new.tap { |c| c.extend(::API::V3::Utilities::PathHelper) }.api_v3_paths }
+
+  context 'attachments paths' do
+    describe '#attachments_by_grid' do
+      subject { helper.attachments_by_grid 1 }
+
+      it 'provides the path' do
+        is_expected.to match('/grids/1/attachments')
+      end
+    end
   end
 end

--- a/modules/grids/spec/models/grids/grid_spec.rb
+++ b/modules/grids/spec/models/grids/grid_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 require_relative './shared_model'
 
 describe Grids::Grid, type: :model do
-  let(:instance) { Grids::Grid.new }
+  let(:instance) { Grids::Grid.new column_count: 5, row_count: 5 }
 
   it_behaves_like 'grid attributes'
 end

--- a/modules/grids/spec/models/grids/shared_model.rb
+++ b/modules/grids/spec/models/grids/shared_model.rb
@@ -74,4 +74,9 @@ shared_examples_for 'grid attributes' do
         .to match_array widgets
     end
   end
+
+  it_behaves_like 'acts_as_attachable included' do
+    let(:model_instance) { instance }
+    let(:project) { FactoryBot.create(:project) }
+  end
 end

--- a/modules/grids/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
+++ b/modules/grids/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
@@ -67,7 +67,9 @@ describe "POST /api/v3/grids/form", type: :request, content_type: :json do
         "columnCount": 5,
         "widgets": [],
         "options": {},
-        "_links": {}
+        "_links": {
+          "attachments": []
+        }
       }
 
       expect(subject.body)

--- a/modules/grids/spec/services/grids/set_attributes_service_spec.rb
+++ b/modules/grids/spec/services/grids/set_attributes_service_spec.rb
@@ -64,7 +64,7 @@ describe Grids::SetAttributesService, type: :model do
   describe 'call' do
     let(:call_attributes) do
       {
-        row_count: 5
+        column_count: 6
       }
     end
 

--- a/modules/grids/spec/services/grids/update_service_spec.rb
+++ b/modules/grids/spec/services/grids/update_service_spec.rb
@@ -76,6 +76,8 @@ describe Grids::UpdateService, type: :model do
     allow(service)
       .to receive(:call)
       .and_return(set_attributes_result)
+
+    service
   end
 
   describe 'call' do
@@ -142,6 +144,30 @@ describe Grids::UpdateService, type: :model do
 
     context 'with parameters' do
       let(:call_attributes) { { row_count: 5 } }
+
+      it_behaves_like 'service call'
+    end
+
+    context 'with parameters only for widgets' do
+      let(:call_attributes) { { widgets: [FactoryBot.build_stubbed(:grid_widget)] } }
+
+      before do
+        allow(set_attributes_service)
+          .to receive(:call) do |params|
+            grid.widgets.build(params[:widgets].first.attributes)
+
+            allow(grid.widgets.last)
+              .to receive(:saved_changes?)
+              .and_return(true)
+
+            if set_attributes_success && grid_valid
+              expect(grid)
+                .to receive(:touch)
+            end
+
+            set_attributes_result
+          end
+      end
 
       it_behaves_like 'service call'
     end

--- a/modules/my_page/app/models/grids/my_page.rb
+++ b/modules/my_page/app/models/grids/my_page.rb
@@ -31,5 +31,15 @@
 module Grids
   class MyPage < Grid
     belongs_to :user
+
+    # The requirement on view_project is more or less arbitrary.
+    # We need a permission here and view_project is a public one so everybody
+    # should have it.
+    # In the long run it would be better to have a global permission to
+    # maintain a my page.
+    set_acts_as_attachable_options view_permission: :view_project,
+                                   delete_permission: :view_project,
+                                   add_permission: :view_project,
+                                   only_user_allowed: true
   end
 end

--- a/modules/my_page/lib/my_page/engine.rb
+++ b/modules/my_page/lib/my_page/engine.rb
@@ -7,5 +7,11 @@ module MyPage
     config.to_prepare do
       MyPage::GridRegistration.register!
     end
+
+    initializer 'my_page.conversion' do
+      require Rails.root.join('config', 'constants', 'ar_to_api_conversions')
+
+      Constants::ARToAPIConversions.add('grids/my_page': 'grid')
+    end
   end
 end

--- a/modules/my_page/lib/my_page/grid_registration.rb
+++ b/modules/my_page/lib/my_page/grid_registration.rb
@@ -3,14 +3,15 @@ module MyPage
     grid_class 'Grids::MyPage'
     to_scope :my_page_path
 
-    widgets 'work_packages_assigned',
+    widgets 'custom_text',
+            'documents',
+            'work_packages_assigned',
             'work_packages_accountable',
             'work_packages_watched',
             'work_packages_created',
             'work_packages_calendar',
             'work_packages_table',
             'time_entries_current_user',
-            'documents',
             'news'
 
     wp_table_strategy_proc = Proc.new do
@@ -26,6 +27,14 @@ module MyPage
     widget_strategy 'work_packages_accountable', &wp_table_strategy_proc
     widget_strategy 'work_packages_watched', &wp_table_strategy_proc
     widget_strategy 'work_packages_created', &wp_table_strategy_proc
+
+    widget_strategy 'custom_text' do
+      # Requiring a permission here as one is required to assign attachments.
+      # Should be replaced by a global permission to have a my page
+      allowed ->(user, _project) { user.allowed_to_globally?(:view_project) }
+
+      options_representer '::API::V3::Grids::Widgets::CustomTextOptionsRepresenter'
+    end
 
     defaults -> {
       {

--- a/modules/my_page/spec/features/my/custom_text_spec.rb
+++ b/modules/my_page/spec/features/my/custom_text_spec.rb
@@ -1,0 +1,123 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+require_relative '../../support/pages/my/page'
+
+describe 'Custom text widget on my page', type: :feature, js: true do
+  let(:permissions) do
+    []
+  end
+  let(:project) { FactoryBot.create(:project) }
+
+  let(:role) do
+    FactoryBot.create(:role, permissions: permissions)
+  end
+
+  let(:user) do
+    FactoryBot.create(:user, member_in_project: project, member_with_permissions: permissions)
+  end
+  let(:other_user) do
+    FactoryBot.create(:user, member_in_project: project, member_with_permissions: permissions)
+  end
+  let(:my_page) do
+    Pages::My::Page.new
+  end
+  let(:image_fixture) { Rails.root.join('spec/fixtures/files/image.png') }
+  let(:editor) { ::Components::WysiwygEditor.new 'body' }
+  let(:field) { WorkPackageEditorField.new(page, 'description', selector: '.wp-inline-edit--active-field') }
+
+  before do
+    login_as user
+
+    my_page.visit!
+  end
+
+  it 'can add the widget set custom text and upload attachments' do
+    my_page.add_column(3, before_or_after: :before)
+
+    sleep(0.1)
+
+    my_page.add_widget(2, 3, "Custom text")
+
+    sleep(0.1)
+
+    # As the user lacks the manage_public_queries and save_queries permission, no other widget is present
+    custom_text_widget = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(1)')
+
+    custom_text_widget.expect_to_span(2, 3, 5, 5)
+    custom_text_widget.resize_to(6, 5)
+
+    custom_text_widget.expect_to_span(2, 3, 7, 6)
+
+    within custom_text_widget.area do
+      find('.inplace-editing--trigger-container').click
+
+      field.set_value('My own little text')
+      field.save!
+
+      expect(page)
+        .to have_selector('.wp-edit-field--display-field', text: 'My own little text')
+
+      find('.inplace-editing--trigger-container').click
+
+      field.set_value('My new text')
+      field.cancel_by_click
+
+      expect(page)
+        .to have_selector('.wp-edit-field--display-field', text: 'My own little text')
+
+      # adding an image
+      find('.inplace-editing--trigger-container').click
+
+      sleep(0.1)
+    end
+
+    # The drag_attachment is written in a way that it requires to be executed with page on body
+    # so we cannot have it wrapped in the within block.
+    editor.drag_attachment image_fixture, 'Image uploaded'
+
+    within custom_text_widget.area do
+      expect(page).to have_selector('attachment-list-item', text: 'image.png')
+      expect(page).to have_no_selector('notifications-upload-progress')
+
+      field.save!
+
+      expect(page)
+        .to have_selector('#content img', count: 1)
+
+      expect(page)
+        .to have_no_selector('attachment-list-item', text: 'image.png')
+    end
+
+    # ensure no one but the page's user can see the uploaded attachment
+    expect(Attachment.last.visible?(other_user))
+      .to be_falsey
+  end
+end

--- a/modules/my_page/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
+++ b/modules/my_page/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
@@ -114,6 +114,7 @@ describe "POST /api/v3/grids/form", type: :request, content_type: :json do
             }
           ],
           "_links": {
+            "attachments": [],
             "scope": {
               "href": "/my/page",
               "type": "text/html"

--- a/modules/my_page/spec/requests/api/v3/grids/grids_update_form_resource_spec.rb
+++ b/modules/my_page/spec/requests/api/v3/grids/grids_update_form_resource_spec.rb
@@ -100,6 +100,7 @@ describe "PATCH /api/v3/grids/:id/form", type: :request, content_type: :json do
           }
         ],
         "_links": {
+          "attachments": [],
           "scope": {
             "href": "/my/page",
             "type": "text/html"

--- a/spec/models/wiki_page_spec.rb
+++ b/spec/models/wiki_page_spec.rb
@@ -36,11 +36,12 @@ describe WikiPage, type: :model do
   it_behaves_like 'acts_as_watchable included' do
     let(:model_instance) { FactoryBot.create(:wiki_page) }
     let(:watch_permission) { :view_wiki_pages }
-    let(:project) { model_instance.wiki.project }
+    let(:project) { model_instance.project }
   end
 
   it_behaves_like 'acts_as_attachable included' do
     let(:model_instance) { FactoryBot.create(:wiki_page_with_content) }
+    let(:project) { model_instance.project }
   end
 
   describe '#create' do

--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -4,7 +4,6 @@ module Components
     include RSpec::Matchers
     attr_reader :context_selector, :attachments
 
-
     def initialize(context = '#content')
       @context_selector = context
       @attachments = ::Components::Attachments.new
@@ -86,7 +85,6 @@ module Components
         # Besides testing caption functionality this also slows down clicking on the submit button
         # so that the image is properly embedded
         editable.all('figure').each do |figure|
-
           # Locate image within figure
           # Click on image to show figcaption
           img = figure.find('img')
@@ -108,7 +106,7 @@ module Components
       warn "Failed to refocus on first editor element #{e}"
     end
 
-  def insert_link(link)
+    def insert_link(link)
       click_toolbar_button 'Link (Ctrl+K)'
       page.find('.ck-input-text').set link
       page.find('.ck-button-save').click

--- a/spec/support/shared/acts_as_attachable.rb
+++ b/spec/support/shared/acts_as_attachable.rb
@@ -29,6 +29,7 @@
 shared_examples_for 'acts_as_attachable included' do
   let(:attachment1) { FactoryBot.create(:attachment, container: nil, author: current_user) }
   let(:attachment2) { FactoryBot.create(:attachment, container: nil, author: current_user) }
+  let(:instance_project) { respond_to?(:project) ? project : model_instance.project }
   let(:add_permission_user) do
     permission = if model_instance.persisted?
                    Array(described_class.attachable_options[:add_on_persisted_permission])
@@ -36,12 +37,12 @@ shared_examples_for 'acts_as_attachable included' do
                    Array(described_class.attachable_options[:add_on_new_permission])
                  end
     FactoryBot.create(:user,
-                      member_in_project: model_instance.project,
+                      member_in_project: instance_project,
                       member_with_permissions: permission)
   end
   let(:no_permission_user) do
     FactoryBot.create(:user,
-                      member_in_project: model_instance.project,
+                      member_in_project: instance_project,
                       member_with_permissions: [])
   end
   let(:other_user) do


### PR DESCRIPTION
Allows grids to be attachable. This is employed to have images in custom text widgets.

https://community.openproject.com/projects/openproject/work_packages/30525

### TODOS

* [x] define permissions for other grids (my_page, boards)
* [x] double check grid set attributes service so that attachments are only saved when the whole of the changes is accepted. Possibly, extract code from work packages which does that.