### PR TITLE
fix dragging to outside of grid

### DIFF
--- a/frontend/src/app/modules/grids/grid/grid.component.html
+++ b/frontend/src/app/modules/grids/grid/grid.component.html
@@ -19,8 +19,7 @@
     <div class="grid--area-content widget-box"
          cdkDrag
          (cdkDragStarted)="drag.start(area)"
-         (cdkDragDropped)="drag.drop(area, $event)"
-         (cdkDragEnded)="drag.stop()">
+         (cdkDragDropped)="drag.drop(area)">
 
       <span *ngIf="drag.isDraggable"
             class="grid--area-drag-handle


### PR DESCRIPTION
AS the code relied on the mousedOverArea, and that area was not set when moving outside of the grid or over another widget, the drop failed. As we no longer rely on the drop even being fired by the receiving grid-area but listen to the drop event on the moved widget area we can get rid of the stop() function which used to complicate things. By that, we can also simplify the abort case and no longer need to maintin the magic `aborted` variable.

https://community.openproject.com/projects/openproject/work_packages/31518
https://community.openproject.com/projects/openproject/work_packages/31515