### PR TITLE
restrict wp_graph widget to be ee only

### DIFF
--- a/app/models/enterprise_token.rb
+++ b/app/models/enterprise_token.rb
@@ -48,7 +48,7 @@ class EnterpriseToken < ActiveRecord::Base
     def set_current_token
       token = EnterpriseToken.order(Arel.sql('created_at DESC')).first
 
-      if token && token.token_object
+      if token&.token_object
         token
       end
     end

--- a/app/services/authorization/enterprise_service.rb
+++ b/app/services/authorization/enterprise_service.rb
@@ -43,7 +43,8 @@ class Authorization::EnterpriseService
                        conditional_highlighting
                        readonly_work_packages
                        attachment_filters
-                       board_view).freeze
+                       board_view
+                       grid_widget_wp_graph).freeze
 
   def initialize(token)
     self.token = token

--- a/modules/dashboards/spec/features/work_package_graph_spec.rb
+++ b/modules/dashboards/spec/features/work_package_graph_spec.rb
@@ -85,12 +85,15 @@ describe 'Arbitrary WorkPackage query graph widget dashboard', type: :feature, j
   let(:dashboard_page) do
     Pages::Dashboard.new(project)
   end
+  let(:enterprise_edition) { true }
 
   let(:modal) { ::Components::WorkPackages::TableConfigurationModal.new }
   let(:filters) { ::Components::WorkPackages::TableConfiguration::Filters.new }
   let(:general) { ::Components::WorkPackages::TableConfiguration::GraphGeneral.new }
 
   before do
+    with_enterprise_token(enterprise_edition ? :grid_widget_wp_graph : nil)
+
     login_as user
 
     dashboard_page.visit!
@@ -106,7 +109,7 @@ describe 'Arbitrary WorkPackage query graph widget dashboard', type: :feature, j
 
       filter_area.expect_to_span(1, 1, 2, 2)
 
-      sleep(0.1)
+      sleep(0.5)
 
       # User has the ability to modify the query
 
@@ -147,6 +150,14 @@ describe 'Arbitrary WorkPackage query graph widget dashboard', type: :feature, j
 
     it 'cannot add the widget' do
       dashboard_page.expect_unable_to_add_widget(1, 1, :within, "Work packages graph")
+    end
+  end
+
+  context 'without an enterprise edition' do
+    let(:enterprise_edition) { false }
+
+    it 'cannot add the widget' do
+      dashboard_page.expect_unable_to_add_widget(1, 2, :within, "Work packages graph")
     end
   end
 end

--- a/modules/grids/lib/grids/configuration/in_project_base_registration.rb
+++ b/modules/grids/lib/grids/configuration/in_project_base_registration.rb
@@ -22,6 +22,11 @@ module Grids::Configuration
         user.allowed_to?(:manage_public_queries, project)
     }
 
+    queries_permission_and_ee_lambda = ->(user, project) {
+      save_or_manage_queries_lambda.call(user, project) &&
+        EnterpriseToken.allows_to?(:grid_widget_wp_graph)
+    }
+
     view_work_packages_lambda = ->(user, project) {
       user.allowed_to?(:view_work_packages, project)
     }
@@ -37,7 +42,7 @@ module Grids::Configuration
     widget_strategy 'work_packages_graph' do
       after_destroy remove_query_lambda
 
-      allowed save_or_manage_queries_lambda
+      allowed queries_permission_and_ee_lambda
 
       options_representer '::API::V3::Grids::Widgets::ChartOptionsRepresenter'
     end

--- a/spec/services/authorization/enterprise_service_spec.rb
+++ b/spec/services/authorization/enterprise_service_spec.rb
@@ -77,7 +77,8 @@ describe Authorization::EnterpriseService do
          multiselect_custom_fields
          edit_attribute_groups
          work_package_query_relation_columns
-         attribute_help_texts).each do |guarded_action|
+         attribute_help_texts
+         grid_widget_wp_graph).each do |guarded_action|
         context "guarded action #{guarded_action}" do
           let(:action) { guarded_action }
 


### PR DESCRIPTION
Prevents adding a wp graph widget to the dashboard and overview page.

https://community.openproject.com/projects/openproject/work_packages/31058