### PR TITLE
fix redirecting to overview component when project has `new` in name

### DIFF
--- a/frontend/src/app/modules/overview/openproject-overview.module.ts
+++ b/frontend/src/app/modules/overview/openproject-overview.module.ts
@@ -54,7 +54,7 @@ export function uiRouterOverviewConfiguration(uiRouter:UIRouter) {
   // cf., https://community.openproject.com/wp/29754
   uiRouter.urlService.rules
     .when(
-      new RegExp("^/projects(?!/new)/([^/]+)$"),
+      new RegExp("^/projects(?!/new$)/([^/]+)$"),
       match => `/projects/${match[1]}/`
     );
 }


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/31226