### PR TITLE
actually provide all relevant custom fields for performance hack

### DIFF
--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -304,7 +304,6 @@ module API
           def form_config_attribute_representation(group)
             cache_keys = ['wp_schema_attribute_group',
                           group.key,
-                          group.attributes,
                           I18n.locale,
                           represented.project,
                           represented.type,

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -175,7 +175,7 @@ module API
           schemas = schema_pairs.map do |project, type, available_custom_fields|
             # This hack preloads the custom fields for a project so that they do not have to be
             # loaded again later on
-            project.instance_variable_set(:'@all_work_package_custom_fields', available_custom_fields)
+            project.instance_variable_set(:'@all_work_package_custom_fields', all_cfs_of_project[project.id])
 
             Schema::TypedWorkPackageSchema.new(project: project, type: type, custom_fields: available_custom_fields)
           end
@@ -197,6 +197,13 @@ module API
           represented
             .map { |work_package| [work_package.project, work_package.type, work_package.available_custom_fields] }
             .uniq
+        end
+
+        def all_cfs_of_project
+          @all_cfs_of_project ||= represented
+                                  .group_by(&:project_id)
+                                  .map { |id, wps| [id, wps.map(&:available_custom_fields).flatten.uniq] }
+                                  .to_h
         end
 
         def paged_models(models)


### PR DESCRIPTION
Before, the last iteration on a project determined the custom fields that where hacked to be loaded in a project. That way, when the last project had e.g. no custom fields on a specific type, the custom fields would be missing for all evaluations later on, even though it might actually have custom fields defined for other types. As the results of the first call would be cached, this would then also affect later requests.

This is a bug in itself but I expect it to also fix: https://community.openproject.com/projects/openproject/work_packages/30903