### PR TITLE
[31487] Error when moving widget based on seed data

### DIFF
--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -49,7 +49,8 @@ export class GridAreaService {
   }
 
   public cleanupUnusedAreas() {
-    let unusedRows = Array.from(Array(this.numRows + 1).keys()).slice(1);
+    // array containing Numbers from this.numRows to 1
+    let unusedRows = _.range(this.numRows, 0, -1);
 
     this.widgetAreas.forEach(widget => {
       unusedRows = unusedRows.filter(item => item !== widget.startRow);
@@ -61,7 +62,7 @@ export class GridAreaService {
       }
     });
 
-    let unusedColumns = Array.from(Array(this.numColumns + 1).keys()).slice(1);
+    let unusedColumns = _.range(this.numColumns, 0, -1);
 
     this.widgetAreas.forEach(widget => {
       unusedColumns = unusedColumns.filter(item => item !== widget.startColumn);

--- a/frontend/src/app/modules/grids/grid/grid.component.ts
+++ b/frontend/src/app/modules/grids/grid/grid.component.ts
@@ -112,17 +112,8 @@ export class GridComponent implements OnDestroy, OnInit {
     return this.sanitization.bypassSecurityTrustStyle(style);
   }
 
-  // array containing Numbers from 1 to this.numColumns
-  public get columnNumbers() {
-    return Array.from(Array(this.layout.numColumns + 1).keys()).slice(1);
-  }
-
   public get gridRowStyle() {
     return this.sanitization.bypassSecurityTrustStyle(`repeat(${this.layout.numRows}, ${this.GRID_AREA_HEIGHT})`);
-  }
-
-  public get rowNumbers() {
-    return Array.from(Array(this.layout.numRows + 1).keys()).slice(1);
   }
 
   public identifyGridArea(index:number, area:GridArea) {

--- a/modules/overviews/config/locales/en.seeders.bim.yml
+++ b/modules/overviews/config/locales/en.seeders.bim.yml
@@ -32,7 +32,7 @@ en:
         projects:
           demo-construction-project:
             project-overview:
-              row_count: 4
+              row_count: 5
               column_count: 2
               widgets:
                 - identifier: 'custom_text'
@@ -101,7 +101,7 @@ en:
                     queryId: '##query.id:"Milestones"'
           demo-planning-constructing-project:
             project-overview:
-              row_count: 4
+              row_count: 5
               column_count: 2
               widgets:
                 - identifier: 'custom_text'
@@ -166,7 +166,7 @@ en:
                     queryId: '##query.id:"Milestones"'
           demo-bim-project:
             project-overview:
-              row_count: 4
+              row_count: 5
               column_count: 2
               widgets:
                 - identifier: 'custom_text'

--- a/modules/overviews/config/locales/en.seeders.standard.yml
+++ b/modules/overviews/config/locales/en.seeders.standard.yml
@@ -32,7 +32,7 @@ en:
         projects:
           demo-project:
             project-overview:
-              row_count: 4
+              row_count: 5
               column_count: 2
               widgets:
                 - identifier: 'custom_text'
@@ -97,7 +97,7 @@ en:
                     queryId: '##query.id:"Milestones"'
           scrum-project:
             project-overview:
-              row_count: 4
+              row_count: 5
               column_count: 2
               widgets:
                 - identifier: 'custom_text'


### PR DESCRIPTION
When cleaning up unused rows, switch the order to be sure that all widgets below are updated accordingly. Now we start with the highest number. Otherwise, the [widget update check](https://github.com/opf/openproject/blob/dev/frontend/src/app/modules/grids/grid/area.service.ts#L327) may fail because the start row has already been counted down from previous remote rows. 

https://community.openproject.com/projects/openproject/work_packages/31487/activity