### PR TITLE
[31765] Selected long cf values are reduced to ... in ng-select

### DIFF
--- a/app/assets/stylesheets/content/_autocomplete.sass
+++ b/app/assets/stylesheets/content/_autocomplete.sass
@@ -175,6 +175,9 @@ mark.ui-autocomplete-match
   height: initial !important
   min-height: initial !important
 
+  .wp-table--cell-container & .ng-value-label
+    display: initial !important
+
 // Ensure dropdown is above modals
 .ng-dropdown-panel
   z-index: 9500 !important

--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_display_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_display_fields.sass
@@ -45,8 +45,11 @@
 
   // Always render custom options as inline
   // when only one line
-  .custom-option:not(.-multiple-lines)
-    display: inline
+  .custom-option
+    @include text-shortener
+    white-space: normal
+    &:not(.-multiple-lines)
+      display: inline
 
   &.split-time-field
     white-space: nowrap


### PR DESCRIPTION
Truncate long multi-CF values and take care that they are not to much truncated in the WP table.

https://community.openproject.com/projects/openproject/work_packages/31765/activity