### PR TITLE
[30877] Relations cannot be created

### DIFF
--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relation-create.template.html
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relation-create.template.html
@@ -4,7 +4,7 @@
     <div class="grid-block">
       <div class="grid-content collapse wp-inline-create-button">
         <a class="wp-inline-create--add-link relation-create"
-           #focusAfterSave
+           autoFocus
            (accessibleClick)="toggleRelationsCreateForm()"
            href
            id="relation--add-relation">

--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component.ts
@@ -134,7 +134,7 @@ export class WorkPackageRelationsAutocomplete implements AfterContentInit {
 
   private autocompleteWorkPackages(query:string):Observable<WorkPackageResource[]> {
     // Return when the search string is empty
-    if (query.length === 0) {
+    if (query === null || query.length === 0) {
       this.isLoading = false;
       return of([]);
     }

--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.html
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.html
@@ -7,7 +7,6 @@
            [placeholder]="inputPlaceholder"
            [typeahead]="searchInput$"
            [closeOnSelect]="true"
-           (close)="cancel()"
            (open)="onOpen()"
            (change)="onWorkPackageSelected($event)">
   <ng-template ng-label-tmp let-item="item">

--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
@@ -13,7 +13,6 @@ import {WorkPackageEventsService} from "core-app/modules/work_packages/events/wo
 })
 export class WorkPackageRelationsCreateComponent {
   @Input() readonly workPackage:WorkPackageResource;
-  @ViewChild('focusAfterSave', { static: false }) readonly focusAfterSave:ElementRef;
 
   public showRelationsCreateForm:boolean = false;
   public selectedRelationType:string = RelationResource.DEFAULT();
@@ -77,13 +76,7 @@ export class WorkPackageRelationsCreateComponent {
 
   public toggleRelationsCreateForm() {
     this.showRelationsCreateForm = !this.showRelationsCreateForm;
-
-    setTimeout(() => {
-      if (!this.showRelationsCreateForm) {
-        // Reset value
-        this.selectedWpId = '';
-        this.focusAfterSave.nativeElement.focus();
-      }
-    }, 50);
+    // Reset value
+    this.selectedWpId = '';
   }
 }


### PR DESCRIPTION
Before a relation gets created, we load the work package schema. There was a timing problem in which the autocompleter was destroyed before the schema was finished loading. Thus the `onSelected` event was never send and the relation was not created.

This PR prevents that the `cancel` event is send when the dropdown of the autocompleter closes. Thus we can be sure, that the element won't get destroyed too early.

https://community.openproject.com/projects/openproject/work_packages/30877/activity