### PR TITLE
[30742] Users and permissions tile in the administration should link to the users table instead of the user settings

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -130,7 +130,7 @@ Redmine::MenuManager.map :admin_menu do |menu|
             first: true
 
   menu.push :users_and_permissions,
-            { controller: '/users_settings' },
+            { controller: '/users' },
             caption: :label_user_and_permission,
             icon: 'icon2 icon-group'
 


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/30742/activity