### PR TITLE
Fix/copy project without members

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -769,8 +769,6 @@ class Project < ActiveRecord::Base
     update_attribute :status, STATUS_ARCHIVED
   end
 
-  protected
-
   def self.possible_principles_condition
     condition = if Setting.work_package_group_assignment?
                   ["(#{Principal.table_name}.type=? OR #{Principal.table_name}.type=?)", 'User', 'Group']
@@ -785,6 +783,8 @@ class Project < ActiveRecord::Base
 
     sanitize_sql_array condition
   end
+
+  protected
 
   def guarantee_project_or_nil_or_false(p)
     if p.is_a?(Project)

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -67,6 +67,8 @@ class Query < ActiveRecord::Base
 
   scope(:hidden, -> { where(hidden: true) })
 
+  scope(:non_hidden, -> { where(hidden: false) })
+
   def self.new_default(attributes = nil)
     new(attributes).tap do |query|
       query.add_default_filter

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -33,14 +33,14 @@ describe 'Projects copy',
          js: true do
   let!(:project) do
     project = FactoryBot.create(:project,
-                                 parent: parent_project,
-                                 types: active_types,
-                                 custom_field_values: { project_custom_field.id => 'some text cf' })
+                                parent: parent_project,
+                                types: active_types,
+                                custom_field_values: { project_custom_field.id => 'some text cf' })
 
     FactoryBot.create(:member,
-                       project: project,
-                       user: user,
-                       roles: [role])
+                      project: project,
+                      user: user,
+                      roles: [role])
 
     project.work_package_custom_fields << wp_custom_field
     project.types.first.custom_fields << wp_custom_field
@@ -54,9 +54,9 @@ describe 'Projects copy',
     project = FactoryBot.create(:project)
 
     FactoryBot.create(:member,
-                       project: project,
-                       user: user,
-                       roles: [role])
+                      project: project,
+                      user: user,
+                      roles: [role])
     project
   end
   let!(:project_custom_field) do
@@ -77,16 +77,16 @@ describe 'Projects copy',
   let(:user) { FactoryBot.create(:user) }
   let(:role) do
     FactoryBot.create(:role,
-                       permissions: permissions)
+                      permissions: permissions)
   end
   let(:permissions) { %i(copy_projects edit_project add_subprojects manage_types view_work_packages) }
   let(:wp_user) do
     user = FactoryBot.create(:user)
 
     FactoryBot.create(:member,
-                       project: project,
-                       user: user,
-                       roles: [role])
+                      project: project,
+                      user: user,
+                      roles: [role])
     user
   end
   let(:category) do
@@ -97,16 +97,16 @@ describe 'Projects copy',
   end
   let!(:work_package) do
     FactoryBot.create(:work_package,
-                       project: project,
-                       type: project.types.first,
-                       author: wp_user,
-                       assigned_to: wp_user,
-                       responsible: wp_user,
-                       done_ratio: 20,
-                       category: category,
-                       fixed_version: version,
-                       description: 'Some desciption',
-                       custom_field_values: { wp_custom_field.id => 'Some wp cf text' })
+                      project: project,
+                      type: project.types.first,
+                      author: wp_user,
+                      assigned_to: wp_user,
+                      responsible: wp_user,
+                      done_ratio: 20,
+                      category: category,
+                      fixed_version: version,
+                      description: 'Some desciption',
+                      custom_field_values: { wp_custom_field.id => 'Some wp cf text' })
   end
 
   let!(:wiki) { project.wiki }


### PR DESCRIPTION
Handles copying work packages within the copy project job when the user chooses to not copy members. If the value of assignee, responsible or a user custom fields does not exist in the new project (because it was not copied or because the source wp was invalid in the first place), the attribute is set to nil in the copied work package.

There are still tons of other inconsistencies in the copy job. E.g. the queries can still have invalid filter values. I limited the fixes to those necessary to comply to https://community.openproject.com/projects/openproject/work_packages/30872/activity

The PR also removes the hidden queries from those being copied as it will need to be handled by specifically. For now, it just lead to errors being reported in the email send to the user.