### PR TITLE
Fix/template and initialize deprecations

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -37,4 +37,4 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <% @page_header_title = l(:label_administration) %>
 
-<%= render file: "layouts/base", locals: { menu_name: :admin_menu } %>
+<%= render template: "layouts/base", locals: { menu_name: :admin_menu } %>

--- a/app/views/layouts/my.html.erb
+++ b/app/views/layouts/my.html.erb
@@ -27,4 +27,4 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= render file: "layouts/base", locals: { menu_name: :my_menu } %>
+<%= render template: "layouts/base", locals: { menu_name: :my_menu } %>

--- a/app/views/layouts/no_menu.html.erb
+++ b/app/views/layouts/no_menu.html.erb
@@ -27,4 +27,4 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= render file: "layouts/base", locals: { menu_name: nil, current_menu_item: nil } %>
+<%= render template: "layouts/base", locals: { menu_name: nil, current_menu_item: nil } %>

--- a/modules/backlogs/app/controllers/rb_application_controller.rb
+++ b/modules/backlogs/app/controllers/rb_application_controller.rb
@@ -60,7 +60,7 @@ class RbApplicationController < ApplicationController
     settings = Setting.plugin_openproject_backlogs
     if settings['story_types'].blank? || settings['task_type'].blank?
       respond_to do |format|
-        format.html { render file: 'shared/not_configured' }
+        format.html { render template: 'shared/not_configured' }
       end
     end
   end

--- a/spec/factories/role_factory.rb
+++ b/spec/factories/role_factory.rb
@@ -38,14 +38,14 @@ FactoryBot.define do
       name { 'Non member' }
       builtin { Role::BUILTIN_NON_MEMBER }
       assignable { false }
-      initialize_with { Role.find_or_create_by(name: name) }
+      initialize_with { Role.where(name: name).first_or_initialize }
     end
 
     factory :anonymous_role do
       name { 'Anonymous' }
       builtin { Role::BUILTIN_ANONYMOUS }
       assignable { false }
-      initialize_with { Role.find_or_create_by(name: name) }
+      initialize_with { Role.where(name: name).first_or_initialize }
     end
 
     factory :existing_role do


### PR DESCRIPTION
Fixes deprecations but actually improves the behaviour doing it:

* templates should not be rendered via `file`
* initializing the role will allow for build_stubbed to be more performant