### PR TITLE
Feature/bcf api topics

### DIFF
--- a/modules/bcf/app/controllers/bcf/api/v2_1/topics_api.rb
+++ b/modules/bcf/app/controllers/bcf/api/v2_1/topics_api.rb
@@ -29,31 +29,18 @@
 #++
 
 module Bcf::API::V2_1
-  class ProjectsAPI < ::API::OpenProjectAPI
-    resources :projects do
+  class TopicsAPI < ::API::OpenProjectAPI
+    resources :topics do
       helpers do
-        def visible_projects
-          Project
-            .visible(current_user)
-            .has_module(:bcf)
+        def topics
+          Bcf::Issue.of_project(@project)
         end
       end
 
-      get &::Bcf::API::V2_1::Endpoints::Index.new(model: Project,
-                                                  scope: -> { visible_projects })
+      get &::Bcf::API::V2_1::Endpoints::Index.new(model: Bcf::Issue,
+                                                  api_name: 'Topics',
+                                                  scope: -> { topics })
                                              .mount
-
-      route_param :id, regexp: /\A(\d+)\z/ do
-        after_validation do
-          @project = visible_projects
-                     .find(params[:id])
-        end
-
-        get &::Bcf::API::V2_1::Endpoints::Show.new(model: Project).mount
-        put &::Bcf::API::V2_1::Endpoints::Update.new(model: Project).mount
-
-        mount Bcf::API::V2_1::TopicsAPI
-      end
     end
   end
 end

--- a/modules/bcf/app/models/bcf/issue.rb
+++ b/modules/bcf/app/models/bcf/issue.rb
@@ -14,14 +14,27 @@ module Bcf
         select '*',
                extract_first_node(title_path, 'title'),
                extract_first_node(description_path, 'description'),
-               extract_first_node(priority_path, 'priority_text'),
-               extract_first_node(status_path, 'status_text'),
-               extract_first_node(type_path, 'type_text'),
-               extract_first_node(assignee_path, 'assignee_text'),
-               extract_first_node(due_date_path, 'due_date_text'),
-               extract_first_node(index_path, 'index_text'),
+               extract_first_node(priority_text_path, 'priority_text'),
+               extract_first_node(status_text_path, 'status_text'),
+               extract_first_node(type_text_path, 'type_text'),
+               extract_first_node(assignee_text_path, 'assignee_text'),
+               extract_first_node(due_date_text_path, 'due_date_text'),
+               extract_first_node(creation_date_text_path, 'creation_date_text'),
+               extract_first_node(creation_author_text_path, 'creation_author_text'),
+               extract_first_node(modified_date_text_path, 'modified_date_text'),
+               extract_first_node(modified_author_text_path, 'modified_author_text'),
+               extract_first_node(index_text_path, 'index_text'),
+               extract_first_node(stage_text_path, 'stage_text'),
                extract_nodes(labels_path, 'labels')
       end
+
+      def of_project(project)
+        includes(:work_package)
+          .references(:work_packages)
+          .merge(WorkPackage.for_projects(project))
+      end
+
+      protected
 
       def title_path
         '/Markup/Topic/Title/text()'
@@ -31,27 +44,47 @@ module Bcf
         '/Markup/Topic/Description/text()'
       end
 
-      def priority_path
+      def priority_text_path
         '/Markup/Topic/Priority/text()'
       end
 
-      def status_path
+      def status_text_path
         '/Markup/Topic/@TopicStatus'
       end
 
-      def type_path
+      def type_text_path
         '/Markup/Topic/@TopicType'
       end
 
-      def assignee_path
+      def assignee_text_path
         '/Markup/Topic/AssignedTo/text()'
       end
 
-      def due_date_path
+      def due_date_text_path
         '/Markup/Topic/DueDate/text()'
       end
 
-      def index_path
+      def stage_text_path
+        '/Markup/Topic/Stage/text()'
+      end
+
+      def creation_date_text_path
+        '/Markup/Topic/CreationDate/text()'
+      end
+
+      def creation_author_text_path
+        '/Markup/Topic/CreationAuthor/text()'
+      end
+
+      def modified_date_text_path
+        '/Markup/Topic/ModifiedDate/text()'
+      end
+
+      def modified_author_text_path
+        '/Markup/Topic/ModifiedAuthor/text()'
+      end
+
+      def index_text_path
         '/Markup/Topic/Index/text()'
       end
 
@@ -70,76 +103,26 @@ module Bcf
       end
     end
 
-    def title
-      if attributes.keys.include? 'title'
-        self[:title]
-      else
-        markup_doc.xpath(self.class.title_path).first.to_s.presence
-      end
-    end
-
-    def description
-      if attributes.keys.include? 'description'
-        self[:description]
-      else
-        markup_doc.xpath(self.class.description_path).first.to_s.presence
-      end
-    end
-
-    def priority_text
-      if attributes.keys.include? 'priority_text'
-        self[:priority_text]
-      else
-        markup_doc.xpath(self.class.priority_path).first.to_s.presence
-      end
-    end
-
-    def status_text
-      if attributes.keys.include? 'status_text'
-        self[:status_text]
-      else
-        markup_doc.xpath(self.class.status_path).first.to_s.presence
-      end
-    end
-
-    def type_text
-      if attributes.keys.include? 'type_text'
-        self[:type_text]
-      else
-        markup_doc.xpath(self.class.type_path).first.to_s.presence
-      end
-    end
-
-    def assignee_text
-      if attributes.keys.include? 'assignee_text'
-        self[:assignee_text]
-      else
-        markup_doc.xpath(self.class.assignee_path).first.to_s.presence
-      end
-    end
-
-    def due_date_text
-      if attributes.keys.include? 'due_date_text'
-        self[:due_date_text]
-      else
-        markup_doc.xpath(self.class.due_date_path).first.to_s.presence
-      end
-    end
-
-    def index_text
-      if attributes.keys.include? 'index_text'
-        self[:index_text]
-      else
-        markup_doc.xpath(self.class.index_path).first.to_s.presence
+    %i[title
+       description
+       priority_text
+       status_text
+       type_text
+       assignee_text
+       due_date_text
+       creation_date_text
+       creation_author_text
+       modified_date_text
+       modified_author_text
+       stage_text
+       index_text].each do |name|
+      define_method name do
+        from_attributes_or_doc name
       end
     end
 
     def labels
-      if attributes.keys.include? 'labels'
-        self[:labels]
-      else
-        markup_doc.xpath(self.class.labels_path).map(&:to_s)
-      end
+      from_attributes_or_doc :labels, multiple: true
     end
 
     def markup_doc
@@ -148,6 +131,22 @@ module Bcf
 
     def invalidate_markup_cache
       @markup_doc = nil
+    end
+
+    private
+
+    def from_attributes_or_doc(key, multiple: false)
+      if attributes.keys.include? key.to_s
+        self[key]
+      else
+        path = markup_doc.xpath(self.class.send("#{key}_path"))
+
+        if multiple
+          path.map(&:to_s)
+        else
+          path.first.to_s.presence
+        end
+      end
     end
   end
 end

--- a/modules/bcf/app/representers/bcf/api/v2_1/auth/single_representer.rb
+++ b/modules/bcf/app/representers/bcf/api/v2_1/auth/single_representer.rb
@@ -29,8 +29,7 @@
 #++
 
 module Bcf::API::V2_1
-  class Auth::SingleRepresenter < Roar::Decorator
-    include Representable::JSON
+  class Auth::SingleRepresenter < BaseRepresenter
     include OpenProject::StaticRouting::UrlHelpers
 
     property :oauth2_auth_url,

--- a/modules/bcf/app/representers/bcf/api/v2_1/base_representer.rb
+++ b/modules/bcf/app/representers/bcf/api/v2_1/base_representer.rb
@@ -29,31 +29,9 @@
 #++
 
 module Bcf::API::V2_1
-  class ProjectsAPI < ::API::OpenProjectAPI
-    resources :projects do
-      helpers do
-        def visible_projects
-          Project
-            .visible(current_user)
-            .has_module(:bcf)
-        end
-      end
+  class BaseRepresenter < Roar::Decorator
+    include Representable::JSON
 
-      get &::Bcf::API::V2_1::Endpoints::Index.new(model: Project,
-                                                  scope: -> { visible_projects })
-                                             .mount
-
-      route_param :id, regexp: /\A(\d+)\z/ do
-        after_validation do
-          @project = visible_projects
-                     .find(params[:id])
-        end
-
-        get &::Bcf::API::V2_1::Endpoints::Show.new(model: Project).mount
-        put &::Bcf::API::V2_1::Endpoints::Update.new(model: Project).mount
-
-        mount Bcf::API::V2_1::TopicsAPI
-      end
-    end
+    defaults render_nil: true
   end
 end

--- a/modules/bcf/app/representers/bcf/api/v2_1/errors/error_representer.rb
+++ b/modules/bcf/app/representers/bcf/api/v2_1/errors/error_representer.rb
@@ -29,9 +29,7 @@
 #++
 
 module Bcf::API::V2_1::Errors
-  class ErrorRepresenter < Roar::Decorator
-    include Representable::JSON
-
+  class ErrorRepresenter < BaseRepresenter
     property :message,
              getter: ->(*) { message },
              render_nil: true

--- a/modules/bcf/app/representers/bcf/api/v2_1/projects/single_representer.rb
+++ b/modules/bcf/app/representers/bcf/api/v2_1/projects/single_representer.rb
@@ -29,9 +29,7 @@
 #++
 
 module Bcf::API::V2_1
-  class Projects::SingleRepresenter < Roar::Decorator
-    include Representable::JSON
-
+  class Projects::SingleRepresenter < BaseRepresenter
     property :id,
              as: :project_id
 

--- a/modules/bcf/app/representers/bcf/api/v2_1/topics/single_representer.rb
+++ b/modules/bcf/app/representers/bcf/api/v2_1/topics/single_representer.rb
@@ -29,31 +29,53 @@
 #++
 
 module Bcf::API::V2_1
-  class ProjectsAPI < ::API::OpenProjectAPI
-    resources :projects do
-      helpers do
-        def visible_projects
-          Project
-            .visible(current_user)
-            .has_module(:bcf)
-        end
-      end
+  class Topics::SingleRepresenter < BaseRepresenter
+    include API::V3::Utilities::PathHelper
 
-      get &::Bcf::API::V2_1::Endpoints::Index.new(model: Project,
-                                                  scope: -> { visible_projects })
-                                             .mount
+    property :uuid,
+             as: :guid
 
-      route_param :id, regexp: /\A(\d+)\z/ do
-        after_validation do
-          @project = visible_projects
-                     .find(params[:id])
-        end
+    property :type_text,
+             as: :topic_type
 
-        get &::Bcf::API::V2_1::Endpoints::Show.new(model: Project).mount
-        put &::Bcf::API::V2_1::Endpoints::Update.new(model: Project).mount
+    property :status_text,
+             as: :topic_status
 
-        mount Bcf::API::V2_1::TopicsAPI
-      end
-    end
+    property :reference_links,
+             getter: ->(decorator:, **) {
+               [decorator.api_v3_paths.work_package(work_package.id)]
+             }
+
+    property :title
+
+    property :index_text,
+             as: :index
+
+    property :labels
+
+    property :creation_date_text,
+             as: :creation_date
+
+    property :creation_author_text,
+             as: :creation_author
+
+    property :modified_date_text,
+             as: :modified_date
+
+    property :modified_author_text,
+             as: :modified_author
+
+    property :assignee_text,
+             as: :assigned_to
+
+    property :stage_text,
+             as: :stage
+
+    property :description
+
+    # TODO bim snippet property does not exist in the xml
+
+    property :due_date_text,
+             as: :due_date
   end
 end

--- a/modules/bcf/app/representers/bcf/api/v2_1/users/single_representer.rb
+++ b/modules/bcf/app/representers/bcf/api/v2_1/users/single_representer.rb
@@ -29,9 +29,7 @@
 #++
 
 module Bcf::API::V2_1
-  class Users::SingleRepresenter < Roar::Decorator
-    include Representable::JSON
-
+  class Users::SingleRepresenter < BaseRepresenter
     property :mail,
              as: :id
 

--- a/modules/bcf/spec/factories/bcf_issue_factory.rb
+++ b/modules/bcf/spec/factories/bcf_issue_factory.rb
@@ -35,6 +35,86 @@
 
 FactoryBot.define do
   factory :bcf_issue, class: ::Bcf::Issue do
+    markup do
+      <<-MARKUP
+    <Markup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <Header>
+        <File IfcProject="0M6o7Znnv7hxsbWgeu7oQq" IfcSpatialStructureElement="23B$bNeGHFQuMYJzvUX0FD" isExternal="false">
+          <Filename>IfcPile_01.ifc</Filename>
+          <Date>2014-10-27T16:27:27Z</Date>
+          <Reference>../IfcPile_01.ifc</Reference>
+        </File>
+      </Header>
+      <Topic Guid="63E78882-7C6A-4BF7-8982-FC478AFB9C97" TopicType="Structural" TopicStatus="Open">
+        <ReferenceLink>https://bim--it.net</ReferenceLink>
+        <Title>Maximum Content</Title>
+        <Priority>High</Priority>
+        <Index>0</Index>
+        <Labels>Structural</Labels>
+        <Labels>IT Development</Labels>
+        <CreationDate>2015-06-21T12:00:00Z</CreationDate>
+        <CreationAuthor>mike@example.com</CreationAuthor>
+        <ModifiedDate>2015-06-21T14:22:47Z</ModifiedDate>
+        <ModifiedAuthor>michelle@example.com</ModifiedAuthor>
+        <AssignedTo>andy@example.com</AssignedTo>
+        <Description>This is a topic with all information present.</Description>
+        <Stage>Construction start</Stage>
+        <BimSnippet SnippetType="JSON">
+          <Reference>JsonElement.json</Reference>
+          <ReferenceSchema>http://json-schema.org</ReferenceSchema>
+        </BimSnippet>
+        <DocumentReference isExternal="true">
+          <ReferencedDocument>https://github.com/BuildingSMART/BCF-XML</ReferencedDocument>
+          <Description>GitHub BCF Specification</Description>
+        </DocumentReference>
+        <DocumentReference>
+          <ReferencedDocument>../markup.xsd</ReferencedDocument>
+          <Description>Markup.xsd Schema</Description>
+        </DocumentReference>
+        <RelatedTopic Guid="5019D939-62A4-45D9-B205-FAB602C98FE8" />
+      </Topic>
+      <Comment Guid="780FAE52-C432-42BE-ADEA-FF3E7A8CD8E1">
+        <Date>2015-08-31T12:40:17Z</Date>
+        <Author>mike@example.com</Author>
+        <Comment>This is an unmodified topic at the uppermost hierarchical level.
+    All times in the XML are marked as UTC times.</Comment>
+      </Comment>
+      <Comment Guid="897E4909-BDF3-4CC7-A283-6506CAFF93DD">
+        <Date>2015-08-31T14:00:01Z</Date>
+        <Author>mike@example.com</Author>
+        <Comment>This comment was a reply to the first comment in BCF v2.0. This is a no longer supported functionality and therefore is to be treated as a regular comment in v2.1.</Comment>
+      </Comment>
+      <Comment Guid="39C4B780-1B48-44E5-9802-D359007AA44E">
+        <Date>2015-08-31T13:07:11Z</Date>
+        <Author>mike@example.com</Author>
+        <Comment>This comment again is in the highest hierarchy level.
+    It references a viewpoint.</Comment>
+        <Viewpoint Guid="8dc86298-9737-40b4-a448-98a9e953293a" />
+      </Comment>
+      <Comment Guid="BD17158C-4267-4433-98C1-904F9B41CA50">
+        <Date>2015-08-31T15:42:58Z</Date>
+        <Author>mike@example.com</Author>
+        <Comment>This comment contained some spllng errs.
+    Hopefully, the modifier did catch them all.</Comment>
+        <ModifiedDate>2015-08-31T16:07:11Z</ModifiedDate>
+        <ModifiedAuthor>mike@example.com</ModifiedAuthor>
+      </Comment>
+      <Viewpoints Guid="8dc86298-9737-40b4-a448-98a9e953293a">
+        <Viewpoint>Viewpoint_8dc86298-9737-40b4-a448-98a9e953293a.bcfv</Viewpoint>
+        <Snapshot>Snapshot_8dc86298-9737-40b4-a448-98a9e953293a.png</Snapshot>
+      </Viewpoints>
+      <Viewpoints Guid="21dd4807-e9af-439e-a980-04d913a6b1ce">
+        <Viewpoint>Viewpoint_21dd4807-e9af-439e-a980-04d913a6b1ce.bcfv</Viewpoint>
+        <Snapshot>Snapshot_21dd4807-e9af-439e-a980-04d913a6b1ce.png</Snapshot>
+      </Viewpoints>
+      <Viewpoints Guid="81daa431-bf01-4a49-80a2-1ab07c177717">
+        <Viewpoint>Viewpoint_81daa431-bf01-4a49-80a2-1ab07c177717.bcfv</Viewpoint>
+        <Snapshot>Snapshot_81daa431-bf01-4a49-80a2-1ab07c177717.png</Snapshot>
+      </Viewpoints>
+    </Markup>
+      MARKUP
+    end
+
     factory :bcf_issue_with_comment do
       after(:create) do |issue|
         viewpoint = create(:bcf_viewpoint, issue: issue)

--- a/modules/bcf/spec/models/bcf/issue_spec.rb
+++ b/modules/bcf/spec/models/bcf/issue_spec.rb
@@ -31,86 +31,7 @@ require 'spec_helper'
 describe ::Bcf::Issue, type: :model do
   let(:type) { FactoryBot.create :type, name: "Issue [BCF]" }
   let(:work_package) { FactoryBot.create :work_package, type: type }
-  let(:markup) do
-    <<-MARKUP
-    <Markup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-      <Header>
-        <File IfcProject="0M6o7Znnv7hxsbWgeu7oQq" IfcSpatialStructureElement="23B$bNeGHFQuMYJzvUX0FD" isExternal="false">
-          <Filename>IfcPile_01.ifc</Filename>
-          <Date>2014-10-27T16:27:27Z</Date>
-          <Reference>../IfcPile_01.ifc</Reference>
-        </File>
-      </Header>
-      <Topic Guid="63E78882-7C6A-4BF7-8982-FC478AFB9C97" TopicType="Structural" TopicStatus="Open">
-        <ReferenceLink>https://bim--it.net</ReferenceLink>
-        <Title>Maximum Content</Title>
-        <Priority>High</Priority>
-        <Index>0</Index>
-        <Labels>Structural</Labels>
-        <Labels>IT Development</Labels>
-        <CreationDate>2015-06-21T12:00:00Z</CreationDate>
-        <CreationAuthor>mike@example.com</CreationAuthor>
-        <ModifiedDate>2015-06-21T14:22:47Z</ModifiedDate>
-        <ModifiedAuthor>mike@example.com</ModifiedAuthor>
-        <AssignedTo>andy@example.com</AssignedTo>
-        <Description>This is a topic with all information present.</Description>
-        <BimSnippet SnippetType="JSON">
-          <Reference>JsonElement.json</Reference>
-          <ReferenceSchema>http://json-schema.org</ReferenceSchema>
-        </BimSnippet>
-        <DocumentReference isExternal="true">
-          <ReferencedDocument>https://github.com/BuildingSMART/BCF-XML</ReferencedDocument>
-          <Description>GitHub BCF Specification</Description>
-        </DocumentReference>
-        <DocumentReference>
-          <ReferencedDocument>../markup.xsd</ReferencedDocument>
-          <Description>Markup.xsd Schema</Description>
-        </DocumentReference>
-        <RelatedTopic Guid="5019D939-62A4-45D9-B205-FAB602C98FE8" />
-      </Topic>
-      <Comment Guid="780FAE52-C432-42BE-ADEA-FF3E7A8CD8E1">
-        <Date>2015-08-31T12:40:17Z</Date>
-        <Author>mike@example.com</Author>
-        <Comment>This is an unmodified topic at the uppermost hierarchical level.
-    All times in the XML are marked as UTC times.</Comment>
-      </Comment>
-      <Comment Guid="897E4909-BDF3-4CC7-A283-6506CAFF93DD">
-        <Date>2015-08-31T14:00:01Z</Date>
-        <Author>mike@example.com</Author>
-        <Comment>This comment was a reply to the first comment in BCF v2.0. This is a no longer supported functionality and therefore is to be treated as a regular comment in v2.1.</Comment>
-      </Comment>
-      <Comment Guid="39C4B780-1B48-44E5-9802-D359007AA44E">
-        <Date>2015-08-31T13:07:11Z</Date>
-        <Author>mike@example.com</Author>
-        <Comment>This comment again is in the highest hierarchy level.
-    It references a viewpoint.</Comment>
-        <Viewpoint Guid="8dc86298-9737-40b4-a448-98a9e953293a" />
-      </Comment>
-      <Comment Guid="BD17158C-4267-4433-98C1-904F9B41CA50">
-        <Date>2015-08-31T15:42:58Z</Date>
-        <Author>mike@example.com</Author>
-        <Comment>This comment contained some spllng errs.
-    Hopefully, the modifier did catch them all.</Comment>
-        <ModifiedDate>2015-08-31T16:07:11Z</ModifiedDate>
-        <ModifiedAuthor>mike@example.com</ModifiedAuthor>
-      </Comment>
-      <Viewpoints Guid="8dc86298-9737-40b4-a448-98a9e953293a">
-        <Viewpoint>Viewpoint_8dc86298-9737-40b4-a448-98a9e953293a.bcfv</Viewpoint>
-        <Snapshot>Snapshot_8dc86298-9737-40b4-a448-98a9e953293a.png</Snapshot>
-      </Viewpoints>
-      <Viewpoints Guid="21dd4807-e9af-439e-a980-04d913a6b1ce">
-        <Viewpoint>Viewpoint_21dd4807-e9af-439e-a980-04d913a6b1ce.bcfv</Viewpoint>
-        <Snapshot>Snapshot_21dd4807-e9af-439e-a980-04d913a6b1ce.png</Snapshot>
-      </Viewpoints>
-      <Viewpoints Guid="81daa431-bf01-4a49-80a2-1ab07c177717">
-        <Viewpoint>Viewpoint_81daa431-bf01-4a49-80a2-1ab07c177717.bcfv</Viewpoint>
-        <Snapshot>Snapshot_81daa431-bf01-4a49-80a2-1ab07c177717.png</Snapshot>
-      </Viewpoints>
-    </Markup>
-    MARKUP
-  end
-
-  let(:issue) { FactoryBot.create :bcf_issue, work_package: work_package, markup: markup }
+  let(:issue) { FactoryBot.create :bcf_issue, work_package: work_package }
 
   shared_examples_for 'provides attributes' do
     it "provides attributes" do
@@ -123,6 +44,11 @@ describe ::Bcf::Issue, type: :model do
       expect(subject.index_text).to be_eql '0'
       expect(subject.labels).to contain_exactly 'Structural', 'IT Development'
       expect(subject.due_date_text).to be_nil
+      expect(subject.creation_date_text).to eql "2015-06-21T12:00:00Z"
+      expect(subject.creation_author_text).to eql "mike@example.com"
+      expect(subject.modified_date_text).to eql "2015-06-21T14:22:47Z"
+      expect(subject.modified_author_text).to eql "michelle@example.com"
+      expect(subject.stage_text).to eql "Construction start"
     end
   end
 
@@ -152,5 +78,15 @@ describe ::Bcf::Issue, type: :model do
     end
 
     it_behaves_like 'provides attributes'
+  end
+
+  describe '.of_project' do
+    let!(:other_work_package) { FactoryBot.create :work_package, type: type }
+    let!(:other_issue) { FactoryBot.create :bcf_issue, work_package: other_work_package }
+
+    it 'returns all issues of the provided project' do
+      expect(described_class.of_project(issue.project))
+        .to match_array [issue]
+    end
   end
 end

--- a/modules/bcf/spec/representers/bcf/api/v2_1/shared_examples.rb
+++ b/modules/bcf/spec/representers/bcf/api/v2_1/shared_examples.rb
@@ -1,8 +1,7 @@
 shared_examples_for 'attribute' do
-  it 'reflects the project' do
+  it 'reflects the value in the object' do
     expect(subject)
       .to be_json_eql(value.to_json)
-            .at_path(path)
+      .at_path(path)
   end
 end
-

--- a/modules/bcf/spec/representers/bcf/api/v2_1/topics/single_representer_rendering_spec.rb
+++ b/modules/bcf/spec/representers/bcf/api/v2_1/topics/single_representer_rendering_spec.rb
@@ -1,0 +1,149 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2019 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+require_relative '../shared_examples'
+
+describe Bcf::API::V2_1::Topics::SingleRepresenter, 'rendering' do
+  include API::V3::Utilities::PathHelper
+
+  let(:work_package) { FactoryBot.build_stubbed(:stubbed_work_package, type: FactoryBot.build_stubbed(:type)) }
+  let(:issue) { FactoryBot.build_stubbed(:bcf_issue, work_package: work_package) }
+
+  let(:instance) { described_class.new(issue) }
+
+  subject { instance.to_json }
+
+  describe 'attributes' do
+    context 'guid' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.uuid }
+        let(:path) { 'guid' }
+      end
+    end
+
+    context 'topic_type' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.type_text }
+        let(:path) { 'topic_type' }
+      end
+    end
+
+    context 'topic_status' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.status_text }
+        let(:path) { 'topic_status' }
+      end
+    end
+
+    context 'reference_links' do
+      it_behaves_like 'attribute' do
+        let(:value) { [api_v3_paths.work_package(work_package.id)] }
+        let(:path) { 'reference_links' }
+      end
+    end
+
+    context 'title' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.title }
+        let(:path) { 'title' }
+      end
+    end
+
+    context 'index' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.index_text }
+        let(:path) { 'index' }
+      end
+    end
+
+    context 'labels' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.labels }
+        let(:path) { 'labels' }
+      end
+    end
+
+    context 'creation_date' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.creation_date_text }
+        let(:path) { 'creation_date' }
+      end
+    end
+
+    context 'creation_author' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.creation_author_text }
+        let(:path) { 'creation_author' }
+      end
+    end
+
+    context 'modified_date' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.modified_date_text }
+        let(:path) { 'modified_date' }
+      end
+    end
+
+    context 'modified_author' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.modified_author_text }
+        let(:path) { 'modified_author' }
+      end
+    end
+
+    context 'description' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.description }
+        let(:path) { 'description' }
+      end
+    end
+
+    context 'due_date' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.due_date_text }
+        let(:path) { 'due_date' }
+      end
+    end
+
+    context 'assigned_to' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.assignee_text }
+        let(:path) { 'assigned_to' }
+      end
+    end
+
+    context 'stage' do
+      it_behaves_like 'attribute' do
+        let(:value) { issue.stage_text }
+        let(:path) { 'stage' }
+      end
+    end
+  end
+end

--- a/modules/bcf/spec/requests/api/bcf/v2_1/shared_responses.rb
+++ b/modules/bcf/spec/requests/api/bcf/v2_1/shared_responses.rb
@@ -32,7 +32,7 @@ shared_examples_for 'bcf api successful response' do
       .to eql 200
   end
 
-  it 'returns the project' do
+  it 'returns the resource' do
     expect(subject.body)
       .to be_json_eql(expected_body.to_json)
   end

--- a/modules/bcf/spec/requests/api/bcf/v2_1/topics_api_spec.rb
+++ b/modules/bcf/spec/requests/api/bcf/v2_1/topics_api_spec.rb
@@ -1,0 +1,73 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2019 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+require_relative './shared_responses'
+
+describe 'BCF 2.1 topics resource', type: :request, content_type: :json do
+  include Rack::Test::Methods
+
+  let(:view_only_user) do
+    FactoryBot.create(:user,
+                      member_in_project: project,
+                      member_with_permissions: [:view_linked_issues])
+  end
+  let(:non_member_user) do
+    FactoryBot.create(:user)
+  end
+
+  let(:project) do
+    FactoryBot.create(:project,
+                      enabled_module_names: [:bcf])
+  end
+  let(:work_package) { FactoryBot.create(:work_package, project: project) }
+  let(:bcf_issue) { FactoryBot.create(:bcf_issue, work_package: work_package) }
+
+  subject(:response) { last_response }
+
+  describe 'GET /api/bcf/2.1/projects/:project_id/topics' do
+    let(:path) { "/api/bcf/2.1/projects/#{project.id}/topics" }
+    let(:current_user) { view_only_user }
+
+    before do
+      login_as(current_user)
+      bcf_issue
+      get path
+    end
+
+    it_behaves_like 'bcf api successful response' do
+      let(:expected_body) do
+        [{
+          guid: bcf_issue.uuid
+        }]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the topics part of https://github.com/buildingSMART/BCF-API#42-topic-services to the BCF API.

### TODO

* [ ] Add get show end point
* [ ] Add get collection end point
* [ ] Add post end point 
* [ ] Add put end point
* [ ] Add delete end point
* [ ] Add odata for
  * [ ] filtering 
  * [ ] limit/next/previous

### Out of scope
* [ ] Add Bim Snippet to Topic representer ( we won't need that )

https://community.openproject.com/projects/openproject/work_packages/31602


