### PR TITLE
[31922] Child WP version cannot be edited although parent is no backlogs type

### DIFF
--- a/modules/backlogs/lib/open_project/backlogs/patches/specific_work_package_schema_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/specific_work_package_schema_patch.rb
@@ -43,11 +43,17 @@ module OpenProject::Backlogs::Patches::SpecificWorkPackageSchemaPatch
     def writable?(property)
       if property == :remaining_time && !@work_package.leaf?
         false
-      elsif property == :version && @work_package.is_task?
+      elsif version_with_backlogs_parent(property)
         false
       else
         super
       end
+    end
+
+    private
+
+    def version_with_backlogs_parent(property)
+      property == :version && @work_package.is_task? && WorkPackage.find(@work_package.parent_id).in_backlogs_type?
     end
   end
 end

--- a/modules/backlogs/spec/api/work_packages/schema/specific_work_package_schema_spec.rb
+++ b/modules/backlogs/spec/api/work_packages/schema/specific_work_package_schema_spec.rb
@@ -44,6 +44,32 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
     end
   end
 
+  shared_examples_for 'with parent which is a BACKLOGS type' do |writable|
+    let(:parent) { FactoryBot.create(:work_package, type: type_task) }
+
+    before do
+      work_package.parent_id = parent.id
+      work_package.save!
+    end
+
+    it "is #{'not' unless writable} writable" do
+      expect(subject.writable?(:version)).to eql(writable)
+    end
+  end
+
+  shared_examples_for 'with parent which is not a BACKLOGS type' do
+    let(:parent) { FactoryBot.create(:work_package, type: type_feature) }
+
+    before do
+      work_package.parent_id = parent.id
+      work_package.save!
+    end
+
+    it "is writable" do
+      expect(subject.writable?(:version)).to eql(true)
+    end
+  end
+
   before do
     login_as(current_user)
   end
@@ -74,29 +100,34 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
 
   describe '#version_writable?' do
     subject { described_class.new(work_package: work_package) }
+    let(:type_task) { FactoryBot.create(:type_task) }
+    let(:type_feature) { FactoryBot.create(:type_feature) }
 
-    context 'work_package is a task' do
+    before do
+      allow(WorkPackage).to receive(:backlogs_types).and_return([type_task.id])
+      allow(work_package).to receive(:backlogs_enabled?).and_return(true)
+    end
+
+    describe 'work_package is a task' do
       before do
         allow(work_package)
           .to receive(:is_task?)
           .and_return(true)
       end
 
-      it 'is writable' do
-        expect(subject.writable?(:version)).to eql(false)
-      end
+      it_behaves_like 'with parent which is a BACKLOGS type', false
+      it_behaves_like 'with parent which is not a BACKLOGS type'
     end
 
-    context 'work_package is no task' do
+    describe 'work_package is no task' do
       before do
         allow(work_package)
           .to receive(:is_task?)
           .and_return(false)
       end
 
-      it 'is not writable' do
-        expect(subject.writable?(:version)).to eql(true)
-      end
+      it_behaves_like 'with parent which is a BACKLOGS type', true
+      it_behaves_like 'with parent which is not a BACKLOGS type'
     end
   end
 end


### PR DESCRIPTION
Add a check whether the parent is one of the backlogs type before editing the version is forbidden. 


https://community.openproject.com/projects/openproject/work_packages/31922/activity