### PR TITLE
use the wp payload instead of the resource

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -85,12 +85,12 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
     return unless default_description.present?
 
     # And the current description matches ANY current default text
-    return unless work_package.description.blank? || is_default_description?
+    return unless work_package.description.blank? || default_description?
 
     work_package.description = default_description
   end
 
-  def is_default_description?
+  def default_description?
     Type
       .pluck(:description)
       .compact

--- a/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.component.ts
@@ -54,8 +54,6 @@ export class WorkPackageStatusButtonComponent implements OnInit, OnDestroy {
 
   constructor(readonly I18n:I18nService,
               readonly cdRef:ChangeDetectorRef,
-              readonly wpCacheService:WorkPackageCacheService,
-              readonly schemaCacheService:SchemaCacheService,
               @Inject(IWorkPackageEditingServiceToken) protected wpEditing:WorkPackageEditingService) {
   }
 

--- a/frontend/src/app/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.ts
+++ b/frontend/src/app/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.ts
@@ -27,13 +27,16 @@
 // ++
 
 
-import {Component, HostListener, Input} from '@angular/core';
+import {Component, HostListener, Input, Inject} from '@angular/core';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {WorkPackageCacheService} from 'core-components/work-packages/work-package-cache.service';
 import {WorkPackageNotificationService} from 'core-components/wp-edit/wp-notification.service';
 import {HalResourceService} from 'core-app/modules/hal/services/hal-resource.service';
 import {CustomActionResource} from 'core-app/modules/hal/resources/custom-action-resource';
 import {WorkPackagesActivityService} from 'core-components/wp-single-view-tabs/activity-panel/wp-activity.service';
+import {IWorkPackageEditingServiceToken} from "core-components/wp-edit-form/work-package-editing.service.interface";
+import {WorkPackageEditingService} from "core-components/wp-edit-form/work-package-editing-service";
+import {SchemaCacheService} from "core-components/schemas/schema-cache.service";
 
 @Component({
   selector: 'wp-custom-action',
@@ -46,8 +49,10 @@ export class WpCustomActionComponent {
 
   constructor(private halResourceService:HalResourceService,
               private wpCacheService:WorkPackageCacheService,
+              private wpSchemaCacheService:SchemaCacheService,
               private wpActivity:WorkPackagesActivityService,
-              private wpNotificationsService:WorkPackageNotificationService) { }
+              private wpNotificationsService:WorkPackageNotificationService,
+              @Inject(IWorkPackageEditingServiceToken) protected wpEditing:WorkPackageEditingService) {}
 
   private fetchAction() {
     this.halResourceService.get<CustomActionResource>(this.action.href!)
@@ -73,7 +78,12 @@ export class WpCustomActionComponent {
         this.wpNotificationsService.showSave(savedWp, false);
         this.workPackage = savedWp;
         this.wpActivity.clear(this.workPackage.id!);
-        this.wpCacheService.updateWorkPackage(savedWp);
+        // Loading the schema might be necessary in cases where the button switches
+        // project or type.
+        this.wpSchemaCacheService.ensureLoaded(savedWp).then(() => {
+          this.wpCacheService.updateWorkPackage(savedWp, true);
+          this.wpEditing.stopEditing(savedWp.id!);
+        });
       }).catch((errorResource:any) => {
         this.wpNotificationsService.handleRawError(errorResource, this.workPackage);
       });

--- a/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
@@ -56,18 +56,12 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
   public wpActivity:WorkPackagesActivityService = this.injector.get(WorkPackagesActivityService);
   public halResourceService:HalResourceService = this.injector.get(HalResourceService);
 
-  // The changeset to be applied to the work package
-  // private changes:{ [attribute:string]:any } = {};
   public inFlight:boolean = false;
-
-  // The current editing resource
-  public editingResource:WorkPackageResource|null;
 
   private wpFormPromise:Promise<FormResource>|null;
 
   public reset(key:string) {
     delete this.changes[key];
-    this.buildResource();
   }
 
   public isChanged(attribute:string) {
@@ -78,6 +72,7 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
   public clear() {
     this.changes = {};
     this.resetForm();
+    this.buildResource();
   }
 
   /**
@@ -90,7 +85,7 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
     });
   }
 
-  public resetForm() {
+  private resetForm() {
     this.form = null;
   }
 
@@ -116,7 +111,7 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
   /**
    * Update the form resource from the API.
    */
-  public updateForm():Promise<FormResource> {
+  public updateForm():Promise<FormResource<WorkPackageResource>> {
     let payload = this.buildPayloadFromChanges();
 
     if (!this.wpFormPromise) {
@@ -124,7 +119,6 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
         .update(payload)
         .then((form:FormResource) => {
           this.form = form;
-          this.rebuildDefaults(form.payload);
 
           this.buildResource();
 
@@ -180,12 +174,11 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
                 if (this.resource.parent) {
                   this.wpCacheService.loadWorkPackage(this.resource.parent.id.toString(), true);
                 }
-                this.editingResource = null;
                 this.clear();
                 resolve(this.resource);
               });
             })
-            .catch(error => {
+            .catch((error:any) => {
               // Update the resource anyway
               this.buildResource();
               reject(error);
@@ -201,27 +194,12 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
   }
 
   /**
-   * Rebuild default attributes we know might change
-   * Will only apply for new work packages.
-   */
-  private rebuildDefaults(payload:HalResource) {
-    if (!this.resource.isNew) {
-      return;
-    }
-
-    // Take over the description from the form
-    // Either it's the same as our changeset or it was set by
-    // a default type value.
-    this.setValue('description', payload.description);
-  }
-
-  /**
    * Merge the current changes into the payload resource.
    *
    * @param {FormResource} form
    * @return {any}
    */
-  private mergeWithPayload(plainPayload:any) {
+  private applyChanges(plainPayload:any) {
     // Fall back to the last known state of the work package should the form not be loaded.
     let reference = this.resource.$source;
     if (this.form) {
@@ -269,12 +247,17 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
         .attachments
         .elements
         .map((a:HalResource) => { return { href: a.href }; });
+
+      // Explicitly delete the description if it was not set by the user.
+      // if it was set by the user, #applyChanges will set it again.
+      // Otherwise, the backend will set it for us.
+      delete payload.description;
     } else {
       // Otherwise, simply use the bare minimum, which is the lock version.
       payload = this.minimalPayload;
     }
 
-    return this.mergeWithPayload(payload);
+    return this.applyChanges(payload);
   }
 
   private get minimalPayload() {
@@ -301,10 +284,10 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
     }
 
     if (isArray && isArrayType) {
-      var links:{ href:string }[] = [];
+      let links:{ href:string }[] = [];
 
       if (val) {
-        var elements = (val.forEach && val) || val.elements;
+        let elements = (val.forEach && val) || val.elements;
 
         elements.forEach((link:{ href:string }) => {
           if (link.href) {
@@ -318,15 +301,6 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
       return {href: _.get(val, 'href', null)};
     }
   }
-
-  /**
-   * Get the best schema currently available, either the default WP schema (must exist).
-   * If loaded, return the form schema, which provides better information on writable status
-   * and contains available values.
-   */
-  //public get schema():SchemaResource {
-  //  return (this.form || this.resource).schema;
-  //}
 
   /**
    * Check whether the given attribute is writable.
@@ -352,18 +326,45 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
   }
 
   private buildResource() {
-    if (this.empty) {
-      this.editingResource = null;
-      this.wpEditing.updateValue(this.resource.id!, this);
+    let payload = this.sourceFromResourceAndForm();
+
+    if (!payload) {
       return;
     }
 
-    let payload:any = { ... this.resource.$source };
+    const resource = this.halResourceService.createHalResourceOfType('WorkPackage', this.applyChanges(payload));
 
-    const resource = this.halResourceService.createHalResourceOfType('WorkPackage', this.mergeWithPayload(payload));
+    if (resource.isNew && this.form) {
+      resource.initializeNewResource(this.form);
+    }
 
+    if (resource.isNew) {
+      resource.attachments = this.resource.attachments;
+    }
     resource.overriddenSchema = this.schema;
-    this.editingResource = (resource as WorkPackageResource);
+
+    resource.__initialized_at = this.resource.__initialized_at;
+
+    this.resource = (resource as WorkPackageResource);
     this.wpEditing.updateValue(this.resource.id!, this);
+  }
+
+  /**
+   * Constructs the source from a combination of the resource
+   * and the form payload. The payload takes precedences.
+   * That way, values, that stem from the backend take precedence.
+   */
+  private sourceFromResourceAndForm() {
+    if (!this.wpCacheService.state(this.resource.id!).value) {
+      return null;
+    }
+    let payload =  _.merge({},
+                           this.wpCacheService.state(this.resource.id!).value!.$source);
+
+    if (this.form) {
+      _.merge(payload, this.form.payload.$source);
+    }
+
+    return payload;
   }
 }

--- a/frontend/src/app/components/wp-edit-form/work-package-editing-service.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-editing-service.ts
@@ -75,7 +75,6 @@ export class WorkPackageEditingService extends StateCacheService<WorkPackageChan
     }
 
     const changeset = state.value!;
-    changeset.resource = workPackage;
 
     return changeset;
   }
@@ -99,8 +98,8 @@ export class WorkPackageEditingService extends StateCacheService<WorkPackageChan
       ($) => $
         .pipe(
           map(([wp, changeset]) => {
-            if (wp && changeset && changeset.editingResource) {
-              return changeset.editingResource;
+            if (wp && changeset && !changeset.empty) {
+              return changeset.resource;
             } else {
               return wp;
             }

--- a/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
@@ -25,7 +25,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, OnInit, ViewChild} from "@angular/core";
+import {Component, OnInit, ViewChild, ChangeDetectionStrategy} from "@angular/core";
 import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 import {EditFieldComponent} from "core-app/modules/fields/edit/edit-field.component";
 import {OpCkeditorComponent} from "core-app/modules/common/ckeditor/op-ckeditor.component";
@@ -53,7 +53,8 @@ export const formattableFieldTemplate = `
 `;
 
 @Component({
-  template: formattableFieldTemplate
+  template: formattableFieldTemplate,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FormattableEditFieldComponent extends EditFieldComponent implements OnInit {
   public readonly field = this;
@@ -94,7 +95,11 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
   }
 
   public onContentChange(value:string) {
-    this.rawValue = value;
+    // Have the guard clause to avoid the text being set
+    // in the changeset when no actual change has taken place.
+    if (this.rawValue !== value) {
+      this.rawValue = value;
+    }
   }
 
   public handleUserSubmit() {
@@ -125,6 +130,8 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
   public reset() {
     if (this.editor && this.editor.initialized) {
       this.editor.content = this.rawValue;
+
+      this.cdRef.markForCheck();
     }
   }
 

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -160,13 +160,13 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   public onOpen() {
     setTimeout(() => {
       jQuery(this.hiddenOverflowContainer).addClass('-hidden-overflow');
-    }, 1000)
+    }, 1000);
   }
 
   public onClose() {
     setTimeout(() => {
       jQuery(this.hiddenOverflowContainer).removeClass('-hidden-overflow');
-    }, 1000)
+    }, 1000);
   }
 
   public onChange(value:HalResource) {

--- a/frontend/src/app/modules/hal/resources/form-resource.ts
+++ b/frontend/src/app/modules/hal/resources/form-resource.ts
@@ -27,13 +27,18 @@
 //++
 
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
+
 import {SchemaResource} from 'core-app/modules/hal/resources/schema-resource';
 import {
   ErrorResource,
   v3ErrorIdentifierMultipleErrors
 } from 'core-app/modules/hal/resources/error-resource';
 
-export class FormResource extends HalResource {
+export interface FormResourceLinks<T = HalResource> {
+  commit(payload:any):Promise<T>;
+}
+
+export class FormResource<T = HalResource> extends HalResource {
 
   public schema:SchemaResource;
   public validationErrors:{ [attribute:string]:ErrorResource };
@@ -58,3 +63,5 @@ export class FormResource extends HalResource {
     return resource;
   }
 }
+
+export interface FormResource extends FormResourceLinks {}

--- a/frontend/src/app/modules/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/modules/hal/resources/work-package-resource.ts
@@ -45,6 +45,7 @@ import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper
 import {NotificationsService} from 'core-app/modules/common/notifications/notifications.service';
 import {Attachable} from 'core-app/modules/hal/resources/mixins/attachable-mixin';
 import {WorkPackageDmService} from "core-app/modules/hal/dm-services/work-package-dm.service";
+import {FormResource} from "core-app/modules/hal/resources/form-resource";
 
 export interface WorkPackageResourceEmbedded {
   activities:CollectionResource;
@@ -97,11 +98,11 @@ export interface WorkPackageResourceLinks extends WorkPackageResourceEmbedded {
 
   removeWatcher():Promise<any>;
 
-  self():Promise<any>;
+  self():Promise<WorkPackageResource>;
 
-  update(payload:any):Promise<any>;
+  update(payload:any):Promise<FormResource<WorkPackageResource>>;
 
-  updateImmediately(payload:any):Promise<any>;
+  updateImmediately(payload:any):Promise<WorkPackageResource>;
 
   watch():Promise<any>;
 }
@@ -273,7 +274,7 @@ export class WorkPackageBaseResource extends HalResource {
    * Assign values from the form for a newly created work package resource.
    * @param form
    */
-  public initializeNewResource(form:any) {
+  public initializeNewResource(form:FormResource) {
     this.overriddenSchema = form.schema;
     this.$source.id = 'new';
 

--- a/spec/features/work_packages/details/closed_status_and_version_spec.rb
+++ b/spec/features/work_packages/details/closed_status_and_version_spec.rb
@@ -25,7 +25,6 @@ describe 'Closed status and version in full view', js: true do
     wp_page.expect_and_dismiss_notification type: :error,
                                             message: I18n.t('js.work_packages.message_work_package_status_blocked')
 
-
     expect(page).to have_selector('.wp-status-button button[disabled]')
   end
 end

--- a/spec/features/work_packages/new/work_package_default_description_spec.rb
+++ b/spec/features/work_packages/new/work_package_default_description_spec.rb
@@ -3,13 +3,14 @@ require 'support/work_packages/work_package_field'
 require 'features/work_packages/work_packages_page'
 require 'features/page_objects/notification'
 
-describe 'new work package', js: true do
+describe 'new work package', js: true, with_mail: false do
   let(:type_task) { FactoryBot.create(:type_task, description: "# New Task template\n\nHello there") }
+  let(:type_feature) { FactoryBot.create(:type_feature, description: "", is_default: true) }
   let(:type_bug) { FactoryBot.create(:type_bug, description: "# New Bug template\n\nGeneral Kenobi") }
   let!(:status) { FactoryBot.create(:status, is_default: true) }
   let!(:priority) { FactoryBot.create(:priority, is_default: true) }
   let!(:project) do
-    FactoryBot.create(:project, types: [type_task, type_bug])
+    FactoryBot.create(:project, types: [type_feature, type_task, type_bug], no_types: true)
   end
 
   let(:user) { FactoryBot.create :admin }
@@ -24,6 +25,11 @@ describe 'new work package', js: true do
   # Changing the type changes the description if it was empty or still the default.
   # Changes in the description shall not be overridden.
   def change_type_and_expect_description(set_project: false)
+    if !set_project
+      expect(page).to have_selector('.wp-edit-field.type', text: type_feature.name)
+    end
+    expect(page).to have_selector('.wp-edit-field.description', text: '')
+
     type_field.openSelectField
     type_field.set_value type_task
     expect(page).to have_selector('.wp-edit-field.description h1', text: 'New Task template')
@@ -77,7 +83,7 @@ describe 'new work package', js: true do
 
     it 'shows the template after selection of project and type' do
       wp_table.visit!
-      wp_table.create_wp_split_screen type_task
+      wp_table.create_wp_split_screen type_feature
 
       wp_page.expect_fully_loaded
 


### PR DESCRIPTION
That way, local changes will not be ported over between states except when the user has explicitly made them. E.g. changes by the user to the subject should be ported over, but changes to the description, caused by a default description, should not.

https://community.openproject.com/projects/openproject/work_packages/30795