### PR TITLE
[30802] add left/right margin of timeline viewport into account for zoom

### DIFF
--- a/frontend/src/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
+++ b/frontend/src/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
@@ -300,7 +300,6 @@ export class WorkPackageTimelineTableController implements AfterViewInit, OnDest
     const nonVisibleDaysLeft = Math.floor(scrollLeft / this.viewParameters.pixelPerDay);
     return this.viewParameters.dateDisplayStart.clone().add(nonVisibleDaysLeft, 'days');
   }
-
   getLastDayInViewport() {
     const outerContainer = this.getParentScrollContainer();
     const scrollLeft = outerContainer.scrollLeft;
@@ -401,7 +400,7 @@ export class WorkPackageTimelineTableController implements AfterViewInit, OnDest
     });
 
     // left spacing
-    newParams.dateDisplayStart.subtract(currentParams.dayCountForMarginLeft, 'days');
+    newParams.dateDisplayStart = newParams.dateDisplayStart.subtract(currentParams.dayCountForMarginLeft, 'days');
 
     // right spacing
     // RR: kept both variants for documentation purpose.
@@ -412,7 +411,7 @@ export class WorkPackageTimelineTableController implements AfterViewInit, OnDest
 
     const pixelPerDay = currentParams.pixelPerDay;
     const visibleDays = Math.ceil((width / pixelPerDay) * 1.5);
-    newParams.dateDisplayEnd.add(visibleDays, 'days');
+    newParams.dateDisplayEnd = newParams.dateDisplayEnd.add(visibleDays, 'days');
 
     // Check if view params changed:
 


### PR DESCRIPTION
The zoom was off since adding a margin to the start and end to add spaces for moving work packages on each side of the TL viewport. 

This meant that zooming was computed to stay within the first and last work package date, not the viewport date

https://community.openproject.com/wp/30802
Likely also fixes https://community.openproject.com/wp/30801