### PR TITLE
restict tsv extraction to work package

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -198,21 +198,21 @@ class Attachment < ActiveRecord::Base
   end
 
   def extract_fulltext
-    return unless OpenProject::Database.allows_tsv?
+    return unless OpenProject::Database.allows_tsv? && (!container || container.class.attachment_tsv_extracted?)
 
     ExtractFulltextJob.perform_later(id)
   end
 
   # Extract the fulltext of any attachments where fulltext is still nil.
-  # This runs inline and not in a asynchronous worker.
+  # This runs inline and not in an asynchronous worker.
   def self.extract_fulltext_where_missing(run_now: true)
     return unless OpenProject::Database.allows_tsv?
 
     Attachment
       .where(fulltext: nil)
+      .where(container_type: tsv_extracted_containers)
       .pluck(:id)
       .each do |id|
-
       if run_now
         ExtractFulltextJob.perform_now(id)
       else
@@ -226,6 +226,17 @@ class Attachment < ActiveRecord::Base
 
     Attachment.pluck(:id).each do |id|
       ExtractFulltextJob.perform_now(id)
+    end
+  end
+
+  def tsv_extracted_containers
+    Attachment
+      .select(:container_type)
+      .distinct
+      .pluck(:container_type)
+      .compact
+      .select do |container_class|
+      container_class.constantize.attachment_tsv_extracted?
     end
   end
 

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -158,7 +158,8 @@ class WorkPackage < ActiveRecord::Base
                      order: "#{Attachment.table_name}.file",
                      add_on_new_permission: :add_work_packages,
                      add_on_persisted_permission: :edit_work_packages,
-                     modification_blocked: ->(*) { readonly_status? }
+                     modification_blocked: ->(*) { readonly_status? },
+                     extract_tsv: true
 
   after_validation :set_attachments_error_details,
                    if: lambda { |work_package| work_package.errors.messages.has_key? :attachments }

--- a/lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb
+++ b/lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb
@@ -62,7 +62,8 @@ module Redmine
             add_on_new_permission: add_on_new_permission(options),
             add_on_persisted_permission: add_on_persisted_permission(options),
             only_user_allowed: only_user_allowed(options),
-            modification_blocked: options[:modification_blocked]
+            modification_blocked: options[:modification_blocked],
+            extract_tsv: attachable_extract_tsv_option(options)
           }
 
           options.except!(:view_permission,
@@ -71,7 +72,8 @@ module Redmine
                           :add_on_persisted_permission,
                           :add_permission,
                           :only_user_allowed,
-                          :modification_blocked)
+                          :modification_blocked,
+                          :extract_tsv)
         end
 
         def view_permission(options)
@@ -101,6 +103,10 @@ module Redmine
         def edit_permission_default
           "edit_#{name.pluralize.underscore}".to_sym
         end
+
+        def attachable_extract_tsv_option(options)
+          options.fetch(:extract_tsv, false)
+        end
       end
 
       module InstanceMethods
@@ -118,6 +124,10 @@ module Redmine
           def attachments_addable?(user = User.current)
             user.allowed_to_globally?(attachable_options[:add_on_new_permission]) ||
               user.allowed_to_globally?(attachable_options[:add_on_persisted_permission])
+          end
+
+          def attachment_tsv_extracted?
+            attachable_options[:extract_tsv]
           end
         end
 


### PR DESCRIPTION
On attachment creation, or when the rake task to extract for all attachments is run, only attachments with work packages as their container are considered. The rake task that forces an extraction on a particular attachment however ignores such limitations.

The configuration is done via the attachable options.

https://community.openproject.com/projects/openproject/work_packages/32095