### PR TITLE
[31537] Can not inline create versions

### DIFF
--- a/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
@@ -64,6 +64,7 @@ export class CreateAutocompleterComponent implements AfterViewInit {
     } else {
       this._createAllowed = false;
     }
+    this.cdRef.detectChanges();
 
     setTimeout(() => {
       if (this.openDirectly) {


### PR DESCRIPTION
Push changes in permission to autocompleter component. The initial value for `createAllowed` is `false`, so the change for the version field didn't get through to the component.

https://community.openproject.com/projects/openproject/work_packages/31537/activity