### PR TITLE
[31871] Fix: Keyboard opens unnecessarily on Safari mobile

### DIFF
--- a/frontend/src/app/components/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/components/main-menu/main-menu-toggle.service.ts
@@ -115,6 +115,7 @@ export class MainMenuToggleService {
   public closeMenu():void {
     this.setWidth(0);
     this.hideElements.addClass('hidden-navigation');
+    jQuery('.wp-query-menu--search-input').blur();
   }
 
   public closeWhenOnMobile():void {


### PR DESCRIPTION
### Description
The keyboard used to pop up in mobile Safari bowser when opening another query on the work packages page. This issue was caused by the search input field within the sidebar that was still focused after closing the menu.

### Solution
Blur input field after closing the menu

See also: https://community.openproject.com/projects/openproject/work_packages/31871