### PR TITLE
[30791] Seed data: Kanban board uses status "in progress" but that status is not part of the workflow of type "Feature" 

### DIFF
--- a/app/seeders/standard_seeder/basic_data/status_seeder.rb
+++ b/app/seeders/standard_seeder/basic_data/status_seeder.rb
@@ -63,7 +63,6 @@ module StandardSeeder
           { name: I18n.t(:default_status_to_be_scheduled),  color_id: colors[4], is_closed: false, is_default: false, position: 5  },
           { name: I18n.t(:default_status_scheduled),        color_id: colors[5], is_closed: false, is_default: false, position: 6  },
           { name: I18n.t(:default_status_in_progress),      color_id: colors[6], is_closed: false, is_default: false, position: 7  },
-          { name: I18n.t(:default_status_in_development),   color_id: colors[7], is_closed: false, is_default: false, position: 8  },
           { name: I18n.t(:default_status_developed),        color_id: colors[8], is_closed: false, is_default: false, position: 9  },
           { name: I18n.t(:default_status_in_testing),       color_id: colors[9], is_closed: false, is_default: false, position: 10 },
           { name: I18n.t(:default_status_tested),           color_id: colors[10], is_closed: false, is_default: false, position: 11 },

--- a/app/seeders/standard_seeder/basic_data/workflow_seeder.rb
+++ b/app/seeders/standard_seeder/basic_data/workflow_seeder.rb
@@ -42,7 +42,6 @@ module StandardSeeder
         to_be_scheduled  = Status.find_by(name: I18n.t(:default_status_to_be_scheduled))
         scheduled        = Status.find_by(name: I18n.t(:default_status_scheduled))
         in_progress      = Status.find_by(name: I18n.t(:default_status_in_progress))
-        in_development   = Status.find_by(name: I18n.t(:default_status_in_development))
         developed        = Status.find_by(name: I18n.t(:default_status_developed))
         in_testing       = Status.find_by(name: I18n.t(:default_status_in_testing))
         tested           = Status.find_by(name: I18n.t(:default_status_tested))
@@ -55,10 +54,10 @@ module StandardSeeder
           types[I18n.t(:default_type_task)]       => [new, in_progress, on_hold, rejected, closed],
           types[I18n.t(:default_type_milestone)]  => [new, to_be_scheduled, scheduled, in_progress, on_hold, rejected, closed],
           types[I18n.t(:default_type_phase)]      => [new, to_be_scheduled, scheduled, in_progress, on_hold, rejected, closed],
-          types[I18n.t(:default_type_feature)]    => [new, in_specification, specified, in_development, developed, in_testing, tested, test_failed, on_hold, rejected, closed],
-          types[I18n.t(:default_type_epic)]       => [new, in_specification, specified, in_development, developed, in_testing, tested, test_failed, on_hold, rejected, closed],
-          types[I18n.t(:default_type_user_story)] => [new, in_specification, specified, in_development, developed, in_testing, tested, test_failed, on_hold, rejected, closed],
-          types[I18n.t(:default_type_bug)]        => [new, confirmed, in_development, developed, in_testing, tested, test_failed, on_hold, rejected, closed]
+          types[I18n.t(:default_type_feature)]    => [new, in_specification, specified, in_progress, developed, in_testing, tested, test_failed, on_hold, rejected, closed],
+          types[I18n.t(:default_type_epic)]       => [new, in_specification, specified, in_progress, developed, in_testing, tested, test_failed, on_hold, rejected, closed],
+          types[I18n.t(:default_type_user_story)] => [new, in_specification, specified, in_progress, developed, in_testing, tested, test_failed, on_hold, rejected, closed],
+          types[I18n.t(:default_type_bug)]        => [new, confirmed, in_progress, developed, in_testing, tested, test_failed, on_hold, rejected, closed]
         }
       end
 

--- a/modules/bim_seeder/app/seeders/bim_seeder/basic_data/status_seeder.rb
+++ b/modules/bim_seeder/app/seeders/bim_seeder/basic_data/status_seeder.rb
@@ -63,7 +63,6 @@ module BimSeeder
           { name: I18n.t(:default_status_to_be_scheduled),  color_id: colors[4], is_closed: false, is_default: false, position: 5  },
           { name: I18n.t(:default_status_scheduled),        color_id: colors[5], is_closed: false, is_default: false, position: 6  },
           { name: I18n.t(:default_status_in_progress),      color_id: colors[6], is_closed: false, is_default: false, position: 7  },
-          { name: I18n.t(:default_status_in_development),   color_id: colors[7], is_closed: false, is_default: false, position: 8  },
           { name: I18n.t(:default_status_developed),        color_id: colors[8], is_closed: false, is_default: false, position: 9  },
           { name: I18n.t(:default_status_in_testing),       color_id: colors[9], is_closed: false, is_default: false, position: 10 },
           { name: I18n.t(:default_status_tested),           color_id: colors[10], is_closed: false, is_default: false, position: 11 },

--- a/modules/bim_seeder/app/seeders/bim_seeder/basic_data/workflow_seeder.rb
+++ b/modules/bim_seeder/app/seeders/bim_seeder/basic_data/workflow_seeder.rb
@@ -41,7 +41,6 @@ module BimSeeder
         to_be_scheduled  = Status.find_by(name: I18n.t(:default_status_to_be_scheduled))
         scheduled        = Status.find_by(name: I18n.t(:default_status_scheduled))
         in_progress      = Status.find_by(name: I18n.t(:default_status_in_progress))
-        in_development   = Status.find_by(name: I18n.t(:default_status_in_development))
         developed        = Status.find_by(name: I18n.t(:default_status_developed))
         in_testing       = Status.find_by(name: I18n.t(:default_status_in_testing))
         tested           = Status.find_by(name: I18n.t(:default_status_tested))
@@ -54,9 +53,9 @@ module BimSeeder
           types[I18n.t(:default_type_task)]                         => [new, in_progress, on_hold, rejected, closed],
           types[I18n.t(:default_type_milestone)]                    => [new, to_be_scheduled, scheduled, in_progress, on_hold, rejected, closed],
           types[I18n.t(:default_type_phase)]                        => [new, to_be_scheduled, scheduled, in_progress, on_hold, rejected, closed],
-          types[I18n.t('seeders.bim.default_type_building_model')]  => [new, in_specification, specified, in_development, developed, in_testing, tested, test_failed, on_hold, rejected, closed],
-          types[I18n.t('seeders.bim.default_type_defect')]          => [new, in_specification, specified, in_development, developed, in_testing, tested, test_failed, on_hold, rejected, closed],
-          types[I18n.t('seeders.bim.default_type_approval')]        => [new, in_specification, specified, in_development, developed, in_testing, tested, test_failed, on_hold, rejected, closed]
+          types[I18n.t('seeders.bim.default_type_building_model')]  => [new, in_specification, specified, in_progress, developed, in_testing, tested, test_failed, on_hold, rejected, closed],
+          types[I18n.t('seeders.bim.default_type_defect')]          => [new, in_specification, specified, in_progress, developed, in_testing, tested, test_failed, on_hold, rejected, closed],
+          types[I18n.t('seeders.bim.default_type_approval')]        => [new, in_specification, specified, in_progress, developed, in_testing, tested, test_failed, on_hold, rejected, closed]
         }
       end
 


### PR DESCRIPTION
Remove status "in development" from seed data to avoid error messages on status board.

https://community.openproject.com/projects/openproject/work_packages/30791/activity