### PR TITLE
[31095] Fix double saving query title due to blur

### DIFF
--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.component.ts
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.component.ts
@@ -159,7 +159,17 @@ export class EditableToolbarTitleComponent implements OnInit, OnChanges {
       (this.inputField.nativeElement as HTMLInputElement).blur();
     }
 
+    // Avoid double saving
+    if (this.inFlight) {
+      return;
+    }
+
+    this.inFlight = true;
+
     this.emitSave(this.selectedTitle);
+
+    // Unset in-flight after some delay not to trigger the blur
+    setTimeout(() => this.inFlight = false, 100);
   }
 
   public get isEmpty():boolean {

--- a/spec/features/work_packages/table/queries/query_menu_spec.rb
+++ b/spec/features/work_packages/table/queries/query_menu_spec.rb
@@ -33,6 +33,7 @@ describe 'Query menu item', js: true do
   let(:project) { FactoryBot.create :project }
   let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
   let(:filters) { ::Components::WorkPackages::Filters.new }
+  let(:query_title) { ::Components::WorkPackages::QueryTitle.new }
 
   before do
     login_as(user)
@@ -73,6 +74,20 @@ describe 'Query menu item', js: true do
 
       last_query = Query.last
       expect(last_query.is_public).to be_truthy
+    end
+
+    it 'only saves a single query when saving through the title input (Regression #31095)' do
+      filters.open
+      filters.remove_filter('status')
+
+      filters.expect_filter_count 0
+      query_title.expect_changed
+
+      query_title.input_field.click
+      query_title.rename 'My special query!123'
+
+      query_title.expect_title 'My special query!123'
+      expect(page).to have_selector('.ui-menu-item', text: 'My special query!123', wait: 20, count: 1)
     end
 
     it 'allows filtering, saving, retrieving and altering the saved filter (Regression #25372)' do


### PR DESCRIPTION
The blur event causes another save that is only caught for new queries

https://community.openproject.com/wp/31095