### PR TITLE
display `read only` icon when project widgets not editable

### DIFF
--- a/frontend/src/app/modules/hal/resources/hal-resource.ts
+++ b/frontend/src/app/modules/hal/resources/hal-resource.ts
@@ -145,14 +145,16 @@ export class HalResource {
   }
 
   /**
-   * Return whether the work package is editable with the user's permission
-   * on the given work package attribute.
+   * Return whether the resource is editable with the user's permission
+   * on the given resource package attribute.
+   * In order to be editable, there needs to be an update link on the resource and the schema for
+   * the attribute needs to indicate the writability.
    *
    * @param property
    */
   public isAttributeEditable(property:string):boolean {
     const fieldSchema = this.schema[property];
-    return fieldSchema && fieldSchema.writable;
+    return this.$links.update && fieldSchema && fieldSchema.writable;
   }
 
   /**


### PR DESCRIPTION
By changing the check on whether an attribute is editable to also requiring an update link to exist, we can easily check whether any attribute is editable which suffices to determine the editability of:
* project status
* project description
* project custom fields

as it the edit_project permission includes all the attributes.

https://community.openproject.com/projects/openproject/work_packages/31453