### PR TITLE
Dynamically add CSS classes to body to indicate a widget grid (with gray background)

### DIFF
--- a/app/assets/stylesheets/content/_grid.sass
+++ b/app/assets/stylesheets/content/_grid.sass
@@ -8,6 +8,11 @@ $grid--widget-padding: 20px 20px 20px 20px
 @mixin grid--commons
   display: grid
 
+body.widget-grid-layout
+  #content-wrapper,
+  #content
+    background-color: $grid-background-color
+
 .grid--container
   @include grid--commons
 

--- a/app/assets/stylesheets/content/_my_page.sass
+++ b/app/assets/stylesheets/content/_my_page.sass
@@ -26,11 +26,6 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-.controller-my_page\/angular
-  #content-wrapper,
-  #content
-    background-color: $grid-background-color
-
 .my-page--container
   #right,
   #left

--- a/app/assets/stylesheets/content/_project_overview.sass
+++ b/app/assets/stylesheets/content/_project_overview.sass
@@ -26,11 +26,6 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-.controller-overviews\/overviews
-  #content-wrapper,
-  #content
-    background-color: $grid-background-color
-
 /* Align widget boxes with description above on project overview */
 .project-overview
   margin: 0 -10px

--- a/frontend/src/app/modules/dashboards/openproject-dashboards.module.ts
+++ b/frontend/src/app/modules/dashboards/openproject-dashboards.module.ts
@@ -42,7 +42,7 @@ export const DASHBOARDS_ROUTES:Ng2StateDeclaration[] = [
     // cf., https://community.openproject.com/wp/29754
     url: '/dashboards/',
     data: {
-      bodyClasses: 'router--dashboards-view-base',
+      bodyClasses: ['router--dashboards-view-base', 'widget-grid-layout'],
       menuItem: menuItemClass
     },
     component: DashboardComponent

--- a/frontend/src/app/modules/my-page/openproject-my-page.module.ts
+++ b/frontend/src/app/modules/my-page/openproject-my-page.module.ts
@@ -38,7 +38,7 @@ export const MY_PAGE_ROUTES:Ng2StateDeclaration[] = [
     url: '/my/page',
     component: MyPageComponent,
     data: {
-      bodyClasses: 'router--work-packages-my-page',
+      bodyClasses: ['router--work-packages-my-page', 'widget-grid-layout'],
       parent: 'work-packages'
     }
   },

--- a/frontend/src/app/modules/overview/openproject-overview.module.ts
+++ b/frontend/src/app/modules/overview/openproject-overview.module.ts
@@ -42,7 +42,7 @@ export const OVERVIEW_ROUTES:Ng2StateDeclaration[] = [
     // cf., https://community.openproject.com/wp/29754
     url: '/',
     data: {
-      bodyClasses: 'router--overview-view-base',
+      bodyClasses: ['router--overview-view-base', 'widget-grid-layout'],
       menuItem: menuItemClass
     },
     component: OverviewComponent

--- a/frontend/src/app/modules/router/openproject.routes.ts
+++ b/frontend/src/app/modules/router/openproject.routes.ts
@@ -67,9 +67,15 @@ export const OPENPROJECT_ROUTES = [
  * @param className
  * @param action
  */
-export function bodyClass(className:string|null|undefined, action:'add'|'remove' = 'add') {
+export function bodyClass(className:string[]|string|null|undefined, action:'add'|'remove' = 'add') {
   if (className) {
-    document.body.classList[action](className);
+    if (Array.isArray(className)) {
+      className.forEach((cssClass:string) => {
+        document.body.classList[action](cssClass);
+      });
+    } else {
+      document.body.classList[action](className);
+    }
   }
 }
 export function updateMenuItem(menuItemClass:string|undefined, action:'add'|'remove' = 'add') {


### PR DESCRIPTION
Add a class `widget-grid-layout` to the `body` element for overview, my-page and dashboards. 

https://community.openproject.com/wp/31459