### PR TITLE
[29836] Rename "Move" to "Change project" in WP context menu

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -63,6 +63,7 @@ en:
     button_back_to_list_view: "Back to list view"
     button_cancel: "Cancel"
     button_close: "Close"
+    button_change_project: "Change project"
     button_check_all: "Check all"
     button_configure-form: "Configure form"
     button_confirm: "Confirm"
@@ -80,7 +81,6 @@ en:
     button_show_view: "Fullscreen view"
     button_log_time: "Log time"
     button_more: "More"
-    button_move: "Move"
     button_open_details: "Open details view"
     button_close_details: "Close details view"
     button_open_fullscreen: "Open fullscreen view"
@@ -642,7 +642,7 @@ en:
       image: "Image"
     work_packages:
       bulk_actions:
-        move: 'Bulk move'
+        move: 'Bulk change of project'
         edit: 'Bulk edit'
         copy: 'Bulk copy'
         delete: 'Bulk delete'

--- a/frontend/src/app/components/op-context-menu/wp-context-menu/wp-static-context-menu-actions.ts
+++ b/frontend/src/app/components/op-context-menu/wp-context-menu/wp-static-context-menu-actions.ts
@@ -5,7 +5,8 @@ export const PERMITTED_CONTEXT_MENU_ACTIONS = [
     resource: 'workPackage'
   },
   {
-    key: 'move',
+    key: 'change_project',
+    icon: 'icon-move',
     link: 'move',
     resource: 'workPackage'
   },

--- a/spec/features/work_packages/bulk/move_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/move_work_package_spec.rb
@@ -74,7 +74,7 @@ describe 'Moving a work package through Rails view', js: true do
         expect(child_wp.project_id).to eq(project.id)
 
         context_menu.open_for work_package
-        context_menu.choose 'Move'
+        context_menu.choose 'Change project'
 
         # On work packages move page
         expect(page).to have_selector('#new_project_id')
@@ -117,7 +117,7 @@ describe 'Moving a work package through Rails view', js: true do
 
       it 'does not allow to move' do
         context_menu.open_for work_package
-        context_menu.expect_no_options 'Move'
+        context_menu.expect_no_options 'Change project'
       end
     end
   end
@@ -134,7 +134,7 @@ describe 'Moving a work package through Rails view', js: true do
 
       it 'does allow to move' do
         context_menu.open_for work_package, false
-        context_menu.expect_options ['Bulk move']
+        context_menu.expect_options ['Bulk change of project']
       end
     end
 
@@ -143,7 +143,7 @@ describe 'Moving a work package through Rails view', js: true do
 
       it 'does not allow to move' do
         context_menu.open_for work_package, false
-        context_menu.expect_no_options ['Bulk move']
+        context_menu.expect_no_options ['Bulk change of project']
       end
     end
   end

--- a/spec/features/work_packages/table/context_menu_spec.rb
+++ b/spec/features/work_packages/table/context_menu_spec.rb
@@ -47,7 +47,7 @@ describe 'Work package table context menu', js: true do
 
         # Open Move
         goto_context_menu list_view
-        menu.choose('Move')
+        menu.choose('Change project')
         expect(page).to have_selector('h2', text: I18n.t(:button_move))
         expect(page).to have_selector('a.issue', text: "##{work_package.id}")
 
@@ -100,7 +100,7 @@ describe 'Work package table context menu', js: true do
 
         menu.open_for(work_package, list_view)
         menu.expect_options ['Open details view', 'Open fullscreen view',
-                             'Bulk edit', 'Bulk copy', 'Bulk move', 'Bulk delete']
+                             'Bulk edit', 'Bulk copy', 'Bulk change of project', 'Bulk delete']
       end
     end
   end


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/29836/activity