### PR TITLE
[31136] Remove visual difference between display and edit field for subject

### DIFF
--- a/app/assets/stylesheets/layout/work_packages/_details_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_details_view.sass
@@ -101,6 +101,14 @@ body.router--work-packages-split-view-new
       height: 38px
       line-height: 36px
 
+    // Style edit field to look like the display field.
+    // Thus we avoid a visual jump when editing the subject.
+    &.-active input
+      height: 34px
+      line-height: 34px
+      padding: 5px 0 5px 5px
+      font-size: 18px
+
 .work-packages--type-selector
   flex-shrink: 0
 

--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -194,6 +194,14 @@
       .wp-inline-edit--field
         height: 34px
 
+      // Style edit field to look like the display field.
+      // Thus we avoid a visual jump when editing the subject.
+      &.-active input
+        height: 36px
+        line-height: 36px
+        padding: 5px 0 5px 5px
+        font-size: 20px
+
   > .toolbar-container
     margin: 10px 0 5px 0
     padding-right: 15px


### PR DESCRIPTION
For the work package fields we implemented a visual change a while ago, so that edit and display fields look the same. Thus there is no visual jump when editing a WP field. This PR does the same for the WP subject. 

This is however somehow inconsistent to how we handle headlines for example in the board view. There we use a separate component which also looks slightly different. However I think this solution is good enough for now, to create a smooth behaviour for the user. If we want to replace the edit field with the `editable-toolbar`, we can do that later.
