### PR TITLE
[31468] Don't set body class on root url

### DIFF
--- a/frontend/src/app/modules/grids/grid/page/grid-page.component.ts
+++ b/frontend/src/app/modules/grids/grid/page/grid-page.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectorRef, OnInit} from '@angular/core';
+import {ChangeDetectorRef, OnDestroy, OnInit, Renderer2} from '@angular/core';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {Title} from '@angular/platform-browser';
 import {GridInitializationService} from "core-app/modules/grids/grid/initialization.service";
@@ -8,7 +8,7 @@ import {GridAddWidgetService} from "core-app/modules/grids/grid/add-widget.servi
 import {GridAreaService} from "core-app/modules/grids/grid/area.service";
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 
-export abstract class GridPageComponent implements OnInit {
+export abstract class GridPageComponent implements OnInit, OnDestroy {
   public text = { title: this.i18n.t(`js.${this.i18nNamespace()}.label`),
                   html_title: this.i18n.t(`js.${this.i18nNamespace()}.label`) };
 
@@ -20,11 +20,13 @@ export abstract class GridPageComponent implements OnInit {
               readonly cdRef:ChangeDetectorRef,
               readonly title:Title,
               readonly addWidget:GridAddWidgetService,
+              readonly renderer:Renderer2,
               readonly areas:GridAreaService) {}
 
   public grid:GridResource;
 
   ngOnInit() {
+    this.renderer.addClass(document.body, 'widget-grid-layout');
     this
       .gridInitialization
       .initialize(this.gridScopePath())
@@ -34,6 +36,10 @@ export abstract class GridPageComponent implements OnInit {
       });
 
     this.setHtmlTitle();
+  }
+
+  ngOnDestroy():void {
+    this.renderer.removeClass(document.body, 'widget-grid-layout');
   }
 
   private setHtmlTitle() {

--- a/frontend/src/app/modules/overview/openproject-overview.module.ts
+++ b/frontend/src/app/modules/overview/openproject-overview.module.ts
@@ -42,7 +42,6 @@ export const OVERVIEW_ROUTES:Ng2StateDeclaration[] = [
     // cf., https://community.openproject.com/wp/29754
     url: '/',
     data: {
-      bodyClasses: ['router--overview-view-base', 'widget-grid-layout'],
       menuItem: menuItemClass
     },
     component: OverviewComponent


### PR DESCRIPTION
The overview dashboard matches `/projects/X/` and `/` due to projects being optional. I haven't found a way to restrict the URL with ui-router unfortunately.

Thus I set the body class in the abstract grid component instead.

https://community.openproject.com/wp/31468