### PR TITLE
have a fixed width for grid columns

### DIFF
--- a/frontend/src/app/modules/grids/grid/grid.component.ts
+++ b/frontend/src/app/modules/grids/grid/grid.component.ts
@@ -92,7 +92,7 @@ export class GridComponent implements OnDestroy, OnInit {
   public get gridColumnStyle() {
     let style = '';
     for (let i = 0; i < this.layout.numColumns; i++) {
-      style += '20px 1fr ';
+      style += `20px calc((100% - 20px * ${this.layout.numColumns + 1}) / ${this.layout.numColumns}) `;
     }
 
     style += '20px';


### PR DESCRIPTION
That way, when the content size is increased (e.g. when resizing the widget), the column width stays the same.

This will support implementing https://community.openproject.com/projects/openproject/work_packages/31012 but does not do so in itself. The resizer will still have to listen for the mouse being moved and the resized widget will have to receive an explicit width/height when it does.