### PR TITLE
Attempt to stabilise attachments_upload_spec

### DIFF
--- a/spec/features/work_packages/attachments/attachment_upload_spec.rb
+++ b/spec/features/work_packages/attachments/attachment_upload_spec.rb
@@ -103,10 +103,12 @@ describe 'Upload attachment to work package', js: true do
           expect(editable).to have_selector('img[src*="/api/v3/attachments/"]', wait: 20)
         end
 
+        sleep 2
+
         # Besides testing caption functionality this also slows down clicking on the submit button
         # so that the image is properly embedded
         caption = page.find('figure.image figcaption')
-        caption.click
+        caption.click(x: 10, y: 10)
         sleep 0.2
         caption.base.send_keys('Some image caption')
 


### PR DESCRIPTION
Assumption: The click is either done to early or in a small area at the bottom of the fig-caption where the whole image is selected. This would then replace the image when the text is entered instead of setting the caption.