### PR TITLE
[31737] Double click on WP row not working

### DIFF
--- a/frontend/src/app/components/wp-fast-table/handlers/row/click-handler.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/row/click-handler.ts
@@ -9,6 +9,8 @@ import {tableRowClassName} from '../../builders/rows/single-row-builder';
 import {WorkPackageTable} from '../../wp-fast-table';
 import {TableEventHandler} from '../table-handler-registry';
 import {WorkPackageViewSelectionService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-selection.service";
+import {displayClassName} from "core-components/wp-edit-form/display-field-renderer";
+import {activeFieldClassName} from "core-app/modules/fields/edit/edit-form/edit-form";
 
 export class RowClickHandler implements TableEventHandler {
 
@@ -45,7 +47,7 @@ export class RowClickHandler implements TableEventHandler {
 
     // Shortcut to any clicks within a cell
     // We don't want to handle these.
-    if (target.parents(`.${tdClassName}`).length) {
+    if (target.hasClass(`${displayClassName}`) || target.hasClass(`${activeFieldClassName}`)) {
       debugLog('Skipping click on inner cell');
       return true;
     }

--- a/frontend/src/app/components/wp-fast-table/handlers/row/double-click-handler.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/row/double-click-handler.ts
@@ -9,6 +9,8 @@ import {WorkPackageTable} from '../../wp-fast-table';
 import {TableEventHandler} from '../table-handler-registry';
 import {LinkHandling} from "core-app/modules/common/link-handling/link-handling";
 import {WorkPackageViewSelectionService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-selection.service";
+import {displayClassName} from "core-components/wp-edit-form/display-field-renderer";
+import {activeFieldClassName} from "core-app/modules/fields/edit/edit-form/edit-form";
 
 export class RowDoubleClickHandler implements TableEventHandler {
 
@@ -44,7 +46,7 @@ export class RowDoubleClickHandler implements TableEventHandler {
 
     // Shortcut to any clicks within a cell
     // We don't want to handle these.
-    if (target.parents(`.${tdClassName}`).length) {
+    if (target.hasClass(`${displayClassName}`) || target.hasClass(`${activeFieldClassName}`)) {
       debugLog('Skipping click on inner cell');
       return true;
     }


### PR DESCRIPTION
Because of these changes https://github.com/opf/openproject/pull/7892 the WP table subjects span is now wider. Thus it always catches the click events and we need to specify the condition in the click handlers.

https://community.openproject.com/projects/openproject/work_packages/31737/activity