### PR TITLE
harmonize header of classical widget and grid

### DIFF
--- a/app/assets/stylesheets/content/_grid.sass
+++ b/app/assets/stylesheets/content/_grid.sass
@@ -69,16 +69,6 @@ $grid--widget-padding: 20px
   .widget-box--header
     display: flex
 
-  .widget-box--header-title
-    flex-grow: 1
-    align-self: center
-
-    // Ensure style for read-only widget headers
-    .editable-toolbar-title--fixed
-      color: #5F5F5F
-      font-size: 18px
-      font-weight: normal
-
   icon-triggered-context-menu
     visibility: hidden
 
@@ -133,11 +123,7 @@ $grid--widget-padding: 20px
     height: 100%
 
   input[type="text"].toolbar--editable-toolbar
-    font-size: 18px
     font-weight: normal
-
-  .title-container
-    margin-bottom: 0px
 
 .grid--widget-content
   height: 100%

--- a/app/assets/stylesheets/content/_widget_box.sass
+++ b/app/assets/stylesheets/content/_widget_box.sass
@@ -64,7 +64,7 @@ $widget-box--enumeration-width: 20px
   .widget-box
     position: relative
     @include widget-box--style
-    padding: 10px 20px 30px 20px
+    padding: 20px
     min-height: 250px
     word-wrap: break-word
     overflow: hidden
@@ -79,18 +79,6 @@ $widget-box--enumeration-width: 20px
       padding: 0
       border: 0
 
-    .widget-box--header
-      font-weight: bold
-      font-size: 1.25rem
-      border: none
-
-      .widget-box--header-title
-        vertical-align: middle
-      .icon:before,
-      .icon-context:before
-        display: inline-block
-        padding-top: 0
-        vertical-align: middle
 
     .widget-box--enumeration
       margin-left: 1.5rem
@@ -119,6 +107,30 @@ $widget-box--enumeration-width: 20px
       max-height: 100px
       margin-left: auto
       margin-right: auto
+
+.widget-box--header
+  font-weight: bold
+  font-size: 1.25rem
+  display: flex
+
+.widget-box--header-title
+  vertical-align: middle
+  margin-bottom: 0
+  flex-grow: 1
+  align-self: center
+
+  .widget-box--header-icon + &
+    padding-left: 5px
+
+  // Ensure style for read-only widget headers
+  .editable-toolbar-title--fixed
+    color: #5F5F5F
+    font-size: 20px
+    font-weight: normal
+
+.widget-box--header-icon
+  align-self: center
+  line-height: 28px
 
 .widget-box--additional-info
   font-style: italic

--- a/app/helpers/homescreen_helper.rb
+++ b/app/helpers/homescreen_helper.rb
@@ -41,12 +41,6 @@ module HomescreenHelper
   end
 
   ##
-  # Returns the user avatar or a default image
-  def homescreen_user_avatar
-    op_icon('icon-context icon-user')
-  end
-
-  ##
   # Render a static link defined in OpenProject::Static::Links
   def static_link_to(key)
     link = OpenProject::Static::Links.links[key]

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -98,6 +98,12 @@ module UsersHelper
     result
   end
 
+  ##
+  # Returns the user avatar or a default image
+  def user_avatar_icon
+    op_icon('icon-context icon-user')
+  end
+
   def change_user_status_buttons(user)
     build_change_user_status_action(user) do |title, name|
       submit_tag(title, name: name, class: 'button')

--- a/app/views/homescreen/blocks/_administration.html.erb
+++ b/app/views/homescreen/blocks/_administration.html.erb
@@ -1,7 +1,4 @@
-<h3 class="widget-box--header">
-  <%= op_icon('icon-context icon-settings') %>
-  <span class="widget-box--header-title"><%= l(:label_administration) %></span>
-</h3>
+<%= render 'homescreen/blocks/header', icon: 'settings', title: t(:label_administration) %>
 
 <ul class="widget-box--arrow-links">
   <li>

--- a/app/views/homescreen/blocks/_community.html.erb
+++ b/app/views/homescreen/blocks/_community.html.erb
@@ -1,7 +1,4 @@
-<h3 class="widget-box--header">
-  <%= op_icon('icon-context icon-openproject') %>
-  <span class="widget-box--header-title"><%= l('homescreen.blocks.community') %></span>
-</h3>
+<%= render 'homescreen/blocks/header', icon: 'openproject', title: t('homescreen.blocks.community') %>
 
 <ul class="widget-box--arrow-links">
   <li>

--- a/app/views/homescreen/blocks/_header.html.erb
+++ b/app/views/homescreen/blocks/_header.html.erb
@@ -1,0 +1,6 @@
+<h3 class="widget-box--header">
+  <%= op_icon("icon-context icon-#{icon} widget-box--header-icon") %>
+  <div class="widget-box--header-title title-container">
+    <h2 class="editable-toolbar-title--fixed"><%= title %></h2>
+  </div>
+</h3>

--- a/app/views/homescreen/blocks/_my_account.html.erb
+++ b/app/views/homescreen/blocks/_my_account.html.erb
@@ -1,7 +1,4 @@
-<h3 class="widget-box--header">
-  <%= homescreen_user_avatar %>
-  <span class="widget-box--header-title"><%= l(:label_my_account) %></span>
-</h3>
+<%= render 'homescreen/blocks/header', icon: 'user', title: t('label_my_account') %>
 
 <ul class="widget-box--arrow-links">
   <li>

--- a/app/views/homescreen/blocks/_new_features.html.erb
+++ b/app/views/homescreen/blocks/_new_features.html.erb
@@ -1,6 +1,3 @@
-<h3 class="widget-box--header">
-  <%= op_icon('icon-star') %>
-  <span class="widget-box--header-title"><%= t(:label_new_features) %></span>
-</h3>
+<%= render 'homescreen/blocks/header', icon: 'star', title: t(:label_new_features) %>
 
 <homescreen-new-features-block></homescreen-new-features-block>

--- a/app/views/homescreen/blocks/_news.html.erb
+++ b/app/views/homescreen/blocks/_news.html.erb
@@ -1,7 +1,4 @@
-<h3 class="widget-box--header">
-  <%= op_icon('icon-context icon-news') %>
-  <span class="widget-box--header-title"><%= l(:label_news_latest) %></span>
-</h3>
+<%= render 'homescreen/blocks/header', icon: 'news', title: t(:label_news_latest) %>
 
 <% unless @news.empty? %>
   <ul class="widget-box--arrow-links">

--- a/app/views/homescreen/blocks/_projects.html.erb
+++ b/app/views/homescreen/blocks/_projects.html.erb
@@ -1,7 +1,4 @@
-<h3 class="widget-box--header">
-  <%= op_icon('icon-context icon-projects') %>
-  <span class="widget-box--header-title"><%= l(:label_project_plural) %></span>
-</h3>
+<%= render 'homescreen/blocks/header', icon: 'projects', title: t(:label_project_plural) %>
 
 <% if @newest_projects.empty? %>
   <p class="widget-box--additional-info">

--- a/app/views/homescreen/blocks/_upsale.html.erb
+++ b/app/views/homescreen/blocks/_upsale.html.erb
@@ -1,7 +1,4 @@
-<h3 class="widget-box--header">
-  <%= op_icon('icon-context icon-cart') %>
-  <span class="widget-box--header-title"><%= t('homescreen.blocks.upsale.title') %></span>
-</h3>
+<%= render 'homescreen/blocks/header', icon: 'cart', title: t('homescreen.blocks.upsale.title') %>
 
 <%= image_tag "enterprise_edition.png", class: "widget-box--teaser-image" %>
 

--- a/app/views/homescreen/blocks/_users.html.erb
+++ b/app/views/homescreen/blocks/_users.html.erb
@@ -1,7 +1,5 @@
-<h3 class="widget-box--header">
-  <%= op_icon('icon-context icon-group') %>
-  <span class="widget-box--header-title"><%= l(:label_user_plural) %></span>
-</h3>
+<%= render 'homescreen/blocks/header', icon: 'group', title: t(:label_user_plural) %>
+
 <p class="widget-box--additional-info"><%= l('homescreen.additional.users') %></p>
 
 <% unless @newest_users.empty? %>

--- a/app/views/homescreen/blocks/_welcome.html.erb
+++ b/app/views/homescreen/blocks/_welcome.html.erb
@@ -1,7 +1,5 @@
-<h3 class="widget-box--header">
-  <%= op_icon('icon-context icon-projects') %>
-  <span class="widget-box--header-title"><%= Setting.welcome_title.presence || organization_name %></span>
-</h3>
+<%= render 'homescreen/blocks/header', icon: 'projects', title: Setting.welcome_title.presence || organization_name %>
+
 <div class="wiki">
   <%= format_text(Setting.welcome_text, headings: false) %>
 </div>

--- a/app/views/onboarding/_configuration_modal.html.erb
+++ b/app/views/onboarding/_configuration_modal.html.erb
@@ -31,7 +31,7 @@ See docs/COPYRIGHT.rdoc for more details.
   <%= labelled_tabular_form_for current_user, url: { action: 'user_settings', controller: 'onboarding' }, html: { id: 'user-form' } do |f| %>
       <div class="onboarding--start-modal">
         <div class="onboarding--top-menu op-modal--modal-header">
-          <%= homescreen_user_avatar %>
+          <%= user_avatar_icon %>
           <h2><%= I18n.t('onboarding.welcome') %>, <%= current_user.name %></h2>
           <a class="op-modal--modal-close-button dynamic-content-modal--close-button"
              title="<%= t('js.close_popup_title') %>"

--- a/app/views/onboarding/_onboarding_video_modal.html.erb
+++ b/app/views/onboarding/_onboarding_video_modal.html.erb
@@ -30,7 +30,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <div class="modal-wrapper--content">
   <div class="onboarding--start-modal">
     <div class="onboarding--top-menu op-modal--modal-header">
-      <%= homescreen_user_avatar %>
+      <%= user_avatar_icon %>
       <h2><%= I18n.t('onboarding.welcome') %></h2>
       <a class="op-modal--modal-close-button dynamic-content-modal--close-button"
          title="<%= t('js.close_popup_title') %>"

--- a/frontend/src/app/modules/grids/widgets/header/header.component.sass
+++ b/frontend/src/app/modules/grids/widgets/header/header.component.sass
@@ -5,10 +5,7 @@
     margin-top: 0
 
     .widget-box--header-icon
-      padding-top: 5px
-
-.widget-box--header-icon
-  align-self: center
+      line-height: 34px
 
 .widget-box--header-title
   padding-right: 5px


### PR DESCRIPTION
Widgets, in particular the headers, on the home screen now look more alike to the grid widgets:

![image](https://user-images.githubusercontent.com/617519/65127689-425cb700-d9f8-11e9-9470-11e51a08ee3e.png)

In the long run, the grid.sass and widget.sass will need to be combined. 

https://community.openproject.com/projects/openproject/work_packages/31063