### PR TITLE
[30939] Avoid trying to parse string version in postgres

### DIFF
--- a/lib/open_project/database.rb
+++ b/lib/open_project/database.rb
@@ -157,14 +157,7 @@ module OpenProject
     def self.version(raw = false)
       @version ||= ActiveRecord::Base.connection.select_value('SELECT version()')
 
-      raw ? @version : @version.match(/\APostgreSQL (\S+)/i)[1]
-    end
-
-    def self.semantic_version(version_string = version)
-      Semantic::Version.new version_string
-    rescue ArgumentError
-      # Cut anything behind the -
-      Semantic::Version.new version_string.gsub(/\-.+$/, '')
+      raw ? @version : @version.match(/\APostgreSQL ([\d\.]+)/i)[1]
     end
 
     def self.numeric_version
@@ -174,7 +167,7 @@ module OpenProject
     # Return if the version of the underlying database engine is capable of TSVECTOR features, needed for full-text
     # search.
     def self.allows_tsv?
-      Gem::Version.new(OpenProject::Database.version) >= Gem::Version.new('9.5')
+      version_matches?
     end
   end
 end

--- a/spec/lib/database_spec.rb
+++ b/spec/lib/database_spec.rb
@@ -43,22 +43,6 @@ describe OpenProject::Database do
     expect(OpenProject::Database.name).to equal(:postgresql)
   end
 
-  it 'should be able to parse semantic versions' do
-    version = OpenProject::Database.semantic_version '5.7.0'
-    version2 = OpenProject::Database.semantic_version '5.5.60-0+deb8u1'
-
-    expect(version2.major).to eq 5
-    expect(version2 < version).to be_truthy
-
-    version3 = OpenProject::Database.semantic_version '10.1.26-MariaDB-0+deb9u1'
-    expect(version3.major).to eq 10
-
-    version4 = OpenProject::Database.semantic_version '5.7.23-0ubuntu0.16.04.1'
-    expect(version4.major).to eq 5
-    # Cuts the build if its invalid semver
-    expect(version4.build).to be_nil
-  end
-
   it 'should be able to use the helper methods' do
     allow(OpenProject::Database).to receive(:adapter_name).and_return 'PostgresQL'
 


### PR DESCRIPTION
We get a numeric version for comparison anyway, so use that since apparently, versions are not always semantic.

Also corrects the string regex for nicer printing, but that should no longer be used for comparsion as stated in the ticket.

https://community.openproject.com/wp/30939