### PR TITLE
[31027] Align editable and non-editable grid widget headers

### DIFF
--- a/frontend/src/app/modules/grids/widgets/header/header.component.html
+++ b/frontend/src/app/modules/grids/widgets/header/header.component.html
@@ -1,6 +1,6 @@
 <h3 class="widget-box--header"
     [ngClass]="{ '-editable': isRenameable }">
-  <i class="icon-context"
+  <i class="widget-box--header-icon icon-context"
      aria-hidden="true"
      [ngClass]="iconClass"></i>
 

--- a/frontend/src/app/modules/grids/widgets/header/header.component.sass
+++ b/frontend/src/app/modules/grids/widgets/header/header.component.sass
@@ -1,7 +1,14 @@
-.widget-box--header.-editable
-  .icon-context
-    padding-top: 5px
+.widget-box--header
+  margin-top: 5px
 
+  &.-editable
+    margin-top: 0
+
+    .widget-box--header-icon
+      padding-top: 5px
+
+.widget-box--header-icon
+  align-self: center
 
 .widget-box--header-title
   padding-right: 5px


### PR DESCRIPTION
Due to the additional padding of the input in the grid headers, the
offset needs to be different in the two to match the outer positioned
drag handle icon.

This PR now ensures they are actually correctly positioned in  both cases:

![screenshot_8](https://user-images.githubusercontent.com/459462/64843281-fe873d80-d604-11e9-9b4a-94c0123c1b4f.png)

https://community.openproject.com/wp/31027