### PR TITLE
[31312] Filter only for the one relevant available_project

### DIFF
--- a/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.html
+++ b/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.html
@@ -1,0 +1,20 @@
+<ng-select #ngSelectComponent
+           [(ngModel)]="model"
+           [items]="availableValues"
+           [ngClass]="classes"
+           [addTag]="createAllowed"
+           [virtualScroll]="true"
+           [required]="required"
+           [clearable]="!required"
+           [disabled]="disabled"
+           [appendTo]="appendTo"
+           [id]="id"
+           (change)="changeModel($event)"
+           (open)="opened()"
+           (close)="closed()"
+           (keydown)="keyPressed($event)"
+           bindLabel="name">
+  <ng-template ng-tag-tmp let-search="searchTerm">
+    <b [textContent]="text.add_new_action"></b>: {{search}}
+  </ng-template>
+</ng-select>

--- a/frontend/src/app/modules/common/autocomplete/version-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/version-autocompleter.component.ts
@@ -26,68 +26,46 @@
 // See doc/COPYRIGHT.rdoc for more details.
 // ++
 
-import {AfterViewInit, Component, EventEmitter, OnInit, Output, ViewChild} from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewChild
+} from '@angular/core';
 import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
 import {VersionDmService} from "core-app/modules/hal/dm-services/version-dm.service";
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 import {VersionResource} from "core-app/modules/hal/resources/version-resource";
-import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {CreateAutocompleterComponent} from "core-app/modules/common/autocomplete/create-autocompleter.component";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
 
 @Component({
-  template: `
-    <create-autocompleter #createAutocompleter
-                          [availableValues]="availableValues"
-                          [createAllowed]="createAllowed"
-                          [finishedLoading]="loaded"
-                          [appendTo]="appendTo"
-                          [model]="model"
-                          [required]="required"
-                          [disabled]="disabled"
-                          [id]="id"
-                          [classes]="classes"
-                          (create)="createNewVersion($event)"
-                          (onChange)="changeModel($event)"
-                          (onOpen)="opened()"
-                          (onClose)="closed()"
-                          (onKeydown)="keyPressed($event)"
-                          (onAfterViewInit)="afterViewinited()">
-    </create-autocompleter>
-  `,
+  templateUrl: './create-autocompleter.component.html',
   selector: 'version-autocompleter'
 })
-
-export class VersionAutocompleterComponent extends CreateAutocompleterComponent implements OnInit, AfterViewInit {
-  @ViewChild('createAutocompleter', { static: true }) public createAutocompleter:CreateAutocompleterComponent;
+export class VersionAutocompleterComponent extends CreateAutocompleterComponent implements OnInit {
+  @Input() public openDirectly:boolean = false;
   @Output() public onCreate = new EventEmitter<VersionResource>();
-
-  public createAllowed:boolean = false;
-  public loaded:boolean = false;
 
   constructor(readonly I18n:I18nService,
               readonly currentProject:CurrentProjectService,
+              readonly cdRef:ChangeDetectorRef,
               readonly pathHelper:PathHelperService,
               readonly versionDm:VersionDmService,
               readonly halNotification:HalResourceNotificationService) {
-    super(I18n, currentProject, pathHelper);
+    super(I18n, cdRef, currentProject, pathHelper);
   }
 
   ngOnInit() {
     this.canCreateNewActionElements().then((val) => {
-      this.loaded = true;
-      this.createAutocompleter.createAllowed = val;
+      this.createAllowed = val;
     });
-  }
-
-  ngAfterViewInit() {
-    // Prevent a second event to bubble
-  }
-
-  public afterViewinited() {
-    this.onAfterViewInit.emit(this.createAutocompleter);
   }
 
   /**
@@ -96,21 +74,18 @@ export class VersionAutocompleterComponent extends CreateAutocompleterComponent 
    * @returns {Promise<boolean>}
    */
   public canCreateNewActionElements():Promise<boolean> {
-    let that = this;
-    return this.versionDm.listProjectsAvailableForVersions().then((collection) => {
-      return collection.elements.some((e:HalResource) => e.id === that.currentProject.id!);
-    }).catch(() => {
-      return false;
-    });
+    return this.versionDm
+      .canCreateVersionInProject(this.currentProject.id!)
+      .catch(() => false);
   }
 
-  public createNewVersion(name:string) {
+  protected performCreate(name:string) {
     this.versionDm.createVersion(this.getVersionPayload(name))
       .then((version) => {
         this.onCreate.emit(version);
       })
       .catch(error =>  {
-        this.createAutocompleter.closeSelect();
+        this.closeSelect();
         this.halNotification.handleRawError(error);
       });
   }

--- a/frontend/src/app/modules/hal/dm-services/version-dm.service.ts
+++ b/frontend/src/app/modules/hal/dm-services/version-dm.service.ts
@@ -36,6 +36,7 @@ import {ProjectResource} from "core-app/modules/hal/resources/project-resource";
 import {GridResource} from "core-app/modules/hal/resources/grid-resource";
 import {SchemaResource} from "core-app/modules/hal/resources/schema-resource";
 import {Observable} from "rxjs";
+import {buildApiV3Filter} from "core-components/api/api-v3/api-v3-filter-builder";
 
 @Injectable()
 export class VersionDmService {
@@ -72,6 +73,18 @@ export class VersionDmService {
     return this.halResourceService
       .get<CollectionResource<VersionResource>>(this.pathHelper.api.v3.projects.id(projectId).versions.toString())
       .toPromise();
+  }
+
+  public canCreateVersionInProject(id:string):Promise<boolean> {
+    return this.halResourceService
+      .get<CollectionResource<ProjectResource>>(
+        this.pathHelper.api.v3.versions.availableProjects.toString(),
+        { filters: buildApiV3Filter('id', '=', [id]).toJson() }
+      )
+      .toPromise()
+      .then((collection) => {
+        return collection.elements.length === 1;
+      });
   }
 
   public listProjectsAvailableForVersions():Promise<CollectionResource<ProjectResource>> {

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -122,7 +122,7 @@ class EditField
   # For fields of type select, will check for an option with that value.
   def set_value(content)
     scroll_to_element(input_element)
-    if field_type == 'create-autocompleter'
+    if field_type.end_with?('-autocompleter')
       page.find('.ng-dropdown-panel .ng-option', text: content).click
     else
       # A normal fill_in would cause the focus loss on the input for empty strings.
@@ -138,7 +138,7 @@ class EditField
   def unset_value(content, multi=false)
     scroll_to_element(input_element)
 
-    if field_type == 'create-autocompleter'
+    if field_type.end_with?('-autocompleter')
       if multi
         page.find('.ng-value-label', text: content).sibling('.ng-value-icon').click
       else
@@ -174,13 +174,13 @@ class EditField
       set_value value
 
       # select fields are saved on change
-      save! if save && field_type != 'create-autocompleter'
+      save! if save && !field_type.end_with?('-autocompleter')
       expect_state! open: expect_failure
     end
   end
 
   def submit_by_enter
-    if field_type == 'create-autocompleter'
+    if field_type.end_with? '-autocompleter'
       autocomplete_selector.send_keys :return
     else
       input_element.native.send_keys :return
@@ -188,7 +188,7 @@ class EditField
   end
 
   def cancel_by_escape
-    if field_type == 'create-autocompleter'
+    if field_type.end_with? '-autocompleter'
       autocomplete_selector.send_keys :escape
     else
       input_element.native.send_keys :escape
@@ -214,13 +214,14 @@ class EditField
   def field_type
     @field_type ||= begin
       case property_name.to_s
+      when 'version'
+        'version-autocompleter'
       when 'assignee',
            'responsible',
            'priority',
            'status',
            'project',
            'type',
-           'version',
            'category'
         'create-autocompleter'
       else


### PR DESCRIPTION
The version autocompleter loads all available projects to filter in the frontend.

It was also wrongly inheriting AND using the create-autocompleter component at the same time. Instead it is now reusing the same template and subclassing it.

https://community.openproject.com/wp/31312