### PR TITLE
[30788][30789] Admin menu bugs

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -38,7 +38,8 @@ class AdminController < ApplicationController
 
   def index
     @menu_nodes = Redmine::MenuManager.items(:admin_menu).children
-    @menu_nodes.shift
+    @menu_nodes.delete_if { |node| node.name === :enterprise } unless OpenProject::Configuration.ee_manager_visible?
+    @menu_nodes.delete_if { |node| node.name === :admin_overview }
   end
 
   def projects

--- a/app/controllers/work_packages/settings_controller.rb
+++ b/app/controllers/work_packages/settings_controller.rb
@@ -30,7 +30,9 @@
 
 class WorkPackages::SettingsController < ::ApplicationController
   layout 'admin'
-  menu_item :work_packages_setting
+  current_menu_item :index do
+    :work_packages_setting
+  end
 
   def index
     render 'work_packages/settings/work_package_tracking'


### PR DESCRIPTION
Hide EE menu node on the overview page for the Cloud edition && fix menu highlighting for WP settings.

https://community.openproject.com/projects/openproject/work_packages/30788/activity
https://community.openproject.com/projects/openproject/work_packages/30789/activity