### PR TITLE
added translation for project.archive.archived inside en

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1986,6 +1986,7 @@ en:
       title: Change the project's identifier
     archive:
       are_you_sure: "Are you sure you want to archive the project '%{name}'?"
+      archived: "Archived"
 
   project_module_activity: "Activity"
   project_module_forums: "Forums"


### PR DESCRIPTION
First commit trying on this old bug. I could not access the description to test it, properly. 
https://community.openproject.com/projects/openproject/work_packages/29828/activity?query_id=491
But there is the translation.