### PR TITLE
[31631] Feature: Wp cards on mobile

### DIFF
--- a/frontend/src/app/components/wp-card-view/event-handler/click-handler.ts
+++ b/frontend/src/app/components/wp-card-view/event-handler/click-handler.ts
@@ -3,12 +3,15 @@ import {CardEventHandler} from "core-components/wp-card-view/event-handler/card-
 import {WorkPackageCardViewComponent} from "core-components/wp-card-view/wp-card-view.component";
 import {WorkPackageViewSelectionService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-selection.service";
 import {WorkPackageViewFocusService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-focus.service";
-
 import {WorkPackageCardViewService} from "core-components/wp-card-view/services/wp-card-view.service";
+import {StateService} from "@uirouter/core";
+import {DeviceService} from "core-app/modules/common/browser/device.service";
 
 export class CardClickHandler implements CardEventHandler {
 
   // Injections
+  public deviceService:DeviceService = this.injector.get(DeviceService);
+  public $state:StateService = this.injector.get(StateService);
   public wpTableSelection:WorkPackageViewSelectionService = this.injector.get(WorkPackageViewSelectionService);
   public wpTableFocus:WorkPackageViewFocusService = this.injector.get(WorkPackageViewFocusService);
   public wpCardView:WorkPackageCardViewService = this.injector.get(WorkPackageCardViewService);
@@ -67,7 +70,15 @@ export class CardClickHandler implements CardEventHandler {
     // not matter what other card are (de-)selected below.
     // Thus save that card for the details view button.
     this.wpTableFocus.updateFocus(wpId);
+
+    // open work package on mobile after first click
+    if (this.deviceService.isMobile) {
+      this.$state.go(
+        'work-packages.show',
+        {workPackageId: wpId}
+      );
+    }
+
     return false;
   }
 }
-

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -33,6 +33,7 @@ import {CardViewHandlerRegistry} from "core-components/wp-card-view/event-handle
 import {WorkPackageCardViewService} from "core-components/wp-card-view/services/wp-card-view.service";
 import {WorkPackageCardDragAndDropService} from "core-components/wp-card-view/services/wp-card-drag-and-drop.service";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
+import {DeviceService} from "core-app/modules/common/browser/device.service";
 
 export type CardViewOrientation = 'horizontal'|'vertical';
 
@@ -100,7 +101,8 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
               readonly wpTableSelection:WorkPackageViewSelectionService,
               readonly wpViewOrder:WorkPackageViewOrderService,
               readonly cardView:WorkPackageCardViewService,
-              readonly cardDragDrop:WorkPackageCardDragAndDropService) {
+              readonly cardDragDrop:WorkPackageCardDragAndDropService,
+              readonly deviceService:DeviceService) {
   }
 
   ngOnInit() {
@@ -140,9 +142,12 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit() {
-    // Register Drag & Drop
     this.cardDragDrop.init(this);
-    this.cardDragDrop.registerDragAndDrop();
+
+    // Register Drag & Drop only on desktop
+    if (!this.deviceService.isMobile) {
+      this.cardDragDrop.registerDragAndDrop();
+    }
 
     // Register event handlers for the cards
     new CardViewHandlerRegistry(this.injector).attachTo(this);

--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.html
@@ -5,7 +5,7 @@
        [ngClass]="cardHighlightingClass(workPackage)">
   </div>
 
-  <div class="wp-card--inline-buttons">
+  <div class="wp-card--inline-buttons hidden-for-mobile">
     <a class="wp-card--inline-cancel-button -no-decoration"
        *ngIf="workPackage.isNew || showRemoveButton"
        [ngClass]="{ '-show': workPackage.isNew }"

--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -85,3 +85,7 @@
 
   flex-basis: 200px
   object-fit: cover
+
+@media only screen and (max-width: 679px)
+  .wp-card
+    max-width: none

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -123,7 +123,7 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
       this.currentQuery = query;
 
       // Update the visible representation
-      if (this.wpDisplayRepresentation.valueFromQuery(query) === wpDisplayCardRepresentation) {
+      if (this.deviceService.isMobile || this.wpDisplayRepresentation.valueFromQuery(query) === wpDisplayCardRepresentation) {
         this.showListView = false;
       } else {
         this.showListView = true;

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/work-packages-view.base.ts
@@ -55,6 +55,7 @@ import {WorkPackageViewDisplayRepresentationService} from "core-app/modules/work
 import {HalEvent, HalEventsService} from "core-app/modules/hal/services/hal-events.service";
 import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
+import {DeviceService} from "core-app/modules/common/browser/device.service";
 
 export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
 
@@ -83,6 +84,7 @@ export abstract class WorkPackagesViewBase implements OnInit, OnDestroy {
   readonly cdRef:ChangeDetectorRef = this.injector.get(ChangeDetectorRef);
   readonly wpDisplayRepresentation:WorkPackageViewDisplayRepresentationService = this.injector.get(WorkPackageViewDisplayRepresentationService);
   readonly halEvents:HalEventsService = this.injector.get(HalEventsService);
+  readonly deviceService:DeviceService = this.injector.get(DeviceService);
 
 
   constructor(protected injector:Injector) {

--- a/spec/features/work_packages/display_representations/switch_display_representations_spec.rb
+++ b/spec/features/work_packages/display_representations/switch_display_representations_spec.rb
@@ -112,6 +112,26 @@ describe 'Work package timeline navigation',
     end
   end
 
+  context 'switching to mobile card view' do
+    it 'can switch the representation automatically on mobile after a refresh' do
+      # Change browser size to mobile
+      page.driver.browser.manage.window.resize_to(679,1080)
+      # Expect the representation to switch to card on mobile
+      page.driver.browser.navigate.refresh
+      expect(page).to have_selector("wp-single-card[data-work-package-id='#{wp_1.id}']")
+      expect(page).to have_selector("wp-single-card[data-work-package-id='#{wp_2.id}']")
+    end
+    it 'can switch back and keep the original query' do
+      # Change browser size to desktop view and refesh page
+      page.driver.browser.manage.window.resize_to(680,1080)
+      page.driver.browser.navigate.refresh
+      # Expect WP to be disaplyed as list again (query has not changed)
+      wp_table.expect_work_package_listed wp_1, wp_2
+      expect(page).to have_selector("#{wp_table.row_selector(wp_1)}")
+      expect(page).to have_selector("#{wp_table.row_selector(wp_2)}")
+    end
+  end
+
   context 'when reordering an unsaved query' do
     it 'retains that order' do
       wp_table.expect_work_package_order wp_1, wp_2

--- a/spec/features/work_packages/display_representations/switch_display_representations_spec.rb
+++ b/spec/features/work_packages/display_representations/switch_display_representations_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe 'Work package timeline navigation',
+describe 'Switching work package view',
          with_ee: %i[conditional_highlighting],
          js: true do
   let(:user) { FactoryBot.create(:admin) }
@@ -69,8 +69,7 @@ describe 'Work package timeline navigation',
     before do
       # Enable card representation
       display_representation.switch_to_card_layout
-      expect(page).to have_selector("wp-single-card[data-work-package-id='#{wp_1.id}']")
-      expect(page).to have_selector("wp-single-card[data-work-package-id='#{wp_2.id}']")
+      cards.expect_work_package_listed wp_1, wp_2
     end
 
     it 'can switch the representations and keep the configuration settings' do
@@ -107,8 +106,7 @@ describe 'Work package timeline navigation',
     it 'saves the representation in the query' do
       # After refresh the WP are still disaplyed as cards
       page.driver.browser.navigate.refresh
-      expect(page).to have_selector("wp-single-card[data-work-package-id='#{wp_1.id}']")
-      expect(page).to have_selector("wp-single-card[data-work-package-id='#{wp_2.id}']")
+      cards.expect_work_package_listed wp_1, wp_2
     end
   end
 
@@ -116,19 +114,29 @@ describe 'Work package timeline navigation',
     it 'can switch the representation automatically on mobile after a refresh' do
       # Change browser size to mobile
       page.driver.browser.manage.window.resize_to(679,1080)
+
       # Expect the representation to switch to card on mobile
       page.driver.browser.navigate.refresh
-      expect(page).to have_selector("wp-single-card[data-work-package-id='#{wp_1.id}']")
-      expect(page).to have_selector("wp-single-card[data-work-package-id='#{wp_2.id}']")
-    end
-    it 'can switch back and keep the original query' do
-      # Change browser size to desktop view and refesh page
+
+      # It shows the elements as cards
+      cards.expect_work_package_listed wp_1, wp_2
+
+      # A single click leads to the full view
+      cards.select_work_package(wp_1)
+      expect(page).to have_selector('.work-packages--details--subject',
+                                    text: wp_1.subject)
+      page.find('.work-packages-back-button').click
+
+      # The query is however unchanged
+      expect(page).not_to have_selector('.editable-toolbar-title--save')
+      url = URI.parse(page.current_url).query
+      expect(url).not_to match(/query_props=.+/)
+
+      # Since the query is unchanged, the WPs will be displayed as list on larger screens again
       page.driver.browser.manage.window.resize_to(680,1080)
       page.driver.browser.navigate.refresh
-      # Expect WP to be disaplyed as list again (query has not changed)
       wp_table.expect_work_package_listed wp_1, wp_2
-      expect(page).to have_selector("#{wp_table.row_selector(wp_1)}")
-      expect(page).to have_selector("#{wp_table.row_selector(wp_2)}")
+      wp_table.expect_work_package_order wp_1, wp_2
     end
   end
 

--- a/spec/support/pages/work_packages/work_package_cards.rb
+++ b/spec/support/pages/work_packages/work_package_cards.rb
@@ -37,6 +37,12 @@ module Pages
       @project = project
     end
 
+    def expect_work_package_listed(*work_packages)
+      work_packages.each do |wp|
+        expect(page).to have_selector("wp-single-card[data-work-package-id='#{wp.id}']")
+      end
+    end
+
     def expect_work_package_order(*ids)
       retry_block do
         rows = page.all 'wp-single-card'


### PR DESCRIPTION
### Changes
- Always display work packages as cards on mobile screen width (only after reload, not resize)
- Drag and Drop disabled for mobile devices
- Split screen icon hidden for mobile