### PR TITLE
Reactivate event base file checkers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -234,6 +234,8 @@ group :ldap do
 end
 
 group :development do
+  gem 'listen', '~> 3.2.1' # Use for event-based reloaders
+
   gem 'faker'
   gem 'letter_opener'
   gem 'livingstyleguide', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -580,6 +580,9 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.7.0)
       launchy (~> 2.2)
+    listen (3.2.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     livingstyleguide (2.1.0)
       minisyntax (>= 0.2.5)
       redcarpet
@@ -754,6 +757,9 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.0)
     rake (13.0.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     rbtree3 (0.5.0)
     rdoc (6.1.1)
     recaptcha (5.1.0)
@@ -1003,6 +1009,7 @@ DEPENDENCIES
   ladle
   launchy (~> 2.4.3)
   letter_opener
+  listen (~> 3.2.1)
   livingstyleguide (~> 2.1.0)
   lograge (~> 0.10.0)
   meta-tags (~> 2.11.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,11 +41,8 @@ OpenProject::Application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # File watcher
-  # using ActiveSupport::EventedFileUpdateChecker depends on listen which depends on fsevent
-  # which seems to be prone to creating zombie process (+200 of them) which can cause
-  # the process limit (on mac) to be reached which causes the system to need a reboot.
-  config.file_watcher = ActiveSupport::FileUpdateChecker
+  # Asynchronous file watcher
+  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local


### PR DESCRIPTION
This reverts commit f920cc73a04cd61b6e29519be18ae5ab29c02309.

We originally removed event base file checking to cope with problems on
os x that would lead to having a multitude of fsevent_watch processes
(one for every directory) and those processes would sometimes, e. g. when
the system was sent to standby turn zombie. If not killed dutifully by the
developer, the system would become unresponsive as the maximum number of
processes as dictated by the os would be reached. Not even killing
processes would be possible any more as kill requires forking.

Now the listen gem was released as version 3.2.1 which changed to only
needing one process to watch all directories.

As event based dirty checking promises to be more performant than
checking all the files, and the reload time in dev mode would exceed
tens of seconds if kept running for a longer period of time, I took
another stab at integrating the listen gem again:

The good:

* The file checking seems to work. Altering the code is reflected by the
application.
* Only two fsevent_watch processes are created (one for the code files
and one for the locales.)
* The fsevent_watch processes where exited as desired when the rails
process was existed. I did not yet test it for an extended amount of
time but this also seems to hold true when the system was suspended in
the meantime.

The bad:

* Subjectively, reloading did not seem to be faster. However, I did not
leave the server running over an extended period of changes. So the
event based detection might shine in the long run.

The ugly:

* When running multitreaded, the server seems to be running into
deadlocks. I assume, that there is a shared, but mutexed, resource multiple threads
attempt to access at the same time. It does not happen on every page but
one of the roadmap pages on my development env causes the problem
consistently. The problem can be circumvented by disabling multi
treading:

`RAILS_MIN_THREADS=1 RAILS_MAX_THREADS=1 bundle exec rails s`

The same problem does not occur when running the server with multiple
worker processes:

`OPENPROJECT_WEB_WORKERS=4 RAILS_MIN_THREADS=1 RAILS_MAX_THREADS=1
bundle exec rails s`