### PR TITLE
[30988] Translate widgets in the frontend

### DIFF
--- a/frontend/src/app/modules/grids/widgets/abstract-widget.component.ts
+++ b/frontend/src/app/modules/grids/widgets/abstract-widget.component.ts
@@ -14,7 +14,12 @@ export abstract class AbstractWidgetComponent {
   @Output() resourceChanged = new EventEmitter<WidgetChangeset>();
 
   public get widgetName() {
-    return this.resource.options.name;
+    let fallback = this.resource.options.name;
+    let widgetIdentifier = this.resource.identifier;
+    return this.i18n.t(
+      `js.grid.widgets.${widgetIdentifier}.title`,
+      { defaultValue: fallback }
+    );
   }
 
   public renameWidget(name:string) {


### PR DESCRIPTION
Use the widget identifier to assume the default translateable title only to fall back to the provided name.

https://community.openproject.com/wp/30988
