### PR TITLE
[31123] Only cast numeric custom values

### DIFF
--- a/app/models/custom_field/order_statements.rb
+++ b/app/models/custom_field/order_statements.rb
@@ -121,11 +121,10 @@ module CustomField::OrderStatements
     <<-SQL
       COALESCE((SELECT string_agg(co_sort.value, '.' ORDER BY co_sort.position ASC) FROM #{CustomOption.table_name} co_sort
         LEFT JOIN #{CustomValue.table_name} cv_sort
-        ON co_sort.id = CAST(cv_sort.value AS decimal(60,3))
+        ON cv_sort.value ~ '^[0-9]+$' AND co_sort.id = cv_sort.value::numeric
         WHERE cv_sort.customized_type='#{self.class.customized_class.name}'
           AND cv_sort.customized_id=#{self.class.customized_class.table_name}.id
-          AND cv_sort.custom_field_id=#{id}
-          AND cv_sort.value IS NOT NULL), '')
+          AND cv_sort.custom_field_id=#{id}), '')
     SQL
   end
 

--- a/spec/features/custom_fields/multi_value_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_value_custom_field_spec.rb
@@ -202,16 +202,16 @@ describe "multi select custom values", clear_cache: true, js: true do
         work_package2
 
         login_as(user)
-
-        wp_table.visit_query query
-        wp_table.expect_work_package_listed(work_package)
-        wp_table.expect_work_package_listed(work_package2)
       end
 
       describe 'sorting by the multi select field' do
         let(:multi_value) { true }
 
         it 'sorts as expected asc and desc' do
+          wp_table.visit_query query
+          wp_table.expect_work_package_listed(work_package)
+          wp_table.expect_work_package_listed(work_package2)
+
           expect(wp1_field.display_element).to have_text('ham')
           expect(wp1_field.display_element).to have_text('pineapple')
           expect(wp2_field.display_element).to have_text('ham')
@@ -225,6 +225,21 @@ describe "multi select custom values", clear_cache: true, js: true do
           wp_table.expect_work_package_listed(work_package2)
           wp_table.expect_work_package_order work_package, work_package2
         end
+
+        context 'when one of the custom_values is not numeric' do
+          it 'does not break the query (Regression #31123)' do
+            # Break one integer custom_value into something not castable
+            work_package2.custom_values.first.update_column(:value, 'string value')
+
+            wp_table.visit_query query
+            wp_table.expect_work_package_listed(work_package)
+            wp_table.expect_work_package_listed(work_package2)
+
+            expect(wp2_field.display_element).to have_text('string value not found')
+            expect(wp1_field.display_element).to have_text('pineapple')
+            expect(wp1_field.display_element).to have_text('ham')
+          end
+        end
       end
 
       describe 'sorting by the single select field' do
@@ -233,6 +248,10 @@ describe "multi select custom values", clear_cache: true, js: true do
         let(:work_package_options) { %w[mushrooms] } # position 4
 
         it 'sorts as expected asc and desc' do
+          wp_table.visit_query query
+          wp_table.expect_work_package_listed(work_package)
+          wp_table.expect_work_package_listed(work_package2)
+
           expect(wp2_field.display_element).to have_text('onions')
           expect(wp1_field.display_element).to have_text('mushrooms')
 


### PR DESCRIPTION
It turns out that community still has some custom values that have not been turned intocustom_options with their values a numeric reference.

This results in trying to cast string values that cannot be casted as numeric. We can avoid this without migrating all custom values again by checking their format with a regex. This is slower as executed on every sort, but will only affect multi-select list custom field sorting, which is one sort criteria on the query:

https://community.openproject.com/projects/openproject/work_packages?query_id=1910

https://community.openproject.com/wp/31123