### PR TITLE
[31596] Use pristine, not projected resource for delta building

### DIFF
--- a/frontend/src/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/timeline-milestone-cell-renderer.ts
@@ -77,7 +77,7 @@ export class TimelineMilestoneCellRenderer extends TimelineCellRenderer {
                      delta:number,
                      direction:'left' | 'right' | 'both' | 'create' | 'dragright') {
 
-    const initialDate = change.projectedResource.date;
+    const initialDate = change.pristineResource.date;
     let dates:CellDateMovement = {};
 
     if (initialDate) {


### PR DESCRIPTION
The milestone delta computation must not use the projected resource, as that contains the "would-be" date to be applied. Instead the delta needs to be applied to the original date value

https://community.openproject.com/wp/31596