### PR TITLE
[31702] Remove borders of card view on mobile work package page

### DIFF
--- a/app/assets/stylesheets/layout/_toolbar_mobile.sass
+++ b/app/assets/stylesheets/layout/_toolbar_mobile.sass
@@ -53,7 +53,3 @@
 
         > form input.button
           width: 100%
-
-    overview-page-layout
-      .toolbar-item:first-child
-        flex-basis: calc(100% - 10px) // 10px right margin

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -141,7 +141,7 @@
     .work-packages-split-view--details-side
       overflow-x: auto
 
-  .router--work-packages-base
+  .router--work-packages-list-view
     // Ensure the WP cards can span the complete width on mobile
     #content-wrapper
       padding: 15px 0 !important

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -140,3 +140,12 @@
   .router--work-packages-split-view-new
     .work-packages-split-view--details-side
       overflow-x: auto
+
+  .router--work-packages-base
+    // Ensure the WP cards can span the complete width on mobile
+    #content-wrapper
+      padding: 15px 0 !important
+
+      .toolbar-container
+        margin-left: 15px
+        margin-right: 15px

--- a/app/assets/stylesheets/layout/work_packages/_table.sass
+++ b/app/assets/stylesheets/layout/work_packages/_table.sass
@@ -33,11 +33,6 @@
     #main
       top: 12px
 
-.router--work-packages-list-view:not(.router--work-packages-full-create),
-.router--work-packages-full-view:not(.router--work-packages-full-create)
-  #content-wrapper
-    padding: 0 0 0 20px
-
 // Ensure correct height applied to child elements.
 // The dom looks like this:
 // flash (generated from rails - if it was generated when rendering the page)

--- a/app/assets/stylesheets/layout/work_packages/_table.sass
+++ b/app/assets/stylesheets/layout/work_packages/_table.sass
@@ -33,6 +33,11 @@
     #main
       top: 12px
 
+.router--work-packages-list-view:not(.router--work-packages-full-create),
+.router--work-packages-full-view:not(.router--work-packages-full-create)
+  #content-wrapper
+    padding: 0 0 0 20px
+
 // Ensure correct height applied to child elements.
 // The dom looks like this:
 // flash (generated from rails - if it was generated when rendering the page)

--- a/frontend/src/app/components/wp-card-view/styles/wp-card-view-horizontal.sass
+++ b/frontend/src/app/components/wp-card-view/styles/wp-card-view-horizontal.sass
@@ -4,3 +4,10 @@
   grid-column-gap: 10px
   grid-row-gap: 10px
   margin-right: 5px
+
+  @media only screen and (max-width: 679px)
+    &.-mobile-cards
+      grid-row-gap: 0
+
+      .form--separator
+        margin-bottom: 0

--- a/frontend/src/app/components/wp-card-view/styles/wp-card-view-horizontal.sass
+++ b/frontend/src/app/components/wp-card-view/styles/wp-card-view-horizontal.sass
@@ -7,6 +7,7 @@
 
   @media only screen and (max-width: 679px)
     &.-shrink
+      grid-template-columns: 1fr
       grid-row-gap: 0
       margin-right: 0
 

--- a/frontend/src/app/components/wp-card-view/styles/wp-card-view-horizontal.sass
+++ b/frontend/src/app/components/wp-card-view/styles/wp-card-view-horizontal.sass
@@ -6,8 +6,9 @@
   margin-right: 5px
 
   @media only screen and (max-width: 679px)
-    &.-mobile-cards
+    &.-shrink
       grid-row-gap: 0
+      margin-right: 0
 
       .form--separator
         margin-bottom: 0

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.html
@@ -1,5 +1,5 @@
 <div #container
-     [ngClass]="'wp-cards-container -' + orientation">
+     [ngClass]="classes()">
   <div *ngIf="inReference"
        class="wp-inline-create--reference-container">
     <ndc-dynamic [ndcDynamicComponent]="referenceClass"
@@ -8,19 +8,24 @@
     </ndc-dynamic>
   </div>
 
-  <wp-single-card *ngFor="let wp of workPackages; trackBy:trackByHref"
-                  [workPackage]="wp"
-                  [attr.data-is-new]="wp.isNew || undefined"
-                  [attr.data-work-package-id]="wp.id"
-                  [attr.data-class-identifier]="cardView.classIdentifier(wp)"
-                  [showInfoButton]="showInfoButton"
-                  [showStatusButton]="showStatusButton"
-                  [showRemoveButton]="cardsRemovable"
-                  [highlightingMode]="highlightingMode"
-                  [draggable]="this.canDragOutOf(wp)"
-                  [orientation]="orientation"
-                  (onRemove)="removeCard(wp)">
-  </wp-single-card>
+  <ng-container *ngFor="let wp of workPackages; trackBy:trackByHref">
+    <wp-single-card [workPackage]="wp"
+                    [attr.data-is-new]="wp.isNew || undefined"
+                    [attr.data-work-package-id]="wp.id"
+                    [attr.data-class-identifier]="cardView.classIdentifier(wp)"
+                    [showInfoButton]="showInfoButton"
+                    [showStatusButton]="showStatusButton"
+                    [showRemoveButton]="cardsRemovable"
+                    [highlightingMode]="highlightingMode"
+                    [draggable]="this.canDragOutOf(wp)"
+                    [orientation]="orientation"
+                    [shrinkOnMobile]="shrinkOnMobile"
+                    (onRemove)="removeCard(wp)">
+    </wp-single-card>
+
+    <hr *ngIf="shrinkOnMobile"
+        class="form--separator hidden-for-desktop">
+  </ng-container>
 </div>
 
 <div *ngIf="showEmptyResultsBox && isResultEmpty">

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -55,6 +55,8 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
   @Input() public cardsRemovable:boolean = false;
   /** Whether a notification box shall be shown when there are no WP to display */
   @Input() public showEmptyResultsBox:boolean = false;
+  /** Whether on special mobile version of the cards shall be shown */
+  @Input() public shrinkOnMobile:boolean = false;
 
   /** Container reference */
   @ViewChild('container', { static: true }) public container:ElementRef;
@@ -184,6 +186,13 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
     await this.cardDragDrop.onCardSaved(wp);
   }
 
+  public classes() {
+    let classes = 'wp-cards-container ';
+    classes += '-' + this.orientation;
+    classes += this.shrinkOnMobile ? ' -mobile-cards':'';
+
+    return classes;
+  }
   /**
    * Listen to newly created work packages to detect whether the WP is the one we created,
    * and properly reset inline create in this case

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -189,7 +189,7 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
   public classes() {
     let classes = 'wp-cards-container ';
     classes += '-' + this.orientation;
-    classes += this.shrinkOnMobile ? ' -mobile-cards':'';
+    classes += this.shrinkOnMobile ? ' -shrink' : '';
 
     return classes;
   }

--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -89,7 +89,7 @@
   .wp-card
     max-width: none
 
-    &.-mobile-cards
+    &.-shrink
       border: none
       box-shadow: none
-      padding: 10px 0
+      padding: 15px

--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -45,7 +45,6 @@
     grid-area: type
   .wp-card--subject
     grid-area: subject
-    max-width: 230px
     @include text-shortener
     white-space: normal
   .wp-card--assignee
@@ -89,3 +88,8 @@
 @media only screen and (max-width: 679px)
   .wp-card
     max-width: none
+
+    &.-mobile-cards
+      border: none
+      box-shadow: none
+      padding: 10px 0

--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.ts
@@ -62,7 +62,7 @@ export class WorkPackageSingleCardComponent {
     classes += wp.isNew ? ' -new' : '';
     classes += ' wp-card-' + wp.id;
     classes += ' -' + this.orientation;
-    classes += this.shrinkOnMobile ? ' -mobile-cards' : '';
+    classes += this.shrinkOnMobile ? ' -shrink' : '';
     return classes;
   }
 

--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.ts
@@ -25,6 +25,7 @@ export class WorkPackageSingleCardComponent {
   @Input() public highlightingMode:CardHighlightingMode = 'inline';
   @Input() public draggable:boolean = false;
   @Input() public orientation:CardViewOrientation = 'vertical';
+  @Input() public shrinkOnMobile:boolean = false;
 
   @Output() public onRemove = new EventEmitter<WorkPackageResource>();
 
@@ -61,6 +62,7 @@ export class WorkPackageSingleCardComponent {
     classes += wp.isNew ? ' -new' : '';
     classes += ' wp-card-' + wp.id;
     classes += ' -' + this.orientation;
+    classes += this.shrinkOnMobile ? ' -mobile-cards' : '';
     return classes;
   }
 

--- a/frontend/src/app/components/wp-grid/wp-grid.component.ts
+++ b/frontend/src/app/components/wp-grid/wp-grid.component.ts
@@ -48,7 +48,8 @@ import {WorkPackagesListService} from "core-components/wp-list/wp-list.service";
                   [orientation]="gridOrientation"
                   (onMoved)="switchToManualSorting()"
                   [showEmptyResultsBox]="true"
-                  [showInfoButton]="true">
+                  [showInfoButton]="true"
+                  [shrinkOnMobile]="true">
     </wp-card-view>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.sass
@@ -10,3 +10,8 @@
   overflow: auto
   padding-bottom: 5px
   @include styled-scroll-bar
+
+  @media screen and (max-width: 659px)
+    // Ensure the WP cards span the complete width on mobile
+    // --> Move scrollbar out of visible area
+    min-width: calc(100vw + 10px)


### PR DESCRIPTION
### ToDo

- [x] Remove borders of card view on WP page, but not the board view
- [x] Add horizontal dividing line which spans the complete screen width
- [x] Let subject span complete width available within a card
