### PR TITLE
[31723] Bottom bar overlaps content on mobile

### DIFF
--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -29,24 +29,36 @@
 @include breakpoint(680px down)
   body, html
     position: relative
-    overflow: hidden
     -webkit-overflow-scrolling: touch
     height: 100%
 
-  #main-menu ~ #content-wrapper
-    padding: 15px
+  // ------------------- BEGIN CHANGED SCROLL BEHAVIOR
+  // Change scroll behavior on mobile:
+  // Let the window be the one who scrolls.
+  // Thus we make sure, that mobile browsers (like iOS Safari) hide their toolbars on scroll.
+  html
+    overflow: auto
+  body
+    overflow: visible
+
+  #wrapper,
+  #main,
+  #content-wrapper,
+  #content
+    overflow: hidden
+
+  #main
+    margin-top: $header-height
+
+    .-header-scrolled &
+      margin-top: 0
 
   #content-wrapper
-    transition: height .4s
+    height: initial
+  // ------------------- END CHANGED SCROLL BEHAVIOR
 
-    // Slide header in and out on scroll (see also: _top_menu_mobile.sass)
-    .-header-scrolled &
-      height: 100vh
-
-  body.-browser-safari
-    #content-wrapper
-      // Needed for smooth scrolling on Safari mobile
-      transition: height 0s
+  #main-menu ~ #content-wrapper
+    padding: 15px
 
   #main
     grid-template-columns: auto

--- a/app/assets/stylesheets/layout/_top_menu_mobile.sass
+++ b/app/assets/stylesheets/layout/_top_menu_mobile.sass
@@ -34,12 +34,15 @@
     background-color: transparent
 
   #top-menu
+    position: fixed
+    right: 0
+    left: 0
     margin-top: 0px
     transition: margin-top .4s
 
     // Slide header in and out on scroll (see also: _base_mobile.sass)
     .-header-scrolled &
-      margin-top: -55px
+      margin-top: -$header-height
       transition: margin-top .4s
 
     #nav-login-content

--- a/frontend/src/app/globals/global-listeners.ts
+++ b/frontend/src/app/globals/global-listeners.ts
@@ -100,7 +100,7 @@ import {scrollHeaderOnMobile} from "core-app/globals/global-listeners/top-menu-s
     const deviceService:DeviceService = new DeviceService();
     // Register scroll handler on mobile header
     if (deviceService.isMobile) {
-      scrollHeaderOnMobile(jQuery('#content-wrapper'));
+      scrollHeaderOnMobile();
     }
   });
 

--- a/frontend/src/app/globals/global-listeners/top-menu-scroll.ts
+++ b/frontend/src/app/globals/global-listeners/top-menu-scroll.ts
@@ -28,13 +28,13 @@
 
 
 // Scroll header on mobile in and out when user scrolls the container
-export function scrollHeaderOnMobile(elem:JQuery) {
+export function scrollHeaderOnMobile() {
   const headerHeight = 55;
-  let prevScrollPos = elem.scrollTop()!;
+  let prevScrollPos = window.scrollY;
 
-  elem.on('scroll', function() {
+  window.addEventListener('scroll', function() {
     // Condition needed for safari browser to avoid negative positions
-    let currentScrollPos = elem.scrollTop()! < 0 ? 0 : elem.scrollTop()!;
+    let currentScrollPos = window.scrollY < 0 ? 0 :  window.scrollY;
     // Only if sidebar is not opened or search bar is opened
     if (!(jQuery('#main').hasClass('hidden-navigation')) ||
         jQuery('#top-menu').hasClass('-global-search-expanded') ||

--- a/frontend/src/app/modules/router/openproject.routes.ts
+++ b/frontend/src/app/modules/router/openproject.routes.ts
@@ -144,6 +144,9 @@ export function initializeUiRouterListeners(injector:Injector) {
       if (transition.from().data && _.get(state, 'data.menuItem') !== transition.from().data.menuItem) {
         updateMenuItem(_.get(state, 'data.menuItem'), 'add');
       }
+
+      // Reset scroll position, mostly relevant for mobile
+      window.scrollTo(0, 0);
     });
 
     $transitions.onExit({}, function(transition:Transition, state:StateDeclaration) {

--- a/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list/wp-list.component.ts
@@ -133,11 +133,6 @@ export class WorkPackagesListComponent extends WorkPackagesViewBase implements O
       }
 
       this.cdRef.detectChanges();
-
-      // Register scroll handler on mobile header
-      if (this.deviceService.isMobile) {
-        scrollHeaderOnMobile(jQuery('.work-packages--card-view-container'));
-      }
     });
   }
 


### PR DESCRIPTION
This PR changes the mobile scroll behavior so that the window itself scrolls. Only then do mobile browsers (like iOS Safari) hide their toolbars on scroll. See: https://stackoverflow.com/a/7487346/8900797 

https://community.openproject.com/projects/openproject/work_packages/31723/activity