### PR TITLE
[31525] Widgets overlap each other

### DIFF
--- a/frontend/src/app/modules/grids/areas/grid-widget-area.ts
+++ b/frontend/src/app/modules/grids/areas/grid-widget-area.ts
@@ -76,4 +76,11 @@ export class GridWidgetArea extends GridArea {
     this.widget.startColumn = this.startColumn;
     this.widget.endColumn = this.endColumn;
   }
+
+  public copyDimensionsTo(sink:GridWidgetArea) {
+    sink.startRow = this.startRow;
+    sink.startColumn = this.startColumn;
+    sink.endRow = this.endRow;
+    sink.endColumn = this.endColumn;
+  }
 }

--- a/frontend/src/app/modules/grids/grid/drag-and-drop.service.ts
+++ b/frontend/src/app/modules/grids/grid/drag-and-drop.service.ts
@@ -50,6 +50,10 @@ export class GridDragAndDropService implements OnDestroy {
     }
     let widgetArea = this.draggedArea!;
 
+    // Set the draggedArea's startRow/startColumn properties
+    // to the drop zone ones.
+    // The dragged Area should keep it's height and width normally but will
+    // shrink if the area would otherwise end outside the grid.
     // we cannot use the widget's original area as moving it while dragging confuses cdkDrag
     this.copyPositionButRestrict(dropArea, this.placeholderArea);
 
@@ -91,11 +95,7 @@ export class GridDragAndDropService implements OnDestroy {
       return;
     }
 
-    // Set the draggedArea's startRow/startColumn properties
-    // to the drop zone ones.
-    // The dragged Area should keep it's height and width normally but will
-    // shrink if the area would otherwise end outside the grid.
-    this.copyPositionButRestrict(this.placeholderArea!, this.draggedArea!);
+    this.placeholderArea!.copyDimensionsTo(this.draggedArea!)
 
     if (!this.draggedArea!.unchangedSize) {
       this.layout.writeAreaChangesToWidgets();

--- a/frontend/src/app/modules/grids/grid/move.service.ts
+++ b/frontend/src/app/modules/grids/grid/move.service.ts
@@ -87,8 +87,7 @@ export class GridMoveService {
       let referenceArea = overlappingArea!;
 
       anchorAreas.forEach((anchorArea) => {
-        if (anchorArea.endRow > referenceArea.endRow &&
-          toMoveArea!.startColumn >= anchorArea.startColumn && toMoveArea!.startColumn < anchorArea.endColumn) {
+        if (anchorArea.endRow > referenceArea.endRow && toMoveArea!.columnOverlaps(anchorArea)) {
           referenceArea = anchorArea;
         }
       });


### PR DESCRIPTION
If a widget with a height greater than 1 is moved, a special case must be queried during collision detection.
EXAMPLE: It is possible that the widget X (with height 2) moves an element Y downwards. In its new position, X collides with an element Z. In this case Z must not moved only under X, but also under Y. Currently Y and Z simply overlap each other, which is of course wrong. 
The check already existed in the code, but the query did not work correctly. 


https://community.openproject.com/projects/openproject/work_packages/31525/activity