### PR TITLE
Avoid trying to call JSON.stringify on HalResources

### DIFF
--- a/frontend/src/app/modules/hal/resources/error-resource.ts
+++ b/frontend/src/app/modules/hal/resources/error-resource.ts
@@ -28,6 +28,7 @@
 
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
 import {FormResource} from 'core-app/modules/hal/resources/form-resource';
+import {HttpErrorResponse} from "@angular/common/http";
 
 export const v3ErrorIdentifierQueryInvalid = 'urn:openproject-org:api:v3:errors:InvalidQuery';
 export const v3ErrorIdentifierMultipleErrors = 'urn:openproject-org:api:v3:errors:MultipleErrors';
@@ -38,7 +39,18 @@ export class ErrorResource extends HalResource {
   public details:any;
   public errorIdentifier:string;
 
+  /** We may get a reference to the underlying http error */
+  public httpError?:HttpErrorResponse;
+
   public isValidationError:boolean = false;
+
+  /**
+   * Override toString to ensure the resource can
+   * be printed nicely on console and in errors
+   */
+  public toString() {
+    return `[ErrorResource ${this.message}]`;
+  }
 
   public get errorMessages():string[] {
     if (this.isMultiErrorMessage()) {

--- a/frontend/src/app/modules/hal/resources/hal-resource.ts
+++ b/frontend/src/app/modules/hal/resources/hal-resource.ts
@@ -116,6 +116,18 @@ export class HalResource {
   }
 
   /**
+   * Override toString to ensure the resource can
+   * be printed nicely on console and in errors
+   */
+  public toString() {
+    if (this.$href) {
+      return `[HalResource href=${this.$href}]`;
+    } else {
+      return `[HalResource id=${this.id}]`;
+    }
+  }
+
+  /**
    * Returns the ID and ensures it's a string, null.
    * Returns a string when:
    *  - The embedded ID is actually set

--- a/frontend/src/app/modules/hal/services/hal-aware-error-handler.ts
+++ b/frontend/src/app/modules/hal/services/hal-aware-error-handler.ts
@@ -6,7 +6,7 @@ import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 @Injectable()
 export class HalAwareErrorHandler extends ErrorHandler {
   private text = {
-    internal_error: this.I18n.t('js.errors.internal')
+    internal_error: this.I18n.t('js.error.internal')
   };
 
   constructor(private readonly I18n:I18nService) {

--- a/frontend/src/app/modules/hal/services/hal-resource.service.ts
+++ b/frontend/src/app/modules/hal/services/hal-resource.service.ts
@@ -36,6 +36,8 @@ import {CollectionResource} from 'core-app/modules/hal/resources/collection-reso
 import {HalLink, HalLinkInterface} from 'core-app/modules/hal/hal-link/hal-link';
 import {initializeHalProperties} from 'core-app/modules/hal/helpers/hal-resource-builder';
 import {URLParamsEncoder} from 'core-app/modules/hal/services/url-params-encoder';
+import {ErrorReporter} from "core-app/sentry/sentry-reporter";
+import {ErrorResource} from "core-app/modules/hal/resources/error-resource";
 
 export interface HalResourceFactoryConfigInterface {
   cls?:any;
@@ -97,7 +99,9 @@ export class HalResourceService {
         map((response:any) => this.createHalResource(response)),
         catchError((error:HttpErrorResponse) => {
           console.error(`Failed to ${method} ${href}: ${error.name}`);
-          return throwError(this.createHalResource(error.error));
+          const resource = this.createHalResource<ErrorResource>(error.error);
+          resource.httpError = error;
+          return throwError(resource);
         })
       ) as any;
   }


### PR DESCRIPTION
Zone.js does this as a default zone rejection handler, and checks for
the presence of a custom `toString` method.

Fixes https://sentry.openproject.com/share/issue/fa3d58917a2d44b499eece22c1fabe09/
Fixes https://sentry.openproject.com/share/issue/0b5fef9a3b3b42adb55466abbb1cecbb/