### PR TITLE
Add possibility to use username or email to authenticate

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -217,6 +217,7 @@ class User < Principal
     # Make sure no one can sign in with an empty password
     return nil if password.to_s.empty?
     user = find_by_login(login)
+    user ||= find_by_mail(login)
     user = if user
              try_authentication_for_existing_user(user, password, session)
            else


### PR DESCRIPTION
Hello,

I have recently installed OpenProject and some users where confused about how to login. Some use their username, others their email address.
It is a common practice to accept both as login (see nextcloud for example), so I ended to add this possibility in OpenProject.

It is a very minor change and I don't know if I'm the only one who want that behaviour.