### PR TITLE
avoid add widget modal being too high for viewport

### DIFF
--- a/app/assets/stylesheets/content/_grid.sass
+++ b/app/assets/stylesheets/content/_grid.sass
@@ -240,3 +240,9 @@ $grid--widget-padding: 20px
   @include widget-box--style
   margin-left: -$grid--widget-padding
   margin-top: -$grid--widget-padding
+
+.grid--add-widget-ee
+  .notification-box
+    position: sticky
+    bottom: 0
+    margin-bottom: 0

--- a/frontend/src/app/modules/grids/widgets/add/add.modal.html
+++ b/frontend/src/app/modules/grids/widgets/add/add.modal.html
@@ -1,4 +1,4 @@
-<div class="op-modal--portal ngdialog-theme-openproject grid--add-modal">
+<div class="op-modal--portal ngdialog-theme-openproject">
   <div class="op-modal--modal-container confirm-dialog--modal loading-indicator--location"
        data-indicator-name="modal"
        tabindex="0">
@@ -20,12 +20,13 @@
            [textContent]="widget.title"
            class="grid--addable-widget" >
       </div>
-    </div>
 
-    <enterprise-banner *ngIf="eeShowBanners"
-                       [linkMessage]="text.upsale_link"
-                       [textMessage]="text.upsale_text"
-                       opReferrer="grids#add-widget">
-    </enterprise-banner>
+      <enterprise-banner *ngIf="eeShowBanners"
+                         [linkMessage]="text.upsale_link"
+                         [textMessage]="text.upsale_text"
+                         class="grid--add-widget-ee"
+                         opReferrer="grids#add-widget">
+      </enterprise-banner>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
The ee notification is now placed within the part that determines the height and is made sticky to ensure that it is always visible. This is a quick fix as it is planned to restyle the add modal.

https://community.openproject.com/projects/openproject/work_packages/31396