### PR TITLE
[30994] Update empty changesets to match the latest resource

### DIFF
--- a/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-changeset.ts
@@ -175,6 +175,7 @@ export class WorkPackageChangeset extends EditChangeset<WorkPackageResource> {
                   this.wpCacheService.loadWorkPackage(this.resource.parent.id.toString(), true);
                 }
                 this.clear();
+                this.wpEditing.stopEditing(this.resource.id!);
                 resolve(this.resource);
               });
             })

--- a/frontend/src/app/components/wp-edit-form/work-package-editing.service.interface.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-editing.service.interface.ts
@@ -38,6 +38,7 @@ export const IWorkPackageEditingServiceToken = new InjectionToken<IWorkPackageEd
  */
 export interface IWorkPackageEditingService {
   updateValue(id:string, changeset:any):void;
+  stopEditing(id:string):void;
   changesetFor(wp:WorkPackageResource):WorkPackageChangeset;
 }
 


### PR DESCRIPTION
If a work package changeset is openend, and then some other action happens that does not run through a changeset (updating a parent id e.g.,), the old changeset will still be present and returned by the editing service. This results in getting an older lockVersion for the edit, even though the work package is up to date.

https://community.openproject.com/wp/30994