### PR TITLE
[31736] Feature: Show toolbar icons next to query title on mobile

### DIFF
--- a/app/assets/stylesheets/content/work_packages/fullscreen/_back_button.sass
+++ b/app/assets/stylesheets/content/work_packages/fullscreen/_back_button.sass
@@ -13,10 +13,11 @@
       line-height: 22px
 
   @media only screen and (max-width: 679px)
-    // Move button in the current reverse order to front
-    position: absolute
-    top: 0
-    z-index: 1
+    .router--work-packages-base &
+      // Move button in the current reverse order to front
+      position: absolute
+      top: 0
+      z-index: 1
 
-    a
-      width: 100%
+      a
+        width: 100%

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -126,7 +126,7 @@ $nm-color-success-background: #d8fdd1
     .button--icon
       font-size: 14px
     .button--text
-      margin-left: 0.5em
+      margin-left: 0.2em
     .badge
       font-size: 14px
       vertical-align: 1px

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -126,7 +126,7 @@ $nm-color-success-background: #d8fdd1
     .button--icon
       font-size: 14px
     .button--text
-      margin-left: 0.2em
+      margin-left: 0.5em
     .badge
       font-size: 14px
       vertical-align: 1px

--- a/app/assets/stylesheets/layout/_toolbar_mobile.sass
+++ b/app/assets/stylesheets/layout/_toolbar_mobile.sass
@@ -31,14 +31,19 @@
     .toolbar-container
       margin-top: 10px
 
+      .toolbar
+        flex-wrap: nowrap
+
       .title-container
         margin-right: 10px
 
       .toolbar-items
         display: flex
-        flex-wrap: wrap
+        flex-wrap: nowrap
         justify-content: flex-end
-        width: calc(100% + 10px)
+
+        .op-icon--wrapper
+          margin: 0
 
         > li
           .button

--- a/app/assets/stylesheets/layout/_toolbar_mobile.sass
+++ b/app/assets/stylesheets/layout/_toolbar_mobile.sass
@@ -37,6 +37,11 @@
       .title-container
         margin-right: 10px
 
+        .toolbar--editable-toolbar
+          &:focus
+            position: absolute
+            width: calc(100vw - 30px)
+
       .toolbar-items
         display: flex
         flex-wrap: nowrap

--- a/app/assets/stylesheets/layout/_toolbar_mobile.sass
+++ b/app/assets/stylesheets/layout/_toolbar_mobile.sass
@@ -34,19 +34,19 @@
       .toolbar
         flex-wrap: nowrap
 
-      .title-container
+      .title-container:not(editable-toolbar-title)
         margin-right: 10px
-
-        .toolbar--editable-toolbar
-          &:focus
-            position: absolute
-            width: calc(100vw - 30px)
 
       .toolbar-items
         display: flex
         flex-wrap: nowrap
         justify-content: flex-end
+        margin-right: 0
 
+        .toolbar-item
+          margin: 0 0 10px 10px
+
+        // Hide toolbar button texts on mobile
         .button--text,
         .icon-pulldown
           display: none

--- a/app/assets/stylesheets/layout/_toolbar_mobile.sass
+++ b/app/assets/stylesheets/layout/_toolbar_mobile.sass
@@ -42,6 +42,10 @@
         flex-wrap: nowrap
         justify-content: flex-end
 
+        .button--text,
+        .icon-pulldown
+          display: none
+
         .op-icon--wrapper
           margin: 0
 

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -33,10 +33,10 @@ See docs/COPYRIGHT.rdoc for more details.
 %>
 <% title avatar(@topic.author) + h(@topic.subject) %>
 <%= toolbar title: title do %>
-    <li class="toolbar-item">
+    <li class="toolbar-item hidden-for-mobile">
       <%= watcher_link(@topic, User.current) %>
     </li>
-    <li class="toolbar-item">
+    <li class="toolbar-item hidden-for-mobile">
       <% if !@topic.locked? && authorize_for('messages', 'reply') %>
           <%= link_to({ action: 'quote', id: @topic }, class: 'boards--quote-button button') do %>
               <%= op_icon('button--icon icon-quote') %>

--- a/app/views/project_settings/show.html.erb
+++ b/app/views/project_settings/show.html.erb
@@ -41,7 +41,7 @@ See docs/COPYRIGHT.rdoc for more details.
     </li>
   <% end %>
   <% if @project.copy_allowed? %>
-    <li class="toolbar-item">
+    <li class="toolbar-item hidden-for-mobile">
       <%= link_to copy_from_project_path(@project, coming_from: :settings), class: 'button copy', accesskey: accesskey(:copy) do %>
         <%= op_icon('button--icon icon-copy') %>
         <span class="button--text"><%= t(:label_copy_project) %></span>
@@ -49,7 +49,7 @@ See docs/COPYRIGHT.rdoc for more details.
     </li>
   <% end %>
   <% if User.current.admin? %>
-    <li class="toolbar-item">
+    <li class="toolbar-item hidden-for-mobile">
       <%= link_to(archive_project_path(@project, status: '', name: @project.name),
                     data: { confirm: t('project.archive.are_you_sure', name: @project.name) },
                     method: :put,

--- a/app/views/repositories/_repository_header.html.erb
+++ b/app/views/repositories/_repository_header.html.erb
@@ -35,7 +35,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l('repositories.named_repository',
                      vendor_name: @repository.class.vendor_name) do %>
   <% if @instructions && @instructions.available? %>
-  <li class="toolbar-item toolbar-input-group">
+  <li class="toolbar-item toolbar-input-group hidden-for-mobile">
     <div class="toolbar-input-group--affix -prepend">
       <span><%= @instructions.checkout_command %></span>
     </div>

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -51,14 +51,14 @@ See docs/COPYRIGHT.rdoc for more details.
                id: 'revision_selector',
                class: 'form -vertical'
               ) do %>
-    <li class="toolbar-item toolbar-input-group">
+    <li class="toolbar-item toolbar-input-group hidden-for-mobile">
       <div>
         <%= label_tag 'rev', I18n.t('repositories.go_to_revision') %>
       </div>
       <%= text_field_tag :rev, @rev, id: 'revision-identifier-input', placeholder: l(:label_revision) %>
     </li>
     <% if !@repository.branches.nil? && @repository.branches.length > 0 %>
-    <li class="toolbar-item toolbar-input-group">
+    <li class="toolbar-item toolbar-input-group hidden-for-mobile">
       <div>
         <%= label_tag 'branch', I18n.t(:label_branch) %>
       </div>
@@ -66,7 +66,7 @@ See docs/COPYRIGHT.rdoc for more details.
     </li>
     <% end %>
     <% if !@repository.tags.nil? && @repository.tags.length > 0 %>
-    <li class="toolbar-item toolbar-input-group">
+    <li class="toolbar-item toolbar-input-group hidden-for-mobile">
       <div>
         <%= label_tag 'tag', I18n.t(:label_tag) %>
       </div>

--- a/app/views/users/_toolbar.html.erb
+++ b/app/views/users/_toolbar.html.erb
@@ -29,7 +29,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= breadcrumb_toolbar(@user.new_record? ? l(:label_user_new) : @user.name) do %>
   <% unless @user.new_record? %>
     <% if current_user.admin? || current_user.id == @user.id %>
-      <li class="toolbar-item">
+      <li class="toolbar-item hidden-for-mobile">
         <%= form_for(@user, html: { class: 'toolbar-item'},
                             url: { action: :resend_invitation },
                             method: :post) do |_form| %>
@@ -47,7 +47,7 @@ See docs/COPYRIGHT.rdoc for more details.
       <% end %>
     </li>
     <% unless current_user.id == @user.id %>
-      <%= form_for @user, html: { class: 'toolbar-item' }, :url => {:action => :change_status},
+      <%= form_for @user, html: { class: 'toolbar-item hidden-for-mobile' }, :url => {:action => :change_status},
                 :method => :post do %>
         <li>
           <%= change_user_status_buttons(@user) %>

--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -37,7 +37,7 @@ See docs/COPYRIGHT.rdoc for more details.
         </li>
     <% end %>
     <% if authorize_for(:wiki, :edit) && !(@version.wiki_page_title.blank? || @version.project.wiki.nil?) %>
-        <li class="toolbar-item">
+        <li class="toolbar-item hidden-for-mobile">
           <%= link_to({controller: '/wiki', action: 'edit',
                        project_id: @version.project,
                        id: @version.wiki_page_title},

--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -56,22 +56,29 @@ See docs/COPYRIGHT.rdoc for more details.
     <% end %>
     <% if @content.version == @page.content.version %>
       <li class="toolbar-item">
-        <%= link_to_if_authorized(l(:button_edit), {action: 'edit', id: @page}, class: 'button icon-edit', accesskey: accesskey(:edit)) %>
+        <%= link_to_if_authorized({ action: 'edit', id: @page },
+                                  { aria: { label: t(:button_edit) },
+                                    title: t(:button_edit),
+                                    class: 'button' }) do %>
+          <%= op_icon('button--icon icon-edit') %>
+          <span class="button--text"><%= l(:button_edit) %></span>
+        <% end %>
       </li>
     <% end %>
     <% if Setting.notified_events.include?("wiki_content_added") or Setting.notified_events.include?("wiki_content_updated") %>
-      <li class="toolbar-item">
+      <li class="toolbar-item hidden-for-mobile">
         <%= watcher_link(@page, User.current) %>
       </li>
     <% end %>
     <% if @content.version != @page.content.version %>
-      <li class="toolbar-item">
+      <li class="toolbar-item  hidden-for-mobile">
         <%= link_to(l(:label_history), {action: 'history', id: @page}, class: 'button icon-wiki') %>
       </li>
     <% end %>
   <% end %>
   <li class="toolbar-item drop-down">
     <a href="#" aria-haspopup="true" title="<%= t(:label_more) %>" class="button">
+      <%= op_icon('button--icon icon-show-more hidden-for-desktop') %>
       <span class="button--text"><%= t(:label_more) %></span>
       <%= op_icon('button--dropdown-indicator') %>
     </a>

--- a/app/views/workflows/_toolbar.html.erb
+++ b/app/views/workflows/_toolbar.html.erb
@@ -28,7 +28,7 @@ See docs/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%= toolbar title: title do %>
-  <li class="toolbar-item">
+  <li class="toolbar-item hidden-for-mobile">
     <%= link_to({ action: 'copy' }, class: 'button') do %>
       <%= op_icon('button--icon icon-copy') %>
       <span class="button--text"><%= l(:button_copy) %></span>

--- a/frontend/src/app/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
@@ -177,6 +177,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger implements OnD
         // Insert columns
         linkText: this.I18n.t('js.work_packages.query.insert_columns'),
         icon: 'icon-columns',
+        class: 'hidden-for-mobile',
         onClick: () => {
           this.opModalService.show<WpTableConfigurationModalComponent>(
             WpTableConfigurationModalComponent,
@@ -203,6 +204,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger implements OnD
         // Group by
         linkText: this.I18n.t('js.toolbar.settings.group_by'),
         icon: 'icon-group-by',
+        class: 'hidden-for-mobile',
         onClick: () => {
           this.opModalService.show<WpTableConfigurationModalComponent>(
             WpTableConfigurationModalComponent,

--- a/frontend/src/app/components/wp-buttons/wp-create-button/wp-create-button.html
+++ b/frontend/src/app/components/wp-buttons/wp-create-button/wp-create-button.html
@@ -7,7 +7,7 @@
           [stateName]="stateName"
           [dropdownActive]="allowed">
     <op-icon icon-classes="button--icon icon-add"></op-icon>
-    <span class="button--text hidden-for-mobile"
+    <span class="button--text"
           [textContent]="text.createWithDropdown"
           aria-hidden="true"></span>
     <op-icon icon-classes="button--icon icon-small icon-pulldown hidden-for-mobile"></op-icon>

--- a/frontend/src/app/components/wp-buttons/wp-create-button/wp-create-button.html
+++ b/frontend/src/app/components/wp-buttons/wp-create-button/wp-create-button.html
@@ -7,9 +7,9 @@
           [stateName]="stateName"
           [dropdownActive]="allowed">
     <op-icon icon-classes="button--icon icon-add"></op-icon>
-    <span class="button--text"
+    <span class="button--text hidden-for-mobile"
           [textContent]="text.createWithDropdown"
           aria-hidden="true"></span>
-    <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
+    <op-icon icon-classes="button--icon icon-small icon-pulldown hidden-for-mobile"></op-icon>
   </button>
 </div>

--- a/frontend/src/app/components/wp-buttons/wp-filter-button/wp-filter-button.html
+++ b/frontend/src/app/components/wp-buttons/wp-filter-button/wp-filter-button.html
@@ -7,7 +7,7 @@
         (click)="performAction($event)"
         [ngClass]="{ '-active': isActive }">
   <op-icon icon-classes="{{ iconClass }} button--icon"></op-icon>
-  <span class="button--text">
+  <span class="button--text hidden-for-mobile">
     {{ buttonText }}
     <span class="badge -secondary" *ngIf="initialized" [textContent]="filterCount"></span>
   </span>

--- a/frontend/src/app/components/wp-buttons/wp-filter-button/wp-filter-button.html
+++ b/frontend/src/app/components/wp-buttons/wp-filter-button/wp-filter-button.html
@@ -7,7 +7,7 @@
         (click)="performAction($event)"
         [ngClass]="{ '-active': isActive }">
   <op-icon icon-classes="{{ iconClass }} button--icon"></op-icon>
-  <span class="button--text hidden-for-mobile">
+  <span class="button--text">
     {{ buttonText }}
     <span class="badge -secondary" *ngIf="initialized" [textContent]="filterCount"></span>
   </span>

--- a/frontend/src/app/modules/boards/index-page/boards-index-page.component.html
+++ b/frontend/src/app/modules/boards/index-page/boards-index-page.component.html
@@ -1,22 +1,24 @@
-<div class="toolbar">
-  <div class="title-container">
-    <h2 [textContent]="text.boards">
-    </h2>
+<div class="toolbar-container">
+  <div class="toolbar">
+    <div class="title-container">
+      <h2 [textContent]="text.boards">
+      </h2>
+    </div>
+    <ul class="toolbar-items"
+        *ngIf="showBoardIndexView()">
+      <li *ngIf="canAdd"
+          class="toolbar-item">
+        <a class="button -alt-highlight"
+           (click)="newBoard()">
+          <op-icon icon-classes="icon-add icon4">
+          </op-icon>
+          <span class="button--text"
+                [textContent]="text.board">
+          </span>
+        </a>
+      </li>
+    </ul>
   </div>
-  <ul class="toolbar-items"
-      *ngIf="showBoardIndexView()">
-    <li *ngIf="canAdd"
-        class="toolbar-item">
-      <a class="button -alt-highlight"
-         (click)="newBoard()">
-        <op-icon icon-classes="icon-add icon4">
-        </op-icon>
-        <span class="button--text"
-              [textContent]="text.board">
-        </span>
-      </a>
-    </li>
-  </ul>
 </div>
 
 <div class="boards--listing-group loading-indicator--location"

--- a/frontend/src/app/modules/boards/index-page/boards-index-page.component.html
+++ b/frontend/src/app/modules/boards/index-page/boards-index-page.component.html
@@ -10,7 +10,7 @@
           class="toolbar-item">
         <a class="button -alt-highlight"
            (click)="newBoard()">
-          <op-icon icon-classes="icon-add icon4">
+          <op-icon icon-classes="button--icon icon-add">
           </op-icon>
           <span class="button--text"
                 [textContent]="text.board">

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.component.ts
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.component.ts
@@ -115,7 +115,12 @@ export class EditableToolbarTitleComponent implements OnInit, OnChanges {
   }
 
   public onFocus(event:FocusEvent) {
+    this.toggleToolbarButtonVisibility(true);
     this.selectInputOnInitalFocus(event.target as HTMLInputElement);
+  }
+
+  public onBlur() {
+    this.toggleToolbarButtonVisibility(false);
   }
 
   public selectInputOnInitalFocus(input:HTMLInputElement) {
@@ -205,5 +210,9 @@ export class EditableToolbarTitleComponent implements OnInit, OnChanges {
       const el = this.inputField.nativeElement;
       el.classList.remove('-error');
     }
+  }
+
+  private toggleToolbarButtonVisibility(hidden:boolean) {
+    jQuery('.toolbar-items').toggleClass('hidden-for-mobile', hidden);
   }
 }

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
@@ -15,6 +15,7 @@
          [attr.name]="selectableTitleIdentifier"
          [focus]="this.initialFocus || undefined"
          (focus)="onFocus($event)"
+         (blur)="onBlur()"
          (keydown.escape)="reset($event)"
          (keydown.enter)="save($event)"
          [attr.placeholder]="text.input_placeholder"

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp.list.component.html
@@ -25,7 +25,7 @@
             *ngIf="bcfActivated()">
           <bcf-export-button></bcf-export-button>
         </li>
-        <li class="toolbar-item hidden-for-mobile">
+        <li class="toolbar-item">
           <wp-filter-button>
           </wp-filter-button>
         </li>
@@ -45,7 +45,7 @@
           <zen-mode-toggle-button>
           </zen-mode-toggle-button>
         </li>
-        <li class="toolbar-item hidden-for-mobile">
+        <li class="toolbar-item">
           <button id="work-packages-settings-button"
                   title="{{ text.button_settings }}"
                   class="button last work-packages-settings-button toolbar-icon"

--- a/modules/boards/app/assets/stylesheets/boards/board_header_mobile.sass
+++ b/modules/boards/app/assets/stylesheets/boards/board_header_mobile.sass
@@ -1,7 +1,0 @@
-@media only screen and (max-width: 679px)
-  .board--header-container
-    position: relative
-
-    .title-container
-      position: relative
-      left: 100px

--- a/modules/boards/app/views/boards/boards/index.html.erb
+++ b/modules/boards/app/views/boards/boards/index.html.erb
@@ -1,5 +1,1 @@
 <% html_title(t('boards.label_boards')) -%>
-
-<% content_for :header_tags do %>
-    <%= stylesheet_link_tag "boards/board_header_mobile", media: 'all' %>
-<% end %>

--- a/modules/boards/lib/open_project/boards/engine.rb
+++ b/modules/boards/lib/open_project/boards/engine.rb
@@ -53,10 +53,6 @@ module OpenProject::Boards
 
     patch_with_namespace :BasicData, :SettingSeeder
 
-    initializer 'boards.precompile_assets' do
-      Rails.application.config.assets.precompile += %w(boards/board_header_mobile.css)
-    end
-
     config.to_prepare do
       OpenProject::Boards::GridRegistration.register!
     end

--- a/modules/costs/app/views/cost_objects/show.html.erb
+++ b/modules/costs/app/views/cost_objects/show.html.erb
@@ -25,21 +25,24 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <% if authorize_for(:cost_objects, :edit) %>
     <li class="toolbar-item">
       <%= link_to({ controller: 'cost_objects', action: 'edit',  id: @cost_object }, class: 'button', accesskey: accesskey(:edit)) do %>
-        <%= op_icon('button--icon icon-edit') %> <%= t(:button_update) %>
+        <%= op_icon('button--icon icon-edit') %>
+        <span class="button--text"><%= l(:button_update) %></span>
       <% end %>
     </li>
   <% end %>
   <% if authorize_for(:cost_objects, :copy) %>
     <li class="toolbar-item">
       <%= link_to({ controller: 'cost_objects', action: 'copy', id: @cost_object }, class: 'button') do %>
-        <%= op_icon('button--icon icon-copy') %> <%= t(:button_copy) %>
+        <%= op_icon('button--icon icon-copy') %>
+        <span class="button--text"><%= l(:button_copy) %></span>
       <% end %>
     </li>
   <% end %>
   <% if authorize_for(:cost_objects, :copy) %>
     <li class="toolbar-item">
       <%= link_to({ controller: 'cost_objects', action: 'destroy', id: @cost_object }, class: 'button', method: :delete, data: { confirm: t(:text_are_you_sure)}) do %>
-        <%= op_icon('button--icon icon-delete') %> <%= t(:button_delete) %>
+        <%= op_icon('button--icon icon-delete') %>
+        <span class="button--text"><%= t(:button_delete) %></span>
       <% end %>
     </li>
   <% end %>

--- a/modules/costs/app/views/cost_objects/show.html.erb
+++ b/modules/costs/app/views/cost_objects/show.html.erb
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </li>
   <% end %>
   <% if authorize_for(:cost_objects, :copy) %>
-    <li class="toolbar-item">
+    <li class="toolbar-item hidden-for-mobile">
       <%= link_to({ controller: 'cost_objects', action: 'copy', id: @cost_object }, class: 'button') do %>
         <%= op_icon('button--icon icon-copy') %>
         <span class="button--text"><%= l(:button_copy) %></span>

--- a/modules/documents/app/views/documents/show.html.erb
+++ b/modules/documents/app/views/documents/show.html.erb
@@ -36,21 +36,23 @@ See doc/COPYRIGHT.rdoc for more details.
   <% if authorize_for(:documents, :edit) %>
     <li class="toolbar-item">
       <%= link_to({controller: '/documents', action: 'edit', id: @document}, class: 'button', accesskey: accesskey(:edit)) do %>
-        <%= op_icon('button--icon icon-edit') %> <%= l(:button_edit) %>
+        <%= op_icon('button--icon icon-edit') %>
+        <span class="button--text"><%= l(:button_edit) %></span>
       <% end %>
     </li>
   <% end %>
   <% if authorize_for(:documents, :destroy) %>
     <li class="toolbar-item">
       <%= link_to({controller: '/documents', action: 'destroy', id: @document}, class: 'button', data: { confirm: l(:text_are_you_sure) }, method: :delete) do %>
-        <%= op_icon('button--icon icon-delete') %> <%= l(:button_delete) %>
+        <%= op_icon('button--icon icon-delete') %>
+        <span class="button--text"><%= l(:button_delete) %></span>
       <% end %>
     </li>
   <% end %>
 <% end %>
 
 <div class="wiki">
-<%= format_text @document.description, attachments: @document.attachments %>
+  <%= format_text @document.description, attachments: @document.attachments %>
 </div>
 
 <% resource = ::API::V3::Documents::DocumentRepresenter.new(@document,

--- a/modules/meeting/app/helpers/meeting_contents_helper.rb
+++ b/modules/meeting/app/helpers/meeting_contents_helper.rb
@@ -55,22 +55,26 @@ module MeetingContentsHelper
     case content_type
     when 'meeting_agenda'
       content_tag :li, '', class: 'toolbar-item' do
-        link_to_if_authorized l(:label_meeting_close),
-                              { controller: '/meeting_agendas',
+        link_to_if_authorized({ controller: '/meeting_agendas',
                                 action: 'close',
                                 meeting_id: meeting },
                               method: :put,
                               data: { confirm: I18n.t(:text_meeting_closing_are_you_sure) },
-                              class: 'meetings--close-meeting-button button icon-context icon-locked'
+                              class: 'meetings--close-meeting-button button') do
+          op_icon('button--icon icon-locked') +
+          content_tag('span', l(:label_meeting_close), class: 'button--text')
+        end
       end
     when 'meeting_minutes'
       content_tag :li, '', class: 'toolbar-item' do
-        link_to_if_authorized l(:label_meeting_agenda_close),
-                              { controller: '/meeting_agendas',
+        link_to_if_authorized({ controller: '/meeting_agendas',
                                 action: 'close',
                                 meeting_id: meeting },
                               method: :put,
-                              class: 'button icon-context icon-locked'
+                              class: 'button') do
+          op_icon('button--icon icon-locked') +
+          content_tag('span', l(:label_meeting_agenda_close), class: 'button--text')
+        end
       end
     end
   end
@@ -79,13 +83,15 @@ module MeetingContentsHelper
     case content_type
     when 'meeting_agenda'
       content_tag :li, '', class: 'toolbar-item' do
-        link_to_if_authorized l(:label_meeting_open),
-                              { controller: '/meeting_agendas',
+        link_to_if_authorized({ controller: '/meeting_agendas',
                                 action: 'open',
                                 meeting_id: meeting },
                               method: :put,
-                              class: 'button icon-context icon-unlocked',
-                              confirm: l(:text_meeting_agenda_open_are_you_sure)
+                              class: 'button',
+                              confirm: l(:text_meeting_agenda_open_are_you_sure)) do
+          op_icon('button--icon icon-unlocked') +
+          content_tag('span', l(:label_meeting_open), class: 'button--text')
+        end
       end
     when 'meeting_minutes'
     end
@@ -93,46 +99,51 @@ module MeetingContentsHelper
 
   def meeting_content_edit_link(content_type)
     content_tag :li, '', class: 'toolbar-item' do
-
-      content_tag :button,
-                  '',
-                  data: { 'content-type': content_type },
-                  class: 'button button--edit-agenda' do
-        link_to l(:button_edit),
-                '',
-                class: 'icon-context icon-edit',
-                accesskey: accesskey(:edit)
-      end
+      link_to '',
+              class: 'button button--edit-agenda',
+              data: { 'content-type': content_type },
+              accesskey: accesskey(:edit) do
+                op_icon('button--icon icon-edit') +
+                content_tag('span', l(:label_edit), class: 'button--text')
+              end
     end
   end
 
   def meeting_content_history_link(content_type, meeting)
     content_tag :li, '', class: 'toolbar-item' do
-      link_to_if_authorized l(:label_history),
-                            { controller: '/' + content_type.pluralize,
+      link_to_if_authorized({ controller: '/' + content_type.pluralize,
                               action: 'history',
                               meeting_id: meeting },
-                            class: 'button icon-context icon-wiki'
+                            aria: { label: t(:label_history) },
+                            title: t(:label_history),
+                            class: 'button') do
+        op_icon('button--icon icon-wiki') +
+        content_tag('span', l(:label_history), class: 'button--text')
+      end
     end
   end
 
   def meeting_content_notify_link(content_type, meeting)
     content_tag :li, '', class: 'toolbar-item' do
-      link_to_if_authorized l(:label_notify),
-                            { controller: '/' + content_type.pluralize,
+      link_to_if_authorized({ controller: '/' + content_type.pluralize,
                               action: 'notify', meeting_id: meeting },
                             method: :put,
-                            class: 'button icon-context icon-mail1'
+                            class: 'button') do
+        op_icon('button--icon icon-mail1') +
+        content_tag('span', l(:label_notify), class: 'button--text')
+      end
     end
   end
 
   def meeting_content_icalendar_link(content_type, meeting)
     content_tag :li, '', class: 'toolbar-item' do
-      link_to_if_authorized l(:label_icalendar),
-                            { controller: '/' + content_type.pluralize,
+      link_to_if_authorized({ controller: '/' + content_type.pluralize,
                               action: 'icalendar', meeting_id: meeting },
                             method: :put,
-                            class: 'button icon-context icon-calendar2'
+                            class: 'button') do
+        op_icon('button--icon icon-calendar2') +
+        content_tag('span', l(:label_icalendar), class: 'button--text')
+      end
     end
   end
 end

--- a/modules/meeting/app/views/meeting_contents/diff.html.erb
+++ b/modules/meeting/app/views/meeting_contents/diff.html.erb
@@ -25,7 +25,8 @@ See doc/COPYRIGHT.md for more details.
   <% if authorize_for(@content_type.pluralize, :history) %>
     <li class="toolbar-item">
       <%= link_to({controller: "/#{@content_type.pluralize}", action: 'history', meeting_id: @meeting }, class: 'button') do %>
-        <%= op_icon('button--icon icon-wiki') %> <%= l(:label_history) %>
+        <%= op_icon('button--icon icon-wiki') %>
+        <span class="button--text"><%= l(:button_history) %></span>
       <% end %>
     </li>
   <% end %>

--- a/modules/meeting/app/views/meetings/show.html.erb
+++ b/modules/meeting/app/views/meetings/show.html.erb
@@ -24,7 +24,7 @@ See doc/COPYRIGHT.md for more details.
             link_to: link_to(@meeting),
             html: { class: 'meeting--main-toolbar' } do %>
   <% unless User.current.anonymous? %>
-    <li class="toolbar-item">
+    <li class="toolbar-item hidden-for-mobile">
       <div class="button">
         <%= watcher_link @meeting, User.current %>
       </div>
@@ -39,7 +39,7 @@ See doc/COPYRIGHT.md for more details.
     </li>
   <% end %>
   <% if authorize_for(:meetings, :copy) %>
-    <li class="toolbar-item">
+    <li class="toolbar-item hidden-for-mobile">
       <%= link_to({:controller => '/meetings', :action => 'copy', :id => @meeting}, class: 'button') do %>
         <%= op_icon('button--icon icon-copy') %>
         <span class="button--text"><%= l(:button_copy) %></span>

--- a/modules/meeting/app/views/meetings/show.html.erb
+++ b/modules/meeting/app/views/meetings/show.html.erb
@@ -33,14 +33,16 @@ See doc/COPYRIGHT.md for more details.
   <% if authorize_for(:meetings, :edit) %>
     <li class="toolbar-item">
       <%= link_to({:controller => '/meetings', :action => 'edit', :id => @meeting}, class: 'button',:accesskey => accesskey(:edit)) do%>
-        <%= op_icon('button--icon icon-edit') %> <%= t(:button_edit) %>
+        <%= op_icon('button--icon icon-edit') %>
+        <span class="button--text"><%= l(:button_edit) %></span>
       <% end %>
     </li>
   <% end %>
   <% if authorize_for(:meetings, :copy) %>
     <li class="toolbar-item">
       <%= link_to({:controller => '/meetings', :action => 'copy', :id => @meeting}, class: 'button') do %>
-        <%= op_icon('button--icon icon-copy') %> <%= t(:button_copy) %>
+        <%= op_icon('button--icon icon-copy') %>
+        <span class="button--text"><%= l(:button_copy) %></span>
       <% end %>
     </li>
   <% end %>
@@ -50,7 +52,8 @@ See doc/COPYRIGHT.md for more details.
                   class: 'button',
                   method: :delete,
                   data: { confirm: t(:text_are_you_sure) }) do %>
-        <%= op_icon('button--icon icon-delete') %> <%= t(:button_delete) %>
+        <%= op_icon('button--icon icon-delete') %>
+        <span class="button--text"><%= t(:button_delete) %></span>
       <% end %>
     </li>
   <% end %>

--- a/modules/meeting/spec/features/meetings_attachments_spec.rb
+++ b/modules/meeting/spec/features/meetings_attachments_spec.rb
@@ -31,7 +31,7 @@ describe 'Add an attachment to a meeting (agenda)', js: true do
     visit "/meetings/#{meeting.id}"
 
     within "#tab-content-agenda .toolbar" do
-      click_button "Edit"
+      click_link "Edit"
     end
   end
 


### PR DESCRIPTION
### Changes
- Show (relevant) toolbar icons on mobile
- Editable title spans the whole width on focus

### To-Do
- [x] Check all pages with toolbar

https://community.openproject.com/projects/openproject/work_packages/31736/activity