### PR TITLE
prevent invalid resizes on grid

### DIFF
--- a/frontend/src/app/modules/grids/grid/resize.service.ts
+++ b/frontend/src/app/modules/grids/grid/resize.service.ts
@@ -39,8 +39,24 @@ export class GridResizeService {
     this.resizedArea = resizedArea;
 
     let resizeTargets = this.layout.gridAreas.filter((area) => {
-      return area.startRow >= this.placeholderArea!.startRow &&
-        area.startColumn >= this.placeholderArea!.startColumn;
+      // All areas on the same row which are after the current column are valid targets.
+      let sameRow = area.startRow === this.placeholderArea!.startRow &&
+                     area.endRow === this.placeholderArea!.endRow &&
+                     area.startColumn >= this.placeholderArea!.startColumn;
+
+      // Areas that are on higher (number, they are printed below) rows
+      // are allowed as long as there is guaranteed to always be one widget
+      // before or after the resized to area.
+      let higherRow = area.startRow > this.placeholderArea!.startRow &&
+                      area.startColumn >= this.placeholderArea!.startColumn &&
+                      this.layout.widgetAreas.some((fixedArea) => {
+                        return fixedArea.startRow === area.startRow &&
+                        // before
+                        (fixedArea.endColumn <= this.placeholderArea!.startColumn ||
+                          // after
+                          fixedArea.startColumn >= area.endColumn);
+                      });
+       return sameRow || higherRow;
     });
 
     this.targetIds = resizeTargets

--- a/modules/overviews/spec/features/managing_overview_page_spec.rb
+++ b/modules/overviews/spec/features/managing_overview_page_spec.rb
@@ -100,7 +100,7 @@ describe 'Overview page managing', type: :feature, js: true, with_mail: false do
     table_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(5)')
     table_area.expect_to_span(1, 1, 2, 2)
 
-    table_area.resize_to(2, 2)
+    table_area.resize_to(1, 2)
 
     overview_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
 


### PR DESCRIPTION
Prevent resizing a widget to an area which later on would lead to that same area being squashed on the basis of not having a widget start within that row. By that, inconsistent row heights as described in https://community.openproject.com/projects/openproject/work_packages/31048 are prevented.

Does not alter the design of the resized element.  