### PR TITLE
[31448] Work Package subject jumps again when editing

### DIFF
--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -205,12 +205,6 @@
   display: flex
   position: relative
 
-  // Fix: align and size hover border like buttons in toolbar.
-  .inline-edit--container .inline-edit--display-field
-    padding-top: 3px
-    padding-bottom: 3px
-    margin-top: 2px
-
 .work-packages--type-selector:not(.wp-new-top-row--element)
   .inline-edit--display-field
     padding-right: 5px !important


### PR DESCRIPTION
Remove old styles which break more than they fix. The padding is overridden and the margin causes the line to be **not** aligned with the toolbar. This causes also the jump when editing the subject.

https://community.openproject.com/projects/openproject/work_packages/31448/activity
