### PR TITLE
[30857] Unnecessary scrollbars in work package view

### DIFF
--- a/app/assets/stylesheets/content/_autocomplete.sass
+++ b/app/assets/stylesheets/content/_autocomplete.sass
@@ -169,6 +169,7 @@ mark.ui-autocomplete-match
         box-sizing: border-box !important
   .ng-value
     @include text-shortener
+    line-height: 22px
 
 .ng-select.-multi-select .ng-select-container
   height: initial !important
@@ -179,7 +180,7 @@ mark.ui-autocomplete-match
   z-index: 9500 !important
 
 .ng-option
-  font-size: 0.875rem
-  line-height: 1.6
+  font-size: 14px
+  line-height: 22px
 .work-package-table--container .ng-dropdown-panel
   z-index: auto !important


### PR DESCRIPTION
The `rem`-based height values for the automcompleter options have resulted in half pixel values. A state that is not allowed and is resolved differently by browsers and operating systems. Under Windows this has led to a scroll bar being displayed in the autocompleter. This looked particularly terrible by the awful display of scrollbars under Windows.

https://community.openproject.com/projects/openproject/work_packages/30857/activity