### PR TITLE
Fix/grid permission caching

### DIFF
--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -154,7 +154,7 @@ module Type::Attributes
   end
 
   ##
-  # Get all applicale work package attributes
+  # Get all applicable work package attributes
   def work_package_attributes(merge_date: true)
     all_attributes = self.class.all_work_package_form_attributes(merge_date: merge_date)
 

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -302,11 +302,12 @@ module API
           end
 
           def form_config_attribute_representation(group)
-            cache_keys = ['wp_schema_attribute_group', group.key,
+            cache_keys = ['wp_schema_attribute_group',
+                          group.key,
                           I18n.locale,
                           represented.project,
                           represented.type,
-                          represented.available_custom_fields]
+                          represented.available_custom_fields.sort_by(&:id)]
 
             OpenProject::Cache.fetch(OpenProject::Cache::CacheKey.expand(cache_keys.flatten.compact)) do
               ::JSON::parse(::API::V3::WorkPackages::Schema::FormConfigurations::AttributeRepresenter

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -41,7 +41,7 @@ module API
           include API::Caching::CachedRepresenter
           cached_representer key_parts: %i[project type],
                              dependencies: -> {
-                               User.current.roles_for_project(represented.project).map(&:permissions).sort +
+                               User.current.roles_for_project(represented.project).map(&:permissions).flatten.uniq.sort +
                                  [Setting.work_package_done_ratio]
                              }
 

--- a/modules/grids/app/representers/api/v3/grids/grid_representer.rb
+++ b/modules/grids/app/representers/api/v3/grids/grid_representer.rb
@@ -54,27 +54,24 @@ module API
 
         self_link title_getter: ->(*) { nil }
 
-        link :updateImmediately do
-          next unless write_allowed?
-
+        link :updateImmediately,
+             cache_if: -> { write_allowed? } do
           {
             href: api_v3_paths.grid(represented.id),
             method: :patch
           }
         end
 
-        link :update do
-          next unless write_allowed?
-
+        link :update,
+             cache_if: -> { write_allowed? } do
           {
             href: api_v3_paths.grid_form(represented.id),
             method: :post
           }
         end
 
-        link :delete do
-          next unless delete_allowed?
-
+        link :delete,
+             cache_if: -> { delete_allowed? } do
           {
             href: api_v3_paths.grid(represented.id),
             method: :delete


### PR DESCRIPTION
Mainly fixes caching of action links on the grid representer. Those need to be evaluated on a per user basis and not by the first user rendering the representer.