### PR TITLE
[31656] Use schema options hash for additional attributes

### DIFF
--- a/app/assets/javascripts/custom-fields.js
+++ b/app/assets/javascripts/custom-fields.js
@@ -44,7 +44,8 @@
         possibleValues        = $('#custom_field_possible_values_attributes'),
         defaultValueFields    = $('#custom_field_default_value_attributes'),
         spanDefaultText       = $('#default_value_text'),
-        spanDefaultBool       = $('#default_value_bool');
+        spanDefaultBool       = $('#default_value_bool'),
+        textOrientationField  = $('#custom_field_text_orientation');
 
     var deactivate = function(element) {
       element.hide().find('input, textarea').not('.destroy_flag,.-cf-ignore-disabled').attr('disabled', true);
@@ -65,7 +66,7 @@
           unsearchable = function() { searchable.attr('checked', false).hide(); };
 
       // defaults (reset these fields before doing anything else)
-      $.each([spanDefaultBool, spanDefaultText, multiSelect], function(idx, element) {
+      $.each([spanDefaultBool, spanDefaultText, multiSelect, textOrientationField], function(idx, element) {
         deactivate(element);
       });
       show(defaultValueFields);
@@ -106,6 +107,11 @@
           deactivate(possibleValues);
           hide(lengthField, regexpField, defaultValueFields);
           unsearchable();
+          break;
+        case 'text':
+          show(lengthField, regexpField, searchable, textOrientationField);
+          deactivate(possibleValues);
+          activate(textOrientationField);
           break;
         default:
           show(lengthField, regexpField, searchable);

--- a/app/assets/stylesheets/openproject/_generic.sass
+++ b/app/assets/stylesheets/openproject/_generic.sass
@@ -88,6 +88,8 @@
   font-size: 12px
 .-rtl
   direction: rtl
+  .-placeholder &
+    direction: ltr
 
 .drop-zone.-dragged-over
   background-color: #eaeaea60

--- a/app/assets/stylesheets/openproject/_generic.sass
+++ b/app/assets/stylesheets/openproject/_generic.sass
@@ -86,6 +86,8 @@
   font-style: italic
 .-small-font
   font-size: 12px
+.-rtl
+  direction: rtl
 
 .drop-zone.-dragged-over
   background-color: #eaeaea60

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -480,6 +480,7 @@ class PermittedParams
           :default_value,
           :possible_values,
           :multi_value,
+          :content_right_to_left,
           { custom_options_attributes: %i(id value default_value position) },
           type_ids: []
         ],

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -107,6 +107,7 @@ See docs/COPYRIGHT.rdoc for more details.
     <div class="form--field"><%= f.check_box :is_for_all %></div>
     <div class="form--field"><%= f.check_box :is_filter %></div>
     <div class="form--field" id="searchable_container"><%= f.check_box :searchable %></div>
+    <div class="form--field" id="custom_field_text_orientation"><%= f.check_box :content_right_to_left %></div>
   <% when "UserCustomField" %>
     <div class="form--field"><%= f.check_box :is_required %></div>
     <div class="form--field"><%= f.check_box :visible %></div>

--- a/db/migrate/20191115141154_add_content_orientation_to_custom_fields.rb
+++ b/db/migrate/20191115141154_add_content_orientation_to_custom_fields.rb
@@ -1,0 +1,5 @@
+class AddContentOrientationToCustomFields < ActiveRecord::Migration[6.0]
+  def change
+    add_column :custom_fields, :content_right_to_left, :boolean, default: false
+  end
+end

--- a/frontend/src/app/components/wp-edit-form/display-field-renderer.ts
+++ b/frontend/src/app/components/wp-edit-form/display-field-renderer.ts
@@ -61,7 +61,7 @@ export class DisplayFieldRenderer<T extends HalResource = HalResource> {
     }
 
     const field = this.getField(resource, fieldSchema, schemaName, change);
-    field.render(span, this.getText(field, fieldSchema, placeholder));
+    field.render(span, this.getText(field, fieldSchema, placeholder), fieldSchema.options);
 
     const title = field.title;
     if (title) {

--- a/frontend/src/app/modules/common/ckeditor/ckeditor-setup.service.ts
+++ b/frontend/src/app/modules/common/ckeditor/ckeditor-setup.service.ts
@@ -28,6 +28,10 @@ export interface ICKEditorContext {
   removePlugins?:string[];
   // Set of enabled macro plugins or false to disable all
   macros?:'none'|'wp'|'full'|boolean|string[];
+  // Additional options like the text orientation of the editors content
+  options?:{
+    rtl?:boolean;
+  };
   // context link to append on preview requests
   previewContext?:string;
 }
@@ -61,10 +65,15 @@ export class CKEditorSetupService {
     const toolbarWrapper = wrapper.querySelector('.document-editor__toolbar') as HTMLElement;
     const contentWrapper = wrapper.querySelector('.document-editor__editable') as HTMLElement;
 
+    var contentLanguage = context.options && context.options.rtl ? 'ar' : 'en';
+
     return editor
       .createCustomized(contentWrapper, {
         openProject: this.createConfig(context),
-        initialData: initialData
+        initialData: initialData,
+        language: {
+          content: contentLanguage
+        }
       })
       .then((editor) => {
         // Add decoupled toolbar

--- a/frontend/src/app/modules/fields/display/display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/display-field.module.ts
@@ -118,7 +118,7 @@ export class DisplayField<T extends HalResource = HalResource> extends Field {
     return this.valueString;
   }
 
-  public render(element:HTMLElement, displayText:string):void {
+  public render(element:HTMLElement, displayText:string, options:any = {}):void {
     element.textContent = displayText;
   }
 

--- a/frontend/src/app/modules/fields/display/field-types/formattable-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/formattable-display-field.module.ts
@@ -37,8 +37,12 @@ export class FormattableDisplayField extends DisplayField {
 
   public render(element:HTMLElement, displayText:string, options:any = {}):void {
     let div = document.createElement('div');
+
     div.classList.add('read-value--html', 'wiki', 'highlight', '-multiline');
-    if (options.rtl) { div.classList.add('-rtl'); }
+    if (options.rtl) {
+      div.classList.add('-rtl');
+    }
+
     div.innerHTML = displayText;
 
     element.innerHTML = '';

--- a/frontend/src/app/modules/fields/display/field-types/formattable-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/formattable-display-field.module.ts
@@ -35,9 +35,10 @@ export class FormattableDisplayField extends DisplayField {
 
   private readonly appRef = this.$injector.get(ApplicationRef);
 
-  public render(element:HTMLElement, displayText:string):void {
+  public render(element:HTMLElement, displayText:string, options:any = {}):void {
     let div = document.createElement('div');
     div.classList.add('read-value--html', 'wiki', 'highlight', '-multiline');
+    if (options.rtl) { div.classList.add('-rtl'); }
     div.innerHTML = displayText;
 
     element.innerHTML = '';

--- a/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
@@ -116,7 +116,8 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
     return {
       resource: this.resource,
       macros: 'none' as 'none',
-      previewContext: this.previewContext
+      previewContext: this.previewContext,
+      options: { rtl: this.schema.options.rtl }
     };
   }
 

--- a/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
@@ -117,7 +117,7 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
       resource: this.resource,
       macros: 'none' as 'none',
       previewContext: this.previewContext,
-      options: { rtl: this.schema.options.rtl }
+      options: { rtl: this.schema.options && this.schema.options.rtl }
     };
   }
 

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -42,7 +42,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   @ViewChild(NgSelectComponent, { static: true }) public ngSelectComponent:NgSelectComponent;
 
   readonly I18n:I18nService = this.injector.get(I18nService);
-  public options:any[] = [];
+  public availableOptions:any[] = [];
   public valueOptions:ValueOption[];
   public text = {
     requiredPlaceholder: this.I18n.t('js.placeholders.selection'),
@@ -70,7 +70,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
         untilComponentDestroyed(this),
       )
       .subscribe(() => {
-        this.requestFocus = this.options.length === 0;
+        this.requestFocus = this.availableOptions.length === 0;
 
         // If we already have all values loaded, open now.
         if (!this.requestFocus) {
@@ -108,7 +108,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
   public set selectedOption(val:ValueOption[]) {
     this._selectedOption = val;
     let mapper = (val:ValueOption) => {
-      let option = _.find(this.options, o => o.$href === val.$href) || this.nullOption;
+      let option = _.find(this.availableOptions, o => o.$href === val.$href) || this.nullOption;
 
       // Special case 'null' value, which angular
       // only understands in ng-options as an empty string.
@@ -166,14 +166,14 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
       });
     }
 
-    this.options = availableValues || [];
-    this.valueOptions = this.options.map(el => {
+    this.availableOptions = availableValues || [];
+    this.valueOptions = this.availableOptions.map(el => {
       return { name: el.name, $href: el.$href };
     });
     this._selectedOption = this.buildSelectedOption();
     this.checkCurrentValueValidity();
 
-    if (this.options.length > 0 && this.requestFocus) {
+    if (this.availableOptions.length > 0 && this.requestFocus) {
       this.openAutocompleteSelectField();
       this.requestFocus = false;
     }
@@ -209,7 +209,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
         // (If value AND)
         // MultiSelect AND there is no value which href is not in the options hrefs
         (!_.some(this.value, (value:HalResource) => {
-          return _.some(this.options, (option) => (option.$href === value.$href))
+          return _.some(this.availableOptions, (option) => (option.$href === value.$href))
         }))
       );
     }

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -48,7 +48,7 @@ export interface ValueOption {
 export class SelectEditFieldComponent extends EditFieldComponent implements OnInit {
   public selectAutocompleterRegister = this.injector.get(SelectAutocompleterRegisterService);
 
-  public options:any[];
+  public availableOptions:any[];
   public valueOptions:ValueOption[];
   public text:{ requiredPlaceholder:string, placeholder:string };
 
@@ -104,7 +104,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   }
 
   public set selectedOption(val:ValueOption) {
-    let option = _.find(this.options, o => o.$href === val.$href);
+    let option = _.find(this.availableOptions, o => o.$href === val.$href);
 
     // Special case 'null' value, which angular
     // only understands in ng-options as an empty string.
@@ -116,9 +116,9 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   }
 
   private setValues(availableValues:HalResource[]) {
-    this.options = this.halSorting.sort(availableValues);
+    this.availableOptions = this.halSorting.sort(availableValues);
     this.addEmptyOption();
-    this.valueOptions = this.options.map(el => {
+    this.valueOptions = this.availableOptions.map(el => {
       return {name: el.name, $href: el.$href};
     });
   }
@@ -138,13 +138,13 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   }
 
   private addValue(val:HalResource) {
-    this.options.push(val);
+    this.availableOptions.push(val);
     this.valueOptions.push({name: val.name, $href: val.$href});
   }
 
   public get currentValueInvalid():boolean {
     return !!(
-      (this.value && !_.some(this.options, (option:HalResource) => (option.$href === this.value.$href)))
+      (this.value && !_.some(this.availableOptions, (option:HalResource) => (option.$href === this.value.$href)))
       ||
       (!this.value && this.schema.required)
     );
@@ -191,7 +191,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
     // the option if one is returned / exists already.
     const emptyOption = this.getEmptyOption();
     if (emptyOption === undefined) {
-      this.options.unshift({
+      this.availableOptions.unshift({
         name: this.text.placeholder,
         $href: ''
       });
@@ -199,6 +199,6 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   }
 
   private getEmptyOption():ValueOption|undefined {
-    return _.find(this.options, el => el.name === this.text.placeholder);
+    return _.find(this.availableOptions, el => el.name === this.text.placeholder);
   }
 }

--- a/frontend/src/app/modules/fields/field.base.ts
+++ b/frontend/src/app/modules/fields/field.base.ts
@@ -36,6 +36,7 @@ export interface IFieldSchema {
   required?:boolean;
   hasDefault:boolean;
   name?:string;
+  options?:any;
 }
 
 export class Field {
@@ -67,6 +68,10 @@ export class Field {
 
   public get hasDefault():boolean {
     return this.schema.hasDefault;
+  }
+
+  public get options():boolean {
+    return this.schema.options;
   }
 
   public isEmpty():boolean {

--- a/lib/api/decorators/property_schema_representer.rb
+++ b/lib/api/decorators/property_schema_representer.rb
@@ -61,7 +61,8 @@ module API
                     :attribute_group,
                     :min_length,
                     :max_length,
-                    :regular_expression
+                    :regular_expression,
+                    :options
 
       property :type, exec_context: :decorator
       property :name, exec_context: :decorator
@@ -73,6 +74,7 @@ module API
       property :min_length, exec_context: :decorator
       property :max_length, exec_context: :decorator
       property :regular_expression, exec_context: :decorator
+      property :options, exec_context: :decorator
 
       private
 

--- a/lib/api/decorators/property_schema_representer.rb
+++ b/lib/api/decorators/property_schema_representer.rb
@@ -61,7 +61,6 @@ module API
                     :attribute_group,
                     :min_length,
                     :max_length,
-                    :regular_expression,
                     :options
 
       property :type, exec_context: :decorator
@@ -73,7 +72,6 @@ module API
       property :attribute_group, exec_context: :decorator
       property :min_length, exec_context: :decorator
       property :max_length, exec_context: :decorator
-      property :regular_expression, exec_context: :decorator
       property :options, exec_context: :decorator
 
       private

--- a/lib/api/decorators/property_schema_representer.rb
+++ b/lib/api/decorators/property_schema_representer.rb
@@ -59,8 +59,6 @@ module API
                     :writable,
                     :visibility,
                     :attribute_group,
-                    :min_length,
-                    :max_length,
                     :options
 
       property :type, exec_context: :decorator
@@ -70,8 +68,6 @@ module API
       property :writable, exec_context: :decorator
       property :visibility, exec_context: :decorator
       property :attribute_group, exec_context: :decorator
-      property :min_length, exec_context: :decorator
-      property :max_length, exec_context: :decorator
       property :options, exec_context: :decorator
 
       private

--- a/lib/api/decorators/schema_representer.rb
+++ b/lib/api/decorators/schema_representer.rb
@@ -62,7 +62,6 @@ module API
                    attribute_group: nil,
                    min_length: nil,
                    max_length: nil,
-                   regular_expression: nil,
                    options: {},
                    show_if: true)
           getter = ->(*) do
@@ -75,7 +74,6 @@ module API
                                    attribute_group,
                                    min_length,
                                    max_length,
-                                   regular_expression,
                                    options)
           end
 
@@ -288,7 +286,6 @@ module API
                                  attribute_group,
                                  min_length,
                                  max_length,
-                                 regular_expression,
                                  options)
         name = call_or_translate(name_source)
         schema = ::API::Decorators::PropertySchemaRepresenter
@@ -301,7 +298,6 @@ module API
                       attribute_group: call_or_use(attribute_group))
         schema.min_length = min_length
         schema.max_length = max_length
-        schema.regular_expression = regular_expression
         schema.options = options
 
         schema

--- a/lib/api/decorators/schema_representer.rb
+++ b/lib/api/decorators/schema_representer.rb
@@ -63,6 +63,7 @@ module API
                    min_length: nil,
                    max_length: nil,
                    regular_expression: nil,
+                   options: {},
                    show_if: true)
           getter = ->(*) do
             schema_property_getter(type,
@@ -74,7 +75,8 @@ module API
                                    attribute_group,
                                    min_length,
                                    max_length,
-                                   regular_expression)
+                                   regular_expression,
+                                   options)
           end
 
           schema_property(property,
@@ -286,7 +288,8 @@ module API
                                  attribute_group,
                                  min_length,
                                  max_length,
-                                 regular_expression)
+                                 regular_expression,
+                                 options)
         name = call_or_translate(name_source)
         schema = ::API::Decorators::PropertySchemaRepresenter
                  .new(type: call_or_use(type),
@@ -299,6 +302,7 @@ module API
         schema.min_length = min_length
         schema.max_length = max_length
         schema.regular_expression = regular_expression
+        schema.options = options
 
         schema
       end

--- a/lib/api/decorators/schema_representer.rb
+++ b/lib/api/decorators/schema_representer.rb
@@ -60,8 +60,6 @@ module API
                    writable: default_writable_property(property),
                    visibility: nil,
                    attribute_group: nil,
-                   min_length: nil,
-                   max_length: nil,
                    options: {},
                    show_if: true)
           getter = ->(*) do
@@ -72,8 +70,6 @@ module API
                                    writable,
                                    visibility,
                                    attribute_group,
-                                   min_length,
-                                   max_length,
                                    options)
           end
 
@@ -284,8 +280,6 @@ module API
                                  writable,
                                  visibility,
                                  attribute_group,
-                                 min_length,
-                                 max_length,
                                  options)
         name = call_or_translate(name_source)
         schema = ::API::Decorators::PropertySchemaRepresenter
@@ -296,8 +290,6 @@ module API
                       writable: call_or_use(writable),
                       visibility: call_or_use(visibility),
                       attribute_group: call_or_use(attribute_group))
-        schema.min_length = min_length
-        schema.max_length = max_length
         schema.options = options
 
         schema

--- a/lib/api/v3/projects/schemas/project_schema_representer.rb
+++ b/lib/api/v3/projects/schemas/project_schema_representer.rb
@@ -43,14 +43,18 @@ module API
           schema :name,
                  type: 'String',
                  visibility: false,
-                 min_length: 1,
-                 max_length: 255
+                 options: {
+                   min_length: 1,
+                   max_length: 255
+                 }
 
           schema :identifier,
                  type: 'String',
                  visibility: false,
-                 min_length: 1,
-                 max_length: 100
+                 options: {
+                   min_length: 1,
+                   max_length: 100
+                 }
 
           schema :description,
                  type: 'Formattable',

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -186,8 +186,6 @@ module API
                         required: custom_field.is_required,
                         has_default: custom_field.default_value.present?,
                         writable: writable,
-                        min_length: cf_min_length(custom_field),
-                        max_length: cf_max_length(custom_field),
                         options: cf_options(custom_field)
         end
 
@@ -309,19 +307,14 @@ module API
           }
         end
 
-        def cf_min_length(custom_field)
-          custom_field.min_length if custom_field.min_length.positive?
-        end
-
-        def cf_max_length(custom_field)
-          custom_field.max_length if custom_field.max_length.positive?
-        end
-
         def cf_options(custom_field)
-          {
-            regular_expression: custom_field.regexp || '',
-            rtl: ("true" if custom_field.content_right_to_left)
-          }
+          options = Hash.new
+          options[:min_length] = custom_field.min_length if custom_field.min_length.positive?
+          options[:max_length] = custom_field.max_length if custom_field.max_length.positive?
+          options[:regular_expression] = custom_field.regexp unless custom_field.regexp.blank?
+          options[:rtl] = "true" if custom_field.content_right_to_left
+
+          options
         end
 
         def list_schemas_values_callback(custom_field)

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -188,7 +188,6 @@ module API
                         writable: writable,
                         min_length: cf_min_length(custom_field),
                         max_length: cf_max_length(custom_field),
-                        regular_expression: cf_regexp(custom_field),
                         options: cf_options(custom_field)
         end
 
@@ -318,12 +317,9 @@ module API
           custom_field.max_length if custom_field.max_length.positive?
         end
 
-        def cf_regexp(custom_field)
-          custom_field.regexp unless custom_field.regexp.blank?
-        end
-
         def cf_options(custom_field)
           {
+            regular_expression: custom_field.regexp || '',
             rtl: ("true" if custom_field.content_right_to_left)
           }
         end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -188,7 +188,8 @@ module API
                         writable: writable,
                         min_length: cf_min_length(custom_field),
                         max_length: cf_max_length(custom_field),
-                        regular_expression: cf_regexp(custom_field)
+                        regular_expression: cf_regexp(custom_field),
+                        options: cf_options(custom_field)
         end
 
         def path_method_for(custom_field)
@@ -319,6 +320,12 @@ module API
 
         def cf_regexp(custom_field)
           custom_field.regexp unless custom_field.regexp.blank?
+        end
+
+        def cf_options(custom_field)
+          {
+            rtl: ("true" if custom_field.content_right_to_left)
+          }
         end
 
         def list_schemas_values_callback(custom_field)

--- a/lib/api/v3/versions/schemas/version_schema_representer.rb
+++ b/lib/api/v3/versions/schemas/version_schema_representer.rb
@@ -50,8 +50,10 @@ module API
 
           schema :name,
                  type: 'String',
-                 min_length: 1,
-                 max_length: 60,
+                 options: {
+                   min_length: 1,
+                   max_length: 60,
+                 },
                  visibility: false
 
           schema :description,

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -112,8 +112,10 @@ module API
 
           schema :subject,
                  type: 'String',
-                 min_length: 1,
-                 max_length: 255
+                 options: {
+                   min_length: 1,
+                   max_length: 255
+                 }
 
           schema :description,
                  type: 'Formattable',

--- a/spec/lib/api/v3/work_packages/schema/work_package_sums_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_sums_schema_representer_spec.rb
@@ -68,7 +68,8 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSumsSchemaRepresenter do
                      'visibility': 'default',
                      'required': false,
                      'hasDefault': false,
-                     'writable': false }
+                     'writable': false,
+                     'options': {} }
         expect(subject).to be_json_eql(expected.to_json).at_path('estimatedTime')
       end
     end
@@ -93,7 +94,8 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSumsSchemaRepresenter do
                      'visibility': 'default',
                      'required': false,
                      'hasDefault': false,
-                     'writable': false }
+                     'writable': false,
+                     'options': {} }
         expect(subject).to be_json_eql(expected.to_json).at_path("customField#{custom_field.id}")
       end
     end

--- a/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
@@ -209,7 +209,8 @@ describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI, type: :request do
                        'visibility': 'default',
                        'required': false,
                        'hasDefault': false,
-                       'writable': false }
+                       'writable': false,
+                       'options': {} }
           expect(subject.body).to be_json_eql(expected.to_json).at_path('estimatedTime')
         end
       end


### PR DESCRIPTION
In https://github.com/opf/openproject/pull/7884 an `options` Hash for the schema definition is introduced. This should to be used for other attributes, that are not relevant for every resource, too.

- [x] `regular_expression`
- [x] `min_length`
- [x] `max_length`
- [ ] `visibilty` 

⚠️  As this is closely related to https://github.com/opf/openproject/pull/7884, this PR is based on the other one. So it should only be merged afterwards.

https://community.openproject.com/projects/openproject/work_packages/31656/activity