### PR TITLE
Fix/grid d n d on replacing higher widgets

### DIFF
--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -131,6 +131,18 @@ export class GridAreaService {
     this.helpMode = !this.helpMode;
   }
 
+  // This is a hacky way to have the placeholder in the viewport.
+  // It is a noop for firefox and edge as both do not support scrollIntoViewIfNeeded.
+  // But as scrollIntoView will always readjust the viewport, the result would be an unbearable flicker
+  // which causes e.g. dragging to be impossible.
+  public scrollPlaceholderIntoView() {
+    let placeholder = jQuery('.grid--area.-placeholder');
+
+    if ((placeholder[0] as any).scrollIntoViewIfNeeded) {
+      setTimeout(() => (placeholder[0] as any).scrollIntoViewIfNeeded());
+    }
+  }
+
   private saveGrid(resource:GridWidgetResource|any, schema?:SchemaResource) {
     this
       .gridDm

--- a/frontend/src/app/modules/grids/grid/drag-and-drop.service.ts
+++ b/frontend/src/app/modules/grids/grid/drag-and-drop.service.ts
@@ -81,6 +81,7 @@ export class GridDragAndDropService implements OnDestroy {
   public abort() {
     document.dispatchEvent(new Event('mouseup'));
     this.aborted = true;
+    this.layout.resetAreas();
   }
 
   public stop() {
@@ -92,15 +93,14 @@ export class GridDragAndDropService implements OnDestroy {
     this.placeholderArea = null;
   }
 
-  public drop(event:CdkDragDrop<GridArea>) {
+  public drop(draggedArea:GridWidgetArea, event:CdkDragDrop<GridArea>) {
     if (this.aborted) {
       this.aborted = false;
       return;
     }
 
     // this.draggedArea is already reset to null at this point
-    let dropArea = event.container.data;
-    let draggedArea = event.previousContainer.data as GridWidgetArea;
+    let dropArea = this.layout.mousedOverArea!;
 
     // Set the draggedArea's startRow/startColumn properties
     // to the drop zone ones.

--- a/frontend/src/app/modules/grids/grid/drag-and-drop.service.ts
+++ b/frontend/src/app/modules/grids/grid/drag-and-drop.service.ts
@@ -35,6 +35,8 @@ export class GridDragAndDropService implements OnDestroy {
         throttle(val => interval(10))
       ).subscribe(area => {
         this.updateArea(area!);
+
+        this.layout.scrollPlaceholderIntoView();
       });
   }
 

--- a/frontend/src/app/modules/grids/grid/grid.component.html
+++ b/frontend/src/app/modules/grids/grid/grid.component.html
@@ -19,6 +19,7 @@
     <div class="grid--area-content widget-box"
          cdkDrag
          (cdkDragStarted)="drag.start(area)"
+         (cdkDragDropped)="drag.drop(area, $event)"
          (cdkDragEnded)="drag.stop()">
 
       <span *ngIf="drag.isDraggable"
@@ -61,7 +62,6 @@
        [id]="area.guid"
        (mouseover)="layout.setMousedOverArea(area)"
        [cdkDropListData]="area"
-       (cdkDropListDropped)="drag.drop($event)"
        [cdkDropListConnectedTo]="layout.gridAreaIds">
     <div class="grid--widget-add hidden-for-mobile"
          [title]="add.addText"

--- a/frontend/src/app/modules/grids/grid/grid.component.ts
+++ b/frontend/src/app/modules/grids/grid/grid.component.ts
@@ -104,7 +104,7 @@ export class GridComponent implements OnDestroy, OnInit {
 
   public get gridColumnStyle() {
     return this.gridStyle(this.layout.numColumns,
-                          `calc((100% - ${this.GRID_GAP_DIMENSION} * ${this.layout.numColumns + 1}) / ${this.layout.numColumns})`)
+                          `calc((100% - ${this.GRID_GAP_DIMENSION} * ${this.layout.numColumns + 1}) / ${this.layout.numColumns})`);
   }
 
   public get gridRowStyle() {


### PR DESCRIPTION
When dragging, the layout is constantly updated to reflect to the user the way the resulting grid will look like if the user where to drop the currently dragged widget at the given drop zone. In some cases, this will lead to the grid altering its dimensions e.g. it will become quite longer if a longer widget is pushed down. This might cause the viewport to change which might cause the mouse no longer being over the intended drop zone which leads to the drop not being performed. It might also lead to the drop zone no longer being visible.

The first problem is fixed altogether by this PR. The only caveat here is that the mouse is not guaranteed to be over the drop zone any more but it no longer has to be for the drop to be performed.

The second problem is addressed as well but the fix has the caveat to only be available for browsers supporting `scrollIntoViewIfNeeded` which currently boils down to chrome only. Using `scrollIntoView` lead to undesirable flickers whenever dragging so it was worse having the fix for the edge case in all the main cases than having to suffer in the edge case.

https://community.openproject.com/projects/openproject/work_packages/31487