### PR TITLE
[30782] Gantt: Hover highlighting per WP list line broken when highlighting per line configured

### DIFF
--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -94,7 +94,7 @@ module ColorsHelper
 
       styles = color.color_styles
 
-      background_style = styles.map { |k,v| "#{k}:#{v} !important"}.join(';')
+      background_style = styles.map { |k,v| "#{k}:#{v}"}.join(';')
       border_color = color.bright? ? '#555555' : color.hexcode
 
       if name === 'type'


### PR DESCRIPTION
Remove "!important" to allow some styles to override it (e.g. row highlighting).

https://community.openproject.com/projects/openproject/work_packages/30782/activity