### PR TITLE
[31721] Second level menu of boards is not reachable on first click

### DIFF
--- a/frontend/src/app/components/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/components/main-menu/main-menu-toggle.service.ts
@@ -104,7 +104,7 @@ export class MainMenuToggleService {
       this.closeMenu();
     }
 
-    this.addRemoveClassHidden();
+    this.toggleClassHidden();
     this.setToggleTitle();
     // Set focus on first visible main menu item.
     // This needs to be called after AngularJS has rendered the menu, which happens some when after(!) we leave this
@@ -138,7 +138,7 @@ export class MainMenuToggleService {
     this.titleData.next(this.toggleTitle);
   }
 
-  private addRemoveClassHidden():void {
+  private toggleClassHidden():void {
     this.hideElements.toggleClass('hidden-navigation', !this.showNavigation);
   }
 
@@ -169,7 +169,7 @@ export class MainMenuToggleService {
     this.ensureContentVisibility();
 
     this.global.showNavigation = this.showNavigation;
-    this.addRemoveClassHidden();
+    this.toggleClassHidden();
     this.htmlNode.style.setProperty("--main-menu-width", this.elementWidth + 'px');
   }
 
@@ -180,14 +180,13 @@ export class MainMenuToggleService {
       let originalEvent = event.originalEvent as FocusEvent;
       // Check that main menu is not closed and that the `focusout` event is not a click on an element
       // that tries to close the menu anyways.
-      if (!that.showNavigation || document.getElementById('main-menu-toggle') ===  originalEvent.relatedTarget) {
+      if (!that.showNavigation || document.getElementById('main-menu-toggle') === originalEvent.relatedTarget) {
         return;
       }
       else {
         // There might be a time gap between `focusout` and the focussing of the activeElement, thus we need a timeout.
         setTimeout(function() {
-          if (!jQuery.contains(document.getElementById('main-menu')!, document.activeElement!) &&
-              (document.getElementById('main-menu-toggle') !== document.activeElement)) {
+          if (!jQuery.contains(document.getElementById('main-menu')!, originalEvent.relatedTarget as Element)) {
             // activeElement is outside of main menu.
             that.closeMenu();
           }

--- a/frontend/src/app/modules/boards/boards-sidebar/boards-menu.component.ts
+++ b/frontend/src/app/modules/boards/boards-sidebar/boards-menu.component.ts
@@ -1,4 +1,4 @@
-import {Component} from "@angular/core";
+import {Component, OnInit} from "@angular/core";
 import {Observable} from "rxjs";
 import {BoardService} from "core-app/modules/boards/board/board.service";
 import {Board} from "core-app/modules/boards/board/board";
@@ -14,7 +14,7 @@ import {CurrentProjectService} from "core-components/projects/current-project.se
   templateUrl: './boards-menu.component.html'
 })
 
-export class BoardsMenuComponent {
+export class BoardsMenuComponent implements OnInit {
   trackById = AngularTrackingHelpers.compareByAttribute('id');
 
   currentProjectIdentifier = this.currentProject.identifier;
@@ -33,12 +33,22 @@ export class BoardsMenuComponent {
               private readonly boardCache:BoardCacheService,
               private readonly currentProject:CurrentProjectService,
               private readonly mainMenuService:MainMenuNavigationService) {
+  }
 
+  ngOnInit() {
     // When activating the work packages submenu,
     // either initially or through click on the toggle, load the results
     this.mainMenuService
       .onActivate('board_view')
-      .subscribe(() => this.boardService.loadAllBoards());
+      .subscribe(() => {
+        this.focusBackArrow();
+        this.boardService.loadAllBoards()
+      });
+  }
+
+  private focusBackArrow() {
+    let buttonArrowLeft = jQuery('*[data-name="board_view"] .main-menu--arrow-left-to-project');
+    buttonArrowLeft.focus();
   }
 }
 DynamicBootstrapper.register({selector: 'boards-menu', cls: BoardsMenuComponent});


### PR DESCRIPTION
Focus arrow so that the currently focused element is inside the menu and the menu does not close (mobile)

https://community.openproject.com/projects/openproject/work_packages/31721/activity