### PR TITLE
use filtered columns for related work package in xls export

### DIFF
--- a/modules/xls_export/lib/open_project/xls_export/work_package_xls_export.rb
+++ b/modules/xls_export/lib/open_project/xls_export/work_package_xls_export.rb
@@ -67,6 +67,10 @@ module OpenProject
       end
 
       def row(work_package)
+        column_values(work_package)
+      end
+
+      def column_values(work_package)
         columns.collect do |column|
           column_value column, work_package
         end
@@ -139,15 +143,18 @@ module OpenProject
     module WithRelations
       def add_headers!(spreadsheet)
         headers_0 = [I18n.t(:label_work_package_plural)] +
-          columns.size.times.map { |_| "" } +
-          [I18n.t("js.work_packages.tabs.relations")]
+                    columns.size.times.map { |_| "" } +
+                    [I18n.t("js.work_packages.tabs.relations")]
 
         spreadsheet.add_headers headers_0, 0
         spreadsheet.add_headers headers, 1
       end
 
       def headers
-        [""] + super + [""] + with_relations_headers
+        # The filtered work packages columns +
+        # the relations columns +
+        # the columns of the work packages connected by the relations.
+        [""] + super + [""] + with_relations_headers + super
       end
 
       def rows
@@ -205,7 +212,7 @@ module OpenProject
         type = relation_type work_package, other, relation
         delay = relation ? relation.delay : ""
         description = relation ? relation.description : ""
-        relation_columns = ["", type, delay, description, other.id, other.type.name, other.subject]
+        relation_columns = ["", type, delay, description] + column_values(other)
 
         [""] + wp_columns + relation_columns
       end
@@ -225,10 +232,7 @@ module OpenProject
         [
           Relation.human_attribute_name(:relation_type),
           Relation.human_attribute_name(:delay),
-          Relation.human_attribute_name(:description),
-          WorkPackage.human_attribute_name(:id),
-          WorkPackage.human_attribute_name(:type),
-          WorkPackage.human_attribute_name(:subject)
+          Relation.human_attribute_name(:description)
         ]
       end
 

--- a/modules/xls_export/spec/lib/work_package_xls_export_spec.rb
+++ b/modules/xls_export/spec/lib/work_package_xls_export_spec.rb
@@ -93,11 +93,12 @@ describe "WorkPackageXlsExport" do
     # the first header row devides the sheet into work packages and relation columns
     expect(sheet.rows.first.take(8)).to eq ['Work packages', nil, nil, nil, nil, nil, nil, 'Relations']
 
-    # the second header row includes the column names for work packages and relations
+    # the second header row includes the column names for work packages and relations and the related work package
     expect(sheet.rows[1])
       .to eq [
         nil, 'Type', 'ID', 'Subject', 'Status', 'Assignee', 'Priority',
-        nil, 'Relation type', 'Delay', 'Description', 'ID', 'Type', 'Subject',
+        nil, 'Relation type', 'Delay', 'Description',
+        'Type', 'ID', 'Subject', 'Status', 'Assignee', 'Priority',
         nil
       ]
 
@@ -141,7 +142,8 @@ describe "WorkPackageXlsExport" do
     expect(sheet.row(PARENT))
       .to eq [
         nil, parent.type.name, parent.id, parent.subject, parent.status.name, parent.assigned_to, parent.priority.name,
-        nil, 'parent of', nil, nil, child_1.id, child_1.type.name, child_1.subject
+        nil, 'parent of', nil, nil,
+        child_1.type.name, child_1.id, child_1.subject, child_1.status.name, child_1.assigned_to, child_1.priority.name
       ] # delay nil as this is a parent-child relation not represented by an actual Relation record
 
     expect(sheet.row(SINGLE))
@@ -151,9 +153,10 @@ describe "WorkPackageXlsExport" do
 
     expect(sheet.row(FOLLOWED))
       .to eq [
-        nil, followed.type.name, followed.id, followed.subject, followed.status.name,
-          followed.assigned_to, followed.priority.name,
-        nil, 'Precedes', 0, relation.description, child_2.id,  child_2.type.name, child_2.subject
+        nil,
+        followed.type.name, followed.id, followed.subject, followed.status.name, followed.assigned_to, followed.priority.name,
+        nil, 'Precedes', 0, relation.description,
+        child_2.type.name, child_2.id, child_2.subject, child_2.status.name, child_2.assigned_to, child_2.priority.name
       ]
   end
 


### PR DESCRIPTION
Employ the columns the user selected in the work package table ui also for the related work packages when choosing to export work packages to xls including their relations. Before, a static set of attributes was used.

https://community.openproject.com/projects/openproject/work_packages/30052