### PR TITLE
[32457] Type selection drop down looks ugly

### DIFF
--- a/app/assets/stylesheets/content/work_packages/new/_type_status_row.sass
+++ b/app/assets/stylesheets/content/work_packages/new/_type_status_row.sass
@@ -21,7 +21,10 @@
     .inline-edit--field
       min-width: 125px
 
-.work-packages--type-selector,
-.work-packages--status-selector
-  .-active
-    margin: 6px 6px 6px 0px
+  .work-packages--type-selector,
+  .work-packages--status-selector
+    .-active
+      margin: 6px 6px 6px 0px
+
+.work-packages--type-selector .-active
+    margin: 6px 6px 0px 0px

--- a/app/assets/stylesheets/layout/work_packages/_details_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_details_view.sass
@@ -93,7 +93,7 @@ body.router--work-packages-split-view-new
     font-size: 1.125rem
     font-weight: bold
 
-  .work-packages--subject-element
+  .work-packages--details--subject
     line-height: 24px
     overflow: hidden
 

--- a/app/assets/stylesheets/layout/work_packages/_full_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_full_view.sass
@@ -185,7 +185,7 @@
       font-weight: bold
       line-height: 34px
 
-    .work-packages--subject-element
+    .work-packages--details--subject
       .inline-edit--field
         height: 34px
 
@@ -215,8 +215,7 @@
 
   @media only screen and (min-width: 679px)
     .inline-edit--container.-active
-      margin-right: 80px !important
-      width: 95%
+      width: 130px
 
 .edit-all-mode
   .subject-header .work-packages--details--subject .inplace-edit--text-field


### PR DESCRIPTION
The styles that let the subject edit and display fields look the same should **not** be applied on the type selector.

https://community.openproject.com/projects/openproject/work_packages/31457/activity