### PR TITLE
[31214] Outline of display-field extends table cell width

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_content.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_content.sass
@@ -122,8 +122,11 @@ html:not(.-browser-mobile)
 
 .wp-table--cell-container
   @extend .ellipsis
+  display: inline-block
+  vertical-align: middle
   .wp-table--cell-td.-editing &
     display: block
+    width: initial !important
 
   .inline-edit--display-field
     display: initial

--- a/frontend/src/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts
@@ -14,6 +14,7 @@ export const indicatorCollapsedClass = '-hierarchy-collapsed';
 export const hierarchyCellClassName = 'wp-table--hierarchy-span';
 export const additionalHierarchyRowClassName = 'wp-table--hierarchy-aditional-row';
 export const hierarchyIndentation = 20;
+export const hierarchyBaseIndentation = 25;
 
 export class SingleHierarchyRowBuilder extends SingleRowBuilder {
   // Injected
@@ -126,6 +127,8 @@ export class SingleHierarchyRowBuilder extends SingleRowBuilder {
 
     // Assure that the content is still visble when the hierarchy indentation is very large
     jRow.find('td.subject').css('minWidth', 125 + (hierarchyIndentation * hierarchyLevel) + 'px');
+    jRow.find('td.subject .wp-table--cell-container')
+      .css('width', 'calc(100% - ' + hierarchyBaseIndentation + 'px - ' + (hierarchyIndentation * hierarchyLevel) + 'px)');
   }
 
   /**
@@ -134,7 +137,7 @@ export class SingleHierarchyRowBuilder extends SingleRowBuilder {
   private buildHierarchyIndicator(workPackage:WorkPackageResource, jRow:JQuery | null, level:number):HTMLElement {
     const hierarchyIndicator = document.createElement('span');
     const collapsed = this.wpTableHierarchies.collapsed(workPackage.id!);
-    const indicatorWidth = 25 + (hierarchyIndentation * level) + 'px';
+    const indicatorWidth = hierarchyBaseIndentation + (hierarchyIndentation * level) + 'px';
     hierarchyIndicator.classList.add(hierarchyCellClassName);
     hierarchyIndicator.style.width = indicatorWidth;
     hierarchyIndicator.dataset.indentation = indicatorWidth;


### PR DESCRIPTION
Set `block` to the display elements so that the outline is cut off.

https://community.openproject.com/projects/openproject/work_packages/31214/activity