### PR TITLE
[Fix] Distinguish styles for estimated time between table and details view

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_display_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_display_fields.sass
@@ -38,10 +38,16 @@
 
   &.split-time-field
     white-space: nowrap
-    .-actual-value,
-    .-derived-value
-      display: inline-block
-      width: 48%
+
+    // Table specific styles
+    .wp-table--cell-container &
+      .-actual-value,
+      .-derived-value
+        display: inline-block
+        width: 48%
+
+      .-derived-value:not(.-with-actual-value)
+        margin-left: 48%
 
     .-actual-value
       text-align: right
@@ -52,8 +58,6 @@
       font-style: italic
       font-weight: bold
 
-      &:not(.-with-actual-value)
-        margin-left: 48%
 
 .wp-edit-field--text,
 wp-edit-field


### PR DESCRIPTION
Problem: In the details view, there where parts of the derived time missing

<img width="273" alt="Bildschirmfoto 2019-08-22 um 13 07 07" src="https://user-images.githubusercontent.com/7457313/63511423-79b37300-c4e1-11e9-8165-af1027d0f033.png">