### PR TITLE
[30761] Fix changed table.container no longer containing timeline

### DIFF
--- a/frontend/src/app/components/wp-edit-form/table-row-edit-context.ts
+++ b/frontend/src/app/components/wp-edit-form/table-row-edit-context.ts
@@ -140,6 +140,6 @@ export class TableRowEditContext implements WorkPackageEditContext {
   }
 
   private get rowContainer() {
-    return jQuery(this.table.container).find(`.${this.classIdentifier}-table`);
+    return jQuery(this.table.tableAndTimelineContainer).find(`.${this.classIdentifier}-table`);
   }
 }

--- a/frontend/src/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-builder.ts
@@ -72,7 +72,7 @@ export class GroupedRowsBuilder extends RowsBuilder {
     const rendered = this.querySpace.rendered.value!;
     const builder = new GroupHeaderBuilder(this.injector);
 
-    jQuery(this.workPackageTable.container)
+    jQuery(this.workPackageTable.tableAndTimelineContainer)
       .find(`.${rowGroupClassName}`)
       .each((i:number, oldRow:Element) => {
       let groupIndex = jQuery(oldRow).data('groupIndex');

--- a/frontend/src/app/components/wp-fast-table/handlers/cell/edit-cell-handler.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/cell/edit-cell-handler.ts
@@ -30,7 +30,7 @@ export class EditCellHandler extends ClickOrEnterHandler implements TableEventHa
   }
 
   public eventScope(table:WorkPackageTable) {
-    return jQuery(table.container);
+    return jQuery(table.tableAndTimelineContainer);
   }
 
   constructor(public readonly injector:Injector, table:WorkPackageTable) {

--- a/frontend/src/app/components/wp-fast-table/handlers/cell/relations-cell-handler.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/cell/relations-cell-handler.ts
@@ -21,7 +21,7 @@ export class RelationsCellHandler extends ClickOrEnterHandler implements TableEv
   }
 
   public eventScope(table:WorkPackageTable) {
-    return jQuery(table.container);
+    return jQuery(table.tableAndTimelineContainer);
   }
 
   constructor(public readonly injector:Injector,

--- a/frontend/src/app/components/wp-fast-table/handlers/context-menu/context-menu-handler.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/context-menu/context-menu-handler.ts
@@ -22,7 +22,7 @@ export abstract class ContextMenuHandler implements TableEventHandler {
   public abstract get SELECTOR():string;
 
   public eventScope(table:WorkPackageTable) {
-    return jQuery(table.container);
+    return jQuery(table.tableAndTimelineContainer);
   }
 
   public abstract handleEvent(table:WorkPackageTable, evt:JQueryEventObject):boolean;

--- a/frontend/src/app/components/wp-fast-table/handlers/context-menu/context-menu-rightclick-handler.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/context-menu/context-menu-rightclick-handler.ts
@@ -25,6 +25,10 @@ export class ContextMenuRightClickHandler extends ContextMenuHandler {
     return `.${tableRowClassName},.${timelineCellClassName}`;
   }
 
+  public eventScope(table:WorkPackageTable) {
+    return jQuery(table.tableAndTimelineContainer);
+  }
+
   public handleEvent(table:WorkPackageTable, evt:JQueryEventObject):boolean {
     if (!table.configuration.contextMenuEnabled) {
       return false;

--- a/frontend/src/app/components/wp-fast-table/handlers/row/wp-state-links-handler.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/row/wp-state-links-handler.ts
@@ -32,7 +32,7 @@ export class WorkPackageStateLinksHandler implements TableEventHandler {
   }
 
   public eventScope(table:WorkPackageTable) {
-    return jQuery(table.container);
+    return jQuery(table.tableAndTimelineContainer);
   }
 
   protected workPackage:WorkPackageResource;

--- a/frontend/src/app/components/wp-fast-table/handlers/state/drag-and-drop-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/drag-and-drop-transformer.ts
@@ -54,7 +54,7 @@ export class DragAndDropTransformer {
 
     this.dragService.register({
       dragContainer: this.table.tbody,
-      scrollContainers: [this.table.container],
+      scrollContainers: [this.table.scrollContainer],
       accepts: () => true,
       moves: (el:any, source:any, handle:HTMLElement) => {
         if (!handle.classList.contains('wp-table--drag-and-drop-handle')) {

--- a/frontend/src/app/components/wp-fast-table/handlers/state/selection-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/selection-transformer.ts
@@ -57,7 +57,7 @@ export class SelectionTransformer {
    * Update all currently visible rows to match the selection state.
    */
   private renderSelectionState(state:WorkPackageViewSelectionState) {
-    const context = jQuery(this.table.container);
+    const context = jQuery(this.table.tableAndTimelineContainer);
 
     context.find(`.${tableRowClassName}.${checkedClassName}`).removeClass(checkedClassName);
 

--- a/frontend/src/app/components/wp-fast-table/handlers/state/timeline-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/timeline-transformer.ts
@@ -27,7 +27,7 @@ export class TimelineTransformer {
    * Update all currently visible rows to match the selection state.
    */
   private renderVisibility(visible:boolean) {
-    const container = jQuery(this.table.container).parent();
+    const container = jQuery(this.table.tableAndTimelineContainer).parent();
     container.find('.work-packages-tabletimeline--timeline-side').toggle(visible);
     container.find('.work-packages-tabletimeline--table-side').toggleClass('-timeline-visible', visible);
   }

--- a/frontend/src/app/components/wp-fast-table/wp-fast-table.ts
+++ b/frontend/src/app/components/wp-fast-table/wp-fast-table.ts
@@ -47,7 +47,8 @@ export class WorkPackageTable {
   public editing:WorkPackageTableEditingContext = new WorkPackageTableEditingContext(this, this.injector);
 
   constructor(public readonly injector:Injector,
-              public container:HTMLElement,
+              public tableAndTimelineContainer:HTMLElement,
+              public scrollContainer:HTMLElement,
               public tbody:HTMLElement,
               public timelineBody:HTMLElement,
               public timelineController:WorkPackageTimelineTableController,

--- a/frontend/src/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/src/app/components/wp-table/wp-table.directive.ts
@@ -185,10 +185,24 @@ export class WorkPackagesTableController implements OnInit, OnDestroy {
     this.wpTableHoverSync.deactivate();
   }
 
-  public registerTimeline(controller:WorkPackageTimelineTableController, body:HTMLElement) {
+  public registerTimeline(controller:WorkPackageTimelineTableController, timelineBody:HTMLElement) {
     const tbody = this.$element.find('.work-package--results-tbody');
     const scrollContainer = this.$element.find('.work-package-table--container')[0];
-    this.workPackageTable = new WorkPackageTable(this.injector, scrollContainer, tbody[0], body, controller, this.configuration);
+    this.workPackageTable = new WorkPackageTable(
+      this.injector,
+      // Outer container for both table + Timeline
+      this.$element[0],
+      // Scroll container for the table/timeline
+      scrollContainer,
+      // Table tbody to insert into
+      tbody[0],
+      // Timeline body to insert into
+      timelineBody,
+      // Timeline controller
+      controller,
+      // Table configuration
+      this.configuration
+    );
     this.tbody = tbody;
     controller.workPackageTable = this.workPackageTable;
     new TableHandlerRegistry(this.injector).attachTo(this.workPackageTable);

--- a/spec/features/work_packages/timeline/timeline_navigation_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_navigation_spec.rb
@@ -38,9 +38,9 @@ RSpec.feature 'Work package timeline navigation', js: true, selenium: true do
 
   let(:work_package) do
     FactoryBot.create :work_package,
-                       project: project,
-                       start_date: Date.today,
-                       due_date: (Date.today + 5.days)
+                      project: project,
+                      start_date: Date.today,
+                      due_date: (Date.today + 5.days)
   end
 
   before do
@@ -55,18 +55,18 @@ RSpec.feature 'Work package timeline navigation', js: true, selenium: true do
 
     let!(:work_package) do
       FactoryBot.create :work_package,
-                         project: project,
-                         type: type
+                        project: project,
+                        type: type
     end
 
     let!(:work_package2) do
       FactoryBot.create :work_package,
-                         project: project,
-                         type: type2
+                        project: project,
+                        type: type2
     end
 
     let!(:query) do
-      query              = FactoryBot.build(:query, user: user, project: project)
+      query = FactoryBot.build(:query, user: user, project: project)
       query.column_names = ['id', 'type', 'subject']
       query.filters.clear
       query.timeline_visible = false
@@ -78,7 +78,7 @@ RSpec.feature 'Work package timeline navigation', js: true, selenium: true do
     end
 
     let!(:query_tl) do
-      query              = FactoryBot.build(:query, user: user, project: project)
+      query = FactoryBot.build(:query, user: user, project: project)
       query.column_names = ['id', 'type', 'subject']
       query.filters.clear
       query.add_filter('type_id', '=', [type2.id])
@@ -109,6 +109,20 @@ RSpec.feature 'Work package timeline navigation', js: true, selenium: true do
       wp_timeline.expect_timeline!(open: true)
       wp_timeline.expect_work_package_listed work_package2
       wp_timeline.ensure_work_package_not_listed! work_package
+    end
+
+    it 'can open a context menu in the timeline (Regression #30761)' do
+      # Visit timeline query
+      wp_timeline.visit_query query_tl
+
+      wp_timeline.expect_timeline!(open: true)
+      wp_timeline.expect_work_package_listed work_package2
+      wp_timeline.ensure_work_package_not_listed! work_package
+
+      page.find(".wp-row-#{work_package2.id}-timeline").right_click
+
+      expect(page).to have_selector('.menu-item', text: 'Add predecessor')
+      expect(page).to have_selector('.menu-item', text: 'Add follower')
     end
   end
 
@@ -167,10 +181,10 @@ RSpec.feature 'Work package timeline navigation', js: true, selenium: true do
   describe 'with a hierarchy being shown' do
     let!(:child_work_package) do
       FactoryBot.create :work_package,
-                         project: project,
-                         parent: work_package,
-                         start_date: Date.today,
-                         due_date: (Date.today + 5.days)
+                        project: project,
+                        parent: work_package,
+                        start_date: Date.today,
+                        due_date: (Date.today + 5.days)
     end
     let(:hierarchy) { ::Components::WorkPackages::Hierarchies.new }
 
@@ -209,32 +223,32 @@ RSpec.feature 'Work package timeline navigation', js: true, selenium: true do
 
     let!(:wp_cat1) do
       FactoryBot.create :work_package,
-                         project: project,
-                         category: category,
-                         start_date: Date.today,
-                         due_date: (Date.today + 5.days)
+                        project: project,
+                        category: category,
+                        start_date: Date.today,
+                        due_date: (Date.today + 5.days)
     end
     let!(:wp_cat2) do
       FactoryBot.create :work_package,
-                         project: project,
-                         category: category2,
-                         start_date: Date.today + 5.days,
-                         due_date: (Date.today + 10.days)
+                        project: project,
+                        category: category2,
+                        start_date: Date.today + 5.days,
+                        due_date: (Date.today + 10.days)
     end
     let!(:wp_none) do
       FactoryBot.create :work_package,
-                         project: project
+                        project: project
     end
 
     let!(:relation) do
       FactoryBot.create(:relation,
-                         from: wp_cat1,
-                         to: wp_cat2,
-                         relation_type: Relation::TYPE_FOLLOWS)
+                        from: wp_cat1,
+                        to: wp_cat2,
+                        relation_type: Relation::TYPE_FOLLOWS)
     end
 
     let!(:query) do
-      query              = FactoryBot.build(:query, user: user, project: project)
+      query = FactoryBot.build(:query, user: user, project: project)
       query.column_names = ['id', 'subject', 'category']
       query.show_hierarchies = false
       query.timeline_visible = true


### PR DESCRIPTION
The scroll container was changed for the table likely due to drag & drop. This means that `table.container` no longer includes the timline which breaks some event scopes such as `contextmenu`.

A new clearer container was added that contains both

https://community.openproject.com/wp/30761