### PR TITLE
Decide on editor type in hal resource

### DIFF
--- a/frontend/src/app/ckeditor/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/ckeditor/ckeditor-augmented-textarea.component.ts
@@ -63,6 +63,7 @@ export class CkeditorAugmentedTextareaComponent implements OnInit, OnDestroy {
   public resource?:HalResource;
   public context:ICKEditorContext;
   public macros:boolean;
+  public editorType:string;
 
   // Reference to the actual ckeditor instance component
   @ViewChild(OpCkeditorComponent, { static: true }) private ckEditorInstance:OpCkeditorComponent;
@@ -86,6 +87,7 @@ export class CkeditorAugmentedTextareaComponent implements OnInit, OnDestroy {
     this.textareaSelector = this.$element.attr('textarea-selector')!;
     this.previewContext = this.$element.attr('preview-context')!;
     this.macros = this.$element.attr('macros') !== 'false';
+    this.editorType = this.$element.attr('editor-type') || 'full';
 
     // Parse the resource if any exists
     const source = this.$element.data('resource');

--- a/frontend/src/app/ckeditor/ckeditor-augmented-textarea.html
+++ b/frontend/src/app/ckeditor/ckeditor-augmented-textarea.html
@@ -2,6 +2,7 @@
   <div class="op-ckeditor--wrapper">
     <op-ckeditor [context]="context"
                  [content]="initialContent"
+                 [ckEditorType]="editorType"
                  (onInitialized)="setup($event)"
                  (onContentChange)="markEdited()">
     </op-ckeditor>

--- a/frontend/src/app/modules/fields/edit/editing-portal/edit-field-handler.ts
+++ b/frontend/src/app/modules/fields/edit/editing-portal/edit-field-handler.ts
@@ -137,10 +137,6 @@ export abstract class EditFieldHandler {
 
   public abstract setErrors(newErrors:string[]):void;
 
-  public get formattableEditorType() {
-    return 'constrained';
-  }
-
   public previewContext(resource:HalResource):string|undefined {
     return undefined;
   }

--- a/frontend/src/app/modules/fields/edit/field-handler/hal-resource-edit-field-handler.ts
+++ b/frontend/src/app/modules/fields/edit/field-handler/hal-resource-edit-field-handler.ts
@@ -234,14 +234,6 @@ export class HalResourceEditFieldHandler extends EditFieldHandler {
     }
   }
 
-  public get formattableEditorType() {
-    if (this.fieldName === 'description') {
-      return 'full';
-    } else {
-      return 'constrained';
-    }
-  }
-
   public previewContext(resource:HalResource) {
     return resource.previewPath();
   }

--- a/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
@@ -68,6 +68,8 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
   public previewHtml:string = '';
   public text:any = {};
 
+  public editorType = this.resource.getEditorTypeFor(this.field.name);
+
   ngOnInit() {
     super.ngOnInit();
 
@@ -116,10 +118,6 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
       macros: 'none' as 'none',
       previewContext: this.previewContext
     };
-  }
-
-  public get editorType() {
-    return this.handler.formattableEditorType;
   }
 
   private get previewContext() {

--- a/frontend/src/app/modules/grids/widgets/custom-text/custom-text-edit-field.service.ts
+++ b/frontend/src/app/modules/grids/widgets/custom-text/custom-text-edit-field.service.ts
@@ -123,6 +123,7 @@ export class CustomTextEditFieldService extends EditFieldHandler {
 
   private newEditResource(value:GridWidgetResource) {
     return { text: value.options.text,
+             getEditorTypeFor: () => 'full',
              canAddAttachments: value.grid.canAddAttachments,
              uploadAttachments: (files:UploadFile[]) => value.grid.uploadAttachments(files) };
   }

--- a/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.html
+++ b/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.html
@@ -32,7 +32,7 @@
     </attachments>
 
     <div *ngIf="!active"
-         class="inplace-edit--read -no-label"
+         class="inplace-edit--read wiki -no-label"
          [ngClass]="{'inline-edit--container': isTextEditable}">
       <div *ngIf="isTextEditable"
            (accessibleClick)="activate($event)"

--- a/frontend/src/app/modules/hal/resources/hal-resource.ts
+++ b/frontend/src/app/modules/hal/resources/hal-resource.ts
@@ -238,6 +238,10 @@ export class HalResource {
     return undefined;
   }
 
+  public getEditorTypeFor(_fieldName:string):'full'|'constrained' {
+    return 'constrained';
+  }
+
   public $load(force = false):Promise<this> {
     if (!this.state) {
       return this.$loadResource(force);

--- a/frontend/src/app/modules/hal/resources/project-resource.ts
+++ b/frontend/src/app/modules/hal/resources/project-resource.ts
@@ -38,6 +38,14 @@ export class ProjectResource extends HalResource {
     return this.states.projects.get(this.id!) as any;
   }
 
+  public getEditorTypeFor(fieldName:string):"full"|"constrained" {
+    if (['statusExplanation', 'description'].indexOf(fieldName) !== -1) {
+      return 'full';
+    }
+
+    return 'constrained';
+  }
+
   /**
    * Get the schema of the project
    * ensure that it's loaded

--- a/frontend/src/app/modules/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/modules/hal/resources/work-package-resource.ts
@@ -198,6 +198,10 @@ export class WorkPackageBaseResource extends HalResource {
     }
   }
 
+  public getEditorTypeFor(fieldName:string):"full"|"constrained" {
+    return fieldName === 'description' ? 'full' : 'constrained';
+  }
+
   /**
    * Return whether the work package is editable with the user's permission
    * on the given work package attribute.

--- a/lib/custom_field_form_builder.rb
+++ b/lib/custom_field_form_builder.rb
@@ -68,7 +68,7 @@ class CustomFieldFormBuilder < TabularFormBuilder
       input_options[:class] = (input_options[:class] || '') << ' -augmented-datepicker'
       text_field(field, input_options)
     when 'text'
-      text_area(field, input_options.merge(with_text_formatting: true, macros: false))
+      text_area(field, input_options.merge(with_text_formatting: true, macros: false, editor_type: 'constrained'))
     when 'bool'
       formatter = field_format.formatter.new(object)
       check_box(field, input_options.merge(checked: formatter.checked?))

--- a/lib/open_project/text_formatting/formats/markdown/helper.rb
+++ b/lib/open_project/text_formatting/formats/markdown/helper.rb
@@ -58,6 +58,7 @@ module OpenProject::TextFormatting::Formats
         helpers.content_tag 'ckeditor-augmented-textarea',
                             '',
                             'textarea-selector': "##{field_id}",
+                            'editor-type': context[:editor_type] || 'full',
                             'preview-context': context[:preview_context],
                             'data-resource': resource.to_json,
                             'macros': context.fetch(:macros, true)

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -36,7 +36,7 @@ describe CustomFieldFormBuilder do
   let(:builder) { described_class.new(:user, resource, helper, {}) }
 
   describe '#custom_field' do
-    let(:options) { { class: 'custom-class' } }
+    let(:options) { {class: 'custom-class'} }
 
     let(:custom_field) do
       FactoryBot.build_stubbed(:custom_field)
@@ -104,6 +104,7 @@ describe CustomFieldFormBuilder do
                     id="user#{resource.custom_field_id}"
                     name="user[#{resource.custom_field_id}]"
                     with_text_formatting="true"
+                    editor_type="constrained"
                     macros="false">
           </textarea>
         }).at_path('textarea')
@@ -170,7 +171,7 @@ describe CustomFieldFormBuilder do
     context 'for a list custom field' do
       let(:custom_field) do
         FactoryBot.build_stubbed(:list_wp_custom_field,
-                                  custom_options: [custom_option])
+                                 custom_options: [custom_option])
       end
       let(:custom_option) do
         FactoryBot.build_stubbed(:custom_option, value: 'my_option')
@@ -236,7 +237,7 @@ describe CustomFieldFormBuilder do
         resource.customized = project
         allow(project)
           .to receive(:users)
-          .and_return([user1, user2])
+                .and_return([user1, user2])
       end
 
       it_behaves_like 'wrapped in container', 'select-container' do
@@ -286,7 +287,7 @@ describe CustomFieldFormBuilder do
         resource.customized = project
         allow(project)
           .to receive(:shared_versions)
-          .and_return([version1, version2])
+                .and_return([version1, version2])
       end
 
       it_behaves_like 'wrapped in container', 'select-container' do


### PR DESCRIPTION
Allow backend and frontend to set the editor type for given fields.

This disables table functionality on custom field types (pasting however still works due to paste-from-office) and enables tables on project description and statusExplanation

https://community.openproject.com/wp/31483