### PR TITLE
Feature/display pagination range on manual sort

### DIFF
--- a/app/assets/stylesheets/content/_pagination.sass
+++ b/app/assets/stylesheets/content/_pagination.sass
@@ -102,9 +102,12 @@ $pagination--font-size: 0.8125rem
   text-align: right
   @include text-shortener
 
-.pagination--range
+.pagination--range, .pagination--info
   flex: 1
   margin: 0 0 0 5px
   padding: 3px 0
   display: block
   @include text-shortener
+
+.pagination--info
+  flex-basis: auto

--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -160,8 +160,3 @@ body.-browser-edge
 .wp-table--cell-td img.thumbnail
   height: 40px
 
-.work-package--limited-results
-  td
-    height: 40px
-    text-align: center !important
-

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -705,9 +705,8 @@ en:
       no_results:
         title: No work packages to display.
         description: Either none have been created or all work packages are filtered out.
-      limited_results: >
-        There are %{total} total work packages, but only %{count} can be shown in manual sorting mode.
-        Please reduce the results by filtering.
+      limited_results:
+        Only %{count} work packages can be shown in manual sorting mode. Please reduce the results by filtering.
       property_groups:
         details: "Details"
         people: "People"

--- a/frontend/src/app/components/table-pagination/table-pagination.component.html
+++ b/frontend/src/app/components/table-pagination/table-pagination.component.html
@@ -2,7 +2,7 @@
   <nav class="pagination--pages">
     <ul class="pagination--items">
 
-      <li [hidden]="pagination.page == 1" class="pagination--item">
+      <li [hidden]="pagination.page == 1 || !showPageSelections" class="pagination--item">
         <a (accessibleClick)="showPage(pagination.page - 1)"
            rel="prev start"
            [attr.aria-label]="text.label_previous"
@@ -67,6 +67,14 @@
               tabindex="0"
               class="hidden-for-sighted"
               [textContent]="text.no_other_page"></span>
+      </li>
+
+      <li class="pagination--info"
+          *ngIf="infoText">
+        <op-icon icon-classes="icon-info1 icon-context"></op-icon>
+        <span [textContent]="infoText">
+
+        </span>
       </li>
     </ul>
   </nav>

--- a/frontend/src/app/components/table-pagination/table-pagination.component.ts
+++ b/frontend/src/app/components/table-pagination/table-pagination.component.ts
@@ -48,7 +48,9 @@ import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 export class TablePaginationComponent implements OnInit {
   @Input() totalEntries:string;
   @Input() hideForSinglePageResults:boolean = false;
-  @Input() calculatePerPage:boolean = false;
+  @Input() showPerPage:boolean = true;
+  @Input() showPageSelections:boolean = true;
+  @Input() infoText?:string;
   @Output() updateResults = new EventEmitter<PaginationInstance>();
 
   public pagination:PaginationInstance;
@@ -117,7 +119,11 @@ export class TablePaginationComponent implements OnInit {
    */
   public updateCurrentRangeLabel() {
     if (this.pagination.total) {
-      this.currentRange = '(' + this.pagination.getLowerPageBound() + ' - ' + this.pagination.getUpperPageBound(this.pagination.total) + '/' + this.pagination.total + ')';
+      let totalItems = this.pagination.total;
+      let lowerBound = this.pagination.getLowerPageBound();
+      let upperBound = this.pagination.getUpperPageBound(this.pagination.total);
+
+      this.currentRange = '(' + lowerBound + ' - ' + upperBound + '/' + totalItems + ')';
     } else {
       this.currentRange = '(0 - 0/0)';
     }
@@ -129,6 +135,12 @@ export class TablePaginationComponent implements OnInit {
    * @description Defines a list of all pages in numerical order inside the scope
    */
   public updatePageNumbers() {
+    if (!this.showPageSelections) {
+      this.pageNumbers = [];
+      this.postPageNumbers = [];
+      return;
+    }
+
     var maxVisible = this.paginationService.getMaxVisiblePageOptions();
     var truncSize = this.paginationService.getOptionsTruncationSize();
 
@@ -156,7 +168,7 @@ export class TablePaginationComponent implements OnInit {
   }
 
   public showPerPageOptions() {
-    return !this.calculatePerPage &&
+    return this.showPerPage &&
            this.perPageOptions.length > 0 &&
            this.pagination.total > this.perPageOptions[0];
   }

--- a/frontend/src/app/components/wp-table/embedded/wp-embedded-table.component.ts
+++ b/frontend/src/app/components/wp-table/embedded/wp-embedded-table.component.ts
@@ -135,9 +135,6 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
     // We should allow the backend to disable results embedding instead.
     if (!this.configuration.tableVisible) {
       this.queryProps.pageSize = 1;
-    } else if (this.configuration.forcePerPageOption) {
-      // Limit the number of visible work packages
-      this.queryProps.pageSize = this.configuration.forcePerPageOption;
     }
 
     // Set first page

--- a/frontend/src/app/components/wp-table/embedded/wp-embedded-table.html
+++ b/frontend/src/app/components/wp-table/embedded/wp-embedded-table.html
@@ -19,8 +19,7 @@
 
     <!-- Footer -->
     <div class="work-packages-split-view--tabletimeline-footer hide-when-print">
-      <wp-table-pagination [hideForSinglePageResults]="true"
-                           [calculatePerPage]="configuration.forcePerPageOption">
+      <wp-table-pagination [hideForSinglePageResults]="true">
       </wp-table-pagination>
     </div>
   </ng-container>

--- a/frontend/src/app/components/wp-table/table-pagination/wp-table-pagination.component.spec.ts
+++ b/frontend/src/app/components/wp-table/table-pagination/wp-table-pagination.component.spec.ts
@@ -40,6 +40,8 @@ import {HalResourceService} from 'core-app/modules/hal/services/hal-resource.ser
 import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {OpenProject} from "core-app/globals/openproject";
+import {OpIcon} from "core-app/modules/common/icon/op-icon";
+import {WorkPackageViewSortByService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-sort-by.service";
 
 function setupMocks(paginationService:PaginationService) {
   spyOn(paginationService, 'loadPaginationOptions').and.callFake(() => {
@@ -69,11 +71,13 @@ describe('wpTablePagination Directive', () => {
         HttpClientModule
       ],
       declarations: [
-        WorkPackageTablePaginationComponent
+        WorkPackageTablePaginationComponent,
+        OpIcon
       ],
       providers: [
         States,
         PaginationService,
+        WorkPackageViewSortByService,
         PathHelperService,
         WorkPackageViewPaginationService,
         HalResourceService,
@@ -102,7 +106,6 @@ describe('wpTablePagination Directive', () => {
         app.update();
         fixture.detectChanges();
         expect(pageString(element)).toEqual('(1 - 10/11)');
-
       }));
 
     describe('"next" link', function() {

--- a/frontend/src/app/components/wp-table/wp-table-configuration.ts
+++ b/frontend/src/app/components/wp-table/wp-table-configuration.ts
@@ -66,9 +66,6 @@ export class WorkPackageTableConfiguration {
   /** Whether the work packages shall be shown in cards instead of a table */
   public isCardView:boolean = false;
 
-  /** Whether the number of shown WP per page shall be calculated based on the available height */
-  public forcePerPageOption:number|false = false;
-
   /** Whether this table provides a UI for filters*/
   public withFilters:boolean = false;
 

--- a/frontend/src/app/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/components/wp-table/wp-table.directive.html
@@ -58,18 +58,6 @@
              [wp-inline-create--project-identifier]="projectIdentifier"
       >
       </tbody>
-      <tbody class="work-package--limited-results" *ngIf="limitedResults">
-        <tr>
-          <td [attr.colspan]="columns.length + 2">
-            <span>
-              <op-icon icon-classes="icon-info1 icon-context"></op-icon>
-              <span>
-                {{text.limitedResults(results.count, results.total)}}
-              </span>
-            </span>
-          </td>
-        </tr>
-      </tbody>
       <tfoot>
       <tr wpTableSumsRow></tr>
       </tfoot>

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -218,20 +218,7 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
     return this.bcfDetectorService.isBcfActivated;
   }
 
-  public get isManualSortingMode() {
-    return this.wpTableSortBy.isManualSortingMode;
-  }
-
-  public get paginationInfoText() {
-    if (this.isManualSortingMode && (this.currentQuery.results.count < this.currentQuery.results.total)) {
-      return I18n.t('js.work_packages.limited_results',
-                    {count: this.currentQuery.results.count});
-    } else {
-      return null;
-    }
-  }
-
-protected updateQueryOnParamsChanges() {
+  protected updateQueryOnParamsChanges() {
     // Listen for param changes
     this.removeTransitionSubscription = this.$transitions.onSuccess({}, (transition):any => {
       let options = transition.options();

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -68,9 +68,6 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
   /** Do we currently have query props ? */
   hasQueryProps:boolean;
 
-  /** Should we show the pagination ? */
-  showPagination = true;
-
   /** Listener callbacks */
   unRegisterTitleListener:Function;
   removeTransitionSubscription:Function;
@@ -120,7 +117,6 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
       // Update the title whenever the query changes
       this.updateTitle(query);
       this.currentQuery = query;
-      this.showPagination = !this.wpTableSortBy.isManualSortingMode;
 
       // Update the visible representation
       if (this.wpDisplayRepresentation.valueFromQuery(query) === wpDisplayCardRepresentation) {
@@ -222,7 +218,20 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
     return this.bcfDetectorService.isBcfActivated;
   }
 
-  protected updateQueryOnParamsChanges() {
+  public get isManualSortingMode() {
+    return this.wpTableSortBy.isManualSortingMode;
+  }
+
+  public get paginationInfoText() {
+    if (this.isManualSortingMode && (this.currentQuery.results.count < this.currentQuery.results.total)) {
+      return I18n.t('js.work_packages.limited_results',
+                    {count: this.currentQuery.results.count});
+    } else {
+      return null;
+    }
+  }
+
+protected updateQueryOnParamsChanges() {
     // Listen for param changes
     this.removeTransitionSubscription = this.$transitions.onSuccess({}, (transition):any => {
       let options = transition.options();

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -90,8 +90,11 @@
 
       <!-- Footer -->
       <div class="work-packages-split-view--tabletimeline-footer hide-when-print"
-           *ngIf="tableInformationLoaded && showPagination">
-        <wp-table-pagination></wp-table-pagination>
+           *ngIf="tableInformationLoaded">
+        <wp-table-pagination [showPerPage]="!isManualSortingMode"
+                             [showPageSelections]="!isManualSortingMode"
+                             [infoText]="paginationInfoText">
+        </wp-table-pagination>
       </div>
     </div>
 

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -91,10 +91,7 @@
       <!-- Footer -->
       <div class="work-packages-split-view--tabletimeline-footer hide-when-print"
            *ngIf="tableInformationLoaded">
-        <wp-table-pagination [showPerPage]="!isManualSortingMode"
-                             [showPageSelections]="!isManualSortingMode"
-                             [infoText]="paginationInfoText">
-        </wp-table-pagination>
+        <wp-table-pagination></wp-table-pagination>
       </div>
     </div>
 

--- a/spec/features/work_packages/pagination_spec.rb
+++ b/spec/features/work_packages/pagination_spec.rb
@@ -29,11 +29,10 @@
 require 'spec_helper'
 
 RSpec.feature 'Work package pagination', js: true do
-
   let(:admin) { FactoryBot.create(:admin) }
-  let(:project) {
+  let(:project) do
     FactoryBot.create(:project, name: 'project1', identifier: 'project1')
-  }
+  end
 
   shared_examples_for 'paginated work package list' do
     let!(:work_package_1) { FactoryBot.create(:work_package, project: project) }

--- a/spec/features/work_packages/sorting/manual_sorting_spec.rb
+++ b/spec/features/work_packages/sorting/manual_sorting_spec.rb
@@ -52,6 +52,7 @@ describe 'Manual sorting of WP table', type: :feature, js: true do
   let(:sort_by) { ::Components::WorkPackages::SortBy.new }
   let(:hierarchies) { ::Components::WorkPackages::Hierarchies.new }
   let(:dialog) { ::Components::ConfirmationDialog.new }
+  let(:pagination) { ::Components::TablePagination.new }
 
   def expect_query_order(query, expected)
     retry_block do
@@ -100,9 +101,12 @@ describe 'Manual sorting of WP table', type: :feature, js: true do
         raise "Query was not yet saved." unless query.name == 'My sorted query'
       end
 
-
       # Expect sorted 1 and 2, the rest is not positioned
       expect_query_order(query, [work_package_1, work_package_4].map(&:id))
+
+      # Pagination information is shown but no per page options
+      pagination.expect_range(1, 4, 4)
+      pagination.expect_no_per_page_options
     end
 
     it 'can drag an element into a hierarchy' do
@@ -253,6 +257,9 @@ describe 'Manual sorting of WP table', type: :feature, js: true do
           raise "Expected sort_criteria to be updated to manual_sorting, was #{query.sort_criteria.inspect}"
         end
       end
+
+      pagination.expect_range(1, 4, 4)
+      pagination.expect_no_per_page_options
     end
   end
 
@@ -296,6 +303,9 @@ describe 'Manual sorting of WP table', type: :feature, js: true do
       query = Query.last
       expect(query.name).to eq 'Manual sorted query'
       expect_query_order(query, [work_package_1.id, work_package_3.id, work_package_2.id])
+
+      pagination.expect_range(1, 4, 4)
+      pagination.expect_no_per_page_options
     end
 
     it 'does not loose the current order when switching to manual sorting' do

--- a/spec/support/components/table_pagination.rb
+++ b/spec/support/components/table_pagination.rb
@@ -1,0 +1,56 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Components
+  class TablePagination
+    include Capybara::DSL
+    include RSpec::Matchers
+
+    def expect_range(from, to, total)
+      within_pagination do
+        expect(page)
+          .to have_selector('.pagination--range', text: "(#{from} - #{to}/#{total})")
+      end
+    end
+
+    def expect_no_per_page_options
+      within_pagination do
+        expect(page)
+          .to have_no_selector('.pagination--options')
+      end
+    end
+
+    protected
+
+    def within_pagination
+      within('.pagination') do
+        yield
+      end
+    end
+  end
+end


### PR DESCRIPTION
The pagination now looks like this when in manual sort mode:

![image](https://user-images.githubusercontent.com/617519/65227605-3f7dc700-dac9-11e9-8771-fafb92b29791.png)

Per page options are still hidden as the user will not be able to alter the per page options.

Also removes the forcePerPageOption introduced in c2115bbc43 and 3b30a7838f when wp tables where auto calculating how many wps to display given the available height. As this is no longer necessary (4ac48a88ae) so isn't the option.

https://community.openproject.com/projects/openproject/work_packages/31097
