### PR TITLE
[31248] Ensure nested checkbox lists are wrapped

### DIFF
--- a/app/assets/stylesheets/content/editor/_markdown.sass
+++ b/app/assets/stylesheets/content/editor/_markdown.sass
@@ -26,10 +26,16 @@ div.wiki
 
     .task-list-item
       display: flex
+      flex-wrap: wrap
 
       input
         height: 25px
         margin-right: 3px
+
+      // Ensure nested task lists are wrapped
+      // by making nested lists 100% row width
+      ul.task-list
+        flex-basis: 100%
 
   // remove indentation of top-level task-list
   > ul.task-list


### PR DESCRIPTION
Checkbox lists were styled as `flex`, causing nested lists to be shrinked appropriately when possible.

By applying flex-basis 100% and enabling wrap, we ensure that nested lists are always wrapped in their own lines

https://community.openproject.com/wp/31248

**Before**
![Screenshot from 2019-10-14 10-23-03](https://user-images.githubusercontent.com/459462/66737656-db061b80-ee6c-11e9-8a3a-d4e10267c815.png)

**After**
![Screenshot from 2019-10-14 10-22-49](https://user-images.githubusercontent.com/459462/66737666-de010c00-ee6c-11e9-9b89-03c61d12b6ff.png)
