### PR TITLE
Replace deprecated chromedriver-helper with webdrivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ rvm:
   - 2.6.1
 
 sudo: required
-dist: trusty
+dist: xenial
 
 cache:
   bundler: true

--- a/Gemfile
+++ b/Gemfile
@@ -222,7 +222,7 @@ group :test do
   gem 'capybara', '~> 3.13.0'
   gem 'capybara-screenshot', '~> 1.0.17'
   gem 'capybara-select2', git: 'https://github.com/goodwill/capybara-select2', ref: '585192e'
-  gem 'chromedriver-helper', '~> 2.1.0'
+  gem 'webdrivers', '~> 4.1.2', require: false
   gem 'selenium-webdriver', '~> 3.14'
 
   gem 'fuubar', '~> 2.3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,8 +318,6 @@ GEM
       airbrake-ruby (~> 3.0)
     airbrake-ruby (3.1.0)
       tdigest (= 0.1.1)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     attr_required (1.0.1)
@@ -388,9 +386,6 @@ GEM
       cells (>= 4.1.6, < 5.0.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     claide (1.0.3)
     claide-plugins (0.9.2)
       cork
@@ -561,7 +556,6 @@ GEM
     ice_cube (0.16.3)
     ice_nine (0.11.2)
     interception (0.5)
-    io-like (0.3.0)
     ipaddress (0.8.3)
     iso8601 (0.12.1)
     jaro_winkler (1.5.2)
@@ -936,6 +930,10 @@ GEM
       rack (>= 2.0.6)
     warden-basic_auth (0.2.1)
       warden (~> 1.2)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webfinger (1.1.0)
       activesupport
       httpclient (>= 2.4)
@@ -978,7 +976,6 @@ DEPENDENCIES
   carrierwave (~> 1.3.1)
   cells-erb (~> 0.1.0)
   cells-rails (~> 0.0.9)
-  chromedriver-helper (~> 2.1.0)
   commonmarker (~> 0.20.1)
   cucumber (~> 3.1.0)
   cucumber-rails (~> 1.6.0)
@@ -1113,6 +1110,7 @@ DEPENDENCIES
   unicorn-worker-killer
   warden (~> 1.2)
   warden-basic_auth (~> 0.2.1)
+  webdrivers (~> 4.1.2)
   webmock (~> 3.5.0)
   will_paginate (~> 3.1.7)
 

--- a/app/assets/stylesheets/content/_context_menu.sass
+++ b/app/assets/stylesheets/content/_context_menu.sass
@@ -112,3 +112,4 @@ html:not(.-browser-mobile)
   &:hover, &:focus
     .context-menu--icon
       opacity: 100
+

--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -27,10 +27,11 @@
 //++
 
 @include breakpoint(680px down)
-  body
-    overflow: auto !important
-    overflow-y: scroll /* has to be scroll, not auto */
+  body, html
+    position: relative
+    overflow: hidden
     -webkit-overflow-scrolling: touch
+    height: 100%
 
   #main-menu ~ #content-wrapper
     padding: 15px

--- a/spec/features/work_packages/details/inplace_editor/shared_examples.rb
+++ b/spec/features/work_packages/details/inplace_editor/shared_examples.rb
@@ -150,6 +150,9 @@ shared_examples 'a principal autocomplete field' do
       expect(page).to have_selector('.mention-list-item', text: mentioned_group.name)
       expect(page).not_to have_selector('.mention-list-item', text: user.name)
 
+      # Close the autocompleter
+      field.input_element.send_keys :escape
+
       field.input_element.set('', fill_options: { clear: :backspace })
       field.input_element.send_keys(" @Laura Fo")
       expect(page).to have_selector('.mention-list-item', text: mentioned_user.name)

--- a/spec/features/wysiwyg/non_breaking_spaces_spec.rb
+++ b/spec/features/wysiwyg/non_breaking_spaces_spec.rb
@@ -45,13 +45,7 @@ describe 'Wysiwyg &nbsp; behavior',
       end
 
       it 'can insert strong formatting with nbsp' do
-        editor.in_editor do |container, editable|
-
-          editor.click_and_type_slowly 'some text '
-          container.find('.ck-button', visible: :all, text: 'Bold').click
-
-          editor.click_and_type_slowly 'with bold '
-        end
+        editor.click_and_type_slowly 'some text ', [:control, 'b'], 'with bold'
 
         # Save wiki page
         click_on 'Save'

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -1,5 +1,10 @@
-# Force the latest version of chromedriver using the chromedriver-helper gem
-Chromedriver.set_version "2.44"
+# Force the latest version of chromedriver using the webdriver gem
+require 'webdrivers/chromedriver'
+
+if ENV['CI']
+  ::Webdrivers.logger.level = :DEBUG
+  ::Webdrivers::Chromedriver.update
+end
 
 def register_chrome_headless(language)
   name = :"chrome_headless_#{language}"

--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -87,15 +87,25 @@ module Components
         editable.all('figure').each do |figure|
           # Locate image within figure
           # Click on image to show figcaption
-          img = figure.find('img')
-          img.click
-          sleep 0.5
+          figure.find('img')
 
-          # Locate figcaption to create comment
-          figcaption = figure.find('figcaption')
-          figcaption.click
-          figcaption.send_keys(caption)
-          sleep 0.5
+          # Click the figure
+          retry_block do
+            figure.click
+            sleep 1
+
+            # Locate figcaption to create comment
+            figcaption = figure.find('figcaption')
+
+            # Insert the caption with JS to circumvent chrome error
+            script = <<-JS
+              arguments[0].textContent = '' + arguments[1]
+            JS
+            page.execute_script(script, figcaption.native, caption)
+
+            # Expect caption set
+            figure.find('figcaption', text: caption)
+          end
         end
       end
     end

--- a/spec/support/pages/groups.rb
+++ b/spec/support/pages/groups.rb
@@ -27,6 +27,7 @@
 #++
 
 require 'support/pages/page'
+require 'support/components/ng_select_autocomplete_helpers'
 
 module Pages
   class Groups < Page


### PR DESCRIPTION
We're using a fixed outdated version of chromedriver. Instead we should use the latest stable, as we do with the stable chrome version.