### PR TITLE
[31204] Clicking back button from full-view created work package leads to full-view-create

### DIFF
--- a/frontend/src/app/modules/common/back-routing/back-routing.service.ts
+++ b/frontend/src/app/modules/common/back-routing/back-routing.service.ts
@@ -46,7 +46,9 @@ export class BackRoutingService {
   }
 
   public goBack(preferListOverSplit:boolean = false) {
-    if (!this.backRoute) {
+    // Default: back to list
+    // When coming from a deep link or a create form
+    if (!this.backRoute || this.backRoute.name.includes('new')) {
       this.$state.go('work-packages.list', this.$state.params);
     } else {
       if (this.keepTab.isDetailsState(this.backRoute.parent)) {


### PR DESCRIPTION
Do not go back to create form on WPBack button

https://community.openproject.com/projects/openproject/work_packages/31204/activity