### PR TITLE
[30843][30844] Adding existing card and creating new card form can be open at same time

### DIFF
--- a/frontend/src/app/components/wp-card-view/services/wp-card-drag-and-drop.service.ts
+++ b/frontend/src/app/components/wp-card-view/services/wp-card-drag-and-drop.service.ts
@@ -170,6 +170,12 @@ export class WorkPackageCardDragAndDropService {
   /**
    * Remove the new card
    */
+  public removeReferenceWorkPackageForm() {
+    if (this.activeInlineCreateWp) {
+      this.removeCard(this.activeInlineCreateWp);
+    }
+  }
+
   removeCard(wp:WorkPackageResource) {
     const index = this.workPackages.indexOf(wp);
     this.workPackages.splice(index, 1);

--- a/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field.component.ts
+++ b/frontend/src/app/components/wp-edit/wp-edit-field/wp-edit-field.component.ts
@@ -44,7 +44,7 @@ import {
   ElementRef,
   Inject,
   Injector,
-  Input,
+  Input, OnDestroy,
   OnInit,
   ViewChild
 } from '@angular/core';
@@ -62,7 +62,7 @@ import {IWorkPackageEditingServiceToken} from "../../wp-edit-form/work-package-e
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './wp-edit-field.html'
 })
-export class WorkPackageEditFieldComponent implements OnInit {
+export class WorkPackageEditFieldComponent implements OnInit, OnDestroy {
   @Input('fieldName') public fieldName:string;
   @Input('workPackageId') public workPackageId:string;
   @Input('wrapperClasses') public wrapperClasses?:string;
@@ -78,6 +78,8 @@ export class WorkPackageEditFieldComponent implements OnInit {
   public editFieldContainerClass = editFieldContainerClass;
   public active = false;
   private $element:JQuery;
+
+  public destroyed:boolean = false;
 
   constructor(protected states:States,
               protected injector:Injector,
@@ -97,13 +99,19 @@ export class WorkPackageEditFieldComponent implements OnInit {
 
   public setActive(active:boolean = true) {
     this.active = active;
-    this.cdRef.detectChanges();
+    if (!this.destroyed) {
+      this.cdRef.detectChanges();
+    }
   }
 
   public ngOnInit() {
     this.fieldRenderer = new DisplayFieldRenderer(this.injector, 'single-view', this.displayFieldOptions);
     this.$element = jQuery(this.elementRef.nativeElement);
     this.wpEditFieldGroup.register(this);
+  }
+
+  public ngOnDestroy() {
+    this.destroyed = true;
   }
 
   // Open the field when its closed and relay drag & drop events to it.

--- a/frontend/src/app/modules/boards/board/inline-add/board-inline-add-autocompleter.component.ts
+++ b/frontend/src/app/modules/boards/board/inline-add/board-inline-add-autocompleter.component.ts
@@ -27,7 +27,7 @@
 //++
 
 import {
-  AfterContentInit,
+  AfterViewInit,
   ChangeDetectorRef,
   Component,
   EventEmitter,
@@ -49,6 +49,7 @@ import {CurrentProjectService} from "core-components/projects/current-project.se
 import {ApiV3FilterBuilder} from "core-components/api/api-v3/api-v3-filter-builder";
 import {HalResourceService} from "core-app/modules/hal/services/hal-resource.service";
 import {SchemaCacheService} from "core-components/schemas/schema-cache.service";
+import {WorkPackageCardDragAndDropService} from "core-components/wp-card-view/services/wp-card-drag-and-drop.service";
 
 @Component({
   selector: 'board-inline-add-autocompleter',
@@ -58,7 +59,7 @@ import {SchemaCacheService} from "core-components/schemas/schema-cache.service";
   encapsulation: ViewEncapsulation.None,
   styleUrls: ['./board-inline-add-autocompleter.sass']
 })
-export class BoardInlineAddAutocompleterComponent implements AfterContentInit {
+export class BoardInlineAddAutocompleterComponent implements AfterViewInit {
   readonly text = {
     placeholder: this.I18n.t('js.relations_autocomplete.placeholder')
   };
@@ -90,10 +91,11 @@ export class BoardInlineAddAutocompleterComponent implements AfterContentInit {
               private readonly halResourceService:HalResourceService,
               private readonly schemaCacheService:SchemaCacheService,
               private readonly cdRef:ChangeDetectorRef,
-              private readonly I18n:I18nService) {
+              private readonly I18n:I18nService,
+              private readonly wpCardDragDrop:WorkPackageCardDragAndDropService) {
   }
 
-  ngAfterContentInit():void {
+  ngAfterViewInit():void {
     if (!this.ngSelectComponent) {
       return;
     }
@@ -102,6 +104,8 @@ export class BoardInlineAddAutocompleterComponent implements AfterContentInit {
     setTimeout(() => {
       this.ngSelectComponent.focus();
     }, 25);
+
+    this.wpCardDragDrop.removeReferenceWorkPackageForm();
   }
 
   cancel() {


### PR DESCRIPTION
* Avoid the reference and creation form are opened at the same time 
* Focus board inline reference autocompleter when opened

https://community.openproject.com/projects/openproject/work_packages/30843/activity
https://community.openproject.com/projects/openproject/work_packages/30844/activity