### PR TITLE
[30787] Never persist an unsaved form schema to the schema cache

### DIFF
--- a/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.component.ts
@@ -60,26 +60,19 @@ export class WorkPackageStatusButtonComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.wpCacheService
-      .observe(this.workPackage.id!)
+    this.wpEditing
+      .temporaryEditResource(this.workPackage.id!)
+      .values$()
       .pipe(
         untilComponentDestroyed(this)
       )
       .subscribe((wp) => {
         this.workPackage = wp;
         this.cdRef.detectChanges();
-        this.workPackage.status.$load();
-      });
 
-    this.schemaCacheService
-      .state(this.workPackage)
-      .changes$()
-      .pipe(
-        untilComponentDestroyed(this)
-      )
-      .subscribe(() => {
-        // we have to explicitly force the component to update
-        this.cdRef.detectChanges();
+        if (this.workPackage.status) {
+          this.workPackage.status.$load();
+        }
       });
   }
 

--- a/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
@@ -124,10 +124,6 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
         .update(payload)
         .then((form:FormResource) => {
           this.form = form;
-          if (!this.resource.isNew) {
-            this.schemaCacheService.state(this.resource).putValue(form.schema);
-          }
-
           this.rebuildDefaults(form.payload);
 
           this.buildResource();


### PR DESCRIPTION
The form schema got accidentally committed to the schema cache in https://github.com/opf/openproject/commit/cc0145daf6d5ef9a057df95e60de1627718dc30b which resulted in `null` schema hrefs in the cache, breaking all schemas temporary and resulting to the same schema being used, causing #30787

Instead of committing an unsaved schema, we can use the `temporaryEditResource` to access the temporary resource while it is not yet saved, which is what the status button is now doing.



https://community.openproject.com/wp/30787