### PR TITLE
limit max width of the role group keys in the members widget

### DIFF
--- a/app/assets/stylesheets/content/_attributes_key_value.sass
+++ b/app/assets/stylesheets/content/_attributes_key_value.sass
@@ -31,49 +31,63 @@
   flex-wrap: wrap
   font-size: 0.875rem
 
-  .attributes-key-value--key
-    @extend .form--label
-    display: flex
-    flex: 1 0 35%
-    max-width: 35%
-    margin-bottom: 0.1875rem
-    padding: 0.375rem 0
-    font-weight: bold
-    // Ensure that the text is shortened while the help icon will be displayed
-    > wp-replacement-label
-      @include text-shortener
-      flex: 0 1 auto
+.attributes-key-value--key
+  @extend .form--label
+  display: flex
+  flex: 1 0 35%
+  max-width: 35%
+  margin-bottom: 0.1875rem
+  padding: 0.375rem 0
+  font-weight: bold
+  // Ensure that the text is shortened while the help icon will be displayed
+  > wp-replacement-label
+    @include text-shortener
+    flex: 0 1 auto
 
-    &.-minimal
-      @include text-shortener
-      flex: 0 1 auto
+.attributes-key-value--value-container
+  display: flex
+  flex: 1 0 65%
+  max-width: 65%
+  margin-bottom: 0.1875rem
+  align-self: center
 
-  .attributes-key-value--value-container
-    display: flex
-    flex: 1 0 65%
-    max-width: 65%
-    margin-bottom: 0.1875rem
-    align-self: center
+  p
+    font-size: $form-label-fontsize
+    word-wrap: break-word
 
-    p
-      font-size: $form-label-fontsize
-      word-wrap: break-word
+  &.not-editable
+    padding: 6px
 
-    &.not-editable
-      padding: 6px
+.attributes-key-value--value-separator
+  margin: 0px 4px
 
-    &.-minimal
-      wp-edit-field
-        flex-basis: 90px
-      .wp-inline-edit--field
-        width: 90px
+  &:after
+    display: inline
+    content: '-'
 
-  .attributes-key-value--value-separator
-    margin: 0px 4px
+.attributes-key-value--value
+  @include grid-visible-overflow
 
-    &:after
-      display: inline
-      content: '-'
+// Alternative implementation to the one above.
+// It's main advantage is that it can act on the whole of the key/value-pairs.
+// It can e.g. determine the width of the widest label and by that align all key value pairs equally.
 
-  .attributes-key-value--value
-    @include grid-visible-overflow
+.attributes-map
+  display: grid
+  grid-template-columns: 1fr 4fr
+  grid-auto-rows: auto
+  grid-gap: 1rem
+
+  &.-minimal-keys
+    grid-template-columns: max-content 4fr
+
+.attributes-map--key
+  @include text-shortener
+  font-weight: bold
+
+  .attributes-map.-minimal-keys &
+    max-width: 200px
+
+.attributes-map--value
+  // empty for now but it makes sense to also have it present in the style declaration IMO
+  zoom: 1

--- a/frontend/src/app/modules/grids/widgets/members/members.component.html
+++ b/frontend/src/app/modules/grids/widgets/members/members.component.html
@@ -12,30 +12,31 @@
   <no-results *ngIf="noMembers"
               [title]="text.noResults">
   </no-results>
-  <div class="attributes-key-value" *ngFor="let usersByRole of usersByRole">
-    <div class="attributes-key-value--key -minimal">
-      {{usersByRole.role.name}}:
-    </div>
-    <div class="attributes-key-value--value-container">
-      <div class="attributes-key-value--value">
-        <span *ngFor="let principal of usersByRole.users; let last = last">
-
-          <ng-container *ngIf="isGroup(principal)">
-            {{userName(principal)}}
-          </ng-container>
-          <ng-container *ngIf="!isGroup(principal)">
-            <user-avatar [user]="principal"
-                         data-class-list="avatar avatar-mini -spaced">
-            </user-avatar>
-            <a [href]="userPath(principal)"
-               [textContent]="userName(principal)">
-            </a>
-          </ng-container>
-
-          <ng-container *ngIf="!last">, </ng-container>
-        </span>
+  <div class="attributes-map -minimal-keys">
+    <ng-container *ngFor="let usersByRole of usersByRole">
+      <div class="attributes-map--key">
+        {{usersByRole.role.name}}
       </div>
-    </div>
+
+      <div class="attributes-map--value">
+          <span *ngFor="let principal of usersByRole.users; let last = last">
+
+            <ng-container *ngIf="isGroup(principal)">
+              {{userName(principal)}}
+            </ng-container>
+            <ng-container *ngIf="!isGroup(principal)">
+              <user-avatar [user]="principal"
+                           data-class-list="avatar avatar-mini -spaced">
+              </user-avatar>
+              <a [href]="userPath(principal)"
+                 [textContent]="userName(principal)">
+              </a>
+            </ng-container>
+
+            <ng-container *ngIf="!last">, </ng-container>
+          </span>
+      </div>
+    </ng-container>
   </div>
   <div *ngIf="moreMembers"
        class="members-widget--notification">

--- a/frontend/src/app/modules/grids/widgets/members/members.component.sass
+++ b/frontend/src/app/modules/grids/widgets/members/members.component.sass
@@ -8,11 +8,6 @@
   .button
     margin-bottom: 0
 
-.attributes-key-value--value
-  line-height: 1.5rem
-
-.attributes-key-value--key
-  padding-right: 5px
-
-.attributes-key-value
+.attributes-map
   padding-bottom: 0.875rem
+  line-height: 1.5rem


### PR DESCRIPTION
Introduces an alternative implementation to attributes-key-value, attributes-map that is grid based. This allows to determine the max width of the labels which can then be truncated in a consistent way across all groups.

https://community.openproject.com/projects/openproject/work_packages/30925