### PR TITLE
BCF-XML-API V1

### DIFF
--- a/modules/bcf/app/assets/stylesheets/bcf/bcf.sass
+++ b/modules/bcf/app/assets/stylesheets/bcf/bcf.sass
@@ -7,6 +7,8 @@
     flex: 0 0 250px
     margin: 10px
     padding: 10px
+    &.-failed
+      border: 1px solid #EAEAEA
 
   img
     width: 100%

--- a/modules/bcf/app/controllers/bcf/issues_controller.rb
+++ b/modules/bcf/app/controllers/bcf/issues_controller.rb
@@ -46,28 +46,24 @@ module ::Bcf
 
     menu_item :work_packages
 
-    def index
-      @issues = ::Bcf::Issue.in_project(@project)
-                            .with_markup
-                            .includes(:comments, :work_package, viewpoints: :attachments)
-                            .page(page_param)
-                            .per_page(per_page_param)
-    end
-
     def upload; end
+
+    def index
+      redirect_to action: :upload
+    end
 
     def prepare_import
       render_next
     rescue StandardError => e
       flash[:error] = I18n.t('bcf.bcf_xml.import_failed', error: e.message)
-      redirect_to action: :index
+      redirect_to action: :upload
     end
 
     def configure_import
       render_next
     rescue StandardError => e
       flash[:error] = I18n.t('bcf.bcf_xml.import_failed', error: e.message)
-      redirect_to action: :index
+      redirect_to action: :upload
     end
 
     def perform_import

--- a/modules/bcf/app/models/bcf/issue.rb
+++ b/modules/bcf/app/models/bcf/issue.rb
@@ -10,10 +10,6 @@ module Bcf
     after_update :invalidate_markup_cache
 
     class << self
-      def in_project(project)
-        where(project_id: project.try(:id) || project)
-      end
-
       def with_markup
         select '*',
                extract_first_node(title_path, 'title'),

--- a/modules/bcf/app/views/bcf/issues/_render_issues.html.erb
+++ b/modules/bcf/app/views/bcf/issues/_render_issues.html.erb
@@ -3,6 +3,7 @@
     <% issues.each do |issue| %>
       <% status_id = issue.work_package&.status_id %>
       <% highlighting_class = status_id.present? ? "__hl_background_status_#{status_id}" : '' %>
+      <% highlighting_class << ' -failed' if issue.errors.present?  %>
       <div class="<%= highlighting_class %>">
         <p>
           <strong><%= issue.title %></strong>

--- a/modules/bcf/lib/open_project/bcf/bcf_xml/exporter.rb
+++ b/modules/bcf/lib/open_project/bcf/bcf_xml/exporter.rb
@@ -29,6 +29,17 @@ module OpenProject::Bcf::BcfXml
       raise e
     end
 
+    def list_from_api
+      Dir.mktmpdir do |dir|
+        files = create_bcf! dir
+
+        zip_folder dir, files
+      end
+    rescue StandardError => e
+      Rails.logger.error "Failed to export work package list #{e} #{e.message}"
+      raise e
+    end
+
     def success(zip)
       WorkPackage::Exporter::Success
         .new format: :xls,

--- a/modules/bcf/lib/open_project/bcf/bcf_xml/issue_reader.rb
+++ b/modules/bcf/lib/open_project/bcf/bcf_xml/issue_reader.rb
@@ -142,6 +142,7 @@ module OpenProject::Bcf::BcfXml
         issue.work_package = call.result
         create_wp_comment(user, I18n.t('bcf.bcf_xml.import_update_comment')) if is_update
       else
+        issue.errors.merge!(call.errors)
         Rails.logger.error "Failed to synchronize BCF #{issue.uuid} with work package: #{call.errors.full_messages.join('; ')}"
       end
     end

--- a/modules/bcf/lib/open_project/bcf/engine.rb
+++ b/modules/bcf/lib/open_project/bcf/engine.rb
@@ -45,10 +45,11 @@ module OpenProject::Bcf
 
       project_module :bcf do
         permission :view_linked_issues,
-                   'bcf/issues': %i[index]
-
+                   { 'bcf/issues': %i[index] },
+                   dependencies: %i[view_work_packages]
         permission :manage_bcf,
-                   'bcf/issues': %i[index upload prepare_import configure_import perform_import]
+                   { 'bcf/issues': %i[index upload prepare_import configure_import perform_import] },
+                   dependencies: %i[view_linked_issues view_work_packages add_work_packages edit_work_packages]
       end
 
       OpenProject::AccessControl.permission(:view_work_packages).actions << 'bcf/issues/redirect_to_bcf_issues_list'

--- a/modules/bcf/lib/open_project/bcf/engine.rb
+++ b/modules/bcf/lib/open_project/bcf/engine.rb
@@ -154,7 +154,6 @@ module OpenProject::Bcf
       ::API::Root.class_eval do
         content_type :binary, 'application/octet-stream'
         default_format :binary
-        # mount ::API::BCF_XML::V1::Root
         version 'v1', using: :path do
           mount ::API::BcfXml::V1::BcfXmlAPI
         end

--- a/modules/bcf/spec/controllers/issues_controller_spec.rb
+++ b/modules/bcf/spec/controllers/issues_controller_spec.rb
@@ -120,7 +120,7 @@ describe ::Bcf::IssuesController, type: :controller do
 
       it 'should redirect back to where we started from' do
         expect { action }.to change { Attachment.count }.by(1)
-        expect(response).to redirect_to '/projects/bim_project/issues'
+        expect(response).to redirect_to '/projects/bim_project/issues/upload'
       end
     end
   end

--- a/modules/bcf/spec/factories/bcf_viewpoint_factory.rb
+++ b/modules/bcf/spec/factories/bcf_viewpoint_factory.rb
@@ -35,6 +35,10 @@
 
 FactoryBot.define do
   factory :bcf_viewpoint, class: ::Bcf::Viewpoint do
+    new_uuid = SecureRandom.uuid
+    uuid { new_uuid }
+    viewpoint_name { "Viewpoint_#{new_uuid}.bcfv" }
+
     after(:create) do |viewpoint|
       create(:bcf_viewpoint_attachment, container: viewpoint)
     end

--- a/modules/bcf/spec/requests/api/bcf_xml/v1/bcf_xml_api_spec.rb
+++ b/modules/bcf/spec/requests/api/bcf_xml/v1/bcf_xml_api_spec.rb
@@ -1,0 +1,89 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2019 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'BCF XML API v1 bcf_xml resource', type: :request do
+  include Rack::Test::Methods
+
+  let(:current_user) do
+    FactoryBot.create(:user, member_in_project: project, member_through_role: role)
+  end
+  let(:work_package) { FactoryBot.create(:work_package) }
+  let(:project) { work_package.project }
+  let(:bcf_issue) { FactoryBot.create(:bcf_issue_with_comment, work_package: work_package) }
+  let(:role) { FactoryBot.create(:role, permissions: permissions) }
+  let(:permissions) { %i(view_work_packages view_associated_issues) }
+
+  subject(:response) { last_response }
+
+  before do
+    login_as(current_user)
+
+    OpenProject::Cache.clear
+  end
+
+  describe 'GET /bcf_xml_api/v1/projects/<project>/bcf_xml' do
+    let(:path) { "/bcf_xml_api/v1/projects/#{project.identifier}/bcf_xml" }
+
+    context 'without params' do
+      before do
+        get path
+      end
+
+      it 'responds 200 OK' do
+        expect(subject.status).to eq(200)
+      end
+
+      it 'responds with correct Content-Type' do
+        expect(subject.content_type)
+          .to eql("application/octet-stream")
+      end
+
+      it 'responds with correct Content-Disposition' do
+        expect(subject.header["Content-Disposition"])
+          .to match(/attachment; filename="OpenProject_Work_packages_\d\d\d\d-\d\d-\d\d.bcfzip"/)
+      end
+
+      it 'responds with a .bcfzip file in the body ' do
+        bcf_issue
+
+        expect(zip_has_file?(subject.body, 'bcf.version')).to be_truthy
+      end
+    end
+  end
+
+  def zip_has_file?(zip_string, filename)
+    has_bcf_version_file = false
+    Zip::File.open_buffer(zip_string) do |zip_io|
+      has_bcf_version_file = zip_io.find { |entry| entry.name == filename }.present?
+    end
+    has_bcf_version_file
+  end
+end

--- a/modules/bcf/spec/requests/api/bcf_xml/v1/bcf_xml_api_spec.rb
+++ b/modules/bcf/spec/requests/api/bcf_xml/v1/bcf_xml_api_spec.rb
@@ -87,15 +87,11 @@ describe 'BCF XML API v1 bcf_xml resource', type: :request do
         expect(zip_has_file?(subject.body, "#{bcf_issue.uuid}/markup.bcf")).to be_truthy
       end
 
-      %i[view_work_packages view_linked_issues].each do |permission|
-        context "without :#{permission} permission" do
-          let(:permissions) do
-            %i[view_work_packages view_linked_issues] - [permission]
-          end
+      context "without :view_linked_issues permission" do
+        let(:permissions) { %i[view_work_packages] }
 
-          it "returns a status 404" do
-            expect(subject.status).to eql(404)
-          end
+        it "returns a status 404" do
+          expect(subject.status).to eql(404)
         end
       end
     end
@@ -141,25 +137,14 @@ describe 'BCF XML API v1 bcf_xml resource', type: :request do
       end
     end
 
-    context 'without :manage_bcf permission' do
-      let(:permissions) { %i(view_work_packages add_work_packages edit_work_packages view_linked_issues) }
+    context "without :manage_bcf permission" do
+      let(:permissions) do
+        %i[view_work_packages add_work_packages edit_work_packages view_linked_issues]
+      end
 
       it "returns a status 404" do
         expect(subject.status).to eql(404)
         expect(project.work_packages.count).to eql(1)
-      end
-    end
-
-    %i[manage_bcf view_work_packages add_work_packages edit_work_packages view_linked_issues].each do |permission|
-      context "without :#{permission} permission" do
-        let(:permissions) do
-          %i[manage_bcf view_work_packages add_work_packages edit_work_packages view_linked_issues] - [permission]
-        end
-
-        it "returns a status 404" do
-          expect(subject.status).to eql(404)
-          expect(project.work_packages.count).to eql(1)
-        end
       end
     end
   end


### PR DESCRIPTION
This is the very first version of an API for uploading and downloading BCF-XML files. Goal is to provide a first to use with the BCFier. 

When downloading you can use work package query params to filter which work packages you want to download as a BCF-XML file.

It is not yet our aim to promote that API publicly as it is not stable yet. I expect a V2 to come within the next couple of months.

Out of scope for now:
- Rich error messages
- Rich upload responses
- Asynchronous upload and download