### PR TITLE
Add info on thread and connection pool for timeouts errors

### DIFF
--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -89,7 +89,7 @@ module ErrorsHelper
     @message = arg[:message]
 
     if @status >= 500
-      op_handle_error arg[:exception] || "[Error #@status] #@message"
+      op_handle_error(arg[:exception] || "[Error #@status] #@message", payload: arg[:payload])
     end
 
     @message = l(@message) if @message.is_a?(Symbol)

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -245,6 +245,14 @@ module API
     # Handle grape validation errors
     error_response ::Grape::Exceptions::ValidationErrors, ::API::Errors::BadRequest, log: false
 
+    # Handle connection timeouts with appropriate payload
+    error_response ActiveRecord::ConnectionTimeoutError,
+                   ::API::Errors::InternalError,
+                   log: ->(exception) do
+                     payload = ::OpenProject::Logging::ThreadPoolContextBuilder.build!
+                     ::OpenProject.logger.error exception, reference: :APIv3, payload: payload
+                   end
+
     # hide internal errors behind the same JSON response as all other errors
     # only doing it in production to allow for easier debugging
     if Rails.env.production?

--- a/lib/api/utilities/grape_helper.rb
+++ b/lib/api/utilities/grape_helper.rb
@@ -71,7 +71,11 @@ module API
           resp_headers = instance_exec &headers
           env['api.format'] = 'hal+json'
 
-          OpenProject.logger.error original_exception, reference: :APIv3 if log
+          if log == true
+            OpenProject.logger.error original_exception, reference: :APIv3
+          elsif log.respond_to?(:call)
+            log.call(original_exception)
+          end
 
           error_response status: e.code, message: representer.to_json, headers: resp_headers
         }

--- a/lib/open_project/logging/thread_pool_context_builder.rb
+++ b/lib/open_project/logging/thread_pool_context_builder.rb
@@ -1,0 +1,23 @@
+module OpenProject
+  module Logging
+    class ThreadPoolContextBuilder
+      ##
+      # Build an object informing about current Rails connection pool
+      # and active thread usage and their traces
+      def self.build!
+        thread_info = {}
+        Thread.list.each_with_index do |t, i|
+          thread_info[i] = {
+            info: t.inspect,
+            trace: t.backtrace.take(2)
+          }
+        end
+
+        {
+          connection_pool: ActiveRecord::Base.connection_pool.stat,
+          thread_info: thread_info
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
 - Added to Rails controller request handling
- Added to API root to catch all api requests as well

Tested on sentry with both as https://sentry.openproject.com/sentry/localhost/issues/909/?query=is:unresolved