### PR TITLE
Feature/disable grid editing when unpermitted

### DIFF
--- a/frontend/src/app/modules/grids/grid/add-widget.service.ts
+++ b/frontend/src/app/modules/grids/grid/add-widget.service.ts
@@ -25,7 +25,8 @@ export class GridAddWidgetService {
     return !this.drag.currentlyDragging &&
       !this.resize.currentlyResizing &&
       this.layout.mousedOverArea === area &&
-      this.layout.gridAreaIds.includes(area.guid);
+      this.layout.gridAreaIds.includes(area.guid) &&
+      this.isAllowed;
   }
 
   public widget(area:GridArea, schema:SchemaResource) {
@@ -104,5 +105,9 @@ export class GridAddWidgetService {
         resolve(resource);
       });
     });
+  }
+
+  private get isAllowed() {
+    return this.layout.gridResource.updateImmediately;
   }
 }

--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -244,6 +244,10 @@ export class GridAreaService {
     this.numColumns = this.resource.columnCount;
   }
 
+  public get isEditable() {
+    return this.gridResource.updateImmediately !== undefined;
+  }
+
   private buildGridAreaIds() {
     return this.gridAreas.map((area) => {
       return area.guid;

--- a/frontend/src/app/modules/grids/grid/drag-and-drop.service.ts
+++ b/frontend/src/app/modules/grids/grid/drag-and-drop.service.ts
@@ -55,6 +55,10 @@ export class GridDragAndDropService {
     return this.currentlyDragging && this.draggedArea!.guid === area.guid;
   }
 
+  public get isDraggable() {
+    return this.layout.isEditable;
+  }
+
   public start(area:GridWidgetArea) {
     this.draggedArea = area;
     this.placeholderArea = new GridWidgetArea(area.widget);

--- a/frontend/src/app/modules/grids/grid/grid.component.html
+++ b/frontend/src/app/modules/grids/grid/grid.component.html
@@ -1,6 +1,7 @@
 
 <!-- Column headers -->
 <div class="grid--column-headers"
+     *ngIf="isHeadersDisplayed"
      [style.grid-template-columns]="gridColumnStyle">
   <div *ngFor="let column of columnNumbers"
        [style.grid-row-start]="1"
@@ -15,6 +16,7 @@
 
 <!-- Row headers -->
 <div class="grid--row-headers"
+     *ngIf="isHeadersDisplayed"
      [style.grid-template-rows]="gridRowStyle">
   <div *ngFor="let row of rowNumbers"
        [style.grid-row-start]="row"
@@ -48,7 +50,8 @@
          (cdkDragStarted)="drag.start(area)"
          (cdkDragEnded)="drag.stop(area, $event)">
 
-      <span class="grid--area-drag-handle
+      <span *ngIf="drag.isDraggable"
+            class="grid--area-drag-handle
                    icon
                    icon-drag-handle"
             cdkDragHandle></span>
@@ -59,7 +62,7 @@
                    [ndcDynamicOutputs]="widgetComponentOutput(area)">
       </ndc-dynamic>
     </div>
-    <resizer *ngIf="!drag.currentlyDragging"
+    <resizer *ngIf="resize.isResizable"
              (end)="resize.end(area, $event)"
              (start)="resize.start(area)"
              (move)="resize.moving($event)">

--- a/frontend/src/app/modules/grids/grid/grid.component.ts
+++ b/frontend/src/app/modules/grids/grid/grid.component.ts
@@ -111,4 +111,8 @@ export class GridComponent implements OnDestroy, OnInit {
   public identifyGridArea(index:number, area:GridArea) {
     return area.guid;
   }
+
+  public get isHeadersDisplayed() {
+    return this.layout.isEditable;
+  }
 }

--- a/frontend/src/app/modules/grids/grid/resize.service.ts
+++ b/frontend/src/app/modules/grids/grid/resize.service.ts
@@ -4,6 +4,7 @@ import {GridArea} from "core-app/modules/grids/areas/grid-area";
 import {ResizeDelta} from "core-app/modules/common/resizer/resizer.component";
 import {GridAreaService} from "core-app/modules/grids/grid/area.service";
 import {GridMoveService} from "core-app/modules/grids/grid/move.service";
+import {GridDragAndDropService} from "core-app/modules/grids/grid/drag-and-drop.service";
 
 @Injectable()
 export class GridResizeService {
@@ -12,7 +13,8 @@ export class GridResizeService {
   private targetIds:string[];
 
   constructor(readonly layout:GridAreaService,
-              readonly move:GridMoveService) { }
+              readonly move:GridMoveService,
+              readonly drag:GridDragAndDropService) { }
 
   public end(area:GridWidgetArea, deltas:ResizeDelta) {
     if (!this.placeholderArea ||
@@ -68,5 +70,13 @@ export class GridResizeService {
 
   public get currentlyResizing() {
     return this.placeholderArea;
+  }
+
+  public get isResizable() {
+    return !this.drag.currentlyDragging && this.isAllowed;
+  }
+
+  private get isAllowed() {
+    return this.layout.gridResource.updateImmediately;
   }
 }

--- a/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.html
+++ b/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.html
@@ -8,6 +8,17 @@
   </widget-menu>
 </widget-header>
 
+<ng-template #text>
+  <span class="inplace-edit--read-value -default">
+    <span
+        *ngIf="!textEmpty"
+        [innerHTML]="customText"></span>
+    <span
+        *ngIf="textEmpty"
+        [innerHTML]="placeholderText"></span>
+  </span>
+</ng-template>
+
 <div class="grid--widget-content -custom-text">
   <div class="wp-edit-field inplace-edit">
     <edit-form-portal *ngIf="active"
@@ -24,20 +35,19 @@
     <div *ngIf="!active"
          class="inplace-edit--read">
       <accessible-by-keyboard
+          *ngIf="isTextEditable"
           class="inplace-editing--trigger-container"
           [spanClass]="inplaceEditClasses"
           [linkClass]="'inplace-editing--trigger-link'"
           (execute)="activate()">
 
-          <span class="inplace-edit--read-value -default">
-            <span
-                *ngIf="!textEmpty"
-                [innerHTML]="customText"></span>
-            <span
-                *ngIf="textEmpty"
-                [innerHTML]="placeholderText"></span>
-          </span>
+        <ng-container *ngTemplateOutlet="text"></ng-container>
       </accessible-by-keyboard>
+
+
+      <ng-container *ngIf="!isTextEditable">
+        <ng-container *ngTemplateOutlet="text"></ng-container>
+      </ng-container>
     </div>
   </div>
 </div>

--- a/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.ts
+++ b/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.ts
@@ -5,6 +5,7 @@ import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {filter} from 'rxjs/operators';
+import {GridAreaService} from "core-app/modules/grids/grid/area.service";
 
 @Component({
   templateUrl: './custom-text.component.html',
@@ -19,7 +20,8 @@ export class WidgetCustomTextComponent extends AbstractWidgetComponent implement
   constructor (protected i18n:I18nService,
                protected injector:Injector,
                public handler:CustomTextEditFieldService,
-               protected cdr:ChangeDetectorRef) {
+               protected cdr:ChangeDetectorRef,
+               protected layout:GridAreaService) {
     super(i18n, injector);
   }
 
@@ -90,6 +92,10 @@ export class WidgetCustomTextComponent extends AbstractWidgetComponent implement
 
   public get textEmpty() {
     return !this.customText;
+  }
+
+  public get isTextEditable() {
+    return this.layout.isEditable;
   }
 
   private memorizeRawText() {

--- a/frontend/src/app/modules/grids/widgets/header/header.component.html
+++ b/frontend/src/app/modules/grids/widgets/header/header.component.html
@@ -5,6 +5,7 @@
 
   <editable-toolbar-title [title]="name"
                           (onSave)="renamed($event)"
+                          [editable]="isRenameable"
                           class="widget-box--header-title">
   </editable-toolbar-title>
 

--- a/frontend/src/app/modules/grids/widgets/header/header.component.ts
+++ b/frontend/src/app/modules/grids/widgets/header/header.component.ts
@@ -27,6 +27,7 @@
 // ++
 
 import {Component, ChangeDetectionStrategy, Input, EventEmitter, Output} from '@angular/core';
+import {GridAreaService} from "core-app/modules/grids/grid/area.service";
 
 @Component({
   selector: 'widget-header',
@@ -39,11 +40,19 @@ export class WidgetHeaderComponent {
   @Input() icon:string;
   @Output() onRenamed = new EventEmitter<string>();
 
+  constructor(readonly layout:GridAreaService) {
+
+  }
+
   public renamed(name:string) {
     this.onRenamed.emit(name);
   }
 
   public get iconClass() {
     return `icon-${this.icon}`;
+  }
+
+  public get isRenameable() {
+    return this.layout.isEditable;
   }
 }

--- a/frontend/src/app/modules/grids/widgets/menu/widget-abstract-menu.component.ts
+++ b/frontend/src/app/modules/grids/widgets/menu/widget-abstract-menu.component.ts
@@ -31,6 +31,7 @@ import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {OpContextMenuItem} from "core-components/op-context-menu/op-context-menu.types";
 import {GridWidgetResource} from "core-app/modules/hal/resources/grid-widget-resource";
 import {GridRemoveWidgetService} from "core-app/modules/grids/grid/remove-widget.service";
+import {GridAreaService} from "core-app/modules/grids/grid/area.service";
 
 export abstract class WidgetAbstractMenuComponent {
   @Input() resource:GridWidgetResource;
@@ -38,7 +39,8 @@ export abstract class WidgetAbstractMenuComponent {
   protected menuItemList:OpContextMenuItem[] = [this.removeItem];
 
   constructor(readonly i18n:I18nService,
-              protected readonly remove:GridRemoveWidgetService) {
+              protected readonly remove:GridRemoveWidgetService,
+              protected readonly layout:GridAreaService) {
   }
 
   public get menuItems() {
@@ -55,5 +57,9 @@ export abstract class WidgetAbstractMenuComponent {
         return true;
       }
     };
+  }
+
+  public get hasMenu() {
+    return this.layout.isEditable;
   }
 }

--- a/frontend/src/app/modules/grids/widgets/menu/widget-menu.component.html
+++ b/frontend/src/app/modules/grids/widgets/menu/widget-menu.component.html
@@ -1,3 +1,4 @@
 <icon-triggered-context-menu
+    *ngIf="hasMenu"
     [menu-items]="menuItems">
 </icon-triggered-context-menu>

--- a/frontend/src/app/modules/grids/widgets/menu/widget-menu.component.ts
+++ b/frontend/src/app/modules/grids/widgets/menu/widget-menu.component.ts
@@ -26,11 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-import {Component, Input} from '@angular/core';
-import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
-import {OpContextMenuItem} from "core-components/op-context-menu/op-context-menu.types";
-import {GridWidgetResource} from "core-app/modules/hal/resources/grid-widget-resource";
-import {GridRemoveWidgetService} from "core-app/modules/grids/grid/remove-widget.service";
+import {Component} from '@angular/core';
 import {WidgetAbstractMenuComponent} from "core-app/modules/grids/widgets/menu/widget-abstract-menu.component";
 
 @Component({

--- a/frontend/src/app/modules/grids/widgets/menu/wp-set-menu.component.ts
+++ b/frontend/src/app/modules/grids/widgets/menu/wp-set-menu.component.ts
@@ -34,6 +34,7 @@ import {OpModalComponent} from "core-components/op-modals/op-modal.component";
 import {ComponentType} from '@angular/cdk/portal';
 import {WidgetAbstractMenuComponent} from "core-app/modules/grids/widgets/menu/widget-abstract-menu.component";
 import {WpGraphConfigurationModalComponent} from "core-app/modules/work-package-graphs/configuration-modal/wp-graph-configuration.modal";
+import {GridAreaService} from "core-app/modules/grids/grid/area.service";
 
 export abstract class WidgetWpSetMenuComponent extends WidgetAbstractMenuComponent {
   protected configurationComponent:ComponentType<OpModalComponent>;
@@ -49,9 +50,11 @@ export abstract class WidgetWpSetMenuComponent extends WidgetAbstractMenuCompone
   constructor(private readonly injector:Injector,
               private readonly opModalService:OpModalService,
               readonly i18n:I18nService,
-              protected readonly remove:GridRemoveWidgetService) {
-    super(i18n,
-      remove);
+              protected readonly remove:GridRemoveWidgetService,
+              readonly layout:GridAreaService) {
+  super(i18n,
+        remove,
+        layout);
   }
 
   protected get configureItem() {

--- a/modules/boards/spec/requests/api/v3/grids/grids_resource_spec.rb
+++ b/modules/boards/spec/requests/api/v3/grids/grids_resource_spec.rb
@@ -56,7 +56,6 @@ describe 'API v3 Grids resource for Board Grids', type: :request, content_type: 
   let(:other_board_grid) do
     FactoryBot.create(:board_grid, project: other_project)
   end
-  let(:before_hook) { nil }
 
   before do
     login_as(current_user)
@@ -74,8 +73,6 @@ describe 'API v3 Grids resource for Board Grids', type: :request, content_type: 
 
     before do
       stored_grids
-
-      before_hook&.call
 
       get path
     end
@@ -172,15 +169,10 @@ describe 'API v3 Grids resource for Board Grids', type: :request, content_type: 
     end
 
     context 'with the scope not existing' do
-      let(:path) { api_v3_paths.grid(5) }
-      let(:before_hook) do
-        ->(*) do
-          expect_any_instance_of(::Grids::Query)
-            .to receive(:find)
-            .with(1234)
-            .and_raise(ActiveRecord::RecordNotFound)
-        end
+      let(:stored_grids) do
       end
+
+      let(:path) { api_v3_paths.grid(5) }
 
       it 'responds with 404 NOT FOUND' do
         expect(subject.status).to eql 404
@@ -189,7 +181,6 @@ describe 'API v3 Grids resource for Board Grids', type: :request, content_type: 
 
     context 'when lacking permission to see the grid' do
       let(:stored_grids) do
-        manage_board_views_grid
         other_board_grid
       end
 

--- a/modules/dashboards/spec/factories/grid_factory.rb
+++ b/modules/dashboards/spec/factories/grid_factory.rb
@@ -15,4 +15,27 @@ FactoryBot.define do
       ]
     end
   end
+
+  factory :dashboard_with_table, class: Grids::Dashboard do
+    project
+    row_count { 7 }
+    column_count { 4 }
+
+    callback(:after_build) do |dashboard|
+      query = FactoryBot.create(:query, project: dashboard.project, hidden: true, is_public: true)
+
+      widget = FactoryBot.build(:grid_widget,
+                                identifier: 'work_packages_table',
+                                start_row: 1,
+                                end_row: 7,
+                                start_column: 1,
+                                end_column: 3,
+                                options: {
+                                  name: 'Work package table',
+                                  queryId: query.id
+                                })
+
+      dashboard.widgets = [widget]
+    end
+  end
 end

--- a/modules/dashboards/spec/factories/grid_factory.rb
+++ b/modules/dashboards/spec/factories/grid_factory.rb
@@ -38,4 +38,25 @@ FactoryBot.define do
       dashboard.widgets = [widget]
     end
   end
+
+  factory :dashboard_with_custom_text, class: Grids::Dashboard do
+    project
+    row_count { 7 }
+    column_count { 4 }
+
+    callback(:after_build) do |dashboard|
+      widget = FactoryBot.build(:grid_widget,
+                                identifier: 'custom_text',
+                                start_row: 1,
+                                end_row: 7,
+                                start_column: 1,
+                                end_column: 3,
+                                options: {
+                                  name: 'Custom text',
+                                  text: 'Lorem ipsum'
+                                })
+
+      dashboard.widgets = [widget]
+    end
+  end
 end

--- a/modules/dashboards/spec/features/modifying_with_unallowed_spec.rb
+++ b/modules/dashboards/spec/features/modifying_with_unallowed_spec.rb
@@ -1,0 +1,95 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+require_relative '../support/pages/dashboard'
+
+describe 'Modifying a dashboard which already has widgets for which permissions are lacking', type: :feature, js: true do
+  let!(:project) do
+    FactoryBot.create :project
+  end
+
+  let(:permissions) do
+    %i[view_dashboards
+       manage_dashboards]
+  end
+
+  let(:user) do
+    FactoryBot.create(:user, member_in_project: project, member_with_permissions: permissions)
+  end
+  let!(:dashboard) do
+    FactoryBot.create(:dashboard_with_table, project: project)
+  end
+  let(:dashboard_page) do
+    Pages::Dashboard.new(project)
+  end
+  let!(:news) do
+    FactoryBot.create :news,
+                      project: project
+  end
+
+  before do
+    login_as user
+
+    dashboard_page.visit!
+  end
+
+  it 'can add and modify widgets' do
+    dashboard_page.add_widget(1, dashboard.column_count - 1, "News")
+
+    sleep(0.1)
+
+    news_widget = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(2)')
+
+    within news_widget.area do
+      expect(page)
+        .to have_content(news.title)
+    end
+
+    visit root_path
+
+    dashboard_page.visit!
+
+    news_widget = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(2)')
+
+    within news_widget.area do
+      expect(page)
+        .to have_content(news.title)
+    end
+
+    news_widget.remove
+
+    visit root_path
+
+    dashboard_page.visit!
+
+    expect(page)
+      .to have_no_selector('.grid--area.-widgeted:nth-of-type(2)')
+  end
+end

--- a/modules/dashboards/spec/features/read_only_allowed_spec.rb
+++ b/modules/dashboards/spec/features/read_only_allowed_spec.rb
@@ -1,0 +1,94 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+require_relative '../support/pages/dashboard'
+
+describe 'Read only mode when user lacks edit permission on dashboard', type: :feature, js: true do
+  let!(:type) { FactoryBot.create :type }
+  let!(:project) { FactoryBot.create :project, types: [type] }
+  let!(:work_package) do
+    FactoryBot.create :work_package,
+                      project: project,
+                      type: type,
+                      author: user,
+                      responsible: user
+  end
+  let!(:dashboard) do
+    FactoryBot.create(:dashboard_with_table, project: project)
+  end
+
+  let(:permissions) do
+    %i[view_work_packages
+       add_work_packages
+       save_queries
+       manage_public_queries
+       view_dashboards]
+  end
+
+  let(:role) do
+    FactoryBot.create(:role, permissions: permissions)
+  end
+
+  let(:user) do
+    FactoryBot.create(:user).tap do |u|
+      FactoryBot.create(:member, project: project, user: u, roles: [role])
+    end
+  end
+  let(:dashboard_page) do
+    Pages::Dashboard.new(project)
+  end
+
+  before do
+    login_as user
+
+    dashboard_page.visit!
+  end
+
+  it 'can not modify the dashboard but can still use it' do
+    dashboard_page.expect_unable_to_add_widget(dashboard.row_count, dashboard.column_count)
+
+    dashboard_page.expect_no_headers
+
+    table_widget = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(1)')
+
+    table_widget.expect_not_resizable
+
+    table_widget.expect_not_draggable
+
+    table_widget.expect_not_renameable
+
+    table_widget.expect_no_menu
+
+    within table_widget.area do
+      expect(page)
+        .to have_content(work_package.subject)
+    end
+  end
+end

--- a/modules/grids/app/contracts/grids/base_contract.rb
+++ b/modules/grids/app/contracts/grids/base_contract.rb
@@ -86,7 +86,7 @@ module Grids
     def validate_registered_widgets
       return unless config.registered_grid?(grid_class)
 
-      undestroyed_widgets.each do |widget|
+      widgets_to_be_created.each do |widget|
         next if config.allowed_widget?(grid_class, widget.identifier, user, grid_project)
 
         errors.add(:widgets, :inclusion)
@@ -179,6 +179,10 @@ module Grids
 
     def undestroyed_widgets
       model.widgets.reject(&:marked_for_destruction?)
+    end
+
+    def widgets_to_be_created
+      undestroyed_widgets.select(&:new_record?)
     end
 
     def all_allowed_widget_identifiers(user)

--- a/modules/grids/spec/contracts/grids/shared_examples.rb
+++ b/modules/grids/spec/contracts/grids/shared_examples.rb
@@ -31,11 +31,12 @@
 shared_context 'grid contract' do
   let(:user) { FactoryBot.build_stubbed(:user) }
   let(:instance) { described_class.new(grid, user) }
+  let(:widgets) { [] }
   let(:default_values) do
     {
       row_count: 6,
       column_count: 7,
-      widgets: []
+      widgets: widgets
     }
   end
   let(:grid) do
@@ -126,6 +127,81 @@ shared_examples_for 'shared grid contract attributes' do
       it 'is invalid for the grid superclass itself' do
         expect(instance.errors.details[:scope])
           .to match_array [{ error: :inclusion }]
+      end
+    end
+  end
+
+  describe 'widgets' do
+    before do
+      allow(Grids::Configuration)
+        .to receive(:writable?)
+        .and_return(true)
+
+      allow(Grids::Configuration)
+        .to receive(:registered_grid?)
+        .with(Grids::Grid)
+        .and_return(true)
+
+      allow(Grids::Configuration)
+        .to receive(:allowed_widget?)
+        .with(Grids::Grid, 'widget1', user, nil)
+        .and_return(true)
+
+      allow(Grids::Configuration)
+        .to receive(:allowed_widget?)
+        .with(Grids::Grid, 'widget2', user, nil)
+        .and_return(false)
+    end
+
+    context 'if there are new widgets that are not allowed' do
+      let(:widgets) do
+        [Grids::Widget.new(identifier: 'widget2', start_row: 1, end_row: 3, start_column: 1, end_column: 3)]
+      end
+
+      it 'notes the error' do
+        instance.validate
+
+        expect(instance.errors.details[:widgets])
+          .to match_array [{ error: :inclusion }]
+      end
+    end
+
+    context 'if there are new widgets that are allowed' do
+      let(:widgets) do
+        [Grids::Widget.new(identifier: 'widget1', start_row: 1, end_row: 3, start_column: 1, end_column: 3)]
+      end
+
+      it 'is valid' do
+        expect(instance.validate)
+          .to be_truthy
+      end
+    end
+
+    context 'if there are new widgets that are not allowed but marked for destruction' do
+      let(:widgets) do
+        widget = Grids::Widget.new(identifier: 'widget2', start_row: 1, end_row: 3, start_column: 1, end_column: 3)
+
+        allow(widget)
+          .to receive(:marked_for_destruction?)
+          .and_return(true)
+
+        [widget]
+      end
+
+      it 'is valid' do
+        expect(instance.validate)
+          .to be_truthy
+      end
+    end
+
+    context 'if there are existing widgets that are not allowed' do
+      let(:widgets) do
+        [FactoryBot.build_stubbed(:grid_widget, identifier: 'widget2', start_row: 1, end_row: 3, start_column: 1, end_column: 3)]
+      end
+
+      it 'is valid' do
+        expect(instance.validate)
+          .to be_truthy
       end
     end
   end

--- a/modules/grids/spec/support/pages/grid.rb
+++ b/modules/grids/spec/support/pages/grid.rb
@@ -65,14 +65,17 @@ module Pages
       end
     end
 
-    def expect_unable_to_add_widget(row_number, column_number, name)
-      within_add_widget_modal(row_number, column_number) do
-        expect(page)
-          .to have_content(I18n.t('js.grid.add_modal.choose_widget'))
-
-        expect(page)
-          .not_to have_selector('.grid--addable-widget', text: Regexp.new("^#{name}$"))
+    def expect_unable_to_add_widget(row_number, column_number, name = nil)
+      if name
+        expect_specific_widget_unaddable(row_number, column_number, name)
+      else
+        expect_widget_adding_prohibited_generally(row_number, column_number)
       end
+    end
+
+    def expect_no_headers
+      expect(page)
+        .to have_no_selector('.grid--header')
     end
 
     def area_of(row_number, column_number)
@@ -88,6 +91,24 @@ module Pages
 
       within '.op-modal--portal' do
         yield
+      end
+    end
+
+    def expect_widget_adding_prohibited_generally(row_number = 1, column_number = 1)
+      area = area_of(row_number, column_number)
+      area.hover
+
+      expect(area)
+        .to have_no_selector('.grid--widget-add')
+    end
+
+    def expect_specific_widget_unaddable(row_number, column_number, name)
+      within_add_widget_modal(row_number, column_number) do
+        expect(page)
+          .to have_content(I18n.t('js.grid.add_modal.choose_widget'))
+
+        expect(page)
+          .not_to have_selector('.grid--addable-widget', text: Regexp.new("^#{name}$"))
       end
     end
   end

--- a/spec/support/components/grids/grid_area.rb
+++ b/spec/support/components/grids/grid_area.rb
@@ -65,6 +65,38 @@ module Components
         end
       end
 
+      def expect_not_resizable
+        within area do
+          expect(page)
+            .to have_no_selector('.grid--area.-widgeted resizer')
+        end
+      end
+
+      def expect_not_draggable
+        area.hover
+
+        within area do
+          expect(page)
+            .to have_no_selector(".grid--area-drag-handle")
+        end
+      end
+
+      def expect_not_renameable
+        within area do
+          expect(page)
+            .to have_selector(".editable-toolbar-title--fixed")
+        end
+      end
+
+      def expect_no_menu
+        area.hover
+
+        within area do
+          expect(page)
+            .to have_no_selector(".icon-show-more-horizontal")
+        end
+      end
+
       def area
         page.find(*area_selector)
       end


### PR DESCRIPTION
Disables editing UI elements on a grid when the user is lacking edit permissions. 

https://community.openproject.com/projects/openproject/work_packages/30530

Also handles the case where a user having permission to add a widget (e.g. work_packages_table) might have added the widget and later on a user lacking those permissions is adding other widgets. This used to break as all undestroyed widgets where checked. Now, only `new_record?`s are checked.