### PR TITLE
Separately allow to disable sentry without removing dsn

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -53,7 +53,7 @@ See docs/COPYRIGHT.rdoc for more details.
           data-id="<%= User.current.id %>" />
   <% end %>
 
-  <% if OpenProject::Configuration.sentry_dsn.present? %>
+  <% if OpenProject::Configuration.frontend_sentry? %>
     <%= tag :meta, name: 'openproject_sentry', data: { dsn: OpenProject::Configuration.sentry_dsn } %>
   <% end %>
 

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -161,6 +161,8 @@ module OpenProject
 
       # Log errors to sentry instance
       'sentry_dsn' => nil,
+      # Allow error reporting for frontend errors
+      'sentry_report_js' => false,
       'sentry_host' => 'https://sentry.openproject.com'
     }
 

--- a/lib/open_project/configuration/helpers.rb
+++ b/lib/open_project/configuration/helpers.rb
@@ -83,6 +83,12 @@ module OpenProject
         ENV['OPENPROJECT_EDITION'] == 'bim'
       end
 
+      ##
+      # Whether we want to report to sentry
+      def frontend_sentry?
+        self['sentry_dsn'].present? && sentry_report_js?
+      end
+
 
       def available_file_uploaders
         uploaders = {


### PR DESCRIPTION
Allows us to quickly enable/disable only frontend reporting