### PR TITLE
show correct number of active users

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -36,7 +36,7 @@ See docs/COPYRIGHT.rdoc for more details.
   end
 %>
 <% users_info = user_limit && content_tag(:div) do %>
-  <%= t(:label_enterprise_active_users, current: User.active.count, limit: user_limit) %>
+  <%= t(:label_enterprise_active_users, current: OpenProject::Enterprise.active_user_count, limit: user_limit) %>
   &nbsp;
   <a href="<%= OpenProject::Enterprise.upgrade_path %>" class="display-inline button -tiny -highlight" title="<%= t(:title_enterprise_upgrade) %>"><%= t(:button_upgrade) %></a>
 <% end %>

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -33,6 +33,8 @@ describe 'users/index', type: :view do
   let!(:user) { FactoryBot.create :user, firstname: "Scarlet", lastname: "Scallywag" }
 
   before do
+    User.system # create system user which is active but should not count towards limit
+
     assign(:users, [admin, user])
     assign(:status, "all")
     assign(:groups, Group.all)


### PR DESCRIPTION
Builtin users must be not counted. Use method from Enterprise
module so we only have this logic in one place.