### PR TITLE
[31907] New Wiki page are not showed

### DIFF
--- a/app/helpers/wiki_helper.rb
+++ b/app/helpers/wiki_helper.rb
@@ -32,7 +32,7 @@ module WikiHelper
                                    ids: true,
                                    placeholder: true)
     s = if placeholder
-          ["-- #{t('label_no_parent_page')} --", '']
+          [["-- #{t('label_no_parent_page')} --", '']]
         else
           []
         end

--- a/app/views/wiki/index.html.erb
+++ b/app/views/wiki/index.html.erb
@@ -40,7 +40,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <% html_title t(:label_wiki_toc) %>
 
 <div class="wiki-content">
-<%= render_page_hierarchy(@pages_by_parent_id, nil, timestamp: true) %>
+  <%= render_page_hierarchy(@pages_by_parent_id, nil, timestamp: true) %>
 </div>
 
 <% unless @pages.empty? %>

--- a/db/migrate/20200115090742_fix_parent_id_for_wiki_pages.rb
+++ b/db/migrate/20200115090742_fix_parent_id_for_wiki_pages.rb
@@ -1,0 +1,9 @@
+class FixParentIdForWikiPages < ActiveRecord::Migration[6.0]
+  class MyWikiPages < ActiveRecord::Base
+    self.table_name = "wiki_pages"
+  end
+
+  def up
+    MyWikiPages.where(parent_id: 0).update_all(parent_id: nil)
+  end
+end


### PR DESCRIPTION
Correct the wiki hierarchy list in the main menu. The changes made [here](https://github.com/opf/openproject/pull/7926) had a little mistake when adding an extra option to the array of possible wiki pages. Thus users could choose between two options when creating a new wiki page without a parent (see image).

<img width="529" alt="Bildschirmfoto 2020-01-15 um 09 36 26" src="https://user-images.githubusercontent.com/7457313/72421761-6ac7a880-3781-11ea-8743-b247846915ea.png">

The first option set `parent_id` to `nil` the second to `0`. However the method to render the hierarchy in the menu only checked for `nil`. That is why some entries where not shown any more.

