### PR TITLE
[31656] Remove schema property "visibility"

### DIFF
--- a/lib/api/decorators/allowed_values_by_collection_representer.rb
+++ b/lib/api/decorators/allowed_values_by_collection_representer.rb
@@ -46,7 +46,6 @@ module API
                      required: true,
                      has_default: false,
                      writable: true,
-                     visibility: nil,
                      attribute_group: nil,
                      current_user: nil,
                      allowed_values_getter: nil)
@@ -59,7 +58,6 @@ module API
               required: required,
               has_default: has_default,
               writable: writable,
-              visibility: visibility,
               attribute_group: attribute_group,
               current_user: current_user)
       end

--- a/lib/api/decorators/property_schema_representer.rb
+++ b/lib/api/decorators/property_schema_representer.rb
@@ -35,18 +35,13 @@ module API
     class PropertySchemaRepresenter < ::API::Decorators::Single
       def initialize(
         type:, name:, required: true, has_default: false, writable: true,
-        visibility: nil, attribute_group: nil, current_user: nil
+        attribute_group: nil, current_user: nil
       )
         @type = type
         @name = name
         @required = required
         @has_default = has_default
         @writable = writable
-        @visibility = if visibility == false
-                        nil
-                      else
-                        visibility || 'default'
-                      end
         @attribute_group = attribute_group
 
         super(nil, current_user: current_user)
@@ -57,7 +52,6 @@ module API
                     :required,
                     :has_default,
                     :writable,
-                    :visibility,
                     :attribute_group,
                     :min_length,
                     :max_length,
@@ -69,7 +63,6 @@ module API
       property :required, exec_context: :decorator
       property :has_default, exec_context: :decorator
       property :writable, exec_context: :decorator
-      property :visibility, exec_context: :decorator
       property :attribute_group, exec_context: :decorator
       property :min_length, exec_context: :decorator
       property :max_length, exec_context: :decorator

--- a/lib/api/decorators/schema_representer.rb
+++ b/lib/api/decorators/schema_representer.rb
@@ -58,7 +58,6 @@ module API
                    required: true,
                    has_default: false,
                    writable: default_writable_property(property),
-                   visibility: nil,
                    attribute_group: nil,
                    min_length: nil,
                    max_length: nil,
@@ -71,7 +70,6 @@ module API
                                    required,
                                    has_default,
                                    writable,
-                                   visibility,
                                    attribute_group,
                                    min_length,
                                    max_length,
@@ -96,7 +94,6 @@ module API
                                      required: true,
                                      has_default: false,
                                      writable: default_writable_property(property),
-                                     visibility: nil,
                                      attribute_group: nil,
                                      show_if: true)
           getter = ->(*) do
@@ -105,7 +102,6 @@ module API
                                                      required,
                                                      has_default,
                                                      writable,
-                                                     visibility,
                                                      attribute_group,
                                                      href_callback)
           end
@@ -131,7 +127,6 @@ module API
                                            required: true,
                                            has_default: false,
                                            writable: default_writable_property(property),
-                                           visibility: nil,
                                            attribute_group: nil,
                                            show_if: true)
 
@@ -144,7 +139,6 @@ module API
                                                   required,
                                                   has_default,
                                                   writable,
-                                                  visibility,
                                                   attribute_group,
                                                   values_callback,
                                                   nil)
@@ -169,7 +163,6 @@ module API
                                                   required: true,
                                                   has_default: false,
                                                   writable: default_writable_property(property),
-                                                  visibility: nil,
                                                   attribute_group: nil,
                                                   show_if: true)
           getter = ->(*) do
@@ -181,7 +174,6 @@ module API
                                                   required,
                                                   has_default,
                                                   writable,
-                                                  visibility,
                                                   attribute_group,
                                                   values_callback,
                                                   ->(*) {
@@ -284,7 +276,6 @@ module API
                                  required,
                                  has_default,
                                  writable,
-                                 visibility,
                                  attribute_group,
                                  min_length,
                                  max_length,
@@ -297,7 +288,6 @@ module API
                       required: call_or_use(required),
                       has_default: call_or_use(has_default),
                       writable: call_or_use(writable),
-                      visibility: call_or_use(visibility),
                       attribute_group: call_or_use(attribute_group))
         schema.min_length = min_length
         schema.max_length = max_length
@@ -312,7 +302,6 @@ module API
                                                    required,
                                                    has_default,
                                                    writable,
-                                                   visibility,
                                                    attribute_group,
                                                    href_callback)
         representer = ::API::Decorators::AllowedValuesByLinkRepresenter
@@ -321,7 +310,6 @@ module API
                            required: call_or_use(required),
                            has_default: call_or_use(has_default),
                            writable: call_or_use(writable),
-                           visibility: call_or_use(visibility),
                            attribute_group: call_or_use(attribute_group))
 
         if form_embedded
@@ -339,7 +327,6 @@ module API
                                                 required,
                                                 has_default,
                                                 writable,
-                                                visibility,
                                                 attribute_group,
                                                 values_callback,
                                                 allowed_values_getter)
@@ -358,7 +345,6 @@ module API
                        required: call_or_use(required),
                        has_default: call_or_use(has_default),
                        writable: call_or_use(writable),
-                       visibility: call_or_use(visibility),
                        attribute_group: call_or_use(attribute_group) }
 
         attributes[:allowed_values_getter] = allowed_values_getter if allowed_values_getter

--- a/lib/api/v3/memberships/schemas/membership_schema_representer.rb
+++ b/lib/api/v3/memberships/schemas/membership_schema_representer.rb
@@ -39,17 +39,14 @@ module API
           end
 
           schema :id,
-                 type: 'Integer',
-                 visibility: false
+                 type: 'Integer'
 
           schema :created_at,
-                 type: 'DateTime',
-                 visibility: false
+                 type: 'DateTime'
 
           schema_with_allowed_link :project,
                                    has_default: false,
                                    required: true,
-                                   visibility: false,
                                    href_callback: ->(*) {
                                      allowed_projects_href
                                    }
@@ -57,7 +54,6 @@ module API
           schema_with_allowed_link :principal,
                                    has_default: false,
                                    required: true,
-                                   visibility: false,
                                    href_callback: ->(*) {
                                      allowed_principal_href
                                    }
@@ -67,7 +63,6 @@ module API
                                    name_source: :role,
                                    has_default: false,
                                    required: true,
-                                   visibility: false,
                                    href_callback: ->(*) {
                                      api_v3_paths.path_for(:roles, filters: [{ unit: { operator: '=', values: ['project'] } }])
                                    }

--- a/lib/api/v3/projects/schemas/project_schema_representer.rb
+++ b/lib/api/v3/projects/schemas/project_schema_representer.rb
@@ -37,45 +37,37 @@ module API
           custom_field_injector type: :schema_representer
 
           schema :id,
-                 type: 'Integer',
-                 visibility: false
+                 type: 'Integer'
 
           schema :name,
                  type: 'String',
-                 visibility: false,
                  min_length: 1,
                  max_length: 255
 
           schema :identifier,
                  type: 'String',
-                 visibility: false,
                  min_length: 1,
                  max_length: 100
 
           schema :description,
                  type: 'Formattable',
-                 visibility: false,
                  required: false
 
           schema :public,
-                 type: 'Boolean',
-                 visibility: false
+                 type: 'Boolean'
 
           schema :active,
-                 type: 'Boolean',
-                 visibility: false
+                 type: 'Boolean'
 
           schema :status,
                  type: 'ProjectStatus',
                  name_source: ->(*) { I18n.t('activerecord.attributes.project/status.code') },
-                 visibility: false,
                  required: false,
                  writable: ->(*) { represented.writable?(:status) }
 
           schema :status_explanation,
                  type: 'Formattable',
                  name_source: ->(*) { I18n.t('activerecord.attributes.project/status.explanation') },
-                 visibility: false,
                  required: false,
                  writable: ->(*) { represented.writable?(:status) }
 
@@ -93,12 +85,10 @@ module API
                                    }
 
           schema :created_at,
-                 type: 'DateTime',
-                 visibility: false
+                 type: 'DateTime'
 
           schema :updated_at,
-                 type: 'DateTime',
-                 visibility: false
+                 type: 'DateTime'
 
           def self.represented_class
             ::Project

--- a/lib/api/v3/queries/schemas/custom_option_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/custom_option_filter_dependency_representer.rb
@@ -40,7 +40,6 @@ module API
                                          writable: true,
                                          has_default: false,
                                          required: true,
-                                         visibility: false,
                                          values_callback: ->(*) {
                                            represented.custom_field.custom_options
                                          },

--- a/lib/api/v3/queries/schemas/filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/filter_dependency_representer.rb
@@ -46,7 +46,6 @@ module API
                                    writable: true,
                                    has_default: false,
                                    required: true,
-                                   visibility: false,
                                    href_callback: ->(*) {
                                      href_callback
                                    },

--- a/lib/api/v3/queries/schemas/query_filter_instance_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_filter_instance_schema_representer.rb
@@ -41,8 +41,7 @@ module API
                  type: 'String',
                  writable: false,
                  has_default: true,
-                 required: true,
-                 visibility: false
+                 required: true
 
           def self.filter_representer
             ::API::V3::Queries::Filters::QueryFilterRepresenter
@@ -61,7 +60,6 @@ module API
                                          type: 'QueryFilter',
                                          required: true,
                                          writable: true,
-                                         visibility: false,
                                          values_callback: -> {
                                            [filter]
                                          },
@@ -86,7 +84,6 @@ module API
                                          writable: true,
                                          has_default: false,
                                          required: true,
-                                         visibility: false,
                                          values_callback: -> {
                                            filter.available_operators
                                          },

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -61,34 +61,28 @@ module API
           end
 
           schema :id,
-                 type: 'Integer',
-                 visibility: false
+                 type: 'Integer'
 
           schema :name,
                  type: 'String',
                  writable: true,
                  min_length: 1,
-                 max_length: 255,
-                 visibility: false
+                 max_length: 255
 
           schema :created_at,
-                 type: 'DateTime',
-                 visibility: false
+                 type: 'DateTime'
 
           schema :updated_at,
-                 type: 'DateTime',
-                 visibility: false
+                 type: 'DateTime'
 
           schema :user,
                  type: 'User',
-                 has_default: true,
-                 visibility: false
+                 has_default: true
 
           schema_with_allowed_link :project,
                                    type: 'Project',
                                    required: false,
                                    writable: true,
-                                   visibility: false,
                                    href_callback: ->(*) {
                                      api_v3_paths.query_available_projects
                                    }
@@ -100,85 +94,73 @@ module API
                                             represented.project,
                                             global: represented.project.nil?)
                  end,
-                 has_default: true,
-                 visibility: false
+                 has_default: true
 
           schema :sums,
                  type: 'Boolean',
                  required: false,
                  writable: true,
-                 has_default: true,
-                 visibility: false
+                 has_default: true
 
           schema :timeline_visible,
                  type: 'Boolean',
                  required: false,
                  writable: true,
-                 has_default: true,
-                 visibility: false
+                 has_default: true
 
           schema :timeline_zoom_level,
                  type: 'String',
                  required: false,
                  writable: true,
-                 has_default: true,
-                 visibility: false
+                 has_default: true
 
           schema :timeline_labels,
                  type: 'QueryTimelineLabels',
                  required: false,
                  writable: true,
-                 has_default: true,
-                 visibility: false
+                 has_default: true
 
           schema :highlighting_mode,
                  type: 'String',
                  required: false,
                  writable: true,
-                 has_default: true,
-                 visibility: false
+                 has_default: true
 
           schema :display_representation,
                  type: 'String',
                  required: false,
                  writable: true,
-                 has_default: true,
-                 visibility: false
+                 has_default: true
 
           schema :show_hierarchies,
                  type: 'Boolean',
                  required: false,
                  writable: true,
-                 has_default: true,
-                 visibility: false
+                 has_default: true
 
           schema :starred,
                  type: 'Boolean',
                  required: false,
                  writable: false,
-                 has_default: true,
-                 visibility: false
+                 has_default: true
 
           schema :hidden,
                  type: 'Boolean',
                  required: true,
                  writable: true,
-                 has_default: true,
-                 visibility: false
+                 has_default: true
 
           schema :ordered_work_packages,
                  type: 'QueryOrder',
                  required: false,
                  writable: true,
-                 has_default: true,
-                 visibility: false
+                 has_default: true
 
           schema_with_allowed_collection :columns,
                                          type: '[]QueryColumn',
                                          required: false,
                                          writable: true,
                                          has_default: true,
-                                         visibility: false,
                                          values_callback: -> { represented.available_columns },
                                          value_representer: ->(column) {
                                            Columns::QueryColumnsFactory.representer(column)
@@ -204,7 +186,6 @@ module API
                                          type: '[]QueryGroupBy',
                                          required: false,
                                          writable: true,
-                                         visibility: false,
                                          values_callback: -> { represented.groupable_columns },
                                          value_representer: GroupBys::QueryGroupByRepresenter,
                                          link_factory: ->(column) {
@@ -221,7 +202,6 @@ module API
                                          required: false,
                                          writable: true,
                                          has_default: true,
-                                         visibility: false,
                                          values_callback: -> { represented.available_highlighting_columns },
                                          value_representer: ->(column) {
                                            Columns::QueryColumnsFactory.representer(column)
@@ -241,7 +221,6 @@ module API
                                          required: false,
                                          writable: true,
                                          has_default: true,
-                                         visibility: false,
                                          values_callback: -> do
                                            values = represented.sortable_columns.map do |column|
                                              [SortBys::SortByDecorator.new(column, 'asc'),
@@ -263,8 +242,7 @@ module API
           schema :results,
                  type: 'WorkPackageCollection',
                  required: false,
-                 writable: false,
-                 visibility: false
+                 writable: false
 
           property :filters_schemas,
                    embedded: true,

--- a/lib/api/v3/versions/schemas/version_schema_representer.rb
+++ b/lib/api/v3/versions/schemas/version_schema_representer.rb
@@ -45,30 +45,25 @@ module API
           end
 
           schema :id,
-                 type: 'Integer',
-                 visibility: false
+                 type: 'Integer'
 
           schema :name,
                  type: 'String',
                  min_length: 1,
-                 max_length: 60,
-                 visibility: false
+                 max_length: 60
 
           schema :description,
                  type: 'Formattable',
-                 required: false,
-                 visibility: false
+                 required: false
 
           schema :start_date,
                  type: 'Date',
-                 required: false,
-                 visibility: false
+                 required: false
 
           schema :due_date,
                  as: 'endDate',
                  type: 'Date',
-                 required: false,
-                 visibility: false
+                 required: false
 
           schema_with_allowed_string_collection :status,
                                                 type: 'String'
@@ -80,7 +75,6 @@ module API
                                    as: :definingProject,
                                    has_default: false,
                                    required: true,
-                                   visibility: false,
                                    href_callback: ->(*) {
                                      next unless represented.new_record?
 
@@ -88,12 +82,10 @@ module API
                                    }
 
           schema :created_at,
-                 type: 'DateTime',
-                 visibility: false
+                 type: 'DateTime'
 
           schema :updated_at,
-                 type: 'DateTime',
-                 visibility: false
+                 type: 'DateTime'
 
           def self.represented_class
             Version

--- a/modules/backlogs/lib/api/v3/queries/schemas/backlogs_type_dependency_representer.rb
+++ b/modules/backlogs/lib/api/v3/queries/schemas/backlogs_type_dependency_representer.rb
@@ -45,7 +45,6 @@ module API
                                          writable: true,
                                          has_default: false,
                                          required: true,
-                                         visibility: false,
                                          values_callback: ->(*) {
                                            represented.allowed_values
                                          },

--- a/modules/grids/app/representers/api/v3/grids/schemas/grid_schema_representer.rb
+++ b/modules/grids/app/representers/api/v3/grids/schemas/grid_schema_representer.rb
@@ -41,38 +41,30 @@ module API
           end
 
           schema :id,
-                 type: 'Integer',
-                 visibility: false
+                 type: 'Integer'
 
           schema :created_at,
-                 type: 'DateTime',
-                 visibility: false
+                 type: 'DateTime'
 
           schema :updated_at,
-                 type: 'DateTime',
-                 visibility: false
+                 type: 'DateTime'
 
           schema :row_count,
-                 type: 'Integer',
-                 visibility: false
+                 type: 'Integer'
 
           schema :column_count,
-                 type: 'Integer',
-                 visibility: false
+                 type: 'Integer'
 
           schema :name,
-                 type: 'String',
-                 visibility: false
+                 type: 'String'
 
           schema :options,
-                 type: 'JSON',
-                 visibility: false
+                 type: 'JSON'
 
           schema_with_allowed_collection :scope,
                                          type: 'Href',
                                          required: true,
                                          has_default: false,
-                                         visibility: false,
                                          value_representer: false,
                                          link_factory: ->(path) {
                                            {
@@ -84,7 +76,6 @@ module API
                                          type: '[]GridWidget',
                                          required: true,
                                          has_default: false,
-                                         visibility: false,
                                          values_callback: -> do
                                            represented.assignable_widgets.map do |identifier|
                                              OpenStruct.new(identifier: identifier, grid: represented.model, options: {})

--- a/modules/grids/spec/lib/api/v3/grids/schemas/grid_schema_representer_spec.rb
+++ b/modules/grids/spec/lib/api/v3/grids/schemas/grid_schema_representer_spec.rb
@@ -94,8 +94,6 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
         let(:required) { true }
         let(:writable) { false }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'rowCount' do
@@ -107,8 +105,6 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
         let(:required) { true }
         let(:writable) { true }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'columnCount' do
@@ -120,8 +116,6 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
         let(:required) { true }
         let(:writable) { true }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'createdAt' do
@@ -133,8 +127,6 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
         let(:required) { true }
         let(:writable) { false }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'updatedAt' do
@@ -146,8 +138,6 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
         let(:required) { true }
         let(:writable) { false }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'widgets' do

--- a/spec/lib/api/v3/memberships/schemas/membership_schema_representer_spec.rb
+++ b/spec/lib/api/v3/memberships/schemas/membership_schema_representer_spec.rb
@@ -96,8 +96,6 @@ describe ::API::V3::Memberships::Schemas::MembershipSchemaRepresenter do
         let(:required) { true }
         let(:writable) { false }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'createdAt' do
@@ -109,8 +107,6 @@ describe ::API::V3::Memberships::Schemas::MembershipSchemaRepresenter do
         let(:required) { true }
         let(:writable) { false }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'project' do

--- a/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
+++ b/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
@@ -100,8 +100,6 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
         let(:required) { true }
         let(:writable) { false }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'name' do
@@ -118,8 +116,6 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
         let(:min_length) { 1 }
         let(:max_length) { 255 }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'identifier' do
@@ -136,8 +132,6 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
         let(:min_length) { 1 }
         let(:max_length) { 100 }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'description' do
@@ -149,8 +143,6 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
         let(:required) { false }
         let(:writable) { true }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'public' do
@@ -162,8 +154,6 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
         let(:required) { true }
         let(:writable) { true }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'active' do
@@ -175,8 +165,6 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
         let(:required) { true }
         let(:writable) { true }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'statusExplanation' do
@@ -222,8 +210,6 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
         let(:required) { true }
         let(:writable) { false }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'updatedAt' do
@@ -235,8 +221,6 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
         let(:required) { true }
         let(:writable) { false }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'int custom field' do

--- a/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
@@ -105,8 +105,6 @@ describe ::API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter, clea
           let(:writable) { false }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'filter' do
@@ -118,8 +116,6 @@ describe ::API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter, clea
           let(:required) { true }
           let(:writable) { true }
         end
-
-        it_behaves_like 'has no visibility property'
 
         it_behaves_like 'does not link to allowed values'
 
@@ -149,8 +145,6 @@ describe ::API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter, clea
           let(:required) { true }
           let(:writable) { true }
         end
-
-        it_behaves_like 'has no visibility property'
 
         it_behaves_like 'does not link to allowed values'
 

--- a/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
@@ -112,8 +112,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:required) { true }
           let(:writable) { false }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'name' do
@@ -130,8 +128,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:min_length) { 1 }
           let(:max_length) { 255 }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'createdAt' do
@@ -143,8 +139,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:required) { true }
           let(:writable) { false }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'updatedAt' do
@@ -156,8 +150,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:required) { true }
           let(:writable) { false }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'user' do
@@ -170,8 +162,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { false }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'project' do
@@ -183,8 +173,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:required) { false }
           let(:writable) { true }
         end
-
-        it_behaves_like 'has no visibility property'
 
         it_behaves_like 'does not link to allowed values'
 
@@ -207,8 +195,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { false }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
 
         context 'when having the :manage_public_queries permission' do
           before do
@@ -248,8 +234,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { true }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'timelineVisible' do
@@ -262,8 +246,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { true }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'timelineZoomLevel' do
@@ -276,8 +258,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { true }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'timelineLabels' do
@@ -290,8 +270,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { true }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'show hierarchies' do
@@ -304,8 +282,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { true }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'starred' do
@@ -318,8 +294,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { false }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'highlighting_mode' do
@@ -332,8 +306,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { true }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'display_representation' do
@@ -346,8 +318,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { true }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
       end
 
       describe 'columns' do
@@ -360,8 +330,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { true }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
 
         it_behaves_like 'does not link to allowed values'
 
@@ -441,8 +409,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:has_default) { true }
         end
 
-        it_behaves_like 'has no visibility property'
-
         it_behaves_like 'does not link to allowed values'
 
         context 'when global query' do
@@ -477,8 +443,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { true }
         end
 
-        it_behaves_like 'has no visibility property'
-
         it_behaves_like 'does not link to allowed values'
 
         context 'when embedding' do
@@ -510,8 +474,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:writable) { true }
           let(:has_default) { true }
         end
-
-        it_behaves_like 'has no visibility property'
 
         it_behaves_like 'does not link to allowed values'
 
@@ -553,8 +515,6 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:required) { false }
           let(:writable) { false }
         end
-
-        it_behaves_like 'has no visibility property'
       end
     end
 

--- a/spec/lib/api/v3/support/api_v3_filter_dependency.rb
+++ b/spec/lib/api/v3/support/api_v3_filter_dependency.rb
@@ -34,8 +34,6 @@ shared_examples_for 'filter dependency' do
     let(:has_default) { false }
   end
 
-  it_behaves_like 'has no visibility property'
-
   it_behaves_like 'does not link to allowed values'
 
   context 'when embedding' do
@@ -53,8 +51,6 @@ shared_examples_for 'filter dependency with allowed link' do
     let(:has_default) { false }
   end
 
-  it_behaves_like 'has no visibility property'
-
   it_behaves_like 'does not link to allowed values'
 
   context 'when embedding' do
@@ -71,8 +67,6 @@ shared_examples_for 'filter dependency with allowed value link collection' do
     let(:writable) { true }
     let(:has_default) { false }
   end
-
-  it_behaves_like 'has no visibility property'
 
   it_behaves_like 'does not link to allowed values'
 

--- a/spec/lib/api/v3/support/schema_examples.rb
+++ b/spec/lib/api/v3/support/schema_examples.rb
@@ -86,13 +86,6 @@ shared_examples_for 'indicates length requirements' do
   end
 end
 
-shared_examples_for 'has no visibility property' do
-  it 'has no path' do
-    is_expected
-      .not_to have_json_path("#{path}/visibility")
-  end
-end
-
 shared_examples_for 'links to allowed values directly' do
   it 'has the expected number of links' do
     is_expected.to have_json_size(hrefs.size).at_path("#{path}/_links/allowedValues")

--- a/spec/lib/api/v3/versions/schemas/version_schema_representer_spec.rb
+++ b/spec/lib/api/v3/versions/schemas/version_schema_representer_spec.rb
@@ -98,8 +98,6 @@ describe ::API::V3::Versions::Schemas::VersionSchemaRepresenter do
         let(:required) { true }
         let(:writable) { false }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'createdAt' do
@@ -111,8 +109,6 @@ describe ::API::V3::Versions::Schemas::VersionSchemaRepresenter do
         let(:required) { true }
         let(:writable) { false }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'updatedAt' do
@@ -124,8 +120,6 @@ describe ::API::V3::Versions::Schemas::VersionSchemaRepresenter do
         let(:required) { true }
         let(:writable) { false }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'name' do
@@ -142,8 +136,6 @@ describe ::API::V3::Versions::Schemas::VersionSchemaRepresenter do
         let(:min_length) { 1 }
         let(:max_length) { 60 }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'description' do
@@ -155,8 +147,6 @@ describe ::API::V3::Versions::Schemas::VersionSchemaRepresenter do
         let(:required) { false }
         let(:writable) { true }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'int custom field' do
@@ -179,8 +169,6 @@ describe ::API::V3::Versions::Schemas::VersionSchemaRepresenter do
         let(:required) { false }
         let(:writable) { true }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'endDate' do
@@ -192,8 +180,6 @@ describe ::API::V3::Versions::Schemas::VersionSchemaRepresenter do
         let(:required) { false }
         let(:writable) { true }
       end
-
-      it_behaves_like 'has no visibility property'
     end
 
     describe 'definingProject' do

--- a/spec/lib/api/v3/work_packages/schema/work_package_sums_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_sums_schema_representer_spec.rb
@@ -65,7 +65,6 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSumsSchemaRepresenter do
       it 'is represented' do
         expected = { 'type': 'Duration',
                      'name': 'Estimated time',
-                     'visibility': 'default',
                      'required': false,
                      'hasDefault': false,
                      'writable': false,
@@ -91,7 +90,6 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSumsSchemaRepresenter do
       it 'is represented' do
         expected = { 'type': 'Integer',
                      'name': custom_field.name,
-                     'visibility': 'default',
                      'required': false,
                      'hasDefault': false,
                      'writable': false,

--- a/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/work_packages_schemas_resource_spec.rb
@@ -206,7 +206,6 @@ describe API::V3::WorkPackages::Schema::WorkPackageSchemasAPI, type: :request do
         it 'should return the schema for estimated_hours' do
           expected = { 'type': 'Duration',
                        'name': 'Estimated time',
-                       'visibility': 'default',
                        'required': false,
                        'hasDefault': false,
                        'writable': false,


### PR DESCRIPTION
It seems as if the schema property `visibility` is not needed any more and can thus be removed. 

https://community.openproject.com/projects/openproject/work_packages/31656/activity