### PR TITLE
[31260] Correctly remove group key from attribute group

### DIFF
--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -96,11 +96,12 @@ module ::TypesHelper
     type.attribute_groups.map do |group|
       {
         type: group.group_type,
-        key: group.key,
         name: group.translated_key,
         attributes: active_group_attributes_map(group, available, inactive),
         query: query_to_query_props(group)
-      }
+      }.tap do |group_obj|
+        group_obj[:key] = group.key if group.internal_key?
+      end
     end
   end
 

--- a/app/models/type/form_group.rb
+++ b/app/models/type/form_group.rb
@@ -40,11 +40,17 @@ class Type::FormGroup
   end
 
   ##
+  # Returns the symbol key, if it is not translated
+  def internal_key?
+    key.is_a?(Symbol)
+  end
+
+  ##
   # Translate the given attribute group if its internal
   # (== if it's a symbol)
   def translated_key
-    if key.is_a? Symbol
-      I18n.t(Type.default_groups[key])
+    if internal_key?
+      I18n.t(Type.default_groups[key], default: key.to_s)
     else
       key
     end

--- a/frontend/src/app/modules/admin/types/attribute-group.component.ts
+++ b/frontend/src/app/modules/admin/types/attribute-group.component.ts
@@ -23,7 +23,7 @@ export class TypeFormAttributeGroupComponent {
 
   rename(newValue:string) {
     this.group.name = newValue;
-    this.group.key = null;
+    delete this.group.key;
     this.cdRef.detectChanges();
   }
 

--- a/frontend/src/app/modules/admin/types/group-edit-in-place.html
+++ b/frontend/src/app/modules/admin/types/group-edit-in-place.html
@@ -1,8 +1,8 @@
-<span *ngIf="!editing"
+<div *ngIf="!editing"
       (click)="startEditing()"
       [textContent]="name"
       class="group-edit-handler">
-</span>
+</div>
 <input
     #nameInput
     *ngIf="editing"

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -66,7 +66,7 @@ describe 'form configuration', type: :feature, js: true do
         dialog.expect_open
         dialog.cancel
 
-        expect(page).to have_selector('span.group-edit-handler', text: 'WHATEVER')
+        expect(page).to have_selector('.group-edit-handler', text: 'WHATEVER')
 
         # Click the dialog again after some time
         # Otherwise this may cause issues due to the animation,


### PR DESCRIPTION
The attribute group key is used in the frontend to detect whether the group is treated as an internal symbol (translation key).

When renaming the group, the key is removed in the frontend, but always returned again by the backend. When saving that form again (e.g., rename another group), it is treated as internal again with a wrong key, resulting in the `no key` error.

This error is removed by stripping the key field from JSON. Additionally, not found keys are being returned as is, ensuring groups are now named correctly even if they were erroneous before

https://community.openproject.com/wp/31260