### PR TITLE
[30842] Allow multiple parallel creation

### DIFF
--- a/frontend/src/app/components/wp-card-view/services/wp-card-drag-and-drop.service.ts
+++ b/frontend/src/app/components/wp-card-view/services/wp-card-drag-and-drop.service.ts
@@ -185,8 +185,9 @@ export class WorkPackageCardDragAndDropService {
    * On new card saved
    */
   async onCardSaved(wp:WorkPackageResource) {
-    if (this.activeInlineCreateWp && this.activeInlineCreateWp.__initialized_at === wp.__initialized_at) {
-      const index = this.workPackages.indexOf(this.activeInlineCreateWp);
+    const index = this.workPackages.findIndex((el) => el.id === 'new');
+
+    if (index !== -1) {
       this.activeInlineCreateWp = undefined;
 
       // Add this item to the results


### PR DESCRIPTION
Allows multiple parallel creation of the inline created work package in boards, since they are isolated anyway, the create callback can only be the created work package in the board list

https://community.openproject.com/wp/30842