### PR TITLE
close wp comment ourself instead of waiting for repaint

### DIFF
--- a/frontend/src/app/components/work-packages/work-package-comment/work-package-comment.component.ts
+++ b/frontend/src/app/components/work-packages/work-package-comment/work-package-comment.component.ts
@@ -160,7 +160,7 @@ export class WorkPackageCommentComponent extends WorkPackageCommentFieldHandler 
         this.wpLinkedActivities.require(this.workPackage, true);
         this.wpCacheService.updateWorkPackage(this.workPackage);
         this.inFlight = false;
-        this.focus();
+        this.deactivate(true);
       })
       .catch((error:any) => {
         this.inFlight = false;

--- a/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
@@ -26,7 +26,6 @@
 // ++
 
 import {Component, OnInit, ViewChild, ChangeDetectionStrategy} from "@angular/core";
-import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 import {EditFieldComponent} from "core-app/modules/fields/edit/edit-field.component";
 import {OpCkeditorComponent} from "core-app/modules/common/ckeditor/op-ckeditor.component";
 import {ICKEditorContext, ICKEditorInstance} from "core-app/modules/common/ckeditor/ckeditor-setup.service";


### PR DESCRIPTION
By closing the comment instead of relying on the call for activities to update the view, the case where both, the added comment and the still open form is displayed should no longer happen.

https://community.openproject.com/projects/openproject/work_packages/31477