### PR TITLE
print formatted description and comments in pdf export

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,7 +137,7 @@ gem 'lograge', '~> 0.10.0'
 gem 'airbrake', '~> 9.4.3', require: false
 
 gem 'prawn', '~> 2.2'
-gem 'prawn-table', '~> 0.2.2'
+gem 'prawn-markup', '~> 0.2.1'
 
 gem 'cells-erb', '~> 0.1.0'
 gem 'cells-rails', '~> 0.0.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -696,6 +696,10 @@ GEM
     prawn (2.2.2)
       pdf-core (~> 0.7.0)
       ttfunk (~> 1.5)
+    prawn-markup (0.2.1)
+      nokogiri
+      prawn
+      prawn-table
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
     pry (0.12.2)
@@ -1062,6 +1066,7 @@ DEPENDENCIES
   plaintext (~> 0.3.2)
   posix-spawn (~> 0.3.13)
   prawn (~> 2.2)
+  prawn-markup (~> 0.2.1)
   prawn-table (~> 0.2.2)
   pry-byebug (~> 3.7.0)
   pry-rails (~> 0.3.6)

--- a/app/models/work_package/pdf_export/attachments.rb
+++ b/app/models/work_package/pdf_export/attachments.rb
@@ -29,7 +29,6 @@
 #++
 
 module WorkPackage::PdfExport::Attachments
-
   ##
   # Creates cells for each attachment of the work package
   #

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -47,10 +47,7 @@ class WorkPackage::PdfExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
   end
 
   def render!
-    write_title!
-    write_work_packages!
-
-    write_footers!
+    write_content!
 
     success(pdf.render)
   rescue Prawn::Errors::CannotFit
@@ -58,6 +55,14 @@ class WorkPackage::PdfExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
   rescue StandardError => e
     Rails.logger.error { "Failed to generated PDF export: #{e} #{e.message}." }
     error(I18n.t(:error_pdf_failed_to_export, error: e.message))
+  end
+
+  def write_content!
+    write_title!
+    write_headers!
+    write_work_packages!
+
+    write_footers!
   end
 
   def project
@@ -95,11 +100,6 @@ class WorkPackage::PdfExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
                      style: :italic
   end
 
-  def write_work_packages!
-    pdf.font style: :normal, size: 8
-    pdf.table(data, column_widths: column_widths)
-  end
-
   def column_widths
     widths = valid_export_columns.map do |col|
       if col.name == :subject || text_column?(col)
@@ -122,8 +122,9 @@ class WorkPackage::PdfExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
       ['string', 'text'].include?(column.custom_field.field_format)
   end
 
-  def data
-    [data_headers] + data_rows
+  def write_headers!
+    pdf.font style: :normal, size: 8
+    pdf.table([data_headers], column_widths: column_widths)
   end
 
   def data_headers
@@ -132,44 +133,52 @@ class WorkPackage::PdfExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
     end
   end
 
-  def data_rows
+  def write_work_packages!
+    pdf.font style: :normal, size: 8
     previous_group = nil
 
-    work_packages.flat_map do |work_package|
-      values = valid_export_columns.map do |column|
-        make_column_value work_package, column
-      end
+    work_packages.each do |work_package|
+      previous_group = write_group_header!(work_package, previous_group)
 
-      result = [values]
+      write_attributes!(work_package)
 
       if options[:show_descriptions]
-        make_description(work_package.description.to_s).each do |segment|
-          result << [segment]
-        end
+        write_description!(work_package, false)
       end
 
       if options[:show_attachments] && work_package.attachments.exists?
-        attachments = make_attachments_cells(work_package.attachments)
-
-        if attachments.any?
-          result << [
-            { content: pdf.make_table([attachments]), colspan: description_colspan }
-          ]
-        end
+        write_attachments!(work_package)
       end
+    end
+  end
 
-      if query.grouped? && (group = query.group_by_column.value(work_package)) != previous_group
-        label = make_group_label(group)
-        previous_group = group
+  def write_attributes!(work_package)
+    values = valid_export_columns.map do |column|
+      make_column_value work_package, column
+    end
 
-        result.insert 0, [
-          pdf.make_cell(label, font_style: :bold,
-                               colspan: valid_export_columns.size,
-                               background_color: 'DDDDDD')
-        ]
-      end
+    pdf.table([values], column_widths: column_widths)
+  end
 
-      result
+  def write_attachments!(work_package)
+    attachments = make_attachments_cells(work_package.attachments)
+
+    pdf.table([attachments], width: pdf.bounds.width) if attachments.any?
+  end
+
+  def write_group_header!(work_package, previous_group)
+    if query.grouped? && (group = query.group_by_column.value(work_package)) != previous_group
+      label = make_group_label(group)
+      group_cell = pdf.make_cell(label,
+                                 font_style: :bold,
+                                 colspan: valid_export_columns.size,
+                                 background_color: 'DDDDDD')
+
+      pdf.table([[group_cell]], column_widths: column_widths)
+
+      group
+    else
+      previous_group
     end
   end
 


### PR DESCRIPTION
This implementation is a best effort one, relying heavily on the
prawn_markup gem and wrapping borders around it where necessary to keep
the design.

https://community.openproject.com/projects/openproject/work_packages/32065
https://community.openproject.com/projects/openproject/work_packages/31676
https://community.openproject.com/projects/openproject/work_packages/31860