### PR TITLE
embed UserPreferences in Configuration resource

### DIFF
--- a/docs/api/apiv3/endpoints/configuration.apib
+++ b/docs/api/apiv3/endpoints/configuration.apib
@@ -5,9 +5,13 @@ Note that there is no 1:1 relationship between this endpoint and the settings yo
 
 For now this endpoint will only allow access to settings deemed useful for a client to know in general.
 
-| Link                | Description                                      | Type          | Nullable | Supported operations |
-|:-------------------:| ------------------------------------------------ | ------------- | -------- | -------------------- |
-| self                | The configuration                                | Configuration |          | READ                 |
+As clients might rely on the combination of both, the system settings as well as the current user's preferences, the resource
+embeds the current user's preferences so client can fetch both with one request.
+
+| Link                | Description                                      | Type            | Nullable | Supported operations |
+|:-------------------:| ------------------------------------------------ | -------------   | -------- | -------------------- |
+| self                | The configuration                                | Configuration   |          | READ                 |
+| userPreferences     | The preferences of the current user              | UserPreferences |          | READ                 |
 
 ## Local Properties
 | Property                  | Description                                        | Type       | Condition                         | Supported operations |
@@ -23,7 +27,12 @@ For now this endpoint will only allow access to settings deemed useful for a cli
             {
                 "_type": "Configuration",
                 "_links": {
-                    "href": "/api/v3/configuration"
+                    "self": {
+                        "href": "/api/v3/configuration"
+                    },
+                    "userPreferences": {
+                        "href": "/api/v3/my_preferences"
+                    }
                 },
                 "maximumAttachmentFileSize": 5242880,
                 "perPageOptions": [1, 10, 100]

--- a/lib/api/v3/configuration/configuration_api.rb
+++ b/lib/api/v3/configuration/configuration_api.rb
@@ -34,7 +34,7 @@ module API
       class ConfigurationAPI < ::API::OpenProjectAPI
         resources :configuration do
           get do
-            ConfigurationRepresenter.new(Setting, current_user: current_user)
+            ConfigurationRepresenter.new(Setting, current_user: current_user, embed_links: true)
           end
         end
       end

--- a/lib/api/v3/configuration/configuration_representer.rb
+++ b/lib/api/v3/configuration/configuration_representer.rb
@@ -40,14 +40,32 @@ module API
           }
         end
 
+        link :userPreferences do
+          {
+            href: api_v3_paths.my_preferences
+          }
+        end
+
         property :maximum_attachment_file_size,
                  getter: ->(*) { attachment_max_size.to_i.kilobyte }
 
         property :per_page_options,
                  getter: ->(*) { per_page_options_array }
 
+        property :user_preferences,
+                 embedded: true,
+                 exec_context: :decorator,
+                 if: ->(*) {
+                   embed_links
+                 }
+
         def _type
           'Configuration'
+        end
+
+        def user_preferences
+          UserPreferences::UserPreferencesRepresenter.new(current_user.pref,
+                                                          current_user: current_user)
         end
       end
     end

--- a/lib/api/v3/user_preferences/user_preferences_api.rb
+++ b/lib/api/v3/user_preferences/user_preferences_api.rb
@@ -40,7 +40,6 @@ module API
           end
 
           after_validation do
-            fail ::API::Errors::Unauthenticated unless current_user.logged?
             @preferences = current_user.pref
           end
 
@@ -49,6 +48,8 @@ module API
           end
 
           patch do
+            fail ::API::Errors::Unauthenticated unless current_user.logged?
+
             representer = represent_preferences
             representer.from_hash(request_body)
 

--- a/lib/api/v3/user_preferences/user_preferences_representer.rb
+++ b/lib/api/v3/user_preferences/user_preferences_representer.rb
@@ -56,7 +56,7 @@ module API
 
         property :hide_mail
         property :time_zone,
-                 getter: -> (*) { canonical_time_zone },
+                 getter: ->(*) { canonical_time_zone },
                  render_nil: true
 
         property :warn_on_leaving_unsaved

--- a/modules/my_page/spec/features/my/assigned_to_me_spec.rb
+++ b/modules/my_page/spec/features/my/assigned_to_me_spec.rb
@@ -176,16 +176,6 @@ describe 'Assigned to me embedded query on my page', type: :feature, js: true do
     # exists as default
     assigned_area.expect_to_exist
 
-    sleep(0.5)
-
-    assigned_area.resize_to(1, 2)
-
-    sleep(0.1)
-
-    assigned_area.expect_to_span(1, 1, 2, 3)
-    # has been moved down by resizing
-    created_area.expect_to_span(2, 2, 3, 3)
-
     within assigned_area.area do
       expect(page)
         .to have_selector('.subject', text: assigned_work_package.subject)
@@ -199,5 +189,13 @@ describe 'Assigned to me embedded query on my page', type: :feature, js: true do
       expect(page)
         .to have_selector('.subject', text: assigned_work_package_2.subject)
     end
+
+    assigned_area.resize_to(1, 2)
+
+    my_page.expect_notification(message: I18n.t('js.notice_successful_update'))
+
+    assigned_area.expect_to_span(1, 1, 2, 3)
+    # has been moved down by resizing
+    created_area.expect_to_span(2, 2, 3, 3)
   end
 end

--- a/spec/requests/api/v3/configuration_resource_spec.rb
+++ b/spec/requests/api/v3/configuration_resource_spec.rb
@@ -1,0 +1,80 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 Configuration resource', type: :request do
+  include Rack::Test::Methods
+  include ::API::V3::Utilities::PathHelper
+
+  let(:user) { FactoryBot.create(:user) }
+  let(:configuration_path) { api_v3_paths.configuration }
+  subject(:response) { last_response }
+
+  before do
+    login_as(user)
+  end
+
+  describe '#GET' do
+    before do
+      get configuration_path
+    end
+
+    it 'returns 200 OK' do
+      expect(subject.status).to eq(200)
+    end
+
+    it 'returns the configuration', with_settings: { per_page_options: '3, 5, 8, 13' } do
+      expect(subject.body)
+        .to be_json_eql('Configuration'.to_json)
+        .at_path("_type")
+
+      expect(subject.body)
+        .to be_json_eql([3, 5, 8, 13].to_json)
+        .at_path('perPageOptions')
+    end
+
+    it 'embedds the current user preferences' do
+      expect(subject.body)
+        .to be_json_eql('UserPreferences'.to_json)
+        .at_path('_embedded/userPreferences/_type')
+    end
+
+    context 'for a non logged in user' do
+      it 'returns 200 OK' do
+        expect(subject.status).to eq(200)
+      end
+    end
+
+    it 'does not embed the preferences' do
+      expect(subject.body)
+        .not_to have_json_path('_embedded/user_preferences')
+    end
+  end
+end

--- a/spec/requests/api/v3/user_preferences/user_preferences_resource_spec.rb
+++ b/spec/requests/api/v3/user_preferences/user_preferences_resource_spec.rb
@@ -35,7 +35,6 @@ describe 'API v3 UserPreferences resource', type: :request do
 
   let(:user) { FactoryBot.create(:user) }
   let(:preference) { FactoryBot.create(:user_preference, user: user) }
-  let(:representer) { described_class.new(preference, current_user: user) }
   let(:preference_path) { api_v3_paths.my_preferences }
   subject(:response) { last_response }
 
@@ -51,8 +50,13 @@ describe 'API v3 UserPreferences resource', type: :request do
 
     context 'when not logged in' do
       let(:user) { User.anonymous }
-      it 'should respond with 401' do
-        expect(subject.status).to eq(401)
+
+      it 'should respond with 200' do
+        expect(subject.status).to eq(200)
+      end
+
+      it 'should respond with a UserPreferences representer' do
+        expect(subject.body).to be_json_eql('UserPreferences'.to_json).at_path('_type')
       end
     end
 
@@ -60,6 +64,7 @@ describe 'API v3 UserPreferences resource', type: :request do
       it 'should respond with 200' do
         expect(subject.status).to eq(200)
       end
+
       it 'should respond with a UserPreferences representer' do
         expect(subject.body).to be_json_eql('UserPreferences'.to_json).at_path('_type')
       end


### PR DESCRIPTION
Supports https://community.openproject.com/projects/openproject/work_packages/31089 by embedding the user preferences in the Configuration resource.

That way, clients (i.e. the front end) will only have to fetch one resource to get the system settings (e.g. pagination options) combined with the user preferences (e.g. time zone and comment sort order).

The PR does not touch the front end so the configuration service does not yet make use of the additional information and gon is still required.