### PR TITLE
[31082] Remove max-height from ckeditor

### DIFF
--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -299,6 +299,11 @@ fieldset.form--fieldset
   margin-bottom: 0.825rem
   line-height: 2
 
+  // Extend the overflow: visible from form-field
+  // to the container because it's duplicated there.
+  &.-visible-overflow .form--field-container
+    overflow: visible
+
   &.-vertical,
   .form.-vertical &
     @include grid-orient(vertical)

--- a/app/assets/stylesheets/content/editor/_ckeditor.sass
+++ b/app/assets/stylesheets/content/editor/_ckeditor.sass
@@ -80,19 +80,21 @@ ckeditor-augmented-textarea .op-ckeditor--wrapper
 
   .document-editor__toolbar
     position: sticky
-    top: 0
+    top: 0px
     z-index: 1
+
+    // Adjust top offset to match if globally
+    // scrolling (content-wrapper)
+    .ckeditor--content-scrollable &,
+    .form--field.-visible-overflow &
+      top: -10px
 
   .ck.ck-toolbar.ck-rounded-corners
     border-bottom-left-radius: 0
     border-bottom-right-radius: 0
 
   .document-editor__editable-container
-    // Ensure max-height is set to allow stickiness
-    // in global scrolling pages (forums e.g.)
-    max-height: 75vh
     overflow-y: auto
-
     border: 1px solid var(--ck-color-base-border)
     border-top: none
     border-radius: var(--ck-border-radius)

--- a/app/cells/views/settings/text_setting/show.erb
+++ b/app/cells/views/settings/text_setting/show.erb
@@ -21,7 +21,7 @@
        <%= "style=\"display:none\"" unless lang == current_language.to_s %>
        class="lang-select lang-for-<%= name %>"
   >
-    <div class="form--field">
+    <div class="form--field -visible-overflow">
       <%= styled_label_tag "settings[#{name}][#{lang}]", t("setting_#{name}") %>
       <div class="form--field-container">
         <%=

--- a/app/views/attribute_help_texts/_form.html.erb
+++ b/app/views/attribute_help_texts/_form.html.erb
@@ -40,7 +40,7 @@ See docs/COPYRIGHT.rdoc for more details.
       <%= f.select :attribute_name, selectable_attributes(@attribute_help_text), container_class: '-middle' %>
     <% end %>
   </div>
-  <div class="form--field -required">
+  <div class="form--field -required -visible-overflow">
     <%= f.text_area :help_text, cols: 100, rows: 20, class: 'wiki-edit', with_text_formatting: true %>
   </div>
 </section>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -52,7 +52,7 @@ See docs/COPYRIGHT.rdoc for more details.
   </div>
 <% end %>
 
-<div class="form--field -required">
+<div class="form--field -required -visible-overflow">
   <%= f.text_area :content,
                   label: t(:description_message_content),
                   class: 'wiki-edit',

--- a/app/views/news/_form.html.erb
+++ b/app/views/news/_form.html.erb
@@ -37,7 +37,7 @@ See docs/COPYRIGHT.rdoc for more details.
                   class: 'wiki-edit wiki-toolbar -small',
                   container_class: '-xxwide' %>
 </div>
-<div class="form--field">
+<div class="form--field -visible-overflow">
   <%= f.text_area :description,
                   class: 'wiki-edit wiki-toolbar',
                   container_class: '-xxwide',

--- a/app/views/oauth/applications/_form.html.erb
+++ b/app/views/oauth/applications/_form.html.erb
@@ -58,10 +58,10 @@ See docs/COPYRIGHT.rdoc for more details.
             authorization_code_flow_link: static_link_to(:oauth_authorization_code_flow))  %>
     </p>
 
-    <div class="form--field">
+    <div class="form--field -visible-overflow">
       <label class="form--label"> <%= t('doorkeeper.application.client_credentials_user_id') %>
       </label>
-      <div class="form--field-container -visible-overflow">
+      <div class="form--field-container">
         <div class="form--text-field-container -middle">
           <%= f.hidden_field :client_credentials_user_id,  value: @application.client_credentials_user_id %>
           <user-autocompleter data-allow-empty="true"

--- a/app/views/projects/form/attributes/_description.html.erb
+++ b/app/views/projects/form/attributes/_description.html.erb
@@ -27,7 +27,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<div class="form--field">
+<div class="form--field -visible-overflow">
   <%= form.text_area :description,
                      id: :project_description,
                      with_text_formatting: true,

--- a/app/views/settings/_general.html.erb
+++ b/app/views/settings/_general.html.erb
@@ -73,7 +73,7 @@ See docs/COPYRIGHT.rdoc for more details.
     <fieldset class="form--fieldset">
       <legend class="form--fieldset-legend"><%= t(:setting_welcome_text) %></legend>
       <div class="form--field"><%= setting_text_field :welcome_title, size: 30, container_class: '-wide' %></div>
-      <div class="form--field">
+      <div class="form--field -visible-overflow">
         <%= setting_text_area :welcome_text,
                               cols: 60,
                               rows: 5,

--- a/app/views/wiki/_page_form.html.erb
+++ b/app/views/wiki/_page_form.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 <% end %>
 
-<div class="attributes-group wiki--content--attribute form--field -visible-overflow">
+<div class="attributes-group wiki--content--attribute ckeditor--content-scrollable form--field -visible-overflow">
   <%= f.text_area :text,
                   cols: 100,
                   rows: 25,

--- a/modules/costs/app/views/cost_objects/_form.html.erb
+++ b/modules/costs/app/views/cost_objects/_form.html.erb
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <div class="form--field -required">
   <%= f.text_field :subject, required: true, autofocus: true, container_class: '-wide' %>
 </div>
-<div class="form--field">
+<div class="form--field -visible-overflow">
   <%= f.text_area :description,
                   container_class: '-xxwide',
                   with_text_formatting: true,

--- a/modules/documents/app/views/documents/_form.html.erb
+++ b/modules/documents/app/views/documents/_form.html.erb
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <div class="form--field -required">
   <%= f.text_field :title, required: true, container_class: '-wide' %>
 </div>
-<div class="form--field">
+<div class="form--field -visible-overflow">
   <%= f.text_area :description,
                   container_class: '-xxwide',
                   with_text_formatting: true,

--- a/modules/meeting/app/views/meeting_contents/_form.html.erb
+++ b/modules/meeting/app/views/meeting_contents/_form.html.erb
@@ -24,17 +24,18 @@ See doc/COPYRIGHT.md for more details.
 
   <% resource = ::API::V3::MeetingContents::MeetingContentRepresenter.new(content, current_user: current_user, embed_links: true) %>
 
-  <p>
-    <%=
-      f.text_area(
-        :text,
-        class: 'wiki-edit wiki-toolbar',
-        resource: resource,
-        label_options: { class: 'hidden-for-sighted' },
-        with_text_formatting: true
-      )
-    %>
-  </p>
+  <div class="form--field -no-label -visible-overflow">
+      <%=
+        f.text_area(
+            :text,
+            class: 'wiki-edit wiki-toolbar',
+            no_label: true,
+            resource: resource,
+            label_options: { class: 'hidden-for-sighted' },
+            with_text_formatting: true
+        )
+      %>
+  </div>
   <%= f.hidden_field :lock_version %>
   <% path = send("preview_#{content_type}_path", content.meeting) %>
 


### PR DESCRIPTION
As we now have a proper `position: sticky` solution, the max-height is no longer required. It can by itself scroll when the next outer scroll container is being scrolled, which works on both content-wrapper scrolled pages, and work package pages.

However that requires that we avoid `overflow: hidden` on the `form--fields` so this introduces a modifier for globally scrolled pages to do just that.

https://community.openproject.com/wp/31082