### PR TITLE
Feature/no success message on ineffectual resize

### DIFF
--- a/frontend/src/app/modules/grids/areas/grid-widget-area.ts
+++ b/frontend/src/app/modules/grids/areas/grid-widget-area.ts
@@ -63,6 +63,13 @@ export class GridWidgetArea extends GridArea {
            this.rowOverlaps(otherArea);
   }
 
+  public get unchangedSize() {
+    return this.startColumn === this.widget.startColumn &&
+           this.endColumn === this.widget.endColumn &&
+           this.startRow === this.widget.startRow &&
+           this.endRow === this.widget.endRow;
+  }
+
   public writeAreaChangeToWidget() {
     this.widget.startRow = this.startRow;
     this.widget.endRow = this.endRow;

--- a/frontend/src/app/modules/grids/grid/resize.service.ts
+++ b/frontend/src/app/modules/grids/grid/resize.service.ts
@@ -20,10 +20,15 @@ export class GridResizeService {
       return;
     }
 
+    this.resizedArea = null;
+
+    // user aborted dragging
+    if (area.unchangedSize) {
+      return;
+    }
+
     this.layout.writeAreaChangesToWidgets();
     this.layout.cleanupUnusedAreas();
-
-    this.resizedArea = null;
 
     this.layout.rebuildAndPersist();
   }

--- a/modules/my_page/spec/features/my/accountable_spec.rb
+++ b/modules/my_page/spec/features/my/accountable_spec.rb
@@ -82,18 +82,21 @@ describe 'Accountable widget on my page', type: :feature, js: true do
     # Add widget below existing widgets
     my_page.add_widget(2, 2, :row, "Work packages I am accountable for")
 
-    sleep(0.1)
+    # Actually there are two success messages displayed currently. One for the grid getting updated and one
+    # for the query assigned to the new widget being created. A user will not notice it but the automated
+    # browser can get confused. Therefore we wait.
+    sleep(1)
+
+    my_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
 
     accountable_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(3)')
 
     accountable_area.expect_to_span(2, 2, 3, 3)
 
-    sleep(0.2)
-
     assigned_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(1)')
     assigned_area.remove
 
-    sleep(0.1)
+    my_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
 
     created_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(1)')
     created_area.expect_to_span(1, 1, 2, 2)

--- a/modules/overviews/spec/features/managing_overview_page_spec.rb
+++ b/modules/overviews/spec/features/managing_overview_page_spec.rb
@@ -98,16 +98,28 @@ describe 'Overview page managing', type: :feature, js: true, with_mail: false do
     # within top-left area, add an additional widget
     overview_page.add_widget(1, 1, :row, 'Work packages table')
 
+    # Actually there are two success messages displayed currently. One for the grid getting updated and one
+    # for the query assigned to the new widget being created. A user will not notice it but the automated
+    # browser can get confused. Therefore we wait.
+    sleep(1)
+
     overview_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
 
     table_area = Components::Grids::GridArea.new('.grid--area.-widgeted:nth-of-type(6)')
+    table_area.expect_to_span(1, 1, 2, 2)
+
+    # A useless resizing shows no message and does not alter the size
+    table_area.resize_to(1, 1)
+
+    overview_page.expect_no_notification message: I18n.t('js.notice_successful_update')
+
     table_area.expect_to_span(1, 1, 2, 2)
 
     table_area.resize_to(1, 2)
 
     overview_page.expect_and_dismiss_notification message: I18n.t('js.notice_successful_update')
 
-    # Resizing leads to the calendar area now spanning a larger area
+    # Resizing leads to the table area now spanning a larger area
     table_area.expect_to_span(1, 1, 2, 3)
 
     within table_area.area do


### PR DESCRIPTION
No longer displays a success message (as it no longer fires a patch request to grid) on ineffectual resizes, i.e. user not moving the resizer out of the staring area when resizing.

Also attempts to fix two flickering specs:
* `/modules/my_page/spec/features/my/accountable_spec.rb:81`
* `/modules/overviews/spec/features/managing_overview_page_spec.rb:74`