### PR TITLE
Don't break session auth if fallback session provided

### DIFF
--- a/lib/open_project/authentication/session_expiry.rb
+++ b/lib/open_project/authentication/session_expiry.rb
@@ -13,6 +13,9 @@ module OpenProject
         # Only when the TTL setting exists
         return false unless session_ttl_enabled?
 
+        # If the session is rack-provided and empty, also skip it
+        return false if session.empty?
+
         session[:updated_at].nil? || (session[:updated_at] + session_ttl_minutes) < Time.now
       end
     end


### PR DESCRIPTION
When no session is provided (e.g., just curl an attachment URL), Rack will still give you a session that is empty, which of course has TTL attribute outdated if being checked for it.

Thus we accept an empty placeholder session as valid as long there are no attributes. The only user authenticatable through it is `User.anonymous`.