### PR TITLE
[30898] Fix script_name reference to auth provider link

### DIFF
--- a/app/views/hooks/login/_auth_provider.html.erb
+++ b/app/views/hooks/login/_auth_provider.html.erb
@@ -29,7 +29,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <% unless Rails.env.production? %>
   <%
-    opts = {}
+    opts = { script_name: OpenProject::Configuration.rails_relative_url_root }
 
     if params['back_url']
       opts[:origin] = params['back_url']

--- a/modules/auth_plugins/app/views/hooks/login/_providers.html.erb
+++ b/modules/auth_plugins/app/views/hooks/login/_providers.html.erb
@@ -33,7 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% OpenProject::Plugins::AuthPlugin.providers.each do |pro| %>
   <%
-    opts = {}
+    opts = { script_name: OpenProject::Configuration.rails_relative_url_root }
 
     if params['back_url']
       opts[:origin] = params['back_url']

--- a/modules/auth_plugins/spec/features/auth_provider_spec.rb
+++ b/modules/auth_plugins/spec/features/auth_provider_spec.rb
@@ -28,33 +28,26 @@
 
 require 'spec_helper'
 
-describe 'rendering the login buttons for all providers' do
+describe 'rendering the login buttons', js: true do
   let(:providers) do
     [
-      { name: 'mock_auth' },
-      { name: 'test_auth', display_name: 'Test' },
-      { name: 'foob_auth', icon: 'foobar.png' }
+      { name: 'mock_auth' }
     ]
   end
 
-
   before do
     allow(OpenProject::Plugins::AuthPlugin).to receive(:providers).and_return(providers)
-
-    render partial: 'hooks/login/providers', handlers: [:erb], formats: [:html]
   end
 
-  it 'should show the mock_auth button with the name as its label' do
-    expect(rendered).to match /#{providers[0][:name]}/
-  end
+  describe 'in a public project', with_settings: { login_required: false } do
+    let(:public_project) { FactoryBot.build(:project, is_public: true) }
 
-  it 'should show the test_auth button with the given display_name as its label' do
-    expect(rendered).to match /#{providers[1][:display_name]}/
-  end
-
-  context 'with relative url root', with_config: { rails_relative_url_root: '/foobar' } do
     it 'renders correctly' do
-      expect(rendered).to include '/foobar/auth/mock_auth'
+      visit project_path(public_project)
+
+      page.find('a.login').click
+      item = page.find('a.auth-provider', text: 'mock_auth')
+      expect(item[:href]).to end_with '/auth/mock_auth'
     end
   end
 end


### PR DESCRIPTION
No idea why that is not respected by omniauth, but the same was happening for the top menu bar home link / logo in https://github.com/opf/openproject/commit/a7f2395c7bdeacfcd38eed751df77219d1f257f0
 
https://community.openproject.com/wp/30898