### PR TITLE
fix group_by associated resource if only a nil group exists

### DIFF
--- a/app/models/query/group_by.rb
+++ b/app/models/query/group_by.rb
@@ -137,7 +137,7 @@ module ::Query::Grouping
   end
 
   def transform_association_property_keys(association, groups)
-    ar_keys = association.class_name.constantize.find(groups.keys)
+    ar_keys = association.class_name.constantize.find(groups.keys.compact)
 
     groups.map do |key, value|
       [ar_keys.detect { |ar_key| ar_key.id == key }, value]

--- a/spec/models/query/results_spec.rb
+++ b/spec/models/query/results_spec.rb
@@ -109,6 +109,35 @@ describe ::Query::Results, type: :model, with_mail: false do
       end
     end
 
+    context 'grouping by assigned_to' do
+      let(:group_by) { 'assigned_to' }
+
+      before do
+        work_package1
+        work_package2.update_column(:assigned_to_id, user_1.id)
+
+        login_as(user_1)
+      end
+
+      it 'returns a hash of counts by value' do
+        expect(query_results.work_package_count_by_group).to eql(nil => 1, user_1 => 1)
+      end
+    end
+
+    context 'grouping by assigned_to with only a nil group' do
+      let(:group_by) { 'assigned_to' }
+
+      before do
+        work_package1
+
+        login_as(user_1)
+      end
+
+      it 'returns a hash of counts by value' do
+        expect(query_results.work_package_count_by_group).to eql(nil => 1)
+      end
+    end
+
     context 'grouping by type' do
       let(:group_by) { 'type' }
 


### PR DESCRIPTION
Before, a call like:

`User.find([nil])` 

would be issued when only the nil group exists which AR balks at (but is ok with e.g. `[4, nil]` for some reason).

https://community.openproject.com/projects/openproject/work_packages/31377 