### PR TITLE
Feature/speedup projects index api

### DIFF
--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -50,7 +50,7 @@ class MailHandler < ActionMailer::Base
   end
 
   def self.with_options(options)
-    handler = self.new
+    handler = new
 
     handler.options = options
 
@@ -292,7 +292,7 @@ class MailHandler < ActionMailer::Base
     else
       @keywords[attr] = begin
         if (options[:override] || self.options[:allow_override].include?(attr)) &&
-          (v = extract_keyword!(plain_text_body, attr, options[:format]))
+           (v = extract_keyword!(plain_text_body, attr, options[:format]))
           v
         else
           # Return either default or nil

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -220,6 +220,7 @@ module API
         end
 
         self.to_eager_load = [:status,
+                              :parent,
                               :enabled_modules,
                               custom_values: :custom_field]
 

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -219,6 +219,9 @@ module API
           'Project'
         end
 
+        self.to_eager_load = [:status,
+                              custom_values: :custom_field]
+
         self.checked_permissions = [:add_work_packages]
       end
     end

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -220,6 +220,7 @@ module API
         end
 
         self.to_eager_load = [:status,
+                              :enabled_modules,
                               custom_values: :custom_field]
 
         self.checked_permissions = [:add_work_packages]

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -32,7 +32,11 @@ module API
       class ProjectsAPI < ::API::OpenProjectAPI
         resources :projects do
           get &::API::V3::Utilities::Endpoints::Index.new(model: Project,
-                                                          scope: -> { Project.visible(User.current).includes(:enabled_modules).includes(ProjectRepresenter.to_eager_load) })
+                                                          scope: -> {
+                                                            Project
+                                                              .visible(User.current)
+                                                              .includes(ProjectRepresenter.to_eager_load)
+                                                          })
                                                      .mount
 
           post &::API::V3::Utilities::Endpoints::Create.new(model: Project)

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -32,7 +32,7 @@ module API
       class ProjectsAPI < ::API::OpenProjectAPI
         resources :projects do
           get &::API::V3::Utilities::Endpoints::Index.new(model: Project,
-                                                          scope: -> { Project.visible(User.current).includes(:enabled_modules) })
+                                                          scope: -> { Project.visible(User.current).includes(:enabled_modules).includes(ProjectRepresenter.to_eager_load) })
                                                      .mount
 
           post &::API::V3::Utilities::Endpoints::Create.new(model: Project)

--- a/lib/api/v3/utilities/eager_loading/custom_field_accessor.rb
+++ b/lib/api/v3/utilities/eager_loading/custom_field_accessor.rb
@@ -30,18 +30,30 @@
 
 module API
   module V3
-    module Projects
-      class ProjectEagerLoadingWrapper < API::V3::Utilities::EagerLoading::EagerLoadingWrapper
-        include API::V3::Utilities::EagerLoading::CustomFieldAccessor
+    module Utilities
+      module EagerLoading
+        module CustomFieldAccessor
+          extend ActiveSupport::Concern
 
-        class << self
-          def wrap(projects)
-            custom_fields = if projects && !projects.empty?
-                              projects.first.available_custom_fields
-                            end
+          included do
+            # Because of the ruby method lookup,
+            # wrapping the work_package here and define the
+            # available_custom_fields methods on the wrapper does not suffice.
+            # We thus extend each work package.
+            def initialize(object)
+              super
+              object.extend(CustomFieldAccessorPatch)
+            end
 
-            super
-              .each { |project| project.available_custom_fields = custom_fields }
+            module CustomFieldAccessorPatch
+              def available_custom_fields
+                @available_custom_fields
+              end
+
+              def available_custom_fields=(fields)
+                @available_custom_fields = fields
+              end
+            end
           end
         end
       end

--- a/lib/api/v3/utilities/eager_loading/eager_loading_wrapper.rb
+++ b/lib/api/v3/utilities/eager_loading/eager_loading_wrapper.rb
@@ -30,18 +30,23 @@
 
 module API
   module V3
-    module Projects
-      class ProjectEagerLoadingWrapper < API::V3::Utilities::EagerLoading::EagerLoadingWrapper
-        include API::V3::Utilities::EagerLoading::CustomFieldAccessor
+    module Utilities
+      module EagerLoading
+        class EagerLoadingWrapper < SimpleDelegator
+          private_class_method :new
 
-        class << self
-          def wrap(projects)
-            custom_fields = if projects && !projects.empty?
-                              projects.first.available_custom_fields
-                            end
+          ##
+          # Workaround against warnings in flatten
+          # delegator does not forward private method #to_ary
+          def to_ary
+            __getobj__.send(:to_ary)
+          end
 
-            super
-              .each { |project| project.available_custom_fields = custom_fields }
+          class << self
+            def wrap(objects)
+              objects
+                .map { |object| new(object) }
+            end
           end
         end
       end

--- a/lib/api/v3/versions/available_projects_api.rb
+++ b/lib/api/v3/versions/available_projects_api.rb
@@ -36,7 +36,11 @@ module API
 
         resources :available_projects do
           get &::API::V3::Utilities::Endpoints::Index.new(model: Project,
-                                                          scope: -> { Project.allowed_to(User.current, :manage_versions) })
+                                                          scope: -> {
+                                                            Project
+                                                              .allowed_to(User.current, :manage_versions)
+                                                              .includes(::API::V3::Projects::ProjectRepresenter.to_eager_load)
+                                                          })
                                                      .mount
         end
       end

--- a/lib/api/v3/work_packages/eager_loading/custom_value.rb
+++ b/lib/api/v3/work_packages/eager_loading/custom_value.rb
@@ -40,7 +40,7 @@ module API
           end
 
           def self.module
-            CustomFieldAccessor
+            ::API::V3::Utilities::EagerLoading::CustomFieldAccessor
           end
 
           private
@@ -196,31 +196,6 @@ module API
                 by_type_hash[type_id] = Set.new
               end
             end
-          end
-        end
-
-        module CustomFieldAccessor
-          extend ActiveSupport::Concern
-
-          # Because of the ruby method lookup,
-          # wrapping the work_package here and define the
-          # available_custom_fields methods on the wrapper does not suffice.
-          # We thus extend each work package.
-          included do
-            def initialize(work_package)
-              super
-              work_package.extend(CustomFieldAccessorPatch)
-            end
-          end
-        end
-
-        module CustomFieldAccessorPatch
-          def available_custom_fields
-            @available_custom_fields
-          end
-
-          def available_custom_fields=(fields)
-            @available_custom_fields = fields
           end
         end
       end

--- a/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
+++ b/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
@@ -31,18 +31,9 @@
 module API
   module V3
     module WorkPackages
-      class WorkPackageEagerLoadingWrapper < SimpleDelegator
-        private_class_method :new
-
+      class WorkPackageEagerLoadingWrapper < API::V3::Utilities::EagerLoading::EagerLoadingWrapper
         def wrapped?
           true
-        end
-
-        ##
-        # Workaround against warnings in flatten
-        # delegator does not forward private method #to_ary
-        def to_ary
-          __getobj__.send(:to_ary)
         end
 
         class << self

--- a/spec_legacy/unit/mail_handler_spec.rb
+++ b/spec_legacy/unit/mail_handler_spec.rb
@@ -38,45 +38,6 @@ describe MailHandler, type: :model do
     allow(Setting).to receive(:notified_events).and_return(Redmine::Notifiable.all.map(&:name))
   end
 
-  it 'should add work package' do
-    # This email contains: 'Project: onlinestore'
-    issue = submit_email('ticket_on_given_project.eml', allow_override: 'fixed_version')
-    assert issue.is_a?(WorkPackage)
-    assert !issue.new_record?
-    issue.reload
-    assert_equal Project.find(2), issue.project
-    assert_equal issue.project.types.first, issue.type
-    assert_equal 'New ticket on a given project', issue.subject
-    assert_equal User.find_by_login('jsmith'), issue.author
-    assert_equal Status.find_by(name: 'Resolved'), issue.status
-    assert issue.description.include?('Lorem ipsum dolor sit amet, consectetuer adipiscing elit.')
-    assert_equal '2010-01-01', issue.start_date.to_s
-    assert_equal '2010-12-31', issue.due_date.to_s
-    assert_equal User.find_by_login('jsmith'), issue.assigned_to
-    assert_equal Version.find_by(name: 'alpha'), issue.fixed_version
-    assert_equal 2.5, issue.estimated_hours
-    assert_equal 30, issue.done_ratio
-    assert issue.root?
-    assert issue.leaf?
-    # keywords should be removed from the email body
-    assert !issue.description.match(/^Project:/i)
-    assert !issue.description.match(/^Status:/i)
-    assert !issue.description.match(/^Start Date:/i)
-    # Email notification should be sent
-    mail = ActionMailer::Base.deliveries.last
-    refute_nil mail
-    assert mail.subject.include?('New ticket on a given project')
-  end
-
-  it 'should add work package with default type' do
-    # This email contains: 'Project: onlinestore'
-    issue = submit_email('ticket_on_given_project.eml', issue: { type: 'Support request' })
-    assert issue.is_a?(WorkPackage)
-    assert !issue.new_record?
-    issue.reload
-    assert_equal 'Support request', issue.type.name
-  end
-
   it 'should add work package with attributes override' do
     issue = submit_email('ticket_with_attributes.eml', allow_override: 'type,category,priority')
     assert issue.is_a?(WorkPackage)


### PR DESCRIPTION
Speedup requests to 
* `/api/v3/projects`
* `/api/v3/versions/available_projects`

by

* default rails eager loading where possible 
* wrapping the loaded projects with a delegator to only load the available custom fields once

The wrapper has been taken from the work packages eager loading.

However, there is still room for improvement (e.g. eager loading the users of a custom value for a user custom field) but I think that those quick fixes might suffice. If not I believe it more worthwhile to replace all of the representer logic by rendering the json in the DB.

https://community.openproject.com/projects/openproject/work_packages/31312