### PR TITLE
added hooks for user registration and first login

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -134,6 +134,8 @@ class AccountController < ApplicationController
       end
 
       self_registration!
+
+      call_hook :user_registered, { user: @user } if @user.persisted?
     end
   end
 

--- a/app/controllers/concerns/redirect_after_login.rb
+++ b/app/controllers/concerns/redirect_after_login.rb
@@ -33,6 +33,9 @@ module Concerns::RedirectAfterLogin
   def redirect_after_login(user)
     if user.first_login
       user.update_attribute(:first_login, false)
+
+      call_hook :user_first_login, { user: user }
+
       first_login_redirect
     else
       default_redirect


### PR DESCRIPTION
Adds hooks which we need for [#31018](https://community.openproject.com/projects/hubspot-integration/work_packages/31018/activity).

I have added two hooks so we can choose which we use either if we need no extra user consent (registered hook) or if we do (first login hook).

I'm using the first login as the spot because there we can be sure that a user has consented to what ever policy has been set.