### PR TITLE
auto height for grid-areas

### DIFF
--- a/app/assets/stylesheets/content/_grid.sass
+++ b/app/assets/stylesheets/content/_grid.sass
@@ -5,8 +5,8 @@ $grid--header-width: 20px
 
 @mixin grid--commons
   display: grid
-  grid-column-gap: $grid--gap-width
-  grid-row-gap: $grid--gap-width
+  //grid-column-gap: $grid--gap-width
+  //grid-row-gap: $grid--gap-width
 
 .grid--container
   @include grid--commons
@@ -51,6 +51,12 @@ $grid--header-width: 20px
 
   &.-undragged
     pointer-events: none
+
+  &.-row-gap
+    height: $grid--gap-width
+
+  &.-column-gap
+    width: $grid--gap-width
 
   .resizer
     margin-top: 0
@@ -162,6 +168,9 @@ $grid--header-width: 20px
   &:before
     @include icon-font-common
     @include icon-mixin-add
+
+  .-column-gap &, .-row-gap &
+    padding: 5px
 
 .grid--widget-remove
   float: right

--- a/app/assets/stylesheets/content/_grid.sass
+++ b/app/assets/stylesheets/content/_grid.sass
@@ -13,6 +13,7 @@ $grid--header-width: 20px
 
 .grid--area
   overflow: hidden
+  min-height: 30px
 
   &.-drop-target
     background-color: $gray-light
@@ -47,6 +48,9 @@ $grid--header-width: 20px
 
   &.-dragged
     display: none
+
+  &.-undragged
+    pointer-events: none
 
   .resizer
     margin-top: 0
@@ -173,12 +177,6 @@ $grid--header-width: 20px
 .grid--column-headers
   @include grid--commons
   grid-template-rows: $grid--header-width
-
-.grid--row-headers
-  @include grid--commons
-  grid-template-columns: $grid--header-width
-  float: left
-  margin-left: -$grid--header-width
 
 .grid--header
   background-color: $gray-light

--- a/app/assets/stylesheets/content/_grid.sass
+++ b/app/assets/stylesheets/content/_grid.sass
@@ -28,7 +28,7 @@ $grid--header-width: 20px
     padding: 20px
 
     .widget-box
-      height: 100%
+      min-height: 200px
 
     &:hover icon-triggered-context-menu
       visibility: visible

--- a/frontend/src/app/modules/grids/areas/grid-widget-area.ts
+++ b/frontend/src/app/modules/grids/areas/grid-widget-area.ts
@@ -5,10 +5,10 @@ export class GridWidgetArea extends GridArea {
   public widget:GridWidgetResource;
 
   constructor(widget:GridWidgetResource) {
-    super(widget.startRow,
-      widget.endRow,
-      widget.startColumn,
-      widget.endColumn);
+    super(widget.startRow * 2,
+      widget.endRow * 2 - 1,
+      widget.startColumn * 2,
+      widget.endColumn * 2 - 1);
 
     this.widget = widget;
   }

--- a/frontend/src/app/modules/grids/areas/grid-widget-area.ts
+++ b/frontend/src/app/modules/grids/areas/grid-widget-area.ts
@@ -57,9 +57,9 @@ export class GridWidgetArea extends GridArea {
   }
 
   public writeAreaChangeToWidget() {
-    this.widget.startRow = this.startRow;
-    this.widget.endRow = this.endRow;
-    this.widget.startColumn = this.startColumn;
-    this.widget.endColumn = this.endColumn;
+    this.widget.startRow = this.startRow / 2;
+    this.widget.endRow = (this.endRow + 1) / 2;
+    this.widget.startColumn = this.startColumn / 2;
+    this.widget.endColumn = (this.endColumn + 1) / 2;
   }
 }

--- a/frontend/src/app/modules/grids/areas/grid-widget-area.ts
+++ b/frontend/src/app/modules/grids/areas/grid-widget-area.ts
@@ -13,6 +13,13 @@ export class GridWidgetArea extends GridArea {
     this.widget = widget;
   }
 
+  public reset() {
+    this.startRow = this.widget.startRow * 2;
+    this.endRow = this.widget.endRow * 2 - 1;
+    this.startColumn = this.widget.startColumn * 2;
+    this.endColumn = this.widget.endColumn * 2 - 1;
+  }
+
   public moveRight() {
     this.startColumn++;
     this.endColumn++;

--- a/frontend/src/app/modules/grids/grid/add-widget.service.ts
+++ b/frontend/src/app/modules/grids/grid/add-widget.service.ts
@@ -27,16 +27,10 @@ export class GridAddWidgetService {
     return !this.drag.currentlyDragging &&
       !this.resize.currentlyResizing &&
       this.layout.mousedOverArea === area &&
-      this.layout.gridAreaIds.includes(area.guid) &&
       this.isAllowed;
   }
 
   public widget(area:GridArea, schema:SchemaResource) {
-    //let targetArea = area;
-    //if (this.layout.isGap(targetArea)) {
-
-    //}
-
     this
       .select(area, schema)
       .then((widgetResource) => {

--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -40,6 +40,18 @@ export class GridAreaService {
     this.mousedOverArea = area;
   }
 
+  public cleanupUnusedAreas() {
+    let unusedRows = Array.from(Array(this.numRows + 1).keys()).slice(1);
+
+    this.widgetAreas.forEach(widgetArea => {
+      unusedRows = unusedRows.filter(item => item !== widgetArea.startRow);
+    });
+
+    unusedRows.forEach(number => {
+      this.removeRow(number);
+    });
+  }
+
   public buildAreas(save = true) {
     this.gridAreas = this.buildGridAreas();
     this.gridAreaIds = this.buildGridAreaIds();

--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -77,6 +77,10 @@ export class GridAreaService {
     this.saveGrid(payload);
   }
 
+  public isGap(area:GridArea) {
+    return area.startRow % 2 === 1 || area.startColumn % 2 === 1;
+  }
+
   private saveGrid(resource:GridWidgetResource|any, schema?:SchemaResource) {
     this
       .gridDm
@@ -109,23 +113,8 @@ export class GridAreaService {
   private buildGridAreas() {
     let cells:GridArea[] = [];
 
-    for (let row = 1; row <= this.numRows; row++) {
+    for (let row = 1; row <= this.numRows * 2 + 1; row++) {
       cells.push(...this.buildGridAreasRow(row));
-    }
-
-    return cells;
-  }
-
-  private buildGridAreasColumn(column:number) {
-    let cells:GridArea[] = [];
-
-    for (let row = 1; row <= this.numRows; row++) {
-      let cell = new GridArea(row,
-        row + 1,
-        column,
-        column + 1);
-
-      cells.push(cell);
     }
 
     return cells;
@@ -134,7 +123,7 @@ export class GridAreaService {
   private buildGridAreasRow(row:number) {
     let cells:GridArea[] = [];
 
-    for (let column = 1; column <= this.numColumns; column++) {
+    for (let column = 1; column <= this.numColumns * 2 + 1; column++) {
       let cell = new GridArea(row,
         row + 1,
         column,

--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -41,14 +41,16 @@ export class GridAreaService {
   }
 
   public cleanupUnusedAreas() {
-    let unusedRows = Array.from(Array(this.numRows + 1).keys()).slice(1);
+    let unusedRows = Array.from(Array(this.numRows * 2 + 1).keys()).slice(1);
 
     this.widgetAreas.forEach(widgetArea => {
       unusedRows = unusedRows.filter(item => item !== widgetArea.startRow);
     });
 
     unusedRows.forEach(number => {
-      this.removeRow(number);
+      if (number % 2 !== 1) {
+        this.removeRow(number);
+      }
     });
   }
 
@@ -162,7 +164,7 @@ export class GridAreaService {
     this.buildAreas();
   }
 
-  public addRow(row:number) {
+  public addRow(row:number, build = true) {
     this.numRows++;
 
     this.widgetResources.filter((widget) => {
@@ -172,7 +174,9 @@ export class GridAreaService {
       widget.endRow++;
     });
 
-    this.buildAreas();
+    if (build) {
+      this.buildAreas();
+    }
   }
 
   public removeColumn(column:number) {
@@ -264,6 +268,7 @@ export class GridAreaService {
 
   public removeWidget(removedWidget:GridWidgetResource) {
     this.resource.widgets = this.widgetResources.filter((widget) => widget.id !== removedWidget.id );
+    this.cleanupUnusedAreas();
   }
 
   public get widgetResources() {

--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -238,12 +238,7 @@ export class GridAreaService {
   public resetAreas(ignoredArea:GridWidgetArea|null = null) {
     this.widgetAreas.filter((area) => {
       return !ignoredArea || area.guid !== ignoredArea.guid;
-    }).forEach((area) => {
-      area.startRow = area.widget.startRow;
-      area.endRow = area.widget.endRow;
-      area.startColumn = area.widget.startColumn;
-      area.endColumn = area.widget.endColumn;
-    });
+    }).forEach(area => area.reset());
 
     this.numRows = this.resource.rowCount;
     this.numColumns = this.resource.columnCount;
@@ -254,9 +249,10 @@ export class GridAreaService {
   }
 
   private buildGridAreaIds() {
-    return this.gridAreas.map((area) => {
-      return area.guid;
-    });
+    return this
+      .gridAreas
+      .filter(area => !this.isGap(area))
+      .map((area) => area.guid);
   }
 
   private fetchSchema() {

--- a/frontend/src/app/modules/grids/grid/drag-and-drop.service.ts
+++ b/frontend/src/app/modules/grids/grid/drag-and-drop.service.ts
@@ -96,6 +96,7 @@ export class GridDragAndDropService {
       draggedArea.endColumn = dropArea.startColumn + draggedArea.widget.width;
     }
 
+    this.layout.cleanupUnusedAreas();
     this.layout.writeAreaChangesToWidgets();
     this.layout.buildAreas();
   }

--- a/frontend/src/app/modules/grids/grid/drag-and-drop.service.ts
+++ b/frontend/src/app/modules/grids/grid/drag-and-drop.service.ts
@@ -16,7 +16,7 @@ export class GridDragAndDropService {
   }
 
   public entered(event:CdkDragEnter<GridArea>) {
-    if (this.draggedArea) {
+    if (this.draggedArea && !this.layout.isGap(event.container.data)) {
       let dropArea = event.container.data;
       this.layout.resetAreas(this.draggedArea);
       this.moveAreasOnDragging(dropArea);
@@ -30,19 +30,7 @@ export class GridDragAndDropService {
     let widgetArea = this.draggedArea!;
 
     // we cannot use the widget's original area as moving it while dragging confuses cdkDrag
-    this.placeholderArea.startRow = dropArea.startRow;
-    if (this.placeholderArea.startRow + this.placeholderArea.widget.height > this.layout.numRows + 1) {
-      this.placeholderArea.endRow = this.layout.numRows + 1;
-    } else {
-      this.placeholderArea.endRow = dropArea.startRow + this.placeholderArea.widget.height;
-    }
-
-    this.placeholderArea.startColumn = dropArea.startColumn;
-    if (this.placeholderArea.startColumn + this.placeholderArea.widget.width > this.layout.numColumns + 1) {
-      this.placeholderArea.endColumn = this.layout.numColumns + 1;
-    } else {
-      this.placeholderArea.endColumn = dropArea.startColumn + this.placeholderArea.widget.width;
-    }
+    this.copyPositionButRestrict(dropArea, this.placeholderArea);
 
     this.move.down(this.placeholderArea, widgetArea);
   }
@@ -82,23 +70,27 @@ export class GridDragAndDropService {
     // to the drop zone ones.
     // The dragged Area should keep it's height and width normally but will
     // shrink if the area would otherwise end outside the grid.
-    draggedArea.startRow = dropArea.startRow;
-    if (dropArea.startRow + draggedArea.widget.height > this.layout.numRows + 1) {
-      draggedArea.endRow = this.layout.numRows + 1;
-    } else {
-      draggedArea.endRow = dropArea.startRow + draggedArea.widget.height;
-    }
-
-    draggedArea.startColumn = dropArea.startColumn;
-    if (dropArea.startColumn + draggedArea.widget.width > this.layout.numColumns + 1) {
-      draggedArea.endColumn = this.layout.numColumns + 1;
-    } else {
-      draggedArea.endColumn = dropArea.startColumn + draggedArea.widget.width;
-    }
+    this.copyPositionButRestrict(dropArea, draggedArea);
 
     this.layout.cleanupUnusedAreas();
     this.layout.writeAreaChangesToWidgets();
     this.layout.buildAreas();
+  }
+
+  private copyPositionButRestrict(source:GridArea, sink:GridWidgetArea) {
+    sink.startRow = source.startRow;
+    if (source.startRow + sink.widget.height > this.layout.numRows * 2 + 1) {
+      sink.endRow = this.layout.numRows + 1;
+    } else {
+      sink.endRow = source.startRow + sink.widget.height;
+    }
+
+    sink.startColumn = source.startColumn;
+    if (source.startColumn + sink.widget.width > this.layout.numColumns * 2 + 1) {
+      sink.endColumn = this.layout.numColumns + 1;
+    } else {
+      sink.endColumn = source.startColumn + sink.widget.width;
+    }
   }
 
 }

--- a/frontend/src/app/modules/grids/grid/grid.component.html
+++ b/frontend/src/app/modules/grids/grid/grid.component.html
@@ -42,7 +42,7 @@
   <!-- One grid area per cell (row x columns) -->
   <div *ngFor="let area of layout.gridAreas; trackBy: identifyGridArea;"
        class="grid--area"
-       [ngClass] = "{'-drop-target': drag.currentlyDragging,
+       [ngClass] = "{'-drop-target': drag.currentlyDragging && !layout.isGap(area),
                      '-resize-target': resize.isTarget(area),
                      '-addable': add.isAddable(area),
                      '-row-gap': area.startRow % 2 === 1,

--- a/frontend/src/app/modules/grids/grid/grid.component.html
+++ b/frontend/src/app/modules/grids/grid/grid.component.html
@@ -1,19 +1,3 @@
-
-<!-- Column headers -->
-<div class="grid--column-headers"
-     *ngIf="isHeadersDisplayed"
-     [style.grid-template-columns]="gridColumnStyle">
-  <div *ngFor="let column of columnNumbers"
-       [style.grid-row-start]="1"
-       [style.grid-row-end]="1"
-       [style.grid-column-start]="column"
-       [style.grid-column-end]="column + 1"
-       class="grid--header"
-       gridColumnContextMenu
-       [gridColumnContextMenu-columnNumber]="column">
-  </div>
-</div>
-
 <div class="grid--container"
      [style.grid-template-columns]="gridColumnStyle"
      [style.grid-template-rows]="gridRowStyle">
@@ -60,7 +44,9 @@
        class="grid--area"
        [ngClass] = "{'-drop-target': drag.currentlyDragging,
                      '-resize-target': resize.isTarget(area),
-                     '-addable': add.isAddable(area) }"
+                     '-addable': add.isAddable(area),
+                     '-row-gap': area.startRow % 2 === 1,
+                     '-column-gap': area.startColumn % 2 === 1}"
        [style.grid-row-start]="area.startRow"
        [style.grid-row-end]="area.endRow"
        [style.grid-column-start]="area.startColumn"
@@ -73,7 +59,7 @@
        (cdkDropListEntered)="drag.entered($event)"
        [cdkDropListConnectedTo]="layout.gridAreaIds">
     <div class="grid--widget-add"
-         *ngIf="add.isAddable(area)"
+         *ngIf="add.isAddable(area) && !(area.startRow % 2 === 1 && area.startColumn % 2 === 1)"
          (click)="add.widget(area, layout.schema)">
     </div>
   </div>

--- a/frontend/src/app/modules/grids/grid/grid.component.html
+++ b/frontend/src/app/modules/grids/grid/grid.component.html
@@ -14,21 +14,6 @@
   </div>
 </div>
 
-<!-- Row headers -->
-<div class="grid--row-headers"
-     *ngIf="isHeadersDisplayed"
-     [style.grid-template-rows]="gridRowStyle">
-  <div *ngFor="let row of rowNumbers"
-       [style.grid-row-start]="row"
-       [style.grid-row-end]="row + 1"
-       [style.grid-column-start]="1"
-       [style.grid-column-end]="2"
-       class="grid--header"
-       gridRowContextMenu
-       [gridRowContextMenu-rowNumber]="row">
-  </div>
-</div>
-
 <div class="grid--container"
      [style.grid-template-columns]="gridColumnStyle"
      [style.grid-template-rows]="gridRowStyle">
@@ -36,7 +21,8 @@
   <!-- Grid areas that have a widget in them -->
   <div *ngFor="let area of layout.widgetAreas; trackBy: identifyGridArea;"
        class="grid--area -widgeted"
-       [ngClass]="{'-dragged': drag.isDragged(area)}"
+       [ngClass]="{'-dragged': drag.isDragged(area),
+                   '-undragged': drag.currentlyDragging && !drag.isDragged(area)}"
        [style.grid-row-start]="area.startRow"
        [style.grid-row-end]="area.endRow"
        [style.grid-column-start]="area.startColumn"

--- a/frontend/src/app/modules/grids/grid/grid.component.ts
+++ b/frontend/src/app/modules/grids/grid/grid.component.ts
@@ -92,7 +92,14 @@ export class GridComponent implements OnDestroy, OnInit {
   }
 
   public get gridColumnStyle() {
-    return this.sanitization.bypassSecurityTrustStyle(`repeat(${this.layout.numColumns}, 1fr)`);
+    let style = '';
+    for (let i = 0; i < this.layout.numColumns; i++) {
+      style += '20px 1fr ';
+    }
+
+    style += '20px';
+
+    return this.sanitization.bypassSecurityTrustStyle(style);
   }
 
   // array containing Numbers from 1 to this.numColumns
@@ -101,7 +108,7 @@ export class GridComponent implements OnDestroy, OnInit {
   }
 
   public get gridRowStyle() {
-    return this.sanitization.bypassSecurityTrustStyle(`repeat(${this.layout.numRows}, ${this.GRID_AREA_HEIGHT}px)`);
+    return this.sanitization.bypassSecurityTrustStyle(`repeat(${this.layout.numRows}, ${this.GRID_AREA_HEIGHT})`);
   }
 
   public get rowNumbers() {

--- a/frontend/src/app/modules/grids/grid/grid.component.ts
+++ b/frontend/src/app/modules/grids/grid/grid.component.ts
@@ -42,7 +42,7 @@ export interface WidgetRegistration {
 })
 export class GridComponent implements OnDestroy, OnInit {
   public uiWidgets:ComponentRef<any>[] = [];
-  public GRID_AREA_HEIGHT = 100;
+  public GRID_AREA_HEIGHT = 'auto';
 
   public component = WidgetWpGraphComponent;
 

--- a/frontend/src/app/modules/grids/grid/move.service.ts
+++ b/frontend/src/app/modules/grids/grid/move.service.ts
@@ -41,11 +41,11 @@ export class GridMoveService {
 
       let areaHeight = toMoveArea.widget.height;
 
-      toMoveArea.startRow = anchorArea.endRow;
-      toMoveArea.endRow = toMoveArea.startRow + areaHeight;
+      toMoveArea.startRow = anchorArea.endRow + 1;
+      toMoveArea.endRow = toMoveArea.startRow + areaHeight + 1;
 
-      if (this.layout.numRows < toMoveArea.endRow - 1) {
-        this.layout.numRows = toMoveArea.endRow - 1;
+      if (this.layout.numRows < toMoveArea.endRow - 2) {
+        this.layout.numRows = toMoveArea.endRow - 2;
       }
 
       return toMoveArea;

--- a/frontend/src/app/modules/grids/grid/resize.service.ts
+++ b/frontend/src/app/modules/grids/grid/resize.service.ts
@@ -38,12 +38,12 @@ export class GridResizeService {
 
     let resizeTargets = this.layout.gridAreas.filter((area) => {
       return area.startRow >= this.placeholderArea!.startRow &&
-        area.startColumn >= this.placeholderArea!.startColumn;
+        area.startColumn >= this.placeholderArea!.startColumn &&
+        !this.layout.isGap(area);
     });
 
-    this.targetIds = resizeTargets.map((area) => {
-      return area.guid;
-    });
+    this.targetIds = resizeTargets
+                     .map(area => area.guid);
   }
 
   public moving(deltas:ResizeDelta) {

--- a/frontend/src/app/modules/grids/grid/resize.service.ts
+++ b/frontend/src/app/modules/grids/grid/resize.service.ts
@@ -26,6 +26,7 @@ export class GridResizeService {
     this.resizedArea.endColumn = this.placeholderArea.endColumn;
 
     this.layout.writeAreaChangesToWidgets();
+    this.layout.cleanupUnusedAreas();
     this.layout.buildAreas();
 
     this.resizedArea = null;

--- a/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.html
@@ -11,6 +11,5 @@
 
 <wp-embedded-table [queryId]="queryId"
                    [configuration]="configuration"
-                   [externalHeight]="true"
                    *ngIf="queryId">
 </wp-embedded-table>

--- a/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.ts
+++ b/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.ts
@@ -25,12 +25,6 @@ export class WidgetWpTableComponent extends AbstractWidgetComponent {
   public inFlight = false;
   public query$:Observable<QueryResource>;
 
-  // An heuristic based on paddings, margins, the widget header height and the pagination height
-  private static widgetSpaceOutsideTable:number = 230;
-  private static wpLineHeight:number = 40;
-  private static gridAreaHeight:number = 100;
-  private static gridAreaSpace:number = 20;
-
   public configuration:Partial<WorkPackageTableConfiguration> = {
     actionsColumnEnabled: false,
     columnMenuEnabled: false,
@@ -75,25 +69,10 @@ export class WidgetWpTableComponent extends AbstractWidgetComponent {
       ).subscribe((query) => {
       this.ensureFormAndSaveQuery(query);
     });
-
-    this.configuration.forcePerPageOption = this.perPageOption;
   }
 
   public static get identifier():string {
     return 'work_packages_table';
-  }
-
-  private get perPageOption():number|false {
-    if (this.resource) {
-      let numberOfRows = this.resource.height;
-      let availableHeight = numberOfRows * WidgetWpTableComponent.gridAreaHeight +
-        (numberOfRows - 1) * WidgetWpTableComponent.gridAreaSpace;
-      let perPageOption:number = Math.floor((availableHeight - WidgetWpTableComponent.widgetSpaceOutsideTable) / WidgetWpTableComponent.wpLineHeight);
-
-      return perPageOption < 1 ? 1 : perPageOption;
-    } else {
-      return false;
-    }
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
This is a spike to evaluate replacing the fixed height rows by an automatic row height. The benefits of this approach is that it guarantees displaying the whole contents of each widget. This comes at the cost of possibly additional white space in the same row with less contents. But as this is the more common approach to a grid like representation, I find that drawback acceptable.

This spike is not intended for merging. 