### PR TITLE
[31504] Reload attachments again after coming from list

### DIFF
--- a/frontend/src/app/modules/attachments/attachment-list/attachment-list.component.ts
+++ b/frontend/src/app/modules/attachments/attachment-list/attachment-list.component.ts
@@ -40,7 +40,7 @@ import {AngularTrackingHelpers} from "core-components/angular/tracking-functions
   selector: 'attachment-list',
   templateUrl: './attachment-list.html'
 })
-export class AttachmentListComponent implements OnInit, OnChanges, OnDestroy {
+export class AttachmentListComponent implements OnInit, OnDestroy {
   @Input() public resource:HalResource;
   @Input() public destroyImmediately:boolean = true;
 
@@ -60,11 +60,7 @@ export class AttachmentListComponent implements OnInit, OnChanges, OnDestroy {
   ngOnInit() {
     this.$element = jQuery(this.elementRef.nativeElement);
 
-    if (this.attachmentsUpdatable) {
-      this.resource.updateAttachments();
-    }
-
-    this.attachments = this.resource.attachments.elements;
+    this.updateAttachments();
     this.setupResourceUpdateListener();
 
     if (!this.destroyImmediately) {
@@ -81,7 +77,8 @@ export class AttachmentListComponent implements OnInit, OnChanges, OnDestroy {
       )
       .subscribe((newResource:HalResource) => {
         this.resource = newResource || this.resource;
-        this.attachments = [...this.resource.attachments.elements];
+
+        this.updateAttachments();
         this.cdRef.detectChanges();
       });
   }
@@ -89,12 +86,6 @@ export class AttachmentListComponent implements OnInit, OnChanges, OnDestroy {
   ngOnDestroy():void {
     if (!this.destroyImmediately) {
       this.$formElement.off('submit.attachment-component');
-    }
-  }
-
-  ngOnChanges() {
-    if (this.attachmentsUpdatable) {
-      this.resource.attachments.updateElements();
     }
   }
 
@@ -127,6 +118,22 @@ export class AttachmentListComponent implements OnInit, OnChanges, OnDestroy {
         .resource
         .removeAttachment(attachment);
     });
+  }
+
+  private updateAttachments() {
+    if (!this.attachmentsUpdatable) {
+      this.attachments = this.resource.attachments.elements;
+      return;
+    }
+
+    this
+      .resource
+      .attachments
+      .updateElements()
+      .then(() => {
+        this.attachments = this.resource.attachments.elements;
+        this.cdRef.detectChanges();
+      });
   }
 }
 


### PR DESCRIPTION
Due to the way the attachments are embedded in HAL, we can end up with two situations:

1. We load the work package in single-view and attachments are embedded ($loaded = true)

2. We load the work package in the list and attachments are not embedded ($loaded = false)

The attachment-list doesn't properly reload the attachments in the first case after being initialized. Assume you open the single-view, upload an  attachment and then let the list reload, the work package attachments will become unloaded since they are contained in the work package
resource and not in a separate state.

We thus have to reload attachments more often to ensure they get reloaded in this case. The proper solution would be to have attachments tracked in a separate resource.

Note that this might result in loading the attachments multiple times in the worst case when first stepping through 1, then 2 above.

https://community.openproject.com/wp/31504