### PR TITLE
[30853] Author field is cut off even though there is plenty of space

### DIFF
--- a/app/assets/stylesheets/content/_table.sass
+++ b/app/assets/stylesheets/content/_table.sass
@@ -179,6 +179,13 @@ table.generic-table
         width: 100%
         max-width: 500px
 
+      // The avatar image is not taken into the width calculation of the table cell by the browser.
+         That is why we add the space manually.
+      &.-contains-avatar
+        text-overflow: clip
+        .wp-table--cell-container
+          padding-right: 35px
+
       &.info
         a
           text-decoration: none

--- a/frontend/src/app/components/wp-fast-table/builders/cell-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/cell-builder.ts
@@ -4,6 +4,7 @@ import {
   editFieldContainerClass
 } from '../../wp-edit-form/display-field-renderer';
 import {Injector} from '@angular/core';
+import {QueryColumn} from "core-components/wp-query/query-column";
 export const tdClassName = 'wp-table--cell-td';
 export const editCellContainer = 'wp-table--cell-container';
 export const wpCellTdClassName = 'wp-table--cell-td';
@@ -15,12 +16,18 @@ export class CellBuilder {
   constructor(public injector:Injector) {
   }
 
-  public build(workPackage:WorkPackageResource, attribute:string) {
+  public build(workPackage:WorkPackageResource, column:QueryColumn) {
     const td = document.createElement('td');
+    const attribute = column.id;
     td.classList.add(tdClassName, wpCellTdClassName, attribute);
 
     if (attribute === 'subject') {
       td.classList.add('-max');
+    }
+
+    const schema = workPackage.schema[attribute];
+    if (schema && schema.type === 'User') {
+      td.classList.add('-contains-avatar');
     }
 
     const container = document.createElement('span');

--- a/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
@@ -83,7 +83,7 @@ export class SingleRowBuilder {
           return null;
         }
       default:
-        return this.cellBuilder.build(workPackage, column.id);
+        return this.cellBuilder.build(workPackage, column);
     }
   }
 


### PR DESCRIPTION
It seems as if the avatar image is not taken into account for the width calculation of table cells. That is why the name was sometimes cut off although there was enough space in the table. 

This PR adds space for the avatar manually to avoid that the name is cut off.

https://community.openproject.com/projects/openproject/work_packages/30853/activity