### PR TITLE
[30796] UX: Inconsistency when confirm-click on tick-button is needed for relations

### DIFF
--- a/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
+++ b/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
@@ -133,14 +133,6 @@
 .wp-relation--description-wrapper
   width: 100%
 
-// Disable create link until WP is selected
-.wp-create-relation--save[disabled]
-  color: $relations-save-button--disabled-color
-  cursor: not-allowed
-
-  .icon-button
-    cursor: not-allowed
-
 .wp-relations-create--form
   display: flex
 

--- a/frontend/src/app/components/work-packages/wp-breadcrumb/wp-breadcrumb-parent.html
+++ b/frontend/src/app/components/work-packages/wp-breadcrumb/wp-breadcrumb-parent.html
@@ -20,11 +20,12 @@
       linkClass="wp-relation--parent-remove hide-when-print -no-decoration icon-small icon-remove icon4">
   </accessible-by-keyboard>
 </ng-container>
+
 <wp-relations-autocomplete
   *ngIf="active"
   [inputPlaceholder]="text.set_or_remove_parent"
   [workPackage]="workPackage"
   (onCancel)="close()"
-  (onReferenced)="updateParent($event)"
+  (onSelected)="updateParent($event)"
   filterCandidatesFor="parent">
 </wp-relations-autocomplete>

--- a/frontend/src/app/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.html
+++ b/frontend/src/app/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.html
@@ -4,20 +4,12 @@
     <div class="wp-relations-input-section">
       <wp-relations-autocomplete
           [workPackage]="workPackage"
-          (onReferenced)="onReferenced($event)"
+          (onSelected)="onSelected($event)"
           [additionalFilters]="queryFilters"
           [filterCandidatesFor]="relationType">
       </wp-relations-autocomplete>
     </div>
     <div class="wp-relations-controls-section relation-row">
-      <accessible-by-keyboard
-          linkClass="wp-create-relation--save"
-          [isDisabled]="isDisabled"
-          (execute)="addExisting()"
-          aria-hidden="false">
-        <op-icon icon-classes="icon-checkmark" [icon-title]="text.save"></op-icon>
-      </accessible-by-keyboard>
-      &nbsp;
       <accessible-by-keyboard
           linkClass="wp-create-relation--cancel"
           (execute)="cancel()"

--- a/frontend/src/app/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.ts
+++ b/frontend/src/app/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.ts
@@ -52,7 +52,6 @@ export class WpRelationInlineAddExistingComponent {
   public queryFilters = this.buildQueryFilters();
 
   public text = {
-    save: this.I18n.t('js.relation_buttons.save'),
     abort: this.I18n.t('js.relation_buttons.abort'),
   };
 
@@ -98,7 +97,7 @@ export class WpRelationInlineAddExistingComponent {
       });
   }
 
-  public onReferenced(workPackage?:WorkPackageResource) {
+  public onSelected(workPackage?:WorkPackageResource) {
     if (workPackage) {
       this.selectedWpId = workPackage.id!;
       this.addExisting();
@@ -112,7 +111,6 @@ export class WpRelationInlineAddExistingComponent {
   public get workPackage() {
     return this.wpInlineCreate.referenceTarget!;
   }
-
 
   public cancel() {
     this.parent.resetRow();

--- a/frontend/src/app/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
+++ b/frontend/src/app/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
@@ -184,7 +184,6 @@ export class WorkPackageRelationRowComponent implements OnInit, OnDestroy {
 
         this.wpCacheService.updateWorkPackage(this.relatedWorkPackage);
         this.wpNotificationsService.showSave(this.relatedWorkPackage);
-        this.cdRef.detectChanges();
       })
       .catch((err:any) => this.wpNotificationsService.handleRawError(err,
         this.relatedWorkPackage));

--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relation-create.template.html
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relation-create.template.html
@@ -32,22 +32,16 @@
                   [value]="type.name"></option>
         </select>
       </div>
-      <div class="grid-content medium-7">
+      <div class="grid-content medium-8">
         <wp-relations-autocomplete
             [workPackage]="workPackage"
-            (onReferenced)="onReferenced($event)"
+            (onSelected)="onSelected($event)"
+            (onCancel)="toggleRelationsCreateForm()"
             [appendToContainer]="'.work-packages-tab-view--overflow'"
             [selectedRelationType]="selectedRelationType">
         </wp-relations-autocomplete>
       </div>
-      <div class="grid-content medium-2 collapse wp-relations-controls-section relation-row">
-        <accessible-by-keyboard
-            (execute)="createRelation()"
-            [isDisabled]="isDisabled || !selectedWpId"
-            linkClass="wp-create-relation--save"
-            aria-hidden="false">
-          <op-icon icon-classes="icon-checkmark -padded" [icon-title]="text.save"></op-icon>
-        </accessible-by-keyboard>
+      <div class="grid-content medium-1 collapse wp-relations-controls-section relation-row">
         <accessible-by-keyboard
             (execute)="toggleRelationsCreateForm()"
             linkClass="wp-create-relation--cancel"

--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component.ts
@@ -30,7 +30,7 @@ import {
   AfterContentInit,
   ChangeDetectorRef,
   Component,
-  EventEmitter,
+  EventEmitter, HostListener,
   Input,
   Output,
   ViewChild,
@@ -75,7 +75,7 @@ export class WorkPackageRelationsAutocomplete implements AfterContentInit {
   @ViewChild(NgSelectComponent, { static: true }) public ngSelectComponent:NgSelectComponent;
 
   @Output() onCancel = new EventEmitter<undefined>();
-  @Output() onReferenced = new EventEmitter<WorkPackageResource>();
+  @Output() onSelected = new EventEmitter<WorkPackageResource>();
   @Output() onEmptySelected = new EventEmitter<undefined>();
 
   // Whether we're currently loading
@@ -102,6 +102,11 @@ export class WorkPackageRelationsAutocomplete implements AfterContentInit {
               private readonly I18n:I18nService) {
   }
 
+  @HostListener('keydown.escape')
+  public reset() {
+    this.cancel();
+  }
+
   ngAfterContentInit():void {
     if (!this.ngSelectComponent) {
       return;
@@ -121,7 +126,7 @@ export class WorkPackageRelationsAutocomplete implements AfterContentInit {
       this.schemaCacheService
         .ensureLoaded(workPackage)
         .then(() => {
-          this.onReferenced.emit(workPackage);
+          this.onSelected.emit(workPackage);
           this.ngSelectComponent.close();
         });
     }

--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
@@ -24,7 +24,6 @@ export class WorkPackageRelationsCreateComponent {
   public isDisabled = false;
 
   public text = {
-    save: this.I18n.t('js.relation_buttons.save'),
     abort: this.I18n.t('js.relation_buttons.abort'),
     relationType: this.I18n.t('js.relation_buttons.relation_type'),
     addNewRelation: this.I18n.t('js.relation_buttons.add_new_relation')
@@ -51,9 +50,10 @@ export class WorkPackageRelationsCreateComponent {
       .then(() => this.isDisabled = false);
   }
 
-  public onReferenced(workPackage?:WorkPackageResource) {
+  public onSelected(workPackage?:WorkPackageResource) {
     if (workPackage) {
       this.selectedWpId = workPackage.id!;
+      this.createCommonRelation();
     }
   }
 

--- a/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
+++ b/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
@@ -218,7 +218,6 @@ describe 'Work package with relation query group', js: true, selenium: true do
                           query: independent_work_package.subject,
                           select_text: independent_work_package.subject
 
-      container.find('.wp-create-relation--save').click
       embedded_table.expect_work_package_listed(independent_work_package)
       relations.expect_relation(independent_work_package)
 

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -102,8 +102,6 @@ module Components
                             query: to.subject,
                             select_text: to.subject
 
-        container.find('.wp-create-relation--save').click
-
         expect(page).to have_selector('.relation-group--header',
                                       text: relation_label.upcase,
                                       wait: 10)
@@ -183,8 +181,6 @@ module Components
                             query: work_package.id,
                             results_selector: '.ng-dropdown-panel-items',
                             select_text: work_package.subject
-
-        page.find('.wp-relations--add-form .wp-create-relation--save').click
       end
 
       def expect_child(work_package)


### PR DESCRIPTION
* Save relations directly when choosing the work package.
* Close all relations autocompleter on Escape

https://community.openproject.com/projects/openproject/work_packages/30796/activity