### PR TITLE
increase strictness on regexp for default orders

### DIFF
--- a/app/models/queries/members/orders/default_order.rb
+++ b/app/models/queries/members/orders/default_order.rb
@@ -32,6 +32,6 @@ class Queries::Members::Orders::DefaultOrder < Queries::BaseOrder
   self.model = Member
 
   def self.key
-    /id|created_on/
+    /\A(id|created_on)\z/
   end
 end

--- a/app/models/queries/news/orders/default_order.rb
+++ b/app/models/queries/news/orders/default_order.rb
@@ -32,6 +32,6 @@ class Queries::News::Orders::DefaultOrder < Queries::BaseOrder
   self.model = News
 
   def self.key
-    /id|created_on/
+    /\A(id|created_on)\z/
   end
 end

--- a/app/models/queries/projects/orders/default_order.rb
+++ b/app/models/queries/projects/orders/default_order.rb
@@ -32,6 +32,6 @@ class Queries::Projects::Orders::DefaultOrder < Queries::BaseOrder
   self.model = Project
 
   def self.key
-    /id|name|created_at|public|lft/
+    /\A(id|name|created_at|public|lft)\z/
   end
 end

--- a/app/models/queries/relations/orders/default_order.rb
+++ b/app/models/queries/relations/orders/default_order.rb
@@ -34,7 +34,7 @@ module Queries
         self.model = Relation
 
         def self.key
-          /id|from|to|involved|type/
+          /\A(id|from|to|involved|type)\z/
         end
       end
     end

--- a/app/models/queries/time_entries/orders/default_order.rb
+++ b/app/models/queries/time_entries/orders/default_order.rb
@@ -32,6 +32,6 @@ class Queries::TimeEntries::Orders::DefaultOrder < Queries::BaseOrder
   self.model = TimeEntry
 
   def self.key
-    /id|hours|spent_on|created_on/
+    /\A(id|hours|spent_on|created_on)\z/
   end
 end

--- a/app/models/queries/users/orders/default_order.rb
+++ b/app/models/queries/users/orders/default_order.rb
@@ -31,6 +31,6 @@ class Queries::Users::Orders::DefaultOrder < Queries::BaseOrder
   self.model = User
 
   def self.key
-    /id|lastname|firstname|mail|login/
+    /\A(id|lastname|firstname|mail|login)\z/
   end
 end

--- a/modules/documents/app/models/queries/documents/orders/default_order.rb
+++ b/modules/documents/app/models/queries/documents/orders/default_order.rb
@@ -32,6 +32,6 @@ class Queries::Documents::Orders::DefaultOrder < Queries::BaseOrder
   self.model = Document
 
   def self.key
-    /id|created_on/
+    /\A(id|created_on)\z/
   end
 end


### PR DESCRIPTION
Otherwise partial matches would also count e.g. is_public matches as
public is a substring.