### PR TITLE
[25689] Ensure reminder emails can be sent to groups as well

### DIFF
--- a/lib/open_project/reminders/due_issues_reminder.rb
+++ b/lib/open_project/reminders/due_issues_reminder.rb
@@ -1,0 +1,67 @@
+module OpenProject
+  module Reminders
+    class DueIssuesReminder
+      attr_reader :due_date_in_days, :due_date, :project, :type, :user_ids, :notify_count
+
+      def initialize(days: 7, project_id: nil, type_id: nil, user_ids: [])
+        @due_date_in_days = days.to_i
+        @due_date = due_date_in_days.days.from_now.to_date
+        @project = Project.find_by(id: project_id.to_i) if project_id
+        @type = ::Type.find_by(id: type_id.to_i) if type_id
+        @user_ids = Array(user_ids).map(&:to_i).reject(&:zero?)
+        @notify_count = 0
+      end
+
+      ##
+      # Send reminder mails for the given instantiation
+      def remind_users
+        assigned_principals.each do |principal, issues|
+          case principal
+          when Group
+            group.users.each { |u| send_reminder_mail!(u, issues) }
+          when User
+            send_reminder_mail!(principal, issues)
+          else
+            Rails.logger.info { "Skipping reminder mail for undeliverable principal #{principal.class.name} #{principal.id} " }
+          end
+        end
+      end
+
+      ##
+      # Deliver the reminder mail now for the given user
+      # assuming it is active
+      def send_reminder_mail!(user, issues)
+        if user&.active?
+          UserMailer.reminder_mail(user, issues, due_date_in_days).deliver_now
+          @notify_count += 1
+        end
+      rescue StandardError => e
+        Rails.logger.error { "Failed to deliver reminder_mail to user##{user.id}: #{e.message}" }
+      end
+
+      def assigned_principals
+        scope = WorkPackage
+          .includes(:status, :assigned_to, :project, :type)
+          .where("#{Status.table_name}.is_closed = false AND #{WorkPackage.table_name}.due_date <= ?", due_date)
+          .where("#{WorkPackage.table_name}.assigned_to_id IS NOT NULL")
+          .where("#{Project.table_name}.status = #{Project::STATUS_ACTIVE}")
+
+        if user_ids.any?
+          scope = scope.where("#{WorkPackage.table_name}.assigned_to_id IN (?)", user_ids)
+        end
+
+        if project
+          scope = scope.where("#{WorkPackage.table_name}.project_id = #{project.id}")
+        end
+
+        if type
+          scope = scope.where("#{WorkPackage.table_name}.type_id = #{type.id}")
+        end
+
+        scope
+          .references(:projects, :statuses, :work_packages)
+          .group_by(&:assigned_to)
+      end
+    end
+  end
+end

--- a/spec/lib/reminders/due_issues_reminder_spec.rb
+++ b/spec/lib/reminders/due_issues_reminder_spec.rb
@@ -1,0 +1,84 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe OpenProject::Reminders::DueIssuesReminder do
+  subject do
+    described_class.new(days: days, user_ids: user_ids).tap do |instance|
+      instance.remind_users
+    end
+  end
+
+  context 'with days set to 42' do
+    let(:days) { 42 }
+
+    context 'with user_ids unset' do
+      let(:user_ids) { nil }
+
+      let!(:user) { FactoryBot.create(:user, mail: 'foo@bar.de') }
+      let!(:wp) { FactoryBot.create(:work_package, due_date: Date.tomorrow, assigned_to: user, subject: 'some issue') }
+
+      it 'does notify the user' do
+        expect(subject.notify_count).to be >= 1
+        expect(ActionMailer::Base.deliveries.count).to be >= 1
+
+        mail = ActionMailer::Base.deliveries.detect { |m| m.to.include? user.mail }
+        expect(mail).to be_present
+        expect(mail.body.encoded).to include("#{wp.project.name} - #{wp.type.name} ##{wp.id}: some issue")
+        expect(mail.subject).to eq '1 work package(s) due in the next 42 days'
+      end
+    end
+
+    context 'with user_ids set' do
+      let!(:user) { FactoryBot.create(:user, mail: 'foo@bar.de') }
+      let!(:user2) { FactoryBot.create(:user, mail: 'foo@example.de') }
+      let!(:wp) { FactoryBot.create(:work_package, due_date: Date.tomorrow, assigned_to: user, subject: 'some issue') }
+
+      context 'to an unassigned user' do
+        let(:user_ids) { [user2.id] }
+        it 'does not notify' do
+          expect(subject.notify_count).to eq 0
+        end
+      end
+
+      context 'to an assigned user' do
+        let(:user_ids) { [user.id] }
+        it 'does notify' do
+          expect(subject.notify_count).to eq 1
+          expect(ActionMailer::Base.deliveries.count). to eq 1
+
+          mail = ActionMailer::Base.deliveries.last
+          expect(mail).to be_present
+          expect(mail.body.encoded).to include("#{wp.project.name} - #{wp.type.name} ##{wp.id}: some issue")
+          expect(mail.subject).to eq '1 work package(s) due in the next 42 days'
+        end
+      end
+    end
+  end
+end

--- a/spec_legacy/functional/user_mailer_spec.rb
+++ b/spec_legacy/functional/user_mailer_spec.rb
@@ -330,35 +330,6 @@ describe UserMailer, type: :mailer do
     assert mail.body.encoded.include?("https://redmine.foo/account/activate?token=#{token.value}")
   end
 
-  it 'should reminders' do
-    user  = FactoryBot.create(:user, mail: 'foo@bar.de')
-    issue = FactoryBot.create(:work_package, due_date: Date.tomorrow, assigned_to: user, subject: 'some issue')
-
-    DueIssuesReminder.new(42).remind_users
-    assert_equal 1, ActionMailer::Base.deliveries.size
-    mail = ActionMailer::Base.deliveries.last
-    assert mail.to.include?('foo@bar.de')
-    assert mail.body.encoded.include?("#{issue.project.name} - #{issue.type.name} ##{issue.id}: some issue")
-    assert_equal '1 work package(s) due in the next 42 days', mail.subject
-  end
-
-  it 'should reminders for users' do
-    user1  = FactoryBot.create(:user, mail: 'foo1@bar.de')
-    user2  = FactoryBot.create(:user, mail: 'foo2@bar.de')
-    issue = FactoryBot.create(:work_package, due_date: Date.tomorrow, assigned_to: user1, subject: 'some issue')
-
-    DueIssuesReminder.new(42, nil, nil, [user2.id]).remind_users
-    assert_equal 0, ActionMailer::Base.deliveries.size
-
-    DueIssuesReminder.new(42, nil, nil, [user1.id]).remind_users
-    assert_equal 1, ActionMailer::Base.deliveries.size
-
-    mail = ActionMailer::Base.deliveries.last
-    assert mail.to.include?('foo1@bar.de')
-    assert mail.body.encoded.include?("#{issue.project.name} - #{issue.type.name} ##{issue.id}: some issue")
-    assert_equal '1 work package(s) due in the next 42 days', mail.subject
-  end
-
   context 'with locale settings',
           with_settings: { available_languages: ['en', 'de'], default_language: 'de' } do
     it 'should mailer should not change locale' do


### PR DESCRIPTION
Groups were not expanded to their users for reminder mails, failing in the process due to `assignee.active?` being checked which does not exist for groups.

https://community.openproject.com/wp/25689