### PR TITLE
Fix/attachments on rails pages

### DIFF
--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
@@ -133,8 +133,7 @@
     </div>
 
     <ndc-dynamic [ndcDynamicComponent]="attachmentListComponent()"
-                 [ndcDynamicInputs]="{ resource: workPackage,
-                                       selfDestroy: true }">
+                 [ndcDynamicInputs]="{ resource: workPackage }">
     </ndc-dynamic>
 
     <ndc-dynamic [ndcDynamicComponent]="attachmentUploadComponent()"

--- a/frontend/src/app/modules/attachments/attachment-list/attachment-list-item.component.ts
+++ b/frontend/src/app/modules/attachments/attachment-list/attachment-list-item.component.ts
@@ -41,7 +41,7 @@ export class AttachmentListItemComponent {
   @Input() public resource:HalResource;
   @Input() public attachment:any;
   @Input() public index:any;
-  @Input() public selfDestroy?:boolean;
+  @Input() destroyImmediately:boolean = true;
 
   @Output() public removeAttachment = new EventEmitter<void>();
 
@@ -112,7 +112,7 @@ export class AttachmentListItemComponent {
 
     this.removeAttachment.emit();
 
-    if (!!this.selfDestroy) {
+    if (this.destroyImmediately) {
       this
         .resource
         .removeAttachment(this.attachment);

--- a/frontend/src/app/modules/attachments/attachment-list/attachment-list.html
+++ b/frontend/src/app/modules/attachments/attachment-list/attachment-list.html
@@ -4,7 +4,7 @@
     <attachment-list-item [attachment]="attachment"
                           [resource]="resource"
                           [index]="i"
-                          [selfDestroy]="selfDestroy"
+                          [destroyImmediately]="destroyImmediately"
                           (removeAttachment)="removeAttachment(attachment)">
     </attachment-list-item>
   </ul>

--- a/frontend/src/app/modules/attachments/attachments.component.ts
+++ b/frontend/src/app/modules/attachments/attachments.component.ts
@@ -42,14 +42,11 @@ import {filter, takeUntil} from 'rxjs/operators';
 })
 export class AttachmentsComponent implements OnInit, OnDestroy {
   @Input('resource') public resource:HalResource;
-  @Input() public selfDestroy:boolean = false;
 
   public $element:JQuery;
   public allowUploading:boolean;
   public destroyImmediately:boolean;
   public text:any;
-  public $formElement:JQuery;
-  public initialAttachments:HalResource[];
 
   constructor(protected elementRef:ElementRef,
               protected I18n:I18nService,
@@ -78,17 +75,11 @@ export class AttachmentsComponent implements OnInit, OnDestroy {
       this.destroyImmediately = true;
     }
 
-    this.setupAttachmentDeletionCallback();
     this.setupResourceUpdateListener();
   }
 
-  public setupAttachmentDeletionCallback() {
-    this.memoizeCurrentAttachments();
-
-    this.$formElement = this.$element.closest('form');
-    this.$formElement.on('submit.attachment-component', () => {
-      this.destroyRemovedAttachments();
-    });
+  ngOnDestroy():void {
+    // nothing to do
   }
 
   public setupResourceUpdateListener() {
@@ -99,44 +90,13 @@ export class AttachmentsComponent implements OnInit, OnDestroy {
       )
       .subscribe((newResource:HalResource) => {
         this.resource = newResource || this.resource;
-
-        if (this.destroyImmediately) {
-          this.destroyRemovedAttachments();
-          this.memoizeCurrentAttachments();
-        }
       });
-  }
-
-  ngOnDestroy() {
-    this.$formElement.off('submit.attachment-component');
   }
 
   // Only show attachment list when allow uploading is set
   // or when at least one attachment exists
   public showAttachments() {
     return this.allowUploading || _.get(this.resource, 'attachments.count', 0) > 0;
-  }
-
-  private destroyRemovedAttachments() {
-    if (this.selfDestroy) {
-      return;
-    }
-
-    let missingAttachments = _.differenceBy(this.initialAttachments,
-      this.resource.attachments.elements,
-      (attachment:HalResource) => attachment.id);
-
-    if (missingAttachments.length) {
-      missingAttachments.forEach((attachment) => {
-        this
-          .resource
-          .removeAttachment(attachment);
-      });
-    }
-  }
-
-  private memoizeCurrentAttachments() {
-    this.initialAttachments = _.clone(this.resource.attachments.elements);
   }
 }
 

--- a/frontend/src/app/modules/attachments/attachments.html
+++ b/frontend/src/app/modules/attachments/attachments.html
@@ -5,7 +5,7 @@
   <div id="attachments_fields">
     <attachment-list *ngIf="resource.attachments"
                      [resource]="resource"
-                     [selfDestroy]="selfDestroy">
+                     [destroyImmediately]="destroyImmediately">
     </attachment-list>
     <attachments-upload [resource]="resource"
                         class="hide-when-print"

--- a/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.html
+++ b/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.html
@@ -29,7 +29,6 @@
     </edit-form-portal>
     <attachments *ngIf="active"
                  [resource]="resource.grid"
-                 [selfDestroy]="true"
                  data-allow-uploading="true">
     </attachments>
 

--- a/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.ts
+++ b/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.ts
@@ -63,10 +63,11 @@ export class WidgetCustomTextComponent extends AbstractWidgetComponent implement
       return;
     }
 
-    // load the attachments so that they are displayed in the list;
-    this.resource.grid.updateAttachments();
-
-    this.handler.activate();
+    // Load the attachments so that they are displayed in the list.
+    // Once that is done, we can show the edit form.
+    this.resource.grid.updateAttachments().then(() => {
+      this.handler.activate();
+    });
   }
 
   public get placeholderText() {

--- a/frontend/src/app/modules/hal/resources/mixins/attachable-mixin.ts
+++ b/frontend/src/app/modules/hal/resources/mixins/attachable-mixin.ts
@@ -110,7 +110,7 @@ export function Attachable<TBase extends Constructor<HalResource>>(Base:TBase) {
     }
 
     /**
-     * Get updated attachments and activities from the server and push the state
+     * Get updated attachments from the server and push the state
      *
      * Return a promise that returns the attachments. Reject, if the work package has
      * no attachments.


### PR DESCRIPTION
Fixes deleting attachments on classic/rails based views. If there is a form, the attachments are not removed right away but rather the attachments are deleted once the form is submitted. In case there is no form, the attachments are deleted right away.

For wiki pages, this means that when the page is in edit mode, the attachments are only actually deleted once the user presses "Save". When the page is in show mode, the attachment is deleted right away.

The PR also ensures the attachments are loaded for the custom field component before the attachment list component is opened.

https://community.openproject.com/projects/openproject/work_packages/31126