### PR TITLE
Avoid setting createAllowed=false after initialization of versions

### DIFF
--- a/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
@@ -33,6 +33,7 @@ import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
+import {AddTagFn} from "@ng-select/ng-select/lib/ng-select.component";
 
 @Component({
   templateUrl: './create-autocompleter.component.html',
@@ -57,28 +58,12 @@ export class CreateAutocompleterComponent implements AfterViewInit {
 
   @ViewChild('ngSelectComponent', {static: false}) public ngSelectComponent:NgSelectComponent;
 
-  @Input()
-  public set createAllowed(val:boolean) {
-    if (val) {
-      this._createAllowed = this.createNewElement.bind(this);
-    } else {
-      this._createAllowed = false;
-    }
-    this.cdRef.detectChanges();
-
-    setTimeout(() => {
-      if (this.openDirectly) {
-        this.openSelect();
-      }
-      this.ngAfterViewInit();
-    });
-  }
-
   public text:any = {
     add_new_action: this.I18n.t('js.label_create'),
   };
 
-  private _createAllowed:boolean = false;
+  public createAllowed:boolean|AddTagFn = false;
+
   private _openDirectly:boolean = false;
 
   constructor(readonly I18n:I18nService,
@@ -107,12 +92,6 @@ export class CreateAutocompleterComponent implements AfterViewInit {
     this.ngSelectComponent && this.ngSelectComponent.close();
   }
 
-  public createNewElement(newElement:string) {
-    if (this.createAllowed) {
-      this.performCreate(newElement);
-    }
-  }
-
   public changeModel(element:HalResource) {
     this.onChange.emit(element);
   }
@@ -137,10 +116,6 @@ export class CreateAutocompleterComponent implements AfterViewInit {
     this.onKeydown.emit(event);
   }
 
-  public get createAllowed() {
-    return this._createAllowed;
-  }
-
   public get openDirectly() {
     return this._openDirectly;
   }
@@ -154,10 +129,6 @@ export class CreateAutocompleterComponent implements AfterViewInit {
 
   public focusInputField() {
     this.ngSelectComponent && this.ngSelectComponent.focus();
-  }
-
-  protected performCreate(newElement:string) {
-    // Nothing to do in this base component.
   }
 }
 

--- a/frontend/src/app/modules/common/autocomplete/version-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/version-autocompleter.component.ts
@@ -49,7 +49,7 @@ import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-
   templateUrl: './create-autocompleter.component.html',
   selector: 'version-autocompleter'
 })
-export class VersionAutocompleterComponent extends CreateAutocompleterComponent implements OnInit {
+export class VersionAutocompleterComponent extends CreateAutocompleterComponent implements AfterViewInit {
   @Input() public openDirectly:boolean = false;
   @Output() public onCreate = new EventEmitter<VersionResource>();
 
@@ -62,9 +62,14 @@ export class VersionAutocompleterComponent extends CreateAutocompleterComponent 
     super(I18n, cdRef, currentProject, pathHelper);
   }
 
-  ngOnInit() {
+  ngAfterViewInit() {
+    super.ngAfterViewInit();
+
     this.canCreateNewActionElements().then((val) => {
-      this.createAllowed = val;
+      if (val) {
+        this.createAllowed = (input:string) => this.createNewVersion(input);
+        this.cdRef.detectChanges();
+      }
     });
   }
 
@@ -79,7 +84,7 @@ export class VersionAutocompleterComponent extends CreateAutocompleterComponent 
       .catch(() => false);
   }
 
-  protected performCreate(name:string) {
+  protected createNewVersion(name:string) {
     this.versionDm.createVersion(this.getVersionPayload(name))
       .then((version) => {
         this.onCreate.emit(version);

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.html
@@ -5,7 +5,6 @@
                                    required: required,
                                    disabled: inFlight,
                                    id: handler.htmlId,
-                                   createAllowed: false,
                                    finishedLoading: true,
                                    classes: 'inline-edit--field ' + handler.fieldName }"
              [ndcDynamicOutputs]="referenceOutputs">


### PR DESCRIPTION
When the timing is just right, the result of `createAllowed` setting in the version autocompleter is performed before the initialization of the parent ng-select. This results in the createAllowed defaulting back to false even though it is allowed.

This is caused by `createAllowed` being an input of the createAutocompleter which is set somewhere in the `ngOnInit` phase. Since `createAllowed` only works when a creation callback exists and this is only the case for the version autocompleter, we can remove this input

https://community.openproject.com/wp/31547
https://community.openproject.com/wp/31546