### PR TITLE
Remove from documentation misleading traces of MySQL

### DIFF
--- a/docs/development/development-environment-osx.md
+++ b/docs/development/development-environment-osx.md
@@ -3,7 +3,6 @@
 To develop OpenProject a setup similar to that for using OpenProject in production is needed.
 
 This guide assumes that you have a Mac OS Xinstallation installation with administrative rights. 
-OpenProject will be installed with a PostgreSQL database. This guide will work analogous with a MySQL installation, though. 
 
 **Please note**: This guide is NOT suitable for a production setup, but only for developing with it!
 
@@ -55,7 +54,7 @@ You also need to install [bundler](https://github.com/bundler/bundler/), the rub
 
 ## Setup PostgreSQL database
 
-Next, install a PostgreSQL database. If you wish to use a MySQL database instead and have installed one, skip these steps.
+Next, install a PostgreSQL database.
 
 ```bash
 # Install postgres database
@@ -162,8 +161,6 @@ test:
   <<: *default
   database: openproject_test
 ```
-
-**NOTE:** If you want to use MySQL instead and have a database installed, simply use the MySQL section of the exemplary `database.yml.example` configuration file.
 
 ## Finish the Installation of OpenProject
 

--- a/docs/installation/docker/README.md
+++ b/docs/installation/docker/README.md
@@ -135,16 +135,10 @@ my/apache2/conf:/etc/apache2`. This would entirely replace the configuration
 we're using.
 
 
-* Can I use an external (MySQL or PostgreSQL) database?
+* Can I use an external PostgreSQL database?
 
-Yes. You can simply pass a custom `DATABASE_URL` environment variable on the
-command-line, which could point to an external database. You can even choose to
-use MySQL instead of PostgreSQL if you wish. Here is how you would do it:
-
-    docker run -d ... -e DATABASE_URL=mysql2://user:pass@host:port/dbname openproject/community:8
-
-The container will make sure that the database gets the migrations and demo
-data as well.
+Yes. You can simply pass a custom DATABASE_URL` environment variable on the
+command-line, which could point to an external database. 
 
 * I don't want the all-in-one installation. Can I still use the image to launch a specific process?
 

--- a/docs/installation/manual/README.md
+++ b/docs/installation/manual/README.md
@@ -58,7 +58,7 @@ sudo passwd openproject #(enter desired password)
 
 ## Installation of PostgreSQL
 
-We recommend you use PostgreSQL to serve OpenProject. We require PostgreSQL version of at least 9.5. Please check https://www.postgresql.org/download/ if your distributed package is too old.
+PostgreSQL is from version 10 of OpenProject the only available database to serve OpenProject. The rationales are explained here: https://www.openproject.org/deprecating-mysql-support/ . We require PostgreSQL version of at least 9.5. Please check https://www.postgresql.org/download/ if your distributed package is too old.
 
 ```bash
 [root@host] apt-get install postgresql postgresql-contrib libpq-dev
@@ -88,59 +88,6 @@ Lastly, exit the system user
 ```bash
 [postgres@host] exit
 # You will be root again now.
-```
-
-### Using MySQL instead
-
-We recommend against using MySQL. If you have to use MySQL instead, please ensure a version of >= 5.7 
-(MariaDB version >= 10.2) as it supports special characters such as emojis (emoticons) out of the box.
-
-If your Linux distribution only provides older versions of MySQL it is worth considering
-[adding MySQL as an `apt` source](https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/).
-
-Once you have your `apt` sources nicely set up install the packages.
-
-```bash
-[root@host] apt-get install mysql-server libmysqlclient-dev mysql-client
-```
-
-During the installation you will be asked to set the root password.
-
-
-We use the following command to open a `mysql` console and create
-the OpenProject database.
-
-```bash
-[root@host] mysql -uroot -p
-```
-
-You may replace the string `openproject` with the desired username and
-database name. The password `my_password` should definitely be changed.
-
-**On MySQL version 5.7 (MariaDB 10.2) or greater (recommended)**
-
-```sql
-mysql> CREATE DATABASE openproject CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-```
-
-**On MySQL version 5.6 or older (not recommended)**
-
-(!!) No support for emojis (emoticons). See above! If you have to use
-5.6 or older and you need to support special unicode characters you can
-get there but we don't provide the instructions here as it would bloat
-this manual.  
-
-```sql
-mysql> CREATE DATABASE openproject CHARACTER SET utf8;
-```
-
-**Continue For all MySQL versions**
-
-```sql
-mysql> CREATE USER 'openproject'@'localhost' IDENTIFIED BY 'my_password';
-mysql> GRANT ALL PRIVILEGES ON openproject.* TO 'openproject'@'localhost';
-mysql> FLUSH PRIVILEGES;
-mysql> QUIT
 ```
 
 ## Installation of Ruby
@@ -209,8 +156,7 @@ with OpenProject. For more information, see https://github.com/opf/openproject.
 # Ensure rubygems is up-to-date for bundler 2
 [openproject@host] gem update --system
 [openproject@host] gem install bundler
-# Replace mysql with postgresql if you had to install MySQL
-[openproject@host] bundle install --deployment --without mysql2 sqlite development test therubyracer docker
+[openproject@host] bundle install --deployment --without sqlite development test therubyracer docker
 [openproject@host] npm install
 ```
 
@@ -236,54 +182,6 @@ production:
   username: openproject
   password: openproject
 ```
-
-** MySQL installation: version 5.7 (MariaDB 10.2) or greater (recommended)**
-
-The encoding should be set to `utf8mb4` as we created the DB with that encoding
-a few steps ago.
-
-```yaml
-production:
-  adapter: mysql2
-  database: openproject
-  host: localhost
-  username: openproject
-  password: my_password
-  encoding: utf8mb4
-
-development:
-  adapter: mysql2
-  database: openproject
-  host: localhost
-  username: openproject
-  password: my_password
-  encoding: utf8mb4
-```
-
-**MySQL installation: version 5.6 or older (not recommended)**
-
-The encoding should be set to `utf8` as we created the DB with that encoding a
-few steps ago.
-
-```yaml
-production:
-  adapter: mysql2
-  database: openproject
-  host: localhost
-  username: openproject
-  password: my_password
-  encoding: utf8
-
-development:
-  adapter: mysql2
-  database: openproject
-  host: localhost
-  username: openproject
-  password: my_password
-  encoding: utf8
-```
-
-Next we configure email notifications (this example uses a gmail account) by creating the `configuration.yml` in config directory.
 
 ```bash
 [openproject@host] cp config/configuration.yml.example config/configuration.yml

--- a/docs/installation/packaged/0-preparation.md
+++ b/docs/installation/packaged/0-preparation.md
@@ -21,8 +21,8 @@ The package will set up:
 * Apache 2 (web server) – this component provides the external interface,
   handles SSL termination (if SSL is used) and distributes/forwards web
 requests to the Unicorn processes.
-* MySQL (database management system) – this component is used to store and
-  retrieve data. We do support PostgreSQL as well, but it is not part of the automatic wizard. To configure this instead, see below.
+* PostgreSQL (database management system) – this component is used to store and
+  retrieve data.
 * Unicorn (application server) – this component hosts the actual application.
   By default, there is two unicorn processes running in parallel on the app
 server machine.

--- a/docs/installation/packaged/2-configuration.md
+++ b/docs/installation/packaged/2-configuration.md
@@ -286,7 +286,7 @@ You can list all of the environment variables accessible to the application by r
 
     sudo openproject config
     # this will return something like:
-    DATABASE_URL=mysql2://openproject:9ScapYA1MN7JQrPR7Wkmp7y99K6mRHGU@127.0.0.1:3306/openproject
+    DATABASE_URL=postgresql://openproject:9ScapYA1MN7JQrPR7Wkmp7y99K6mRHGU@127.0.0.1/openproject
     SECRET_TOKEN=c5aa99a90f9650404a885cf5ec7c28f7fe1379550bb811cb0b39058f9407eaa216b9b2b22d27f58fb15ac21adb3bd16494ebe89e39ec225ef4627db048a12530
     ADMIN_EMAIL=mail@example.com
     EMAIL_DELIVERY_METHOD=smtp

--- a/docs/installation/packaged/4-faq.md
+++ b/docs/installation/packaged/4-faq.md
@@ -28,7 +28,7 @@ Yes, but you will lose the ability to enable Git/SVN repository integration. Not
 
 ### Can I use MySQL instead of PostgreSQL?
 
-OpenProject has traditionally supported both MySQL and PostgreSQL, but in order to optimize for performance and SQL functionality, it is unfeasible to support both DBMS that are becoming more and more disjunct when trying to use more modern SQL features. This shift has started some years ago when full-text search was added for PostgreSQL, but at  the time MySQL did not yet support it - and as of yet many distributions still do not support MySQL 8 natively.
+Briefly: no. OpenProject has traditionally supported both MySQL and PostgreSQL, but in order to optimize for performance and SQL functionality, it is unfeasible to support both DBMS that are becoming more and more disjunct when trying to use more modern SQL features. This shift has started some years ago when full-text search was added for PostgreSQL, but at  the time MySQL did not yet support it - and as of yet many distributions still do not support MySQL 8 natively.
 
 This led us to the path of removing support in the upcoming stable releases of OpenProject in order to focus on these goals. [Please see our blog post on the matter for additional notes](https://www.openproject.org/deprecating-mysql-support/).
 

--- a/docs/operations/backup/manual/backup.md
+++ b/docs/operations/backup/manual/backup.md
@@ -12,7 +12,7 @@ Execute the following command in a shell in the directory where OpenProject is i
 RAILS_ENV=production bundle exec rake backup:database:create
 ```
 
-The command will create dump of your database which can be found at `OPENPROJECT_DIRECTORY/backup/openproject-production-db-<DATE>.sql` (for MySQL) or `OPENPROJECT_DIRECTORY/backup/openproject-production-db-<DATE>.backup` (for PostgreSQL).
+The command will create dump of your database which can be found at `OPENPROJECT_DIRECTORY/backup/openproject-production-db-<DATE>.backup`.
 
 Optionally, you can specify the path of the backup file. Therefore you have to replace the `/path/to/file.backup` with the path of your choice
 
@@ -48,7 +48,7 @@ production:
   min_messages: warning
 ```
 
-Locate the database entry for your production database. If your adapter is postgresql, then you have a PostgreSQL database. If it is mysql2, you use a MySQL database. Now follow the steps for your database adapter.
+Locate the database entry for your production database.
 
 #### PostgreSQL
 You can backup your PostgreSQL database with the `pg_dump` command and restore backups with the `pg_restore` command. (There might be other (and more convenient) tools, like pgAdmin, depending on your specific setup.)
@@ -72,26 +72,6 @@ pg_restore --clean --no-owner --single-transaction
 ```
 
 Consult the man page of `pg_restore` for more advanced parameters, if necessary.
-
-#### MySQL
-You can backup your MySQL database for example with the mysqldump command and restore backups with the mysql command line client. (There might be other (and more convenient) tools, like phpMyAdmin, adminer, or other tools, depending on your specific setup.)
-
-An example backup command with `mysqldump` looks like this:
-
-```bash
-mysqldump --single-transaction --add-drop-table --add-locks --result-file=/path/to/your/backup/file.sql --host=HOST --user=MYSQL_USER --password DATABASE_NAME
-```
-
-Please, replace the path to your backup file, the MySQL username, host and database name with your actual data. You can find all relevant information in the `database.yml` file.
-
-Consult the man page of `mysqldump` for more advanced parameters, if necessary.
-
-The database dump can be restored similarly with `mysql` (on a \*nix compatible shell):
-
-```bash
-mysql --host=HOST --user=MYSQL_USER --password DATABASE_NAME < /path/to/your/backup/file.sql
-```
-Consult the man page of mysql for more advanced parameters, if necessary.
 
 ## Backup your Configuration Files
 Please make sure to create a backup copy of at least the following configuration files (all listed as a relative path from the OpenProject installation directory):

--- a/docs/operations/backup/packaged/backup.md
+++ b/docs/operations/backup/packaged/backup.md
@@ -30,14 +30,14 @@ The command will create backup files in the following location on your system
 /var/db/openproject/backup
 ```
 
-The content of that directory should look very similar to the following (depending on your used database,  you will see either a `mysql-dump-<date>.sql.gz` or a `postgresql-dump-<pgdump>` file).
+The content of that directory should look very similar to the following (depending on your used database,  you will see a postgresql-dump-<pgdump>` file).
 
 ```bash
 root@test-packager-backup:/opt/openproject# ls -l /var/db/openproject/backup/
 total 24
 -rw-r----- 1 openproject openproject  117 Apr  8 09:55 attachments-20150408095521.tar.gz
 -rw-r----- 1 openproject openproject  667 Apr  8 09:55 conf-20150408095521.tar.gz
--rw-r----- 1 openproject openproject 8298 Apr  8 09:55 mysql-dump-20150408095521.sql.gz
+-rw-r----- 1 openproject openproject 8298 Apr  8 09:55 postgresql-dump-20150408095521.sql.gz
 -rw-r----- 1 openproject openproject  116 Apr  8 09:55 svn-repositories-20150408095521.tar.gz
 ```
 
@@ -65,7 +65,7 @@ installation. This setting can be seen by running:
 
 ```
 openproject config:get DATABASE_URL
-#=> e.g.: mysql2://dbusername:dbpassword@dbhost:dbport/dbname
+#=> e.g.: postgresql://dbusername:dbpassword@dbhost:dbport/dbname
 ```
 
 
@@ -84,16 +84,3 @@ pg_restore -h <dbhost> -u <dbuser> -W <dbname>
 
 First the dump has to be extracted (unzipped) and then restored. The command
 used should look very similar to this:
-
-#### MySQL
-
-
-
-To restore the MySQL dump it is recommended to use the `mysql` command line client.
-
-First the dump has to be extracted (unzipped) and then restored. The command
-used should look very similar to this:
-
-```bash
-zcat mysql-dump-20150408095521.sql.gz | mysql -u <dbuser> -h <dbhost> -p <dbname>
-```

--- a/docs/operations/migrating/packaged/packaged-migrating.md
+++ b/docs/operations/migrating/packaged/packaged-migrating.md
@@ -10,7 +10,7 @@ To create a dump of all your data in the old installation, please follow our [ba
 
 This guide should leave you with a set of archives that you should manually move to your new environment:
 
-- **Database**: mysql-dump-\<timestamp>.sql.gz or postgresql-dump\<timestamp>.pgdump
+- **Database**: postgresql-dump\<timestamp>.pgdump
 - **Attachments**: attachments-\<timestamp>.tar.gz
 - **Custom env configuration**: conf-\<timestamp>.tar.gz
 - **Repositories**: svn- and git-\<timestamp>.tar.gz
@@ -53,7 +53,6 @@ To read the values from the old installation, you can execute the following comm
 
 ```bash
 openproject config:get DATABASE_URL
-#=> e.g.: mysql2://dbusername:dbpassword@dbhost:dbport/dbname
 ```
 
 First the dump has to be extracted (unzipped) and then restored. The command used should look very similar to this:

--- a/docs/operations/upgrading/docker/upgrading.md
+++ b/docs/operations/upgrading/docker/upgrading.md
@@ -17,6 +17,12 @@ This time, it will use the new image:
 
 # Upgrade Notes
 
+## OpenProject 10.x
+
+### MySQL has been dropped from sources
+
+See below for further details.
+
 ## OpenProject 9.x
 
 ### MySQL is being deprecated

--- a/docs/operations/upgrading/packaged/upgrade-guide-legacy.md
+++ b/docs/operations/upgrading/packaged/upgrade-guide-legacy.md
@@ -85,10 +85,6 @@ If you used autoinstall, the database name and database user name should equal `
 
     sudo openproject-ce config:get DATABASE_URL
    
-Which should output something of the form
-
-    mysql2://<username>:<password>@127.0.0.1:3306/<dbname>
-
 If the URI contains `openproject_ce` as the username and database name as the example above, we can simply continue.
 Otherwise, note user-, database name and password just to be sure.
 
@@ -141,30 +137,19 @@ Add the package source to your package manager, update the sources, and install 
 
 **Important:** Instead of running `openproject configure`, run `openproject reconfigure`, which will lead you through the complete wizard.
 
-In the first step *mysql/autoinstall*, select the **reuse**  option (Use an existing database).
-
-![](https://dl.dropboxusercontent.com/u/270758/op/mysql-reuse.png)
-
 Press OK for the following steps, which will simply take the existing values from your old configuration
 
- * MySQL IP or hostname
- * MySQL port
+ * PostgreSQL IP or hostname
+ * PostgreSQL port
  
-In the dialog `mysql/username`, enter `openproject_ce` if the Database URI from Step 4 contained it. If you chose a different user name in the original CE installation, it should already be set to this value.
+In the dialog `postgresql/username`, enter `openproject_ce` if the Database URI from Step 4 contained it. If you chose a different user name in the original CE installation, it should already be set to this value.
 
-![](https://dl.dropboxusercontent.com/u/270758/op/mysql-username.png)
+In the dialog `postgresql/password`, **leave the password empty**. It will use the value from your original installation. You can optionally enter the password you retrieved from the database URI from Step 4, but that should be identical.
 
-In the dialog `mysql/password`, **leave the password empty**. It will use the value from your original installation. You can optionally enter the password you retrieved from the database URI from Step 4, but that should be identical.
+And again, in the `postgresql/db_name` step,  enter `openproject_ce` if the Database URI from Step 4 contained it. If you chose a different database name in the original CE installation, it should already be set to this value.
 
-![](https://dl.dropboxusercontent.com/u/270758/op/mysql-password.png)
-
-And again, in the `mysql/db_name` step,  enter `openproject_ce` if the Database URI from Step 4 contained it. If you chose a different database name in the original CE installation, it should already be set to this value.
-
-The other installation steps (mysql/db_source_host, mysql/ssl) may again be skipped by pressing OK, as they should still contain the old values from the Community Edition.
+The other installation steps may again be skipped by pressing OK, as they should still contain the old values from the Community Edition.
 
 There will be other new steps in the installation wizard for which we will provide additional information in the packager installation guide.
 
 Once the wizard has completed, the OpenProject instance should be updated to 6.0.x while re-using your existing database.
-
-**Note:** This last step is a workaround for the package upgrading process. We are working on making this step optional.
-The workaround is necessary since since the package appname changed from `openproject-ce` to `openproject`, and the installer wizard automatically sets the database to the app name when selecting an automatic installation of MySQL. Instead, the updater should respect an existing database (user-) name in its configuration.

--- a/docs/operations/upgrading/packaged/upgrading.md
+++ b/docs/operations/upgrading/packaged/upgrading.md
@@ -10,7 +10,7 @@ running the `openproject configure` command.
 
 We try to ensure your upgrade path is as smooth as possible. This means that the below update + configure step should be the only change needed to get up to date with our packaged installation.
 
-In the event of an error during the migrations, you will still want to have a recent backup you can restore to before reaching out to us. This is especially important for MySQL installations, since it does not support transactional migrations with changes to the table schema and you will have to rollback these changes manually. For PostgreSQL, if the Rails migrations fail, all previous changes will be rolled back for you to try again, or to install the older packages.
+In the event of an error during the migrations, you will still want to have a recent backup you can restore to before reaching out to us. If the Rails migrations fails, all previous changes will be rolled back for you to try again, or to install the older packages.
 
 To perform a backup, run the following command
 
@@ -67,12 +67,9 @@ The OpenProject community installation is now using the same repository as the O
 Please update your package source according to [our Download and Installation page](https://www.openproject.org/download-and-installation/).
 You will need to replace `opf/openproject-ce` with `opf/openproject` together with a change from `stable/8` to `stable/9` in order to perform the update.
 
-### MySQL is being deprecated
+### MySQL is deprecated
 
-OpenProject 9.0. is deprecating MySQL support. You can expect full MySQL support for the course of 9.0 releases, but we
-are likely going to be dropping MySQL completely in one of the following releases.
-
-For more information regarding motivation behind this and migration steps, please see https://www.openproject.org/deprecating-mysql-support/
+OpenProject 9.0. has deprecated MySQL support and intagration since version 10. For more information regarding motivation behind this and migration steps, please see https://www.openproject.org/deprecating-mysql-support/
 In this post, you will find documentation for a mostly-automated migration script to PostgreSQL to help you get up and running with PostgreSQL.
 
 ## Upgrade steps


### PR DESCRIPTION
Associated topic : https://community.openproject.com/topics/11275?r=11287

Remove from documentation misleading traces of MySQL

This commit can be considered Hotfix, as it covers documentation bugs.
Since version stable/10, MySQL is not available anymore for installation.
However, there are plenty of traces of MySQL on the documentation itself.

The associated PR is still Requested for Comments and review, there is one
unclear point: pertinence and format of the `DATABASE_URL` env variable.

Maybe iterating to better explain globally the `openproject configure` se-
-ction, all env var indexes with explanation and location of conf files.

Tested and "compiled" successfully on my forked repo (Github display MD).