### PR TITLE
prevent involuntary modal close

### DIFF
--- a/frontend/src/app/components/modals/modal-wrapper/dynamic-content.modal.ts
+++ b/frontend/src/app/components/modals/modal-wrapper/dynamic-content.modal.ts
@@ -36,6 +36,11 @@ import {I18nService} from "core-app/modules/common/i18n/i18n.service";
   templateUrl: './dynamic-content.modal.html'
 })
 export class DynamicContentModal extends OpModalComponent implements OnInit, OnDestroy {
+  // override superclass
+  // Allowing outside clicks to close the modal leads to the user involuntarily closing
+  // the modal when removing error messages or clicking on labels e.g. in the registration modal.
+  public closeOnOutsideClick:boolean = false;
+
   constructor(readonly elementRef:ElementRef,
               @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
               readonly cdRef:ChangeDetectorRef,


### PR DESCRIPTION
When clicking to remove error messages or on the labels e.g. in the registration modal, the elements clicked on are for unknown reasons not part of the DOM. Thus, the check for whether the click was performed inside the modal fails even though the click was performed inside the modal at least from a visual stand point.

Changing the default fixes the problem and does not seem to cause problems with the other modals.

https://community.openproject.com/projects/openproject/work_packages/31808