### PR TITLE
ensure journal notifications value is reset

### DIFF
--- a/app/models/journal_manager.rb
+++ b/app/models/journal_manager.rb
@@ -355,7 +355,7 @@ class JournalManager
     self.send_notification = send_notifications
 
     result = block.call
-
+  ensure
     self.send_notification = old_value
 
     result

--- a/spec/models/journal_manager_spec.rb
+++ b/spec/models/journal_manager_spec.rb
@@ -160,4 +160,41 @@ describe JournalManager, type: :model do
       end
     end
   end
+
+  describe '.with_send_notifications' do
+    let!(:send_notification_before) { described_class.send_notification }
+    let(:proc_called_counter) { OpenStruct.new called: false, send_notifications: !send_notification_before }
+    let(:proc) { Proc.new { proc_called_counter.called = true } }
+
+    it 'executes the block' do
+      described_class.with_send_notifications !send_notification_before, &proc
+
+      expect(proc_called_counter.called)
+        .to be_truthy
+    end
+
+    it 'uses the provided send_notifications value within the proc' do
+      described_class.with_send_notifications !send_notification_before, &proc
+
+      expect(proc_called_counter.send_notifications)
+        .to eql !send_notification_before
+    end
+
+    it 'resets the send_notifications to the value before' do
+      described_class.with_send_notifications !send_notification_before, &proc
+
+      expect(described_class.send_notification)
+        .to eql send_notification_before
+    end
+
+    context 'with an exception being raised within the block' do
+      it 'raises the exception but always resets the notification value' do
+        expect { described_class.with_send_notifications(!send_notification_before) { raise ArgumentError } }
+          .to raise_error ArgumentError
+
+        expect(described_class.send_notification)
+          .to eql send_notification_before
+      end
+    end
+  end
 end

--- a/spec/models/work_package/openproject_notifications_spec.rb
+++ b/spec/models/work_package/openproject_notifications_spec.rb
@@ -38,9 +38,9 @@ describe WorkPackage, type: :model do
     let(:project) { FactoryBot.create :project }
     let(:work_package) do
       FactoryBot.create :work_package,
-                         author: user,
-                         subject: 'I can see you',
-                         project: project
+                        author: user,
+                        subject: 'I can see you',
+                        project: project
     end
 
     let(:journal_ids) { [] }


### PR DESCRIPTION
Before, an execption raised within the block would lead to the value not being reset. This happens e.g. when a transaction is canceled. This caused spec failures to occur from time to time e.g.

`rspec ./spec/models/work_package/openproject_notifications_spec.rb[1:1:1:1] ./spec/requests/api/v3/membership_resources_spec.rb[1:2:3:1] --seed 92792`

but might also have unwanted side effects in production.

Spec failure https://travis-ci.org/opf/openproject/jobs/601170355