### PR TITLE
hide add widget when leaving area

### DIFF
--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -39,7 +39,7 @@ export class GridAreaService {
     return this.resource;
   }
 
-  public setMousedOverArea(area:GridArea) {
+  public setMousedOverArea(area:GridArea|null) {
     this.mousedOverArea = area;
   }
 

--- a/frontend/src/app/modules/grids/grid/grid.component.html
+++ b/frontend/src/app/modules/grids/grid/grid.component.html
@@ -51,13 +51,16 @@
        [style.grid-column-end]="area.gridEndColumn"
        cdkDropList
        [id]="area.guid"
-       (mouseover)="layout.setMousedOverArea(area)"
+       (mouseenter)="layout.setMousedOverArea(area)"
+       (mouseleave)="layout.setMousedOverArea(null)"
        [cdkDropListData]="area"
        (cdkDropListDropped)="drag.drop($event)"
        (cdkDropListEntered)="drag.entered($event)"
        [cdkDropListConnectedTo]="layout.gridAreaIds">
     <div class="grid--widget-add"
          *ngIf="add.isAddable(area)"
+         (mouseenter)="layout.setMousedOverArea(area)"
+         (mouseleave)="layout.setMousedOverArea(null)"
          (click)="add.widget(area)">
     </div>
   </div>
@@ -72,9 +75,12 @@
        [style.grid-column-start]="gap.gridStartColumn"
        [style.grid-column-end]="gap.gridEndColumn"
        [id]="gap.guid"
-       (mouseover)="layout.setMousedOverArea(gap)">
+       (mouseleave)="layout.setMousedOverArea(null)"
+       (mouseenter)="layout.setMousedOverArea(gap)">
     <div class="grid--widget-add -gap"
          *ngIf="add.isAddable(gap)"
+         (mouseenter)="layout.setMousedOverArea(gap)"
+         (mouseleave)="layout.setMousedOverArea(null)"
          (click)="add.widget(gap, layout.schema)">
     </div>
   </div>


### PR DESCRIPTION
Will hide the add icon for widgets upon leaving a grid area so that the icon will be displayed less especially when hovering over a widget or when not being in the grid at all.