### PR TITLE
do not render duplicate roles in memberships representer

### DIFF
--- a/lib/api/v3/memberships/membership_representer.rb
+++ b/lib/api/v3/memberships/membership_representer.rb
@@ -100,7 +100,11 @@ module API
         end
 
         def unmarked_roles
-          represented.member_roles.reject(&:marked_for_destruction?).map(&:role)
+          represented
+            .member_roles
+            .reject(&:marked_for_destruction?)
+            .map(&:role)
+            .uniq
         end
       end
     end

--- a/spec/lib/api/v3/memberships/membership_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/memberships/membership_representer_rendering_spec.rb
@@ -33,7 +33,7 @@ describe ::API::V3::Memberships::MembershipRepresenter, 'rendering' do
 
   let(:member) do
     FactoryBot.build_stubbed(:member,
-                             member_roles: [member_role1, member_role2, marked_member_role],
+                             member_roles: [member_role1, member_role2, member_role2, marked_member_role],
                              principal: principal,
                              project: project,
                              created_on: Time.current)
@@ -154,6 +154,7 @@ describe ::API::V3::Memberships::MembershipRepresenter, 'rendering' do
       it_behaves_like 'has a link collection' do
         let(:link) { 'roles' }
         # excludes member_roles marked for destruction
+        # and duplicates
         let(:hrefs) do
           [
             {


### PR DESCRIPTION
A user can receive duplicate roles for a membership when being added first as an individual and then again as part of a group.

https://community.openproject.com/projects/openproject/work_packages/31548