### PR TITLE
redirect to index on non existing default model

### DIFF
--- a/modules/ifc_models/app/controllers/ifc_models/ifc_models_controller.rb
+++ b/modules/ifc_models/app/controllers/ifc_models/ifc_models_controller.rb
@@ -54,11 +54,11 @@ module ::IFCModels
     def show; end
 
     def show_defaults
-      if @ifc_models.empty?
+      @default_ifc_models = @ifc_models.defaults
+
+      if @default_ifc_models.empty?
         redirect_to action: :index
       end
-
-      @default_ifc_models = @project.ifc_models.defaults
     end
 
     def create

--- a/modules/ifc_models/app/views/ifc_models/ifc_models/_no_default_notice.html.erb
+++ b/modules/ifc_models/app/views/ifc_models/ifc_models/_no_default_notice.html.erb
@@ -1,12 +1,14 @@
-<div class="notification-box -error">
+<div class="notification-box -info">
   <div class="notification-box--content">
     <p><%= t('ifc_models.no_defaults_warning.title') %></p>
     <ul>
       <li><%= t('ifc_models.no_defaults_warning.check_1') %></li>
       <li><%= t('ifc_models.no_defaults_warning.check_2') %></li>
     </ul>
-    <%= link_to(ifc_models_project_ifc_models_path(project), class: 'button', accesskey: accesskey(:edit)) do %>
-      <%= op_icon('button--icon icon-edit') %> <%= t('ifc_models.label_edit_defaults') %>
+    <% unless current_page?(ifc_models_project_ifc_models_path(project)) %>
+      <%= link_to(ifc_models_project_ifc_models_path(project), class: 'button', accesskey: accesskey(:edit)) do %>
+        <%= op_icon('button--icon icon-edit') %> <%= t('ifc_models.label_edit_defaults') %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/modules/ifc_models/app/views/ifc_models/ifc_models/index.html.erb
+++ b/modules/ifc_models/app/views/ifc_models/ifc_models/index.html.erb
@@ -40,7 +40,7 @@ See docs/COPYRIGHT.rdoc for more details.
       <% end %>
     </li>
   <% end %>
-  <% if @ifc_models.any? %>
+  <% if @ifc_models.defaults.any? %>
     <li class="toolbar-item">
       <%= link_to show_defaults_ifc_models_project_ifc_models_path,
                   { class: 'button',
@@ -51,6 +51,10 @@ See docs/COPYRIGHT.rdoc for more details.
       <% end %>
     </li>
   <% end %>
+<% end %>
+
+<% if @ifc_models.defaults.empty? %>
+  <%= render partial: 'no_default_notice', locals: { project: @project } %>
 <% end %>
 
 <%= cell ::IFCModels::Models::TableCell, @ifc_models %>

--- a/modules/ifc_models/spec/features/model_viewer_spec.rb
+++ b/modules/ifc_models/spec/features/model_viewer_spec.rb
@@ -29,6 +29,7 @@
 require 'spec_helper'
 
 require_relative '../support/pages/ifc_models/show'
+require_relative '../support/pages/ifc_models/show_default'
 
 describe 'model viewer', type: :feature, js: true do
   let(:project) { FactoryBot.create :project }

--- a/modules/ifc_models/spec/features/show_default_spec.rb
+++ b/modules/ifc_models/spec/features/show_default_spec.rb
@@ -1,0 +1,102 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+require_relative '../support/pages/ifc_models/index'
+require_relative '../support/pages/ifc_models/show_default'
+
+describe 'show default model', type: :feature, js: true do
+  let(:project) { FactoryBot.create :project }
+  let(:index_page) { Pages::IfcModels::Index.new(project) }
+  let(:show_default_page) { Pages::IfcModels::ShowDefault.new(project) }
+  let(:role) { FactoryBot.create(:role, permissions: %i[view_ifc_models manage_ifc_models]) }
+
+  let(:user) do
+    FactoryBot.create :user,
+                      member_in_project: project,
+                      member_through_role: role
+  end
+
+  let(:model) do
+    FactoryBot.create(:ifc_model_converted,
+                      is_default: model_is_default,
+                      project: project,
+                      uploader: user)
+  end
+  let(:model_is_default) { true }
+
+  before do
+    login_as(user)
+    model
+  end
+
+  context 'with everything ready' do
+    before do
+      show_default_page.visit!
+      show_default_page.finished_loading
+    end
+
+    it 'loads and shows the viewer correctly' do
+      show_default_page.model_viewer_visible true
+      show_default_page.model_viewer_shows_a_toolbar true
+      show_default_page.page_shows_a_toolbar true
+      show_default_page.sidebar_shows_viewer_menu true
+    end
+  end
+
+  context 'without a default model' do
+    let(:model_is_default) { false }
+
+    before do
+      show_default_page.visit!
+    end
+
+    it 'redirects to the index page and displays a notification' do
+      expect(index_page)
+        .to be_current_page
+
+      index_page.expect_notification(type: :info,
+                                     message: I18n.t('ifc_models.no_defaults_warning.title'))
+    end
+  end
+
+  context 'with the default model not being processed' do
+    before do
+      model.xkt_attachment.destroy
+
+      show_default_page.visit!
+    end
+
+    it 'renders a notification' do
+      show_default_page
+        .expect_notification(type: :info,
+                             message: I18n.t(:'ifc_models.processing_notice.processing_default'))
+    end
+  end
+end

--- a/modules/ifc_models/spec/support/pages/ifc_models/show.rb
+++ b/modules/ifc_models/spec/support/pages/ifc_models/show.rb
@@ -26,60 +26,26 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-require 'support/pages/page'
+require_relative 'show_default'
 
 module Pages
   module IfcModels
-    class Show < ::Pages::Page
-      attr_accessor :project, :id
+    class Show < ::Pages::IfcModels::ShowDefault
+      attr_accessor :id
 
       def initialize(project, id)
-        self.project = project
+        super(project)
         self.id = id
       end
+
+      private
 
       def path
         ifc_models_project_ifc_model_path(project, id)
       end
 
-      def finished_loading
-        expect(page).to have_no_selector('.xeokit-busy-modal', visible: true)
-      end
-
-      def model_viewer_visible(visible)
-        selector = '.ifc-model-viewer--model-canvas'
-        expect(page).to (visible ? have_selector(selector) : have_no_selector(selector))
-      end
-
-      def model_viewer_shows_a_toolbar(visible)
-        selector = '.xeokit-btn'
-
-        if visible
-          within ('.ifc-model-viewer--toolbar-container') do
-            expect(page).to have_selector(selector, count: 8)
-          end
-        else
-          expect(page).to have_no_selector(selector)
-          expect(page).to have_no_selector('.ifc-model-viewer--toolbar-container')
-        end
-      end
-
-      def sidebar_shows_viewer_menu(visible)
-        selector = '.xeokit-tab'
-        tabs = ['Models', 'Objects', 'Classes', 'Storeys']
-
-        tabs.each do |tab|
-          expect(page).to (visible ? have_selector(selector, text: tab) : have_no_selector(selector, text: tab))
-        end
-      end
-
-      def page_shows_a_toolbar(visible)
-        selector = '.toolbar-item'
-        buttons = ['Edit', 'Delete']
-
-        buttons.each do |button|
-          expect(page).to (visible ? have_selector(selector, text: button) : have_no_selector(selector, text: button))
-        end
+      def toolbar_items
+        %w(Edit Delete)
       end
     end
   end

--- a/modules/ifc_models/spec/support/pages/ifc_models/show_default.rb
+++ b/modules/ifc_models/spec/support/pages/ifc_models/show_default.rb
@@ -1,0 +1,90 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'support/pages/page'
+
+module Pages
+  module IfcModels
+    class ShowDefault < ::Pages::Page
+      attr_accessor :project
+
+      def initialize(project)
+        self.project = project
+      end
+
+      def path
+        show_defaults_ifc_models_project_ifc_models_path(project)
+      end
+
+      def finished_loading
+        expect(page).to have_no_selector('.xeokit-busy-modal', visible: true)
+      end
+
+      def model_viewer_visible(visible)
+        selector = '.ifc-model-viewer--model-canvas'
+        expect(page).to (visible ? have_selector(selector) : have_no_selector(selector))
+      end
+
+      def model_viewer_shows_a_toolbar(visible)
+        selector = '.xeokit-btn'
+
+        if visible
+          within ('.ifc-model-viewer--toolbar-container') do
+            expect(page).to have_selector(selector, count: 8)
+          end
+        else
+          expect(page).to have_no_selector(selector)
+          expect(page).to have_no_selector('.ifc-model-viewer--toolbar-container')
+        end
+      end
+
+      def sidebar_shows_viewer_menu(visible)
+        selector = '.xeokit-tab'
+        tabs = ['Models', 'Objects', 'Classes', 'Storeys']
+
+        tabs.each do |tab|
+          expect(page).to (visible ? have_selector(selector, text: tab) : have_no_selector(selector, text: tab))
+        end
+      end
+
+      def page_shows_a_toolbar(visible)
+        selector = '.toolbar-item'
+
+        toolbar_items.each do |button|
+          expect(page).to (visible ? have_selector(selector, text: button) : have_no_selector(selector, text: button))
+        end
+      end
+
+      private
+
+      def toolbar_items
+        ['Manage models']
+      end
+    end
+  end
+end


### PR DESCRIPTION
When no default model is defined, the user is redirected to the index page which will now display a notification instructing the user to choose a default model.

https://community.openproject.com/projects/openproject/work_packages/32034