### PR TITLE
[31426] Status dropdown is misplaced when the widget is at the bottom of the page

### DIFF
--- a/app/assets/stylesheets/content/_autocomplete.sass
+++ b/app/assets/stylesheets/content/_autocomplete.sass
@@ -179,10 +179,6 @@ mark.ui-autocomplete-match
 .ng-dropdown-panel
   z-index: 9500 !important
 
-  // Fix to avoid misplacing the ng-select container
-  &.-hidden-until-positioned
-    display: none
-
 .ng-option
   font-size: 14px
   line-height: 22px

--- a/frontend/src/app/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.html
+++ b/frontend/src/app/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.html
@@ -6,7 +6,8 @@
           [workPackage]="workPackage"
           (onSelected)="onSelected($event)"
           [additionalFilters]="queryFilters"
-          [filterCandidatesFor]="relationType">
+          [filterCandidatesFor]="relationType"
+          hiddenOverflowContainer=".work-packages-full-view--split-left">
       </wp-relations-autocomplete>
     </div>
     <div class="wp-relations-controls-section relation-row">

--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relation-create.template.html
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relation-create.template.html
@@ -37,7 +37,7 @@
             [workPackage]="workPackage"
             (onSelected)="onSelected($event)"
             (onCancel)="toggleRelationsCreateForm()"
-            [appendToContainer]="'.work-packages-tab-view--overflow'"
+            [hiddenOverflowContainer]="'.work-packages-tab-view--overflow'"
             [selectedRelationType]="selectedRelationType">
         </wp-relations-autocomplete>
       </div>

--- a/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component.ts
@@ -72,7 +72,7 @@ export class WorkPackageRelationsAutocomplete implements AfterContentInit {
   /** Do we take the current query filters into account? */
   @Input() additionalFilters:ApiV3Filter[] = [];
 
-  @Input() appendToContainer:string = 'body';
+  @Input() hiddenOverflowContainer:string = 'body';
   @ViewChild(NgSelectComponent, { static: true }) public ngSelectComponent:NgSelectComponent;
 
   @Output() onCancel = new EventEmitter<undefined>();
@@ -84,6 +84,8 @@ export class WorkPackageRelationsAutocomplete implements AfterContentInit {
 
   // Search input from ng-select
   public searchInput$ = new Subject<string>();
+
+  public appendToContainer = 'body';
 
   // Search results mapped to input
   public results$:Observable<WorkPackageResource[]> = this.searchInput$.pipe(
@@ -165,7 +167,14 @@ export class WorkPackageRelationsAutocomplete implements AfterContentInit {
     // https://github.com/ng-select/ng-select/issues/1259
     setTimeout(() => {
       const component = (this.ngSelectComponent) as any;
-      component.dropdownPanel._updatePosition();
+      if (component) {
+        component.dropdownPanel._updatePosition();
+      }
+
+      jQuery(this.hiddenOverflowContainer).one('scroll', () => {
+        this.ngSelectComponent.close();
+      });
     }, 25);
+
   }
 }

--- a/frontend/src/app/modules/fields/edit/field-types/project-status-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/project-status-edit-field.component.html
@@ -2,11 +2,11 @@
            [(ngModel)]="currentStatusCode"
            bindLabel="name"
            bindValue="code"
-           class="project-status -hidden-until-positioned"
+           class="project-status"
            (open)="onOpen()"
            (close)="onClose()"
            (change)="onChange()"
-           [appendTo]="hiddenOverflowContainer"
+           [appendTo]="appendToContainer"
            [hideSelected]="true"
            [disabled]="inFlight">
   <ng-template ng-label-tmp let-item="item">

--- a/frontend/src/app/modules/fields/edit/field-types/project-status-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/project-status-edit-field.component.ts
@@ -53,6 +53,7 @@ export class ProjectStatusEditFieldComponent extends EditFieldComponent implemen
   });
 
   public hiddenOverflowContainer = '#content-wrapper';
+  public appendToContainer = 'body';
 
   ngOnInit() {
     this.currentStatusCode = this.resource['status'] === null ? 'not set' : this.resource['status'];
@@ -71,19 +72,21 @@ export class ProjectStatusEditFieldComponent extends EditFieldComponent implemen
   }
 
   public onOpen() {
+    // Force reposition as a workaround for BUG
+    // https://github.com/ng-select/ng-select/issues/1259
     setTimeout(() => {
-      const dropdown = document.getElementById(this.ngSelectComponent.dropdownId);
-      if (dropdown) {
-        dropdown.classList.remove('-hidden-until-positioned');
+      const component = (this.ngSelectComponent) as any;
+      if (component.dropdownPanel) {
+        component.dropdownPanel._updatePosition();
       }
-    }, 25);
 
-    jQuery(this.hiddenOverflowContainer).one('scroll', () => {
-      this.ngSelectComponent.close();
-    });
+      jQuery(this.hiddenOverflowContainer).one('scroll.autocompleteContainer', () => {
+        this.ngSelectComponent.close();
+      });
+    }, 25);
   }
 
   public onClose() {
-    // Nothing to do
+    jQuery(this.hiddenOverflowContainer).off('scroll.autocompleteContainer');
   }
 }


### PR DESCRIPTION
The problem occurred at least in two places: the project status widget and the relations autocompleter: When the page was scrolled, the dropdown was misplaced.

In the PR the dropdown of the project status is appended to the `body`, and is closed when the `content-wrapper` is scrolled. Here only a change of the `appendToContainer` was necessary.

 For the relations dropdown, the same mechanism was applied. The dropdown is appended to body and closed when their container scrolls.

https://community.openproject.com/projects/openproject/work_packages/31426/activity