### PR TITLE
Fix/deployment busts cache

### DIFF
--- a/lib/open_project/cache/cache_key.rb
+++ b/lib/open_project/cache/cache_key.rb
@@ -30,8 +30,9 @@ module OpenProject
   module Cache
     module CacheKey
       def self.key(*parts)
-        ['openproject',
-         OpenProject::VERSION] + parts.flatten(1)
+        version_part = expand([OpenProject::VERSION, OpenProject::VERSION.product_version].compact)
+
+        [version_part] + parts.flatten(1)
       end
 
       ##

--- a/lib/open_project/version.rb
+++ b/lib/open_project/version.rb
@@ -37,86 +37,90 @@ module OpenProject
     PATCH = 0
     TINY  = PATCH # Redmine compat
 
-    # Used by semver to define the special version (if any).
-    # A special version "satify but have a lower precedence than the associated
-    # normal version". So 2.0.0RC1 would be part of the 2.0.0 series but
-    # be considered to be an older version.
-    #
-    #   1.4.0 < 2.0.0RC1 < 2.0.0RC2 < 2.0.0 < 2.1.0
-    #
-    # This method may be overridden by third party code to provide vendor or
-    # distribution specific versions. They may or may not follow semver.org:
-    #
-    #   2.0.0debian-2
-    def self.special
-      ''
-    end
-
-    def self.revision
-      revision, = Open3.capture3('git', 'rev-parse', 'HEAD')
-      if revision.present?
-        revision.strip[0..8]
+    class << self
+      # Used by semver to define the special version (if any).
+      # A special version "satify but have a lower precedence than the associated
+      # normal version". So 2.0.0RC1 would be part of the 2.0.0 series but
+      # be considered to be an older version.
+      #
+      #   1.4.0 < 2.0.0RC1 < 2.0.0RC2 < 2.0.0 < 2.1.0
+      #
+      # This method may be overridden by third party code to provide vendor or
+      # distribution specific versions. They may or may not follow semver.org:
+      #
+      #   2.0.0debian-2
+      def special
+        ''
       end
-    rescue StandardError
-      nil
-    end
 
-    def self.product_version
-      defined?(@product_version) || @product_version = begin
-        path = Rails.root.join('config', 'PRODUCT_VERSION')
-        if File.exists? path
-          File.read(path)
+      def revision
+        cached_or_block(:@revision) do
+          revision, = Open3.capture3('git', 'rev-parse', 'HEAD')
+          if revision.present?
+            revision.strip[0..8]
+          end
         end
-      rescue StandardError
-        nil
       end
 
-      @product_version
+      def product_version
+        cached_or_block(:@product_version) do
+          path = Rails.root.join('config', 'PRODUCT_VERSION')
+          if File.exists? path
+            File.read(path)
+          end
+        end
+      end
+
+      ##
+      # Get information on when this version was created / updated from either
+      # 1. A RELEASE_DATE file
+      # 2. From the git revision
+      def updated_on
+        release_date_from_file || release_date_from_git
+      end
+
+      def to_a; ARRAY end
+
+      def to_s; STRING end
+
+      def to_semver
+        [MAJOR, MINOR, PATCH].join('.') + special
+      end
+
+      private
+
+      def release_date_from_file
+        cached_or_block(:@release_date_from_file) do
+          path = Rails.root.join('config', 'RELEASE_DATE')
+          if File.exists? path
+            s = File.read(path)
+            Date.parse(s)
+          end
+        end
+      end
+
+      def release_date_from_git
+        cached_or_block(:@release_date_from_git) do
+          date, = Open3.capture3('git', 'log', '-1', '--format=%cd', '--date=short')
+          Date.parse(date) if date
+        end
+      end
+
+      def cached_or_block(variable)
+        return instance_variable_get(variable) if instance_variable_defined?(variable)
+
+        value = begin
+                  yield
+                rescue StandardError
+                  nil
+                end
+
+        instance_variable_set(variable, value)
+      end
     end
 
-    ##
-    # Get information on when this version was created / updated from either
-    # 1. A RELEASE_DATE file
-    # 2. From the git revision
-    def self.updated_on
-      release_date_from_file || release_date_from_git
-    end
-
-    REVISION = self.revision
+    REVISION = revision
     ARRAY = [MAJOR, MINOR, PATCH, REVISION].compact
     STRING = ARRAY.join('.')
-
-    def self.to_a; ARRAY end
-    def self.to_s; STRING end
-    def self.to_semver
-      [MAJOR, MINOR, PATCH].join('.') + special
-    end
-
-    private
-
-    def self.release_date_from_file
-      defined?(@file_date) || @file_date = begin
-        path = Rails.root.join('config', 'RELEASE_DATE')
-        if File.exists? path
-          s = File.read(path)
-          Date.parse(s)
-        end
-      rescue StandardError
-        nil
-      end
-
-      @file_date
-    end
-
-    def self.release_date_from_git
-      defined?(@git_date) || @git_date = begin
-        date, = Open3.capture3('git', 'log', '-1', '--format=%cd', '--date=short')
-        Date.parse(date) if date
-      rescue StandardError
-        nil
-      end
-
-      @git_date
-    end
   end
 end

--- a/lib/redmine/menu_manager/top_menu/help_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/help_menu.rb
@@ -31,11 +31,12 @@ require 'open_project/static/links'
 
 module Redmine::MenuManager::TopMenu::HelpMenu
   def render_help_top_menu_node(item = help_menu_item)
-    cache_key = OpenProject::Cache::CacheKey.key('help_top_menu_node',
-                                                 OpenProject::Static::Links.links,
-                                                 I18n.locale,
-                                                 OpenProject::Static::Links.help_link)
-    Rails.cache.fetch(cache_key) do
+    cache_key = ['help_top_menu_node',
+                 OpenProject::Static::Links.links,
+                 I18n.locale,
+                 OpenProject::Static::Links.help_link]
+
+    OpenProject::Cache.fetch(cache_key) do
       if OpenProject::Static::Links.help_link_overridden?
         render_menu_node(item)
         content_tag('li', render_single_menu_node(item), class: 'help-menu--overridden-link')


### PR DESCRIPTION
Adds the contents of the PRODUCT_VERSION file to the OpenProject cache key to bust the cache between deployments on SaaS.

https://community.openproject.com/projects/openproject/work_packages/30901