### PR TITLE
[32114] Parent changes by drag and drop are not saved correctly

### DIFF
--- a/frontend/src/app/components/wp-fast-table/helpers/wp-table-row-helpers.ts
+++ b/frontend/src/app/components/wp-fast-table/helpers/wp-table-row-helpers.ts
@@ -6,6 +6,10 @@ export function rowId(workPackageId:string):string {
   return `wp-row-${workPackageId}-table`;
 }
 
+export function relationRowClass():string {
+  return `wp-table--relations-aditional-row`;
+}
+
 export function locateTableRow(workPackageId:string):JQuery {
   return jQuery('.' + rowId(workPackageId));
 }

--- a/frontend/src/app/components/wp-table/drag-and-drop/actions/hierarchy-drag-action.service.ts
+++ b/frontend/src/app/components/wp-table/drag-and-drop/actions/hierarchy-drag-action.service.ts
@@ -69,10 +69,7 @@ export class HierarchyDragActionService extends TableDragActionService {
 
     // If the sibling is no hierarchy root, return it's parent.
     // Thus, the dropped element will get the same hierarchy level as the sibling
-    return this.wpCacheService.require(previousWpId)
-      .then((wp:WorkPackageResource) => {
-        return Promise.resolve(wp.parent.id);
-    });
+    return this.loadParentOfWP(previousWpId);
   }
 
   private findRelationRowRoot(el:Element):Element|null {
@@ -85,5 +82,12 @@ export class HierarchyDragActionService extends TableDragActionService {
     }
 
     return null;
+  }
+
+  private loadParentOfWP(wpId:string):Promise<string|null> {
+    return this.wpCacheService.require(wpId)
+      .then((wp:WorkPackageResource) => {
+        return Promise.resolve(wp.parent.id);
+      });
   }
 }

--- a/spec/features/work_packages/sorting/manual_sorting_spec.rb
+++ b/spec/features/work_packages/sorting/manual_sorting_spec.rb
@@ -40,13 +40,28 @@ describe 'Manual sorting of WP table', type: :feature, js: true do
     FactoryBot.create(:work_package, subject: 'WP1', project: project, type: type_task, created_at: Time.now)
   end
   let(:work_package_2) do
-    FactoryBot.create(:work_package, subject: 'WP2', project: project, parent: work_package_1, type: type_task, created_at: Time.now - 1.minutes)
+    FactoryBot.create(:work_package,
+                      subject: 'WP2',
+                      project: project,
+                      parent: work_package_1,
+                      type: type_task,
+                      created_at: Time.now - 1.minutes)
   end
   let(:work_package_3) do
-    FactoryBot.create(:work_package, subject: 'WP3', project: project, parent: work_package_2, type: type_bug, created_at: Time.now - 2.minutes)
+    FactoryBot.create(:work_package,
+                      subject: 'WP3',
+                      project: project,
+                      parent: work_package_2,
+                      type: type_bug,
+                      created_at: Time.now - 2.minutes)
   end
   let(:work_package_4) do
-    FactoryBot.create(:work_package, subject: 'WP4', project: project, parent: work_package_3, type: type_bug, created_at: Time.now - 3.minutes)
+    FactoryBot.create(:work_package,
+                      subject: 'WP4',
+                      project: project,
+                      parent: work_package_3,
+                      type: type_bug,
+                      created_at: Time.now - 3.minutes)
   end
 
   let(:sort_by) { ::Components::WorkPackages::SortBy.new }
@@ -122,7 +137,7 @@ describe 'Manual sorting of WP table', type: :feature, js: true do
       hierarchies.expect_leaf_at(work_package_3, work_package_4)
     end
 
-    it 'can drag an element out of the hierarchy' do
+    it 'can drag an element completely out of the hierarchy' do
       # Move up the hierarchy
       wp_table.drag_and_drop_work_package from: 3, to: 0
       loading_indicator_saveguard
@@ -139,6 +154,47 @@ describe 'Manual sorting of WP table', type: :feature, js: true do
       hierarchies.expect_hierarchy_at(work_package_1, work_package_2)
       hierarchies.expect_leaf_at(work_package_3, work_package_4)
       wp_page.expect_no_parent
+    end
+
+    context 'drag an element partly out of the hierarchy' do
+      let(:work_package_5) do
+        FactoryBot.create(:work_package, subject: 'WP5', project: project, parent: work_package_1)
+      end
+      let(:work_package_6) do
+        FactoryBot.create(:work_package, subject: 'WP6', project: project, parent: work_package_1)
+      end
+
+      before do
+        work_package_5
+        work_package_6
+        work_package_4.parent = work_package_2
+        work_package_4.save!
+        wp_table.visit!
+
+        # Hierarchy enabled
+        wp_table.expect_work_package_order(work_package_1,
+                                           work_package_2,
+                                           work_package_3,
+                                           work_package_4,
+                                           work_package_5,
+                                           work_package_6)
+        hierarchies.expect_hierarchy_at(work_package_1, work_package_2)
+        hierarchies.expect_leaf_at(work_package_3, work_package_4, work_package_5, work_package_6)
+      end
+
+      it 'move below a sibling of my parent' do
+        wp_table.drag_and_drop_work_package from: 3, to: 5
+
+        loading_indicator_saveguard
+        wp_table.expect_work_package_order(work_package_1,
+                                           work_package_2,
+                                           work_package_3,
+                                           work_package_5,
+                                           work_package_4,
+                                           work_package_6)
+        hierarchies.expect_hierarchy_at(work_package_1, work_package_2)
+        hierarchies.expect_leaf_at(work_package_3, work_package_4, work_package_5, work_package_6)
+      end
     end
   end
 

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -194,7 +194,7 @@ module Pages
     end
 
     def drag_and_drop_work_package(from:, to:)
-      # Wait a bit because drag & drop in selenium is easily offendedA
+      # Wait a bit because drag & drop in selenium is easily offended
       sleep 1
 
       rows = page.all('.wp-table--row')
@@ -238,7 +238,7 @@ module Pages
         .release
         .perform
 
-      # Wait a bit because drag & drop in selenium is easily offendedA
+      # Wait a bit because drag & drop in selenium is easily offended
       sleep 1
     end
 


### PR DESCRIPTION
Change determineParent algorithm. If the previous element is an open root, it gets the new parent. Otherwise, the parent of the previous element becomes the parent of the new parent of the dropped element. An exception are relation rows, where we have to find the correct element first. 

https://community.openproject.com/projects/openproject/work_packages/32114/activity