### PR TITLE
Fix margin of hidden timeline button

### DIFF
--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -88,6 +88,10 @@ $nm-color-success-background: #d8fdd1
     margin: 0 10px 10px 0 // spacing between nav items
     flex-grow: 1
 
+    // hide right margin for e.g., conditional buttons
+    &.-no-spacing
+      margin-right: 0
+
     .button
       width: 100%
       overflow: hidden

--- a/frontend/src/app/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component.ts
@@ -41,6 +41,7 @@ export interface TimelineButtonText extends ButtonControllerText {
 
 @Component({
   templateUrl: './wp-timeline-toggle-button.html',
+  styleUrls: ['./wp-timeline-toggle-button.sass'],
   selector: 'wp-timeline-toggle-button',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/frontend/src/app/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.sass
+++ b/frontend/src/app/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.sass
@@ -1,0 +1,3 @@
+// Restore right margin if timeline button is visible
+.toolbar-button-group > li:last-child
+  margin-right: 10px

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -37,7 +37,7 @@
           <wp-view-toggle-button>
           </wp-view-toggle-button>
         </li>
-        <li class="toolbar-item hidden-for-mobile">
+        <li class="toolbar-item hidden-for-mobile -no-spacing">
           <wp-timeline-toggle-button>
           </wp-timeline-toggle-button>
         </li>


### PR DESCRIPTION
The timeline button group is hidden but it margin is kept, which causes double margin

![screenshot_5](https://user-images.githubusercontent.com/459462/63321519-3f9b7300-c321-11e9-878e-7edb5a9e09de.png)


[ci skip]