### PR TITLE
[31891] On mobile side menu is cut off when opening side menu

### DIFF
--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -38,11 +38,11 @@
   // Thus we make sure, that mobile browsers (like iOS Safari) hide their toolbars on scroll.
   html
     overflow: auto
-  body
+  body,
+  #main
     overflow: visible
 
   #wrapper,
-  #main,
   #content-wrapper,
   #content
     overflow: hidden


### PR DESCRIPTION
Avoid cut off of menu on small pages on iOS

https://community.openproject.com/projects/openproject/work_packages/31891/activity