### PR TITLE
[30882] Extend seeder to handle default type descriptions and queries in form configuration

### DIFF
--- a/app/seeders/basic_data/type_seeder.rb
+++ b/app/seeders/basic_data/type_seeder.rb
@@ -61,7 +61,8 @@ module BasicData
           is_default:           values[1],
           color_id:             color_id,
           is_in_roadmap:        values[3],
-          is_milestone:         values[4]
+          is_milestone:         values[4],
+          description:          type_description(values[5])
         }
       end
     end
@@ -72,6 +73,18 @@ module BasicData
 
     def type_table
       raise NotImplementedError
+    end
+
+    def type_description(type_name)
+      return '' if demo_data_for('default_description_for_types').nil?
+
+      demo_data_for('default_description_for_types').each do |entry|
+        if I18n.t(entry[:type]) === I18n.t(type_name)
+          return entry[:description]
+        else
+          return ''
+        end
+      end
     end
   end
 end

--- a/app/seeders/demo_data/global_query_seeder.rb
+++ b/app/seeders/demo_data/global_query_seeder.rb
@@ -1,5 +1,7 @@
 #-- encoding: UTF-8
+
 #-- copyright
+
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
 #
@@ -25,17 +27,25 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See doc/COPYRIGHT.rdoc for more details.
-class DemoDataSeeder < CompositeSeeder
-  def data_seeder_classes
-    [
-      DemoData::GroupSeeder,
-      DemoData::AttributeHelpTextSeeder,
-      DemoData::GlobalQuerySeeder,
-      DemoData::ProjectSeeder
-    ]
-  end
+module DemoData
+  class GlobalQuerySeeder < Seeder
+    def initialize
+    end
 
-  def namespace
-    'DemoData'
+    def seed_data!
+      print '    ↳ Creating global queries'
+
+      seed_global_queries
+
+      puts
+    end
+
+    private
+
+    def seed_global_queries
+      Array(demo_data_for('global_queries')).each do |config|
+        DemoData::QueryBuilder.new(config, nil).create!
+      end
+    end
   end
 end

--- a/app/seeders/demo_data/global_query_seeder.rb
+++ b/app/seeders/demo_data/global_query_seeder.rb
@@ -29,8 +29,7 @@
 # See doc/COPYRIGHT.rdoc for more details.
 module DemoData
   class GlobalQuerySeeder < Seeder
-    def initialize
-    end
+    def initialize; end
 
     def seed_data!
       print '    ↳ Creating global queries'

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -69,6 +69,9 @@ module DemoData
       puts ' ↳ Assign groups to projects'
       set_groups
 
+      puts ' ↳ Update form configuration with global queries'
+      set_form_configuration
+
       puts ' ↳ Updating settings'
       seed_settings
     end
@@ -126,6 +129,12 @@ module DemoData
 
     def set_groups
       DemoData::GroupSeeder.new.add_projects_to_groups
+    end
+
+    def set_form_configuration
+      Type.all.each do |type|
+        BasicData::TypeSeeder.new.set_attribute_groups_for_type(type)
+      end
     end
 
     def set_types(project, key)

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -49,10 +49,10 @@ module DemoData
 
     def base_attributes
       {
-        project: project,
         name: config[:name],
         user: User.admin.first,
-        is_public: true,
+        is_public: config[:is_public] != false,
+        hidden: config[:hidden] == true,
         show_hierarchies: config[:hierarchy] == true,
         timeline_visible: config[:timeline] == true
       }
@@ -61,6 +61,7 @@ module DemoData
     def create_query
       attr = base_attributes
 
+      set_project! attr
       set_columns! attr
       set_sort_by! attr
       set_group_by! attr
@@ -79,6 +80,10 @@ module DemoData
         name: SecureRandom.uuid,
         title: query.name
       )
+    end
+
+    def set_project!(attr)
+      attr[:project] = project unless project.nil?
     end
 
     def set_columns!(attr)

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -118,6 +118,7 @@ module DemoData
       set_status_filter! filters
       set_version_filter! filters
       set_type_filter! filters
+      set_parent_filter! filters
 
       filters
     end
@@ -146,6 +147,15 @@ module DemoData
         filters[:type_id] = {
           operator: "=",
           values: types.map(&:id).map(&:to_s)
+        }
+      end
+    end
+
+    def set_parent_filter!(filters)
+      if parent_filter_value = config[:parent].presence
+        filters[:parent] = {
+          operator: "=",
+          values: [parent_filter_value]
         }
       end
     end

--- a/config/locales/en.seeders.standard.yml.example
+++ b/config/locales/en.seeders.standard.yml.example
@@ -29,6 +29,7 @@ en:
   seeders:
     standard:
       demo_data:
+<<<<<<< HEAD
         attribute_help_texts:
           - attribute_name: 'assignee'
             help_text: |
@@ -41,8 +42,22 @@ en:
           - type: :default_type_bug
             description: |
               ### Steps to reproduce
+        global_queries:
+          - name: My cool query
+            status: open
+            timeline: false
+            sort_by: id
+            hidden: true
+            is_public: false
+        type_configuration:
+          - type: :default_type_bug
+            description: |
+              ### Steps to reproduce
 
               ### Actual behavior
+            form_configuration:
+              - group_name: Custom query
+                query_name: My cool query
         groups:
           - name: 'Project Admins'
             projects:

--- a/config/locales/en.seeders.standard.yml.example
+++ b/config/locales/en.seeders.standard.yml.example
@@ -37,6 +37,12 @@ en:
               * Doing the job
               * Tracking the time
               * Update ticket status
+        default_description_for_types:
+          - type: :default_type_bug
+            description: |
+              ### Steps to reproduce
+
+              ### Actual behavior
         groups:
           - name: 'Project Admins'
             projects:

--- a/modules/bim_seeder/config/locales/en.seeders.bim.yml
+++ b/modules/bim_seeder/config/locales/en.seeders.bim.yml
@@ -35,6 +35,26 @@ en:
       default_status_resolved: Resolved
       default_priority_critical: Critical
       demo_data:
+        global_queries:
+          - name: "Embedded table: Children"
+            parent: '{id}'
+            timeline: false
+            sort_by: id
+            hidden: true
+            is_public: false
+            columns:
+              - type
+              - id
+              - subject
+              - status
+              - assigned_to
+              - priority
+              - project
+        type_configuration:
+          - type: :default_type_phase
+            form_configuration:
+              - group_name: "Children"
+                query_name: "Embedded table: Children"
         groups:
           - name: Architects
           - name: BIM Coordinators


### PR DESCRIPTION
Extend seeder to 
* add default description templates for types
* add queries in the form configuration (e.g. all open children)

https://community.openproject.com/projects/openproject/work_packages/30882/activity
https://community.openproject.com/projects/openproject/work_packages/30609/activity