### PR TITLE
fix summing custom fields on wp table

### DIFF
--- a/app/models/query/sums.rb
+++ b/app/models/query/sums.rb
@@ -100,7 +100,8 @@ module ::Query::Sums
 
   def crunch(num)
     return num if num.nil? or num.integer?
-    Float(format '%.2f', num.to_f)
+
+    Float(format('%.2f', num.to_f))
   end
 
   def group_for_issue(issue = @current_issue)
@@ -121,7 +122,7 @@ module ::Query::Sums
 
   def all_total_sums
     query.available_columns.select { |column|
-      column.summable? && Setting.work_package_list_summable_columns.include?(column.name.to_s)
+      should_be_summed_up?(column)
     }.inject({}) { |result, column|
       sum = total_sum_of(column)
       result[column] = sum unless sum.nil?


### PR DESCRIPTION
Before the fix, string values where returned and then the `+` method was called which lead to the strings being concatenated. A subsequent call of `integer?` failed. The fix performs the aggregation in the database which is not only correct then but can also be carried out considerably faster. The drawback is, that the casting breaks the abstraction introduced by the cf strategies.

https://community.openproject.com/projects/openproject/work_packages/31578