### PR TITLE
save notifications on grid

### DIFF
--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -8,6 +8,8 @@ import {GridWidgetResource} from "core-app/modules/hal/resources/grid-widget-res
 import {SchemaResource} from "core-app/modules/hal/resources/schema-resource";
 import {WidgetChangeset} from "core-app/modules/grids/widgets/widget-changeset";
 import * as moment from 'moment';
+import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
+import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 
 @Injectable()
 export class GridAreaService {
@@ -24,7 +26,9 @@ export class GridAreaService {
   public mousedOverArea:GridArea|null;
   public helpMode = false;
 
-  constructor (private gridDm:GridDmService) { }
+  constructor (private gridDm:GridDmService,
+               private notification:NotificationsService,
+               private i18n:I18nService) { }
 
   public set gridResource(value:GridResource) {
     this.resource = value;
@@ -133,6 +137,7 @@ export class GridAreaService {
       .update(resource, schema)
       .then(updatedGrid => {
         this.assignAreasWidget(updatedGrid);
+        this.notification.addSuccess(this.i18n.t('js.notice_successful_update'));
       });
   }
 

--- a/modules/dashboards/spec/features/custom_text_spec.rb
+++ b/modules/dashboards/spec/features/custom_text_spec.rb
@@ -76,7 +76,11 @@ describe 'Project description widget on dashboard', type: :feature, js: true do
 
         field.set_value('My own little text')
         field.save!
+      end
 
+      dashboard_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
+
+      within custom_text_widget.area do
         expect(page)
           .to have_selector('.wp-edit-field--display-field', text: 'My own little text')
 
@@ -87,7 +91,11 @@ describe 'Project description widget on dashboard', type: :feature, js: true do
 
         expect(page)
           .to have_selector('.wp-edit-field--display-field', text: 'My own little text')
+      end
 
+      dashboard_page.expect_no_notification message: I18n.t('js.notice_successful_update')
+
+      within custom_text_widget.area do
         # adding an image
         find('.inplace-editing--container').click
 
@@ -103,7 +111,11 @@ describe 'Project description widget on dashboard', type: :feature, js: true do
         expect(page).to have_no_selector('notifications-upload-progress')
 
         field.save!
+      end
 
+      dashboard_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
+
+      within custom_text_widget.area do
         expect(page)
           .to have_selector('#content img', count: 1)
 

--- a/modules/my_page/spec/features/my/my_page_spec.rb
+++ b/modules/my_page/spec/features/my/my_page_spec.rb
@@ -159,7 +159,7 @@ describe 'My page', type: :feature, js: true do
     # that widgets that have been there are moved down
     created_area.drag_to(1, 3)
 
-    sleep(1)
+    my_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
 
     reload_grid!
 
@@ -174,7 +174,8 @@ describe 'My page', type: :feature, js: true do
     # as no more widgets start in the second column, that column is removed
     news_area.drag_to(1, 3)
 
-    sleep(1)
+    my_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
+
     reload_grid!
 
     # Reloading keeps the user's values

--- a/modules/my_page/spec/features/my/work_package_table_spec.rb
+++ b/modules/my_page/spec/features/my/work_package_table_spec.rb
@@ -107,6 +107,8 @@ describe 'Arbitrary WorkPackage query table widget on my page', type: :feature, 
       columns.assume_opened
       columns.remove 'Subject'
 
+      my_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
+
       expect(filter_area.area)
         .to have_selector('.id', text: type_work_package.id)
 
@@ -124,6 +126,8 @@ describe 'Arbitrary WorkPackage query table widget on my page', type: :feature, 
         input.set('My WP Filter')
         input.native.send_keys(:return)
       end
+
+      my_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
 
       sleep(1)
 

--- a/modules/overviews/spec/features/managing_overview_page_spec.rb
+++ b/modules/overviews/spec/features/managing_overview_page_spec.rb
@@ -95,10 +95,14 @@ describe 'Overview page managing', type: :feature, js: true, with_mail: false do
     # within top-right area, add an additional widget
     overview_page.add_widget(1, 1, :row, 'Work packages table')
 
+    overview_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
+
     table_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(5)')
     table_area.expect_to_span(1, 1, 2, 2)
 
     table_area.resize_to(2, 2)
+
+    overview_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
 
     # Resizing leads to the calendar area now spanning a larger area
     table_area.expect_to_span(1, 1, 2, 3)


### PR DESCRIPTION
Have save notifications whenever the grid is persisted. e.g. after

* drag and drop
* renaming
* adding a widget
* removing a widget
* saving custom text
* modifying the filters of a table/graph

https://community.openproject.com/projects/openproject/work_packages/30975