### PR TITLE
Fixed memcache server setting in configuration.md

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -355,7 +355,7 @@ the configuration flag `security_badge_displayed: false` .
 ## Cache options:
 
 * `rails_cache_store`: `memcache` for [memcached](http://www.memcached.org/) or `memory_store` (default: `file_store`)
-* `cache_memcache_server`: The memcache server host and IP (default: `127.0.0.1:11211`)
+* `MEMCACHE_SERVERS`: The memcache server host and IP (default: 127.0.0.1:11211) [This is used by dalli](https://github.com/petergoldstein/dalli/blob/master/README.md#usage-with-rails-3x-and-4x)
 * `cache_expires_in`: Expiration time for memcache entries (default: `0`, no expiry)
 * `cache_namespace`: Namespace for cache keys, useful when multiple applications use a single memcache server (default: none)
 


### PR DESCRIPTION
For op 10
even if cache_memcache_server is set dalli still tries to access 127.0.0.1:11211