### PR TITLE
Correct wp table widget name and waiting for input value

### DIFF
--- a/frontend/src/app/modules/grids/widgets/abstract-widget.component.ts
+++ b/frontend/src/app/modules/grids/widgets/abstract-widget.component.ts
@@ -13,7 +13,7 @@ export abstract class AbstractWidgetComponent {
 
   @Output() resourceChanged = new EventEmitter<WidgetChangeset>();
 
-  public get widgetName() {
+  public get widgetName():string {
     let fallback = this.resource.options.name;
     let widgetIdentifier = this.resource.identifier;
     return this.i18n.t(

--- a/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.ts
+++ b/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.ts
@@ -71,6 +71,10 @@ export class WidgetWpTableComponent extends AbstractWidgetComponent {
     });
   }
 
+  public get widgetName() {
+    return this.resource.options.name as string;
+  }
+
   public static get identifier():string {
     return 'work_packages_table';
   }

--- a/modules/dashboards/spec/features/work_package_table_spec.rb
+++ b/modules/dashboards/spec/features/work_package_table_spec.rb
@@ -173,8 +173,7 @@ describe 'Arbitrary WorkPackage query table widget dashboard', type: :feature, j
         .not_to have_selector('.subject', text: other_project_work_package.subject)
 
       within filter_area.area do
-        expect(find('.editable-toolbar-title--input').value)
-          .to eql('My WP Filter')
+        expect(page).to have_field('editable-toolbar-title', with: 'My WP Filter', wait: 10)
       end
     end
   end

--- a/modules/my_page/spec/features/my/work_package_table_spec.rb
+++ b/modules/my_page/spec/features/my/work_package_table_spec.rb
@@ -150,8 +150,7 @@ describe 'Arbitrary WorkPackage query table widget on my page', type: :feature, 
         .to have_no_selector('.id', text: other_type_work_package.id)
 
       within filter_area.area do
-        expect(find('.editable-toolbar-title--input').value)
-          .to eql('My WP Filter')
+        expect(page).to have_field('editable-toolbar-title', with: 'My WP Filter', wait: 10)
       end
     end
   end


### PR DESCRIPTION
Using `find(..).value` will not use synchronize, i.e., it does not wait but return the element immediately. This will often happen before the element is changed.

Also, the work package widget is broken by https://github.com/opf/openproject/pull/7666