### PR TITLE
[30859] Use controller_path to get correctly namespaced menu items

### DIFF
--- a/lib/redmine/menu_manager/menu_controller.rb
+++ b/lib/redmine/menu_manager/menu_controller.rb
@@ -42,14 +42,14 @@ module Redmine::MenuManager::MenuController
     #   * menu_item :tickets, only: :list # => sets the menu name to :tickets for the 'list' action only
     #   * menu_item :tickets, only: [:list, :show] # => sets the menu name to :tickets for 2 actions only
     #
-    # The default menu item name for a controller is controller_name by default
+    # The default menu item name for a controller is controller_path by default
     # Eg. the default menu item name for ProjectsController is :projects
     def menu_item(id, options = {})
       if actions = options[:only]
         actions = [] << actions unless actions.is_a?(Array)
-        actions.each { |a| menu_items[controller_name.to_sym][:actions][a.to_sym] = id }
+        actions.each { |a| menu_items[controller_path.to_sym][:actions][a.to_sym] = id }
       else
-        menu_items[controller_name.to_sym][:default] = id
+        menu_items[controller_path.to_sym][:default] = id
       end
     end
 
@@ -57,10 +57,10 @@ module Redmine::MenuManager::MenuController
       raise ArgumentError '#current_menu_item requires a block' unless block_given?
 
       if actions == :default
-        menu_items[controller_name.to_sym][:default] = block
+        menu_items[controller_path.to_sym][:default] = block
       else
         actions = [] << actions unless actions.is_a?(Array)
-        actions.each { |a| menu_items[controller_name.to_sym][:actions][a.to_sym] = block }
+        actions.each { |a| menu_items[controller_path.to_sym][:actions][a.to_sym] = block }
       end
     end
   end
@@ -68,13 +68,13 @@ module Redmine::MenuManager::MenuController
   def menu_items
     self.class.menu_items
   end
-
+  
   # Returns the menu item name according to the current action
   def current_menu_item
     return @current_menu_item if @current_menu_item_determined
 
-    @current_menu_item = menu_items[controller_name.to_sym][:actions][action_name.to_sym] ||
-                         menu_items[controller_name.to_sym][:default]
+    @current_menu_item = menu_items[controller_path.to_sym][:actions][action_name.to_sym] ||
+                         menu_items[controller_path.to_sym][:default]
 
     @current_menu_item = if @current_menu_item.is_a?(Symbol)
                            @current_menu_item

--- a/spec/features/admin/menu_item_traversal_spec.rb
+++ b/spec/features/admin/menu_item_traversal_spec.rb
@@ -1,0 +1,51 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Menu item traversal', type: :feature, js: true do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  describe 'EnterpriseToken management' do
+    before do
+      login_as(admin)
+      visit admin_index_path
+    end
+
+    it 'correctly maps the menu items for controllers in their namespace (Regression #30859)' do
+      expect(page).to have_selector('.admin-overview-menu-item.selected', text: 'Overview')
+
+      find('.plugin-webhooks-menu-item').click
+
+      # using `controller_name` in `menu_controller.rb` has broken this example,
+      # due to the plugin controller also being named 'admin' thus falling back to 'admin#index' => overview selected
+      expect(page).to have_selector('.plugin-webhooks-menu-item.selected', text: 'Webhooks', wait: 5)
+      expect(page).to have_no_selector('.admin-overview-menu-item.selected')
+    end
+  end
+end


### PR DESCRIPTION
using `controller_name` in `menu_controller.rb` breaks items in the admin section that come from controllers also named `admin_controller`, such as the namespaced webhooks controller. 

Routes from `admin#index` to `webhooks/outgoing/admin#index` will then fall to `admin#index` again and get the overview icon. This does only happen when moving from overview to webhooks, not freshly loading the page there due to how the params work.

https://community.openproject.com/wp/30859