### PR TITLE
[30757] Blur editable title after save

### DIFF
--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.component.ts
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.component.ts
@@ -154,6 +154,11 @@ export class EditableToolbarTitleComponent implements OnInit, OnChanges {
       return; // Nothing changed
     }
 
+    // Blur this element
+    if (this.inputField) {
+      (this.inputField.nativeElement as HTMLInputElement).blur();
+    }
+
     this.emitSave(this.selectedTitle);
   }
 

--- a/spec/features/work_packages/timeline/timeline_navigation_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_navigation_spec.rb
@@ -119,10 +119,12 @@ RSpec.feature 'Work package timeline navigation', js: true, selenium: true do
       wp_timeline.expect_work_package_listed work_package2
       wp_timeline.ensure_work_package_not_listed! work_package
 
-      page.find(".wp-row-#{work_package2.id}-timeline").right_click
 
-      expect(page).to have_selector('.menu-item', text: 'Add predecessor')
-      expect(page).to have_selector('.menu-item', text: 'Add follower')
+      retry_block do
+        find(".wp-row-#{work_package2.id}-timeline").right_click
+        find('.menu-item', text: 'Add predecessor')
+        find('.menu-item', text: 'Add follower')
+      end
     end
   end
 


### PR DESCRIPTION
Ensures field is no longer focused after saving

https://community.openproject.com/wp/30757