### PR TITLE
[31700] Fix: iOS zoom in effect on form fields

### DIFF
--- a/app/assets/stylesheets/content/_forms_mobile.sass
+++ b/app/assets/stylesheets/content/_forms_mobile.sass
@@ -66,7 +66,7 @@
   autocomplete-select-decoration
     width: 100%
 
-  html.-browser-safari
+  .-browser-safari
     // Special rule for mobile safari to prevent zooming into the text field
     // when focussed.
     select,
@@ -84,5 +84,5 @@
     input[type="url"],
     input[type="search"],
     input[type="tel"],
-    input[type="color"]
-      font-size: 16px
+    input[type="color"],
+      font-size: 16px !important

--- a/frontend/src/app/modules/global_search/input/global-search-input-mobile.component.sass
+++ b/frontend/src/app/modules/global_search/input/global-search-input-mobile.component.sass
@@ -45,8 +45,6 @@ $search-input-height-mobile: 36px
 
         .ng-input input
           height: 36px
-          // The font-size is necessary to avoid iOS to zoom in when being focused
-          font-size: 16px
 
     .top-menu-search--back-button
       display: initial


### PR DESCRIPTION
### Problem
On mobile iOS devices the Safari browser will zoom in on focussing a form field.

### Solution
To prevent this behaviour a fixed font-size of 16px has to be set on all mobile Safari browser form fields.

See also issue: https://community.openproject.com/projects/openproject/work_packages/31700