### PR TITLE
Update manual install with new node.js version

### DIFF
--- a/docs/installation/manual/README.md
+++ b/docs/installation/manual/README.md
@@ -132,9 +132,9 @@ time to finish.
 [openproject@host] source ~/.profile
 [openproject@host] git clone git://github.com/OiNutter/node-build.git ~/.nodenv/plugins/node-build
 
-[openproject@host] nodenv install 8.12.0
+[openproject@host] nodenv install 12.11.1
 [openproject@host] nodenv rehash
-[openproject@host] nodenv global 8.12.0
+[openproject@host] nodenv global 12.11.1
 ```
 
 To check our Node installation we run `node --version`. It should output something very similar to:


### PR DESCRIPTION
Angular CLI 8.0+ requires Node.js 10.9 or greater.


$ RAILS_ENV="production" ./bin/rake assets:precompile
Linking frontend plugins
Cleaning linked target directory /home/openproject/openproject-10.0.0/frontend/src/app/modules/plugins/linked
Linking frontend of OpenProject plugin openproject-avatars to /home/openproject/openproject-10.0.0/frontend/src/app/modules/plugins/linked/openproject-avatars.
Linking frontend of OpenProject plugin openproject-costs to /home/openproject/openproject-10.0.0/frontend/src/app/modules/plugins/linked/openproject-costs.
Linking frontend of OpenProject plugin openproject-documents to /home/openproject/openproject-10.0.0/frontend/src/app/modules/plugins/linked/openproject-documents.
Regenerating frontend plugin registry /home/openproject/openproject-10.0.0/frontend/src/app/modules/plugins/linked-plugins.module.ts.
Building angular frontend
npm run build

> openproject-frontend@0.1.0 prebuild /home/openproject/openproject-10.0.0/frontend
> ./scripts/link_plugin_placeholder.js

> openproject-frontend@0.1.0 build /home/openproject/openproject-10.0.0/frontend
> ng build --prod

You are running version v8.12.0 of Node.js, which is not supported by Angular CLI 8.0+.
The official Node.js version that is supported is 10.9 or greater.

Please visit https://nodejs.org/en/ to find instructions on how to update Node.js.
npm ERR! code ELIFECYCLE
npm ERR! errno 3
npm ERR! openproject-frontend@0.1.0 build: `ng build --prod`
npm ERR! Exit status 3
npm ERR! 
npm ERR! Failed at the openproject-frontend@0.1.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/openproject/.npm/_logs/2019-10-07T09_44_09_469Z-debug.log
rake aborted!
Failed to compile angular frontend: 3
/home/openproject/openproject-10.0.0/lib/tasks/assets.rake:66:in `block (4 levels) in <top (required)>'
/home/openproject/openproject-10.0.0/lib/tasks/assets.rake:65:in `block (3 levels) in <top (required)>'
/home/openproject/openproject-10.0.0/lib/tasks/assets.rake:64:in `chdir'                                                              
/home/openproject/openproject-10.0.0/lib/tasks/assets.rake:64:in `block (2 levels) in <top (required)>'                               
Tasks: TOP => assets:precompile => assets:compile_environment => assets:prepare_op => assets:angular                                  
(See full trace by running task with --trace)