### PR TITLE
Add support for CentOS / RHEL 8

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -20,6 +20,9 @@ targets:
   centos-7:
    dependencies:
       - epel-release
+  centos-8:
+    dependencies:
+      - epel-release
   sles-12:
     build_dependencies:
       - sqlite3-devel


### PR DESCRIPTION
Enable package for CentOS & RHEL 8. PostgreSQL addon has been fixed for that distro, but there is still a bug in the Apache addon regarding SSL, so do not merge yet.