### PR TITLE
[31161] Reorder widgets after saving in service

### DIFF
--- a/frontend/src/app/modules/boards/board/board.component.ts
+++ b/frontend/src/app/modules/boards/board/board.component.ts
@@ -106,7 +106,6 @@ export class BoardComponent implements OnInit, OnDestroy {
         .save(board)
         .then(board => {
           this.inFlight = false;
-          board.sortWidgets();
           return board;
         })
         .catch((error) => {

--- a/frontend/src/app/modules/boards/board/board.service.ts
+++ b/frontend/src/app/modules/boards/board/board.service.ts
@@ -74,6 +74,7 @@ export class BoardService {
     this.reorderWidgets(board);
     return this.boardDm.save(board)
       .then(board => {
+        board.sortWidgets();
         this.boardCache.update(board);
         return board;
       });


### PR DESCRIPTION
This was added some time ago for board saving requests, which however is
not used for adding lists. This change catches all board save actions
now and reorders the widgets appropriately.

https://community.openproject.com/wp/31161