### PR TITLE
[30675] Don't reload table when switching between layouts

### DIFF
--- a/frontend/src/app/components/op-context-menu/handlers/wp-view-dropdown-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/wp-view-dropdown-menu.directive.ts
@@ -94,10 +94,10 @@ export class WorkPackageViewDropdownMenuDirective extends OpContextMenuTrigger {
         linkText: this.I18n.t('js.views.timeline'),
         icon: 'icon-view-timeline',
         onClick: (evt:any) => {
-          this.wpDisplayRepresentationService.setDisplayRepresentation(wpDisplayListRepresentation);
           if (!this.wpTableTimeline.isVisible) {
             this.wpTableTimeline.toggle();
           }
+          this.wpDisplayRepresentationService.setDisplayRepresentation(wpDisplayListRepresentation);
           return true;
         }
       }

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -107,6 +107,7 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
               readonly cdRef:ChangeDetectorRef,
               readonly pathHelper:PathHelperService,
               readonly wpTableSelection:WorkPackageViewSelectionService,
+              readonly wpViewOrder:WorkPackageViewOrderService,
               readonly cardView:WorkPackageCardViewService,
               readonly cardDragDrop:WorkPackageCardDragAndDropService) {
   }
@@ -131,7 +132,7 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
       filter(([results, query]) => results && !this.causedUpdates.includes(query))
     ).subscribe(([results, query]) => {
       this.query = query;
-      this.workPackages = results.elements;
+      this.workPackages = this.wpViewOrder.orderedWorkPackages();
       this.cardView.updateRenderedCardsValues(this.workPackages);
       this.isResultEmpty = this.workPackages.length === 0;
       this.cdRef.detectChanges();

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-display-representation.service.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-display-representation.service.ts
@@ -58,7 +58,8 @@ export class WorkPackageViewDisplayRepresentationService extends WorkPackageQuer
   public applyToQuery(query:QueryResource) {
     const current = this.current;
     query.displayRepresentation = current === null ? undefined : current;
-    return true;
+
+    return false;
   }
 
   public get current():string|null {

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-order.service.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-order.service.ts
@@ -193,7 +193,7 @@ export class WorkPackageViewOrderService extends WorkPackageQueryStateService<Qu
    * Return ordered work packages
    */
   orderedWorkPackages():WorkPackageResource[] {
-    const upstreamOrder = this.currentQuery.results.elements;
+    const upstreamOrder = this.querySpace.results.value!.elements;
 
     if (this.currentQuery.persisted || this.positions.isPristine()) {
       return upstreamOrder;

--- a/spec/support/pages/work_packages/work_package_cards.rb
+++ b/spec/support/pages/work_packages/work_package_cards.rb
@@ -37,6 +37,16 @@ module Pages
       @project = project
     end
 
+    def expect_work_package_order(*ids)
+      retry_block do
+        rows = page.all '.wp-card'
+        expected = ids.map { |el| el.is_a?(WorkPackage) ? el.id.to_s : el.to_s }
+        found = rows.map { |el| el['data-work-package-id'] }
+
+        raise "Order is incorrect: #{found.inspect} != #{expected.inspect}" unless found == expected
+      end
+    end
+
     def open_full_screen_by_doubleclick(work_package)
       loading_indicator_saveguard
       page.driver.browser.action.double_click(card(work_package).native).perform


### PR DESCRIPTION
All information is present so we don't need to reload the results.
Also, ensure we re-use the manual sort order if it was overridden

https://community.openproject.com/wp/30675