### PR TITLE
add type attribute group attributes to cache key

### DIFF
--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -304,6 +304,7 @@ module API
           def form_config_attribute_representation(group)
             cache_keys = ['wp_schema_attribute_group',
                           group.key,
+                          group.attributes,
                           I18n.locale,
                           represented.project,
                           represented.type,


### PR DESCRIPTION
This is an attempt to fix cases where some custom fields are not displayed. I suspect this will not fix the bug in itself. But it might help to narrow down the problem by preventing the bug to also affect users who are not affected by the bug originally but only because the buggy result was cached for them.

https://community.openproject.com/projects/openproject/work_packages/30903