### PR TITLE
Change selector to not fail on first attempt

### DIFF
--- a/spec/features/work_packages/attachments/attachment_upload_spec.rb
+++ b/spec/features/work_packages/attachments/attachment_upload_spec.rb
@@ -73,7 +73,7 @@ describe 'Upload attachment to work package', js: true do
           editor.click_and_type_slowly 'this is a comment!1'
           comment_field.submit_by_click
 
-          wp_page.expect_comment 'this is a comment!1'
+          wp_page.expect_comment text: 'this is a comment!1'
         end
       end
     end

--- a/spec/features/work_packages/details/markdown/activity_comments_spec.rb
+++ b/spec/features/work_packages/details/markdown/activity_comments_spec.rb
@@ -49,7 +49,7 @@ describe 'activity comments', js: true do
           comment_field.click_and_type_slowly 'this is a comment!1'
           comment_field.submit_by_click
 
-          wp_page.expect_comment 'this is a comment!1'
+          wp_page.expect_comment text: 'this is a comment!1'
         end
 
         it 'submits comments repeatedly' do
@@ -57,7 +57,7 @@ describe 'activity comments', js: true do
           comment_field.submit_by_click
 
           expect(page).to have_selector('.user-comment > .message', count: 2)
-          wp_page.expect_comment 'this is my first comment!1'
+          wp_page.expect_comment text: 'this is my first comment!1'
 
           expect(comment_field.editing?).to be false
           comment_field.activate!
@@ -67,7 +67,7 @@ describe 'activity comments', js: true do
           comment_field.submit_by_click
 
           expect(page).to have_selector('.user-comment > .message', count: 3)
-          wp_page.expect_comment 'this is my second comment!1'
+          wp_page.expect_comment text: 'this is my second comment!1'
         end
       end
 
@@ -114,8 +114,8 @@ describe 'activity comments', js: true do
           end
           comment_field.submit_by_click
 
-          wp_page.expect_comment 'Comment with bold text'
-          expect(page).to have_selector('.user-comment .message strong', text: 'bold text')
+          wp_page.expect_comment text: 'Comment with bold text'
+          wp_page.expect_comment text: 'bold text', subselector: 'strong'
 
           # Hover the new activity
           activity = page.find('#activity-2')
@@ -137,8 +137,8 @@ describe 'activity comments', js: true do
           end
 
           edit.submit_by_click
-          wp_page.expect_comment 'Comment with italic text'
-          expect(page).to have_selector('.user-comment .message em', text: 'italic text', wait: 10)
+          wp_page.expect_comment text: 'Comment with italic text'
+          wp_page.expect_comment text: 'italic text', subselector: 'em'
         end
       end
     end
@@ -175,10 +175,10 @@ describe 'activity comments', js: true do
         # Scroll to the activity
         scroll_to_element(page.find('#activity-2'))
 
-        wp_page.expect_comment 'this is a bold remark'
-        expect(page).to have_selector('.user-comment .message', count: 2)
-        expect(page).to have_selector('.user-comment .message blockquote')
-        expect(page).to have_selector('.user-comment .message strong')
+        wp_page.expect_comment text: 'this is a bold remark'
+        wp_page.expect_comment count: 2
+        wp_page.expect_comment subselector: 'blockquote'
+        wp_page.expect_comment subselector: 'strong', text: 'a bold'
       end
     end
   end

--- a/spec/features/work_packages/edit_work_package_spec.rb
+++ b/spec/features/work_packages/edit_work_package_spec.rb
@@ -214,7 +214,7 @@ describe 'edit work package', js: true do
     wp_page.save_comment
 
     wp_page.expect_notification(message: 'The comment was successfully added.')
-    wp_page.expect_comment 'hallo welt'
+    wp_page.expect_comment text: 'hallo welt'
   end
 
   it 'updates the presented custom fields based on the selected type' do

--- a/spec/features/work_packages/tabs/activity_revisions_spec.rb
+++ b/spec/features/work_packages/tabs/activity_revisions_spec.rb
@@ -207,7 +207,7 @@ describe 'Activity tab', js: true, selenium: true do
         comment_field.click_and_type_slowly "References r#{revision.revision}"
         comment_field.submit_by_click
 
-        work_package_page.expect_comment "References r#{revision.revision}"
+        work_package_page.expect_comment text: "References r#{revision.revision}"
       end
     end
 

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -68,9 +68,13 @@ module Pages
       raise NotImplementedError
     end
 
-    def expect_comment(text)
+    def expect_comment(**args)
+      subselector = args.delete(:subselector)
+
       retry_block do
-        page.find('.user-comment .message', text: text)
+        unless page.has_selector?(".user-comment .message #{subselector}".strip, **args)
+          raise "Failed to find comment with #{args.inspect}. Retrying."
+        end
       end
     end
 


### PR DESCRIPTION
Since we insert the tasklist, angular seems to have a temporary pass that is brekaing these specs. However, the failing screenshots always show the correct comment so I suspect it's a timing issue.

This PR changes the expectation to run in a retry_block without retrying the entire spec