### PR TITLE
Warn for components not using onPush

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,22 @@
 # Fail if jasmine specs contain fdescribe or fit
 fail("jasmine fdescribe left in tests") if `grep --include '*.spec.ts' -rP 'fdescribe|fit' frontend/src/`.length > 1
 
+# Search for modified components not being made OnPush
+git.modified_files
+    .select { |path| path.include?('frontend') && path.end_with?('.ts') }
+    .each do |path|
+  lines = File.readlines(path)
+
+  # Ignore non component files
+  component_line = lines.grep(/@Component/)[0]
+  next unless component_line
+
+  # Check for missing onPush
+  unless lines.grep(/changeDetection:\s+ChangeDetectionStrategy.OnPush/).length > 0
+    warn(
+        "Please use `ChangeDetectionStrategy.OnPush` for this component",
+        file: path,
+        line: lines.index(component_line) || 0
+        )
+  end
+end

--- a/frontend/src/app/components/wp-details/wp-details-toolbar.component.ts
+++ b/frontend/src/app/components/wp-details/wp-details-toolbar.component.ts
@@ -42,6 +42,7 @@ export class WorkPackageSplitViewToolbarComponent {
     button_more: this.I18n.t('js.button_more')
   }
 
+  // some comment to trigger change
 constructor(readonly I18n:I18nService,
             @Inject(IWorkPackageEditingServiceToken) readonly wpEditing:WorkPackageEditingService) {}
 }


### PR DESCRIPTION
Provide a check in the dangerfile to warn components inline that were changed but are not yet using OnPush