### PR TITLE
Remove for attribute from autologin label

### DIFF
--- a/app/views/account/_login.html.erb
+++ b/app/views/account/_login.html.erb
@@ -40,7 +40,7 @@ See docs/COPYRIGHT.rdoc for more details.
         </div>
         <div class="form--field-extra-actions">
           <% if Setting.autologin? %>
-            <label class="form--label-with-check-box" for="autologin"><%= styled_check_box_tag 'autologin', 1, false %> <%= l(:label_stay_logged_in) %></label>
+            <label class="form--label-with-check-box"><%= styled_check_box_tag 'autologin', 1, false %> <%= l(:label_stay_logged_in) %></label>
           <% elsif Setting.self_registration? %>
             <%# show here if autologin is disabled, otherwise below lost_password link %>
               <%= link_to t(:label_register),

--- a/app/views/account/_password_login_form.html.erb
+++ b/app/views/account/_password_login_form.html.erb
@@ -47,7 +47,7 @@ See docs/COPYRIGHT.rdoc for more details.
   <% if Setting.autologin? %>
     <div class="form--field -no-label">
       <div class="form--field-container">
-        <label for="autologin" class="form--label-with-check-box">
+        <label class="form--label-with-check-box">
           <%= styled_check_box_tag 'autologin', 1, false %>
           <%= l(:label_stay_logged_in) %>
         </label>


### PR DESCRIPTION
This patch fixes the auto login label not checking the checkbox on when clicking on the label. It removes the for attribute from the login form for the autologin label.

The html standard allows to have both (contained control element and for attribute if the for attribute points to the contained element) but this leads to a not working checkbox. My guess is that the browser checks the checkbox 2 times (one time for the attribute and one time for the contained element).
