### PR TITLE
[31094] Remove hidden overflow when dropdown opens

### DIFF
--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -158,15 +158,13 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   }
 
   public onOpen() {
-    setTimeout(() => {
-      jQuery(this.hiddenOverflowContainer).addClass('-hidden-overflow');
-    }, 1000);
+    jQuery(this.hiddenOverflowContainer).one('scroll', () => {
+      this._autocompleterComponent.closeSelect();
+    });
   }
 
   public onClose() {
-    setTimeout(() => {
-      jQuery(this.hiddenOverflowContainer).removeClass('-hidden-overflow');
-    }, 1000);
+    // Nothing to do
   }
 
   public onChange(value:HalResource) {


### PR DESCRIPTION
It causes the table to shift due to the removal of the scroll bar which then triggers a reflow. In many cases this takes longer than the reposition if many work packages are shown.

As a workaround for 10.0., we DO allow scrolling the outer container but close the dropdown as soon as it is being scrolled.

https://community.openproject.com/wp/31094