### PR TITLE
BIM: Remove copy link from work package representer for BCFs

### DIFF
--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -105,7 +105,7 @@ module API
         link :copy,
              cache_if: -> { current_user_allowed_to(:add_work_packages, context: represented.project) } do
 
-          next if represented.new_record?
+          next if represented.new_record? || !can_be_copied?
 
           {
             href: work_package_path(represented, 'copy'),
@@ -593,6 +593,12 @@ module API
 
         def load_complete_model(model)
           ::API::V3::WorkPackages::WorkPackageEagerLoadingWrapper.wrap_one(model, current_user)
+        end
+
+        # Check if the represented work package can be copied.
+        # This method might get patched by modules.
+        def can_be_copied?
+          true
         end
       end
     end

--- a/modules/bcf/lib/open_project/bcf/engine.rb
+++ b/modules/bcf/lib/open_project/bcf/engine.rb
@@ -72,6 +72,7 @@ module OpenProject::Bcf
     patch_with_namespace :BasicData, :SettingSeeder
     patch_with_namespace :BasicData, :RoleSeeder
     patch_with_namespace :API, :V3, :Activities, :ActivityRepresenter
+    patch_with_namespace :API, :V3, :WorkPackages, :WorkPackageRepresenter
     patch_with_namespace :Journal, :AggregatedJournal
     patch_with_namespace :API, :V3, :Activities, :ActivitiesSharedHelpers
 

--- a/modules/bcf/lib/open_project/bcf/patches/work_package_representer_patch.rb
+++ b/modules/bcf/lib/open_project/bcf/patches/work_package_representer_patch.rb
@@ -1,0 +1,39 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2019 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject::Bcf::Patches::WorkPackageRepresenterPatch
+  def self.included(base) # :nodoc:
+    base.prepend InstanceMethods
+  end
+
+  module InstanceMethods
+    def can_be_copied?
+      represented.bcf_issue.nil?
+    end
+  end
+end


### PR DESCRIPTION
After a long discussion we agreed that copying BCF WPs does not make sense.