### PR TITLE
[31116] Another stab at ng-select dropdown hiding

### DIFF
--- a/app/assets/stylesheets/content/_autocomplete.sass
+++ b/app/assets/stylesheets/content/_autocomplete.sass
@@ -179,6 +179,10 @@ mark.ui-autocomplete-match
 .ng-dropdown-panel
   z-index: 9500 !important
 
+  // Fix to avoid misplacing the ng-select container
+  &.-hidden-until-positioned
+    display: none
+
 .ng-option
   font-size: 14px
   line-height: 22px

--- a/frontend/src/app/modules/fields/edit/field-types/project-status-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/project-status-edit-field.component.html
@@ -2,7 +2,7 @@
            [(ngModel)]="currentStatusCode"
            bindLabel="name"
            bindValue="code"
-           class="project-status"
+           class="project-status -hidden-until-positioned"
            (open)="onOpen()"
            (close)="onClose()"
            (change)="onChange()"

--- a/frontend/src/app/modules/fields/edit/field-types/project-status-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/project-status-edit-field.component.ts
@@ -71,6 +71,13 @@ export class ProjectStatusEditFieldComponent extends EditFieldComponent implemen
   }
 
   public onOpen() {
+    setTimeout(() => {
+      const dropdown = document.getElementById(this.ngSelectComponent.dropdownId);
+      if (dropdown) {
+        dropdown.classList.remove('-hidden-until-positioned');
+      }
+    }, 25);
+
     jQuery(this.hiddenOverflowContainer).one('scroll', () => {
       this.ngSelectComponent.close();
     });


### PR DESCRIPTION
Since ng-select appended to a container will increase its size by 2px and show a scrollbar, we hide the dropdown until after the position has taken place.

An alternative would be to add the border only after the position happens, but that again changes its width.

FYI @wielinde @HDinger 

https://community.openproject.com/wp/31116