### PR TITLE
only require copy_project permission to show button

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -191,7 +191,7 @@ class Project < ActiveRecord::Base
   end
 
   def copy_allowed?
-    User.current.allowed_to?(:copy_projects, self) && (parent.nil? || User.current.allowed_to?(:add_subprojects, parent))
+    User.current.allowed_to?(:copy_projects, self)
   end
 
   def self.selectable_projects

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -89,38 +89,31 @@ describe Project, type: :model do
     end
   end
 
-  describe 'copy_allowed?' do
-    let(:user) { FactoryBot.create(:user) }
-    let(:role_add_subproject) { FactoryBot.create(:role, permissions: [:add_subprojects]) }
-    let(:role_copy_projects) { FactoryBot.create(:role, permissions: [:edit_project, :copy_projects, :add_project]) }
-    let(:parent_project) { FactoryBot.create(:project) }
-    let(:project) { FactoryBot.create(:project, parent: parent_project) }
-    let!(:subproject_member) do
-      FactoryBot.create(:member,
-                        user: user,
-                        project: project,
-                        roles: [role_copy_projects])
-    end
+  describe '#copy_allowed?' do
+    let(:user) { FactoryBot.build_stubbed(:user) }
+    let(:project) { FactoryBot.build_stubbed(:project) }
+    let(:permission_granted) { true }
+
     before do
+      allow(user)
+        .to receive(:allowed_to?)
+        .with(:copy_projects, project)
+        .and_return(permission_granted)
+
       login_as(user)
     end
 
-    context 'with permission to add subprojects' do
-      let!(:member_add_subproject) do
-        FactoryBot.create(:member,
-                          user: user,
-                          project: parent_project,
-                          roles: [role_add_subproject])
-      end
-
-      it 'should allow copy' do
-        expect(project.copy_allowed?).to eq(true)
+    context 'with copy project permission' do
+      it 'is true' do
+        expect(project.copy_allowed?).to be_truthy
       end
     end
 
-    context 'with permission to add subprojects' do
-      it 'should not allow copy' do
-        expect(project.copy_allowed?).to eq(false)
+    context 'without copy project permission' do
+      let(:permission_granted) { false }
+
+      it 'is false' do
+        expect(project.copy_allowed?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
As we no longer require the user to have the `add_subprojects` permission even when the project to be copied is a child project, we can simplify the permission check to only require the `copy_projects` permission.

However, to visit the page where the button is displayed, the user needs additional permission (e.g `edit_project`)

https://community.openproject.com/projects/openproject/work_packages/31533