### PR TITLE
Fix resetting the session for non-html requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -272,11 +272,14 @@ class ApplicationController < ActionController::Base
   def require_login
     unless User.current.logged?
 
-      # Ensure we reset the session to terminate any old session objects
-      reset_session
-
       respond_to do |format|
-        format.any(:html, :atom) { redirect_to main_app.signin_path(back_url: login_back_url) }
+        format.any(:html, :atom) do
+          # Ensure we reset the session to terminate any old session objects
+          # but ONLY for html requests to avoid double-resetting sessions
+          reset_session
+
+          redirect_to main_app.signin_path(back_url: login_back_url)
+        end
 
         auth_header = OpenProject::Authentication::WWWAuthenticate.response_header(request_headers: request.headers)
 


### PR DESCRIPTION
this caused a CSRF issue on saas. Requests were being redirected to /admin/subscriptions/expired and wrongfully so for API and CSS requests.

Now imagine a request to `/` with `login_required` for a non-logged in user

1. The GET `/` request is redirected to `/login?back_url=...` by ApplicationController. Session is reset here to X

2. The user receives the login form with CSRF value from session X

3. A request is made to `/api/v3/configuration` from the frontend. It too is redirected to a Rails controller and ends up in the same `check_if_login_required` flow, resetting the session again

4. The user now has a session cookie Y, but the CSRF form is still from X

5. submitting it results in 422 CSRF validation error