### PR TITLE
[28472] Fix user mention for new work packages by setting _type

### DIFF
--- a/frontend/src/app/modules/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/modules/hal/resources/work-package-resource.ts
@@ -278,6 +278,9 @@ export class WorkPackageBaseResource extends HalResource {
     this.form = Promise.resolve(form);
     this.$source.id = 'new';
 
+    // Ensure type is set to identify the resource
+    this._type = 'WorkPackage';
+
     // Since the ID will change upon saving, keep track of the WP
     // with the actual creation date
     this.__initialized_at = Date.now();


### PR DESCRIPTION
CKEditor mention requires the passed resource to be of `_type === 'WorkPackage'`. This is set for all existing work packages but the form payload does not contain it.

Thus we need to set it explicitly for new work packages

https://community.openproject.com/wp/28472