### PR TITLE
Fix/30863/color highlight

### DIFF
--- a/app/assets/stylesheets/layout/work_packages/_table.sass
+++ b/app/assets/stylesheets/layout/work_packages/_table.sass
@@ -77,8 +77,12 @@
   // Required for correctly scrolling the inner containers
   overflow: hidden
 
-  .row-hovered
-    background: #E5F2FA
+  // Match both rows and timeline specifically
+  tr.row-hovered,
+  div.row-hovered
+    // Use important to override the background styles from __hl classes
+    // That also have to be important (cf. 30863)
+    background: #E5F2FA !important
     z-index: 1
 
 // Left part of the split view

--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -94,7 +94,7 @@ module ColorsHelper
 
       styles = color.color_styles
 
-      background_style = styles.map { |k,v| "#{k}:#{v}"}.join(';')
+      background_style = styles.map { |k,v| "#{k}:#{v} !important"}.join(';')
       border_color = color.bright? ? '#555555' : color.hexcode
 
       if name === 'type'


### PR DESCRIPTION
- [Revert "Remove "!important"](https://github.com/opf/openproject/commit/72163472dee22eff2610167dd0e47c3209f26a8f) to allow some styles to override it (e.g. row highlighting in column)
- Override table hover style to ensure it overrides background style 


https://community.openproject.com/wp/30863