### PR TITLE
Fix/unwanted filters on projects index

### DIFF
--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -122,18 +122,21 @@ module ProjectsHelper
   def allowed_filters(query)
     query
       .available_filters
-      .reject { |f| blacklisted_project_filter?(f) }
+      .select { |f| whitelisted_project_filter?(f) }
       .sort_by(&:human_name)
   end
 
-  def blacklisted_project_filter?(filter)
-    blacklist = [Queries::Projects::Filters::AncestorFilter,
-                 Queries::Projects::Filters::PrincipalFilter,
-                 Queries::Projects::Filters::IdFilter,
-                 Queries::Projects::Filters::ParentFilter]
-    blacklist << Queries::Filters::Shared::CustomFields::Base unless EnterpriseToken.allows_to?(:custom_fields_in_projects_list)
+  def whitelisted_project_filter?(filter)
+    whitelist = [
+      Queries::Projects::Filters::ActiveOrArchivedFilter,
+      Queries::Projects::Filters::CreatedOnFilter,
+      Queries::Projects::Filters::LatestActivityAtFilter,
+      Queries::Projects::Filters::NameAndIdentifierFilter,
+      Queries::Projects::Filters::TypeFilter
+    ]
+    whitelist << Queries::Filters::Shared::CustomFields::Base if EnterpriseToken.allows_to?(:custom_fields_in_projects_list)
 
-    blacklist.detect { |clazz| filter.is_a? clazz }
+    whitelist.detect { |clazz| filter.is_a? clazz }
   end
 
   def no_projects_result_box_params

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -127,7 +127,10 @@ module ProjectsHelper
   end
 
   def blacklisted_project_filter?(filter)
-    blacklist = [Queries::Projects::Filters::AncestorFilter]
+    blacklist = [Queries::Projects::Filters::AncestorFilter,
+                 Queries::Projects::Filters::PrincipalFilter,
+                 Queries::Projects::Filters::IdFilter,
+                 Queries::Projects::Filters::ParentFilter]
     blacklist << Queries::Filters::Shared::CustomFields::Base unless EnterpriseToken.allows_to?(:custom_fields_in_projects_list)
 
     blacklist.detect { |clazz| filter.is_a? clazz }

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -790,5 +790,15 @@ describe 'Projects index page',
                                child_project_z,
                                public_project)
     end
+
+    feature 'blacklisted filters' do
+      scenario 'are not visible' do
+        load_and_open_filters admin
+
+        expect(page).to_not have_select('add_filter_select', with_options: ["Principal"])
+        expect(page).to_not have_select('add_filter_select', with_options: ["ID"])
+        expect(page).to_not have_select('add_filter_select', with_options: ["Subproject of"])
+      end
+    end
   end
 end


### PR DESCRIPTION
Prevents filters unfit to be displayed on the project index page from being displayed. In particular, filters like the principal filter, whose potential values consist of every user of the project would otherwise lead to a very long options list which crashes the browser.

To prevent the same from happening again unwillingly, the blacklist is turned into a whitelist. 

Project custom fields of type user can still lead to a very long list of options. As this is an enterprise feature, I didn't want to restrict its usage.

https://community.openproject.com/projects/openproject/work_packages/31202