### PR TITLE
[31085] Add missing gon settings to my page

### DIFF
--- a/modules/grids/app/controllers/grids/base_in_project_controller.rb
+++ b/modules/grids/app/controllers/grids/base_in_project_controller.rb
@@ -1,9 +1,11 @@
 module ::Grids
   class BaseInProjectController < ::ApplicationController
+    include OpenProject::ClientPreferenceExtractor
     before_action :find_project_by_project_id
     before_action :authorize
 
     def show
+      gon.settings = client_preferences
       render layout: 'angular'
     end
   end

--- a/modules/my_page/app/controllers/my_page/angular_controller.rb
+++ b/modules/my_page/app/controllers/my_page/angular_controller.rb
@@ -30,8 +30,10 @@
 
 class MyPage::AngularController < ::ApplicationController
   before_action :require_login
+  include OpenProject::ClientPreferenceExtractor
 
   def no_menu
+    gon.settings = client_preferences
     render layout: 'no_menu'
   end
 end

--- a/modules/my_page/app/views/my_page/angular/no_menu.html.erb
+++ b/modules/my_page/app/views/my_page/angular/no_menu.html.erb
@@ -27,4 +27,10 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
+<%= content_for :header_tags do %>
+  <%= nonced_javascript_tag do %>
+    <%= include_gon(need_tag: false) -%>
+  <% end %>
+<% end -%>
+
 <openproject-base></openproject-base>


### PR DESCRIPTION
All pages that render the `openproject-base` tag in a layout must pass the gon settings.

This is actually a bad pattern that could be solvable with the configuration api endpoint. It is being loaded for every work package page load, but does not contain the relevant information such as comment sorting.

In fact, it is only being used for the pagination component and differs in structure from the gon settings.

So this should be considered a quick fix for 10.0. with a proper solution (removing gon settings) to follow in https://community.openproject.com/wp/31089

https://community.openproject.com/wp/31085