### PR TITLE
[30777] Replace most usages of refresh service with global eventing service

### DIFF
--- a/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
@@ -40,6 +40,7 @@ import {IWorkPackageEditingServiceToken} from "../../wp-edit-form/work-package-e
 import {Highlighting} from "core-components/wp-fast-table/builders/highlighting/highlighting.functions";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
+import {WorkPackageEventsService} from "core-app/modules/work_packages/events/work-package-events.service";
 
 @Directive({
   selector: '[wpStatusDropdown]'
@@ -54,7 +55,8 @@ export class WorkPackageStatusDropdownDirective extends OpContextMenuTrigger {
               protected notificationService:NotificationsService,
               @Inject(IWorkPackageEditingServiceToken) protected wpEditing:WorkPackageEditingService,
               protected I18n:I18nService,
-              protected wpTableRefresh:WorkPackageViewRefreshService) {
+              protected wpTableRefresh:WorkPackageViewRefreshService,
+              protected wpEvents:WorkPackageEventsService) {
 
     super(elementRef, opContextMenu);
   }
@@ -89,7 +91,8 @@ export class WorkPackageStatusDropdownDirective extends OpContextMenuTrigger {
     if (!this.workPackage.isNew) {
       changeset.save().then(() => {
         this.wpNotificationsService.showSave(this.workPackage);
-        this.wpTableRefresh.request('Altered work package status via button');
+
+        this.wpEvents.push({ type: 'updated', id: this.workPackage.id! });
       });
     }
   }

--- a/frontend/src/app/components/work-packages/work-package.service.ts
+++ b/frontend/src/app/components/work-packages/work-package.service.ts
@@ -34,6 +34,10 @@ import {PathHelperService} from "core-app/modules/common/path-helper/path-helper
 import {UrlParamsHelperService} from "core-components/wp-query/url-params-helper";
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {
+  WorkPackageDeletedEvent,
+  WorkPackageEventsService
+} from "core-app/modules/work_packages/events/work-package-events.service";
 
 @Injectable()
 export class WorkPackageService {
@@ -48,7 +52,8 @@ export class WorkPackageService {
               private readonly UrlParamsHelper:UrlParamsHelperService,
               private readonly NotificationsService:NotificationsService,
               private readonly I18n:I18nService,
-              private readonly wpTableRefresh:WorkPackageViewRefreshService) {
+              private readonly wpTableRefresh:WorkPackageViewRefreshService,
+              private readonly wpEvents:WorkPackageEventsService) {
   }
 
   public performBulkDelete(ids:string[], defaultHandling:boolean) {
@@ -63,7 +68,8 @@ export class WorkPackageService {
       promise
         .then(() => {
           this.NotificationsService.addSuccess(this.text.successful_delete);
-          this.wpTableRefresh.request('Bulk delete removed elements', { visible: true });
+
+          ids.forEach(id => this.wpEvents.push({ type: 'deleted', id: id } as WorkPackageDeletedEvent));
 
           if (this.$state.includes('**.list.details.**')
             && ids.indexOf(this.$state.params.workPackageId) > -1) {

--- a/frontend/src/app/components/wp-edit-form/work-package-edit-form.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-edit-form.ts
@@ -39,6 +39,7 @@ import {WorkPackageEditContext} from './work-package-edit-context';
 import {WorkPackageEditFieldHandler} from './work-package-edit-field-handler';
 import {IWorkPackageEditingServiceToken} from "core-components/wp-edit-form/work-package-editing.service.interface";
 import {IFieldSchema} from "core-app/modules/fields/field.base";
+import {WorkPackageEventsService} from "core-app/modules/work_packages/events/work-package-events.service";
 
 export const activeFieldContainerClassName = 'wp-inline-edit--active-field';
 export const activeFieldClassName = 'wp-inline-edit--field';
@@ -50,6 +51,7 @@ export class WorkPackageEditForm {
   public wpEditing = this.injector.get(IWorkPackageEditingServiceToken);
   public wpTableRefresh = this.injector.get(WorkPackageViewRefreshService);
   public wpNotificationsService = this.injector.get(WorkPackageNotificationService);
+  public wpEvents = this.injector.get(WorkPackageEventsService);
 
   // All current active (open) edit fields
   public activeFields:{ [fieldName:string]:WorkPackageEditFieldHandler } = {};
@@ -181,9 +183,7 @@ export class WorkPackageEditForm {
           this.wpNotificationsService.showSave(savedWorkPackage, isInitial);
           this.editMode = false;
           this.editContext.onSaved(isInitial, savedWorkPackage);
-          this.wpTableRefresh.request(
-            `Saved work package ${savedWorkPackage.id}`
-          );
+          this.wpEvents.push({ type: 'updated', id: savedWorkPackage.id! });
         })
         .catch((error:ErrorResource|Object) => {
           this.wpNotificationsService.handleRawError(error, this.workPackage);

--- a/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
@@ -61,6 +61,10 @@ import {CurrentUserService} from "core-components/user/current-user.service";
 import {WorkPackageInlineCreateService} from "core-components/wp-inline-create/wp-inline-create.service";
 import {Subscription} from 'rxjs';
 import {WorkPackageViewColumnsService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-columns.service";
+import {
+  WorkPackageEvent,
+  WorkPackageEventsService
+} from "core-app/modules/work_packages/events/work-package-events.service";
 
 @Component({
   selector: '[wpInlineCreate]',

--- a/frontend/src/app/components/wp-new/wp-create.service.ts
+++ b/frontend/src/app/components/wp-new/wp-create.service.ts
@@ -41,6 +41,7 @@ import {WorkPackageEditingService} from "core-components/wp-edit-form/work-packa
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {WorkPackageDmService} from "core-app/modules/hal/dm-services/work-package-dm.service";
 import {FormResource} from "core-app/modules/hal/resources/form-resource";
+import {WorkPackageEventsService} from "core-app/modules/work_packages/events/work-package-events.service";
 
 @Injectable()
 export class WorkPackageCreateService implements IWorkPackageCreateService {
@@ -55,11 +56,13 @@ export class WorkPackageCreateService implements IWorkPackageCreateService {
               protected halResourceService:HalResourceService,
               @Inject(IWorkPackageEditingServiceToken) protected readonly wpEditing:WorkPackageEditingService,
               protected readonly querySpace:IsolatedQuerySpace,
-              protected workPackageDmService:WorkPackageDmService) {
+              protected workPackageDmService:WorkPackageDmService,
+              protected readonly wpEvents:WorkPackageEventsService) {
   }
 
   public newWorkPackageCreated(wp:WorkPackageResource) {
     this.form = undefined;
+    this.wpEvents.push({ type: 'created', id: wp.id! });
     this.newWorkPackageCreatedSubject.next(wp);
   }
 

--- a/frontend/src/app/components/wp-relations/embedded/children/wp-children-query.component.ts
+++ b/frontend/src/app/components/wp-relations/embedded/children/wp-children-query.component.ts
@@ -43,6 +43,7 @@ import {WorkPackageCacheService} from "core-components/work-packages/work-packag
 import {filter} from "rxjs/operators";
 import {QueryResource} from "core-app/modules/hal/resources/query-resource";
 import {GroupDescriptor} from "core-components/work-packages/wp-single-view/wp-single-view.component";
+import {WorkPackageEventsService} from "core-app/modules/work_packages/events/work-package-events.service";
 
 @Component({
   selector: 'wp-children-query',
@@ -73,6 +74,7 @@ export class WorkPackageChildrenQueryComponent extends WorkPackageRelationQueryB
   constructor(protected wpRelationsHierarchyService:WorkPackageRelationsHierarchyService,
               protected PathHelper:PathHelperService,
               protected wpInlineCreate:WorkPackageInlineCreateService,
+              protected wpEvents:WorkPackageEventsService,
               protected wpCacheService:WorkPackageCacheService,
               protected queryUrlParamsHelper:UrlParamsHelperService,
               readonly I18n:I18nService) {
@@ -85,6 +87,18 @@ export class WorkPackageChildrenQueryComponent extends WorkPackageRelationQueryB
 
     // Set up the query props
     this.queryProps = this.buildQueryProps();
+
+    // Fire event that children were added
+    this.wpInlineCreate.newInlineWorkPackageCreated
+      .pipe(untilComponentDestroyed(this))
+      .subscribe((toId:string) => {
+        this.wpEvents.push({
+          type: 'association',
+          id: this.workPackage.id!,
+          relatedWorkPackage: toId,
+          relationType: 'child'
+        });
+      });
 
     // Refresh table when work package is refreshed
     this.wpCacheService

--- a/frontend/src/app/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.ts
+++ b/frontend/src/app/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.ts
@@ -40,6 +40,7 @@ import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/iso
 import {ApiV3Filter} from "core-components/api/api-v3/api-v3-filter-builder";
 import {UrlParamsHelperService} from "core-components/wp-query/url-params-helper";
 import {RelationResource} from "core-app/modules/hal/resources/relation-resource";
+import {WorkPackageEventsService} from "core-app/modules/work_packages/events/work-package-events.service";
 
 @Component({
   templateUrl: './wp-relation-inline-add-existing.component.html'
@@ -61,6 +62,7 @@ export class WpRelationInlineAddExistingComponent {
               protected wpRelations:WorkPackageRelationsService,
               protected wpNotificationsService:WorkPackageNotificationService,
               protected wpTableRefresh:WorkPackageViewRefreshService,
+              protected wpEvents:WorkPackageEventsService,
               protected urlParamsHelper:UrlParamsHelperService,
               protected querySpace:IsolatedQuerySpace,
               protected readonly I18n:I18nService) {
@@ -77,7 +79,14 @@ export class WpRelationInlineAddExistingComponent {
     this.wpInlineCreate.add(this.workPackage, newRelationId)
       .then(() => {
         this.wpCacheService.loadWorkPackage(this.workPackage.id!, true);
-        this.wpTableRefresh.request(`Added relation ${newRelationId}`, { visible: true });
+
+        this.wpEvents.push({
+          type: 'association',
+          id: this.workPackage.id!,
+          relatedWorkPackage: newRelationId,
+          relationType: this.relationType,
+        });
+
         this.isDisabled = false;
         this.wpInlineCreate.newInlineWorkPackageReferenced.next(newRelationId);
         this.cancel();

--- a/frontend/src/app/components/wp-relations/embedded/relations/wp-relation-query.component.ts
+++ b/frontend/src/app/components/wp-relations/embedded/relations/wp-relation-query.component.ts
@@ -44,6 +44,7 @@ import {WorkPackageViewRefreshService} from "core-components/wp-table/wp-table-r
 import {filter, skip} from "rxjs/operators";
 import {QueryResource} from "core-app/modules/hal/resources/query-resource";
 import {GroupDescriptor} from "core-components/work-packages/wp-single-view/wp-single-view.component";
+import {WorkPackageEventsService} from "core-app/modules/work_packages/events/work-package-events.service";
 
 @Component({
   selector: 'wp-relation-query',
@@ -76,6 +77,7 @@ export class WorkPackageRelationQueryComponent extends WorkPackageRelationQueryB
               @Inject(WorkPackageInlineCreateService) protected readonly wpInlineCreate:WpRelationInlineCreateService,
               protected readonly wpRelations:WorkPackageRelationsService,
               protected readonly wpTableRefresh:WorkPackageViewRefreshService,
+              protected readonly wpEvents:WorkPackageEventsService,
               protected readonly queryUrlParamsHelper:UrlParamsHelperService,
               protected readonly wpNotifications:WorkPackageNotificationService,
               protected readonly I18n:I18nService) {
@@ -114,7 +116,12 @@ export class WorkPackageRelationQueryComponent extends WorkPackageRelationQueryB
     this.wpInlineCreate
       .add(this.workPackage, toId)
       .then(() => {
-        this.wpTableRefresh.request(`Added relation ${toId}`, { visible: true });
+        this.wpEvents.push({
+          type: 'association',
+          id: this.workPackage.id!,
+          relatedWorkPackage: toId,
+          relationType: this.getRelationTypeFromQuery()
+        });
       })
       .catch(error => this.wpNotifications.handleRawError(error, this.workPackage));
   }

--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
@@ -6,6 +6,7 @@ import {WorkPackageRelationsService} from '../wp-relations.service';
 import {Component, ElementRef, Inject, Input, ViewChild} from "@angular/core";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {WorkPackageViewRefreshService} from "core-components/wp-table/wp-table-refresh-request.service";
+import {WorkPackageEventsService} from "core-app/modules/work_packages/events/work-package-events.service";
 
 @Component({
   selector: 'wp-relations-create',
@@ -33,6 +34,7 @@ export class WorkPackageRelationsCreateComponent {
               protected wpRelations:WorkPackageRelationsService,
               protected wpNotificationsService:WorkPackageNotificationService,
               protected wpTableRefresh:WorkPackageViewRefreshService,
+              protected wpEvents:WorkPackageEventsService,
               protected wpCacheService:WorkPackageCacheService) {
   }
 
@@ -60,7 +62,12 @@ export class WorkPackageRelationsCreateComponent {
       this.selectedRelationType,
       this.selectedWpId)
       .then(relation => {
-        this.wpTableRefresh.request(`Added relation ${relation.id}`, {visible: true});
+        this.wpEvents.push({
+          type: 'association',
+          id: this.workPackage.id!,
+          relatedWorkPackage: relation.id!,
+          relationType: this.selectedRelationType
+        });
         this.wpNotificationsService.showSave(this.workPackage);
         this.toggleRelationsCreateForm();
       })

--- a/frontend/src/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -42,6 +42,7 @@ import {QueryDmService} from 'core-app/modules/hal/dm-services/query-dm.service'
 import Moment = moment.Moment;
 import {keyCodes} from 'core-app/modules/common/keyCodes.enum';
 import {LoadingIndicatorService} from "core-app/modules/common/loading-indicator/loading-indicator.service";
+import {WorkPackageEventsService} from "core-app/modules/work_packages/events/work-package-events.service";
 
 export const classNameBar = 'bar';
 export const classNameLeftHandle = 'leftHandle';
@@ -54,7 +55,7 @@ export function registerWorkPackageMouseHandler(this:void,
                                                 getRenderInfo:() => RenderInfo,
                                                 workPackageTimeline:WorkPackageTimelineTableController,
                                                 wpCacheService:WorkPackageCacheService,
-                                                wpTableRefresh:WorkPackageViewRefreshService,
+                                                wpEvents:WorkPackageEventsService,
                                                 wpNotificationsService:WorkPackageNotificationService,
                                                 loadingIndicator:LoadingIndicatorService,
                                                 cell:HTMLElement,
@@ -65,7 +66,7 @@ export function registerWorkPackageMouseHandler(this:void,
 
   const querySpace:IsolatedQuerySpace = injector.get(IsolatedQuerySpace);
 
-  let mouseDownStartDay:number | null = null; // also flag to signal active drag'n'drop
+  let mouseDownStartDay:number|null = null; // also flag to signal active drag'n'drop
   renderInfo.changeset = new WorkPackageChangeset(injector, renderInfo.workPackage);
 
   let dateStates:any;
@@ -120,7 +121,7 @@ export function registerWorkPackageMouseHandler(this:void,
     jBody.on('mouseup.timelinecell', () => deactivate(false));
   }
 
-  function createMouseMoveFn(direction:'left' | 'right' | 'both' | 'create' | 'dragright') {
+  function createMouseMoveFn(direction:'left'|'right'|'both'|'create'|'dragright') {
     return (ev:JQuery.MouseMoveEvent) => {
 
       const days = getCursorOffsetInDaysFromLeft(renderInfo, ev.originalEvent!) - mouseDownStartDay!;
@@ -252,8 +253,7 @@ export function registerWorkPackageMouseHandler(this:void,
         loadingIndicator.table.promise =
           queryDm.loadIdsUpdatedSince(ids, updatedAt).then(workPackageCollection => {
             wpCacheService.updateWorkPackageList(workPackageCollection.elements);
-
-            wpTableRefresh.request(`Moved work package ${wp.id} through timeline`);
+            wpEvents.push({ type: 'updated', id: wp.id! });
           });
       })
       .catch((error) => {

--- a/frontend/src/app/components/wp-table/timeline/cells/wp-timeline-cell.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/wp-timeline-cell.ts
@@ -37,6 +37,7 @@ import {TimelineMilestoneCellRenderer} from './timeline-milestone-cell-renderer'
 import {registerWorkPackageMouseHandler} from './wp-timeline-cell-mouse-handler';
 import {Injector} from '@angular/core';
 import {LoadingIndicatorService} from "core-app/modules/common/loading-indicator/loading-indicator.service";
+import {WorkPackageEventsService} from "core-app/modules/work_packages/events/work-package-events.service";
 
 export const classNameLeftLabel = 'labelLeft';
 export const classNameRightContainer = 'containerRight';
@@ -62,7 +63,7 @@ export class WorkPackageCellLabels {
 
 export class WorkPackageTimelineCell {
   readonly wpCacheService:WorkPackageCacheService = this.injector.get(WorkPackageCacheService);
-  readonly wpTableRefresh:WorkPackageViewRefreshService = this.injector.get(WorkPackageViewRefreshService);
+  readonly wpEvents:WorkPackageEventsService = this.injector.get(WorkPackageEventsService);
   readonly wpNotificationsService:WorkPackageNotificationService = this.injector.get(WorkPackageNotificationService);
   readonly states:States = this.injector.get(States);
   readonly loadingIndicator:LoadingIndicatorService = this.injector.get(LoadingIndicatorService);
@@ -159,7 +160,7 @@ export class WorkPackageTimelineCell {
         () => this.latestRenderInfo,
         this.workPackageTimeline,
         this.wpCacheService,
-        this.wpTableRefresh,
+        this.wpEvents,
         this.wpNotificationsService,
         this.loadingIndicator,
         cell[0],

--- a/frontend/src/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
+++ b/frontend/src/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
@@ -59,6 +59,7 @@ import {selectorTimelineSide} from "core-components/wp-table/wp-table-scroll-syn
 import {debugLog, timeOutput} from "core-app/helpers/debug_output";
 import {WorkPackageViewRefreshService} from "core-components/wp-table/wp-table-refresh-request.service";
 import {RenderedWorkPackage} from "core-app/modules/work_packages/render-info/rendered-work-package.type";
+import {WorkPackageEventsService} from "core-app/modules/work_packages/events/work-package-events.service";
 
 @Component({
   selector: 'wp-timeline-container',
@@ -104,6 +105,7 @@ export class WorkPackageTimelineTableController implements AfterViewInit, OnDest
               private wpRelations:WorkPackageRelationsService,
               private wpTableRefresh:WorkPackageViewRefreshService,
               private wpTableHierarchies:WorkPackageViewHierarchiesService,
+              private wpEvents:WorkPackageEventsService,
               readonly I18n:I18nService) {
   }
 
@@ -264,7 +266,14 @@ export class WorkPackageTimelineTableController implements AfterViewInit, OnDest
     this.activateSelectionMode(start.id!, end => {
       this.wpRelations
         .addCommonRelation(start.id!, 'follows', end.id!)
-        .then(() => this.wpTableRefresh.request('Timeline relation'))
+        .then(() => {
+          this.wpEvents.push({
+            type: 'association',
+            id: start.id!,
+            relatedWorkPackage: end.id!,
+            relationType: 'follows'
+          });
+        })
         .catch((error:any) => this.wpNotificationsService.handleRawError(error, end));
     });
   }
@@ -273,7 +282,14 @@ export class WorkPackageTimelineTableController implements AfterViewInit, OnDest
     this.activateSelectionMode(start.id!, end => {
       this.wpRelations
         .addCommonRelation(start.id!, 'precedes', end.id!)
-        .then(() => this.wpTableRefresh.request('Timeline relation'))
+        .then(() => {
+          this.wpEvents.push({
+            type: 'association',
+            id: start.id!,
+            relatedWorkPackage: end.id!,
+            relationType: 'precedes'
+          });
+        })
         .catch((error:any) => this.wpNotificationsService.handleRawError(error, end));
     });
   }

--- a/frontend/src/app/modules/work_packages/events/work-package-events.service.ts
+++ b/frontend/src/app/modules/work_packages/events/work-package-events.service.ts
@@ -1,0 +1,51 @@
+import {Injectable} from "@angular/core";
+import {Observable, Subject} from "rxjs";
+import {buffer, debounceTime, scan} from "rxjs/operators";
+
+export interface WorkPackageEvent {
+  id:string;
+  type:string;
+}
+
+export interface WorkPackageCreatedEvent extends WorkPackageEvent {
+  type:'created';
+}
+
+export interface WorkPackageUpdatedEvent extends WorkPackageEvent {
+  type:'updated';
+}
+
+export interface RelatedWorkPackageEvent extends WorkPackageEvent {
+  type:'association';
+  relatedWorkPackage:string|null;
+  relationType:string;
+}
+
+export interface WorkPackageDeletedEvent extends WorkPackageEvent {
+  type:'deleted';
+}
+
+export type WorkPackageEventTypes =
+  WorkPackageCreatedEvent|WorkPackageUpdatedEvent|RelatedWorkPackageEvent|WorkPackageDeletedEvent;
+
+@Injectable()
+export class WorkPackageEventsService {
+  private _events = new Subject<WorkPackageEvent>();
+
+  /** Entire event stream */
+  public events$ = this._events.asObservable();
+
+  /** Aggregated events */
+  public aggregated$(debounceTimeInMs = 500):Observable<WorkPackageEvent[]> {
+    return this
+      .events$
+      .pipe(
+        buffer(this.events$.pipe(debounceTime(debounceTimeInMs))),
+        scan((acc, curr) => acc.concat(curr))
+      );
+  }
+
+  public push(event:WorkPackageEventTypes) {
+    this._events.next(event);
+  }
+}

--- a/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
@@ -159,6 +159,7 @@ import {WorkPackageIsolatedGraphQuerySpaceDirective} from "core-app/modules/work
 import {WorkPackageViewToggleButton} from "core-components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component";
 import {WorkPackagesGridComponent} from "core-components/wp-grid/wp-grid.component";
 import {WorkPackageViewDropdownMenuDirective} from "core-components/op-context-menu/handlers/wp-view-dropdown-menu.directive";
+import {WorkPackageEventsService} from "core-app/modules/work_packages/events/work-package-events.service";
 
 
 @NgModule({
@@ -209,6 +210,7 @@ import {WorkPackageViewDropdownMenuDirective} from "core-components/op-context-m
     WorkPackageWatchersService,
 
     QueryFormDmService,
+    WorkPackageEventsService,
   ],
   declarations: [
     // Routing

--- a/frontend/src/app/modules/work_packages/query-space/isolated-query-space.ts
+++ b/frontend/src/app/modules/work_packages/query-space/isolated-query-space.ts
@@ -42,6 +42,10 @@ export class IsolatedQuerySpace extends StatesGroup {
     map(rows => rows.filter(row => !!row.workPackageId)))
   );
 
+  renderedWorkPackageIds:State<string[]> = derive(this.renderedWorkPackages, $ => $.pipe(
+    map(rows => rows.map(row => row.workPackageId!.toString())))
+  );
+
   // Current focused work package (e.g, row preselected for details button)
   focusedWorkPackage:InputState<WPFocusState> = input<WPFocusState>();
 

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -95,7 +95,6 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
     this.hasQueryProps = !!this.$state.params.query_props;
 
     // Load query initially
-    this.wpTableRefresh.clear('Impending query loading.');
     this.loadCurrentQuery();
 
     // Load query on URL transitions

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -122,6 +122,7 @@ describe 'Switching types in work package table', js: true do
         message: 'Successful update. Click here to open this work package in fullscreen view.'
       )
 
+      expect(page).to have_no_selector "#{req_text_field.selector} #{req_text_field.display_selector}"
       expect { req_text_field.display_element }.to raise_error(Capybara::ElementNotFound)
     end
 


### PR DESCRIPTION
We are increasingly having one problem: Notifying a parent querySpace of changes within another embedded query space (e.g., a nested embedded children table adding new relations, which should re-render the table).

As the `WorkPackageTableRefreshService` is rightfully part of the query space, it cannot be used for these notifications.

This PR suggests to add a global `WorkPackageEventService` which is called for specific events that can be registered to and events can be received in buffered mode with a debounce. From these events, the table is then refreshed if a visible work package is present in the table.

https://community.openproject.com/wp/30777