### PR TITLE
[31667] Fix ambiguous reference to project_id when group/sort

### DIFF
--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -43,7 +43,7 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
     project: {
       association: 'project',
       sortable: "name",
-      groupable: 'project_id'
+      groupable: "#{WorkPackage.table_name}.project_id"
     },
     subject: {
       sortable: "#{WorkPackage.table_name}.subject"
@@ -51,7 +51,7 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
     type: {
       association: 'type',
       sortable: "position",
-      groupable: 'type_id'
+      groupable: "#{WorkPackage.table_name}.type_id"
     },
     parent: {
       association: 'ancestors_relations',
@@ -62,35 +62,35 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
       association: 'status',
       sortable: "position",
       highlightable: true,
-      groupable: 'status_id'
+      groupable: "#{WorkPackage.table_name}.status_id"
     },
     priority: {
       association: 'priority',
       sortable: "position",
       default_order: 'desc',
       highlightable: true,
-      groupable: 'priority_id'
+      groupable: "#{WorkPackage.table_name}.priority_id"
     },
     author: {
       association: 'author',
       sortable: ["lastname",
                  "firstname",
                  "id"],
-      groupable: 'author_id'
+      groupable: "#{WorkPackage.table_name}.author_id"
     },
     assigned_to: {
       association: 'assigned_to',
       sortable: ["lastname",
                  "firstname",
                  "id"],
-      groupable: 'assigned_to_id'
+      groupable: "#{WorkPackage.table_name}.assigned_to_id"
     },
     responsible: {
       association: 'responsible',
       sortable: ["lastname",
                  "firstname",
                  "id"],
-      groupable: 'responsible_id'
+      groupable: "#{WorkPackage.table_name}.responsible_id"
     },
     updated_at: {
       sortable: "#{WorkPackage.table_name}.updated_at",
@@ -99,13 +99,13 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
     category: {
       association: 'category',
       sortable: "name",
-      groupable: 'category_id'
+      groupable: "#{WorkPackage.table_name}.category_id"
     },
     fixed_version: {
       association: 'fixed_version',
       sortable: ["name"],
       default_order: 'desc',
-      groupable: 'fixed_version_id'
+      groupable: "#{WorkPackage.table_name}.fixed_version_id"
     },
     start_date: {
       # Put empty start_dates in the far future rather than in the far past


### PR DESCRIPTION
Properly reference project_id to avoid ambiguous references to project_id when grouping by project_id and sorting by priority

https://community.openproject.com/wp/31667 