### PR TITLE
Do not override `withCredentials` params when set

### DIFF
--- a/frontend/src/app/components/work-packages/work-package.service.ts
+++ b/frontend/src/app/components/work-packages/work-package.service.ts
@@ -56,7 +56,10 @@ export class WorkPackageService {
       'ids[]': ids
     };
     const promise = this.http
-      .delete(this.PathHelper.workPackagesBulkDeletePath(), {params: params})
+      .delete(
+        this.PathHelper.workPackagesBulkDeletePath(),
+        {params: params, withCredentials: true}
+      )
       .toPromise();
 
     if (defaultHandling) {

--- a/frontend/src/app/modules/hal/dm-services/query-order-dm.service.ts
+++ b/frontend/src/app/modules/hal/dm-services/query-order-dm.service.ts
@@ -51,7 +51,8 @@ export class QueryOrderDmService {
     return this.http
       .patch(
         this.orderPath(id),
-        { delta: delta }
+        { delta: delta },
+        { withCredentials: true }
       )
       .toPromise()
       .then((response:{t:string}) => response.t);

--- a/frontend/src/app/modules/hal/http/openproject-header-interceptor.ts
+++ b/frontend/src/app/modules/hal/http/openproject-header-interceptor.ts
@@ -10,21 +10,26 @@ export class OpenProjectHeaderInterceptor implements HttpInterceptor {
   intercept(req:HttpRequest<any>, next:HttpHandler):Observable<HttpEvent<any>> {
     const csrf_token:string|undefined = jQuery('meta[name=csrf-token]').attr('content');
 
-    let newHeaders = req.headers
-      .set('X-Authentication-Scheme', 'Session')
-      .set('X-Requested-With', 'XMLHttpRequest');
+    if (req.withCredentials !== false) {
 
-    if (csrf_token) {
-      newHeaders = newHeaders.set('X-CSRF-TOKEN',  csrf_token);
+      let newHeaders = req.headers
+        .set('X-Authentication-Scheme', 'Session')
+        .set('X-Requested-With', 'XMLHttpRequest');
+
+      if (csrf_token) {
+        newHeaders = newHeaders.set('X-CSRF-TOKEN',  csrf_token);
+      }
+
+      // Clone the request to add the new header
+      const clonedRequest = req.clone({
+        withCredentials: true,
+        headers: newHeaders
+      });
+
+      // Pass the cloned request instead of the original request to the next handle
+      return next.handle(clonedRequest);
     }
 
-    // Clone the request to add the new header
-    const clonedRequest = req.clone({
-      withCredentials: true,
-      headers: newHeaders
-    });
-
-    // Pass the cloned request instead of the original request to the next handle
-    return next.handle(clonedRequest);
+    return next.handle(req);
   }
 }


### PR DESCRIPTION
This is needed for https://github.com/finnlabs/saas-openproject/pull/69