### PR TITLE
[30763] Use stable sort for manual position

### DIFF
--- a/app/models/queries/work_packages/columns/manual_sorting_column.rb
+++ b/app/models/queries/work_packages/columns/manual_sorting_column.rb
@@ -34,7 +34,7 @@ class Queries::WorkPackages::Columns::ManualSortingColumn < Queries::WorkPackage
   def initialize
     super :manual_sorting,
           default_order: 'asc',
-          sortable: "ordered_work_packages.position NULLS LAST"
+          sortable: "#{OrderedWorkPackage.table_name}.position NULLS LAST, #{WorkPackage.table_name}.id"
   end
 
   def sortable_join_statement(query)


### PR DESCRIPTION
Only moved items are being sorted, to avoid sorting the entire page when that is not yet necessary. This is a design decision to ensure only the minimum number of positions are being assigned and helps when sorting a restricted set of work packages from a bigger set.

To avoid having ambiguous sort results, ensure a second sort parameter by ID.

https://community.openproject.com/wp/30763