### PR TITLE
[BIM edition] Seeding elaborated demo data

### DIFF
--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -188,8 +188,20 @@ module DemoData
           identifier: project_identifier(key),
           description: project_description(key),
           enabled_module_names: project_modules(key),
-          types: project_types
+          types: project_types,
+          parent_id: parent_project_id(key)
         }
+      end
+
+      def parent_project_id(key)
+        parent_project(key).try(:id)
+      end
+
+      def parent_project(key)
+        identifier = project_data_for(key, 'parent')
+        return nil unless identifier.present?
+
+        Project.find_by(identifier: identifier)
       end
 
       def project_name(key)

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -58,8 +58,15 @@ module DemoData
 
       work_packages_data.each do |attributes|
         print '.'
-        create_work_package attributes
+        create_or_update_work_package(attributes)
       end
+    end
+
+    # Decides what to do with work package seed data.
+    # The default here is to create the work package.
+    # Modules may patch this method.
+    def create_or_update_work_package(attributes)
+      create_work_package(attributes)
     end
 
     def create_work_package(attributes)

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -104,7 +104,8 @@ module DemoData
         description:   attributes[:description],
         status:        find_status(attributes),
         type:          find_type(attributes),
-        priority:      find_priority(attributes) || IssuePriority.default
+        priority:      find_priority(attributes) || IssuePriority.default,
+        parent:        WorkPackage.find_by(subject: attributes[:parent])
       }
     end
 

--- a/modules/bim_seeder/app/seeders/bim_seeder/basic_data/status_seeder.rb
+++ b/modules/bim_seeder/app/seeders/bim_seeder/basic_data/status_seeder.rb
@@ -36,7 +36,7 @@ module BimSeeder
           'red-9', # new
           'yellow-3', # in progress
           'green-3', # resolved
-          'green-9' #closed
+          'green-9' # closed
         ]
 
         # When selecting for an array of values, implicit order is applied
@@ -45,10 +45,10 @@ module BimSeeder
         colors = color_names.collect { |name| colors_by_name[name].id }
 
         [
-          { name: I18n.t(:default_status_new),              color_id: colors[0],  is_closed: false, is_default: true,  position: 1  },
-          { name: I18n.t(:default_status_in_progress),      color_id: colors[1],  is_closed: false, is_default: false, position: 2  },
-          { name: I18n.t('seeders.bim.default_status_resolved'),         color_id: colors[2],  is_closed: false,  is_default: false, position: 3 },
-          { name: I18n.t(:default_status_closed),           color_id: colors[3], is_closed: true,  is_default: false, position: 4 },
+          { name: I18n.t(:default_status_new),              color_id: colors[0],  is_closed: false, is_default: true,  position: 1 },
+          { name: I18n.t(:default_status_in_progress),      color_id: colors[1],  is_closed: false, is_default: false, position: 2 },
+          { name: I18n.t('seeders.bim.default_status_resolved'),         color_id: colors[2], is_closed: false, is_default: false, position: 3 },
+          { name: I18n.t(:default_status_closed),           color_id: colors[3], is_closed: true, is_default: false, position: 4 },
         ]
       end
     end

--- a/modules/bim_seeder/app/seeders/bim_seeder/demo_data/bcf_xml_seeder.rb
+++ b/modules/bim_seeder/app/seeders/bim_seeder/demo_data/bcf_xml_seeder.rb
@@ -1,0 +1,61 @@
+#-- encoding: UTF-8
+
+#-- copyright
+
+# OpenProject is a project management system.
+# Copyright (C) 2012-2019 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+module BimSeeder
+  module DemoData
+    class BcfXmlSeeder < ::Seeder
+      attr_reader :project, :key
+
+      def initialize(project, key)
+        @project = project
+        @key = key
+      end
+
+      def seed_data!
+        filename = project_data_for(key, 'bcf_xml_file')
+        return unless filename.present?
+
+        user = User.admin.first
+
+        print '    ↳ Import BCF XML file'
+
+        import_options = {
+          invalid_people_action: 'anonymize',
+          unknown_mails_action:  'anonymize',
+          non_members_action:    'anonymize'
+        }
+
+        bcf_xml_file = File.new(File.join(Rails.root, 'modules/bim_seeder/files', filename))
+        importer = ::OpenProject::Bcf::BcfXml::Importer.new(bcf_xml_file, project, current_user: user)
+        importer.import!(import_options).flatten
+      end
+    end
+  end
+end

--- a/modules/bim_seeder/aspects/extract_seed_data.rb
+++ b/modules/bim_seeder/aspects/extract_seed_data.rb
@@ -1,0 +1,115 @@
+##
+# This file contains code that helps extracting seed data from real OP instances.
+# It is meant to be copy & pasted into the rails console of the the instance from which you want
+# to extract the data from.
+
+# It is very unstable code. However, it should never change the instance it runs in. However, use it with caution.
+
+## Before using it, make sure that all subjects are unique:
+# project_identifiers = %w(construction-project bcf-management seed-daten creating-bim-model)
+# projects = Project.where(identifier: project_identifiers)
+# all_wps = projects.map(&:work_packages).flatten
+# all_wps.group_by(&:subject).select { |subject, members| members.size > 1 }.each { |subject, members| puts "#{subject}\t#{members.map(&:id).join("\t")}" }
+
+class Seedifier
+  attr_accessor :written_work_packages_ids, :project_identifiers, :projects, :base_date
+
+  def initialize(project_identifiers)
+    @project_identifiers = project_identifiers
+    @written_work_packages_ids = []
+    @projects = Project.where(identifier: @project_identifiers)
+
+    all_work_packages = @projects.map { |project| project.work_packages.to_a }.flatten.sort_by(&:start_date)
+    @base_date = all_work_packages.first.start_date.monday
+  end
+
+  def run
+    @projects.each do |project|
+      puts "=== PROJECT: #{project.identifier} ==="
+      work_packages = project.work_packages.reject { |work_package| work_package.parent && work_package.parent.project.identifier == project.identifier }.sort_by(&:start_date)
+      if work_packages.empty?
+        puts "No work packages for project with identifier #{project.identifier}... skipping."
+        next
+      end
+
+      puts work_packages.map { |work_package| seedify_work_package(work_package, project) }.compact.to_yaml
+    end
+  end
+
+  def calc_start_offset(work_package)
+    if work_package.start_date
+      (work_package.start_date - @base_date).to_i
+    else
+      0
+    end
+  end
+
+  def calc_duration(work_package)
+    if work_package.start_date && work_package.due_date
+      (work_package.due_date - work_package.start_date).to_i
+    end
+  end
+
+  def calc_status(work_package)
+    prefix = ''
+    if ["Resolved"].include?(work_package.status.name)
+      prefix = 'seeders.bim.'
+    end
+    "#{prefix}default_status_#{calc_low_dash(work_package.status.name.downcase)}"
+  end
+
+  def calc_type(work_package)
+    prefix = ''
+    if ["Issue", "Clash", "Remark", "Request"].include?(work_package.type.name)
+      prefix = 'seeders.bim.'
+    end
+    "#{prefix}default_type_#{calc_low_dash(work_package.type.name.downcase)}"
+  end
+
+  def calc_low_dash(name)
+    name.tr(" ", "_")
+  end
+
+  ##
+  # Create a hash that only hold those properties that we would like to copy and paste into a seeder YAML file.
+  def seedify_work_package(work_package, project)
+    # Don't seed a WP twice. And don't seed WPs of other projects.
+    return nil if (@written_work_packages_ids.include?(work_package.id) || work_package.project_id != project.id)
+
+    @written_work_packages_ids << work_package.id
+
+    predecessors = work_package.follows.sort_by(&:start_date).map { |predecessor| { to: predecessor.subject, type: 'follows' } }
+
+    children = work_package.children.sort_by(&:start_date).map { |child| seedify_work_package(child, project) }.compact
+
+    assigned_to = work_package.assigned_to.try(:name)
+
+    duration = calc_duration(work_package)
+
+    seedified = {
+      start: calc_start_offset(work_package)
+    }
+
+    if work_package.bcf_issue
+      seedified[:bcf_issue_uuid] = work_package.bcf_issue.uuid
+    else
+      seedified[:subject] = work_package.subject
+      seedified[:description] = work_package.description
+      seedified[:status] = calc_status(work_package)
+      seedified[:type] = calc_type(work_package)
+      seedified[:estimated_hours] = work_package.estimated_hours if work_package.estimated_hours.present?
+      seedified[:children] = children if children.any?
+    end
+
+    seedified[:assigned_to] = assigned_to if assigned_to.present?
+    seedified[:duration] = duration if duration.present?
+    seedified[:parent] = work_package.parent.subject if work_package.parent.present? && (work_package.bcf_issue || work_package.project_id != project.id)
+    seedified[:relations] = predecessors if predecessors.any?
+
+    seedified
+  end
+end
+
+# project_identifiers = ['demo-project']
+project_identifiers = %w(construction-project bcf-management seed-daten creating-bim-model)
+Seedifier.new(project_identifiers).run

--- a/modules/bim_seeder/config/locales/en.seeders.bim.yml
+++ b/modules/bim_seeder/config/locales/en.seeders.bim.yml
@@ -82,7 +82,7 @@ en:
             identifier: demo-construction-project
             description: >
               **This is a demo project**. You can edit the description in
-              the [Project settings -> Description](%{base_url}/projects/demo-project/settings).
+              the [Project settings -> Description](%{base_url}/projects/demo-construction-project/settings).
             timeline:
               name: Timeline
             modules:
@@ -133,13 +133,13 @@ en:
                   - status
                   - assigned_to
             work_packages: []
-          demo-planning-construction-project:
+          demo-planning-constructing-project:
             name: (Demo) Planning & constructing
-            identifier: demo-planning-construction-project
+            identifier: demo-planning-constructing-project
             parent: demo-construction-project
             description: >
               **This is a demo project**. You can edit the description in
-              the [Project settings -> Description](%{base_url}/projects/demo-planning-construction-project/settings).
+              the [Project settings -> Description](%{base_url}/projects/demo-planning-constructing-project/settings).
             timeline:
               name: Timeline
             modules:
@@ -567,9 +567,9 @@ en:
               - :start: 14
                 :subject: Project kick off creating BIM model
                 :description: |-
-                  The project Kick off initializes the start of the project in your company. Everybody being part of this project should be invited to the kick off for a first briefing.
+                  The project Kickoff initializes the start of the project in your company. The whole project team should be invited to the Kickoff for a first briefing.
 
-                  The next step could be checking out the timetable and adjusting the appointments, by looking at the [Gantt chart](https://bcf.openproject-edge.com/projects/creating-bim-model/work_packages?query_props=%7B%22c%22%3A%5B%22id%22%2C%22subject%22%2C%22startDate%22%2C%22dueDate%22%5D%2C%22tv%22%3Atrue%2C%22tzl%22%3A%22weeks%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22status%22%2C%22o%22%3A%22o%22%2C%22v%22%3A%5B%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%7D).
+                  The next step could be to check out the timetable and adjusting the appointments, by looking at the [Gantt chart](https://bcf.openproject-edge.com/projects/creating-bim-model/work_packages?query_props=%7B%22c%22%3A%5B%22id%22%2C%22subject%22%2C%22startDate%22%2C%22dueDate%22%5D%2C%22tv%22%3Atrue%2C%22tzl%22%3A%22weeks%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22status%22%2C%22o%22%3A%22o%22%2C%22v%22%3A%5B%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%7D).
                 :status: default_status_new
                 :type: default_type_milestone
                 :assigned_to: BIM Managers
@@ -609,7 +609,7 @@ en:
                     :description: |-
                       # Goal
 
-                      *   A BIM execution plan shall be defined according to the exchange requirements specifications (ERS)
+                      *   A BIM execution plan will be defined according to the exchange requirements specifications (ERS)
                       *   All team members and partners have a plan on how to reach each of the project goals
 
                       # Description
@@ -721,12 +721,12 @@ en:
                     :description: |-
                       # Goal
 
-                      *   Having a foundation for developing the own model/ offering answers
-                      *   Using the external model to develop the own model
+                      *   Having a foundation for developing the internal model/ offering answers
+                      *   Using the external model to develop the internal model
 
                       # Description
 
-                      *   The external model will be referenced in the BIM platform, thus used for modelling the own model
+                      *   The external model will be referenced in the BIM platform, thus used for modelling the internal model
                       *   ...
                     :status: default_status_new
                     :type: default_type_task
@@ -905,7 +905,7 @@ en:
 
                       ## Description
 
-                      *   The kick-off on the construction site includes an introduction to the model
+                      *   The Kickoff on the construction site includes an introduction to the model
                       *   All the objects should have the information needed for the assigned tasks. If not, data enrichment of the model needs to be done
                       *   ...
                     :status: default_status_new
@@ -957,13 +957,13 @@ en:
                   ## Goal
 
                   *   The BIM model will be used for the Facility Management
-                  *   The model provides all the relevant information for commissioning and operating the building 
+                  *   The model provides all the relevant information for commissioning and operating the building
                   *   ...
 
                   ## Description
 
                   *   The model contains the relevant information for the facility manager
-                  *   The model can be used for the operting system of the building
+                  *   The model can be used for the operating system of the building
                   *   ...
                 :status: default_status_new
                 :type: default_type_milestone
@@ -983,10 +983,10 @@ en:
           demo-bcf-management-project:
             name: (Demo) BCF management
             identifier: demo-bcf-management-project
-            parent: demo-planning-construction-project
+            parent: demo-bim-project
             description: >
               **This is a demo project for BCF**. You can edit the description in
-              the [Project settings -> Description](%{base_url}/projects/demo-bcf-project/settings).
+              the [Project settings -> Description](%{base_url}/projects/demo-bcf-management-project/settings).
             timeline:
               name: Timeline
             modules:

--- a/modules/bim_seeder/config/locales/en.seeders.bim.yml
+++ b/modules/bim_seeder/config/locales/en.seeders.bim.yml
@@ -1063,6 +1063,9 @@ en:
                   - type
                   - status
                   - assigned_to
+            boards:
+              bcf:
+                name: "BCF issues"
             bcf_xml_file: "seed.bcfzip"
             work_packages:
               - :start: 73

--- a/modules/bim_seeder/config/locales/en.seeders.bim.yml
+++ b/modules/bim_seeder/config/locales/en.seeders.bim.yml
@@ -67,9 +67,12 @@ en:
         welcome:
           title: "Welcome to OpenProject BIM Edition!"
           text: |
-            Checkout the demo project to get started with some demo data we have prepared for you.
+            Checkout the demo projects to get started with some examples.
 
-            * [Demo project](%{base_url}/projects/demo-project): to get an overview about classical project management.
+            * [(Demo) Construction project](%{base_url}/projects/demo-construction-project): Planning, BIM process, BCF management, and constructing, all at a glance.
+                * [(Demo) Construction project](%{base_url}/projects/demo-planning-constructing-project): Classical planning and construction management.
+                * [(Demo) Construction project](%{base_url}/projects/demo-bim-project): BIM process and coordination.
+                    * [(Demo) Construction project](%{base_url}/projects/demo-bcf-management-project): BCF management.
 
             Also, you can create a blank [new project](%{base_url}/projects/new).
 

--- a/modules/bim_seeder/config/locales/en.seeders.bim.yml
+++ b/modules/bim_seeder/config/locales/en.seeders.bim.yml
@@ -1154,37 +1154,38 @@ en:
                 :duration: 3
                 :parent: Issue management, first cycle
               - :start: 98
-                :bcf_issue_uuid: 03d1536b-e444-4900-921e-57405142ba82
-                :assigned_to: Planners
-                :duration: 0
+                :bcf_issue_uuid: 73def76d-939d-404c-9bd0-581399f92714
+                :duration: 8
                 :parent: Issue management, construction phase
               - :start: 98
-                :bcf_issue_uuid: 64880305-5c13-4045-9946-fd43441bf063
-                :assigned_to: BIM Modellers
-                :duration: 4
+                :bcf_issue_uuid: b5105e2e-add1-4d48-abb9-ce51fcea3bdd
+                :duration: 8
                 :parent: Issue management, construction phase
               - :start: 98
-                :bcf_issue_uuid: d9c283eb-aac5-4b64-8228-c00d57efe609
-                :assigned_to: Planners
-                :duration: 0
+                :bcf_issue_uuid: 99f03fde-4c74-4a8f-940a-c741738ab073
+                :duration: 2
                 :parent: Issue management, construction phase
-              - :start: 98
-                :bcf_issue_uuid: 1b47968c-86df-4e79-8ffd-f4928ddb1834
-                :assigned_to: Planners
-                :duration: 12
+              - :start: 111
+                :bcf_issue_uuid: af1de642-6d08-489b-8056-ca4c383e0617
+                :duration: 8
                 :parent: Issue management, construction phase
-              - :start: 153
-                :bcf_issue_uuid: 9eb55008-516e-4b37-94d9-482e0a24c00d
-                :assigned_to: Planners
-                :duration: 26
+              - :start: 114
+                :bcf_issue_uuid: e6276745-3d58-4d40-80fb-6de5cb05077e
+                :duration: 8
                 :parent: Issue management, construction phase
-              - :start: 154
-                :bcf_issue_uuid: 33a15f8b-971c-4c82-853e-ec1eec552101
-                :assigned_to: Planners
-                :duration: 4
+              - :start: 149
+                :bcf_issue_uuid: efd7be98-1a64-4a35-ad4c-51b8881d79ed
+                :duration: 8
                 :parent: Issue management, construction phase
-              - :start: 182
-                :bcf_issue_uuid: d54db43e-7a1e-44fd-8f2c-0a3b8752b54f
-                :assigned_to: Planners
-                :duration: 4
+              - :start: 152
+                :bcf_issue_uuid: f689bfd4-ec09-45ca-bbe3-7d1d0f5d9933
+                :duration: 21
+                :parent: Issue management, construction phase
+              - :start: 178
+                :bcf_issue_uuid: 3746180f-ba1e-4ea0-a0fb-6ee69ccabd85
+                :duration: 8
+                :parent: Issue management, construction phase
+              - :start: 178
+                :bcf_issue_uuid: 2adbdbb4-bb60-4250-b8af-3cd786437814
+                :duration: 8
                 :parent: Issue management, construction phase

--- a/modules/bim_seeder/config/locales/en.seeders.bim.yml
+++ b/modules/bim_seeder/config/locales/en.seeders.bim.yml
@@ -135,6 +135,9 @@ en:
                   - type
                   - status
                   - assigned_to
+            boards:
+              bcf:
+                name: "Simple drag'n drop workflow"
             work_packages: []
           demo-planning-constructing-project:
             name: (Demo) Planning & constructing

--- a/modules/bim_seeder/config/locales/en.seeders.bim.yml
+++ b/modules/bim_seeder/config/locales/en.seeders.bim.yml
@@ -62,6 +62,7 @@ en:
           - name: BIM Modellers
           - name: Lead BIM Coordinators
           - name: MEP Engineers
+          - name: Planners
           - name: Structural Engineers
         welcome:
           title: "Welcome to OpenProject BIM Edition!"
@@ -76,9 +77,9 @@ en:
 
             You can change this welcome text [here](%{base_url}/settings).
         projects:
-          demo-project:
-            name: Demo project
-            identifier: demo-project
+          demo-construction-project:
+            name: (Demo) Construction project
+            identifier: demo-construction-project
             description: >
               **This is a demo project**. You can edit the description in
               the [Project settings -> Description](%{base_url}/projects/demo-project/settings).
@@ -99,8 +100,63 @@ en:
               - :default_type_task
               - :default_type_milestone
               - :default_type_phase
-              - 'seeders.bim.default_type_clash'
-              - 'seeders.bim.default_type_request'
+            categories:
+              - Category 1 (to be changed in Project settings)
+            queries:
+              - name: Project plan
+                status: open
+                timeline: true
+                sort_by: id
+                hierarchy: true
+              - name: Milestones
+                status: open
+                type: :default_type_milestone
+                timeline: true
+                columns:
+                  - id
+                  - type
+                  - status
+                  - subject
+                  - start_date
+                  - due_date
+                sort_by: id
+              - name: Tasks
+                status: open
+                type: :default_type_task
+                hierarchy: true
+                sort_by: id
+                columns:
+                  - id
+                  - subject
+                  - priority
+                  - type
+                  - status
+                  - assigned_to
+            work_packages: []
+          demo-planning-construction-project:
+            name: (Demo) Planning & constructing
+            identifier: demo-planning-construction-project
+            parent: demo-construction-project
+            description: >
+              **This is a demo project**. You can edit the description in
+              the [Project settings -> Description](%{base_url}/projects/demo-planning-construction-project/settings).
+            timeline:
+              name: Timeline
+            modules:
+              - work_package_tracking
+              - news
+              - wiki
+              - board_view
+            news:
+              - title: Welcome to your demo project
+                summary: >
+                  We are glad you joined.
+                  In this module you can communicate project news to your team members.
+                description: The actual news
+            types:
+              - :default_type_task
+              - :default_type_milestone
+              - :default_type_phase
             categories:
               - Category 1 (to be changed in Project settings)
             queries:
@@ -134,286 +190,800 @@ en:
                   - status
                   - assigned_to
             work_packages:
-              - subject: Project kick-off
-                description: Plan and execute the project kick-off.
-                status: :default_status_in_progress
+              - :start: 4
+                :subject: Project kick off construction project
+                :description: |-
+                  The project kick off initializes the start of the project in your company. Everybody being part of this project should be invited to the kick off for a first briefing.
+
+                  The next step could be checking out the timetable and adjusting the appointments, by looking at the [Gantt chart](https://bcf.openproject-edge.com/projects/construction-project/work_packages?query_props=%7B%22c%22%3A%5B%22id%22%2C%22subject%22%2C%22startDate%22%2C%22dueDate%22%5D%2C%22tv%22%3Atrue%2C%22tzl%22%3A%22weeks%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22status%22%2C%22o%22%3A%22o%22%2C%22v%22%3A%5B%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%7D).
+                :status: default_status_new
+                :type: default_type_milestone
+                :assigned_to: Planners
+                :duration: 0
+              - :start: 7
+                :subject: Basic evaluation
+                :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                  and &quot;Request&quot;, thus represents a general note.
+                :status: default_status_new
+                :type: default_type_phase
+                :children:
+                  - :start: 7
+                    :subject: Gathering first project information
+                    :description: |-
+                      ## Goal
+
+                      *   Define tasks based on the customer needs
+                      *   Time frame and cost estimation shall be defined
+
+                      ## Description
+
+                      *   Identify the customer needs by having a workshop with him/ her
+                      *   Each need shall represent a task with its corresponding work packages
+                      *   Derive the cost estimation and time frame
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Planners
+                    :duration: 4
+                  - :start: 14
+                    :subject: Summarize the results
+                    :description: |-
+                      ## Goal
+
+                      *   Create a usefull overview of the results
+                      *   Check what has been done and summarize the results
+                      *   Communicate all the relevant results with the customer
+                      *   Identify the fundamental boundary conditions of the project
+
+                      ## Description
+
+                      *   Each topic gets its own overview which will be used as a catalouge of results
+                      *   This overview informs all participants about the decisions made
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Planners
+                    :duration: 4
+                    :relations:
+                      - :to: Gathering first project information
+                        :type: follows
+                  - :start: 21
+                    :subject: End of basic evaluation
+                    :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                      and &quot;Request&quot;, thus represents a general note.
+                    :status: default_status_new
+                    :type: default_type_milestone
+                    :assigned_to: Planners
+                    :duration: 0
+                    :relations:
+                      - :to: Summarize the results
+                        :type: follows
+                :assigned_to: Planners
+                :duration: 14
+                :relations:
+                  - :to: Project kick off construction project
+                    :type: follows
+              - :start: 22
+                :subject: Preliminary planning
+                :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                  and &quot;Request&quot;, thus represents a general note.
+                :status: default_status_new
+                :type: default_type_phase
+                :children:
+                  - :start: 22
+                    :subject: Developing first draft
+                    :description: |-
+                      ## Goal
+
+                      *   Create a usefull overview of the results
+                      *   Check what has been done and summarize the results
+                      *   Communicate all the relevant results with the customer
+                      *   Identify the fundamental boundary conditions of the project
+
+                      ## Description
+
+                      *   Each topic gets its own overview which will be used as a catalouge of results
+                      *   This overview informs all participants about the decisions made
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Planners
+                    :duration: 10
+                    :relations:
+                      - :to: End of basic evaluation
+                        :type: follows
+                  - :start: 35
+                    :subject: Summarize results
+                    :description: |-
+                      ## Goal
+
+                      *   Create a usefull overview of the results
+                      *   Check what has been done and summarize the results
+                      *   Communicate all the relevant results with the customer
+                      *   Identify the fundamental boundary conditions of the project
+
+                      ## Description
+
+                      *   Each topic gets its own overview which will be used as a catalouge of results
+                      *   This overview informs all participants about the decisions made
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Planners
+                    :duration: 4
+                    :relations:
+                      - :to: Developing first draft
+                        :type: follows
+                :assigned_to: Planners
+                :duration: 17
+              - :start: 42
+                :subject: Passing of preliminary planning
+                :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                  and &quot;Request&quot;, thus represents a general note.
+                :status: default_status_new
+                :type: default_type_milestone
+                :assigned_to: Planners
+                :duration: 0
+                :relations:
+                  - :to: Summarize results
+                    :type: follows
+              - :start: 44
+                :subject: Design planning
+                :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                  and &quot;Request&quot;, thus represents a general note.
+                :status: default_status_new
+                :type: default_type_phase
+                :children:
+                  - :start: 44
+                    :subject: Finishing design
+                    :description: |-
+                      ## Goal
+
+                      *   Design is done
+                      *   All parties are happy with the results of the design planning phase
+
+                      ## Description
+
+                      *   The design of the project will be finished
+                      *   All parties agree on the design
+                      *   The owner is happy with the results
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Planners
+                    :duration: 45
+                    :relations:
+                      - :to: Passing of preliminary planning
+                        :type: follows
+                  - :start: 90
+                    :subject: Design freeze
+                    :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                      and &quot;Request&quot;, thus represents a general note.
+                    :status: default_status_new
+                    :type: default_type_milestone
+                    :assigned_to: Planners
+                    :duration: 0
+                    :relations:
+                      - :to: Finishing design
+                        :type: follows
+                :assigned_to: Planners
+                :duration: 46
+              - :start: 98
+                :subject: Construction phase
+                :description: ''
+                :status: default_status_new
+                :type: default_type_phase
+                :children:
+                  - :start: 98
+                    :subject: Start constructing
+                    :description: |-
+                      ## Goal
+
+                      *   Ground breaking ceremony
+                      *   Setting up the construction site
+                      *   ...
+
+                      ## Description
+
+                      *   Preparing the site for the project
+                      *   Get the team together
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Planners
+                    :duration: 31
+                  - :start: 130
+                    :subject: Foundation
+                    :description: |-
+                      ## Goal
+
+                      *   Laying of the foundation stone
+                      *   ...
+
+                      ## Description
+
+                      *   Setting up the concrete mixer
+                      *   Setting up the supply chain for the concrete
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Planners
+                    :duration: 25
+                    :relations:
+                      - :to: Start constructing
+                        :type: follows
+                  - :start: 149
+                    :subject: Building construction
+                    :description: |-
+                      ## Goal
+
+                      *   Topping out ceremony
+                      *   Walls and ceilings are done
+                      *   ...
+
+                      ## Description
+
+                      *   Creating all structural levels of the building
+                      *   Installing doors and windows
+                      *   Finishing the roof structure
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Planners
+                    :duration: 46
+                  - :start: 164
+                    :subject: Finishing the facade
+                    :description: |-
+                      ## Goal
+
+                      *   Facade is done
+                      *   Whole building is waterproof
+                      *   ...
+
+                      ## Description
+
+                      *   Install all elements for the facade
+                      *   Finish the roof
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Planners
+                    :duration: 32
+                  - :start: 178
+                    :subject: Installing the building service systems
+                    :description: |-
+                      ## Goal
+
+                      *   All building service systems are ready to be used
+
+                      ## Description
+
+                      *   Installing the heating system
+                      *   Installing the climate system
+                      *   Electrical installation
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Planners
+                    :duration: 25
+                  - :start: 189
+                    :subject: Final touches
+                    :description: |-
+                      ## Goal
+
+                      *   Handover of the keys
+                      *   The customer is happy with his building
+                      *   ...
+
+                      ## Description
+
+                      *   Finishing the installation of the building service systems
+                      *   Finishing the interior construction
+                      *   Finishing the facade
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Planners
+                    :duration: 18
+                  - :start: 208
+                    :subject: House warming party
+                    :description: |-
+                      ## Goal
+
+                      *   Have a blast!
+
+                      ## Description
+
+                      *   Invite the construction team
+                      *   Invite your friends
+                      *   Bring some drinks, snacks and your smile
+                    :status: default_status_new
+                    :type: default_type_milestone
+                    :duration: 0
+                    :relations:
+                      - :to: Final touches
+                        :type: follows
+                :assigned_to: Planners
+                :duration: 110
+                :relations:
+                  - :to: Design freeze
+                    :type: follows
+          demo-bim-project:
+            name: (Demo) BIM project
+            identifier: demo-bim-project
+            parent: demo-construction-project
+            description: >
+              **This is a demo project**. You can edit the description in
+              the [Project settings -> Description](%{base_url}/projects/demo-bim-project/settings).
+            timeline:
+              name: Timeline
+            modules:
+              - work_package_tracking
+              - news
+              - wiki
+              - board_view
+            news:
+              - title: Welcome to your demo project
+                summary: >
+                  We are glad you joined.
+                  In this module you can communicate project news to your team members.
+                description: The actual news
+            types:
+              - :default_type_task
+              - :default_type_milestone
+              - :default_type_phase
+            categories:
+              - Category 1 (to be changed in Project settings)
+            queries:
+              - name: Project plan
+                status: open
+                timeline: true
+                sort_by: id
+                hierarchy: true
+              - name: Milestones
+                status: open
                 type: :default_type_milestone
-                priority: :default_priority_high
-                estimated_hours: 8
-                start: 4
-                duration: 0
-                done_ratio: 50
-              - subject: Project planning
-                description: |
-                  Please execute the related tasks:
+                timeline: true
+                columns:
+                  - id
+                  - type
+                  - status
+                  - subject
+                  - start_date
+                  - due_date
+                sort_by: id
+              - name: Tasks
+                status: open
+                type: :default_type_task
+                hierarchy: true
+                sort_by: id
+                columns:
+                  - id
+                  - subject
+                  - priority
+                  - type
+                  - status
+                  - assigned_to
+            work_packages:
+              - :start: 14
+                :subject: Project kick off creating BIM model
+                :description: |-
+                  The project Kick off initializes the start of the project in your company. Everybody being part of this project should be invited to the kick off for a first briefing.
 
-                  * ##child:1
-                  * ##child:2
-                  * ##child:3
-                  * ##child:4
-                  * ##child:5
-                  * ##child:6
-                  * ##child:7
-                status: :default_status_in_progress
-                type: :default_type_phase
-                priority: :default_priority_high
-                estimated_hours: 8
-                start: 0
-                duration: 3
-                children:
-                  - subject: Create a new project
-                    description: |
-                      Please [create a new project](%{base_url}/projects/new) from the project drop down menu in the left hand header navigation.
+                  The next step could be checking out the timetable and adjusting the appointments, by looking at the [Gantt chart](https://bcf.openproject-edge.com/projects/creating-bim-model/work_packages?query_props=%7B%22c%22%3A%5B%22id%22%2C%22subject%22%2C%22startDate%22%2C%22dueDate%22%5D%2C%22tv%22%3Atrue%2C%22tzl%22%3A%22weeks%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22status%22%2C%22o%22%3A%22o%22%2C%22v%22%3A%5B%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%7D).
+                :status: default_status_new
+                :type: default_type_milestone
+                :assigned_to: BIM Managers
+                :duration: 0
+              - :start: 15
+                :subject: Project preperation
+                :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                  and &quot;Request&quot;, thus represents a general note.
+                :status: default_status_new
+                :type: default_type_phase
+                :children:
+                  - :start: 15
+                    :subject: Gathering the project specific data and information for the BIM model
+                    :description: |-
+                      ## Goal
 
-                      **You can:**
-                      * give your project a name,
-                      * add a project description,
-                      * create a project structure,
-                      * set a project to public.
+                      *   Identify the information strategy for the customer (e.g. by using plain language questions)
+                      *   If provided, analyze the customer information requirements for the BIM model
+                      *   Define an information delivery strategy according to the customers needs
 
-                      **Visuals:**
-                      ![new project](##attachment:"new_project.jpg")
+                      ## Description
 
-                      **Find out more:**
-                      * https://www.openproject.org/help/administration/manage-projects/
-                    status: :default_status_new
-                    type: :default_type_task
-                    start: 0
-                    duration: 0
-                    attachments:
-                      - new_project.jpg
-                  - subject: Customize project overview page
-                    description: |
-                      You can [customize your project overview page](%{base_url}/my_projects_overview/demo-project/page_layout) to add important information, such as project description, important links, work packages overview, news, and much more.
+                      *   Analyzing the customers needs and goals for using the BIM methodology
+                      *   Results of this tasks should be:
+                          *   The requirements for the project
+                          *   A strategy for the delivery phase
+                          *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Planners
+                    :duration: 3
+                    :relations:
+                      - :to: Project kick off creating BIM model
+                        :type: follows
+                  - :start: 21
+                    :subject: Creating the BIM execution plan
+                    :description: |-
+                      # Goal
 
-                      **You can:**
-                      * edit the project overview by clicking on the gear icon,
-                      * add a project description,
-                      * add links to important project information or custom reports,
-                      * insert news or work packages,
-                      * and much more.
+                      *   A BIM execution plan shall be defined according to the exchange requirements specifications (ERS)
+                      *   All team members and partners have a plan on how to reach each of the project goals
 
-                      **Visuals:**
-                      ![project overview](##attachment:"project_overview.jpg")
+                      # Description
 
-                      **Find out more:**
-                      * https://www.openproject.org/help/project-setup/
-                    status: :default_status_new
-                    type: :default_type_task
-                    start: 0
-                    duration: 0
-                    attachments:
-                      - project_overview.jpg
-                  - subject: Activate further modules
-                    description: |
-                      Please activate further [Modules](%{base_url}/projects/demo-project/settings/modules) in the Project settings in order to have more features in your project.
+                      *   Depending on the identifies use cases, the individual Information Delivery Manuals will be defined
+                      *   To handle the technological interfaces, a software topology will be defined and analyzed and verified
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Lead BIM Coordinators
+                    :duration: 18
+                    :relations:
+                      - :to: Gathering the project specific data and information for the BIM model
+                        :type: follows
+                  - :start: 40
+                    :subject: Completion of the BIM execution plan
+                    :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                      and &quot;Request&quot;, thus represents a general note.
+                    :status: default_status_new
+                    :type: default_type_milestone
+                    :assigned_to: BIM Coordinators
+                    :duration: 0
+                    :relations:
+                      - :to: Creating the BIM execution plan
+                        :type: follows
+                :assigned_to: BIM Managers
+                :duration: 25
+              - :start: 41
+                :subject: End of preperation phase
+                :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                  and &quot;Request&quot;, thus represents a general note.
+                :status: default_status_new
+                :type: default_type_milestone
+                :assigned_to: BIM Managers
+                :duration: 0
+                :relations:
+                  - :to: Project preperation
+                    :type: follows
+              - :start: 44
+                :subject: Creating inital BIM model
+                :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                  and &quot;Request&quot;, thus represents a general note.
+                :status: default_status_new
+                :type: default_type_phase
+                :children:
+                  - :start: 44
+                    :subject: Modelling inital BIM model
+                    :description: |-
+                      # Goal
 
-                      **You can:**
-                      * add time tracking, reporting, and budgets (Time Tracking, Cost Reports, Budgets),
-                      * add a wiki,
-                      * add meetings,
-                      * add BCF import/export,
-                      * and more.
+                      *   Modelling the inital BIM model
+                      *   Creating a BIM model for the whole project team
 
-                      **Visuals:**
-                      ![project modules](##attachment:"project_modules.jpg")
+                      # Description
 
-                      **Find out more:**
-                      * https://www.openproject.org/help/activate-deactivate-modules/
-                    status: :default_status_new
-                    type: :default_type_task
-                    start: 0
-                    duration: 0
-                    attachments:
-                      - project_modules.jpg
-                  - subject: Invite new team members
-                    description: |
-                      Please invite new team members by going to [Members](%{base_url}/projects/demo-project/members) in the project navigation.
+                      *   According to the gathered data from the customer, the inital model will be modelled
+                      *   The model shall be modelled according to the LOD Matrices and contain the information needed
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: BIM Modellers
+                    :duration: 7
+                    :relations:
+                      - :to: End of preperation phase
+                        :type: follows
+                  - :start: 52
+                    :subject: Initial, internal model check and revising
+                    :description: |-
+                      # Goal
 
-                      **You can:**
-                      * add existing users to  a project by typing in their names,
-                      * invite new users to OpenProject by typing in their email address,
-                      * assign a certain role in this project for each user.
+                      *   Submitting a BIM model according to the defined standards
 
-                      **Visuals:**
-                      ![project members](##attachment:"project_members.jpg")
+                      # Description
 
-                      **Find out more:**
-                      * https://www.openproject.org/help/add-project-members/
-                    status: :default_status_new
-                    type: :default_type_task
-                    start: 1
-                    duration: 1
-                    priority: :default_priority_high
-                    attachments:
-                      - project_members.jpg
-                  - subject: Create work packages
-                    description: |
-                      Please create work packages for your project. Go to [Work package](%{base_url}/projects/demo-project/work_packages) and click the green +Create button.
+                      *   The model shall be checked, according to the defined standards (conventions, LOD, ...) and revised
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: Lead BIM Coordinators
+                    :duration: 2
+                    :relations:
+                      - :to: Modelling inital BIM model
+                        :type: follows
+                  - :start: 58
+                    :subject: Submitting inital BIM model
+                    :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                      and &quot;Request&quot;, thus represents a general note.
+                    :status: default_status_new
+                    :type: default_type_milestone
+                    :assigned_to: BIM Modellers
+                    :duration: 0
+                    :relations:
+                      - :to: Initial, internal model check and revising
+                        :type: follows
+                :assigned_to: Architects
+                :duration: 14
+                :relations:
+                  - :to: Completion of the BIM execution plan
+                    :type: follows
+              - :start: 59
+                :subject: Modelling, first cycle
+                :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                  and &quot;Request&quot;, thus represents a general note.
+                :status: default_status_new
+                :type: default_type_phase
+                :children:
+                  - :start: 59
+                    :subject: Referencing external BIM models
+                    :description: |-
+                      # Goal
 
-                      **You can**:
-                      * create any type of work, e.g. features, tasks, bugs, risks, ideas,
-                      * add a title and description,
-                      * add attachments via copy and paste to the description,
-                      * set status, priority and assign it to a team member,
-                      * insert any custom field to the forms.
+                      *   Having a foundation for developing the own model/ offering answers
+                      *   Using the external model to develop the own model
 
-                      **Visuals**:
-                      ![create work package](##attachment:"create_work_package.jpg")
+                      # Description
 
-                      **Find out more**:
-                      * https://www.openproject.org/help/work-packages/create-new-work-package/
-                    status: :default_status_new
-                    type: :default_type_task
-                    start: 1
-                    duration: 1
-                    priority: :default_priority_high
-                    attachments:
-                      - create_work_package.jpg
-                  - subject: Create a project plan
-                    description: |
-                      Please create a project plan by going to [Project plan](##query:"Project plan") in the project navigation.
+                      *   The external model will be referenced in the BIM platform, thus used for modelling the own model
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: BIM Modellers
+                    :duration: 0
+                    :relations:
+                      - :to: Submitting inital BIM model
+                        :type: follows
+                  - :start: 60
+                    :subject: Modelling the BIM model
+                    :description: |-
+                      # Goal
 
-                      **You can:**
-                      * create new phases and milestones by simply clicking in the project plan,
-                      * change phases and milestones with drag and drop,
-                      * add labels, such as start and finish date, title, or assignee,
-                      * add dependencies by right clicking on a phase or milestone and choose pre-decessor or follower,
-                      * custom columns, group, filter and save timeline reports to have them at your fingertips.
+                      *   Creating a BIM model for the project
+                      *   Creating a BIM model for the whole project team
 
-                      **Visuals:**
-                      ![gantt chart](##attachment:"gantt_chart.jpg")
+                      # Description
 
-                      **Find out more:**
-                      * https://www.openproject.org/help/timelines/integrated-timeline-work-package-page/
-                    status: :default_status_new
-                    type: :default_type_task
-                    start: 2
-                    duration: 1
-                    priority: :default_priority_high
-                    attachments:
-                      - gantt_chart.jpg
-                  - subject: Edit a work package
-                    description: |
-                      [Edit a work package](%{base_url}/projects/demo-project/work_packages/41/activity) by double clicking on a row in the list view or open the split screen with the "i".
+                      *   The model will be created according to the BIM execution plan
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: BIM Modellers
+                    :duration: 7
+                    :relations:
+                      - :to: Referencing external BIM models
+                        :type: follows
+                  - :start: 68
+                    :subject: First Cycle, internal model check and revising
+                    :description: |-
+                      # Goal
 
-                      **You can**:
-                      * change title or description,
-                      * assign it to a team member,
-                      * comment on topics or notify team members with @-notifications,
-                      * set status, priority, finish dates or other custom fields,
-                      * include documents or screenshots with copy & paste,
-                      * add relations to other work packages,
-                      * change forms in the Administration settings.
+                      *   Submitting a BIM model according to the defined standards
 
-                      **Visuals**:
-                      ![edit work package](##attachment:"edit_work_package.jpg")
+                      # Description
 
-                      **Find out more**:
-                      * https://www.openproject.org/help/work-packages/
-                    status: :default_status_new
-                    type: :default_type_task
-                    start: 3
-                    duration: 0
-                    priority: :default_priority_high
-                    attachments:
-                      - edit_work_package.jpg
-              - subject: Develop v1.0
-                status: :default_status_in_progress
-                type: :default_type_phase
-                start: 7
-                duration: 17
-                children:
-                  - subject: Big change
-                    status: :default_status_in_progress
-                    type: 'seeders.bim.default_type_request'
-                    start: 7
-                    duration: 8
-                  - subject: Best change
-                    status: :default_status_in_progress
-                    type: 'seeders.bim.default_type_request'
-                    start: 16
-                    duration: 5
-                    relations:
-                      - to: Big change
-                        type: follows
-                  - subject: Terrible fault
-                    status: :default_status_in_progress
-                    type: 'seeders.bim.default_type_clash'
-                    start: 22
-                    duration: 2
-                    relations:
-                      - to: Best change
-                        type: follows
-              - subject: Go-Live v1.0
-                status: :default_status_in_progress
-                type: :default_type_milestone
-                start: 25
-                duration: 0
-                relations:
-                  - to: Develop v1.0
-                    type: follows
-              - subject: Develop v1.1
-                status: :default_status_in_progress
-                type: :default_type_phase
-                start: 28
-                duration: 2
-                children:
-                  - subject: Wonderful change
-                    status: :default_status_in_progress
-                    type: 'seeders.bim.default_type_request'
-                    start: 28
-                    duration: 1
-                  - subject: Ugly fault
-                    status: :default_status_in_progress
-                    type: 'seeders.bim.default_type_clash'
-                    start: 30
-                    duration: 1
-                    relations:
-                      - to: Wonderful change
-                        type: follows
-              - subject: Go-Live v1.1
-                status: :default_status_in_progress
-                type: :default_type_milestone
-                start: 32
-                duration: 0
-                relations:
-                  - to: Develop v1.1
-                    type: follows
-            wiki:
-              - title: Wiki
-                content: |
-                  In this wiki you can collaboratively create and edit pages and sub-pages to create a project wiki.
+                      *   The model shall be checked, according to the defined standards (conventions, LOD, ...) and revised.
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: BIM Coordinators
+                    :duration: 1
+                    :relations:
+                      - :to: Modelling the BIM model
+                        :type: follows
+                  - :start: 72
+                    :subject: Submitting BIM model
+                    :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                      and &quot;Request&quot;, thus represents a general note.
+                    :status: default_status_new
+                    :type: default_type_milestone
+                    :assigned_to: BIM Modellers
+                    :duration: 0
+                    :relations:
+                      - :to: First Cycle, internal model check and revising
+                        :type: follows
+                :assigned_to: BIM Coordinators
+                :duration: 13
+                :relations:
+                  - :to: Submitting inital BIM model
+                    :type: follows
+              - :start: 73
+                :subject: Coordination, first cycle
+                :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                  and &quot;Request&quot;, thus represents a general note.
+                :status: default_status_new
+                :type: default_type_phase
+                :children:
+                  - :start: 73
+                    :subject: Coordinate the different BIM models
+                    :description: |-
+                      # Goal
 
-                  **You can:**
+                      *   Assemble the different BIM models of the whole project team
+                      *   Coordinate the identified issues
 
-                  *   insert text and format it with the toolbar,
-                  *   insert text and images with copy and paste,
-                  *   paste formatted text directly from MSOffice documents,
-                  *   create a page hierarchy by inserting parent pages,
-                  *   use makros to include, e.g. table of contents, work packages lists or Gantt charts,
-                  *   include wiki pages in other text fields, e.g. project overview or meetings,
-                  *   reference tickets with one, two or three "#"+ticket number, depending on what information should be displayed,
-                  *   include links to other documents,
-                  *   view the change history,
-                  *   view as Mardown.
+                      # Description
 
-                  **More information:**
-                  https://www.openproject.org/help/wiki/
-                children:
-                  - title: Project documentation
-                    content: |
-                      This is a sub-page of the wiki. You can change this by editing the Parent page (Click the _EDIT_ button and see bottom of the page).
+                      *   The different BIM models will be assembled and checked
+                      *   The identified model specific issues will be communicated via BCF files
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: BIM Coordinators
+                    :duration: 3
+                  - :start: 73
+                    :subject: Issue management, first cycle
+                    :description: ''
+                    :status: default_status_new
+                    :type: default_type_phase
+                    :assigned_to: BIM Coordinators
+                    :duration: 9
+                  - :start: 83
+                    :subject: Finishing coordination, first cycle
+                    :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                      and &quot;Request&quot;, thus represents a general note.
+                    :status: default_status_new
+                    :type: default_type_milestone
+                    :assigned_to: Lead BIM Coordinators
+                    :duration: 0
+                    :relations:
+                      - :to: Issue management, first cycle
+                        :type: follows
+                :assigned_to: Lead BIM Coordinators
+                :duration: 10
+                :relations:
+                  - :to: Submitting BIM model
+                    :type: follows
+              - :start: 86
+                :subject: Modelling & coordinating, second cycle
+                :description: "## Goal\r\n\r\n*   ...\r\n\r\n## Description\r\n\r\n*   ..."
+                :status: default_status_new
+                :type: default_type_phase
+                :assigned_to: Lead BIM Coordinators
+                :duration: 0
+                :relations:
+                  - :to: Finishing coordination, first cycle
+                    :type: follows
+              - :start: 88
+                :subject: Modelling & coordinating, ... cycle
+                :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                  and &quot;Request&quot;, thus represents a general note.
+                :status: default_status_new
+                :type: default_type_phase
+                :assigned_to: Lead BIM Coordinators
+                :duration: 0
+                :relations:
+                  - :to: Modelling & coordinating, second cycle
+                    :type: follows
+              - :start: 89
+                :subject: Modelling & coordinating, (n-th minus 1) cycle
+                :description: "## Goal\r\n\r\n*   ...\r\n\r\n## Description\r\n\r\n*   ..."
+                :status: default_status_new
+                :type: default_type_phase
+                :assigned_to: Lead BIM Coordinators
+                :duration: 0
+                :relations:
+                  - :to: Modelling & coordinating, ... cycle
+                    :type: follows
+              - :start: 90
+                :subject: Modelling & coordinating n-th cycle
+                :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                  and &quot;Request&quot;, thus represents a general note.
+                :status: default_status_new
+                :type: default_type_phase
+                :assigned_to: BIM Coordinators
+                :duration: 0
+                :relations:
+                  - :to: Modelling & coordinating, (n-th minus 1) cycle
+                    :type: follows
+              - :start: 91
+                :subject: Finishing modelling & coordinating, n-th cycle
+                :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
+                  and &quot;Request&quot;, thus represents a general note.
+                :status: default_status_new
+                :type: default_type_milestone
+                :assigned_to: BIM Coordinators
+                :duration: 0
+                :relations:
+                  - :to: Modelling & coordinating n-th cycle
+                    :type: follows
+              - :start: 93
+                :subject: Use model for construction phase
+                :description: ''
+                :status: default_status_new
+                :type: default_type_phase
+                :children:
+                  - :start: 93
+                    :subject: Handover model for construction crew
+                    :description: |-
+                      ## Goal
 
-                      ## Project scope
+                      *   Everyone knows the model and their tasks
+                      *   Everybody gets all the relevant information, model based
+                      *   ...
 
-                      ## Deliverables
-                    children:
-                      - title: Project manual
-                        content: ''
-          bcf-project:
-            name: Demo BCF project
-            identifier: demo-bcf-project
+                      ## Description
+
+                      *   The kick-off on the construction site includes an introduction to the model
+                      *   All the objects should have the information needed for the assigned tasks. If not, data enrichment of the model needs to be done
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: BIM Coordinators
+                    :duration: 8
+                  - :start: 106
+                    :subject: Construct the building
+                    :description: |-
+                      ## Goal
+
+                      *   New issues realized on construction site will be handled model based
+                      *   Issues will be documented by using the BCF files and the BIM model
+
+                      ## Description
+
+                      *   New issues will be documented using BCF files as sticky notes for the model
+                      *   The BCF files will be used to assign, track and correct issues
+                      *   ...
+                    :status: default_status_new
+                    :type: default_type_task
+                    :assigned_to: BIM Coordinators
+                    :duration: 101
+                  - :start: 208
+                    :subject: Finish construction
+                    :description: ''
+                    :status: default_status_new
+                    :type: default_type_milestone
+                    :assigned_to: BIM Coordinators
+                    :duration: 0
+                    :relations:
+                      - :to: Construct the building
+                        :type: follows
+                :assigned_to: BIM Coordinators
+                :duration: 115
+                :relations:
+                  - :to: Finishing modelling & coordinating, n-th cycle
+                    :type: follows
+              - :start: 98
+                :subject: Issue management, construction phase
+                :description: ''
+                :status: default_status_new
+                :type: default_type_phase
+                :assigned_to: Planners
+                :duration: 88
+              - :start: 210
+                :subject: Handover for Facility Management
+                :description: |-
+                  ## Goal
+
+                  *   The BIM model will be used for the Facility Management
+                  *   The model provides all the relevant information for commissioning and operating the building 
+                  *   ...
+
+                  ## Description
+
+                  *   The model contains the relevant information for the facility manager
+                  *   The model can be used for the operting system of the building
+                  *   ...
+                :status: default_status_new
+                :type: default_type_milestone
+                :assigned_to: Lead BIM Coordinators
+                :duration: 0
+                :relations:
+                  - :to: Finish construction
+                    :type: follows
+              - :start: 212
+                :subject: Asset Management
+                :description: Enjoy your building :)
+                :status: default_status_new
+                :type: default_type_phase
+                :relations:
+                  - :to: Handover for Facility Management
+                    :type: follows
+          demo-bcf-management-project:
+            name: (Demo) BCF management
+            identifier: demo-bcf-management-project
+            parent: demo-planning-construction-project
             description: >
               **This is a demo project for BCF**. You can edit the description in
               the [Project settings -> Description](%{base_url}/projects/demo-bcf-project/settings).
@@ -490,4 +1060,125 @@ en:
                   - type
                   - status
                   - assigned_to
-            work_packages: []
+            bcf_xml_file: "seed.bcfzip"
+            work_packages:
+              - :start: 73
+                :bcf_issue_uuid: f210a2cd-f1f7-4691-b986-2f94117caefe
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 73
+                :bcf_issue_uuid: feb97e6e-14fd-4c62-bbad-607f2bb4ebf5
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 73
+                :bcf_issue_uuid: f55d0ec0-9a0f-4222-9926-cc5744888b02
+                :assigned_to: BIM Modellers
+                :duration: 4
+                :parent: Issue management, first cycle
+              - :start: 73
+                :bcf_issue_uuid: fc560c06-51fc-44fa-81b4-e688be189c6a
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 73
+                :bcf_issue_uuid: fe2f9c1f-631b-4b37-91ea-833c4751725a
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 73
+                :bcf_issue_uuid: 010d9884-8c93-4551-b2bc-570faffe7082
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 73
+                :bcf_issue_uuid: febee8e1-1ad2-45e5-b08d-b4be92d25ad6
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 73
+                :bcf_issue_uuid: f4d71d45-5a2c-4dad-bcb1-8a4935f2ea69
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 73
+                :bcf_issue_uuid: fb9705ea-b32c-46ff-bb6f-d1d049494e05
+                :assigned_to: BIM Modellers
+                :duration: 4
+                :parent: Issue management, first cycle
+              - :start: 73
+                :bcf_issue_uuid: faad0e05-0e05-48d8-96e6-a4fe29ecdbc0
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 79
+                :bcf_issue_uuid: fbbf9ecf-5721-4bf1-a08c-aed50dc19353
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 79
+                :bcf_issue_uuid: f6271a32-acf5-49f8-a1b5-7c445f9158e5
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 79
+                :bcf_issue_uuid: 00efc0da-b4d5-4933-bcb6-e01513ee2bcc
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 79
+                :bcf_issue_uuid: f9e079a8-02f5-40f0-a08a-171f494ee130
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 79
+                :bcf_issue_uuid: f70417a8-174a-42ae-bf1e-a0b6457d0e6f
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 79
+                :bcf_issue_uuid: fc5099c0-bedb-4770-a576-0429a7733517
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 79
+                :bcf_issue_uuid: fbe1d941-06ce-45f4-8ccb-ef48b8426f72
+                :assigned_to: BIM Modellers
+                :duration: 3
+                :parent: Issue management, first cycle
+              - :start: 98
+                :bcf_issue_uuid: 03d1536b-e444-4900-921e-57405142ba82
+                :assigned_to: Planners
+                :duration: 0
+                :parent: Issue management, construction phase
+              - :start: 98
+                :bcf_issue_uuid: 64880305-5c13-4045-9946-fd43441bf063
+                :assigned_to: BIM Modellers
+                :duration: 4
+                :parent: Issue management, construction phase
+              - :start: 98
+                :bcf_issue_uuid: d9c283eb-aac5-4b64-8228-c00d57efe609
+                :assigned_to: Planners
+                :duration: 0
+                :parent: Issue management, construction phase
+              - :start: 98
+                :bcf_issue_uuid: 1b47968c-86df-4e79-8ffd-f4928ddb1834
+                :assigned_to: Planners
+                :duration: 12
+                :parent: Issue management, construction phase
+              - :start: 153
+                :bcf_issue_uuid: 9eb55008-516e-4b37-94d9-482e0a24c00d
+                :assigned_to: Planners
+                :duration: 26
+                :parent: Issue management, construction phase
+              - :start: 154
+                :bcf_issue_uuid: 33a15f8b-971c-4c82-853e-ec1eec552101
+                :assigned_to: Planners
+                :duration: 4
+                :parent: Issue management, construction phase
+              - :start: 182
+                :bcf_issue_uuid: d54db43e-7a1e-44fd-8f2c-0a3b8752b54f
+                :assigned_to: Planners
+                :duration: 4
+                :parent: Issue management, construction phase

--- a/modules/bim_seeder/lib/open_project/bim_seeder/engine.rb
+++ b/modules/bim_seeder/lib/open_project/bim_seeder/engine.rb
@@ -16,5 +16,6 @@ module OpenProject::BimSeeder
     patch_with_namespace :DemoData, :QueryBuilder
     patch_with_namespace :DemoData, :ProjectSeeder
     patch_with_namespace :DemoData, :WorkPackageSeeder
+    patch_with_namespace :DemoData, :WorkPackageBoardSeeder
   end
 end

--- a/modules/bim_seeder/lib/open_project/bim_seeder/engine.rb
+++ b/modules/bim_seeder/lib/open_project/bim_seeder/engine.rb
@@ -14,5 +14,7 @@ module OpenProject::BimSeeder
 
     patches [:RootSeeder]
     patch_with_namespace :DemoData, :QueryBuilder
+    patch_with_namespace :DemoData, :ProjectSeeder
+    patch_with_namespace :DemoData, :WorkPackageSeeder
   end
 end

--- a/modules/bim_seeder/lib/open_project/bim_seeder/patches/project_seeder_patch.rb
+++ b/modules/bim_seeder/lib/open_project/bim_seeder/patches/project_seeder_patch.rb
@@ -1,0 +1,11 @@
+module OpenProject::BimSeeder::Patches::ProjectSeederPatch
+  def self.included(base) # :nodoc:
+    base.prepend InstanceMethods
+  end
+
+  module InstanceMethods
+    def project_data_seeders(project, key)
+      [::BimSeeder::DemoData::BcfXmlSeeder.new(project, key)] + super(project, key)
+    end
+  end
+end

--- a/modules/bim_seeder/lib/open_project/bim_seeder/patches/work_package_board_seeder_patch.rb
+++ b/modules/bim_seeder/lib/open_project/bim_seeder/patches/work_package_board_seeder_patch.rb
@@ -1,0 +1,68 @@
+module OpenProject::BimSeeder::Patches::WorkPackageBoardSeederPatch
+  def self.included(base) # :nodoc:
+    base.prepend InstanceMethods
+  end
+
+  module InstanceMethods
+    def seed_data!
+      super
+
+      if project_has_data_for?(key, 'boards.bcf')
+        print '    ↳ Creating demo BCF board'
+        seed_bcf_board
+        puts
+      end
+    end
+
+    def seed_bcf_board
+      board = ::Boards::Grid.new project: project
+
+      board.name = project_data_for(key, 'boards.bcf.name')
+      board.options = { 'type' => 'action', 'attribute' => 'status', 'highlightingMode' => 'type' }
+
+      board.widgets = seed_bcf_board_queries.each_with_index.map do |query, i|
+        Grids::Widget.new start_row: 1, end_row: 2,
+                          start_column: i + 1, end_column: i + 2,
+                          options: { query_id: query.id,
+                                     filters: [{ status: { operator: '=', values: query.filters[0].values } }] },
+                          identifier: 'work_package_query'
+      end
+
+      board.column_count = board.widgets.count
+      board.row_count = 1
+
+      board.save!
+
+      Setting.boards_demo_data_available = 'true'
+    end
+
+    def seed_bcf_board_queries
+      admin = User.admin.first
+      status_names = ['New', 'In progress', 'Resolved', 'Closed']
+      statuses = Status.where(name: status_names).to_a
+
+      if statuses.size < status_names.size
+        raise StandardError.new "Not all statuses needed for seeding a BCF board are present. Check that they get seeded."
+      end
+
+      statuses.to_a.map do |status|
+        Query.new_default(project: project, user: admin).tap do |query|
+          # Hide the query in the main menu
+          query.hidden = true
+
+          # Make it public so that new members can see it too
+          query.is_public = true
+
+          query.name = status.name
+          # Set filter by this status
+          query.add_filter('status_id', '=', [status.id])
+
+          # Set manual sort filter
+          query.sort_criteria = [[:manual_sorting, 'asc']]
+
+          query.save!
+        end
+      end
+    end
+  end
+end

--- a/modules/bim_seeder/lib/open_project/bim_seeder/patches/work_package_seeder_patch.rb
+++ b/modules/bim_seeder/lib/open_project/bim_seeder/patches/work_package_seeder_patch.rb
@@ -11,9 +11,7 @@ module OpenProject::BimSeeder::Patches::WorkPackageSeederPatch
 
         start_date = calculate_start_date(attributes[:start])
         due_date = calculate_due_date(start_date, attributes[:duration])
-
-
-
+        
         work_package = find_bcf_issue(uuid)
 
         work_package.update_columns(created_at: Time.now,

--- a/modules/bim_seeder/lib/open_project/bim_seeder/patches/work_package_seeder_patch.rb
+++ b/modules/bim_seeder/lib/open_project/bim_seeder/patches/work_package_seeder_patch.rb
@@ -1,0 +1,54 @@
+module OpenProject::BimSeeder::Patches::WorkPackageSeederPatch
+  def self.included(base) # :nodoc:
+    base.prepend InstanceMethods
+  end
+
+  module InstanceMethods
+    def create_or_update_work_package(attributes)
+      uuid = attributes[:bcf_issue_uuid]
+      if uuid
+        puts "Would do something with #{attributes[:bcf_issue_id]}"
+
+        start_date = calculate_start_date(attributes[:start])
+        due_date = calculate_due_date(start_date, attributes[:duration])
+
+
+
+        work_package = find_bcf_issue(uuid)
+
+        work_package.update_columns(created_at: Time.now,
+                                    author_id: user.id,
+                                    assigned_to_id: find_assignee_id(attributes[:assigned_to]),
+                                    start_date: start_date,
+                                    due_date: due_date)
+
+        update_parent(work_package, attributes)
+      else
+        create_work_package(attributes)
+      end
+    end
+
+    def update_parent(work_package, attributes)
+      if attributes[:parent]
+        parent = WorkPackage.find_by(subject: attributes[:parent])
+        if parent.present?
+          work_package.parent = parent
+          work_package.save!
+        end
+      end
+    end
+
+    def find_bcf_issue(uuid)
+      WorkPackage
+        .joins(:bcf_issue)
+        .where(project_id: project.id, 'bcf_issues.uuid': uuid)
+        .references(:bcf_issue).first
+    end
+
+    def find_assignee_id(name)
+      return nil unless name.present?
+
+      Principal.find_by(lastname: name).try(:id)
+    end
+  end
+end

--- a/modules/bim_seeder/spec/seeders/demo_data_seeder_spec.rb
+++ b/modules/bim_seeder/spec/seeders/demo_data_seeder_spec.rb
@@ -56,11 +56,11 @@ describe 'seeds' do
         expect { DemoDataSeeder.new.seed! }.not_to raise_error
 
         expect(User.where(admin: true).count).to eq 1
-        expect(Project.count).to eq 2
-        expect(WorkPackage.count).to eq 18
-        expect(Wiki.count).to eq 1
-        expect(Query.count).to eq 12
-        expect(Group.count).to eq 7
+        expect(Project.count).to eq 4
+        expect(WorkPackage.count).to eq 75
+        expect(Wiki.count).to eq 3
+        expect(Query.count).to eq 18
+        expect(Group.count).to eq 8
         expect(Type.count).to eq 7
         expect(Status.count).to eq 4
         expect(IssuePriority.count).to eq 4

--- a/modules/bim_seeder/spec/seeders/demo_data_seeder_spec.rb
+++ b/modules/bim_seeder/spec/seeders/demo_data_seeder_spec.rb
@@ -57,9 +57,9 @@ describe 'seeds' do
 
         expect(User.where(admin: true).count).to eq 1
         expect(Project.count).to eq 4
-        expect(WorkPackage.count).to eq 75
+        expect(WorkPackage.count).to eq 77
         expect(Wiki.count).to eq 3
-        expect(Query.count).to eq 18
+        expect(Query.count).to eq 26
         expect(Group.count).to eq 8
         expect(Type.count).to eq 7
         expect(Status.count).to eq 4

--- a/modules/overviews/config/locales/en.seeders.bim.yml
+++ b/modules/overviews/config/locales/en.seeders.bim.yml
@@ -55,18 +55,23 @@ en:
                     text: |
                       We are glad you joined! We suggest to try a few things to get started in OpenProject.
 
-                      Discover the most important features with our [Guided Tour](%{base_url}/projects/demo-construction-project/work_packages/?start_onboarding_tour=true).
+                      But before you jump right into it, you should know that this exemplary project is split up into two different projects:
+
+                      1.  [Construction project](%{base_url}/projects/demo-planning-constructing-project): Here you will find the classical roles, some workflows and work packages for your construction project.
+                      2.  [Creating BIM Model](%{base_url}/projects/demo-bim-project): This project also offers roles, workflows and work packages but especially in the BIM context.
 
                       _Try the following steps:_
 
-                      1. *Invite new members to your project*: &rightarrow; Go to [Members](%{base_url}/projects/demo-construction-project/members) in the project navigation.
-                      2. *View the work in your project*: &rightarrow; Go to [Work packages](%{base_url}/projects/demo-construction-project/work_packages) in the project navigation.
-                      3. *Create a new work package*: &rightarrow; Go to [Work packages &rightarrow; Create](%{base_url}/projects/demo-construction-project/work_packages/new).
-                      4. *Create and update a project plan*: &rightarrow; Go to [Project plan](%{base_url}/projects/demo-construction-project/work_packages?query_id=##query.id:"Project plan") in the project navigation.
-                      5. *Activate further modules*: &rightarrow; Go to [Project settings &rightarrow; Modules](%{base_url}/projects/demo-construction-project/settings/modules).
+                      1.  _Invite new members to your project_: → Go to [Members](%{base_url}/projects/demo-construction-project/members) in the project navigation.
+                      2.  _View the work in your projects_: → Go to [Work packages](%{base_url}/projects/demo-construction-project/work_packages?query_props=%7B%22c%22%3A%5B%22type%22%2C%22id%22%2C%22subject%22%2C%22status%22%2C%22assignee%22%2C%22priority%22%5D%2C%22hl%22%3A%22priority%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22bcfIssueAssociated%22%2C%22o%22%3A%22%3D%22%2C%22v%22%3A%5B%22f%22%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%2C%22dr%22%3A%22list%22%7D) in the project navigation.
+                      3.  _Create a new work package_: → Go to [Work packages → Create](%{base_url}/projects/demo-construction-project/work_packages/new?query_props=%7B%22c%22%3A%5B%22type%22%2C%22id%22%2C%22subject%22%2C%22status%22%2C%22assignee%22%2C%22priority%22%5D%2C%22hl%22%3A%22priority%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22bcfIssueAssociated%22%2C%22o%22%3A%22%3D%22%2C%22v%22%3A%5B%22f%22%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%2C%22dr%22%3A%22list%22%7D&type=11).
+                      4.  _Create and update a Gantt chart_: → Go to [Gantt chart](%{base_url}/projects/demo-construction-project/work_packages?query_props=%7B%22c%22%3A%5B%22type%22%2C%22id%22%2C%22subject%22%2C%22assignee%22%2C%22responsible%22%5D%2C%22tv%22%3Atrue%2C%22tzl%22%3A%22weeks%22%2C%22hl%22%3A%22priority%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%2C%22dr%22%3A%22list%22%7D) in the project navigation.
+                      5.  _Activate further modules_: → Go to [Project settings → Modules](%{base_url}/projects/demo-construction-project/settings/modules).
+                      6.  _Check out the tile view to get an overview of your BCF issues:_ → Go to [Work packages](%{base_url}/projects/demo-construction-project/work_packages?query_props=%7B%22c%22%3A%5B%22type%22%2C%22id%22%2C%22subject%22%2C%22status%22%2C%22assignee%22%2C%22priority%22%5D%2C%22hl%22%3A%22priority%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22id%3Aasc%22%2C%22f%22%3A%5B%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%2C%22dr%22%3A%22card%22%7D)
+                      7.  _Agile working? Check out our brand new boards:_ → Go to [Boards](%{base_url}/projects/demo-construction-project/boards)
 
                       Here you will find our [User Guides](https://www.openproject.org/help/).
-                      Please let us know if you have any questions or need support. Contact us: [support[at]openproject.com](mailto:support@openproject.com).
+                      Please let us know if you have any questions or need support. Contact us: [support\[at\]openproject.com](mailto:support@openproject.com).
                 - identifier: 'members'
                   start_row: 2
                   end_row: 3
@@ -89,3 +94,177 @@ en:
                   options:
                     name: 'Milestones'
                     queryId: '##query.id:"Milestones"'
+          demo-planning-constructing-project:
+            project-overview:
+              row_count: 4
+              column_count: 2
+              widgets:
+                - identifier: 'custom_text'
+                  start_row: 1
+                  end_row: 2
+                  start_column: 1
+                  end_column: 3
+                  options:
+                    name: 'Welcome'
+                    text: '![Teaser](##attachment:"demo_project_teaser.png")'
+                  attachments:
+                    - demo_project_teaser.png
+                - identifier: 'custom_text'
+                  start_row: 2
+                  end_row: 4
+                  start_column: 1
+                  end_column: 2
+                  options:
+                    name: 'Getting started'
+                    text: |
+                      We are glad you joined! We suggest to try a few things to get started in OpenProject.
+
+                      Here you will find the classical roles, some workflows and work packages for your construction project.
+
+                      _Try the following steps:_
+
+                      1.  _Invite new members to your project_: → Go to [Members](%{base_url}/projects/demo-planning-constructing-project/members) in the project navigation.
+                      2.  _View the work in your projects_: → Go to [Work packages](%{base_url}/projects/demo-planning-constructing-project/work_packages?query_props=%7B%22c%22%3A%5B%22type%22%2C%22id%22%2C%22subject%22%2C%22status%22%2C%22assignee%22%2C%22priority%22%5D%2C%22hl%22%3A%22priority%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22bcfIssueAssociated%22%2C%22o%22%3A%22%3D%22%2C%22v%22%3A%5B%22f%22%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%2C%22dr%22%3A%22list%22%7D) in the project navigation.
+                      3.  _Create a new work package_: → Go to [Work packages → Create](%{base_url}/projects/demo-planning-constructing-project/work_packages/new?query_props=%7B%22c%22%3A%5B%22type%22%2C%22id%22%2C%22subject%22%2C%22status%22%2C%22assignee%22%2C%22priority%22%5D%2C%22hl%22%3A%22priority%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22bcfIssueAssociated%22%2C%22o%22%3A%22%3D%22%2C%22v%22%3A%5B%22f%22%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%2C%22dr%22%3A%22list%22%7D&type=11).
+                      4.  _Create and update a Gantt chart_: → Go to [Gantt chart](%{base_url}/projects/demo-planning-constructing-project/work_packages?query_props=%7B%22c%22%3A%5B%22type%22%2C%22id%22%2C%22subject%22%2C%22assignee%22%2C%22responsible%22%5D%2C%22tv%22%3Atrue%2C%22tzl%22%3A%22weeks%22%2C%22hl%22%3A%22priority%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%2C%22dr%22%3A%22list%22%7D) in the project navigation.
+                      5.  _Activate further modules_: → Go to [Project settings → Modules](%{base_url}/projects/demo-planning-constructing-project/settings/modules).
+                      6.  _Agile working? Check out our brand new boards:_ → Go to [Boards](%{base_url}/projects/demo-planning-constructing-project/boards)
+
+                      Here you will find our [User Guides](https://www.openproject.org/help/).
+                      Please let us know if you have any questions or need support. Contact us: [support\[at\]openproject.com](mailto:support@openproject.com).
+                - identifier: 'members'
+                  start_row: 2
+                  end_row: 3
+                  start_column: 2
+                  end_column: 3
+                  options:
+                    name: 'Members'
+                - identifier: 'work_packages_overview'
+                  start_row: 3
+                  end_row: 4
+                  start_column: 2
+                  end_column: 3
+                  options:
+                    name: 'Work packages'
+                - identifier: 'work_packages_table'
+                  start_row: 4
+                  end_row: 5
+                  start_column: 1
+                  end_column: 3
+                  options:
+                    name: 'Milestones'
+                    queryId: '##query.id:"Milestones"'
+          demo-bim-project:
+            project-overview:
+              row_count: 4
+              column_count: 2
+              widgets:
+                - identifier: 'custom_text'
+                  start_row: 1
+                  end_row: 2
+                  start_column: 1
+                  end_column: 3
+                  options:
+                    name: 'Welcome'
+                    text: '![Teaser](##attachment:"demo_project_teaser.png")'
+                  attachments:
+                    - demo_project_teaser.png
+                - identifier: 'custom_text'
+                  start_row: 2
+                  end_row: 4
+                  start_column: 1
+                  end_column: 2
+                  options:
+                    name: 'Getting started'
+                    text: |
+                      We are glad you joined! We suggest to try a few things to get started in OpenProject.
+
+                      This demo project offers roles, workflows and work packages that are specificialized for BIM.
+
+                      _Try the following steps:_
+
+                      1.  _Invite new members to your project_: → Go to [Members](%{base_url}/projects/demo-bim-project/members) in the project navigation.
+                      2.  _View the work in your projects_: → Go to [Work packages](%{base_url}/projects/demo-bim-project/work_packages?query_props=%7B%22c%22%3A%5B%22type%22%2C%22id%22%2C%22subject%22%2C%22status%22%2C%22assignee%22%2C%22priority%22%5D%2C%22hl%22%3A%22priority%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22bcfIssueAssociated%22%2C%22o%22%3A%22%3D%22%2C%22v%22%3A%5B%22f%22%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%2C%22dr%22%3A%22list%22%7D) in the project navigation.
+                      3.  _Create a new work package_: → Go to [Work packages → Create](%{base_url}/projects/demo-bim-project/work_packages/new?query_props=%7B%22c%22%3A%5B%22type%22%2C%22id%22%2C%22subject%22%2C%22status%22%2C%22assignee%22%2C%22priority%22%5D%2C%22hl%22%3A%22priority%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22bcfIssueAssociated%22%2C%22o%22%3A%22%3D%22%2C%22v%22%3A%5B%22f%22%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%2C%22dr%22%3A%22list%22%7D&type=11).
+                      4.  _Create and update a Gantt chart_: → Go to [Gantt chart](%{base_url}/projects/demo-bim-project/work_packages?query_props=%7B%22c%22%3A%5B%22type%22%2C%22id%22%2C%22subject%22%2C%22assignee%22%2C%22responsible%22%5D%2C%22tv%22%3Atrue%2C%22tzl%22%3A%22weeks%22%2C%22hl%22%3A%22priority%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%2C%22dr%22%3A%22list%22%7D) in the project navigation.
+                      5.  _Activate further modules_: → Go to [Project settings → Modules](%{base_url}/projects/demo-bim-project/settings/modules).
+                      6.  _Check out the tile view to get an overview of your BCF issues:_ → Go to [Work packages](%{base_url}/projects/demo-bim-project/work_packages?query_props=%7B%22c%22%3A%5B%22type%22%2C%22id%22%2C%22subject%22%2C%22status%22%2C%22assignee%22%2C%22priority%22%5D%2C%22hl%22%3A%22priority%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22id%3Aasc%22%2C%22f%22%3A%5B%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%2C%22dr%22%3A%22card%22%7D)
+                      7.  _Agile working? Check out our brand new boards:_ → Go to [Boards](%{base_url}/projects/demo-bim-project/boards)
+
+                      Here you will find our [User Guides](https://www.openproject.org/help/).
+                      Please let us know if you have any questions or need support. Contact us: [support\[at\]openproject.com](mailto:support@openproject.com).
+                - identifier: 'members'
+                  start_row: 2
+                  end_row: 3
+                  start_column: 2
+                  end_column: 3
+                  options:
+                    name: 'Members'
+                - identifier: 'work_packages_overview'
+                  start_row: 3
+                  end_row: 4
+                  start_column: 2
+                  end_column: 3
+                  options:
+                    name: 'Work packages'
+                - identifier: 'work_packages_table'
+                  start_row: 4
+                  end_row: 5
+                  start_column: 1
+                  end_column: 3
+                  options:
+                    name: 'Milestones'
+                    queryId: '##query.id:"Milestones"'
+          demo-bcf-management-project:
+            project-overview:
+              row_count: 4
+              column_count: 2
+              widgets:
+                - identifier: 'custom_text'
+                  start_row: 1
+                  end_row: 2
+                  start_column: 1
+                  end_column: 3
+                  options:
+                    name: 'Welcome'
+                    text: '![Teaser](##attachment:"demo_project_teaser.png")'
+                  attachments:
+                    - demo_project_teaser.png
+                - identifier: 'custom_text'
+                  start_row: 2
+                  end_row: 4
+                  start_column: 1
+                  end_column: 2
+                  options:
+                    name: 'Getting started'
+                    text: |
+                      We are glad you joined! We suggest to try a few things to get started in OpenProject.
+
+                      This demo BIM project shows you the general functionalities in OpenProject for the BCF Management.
+
+                      _Try the following steps:_
+
+                      1.  _Invite new members to your project_: → Go to [Members](%{base_url}/projects/demo-bcf-management-project/members?show_add_members=true) in the project navigation.
+                      2.  _View the BCF files in your project_: → Go to [BCF](%{base_url}/projects/demo-bcf-management-project/work_packages?query_props=%7B%22c%22%3A%5B%22type%22%2C%22id%22%2C%22subject%22%2C%22status%22%2C%22assignee%22%2C%22priority%22%5D%2C%22hl%22%3A%22status%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22id%3Aasc%22%2C%22f%22%3A%5B%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%2C%22dr%22%3A%22card%22%7D) in the project navigation.
+                      3.  _Load your BCF files:_ → Go to [BCF → Import.](%{base_url}/projects/demo-bcf-management-project/issues/upload)
+                      4.  _Create and update a Gantt chart_: → Go to [Gantt chart](%{base_url}/projects/demo-bcf-management-project/work_packages?query_props=%7B%22c%22%3A%5B%22id%22%2C%22subject%22%2C%22startDate%22%2C%22dueDate%22%5D%2C%22tv%22%3Atrue%2C%22tzl%22%3A%22days%22%2C%22hi%22%3Atrue%2C%22g%22%3A%22%22%2C%22t%22%3A%22startDate%3Aasc%22%2C%22f%22%3A%5B%7B%22n%22%3A%22status%22%2C%22o%22%3A%22o%22%2C%22v%22%3A%5B%5D%7D%5D%2C%22pa%22%3A1%2C%22pp%22%3A100%7D) in the project navigation.
+                      5.  _Activate further modules_: → Go to [Project settings → Modules.](%{base_url}/projects/demo-bcf-management-project/settings/modules)
+                      6.  _Work with your BCF files in the new Boards view:_ → Go to [Boards → Choose](%{base_url}/projects/demo-bcf-management-project/boards).
+
+                      Here you will find our [User Guides](https://www.openproject.org/help/).
+                      Please let us know if you have any questions or need support. Contact us: [support\[at\]openproject.com](mailto:support@openproject.com).
+                - identifier: 'members'
+                  start_row: 2
+                  end_row: 3
+                  start_column: 2
+                  end_column: 3
+                  options:
+                    name: 'Members'
+                - identifier: 'work_packages_overview'
+                  start_row: 3
+                  end_row: 4
+                  start_column: 2
+                  end_column: 3
+                  options:
+                    name: 'Work packages'
+

--- a/modules/overviews/config/locales/en.seeders.bim.yml
+++ b/modules/overviews/config/locales/en.seeders.bim.yml
@@ -30,7 +30,7 @@ en:
     bim:
       demo_data:
         projects:
-          demo-project:
+          demo-construction-project:
             project-overview:
               row_count: 4
               column_count: 2
@@ -55,16 +55,15 @@ en:
                     text: |
                       We are glad you joined! We suggest to try a few things to get started in OpenProject.
 
-                      Discover the most important features with our [Guided Tour](%{base_url}/projects/demo-project/work_packages/?start_onboarding_tour=true).
+                      Discover the most important features with our [Guided Tour](%{base_url}/projects/demo-construction-project/work_packages/?start_onboarding_tour=true).
 
                       _Try the following steps:_
 
-                      1. *Invite new members to your project*: &rightarrow; Go to [Members](%{base_url}/projects/demo-project/members) in the project navigation.
-                      2. *View the work in your project*: &rightarrow; Go to [Work packages](%{base_url}/projects/demo-project/work_packages) in the project navigation.
-                      3. *Create a new work package*: &rightarrow; Go to [Work packages &rightarrow; Create](%{base_url}/projects/demo-project/work_packages/new).
-                      4. *Create and update a project plan*: &rightarrow; Go to [Project plan](%{base_url}/projects/demo-project/work_packages?query_id=##query.id:"Project plan") in the project navigation.
-                      5. *Activate further modules*: &rightarrow; Go to [Project settings &rightarrow; Modules](%{base_url}/projects/demo-project/settings/modules).
-                      6. *Complete your tasks in the project*: &rightarrow; Go to [Work packages &rightarrow; Tasks](%{base_url}/projects/demo-project/work_packages/details/##wp.id:"Edit a work package"/overview?query_id=##query.id:"Tasks").
+                      1. *Invite new members to your project*: &rightarrow; Go to [Members](%{base_url}/projects/demo-construction-project/members) in the project navigation.
+                      2. *View the work in your project*: &rightarrow; Go to [Work packages](%{base_url}/projects/demo-construction-project/work_packages) in the project navigation.
+                      3. *Create a new work package*: &rightarrow; Go to [Work packages &rightarrow; Create](%{base_url}/projects/demo-construction-project/work_packages/new).
+                      4. *Create and update a project plan*: &rightarrow; Go to [Project plan](%{base_url}/projects/demo-construction-project/work_packages?query_id=##query.id:"Project plan") in the project navigation.
+                      5. *Activate further modules*: &rightarrow; Go to [Project settings &rightarrow; Modules](%{base_url}/projects/demo-construction-project/settings/modules).
 
                       Here you will find our [User Guides](https://www.openproject.org/help/).
                       Please let us know if you have any questions or need support. Contact us: [support[at]openproject.com](mailto:support@openproject.com).


### PR DESCRIPTION
Done so far.
- [x] Allow seeding project hierarchies
- [x] Allow seeding cross-project work package hierarchies
- [x] Add seeder for BCF issues
- [x] For using a OP instance as seed data template provider: Add a script to extract work package data and transform it into a copy and pastable YAML format. Use it in a Rails console.
- [x] Update WPs with corrected English
- [x] Update BCFs
- [x] Overview texts
- [x] Seed boards

Probably out of scope for today
- [ ] Custom help texts
- [ ] Seed workflows