### PR TITLE
[30813] BCF specific filter cannot be saved in query

### DIFF
--- a/lib/api/v3/queries/filters/query_filter_instance_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_instance_representer.rb
@@ -111,8 +111,7 @@ module API
                       end
                     },
                     getter: ->(*) {
-                      if represented.respond_to?(:custom_field) &&
-                         represented.custom_field.field_format == 'bool'
+                      if represented_is_boolean_list?(represented)
                         represented.values.map do |value|
                           value == OpenProject::Database::DB_VALUE_TRUE
                         end
@@ -142,8 +141,7 @@ module API
           end
 
           def set_property_values(vals)
-            represented.values = if represented.respond_to?(:custom_field) &&
-                                    represented.custom_field.field_format == 'bool'
+            represented.values = if represented_is_boolean_list?(represented)
                                    vals.map do |value|
                                      if value
                                        OpenProject::Database::DB_VALUE_TRUE
@@ -162,6 +160,10 @@ module API
 
           def query_filter_instance_links_representer(represented)
             ::API::V3::Queries::Filters::QueryFilterInstanceLinksRepresenter.new represented, current_user: current_user
+          end
+
+          def represented_is_boolean_list?(represented)
+            represented.send(:type_strategy).is_a?(::Queries::Filters::Strategies::BooleanList)
           end
         end
       end

--- a/modules/bcf/spec/api/v3/queries/filters/query_filter_instance_representer_spec.rb
+++ b/modules/bcf/spec/api/v3/queries/filters/query_filter_instance_representer_spec.rb
@@ -1,0 +1,74 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Queries::Filters::QueryFilterInstanceRepresenter do
+  let(:operator) { '=' }
+  let(:filter) do
+    ::OpenProject::Bcf::BcfIssueAssociatedFilter.create!(name: "bcf_issue_associated", operator: operator, values: values)
+  end
+
+  let(:representer) { described_class.new(filter) }
+
+  describe 'generation' do
+    subject { representer.to_json }
+
+    context 'with a bool bcf_associated_filter' do
+      context "with 't' as filter value" do
+        let(:values) { [OpenProject::Database::DB_VALUE_TRUE] }
+
+        it "has `true` for 'values'" do
+          is_expected
+            .to be_json_eql([true].to_json)
+                  .at_path('values')
+        end
+      end
+
+      context "with 'f' as filter value" do
+        let(:values) { [OpenProject::Database::DB_VALUE_FALSE] }
+
+        it "has `true` for 'values'" do
+          is_expected
+            .to be_json_eql([false].to_json)
+                  .at_path('values')
+        end
+      end
+
+      context "with something as filter value" do
+        let(:values) { ['blubs'] }
+
+        it "has `false` for 'values'" do
+          is_expected
+            .to be_json_eql([false].to_json)
+                  .at_path('values')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The "Bcf issue associated" filter could not be saved. 

This was already fixed in https://github.com/opf/openproject/commit/a08be20d4f6dcdff87620c3bf506185135785013 , but only for the dev branch. This PRs has cherry-picked the commit and added a test. 

https://community.openproject.com/projects/openproject/work_packages/30813/activity