### PR TITLE
[30865] Allow globally filtering for locally shared versions

### DIFF
--- a/app/helpers/work_packages_filter_helper.rb
+++ b/app/helpers/work_packages_filter_helper.rb
@@ -37,7 +37,8 @@ module WorkPackagesFilterHelper
         filter_object('fixed_version_id', '=', version.id)
       ]
     }
-    project_work_packages_with_query_path(version.project, query, options)
+
+    conditional_query_path(version, query, options)
   end
 
   def project_work_packages_open_version_path(version, options = {})
@@ -47,7 +48,8 @@ module WorkPackagesFilterHelper
         filter_object('fixed_version_id', '=', version.id)
       ]
     }
-    project_work_packages_with_query_path(version.project, query, options)
+
+    conditional_query_path(version, query, options)
   end
 
   # Links for reports
@@ -118,8 +120,21 @@ module WorkPackagesFilterHelper
     'updated_at:desc'
   end
 
+  def conditional_query_path(version, query, options)
+    if version.shared_with_outsiders?
+      global_work_packages_with_query_path(query, options)
+    else
+      query[:f] << filter_object('subproject_id', '*')
+      project_work_packages_with_query_path(version.project, query, options)
+    end
+  end
+
   def project_work_packages_with_query_path(project, query, options = {})
     project_work_packages_path(project, options.reverse_merge!(query_props: query.to_json))
+  end
+
+  def global_work_packages_with_query_path(query, options = {})
+    work_packages_path(options.reverse_merge!(query_props: query.to_json))
   end
 
   def filter_object(property, operator, values = nil)

--- a/app/models/queries/work_packages/filter/version_filter.rb
+++ b/app/models/queries/work_packages/filter/version_filter.rb
@@ -65,7 +65,7 @@ class Queries::WorkPackages::Filter::VersionFilter <
     if project
       project.shared_versions
     else
-      Version.visible.systemwide
+      Version.visible
     end
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -66,6 +66,11 @@ class Version < ActiveRecord::Base
     user.allowed_to?(:view_work_packages, project)
   end
 
+  # Returns whether this version is limited to project and subprojects
+  def shared_with_outsiders?
+    !%w(none descendants).include?(sharing)
+  end
+
   # When a version started.
   #
   # Can either be a set date stored in the database or a dynamic one

--- a/frontend/src/app/modules/work-package-graphs/configuration/wp-graph-configuration.service.ts
+++ b/frontend/src/app/modules/work-package-graphs/configuration/wp-graph-configuration.service.ts
@@ -80,8 +80,8 @@ export class WpGraphConfigurationService {
       .loadWithParams(
         {pageSize: 0},
         undefined,
-        this.currentProject.identifier,
-        WpGraphConfiguration.queryCreationParams(this.I18n, !!this.currentProject.identifier)
+        undefined,
+        WpGraphConfiguration.queryCreationParams(this.I18n, false)
       )
       .then(form => {
         const query = this.queryFormDm.buildQueryResource(form);
@@ -103,7 +103,7 @@ export class WpGraphConfigurationService {
       .find(
         Object.assign({pageSize: 0}, params.props),
         params.id,
-        this.currentProject.identifier,
+        undefined
       )
       .then(query => {
         if (params.name) {

--- a/frontend/src/app/modules/work-package-graphs/overview/wp-overview-graph.component.ts
+++ b/frontend/src/app/modules/work-package-graphs/overview/wp-overview-graph.component.ts
@@ -115,7 +115,7 @@ export class WorkPackageOverviewGraphComponent implements OnInit {
   }
 
   private baseProps(filter?:any) {
-    let filters = [{subprojectId: {operator: '*', values: []}}];
+    let filters = [];
 
     if (filter) {
       filters.push(filter);

--- a/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
@@ -43,9 +43,7 @@ module API
             order = "sortBy=#{to_query [%i(name asc)]}"
 
             if filter.project.nil?
-              filter_params = [{ sharing: { operator: '=', values: ['system'] } }]
-
-              "#{api_v3_paths.versions}?filters=#{to_query filter_params}&#{order}"
+              "#{api_v3_paths.versions}?#{order}"
             else
               "#{api_v3_paths.versions_by_project(filter.project.id)}?#{order}"
             end


### PR DESCRIPTION
Otherwise, we cannot link to a global query with a version that is shared with something other than (none, descendants) to catch all work packages.

https://community.openproject.com/wp/30865