### PR TITLE
Stabilise description_editor test

### DIFF
--- a/spec/features/work_packages/details/inplace_editor/shared_examples.rb
+++ b/spec/features/work_packages/details/inplace_editor/shared_examples.rb
@@ -144,8 +144,8 @@ shared_examples 'a principal autocomplete field' do
 
     it 'autocompletes links to user profiles' do
       field.activate!
-      field.input_element.set('', fill_options: { clear: :backspace })
-      field.input_element.send_keys(" @lau")
+      field.input_element.set(' ', fill_options: { clear: :backspace })
+      field.input_element.set(" @lau")
       expect(page).to have_selector('.mention-list-item', text: mentioned_user.name)
       expect(page).to have_selector('.mention-list-item', text: mentioned_group.name)
       expect(page).not_to have_selector('.mention-list-item', text: user.name)
@@ -153,10 +153,12 @@ shared_examples 'a principal autocomplete field' do
       # Close the autocompleter
       field.input_element.send_keys :escape
 
+      # Clear the field
       sleep(0.01)
-      field.input_element.set('', fill_options: { clear: :backspace })
+      field.input_element.set(' ', fill_options: { clear: :backspace })
       sleep(0.01)
-      field.input_element.send_keys(" @Laura Fo")
+
+      field.input_element.set(" @Laura Fo")
       expect(page).to have_selector('.mention-list-item', text: mentioned_user.name)
       expect(page).not_to have_selector('.mention-list-item', text: mentioned_group.name)
       expect(page).not_to have_selector('.mention-list-item', text: user.name)


### PR DESCRIPTION
Attempt to stabilise the description_editor_spec.rb which fails quite often, e.g on https://travis-ci.org/opf/openproject/jobs/597580565 . 

As seen in the image, there is no space between the two `@`notifications resulting in only one which of course does not find any results. So I assume that this is the source of the error