### PR TITLE
Fix double join on principal_roles table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@
 language: ruby
 
 rvm:
-  - 2.6.1
+  - 2.6.5
 
 sudo: required
 dist: xenial
@@ -57,8 +57,8 @@ before_install:
 
   # work around https://github.com/travis-ci/travis-ci/issues/8969
   - travis_retry gem update --system
-  # Don't install 1.16.3
-  - gem install bundler -v 2.0.1 --no-document
+  # Install latest bundler
+  - gem install bundler
 
   # Install Node latest LTS
   # This should only be necessary when preparing the cache or for npm test runs

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@
 
 source 'https://rubygems.org'
 
-ruby '~> 2.6.1'
+ruby '~> 2.6.5'
 
 gem 'actionpack-xml_parser', '~> 2.0.0'
 gem 'activemodel-serializers-xml', '~> 1.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1106,7 +1106,7 @@ DEPENDENCIES
   will_paginate (~> 3.1.7)
 
 RUBY VERSION
-   ruby 2.6.1p33
+   ruby 2.6.5p114
 
 BUNDLED WITH
    2.0.2

--- a/modules/global_roles/lib/open_project/global_roles/engine.rb
+++ b/modules/global_roles/lib/open_project/global_roles/engine.rb
@@ -59,7 +59,7 @@ module OpenProject::GlobalRoles
     end
 
     config.to_prepare do
-      principal_roles_table = PrincipalRole.arel_table
+      principal_roles_table = PrincipalRole.arel_table.alias('global_role_principal_roles')
       query = Authorization::UserGlobalRolesQuery
       roles_table = query.roles_table
       users_table = query.users_table


### PR DESCRIPTION
Fixes

```
ActiveRecord::StatementInvalid: PG::DuplicateAlias: ERROR:  table name "principal_roles" specified more than once
from /home/oliver/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-6.0.0/lib/active_record/connection_adapters/postgresql_adapter.rb:668:in `async_exec_params'
Caused by PG::DuplicateAlias: ERROR:  table name "principal_roles" specified more than once

app/services/authorization/user_allowed_service.rb:111:in `has_authorized_role?'
app/services/authorization/user_allowed_service.rb:105:in `allowed_to_globally'
app/services/authorization/user_allowed_service.rb:70:in `allowed_to?'
app/services/authorization/user_allowed_service.rb:51:in `call'
```