### PR TITLE
[31012] Unclear size state when resizing widget in dashboard 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ jobs:
       name: 'Prepare cache'
       script:
         # Run the dangerfile
+        - bundle show danger
         - bundle exec danger --fail-on-errors=true || travis_terminate 1;
         # Set up caching
         - bash script/ci/db_setup.sh

--- a/app/assets/stylesheets/content/_grid.sass
+++ b/app/assets/stylesheets/content/_grid.sass
@@ -67,7 +67,7 @@ $grid--widget-padding: 20px
   icon-triggered-context-menu
     visibility: hidden
 
-  &.-drop-target, &.-resize-target
+  &.-drop-target
     border-width: 1px
     border-style: solid
     border-color: $secondary-color

--- a/frontend/src/app/modules/grids/grid/grid.component.html
+++ b/frontend/src/app/modules/grids/grid/grid.component.html
@@ -6,7 +6,8 @@
   <div *ngFor="let area of layout.widgetAreas; trackBy: identifyGridArea;"
        class="grid--area -widgeted"
        [ngClass]="{'-dragged': drag.isDragged(area),
-                   '-passive': drag.isPassive(area) || resize.isPassive(area) }"
+                   '-passive': drag.isPassive(area) || resize.isPassive(area),
+                   '-resizing' : resize.isResized(area) }"
        [style.grid-row-start]="area.gridStartRow"
        [style.grid-row-end]="area.gridEndRow"
        [style.grid-column-start]="area.gridStartColumn"

--- a/frontend/src/app/modules/grids/grid/grid.component.html
+++ b/frontend/src/app/modules/grids/grid/grid.component.html
@@ -88,15 +88,6 @@
     </div>
   </div>
 
-  <!-- Grid area to visualize resizing -->
-  <div class="grid--area -resizing"
-       *ngIf="resize.placeholderArea"
-       [style.grid-row-start]="resize.placeholderArea.gridStartRow"
-       [style.grid-row-end]="resize.placeholderArea.gridEndRow"
-       [style.grid-column-start]="resize.placeholderArea.gridStartColumn"
-       [style.grid-column-end]="resize.placeholderArea.gridEndColumn">
-  </div>
-
   <!-- Grid area used as a placeholder while dragging -->
   <div *ngIf="drag.placeholderArea"
        class="grid--area -widgeted -placeholder"

--- a/frontend/src/app/modules/grids/grid/resize.service.ts
+++ b/frontend/src/app/modules/grids/grid/resize.service.ts
@@ -8,7 +8,6 @@ import {GridDragAndDropService} from "core-app/modules/grids/grid/drag-and-drop.
 
 @Injectable()
 export class GridResizeService {
-  public placeholderArea:GridWidgetArea|null;
   private resizedArea:GridWidgetArea|null;
   private targetIds:string[];
 
@@ -17,42 +16,36 @@ export class GridResizeService {
               readonly drag:GridDragAndDropService) { }
 
   public end(area:GridWidgetArea, deltas:ResizeDelta) {
-    if (!this.placeholderArea ||
-      !this.resizedArea) {
+    if (!this.resizedArea) {
       return;
     }
-
-    this.resizedArea.endRow = this.placeholderArea.endRow;
-    this.resizedArea.endColumn = this.placeholderArea.endColumn;
 
     this.layout.writeAreaChangesToWidgets();
     this.layout.cleanupUnusedAreas();
 
     this.resizedArea = null;
-    this.placeholderArea = null;
 
     this.layout.rebuildAndPersist();
   }
 
   public start(resizedArea:GridWidgetArea) {
-    this.placeholderArea = new GridWidgetArea(resizedArea.widget);
     this.resizedArea = resizedArea;
 
     let resizeTargets = this.layout.gridAreas.filter((area) => {
       // All areas on the same row which are after the current column are valid targets.
-      let sameRow = area.startRow === this.placeholderArea!.startRow &&
-                     area.endRow === this.placeholderArea!.endRow &&
-                     area.startColumn >= this.placeholderArea!.startColumn;
+      let sameRow = area.startRow === this.resizedArea!.startRow &&
+                     area.endRow === this.resizedArea!.endRow &&
+                     area.startColumn >= this.resizedArea!.startColumn;
 
       // Areas that are on higher (number, they are printed below) rows
       // are allowed as long as there is guaranteed to always be one widget
       // before or after the resized to area.
-      let higherRow = area.startRow > this.placeholderArea!.startRow &&
-                      area.startColumn >= this.placeholderArea!.startColumn &&
+      let higherRow = area.startRow > this.resizedArea!.startRow &&
+                      area.startColumn >= this.resizedArea!.startColumn &&
                       this.layout.widgetAreas.some((fixedArea) => {
                         return fixedArea.startRow === area.startRow &&
                         // before
-                        (fixedArea.endColumn <= this.placeholderArea!.startColumn ||
+                        (fixedArea.endColumn <= this.resizedArea!.startColumn ||
                           // after
                           fixedArea.startColumn >= area.endColumn);
                       });
@@ -64,8 +57,7 @@ export class GridResizeService {
   }
 
   public moving(deltas:ResizeDelta) {
-    if (!this.placeholderArea ||
-      !this.resizedArea ||
+    if (!this.resizedArea ||
       !this.layout.mousedOverArea ||
       !this.targetIds.includes(this.layout.mousedOverArea.guid)) {
       return;
@@ -73,16 +65,16 @@ export class GridResizeService {
 
     this.layout.resetAreas();
 
-    this.placeholderArea.endRow = this.layout.mousedOverArea.endRow;
-    this.placeholderArea.endColumn = this.layout.mousedOverArea.endColumn;
+    this.resizedArea.endRow = this.layout.mousedOverArea.endRow;
+    this.resizedArea.endColumn = this.layout.mousedOverArea.endColumn;
 
-    this.move.down(this.placeholderArea, this.resizedArea);
+    this.move.down(this.resizedArea, this.resizedArea);
   }
 
   public isTarget(area:GridArea) {
     let areaId = area.guid;
 
-    return this.placeholderArea && this.targetIds.includes(areaId);
+    return this.resizedArea && this.targetIds.includes(areaId);
   }
 
   public isResized(area:GridWidgetArea) {


### PR DESCRIPTION
Remove placeholder while resizing. Instead the resizing is done directly on the widget. Thus the widgets can grow/shrink while resizing.

https://community.openproject.com/projects/openproject/work_packages/31012/activity