### PR TITLE
readd select/unselect in project settings

### DIFF
--- a/app/assets/javascripts/specific/toggable_fieldset.js
+++ b/app/assets/javascripts/specific/toggable_fieldset.js
@@ -66,7 +66,7 @@ function getFieldset(el) {
 
 function toggleFieldset(el) {
   var fieldset = getFieldset(el);
-  var contentArea = fieldset.find('> div').not('.form--fieldset-control');
+  var contentArea = fieldset.find('> div').not('.form--toolbar');
 
   fieldset.toggleClass('collapsed');
   contentArea.slideToggle('fast', null);

--- a/app/assets/stylesheets/content/_forms.lsg
+++ b/app/assets/stylesheets/content/_forms.lsg
@@ -496,8 +496,8 @@
     <legend class="form--fieldset-legend">
       Various information
     </legend>
-    <div class="form--fieldset-control">
-    <span class="form--fieldset-control-container">
+    <div class="form--toolbar">
+    <span class="form--toolbar-item">
       (<a href="#">Check all</a> | <a href="#">Uncheck all</a>)
     </span>
     </div>

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -283,6 +283,11 @@ fieldset.form--fieldset
   padding: 0 0.25rem
   background-color: inherit
 
+  &.-in-header
+    margin-left: 5px
+    font-style:  italic
+    line-height: 44px
+
 .form--section
   @extend %form--fieldset-or-section
 

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -264,19 +264,22 @@ fieldset.form--fieldset
 #sidebar .form--fieldset-legend
   @include varprop(color, main-menu-fieldset-header-color)
 
-.form--fieldset-control
+.form--toolbar
   float:          right
-  margin-top:     -2.8rem
   text-align:     right
   color:          lighten($body-font-color, 10)
   font-size:      1rem
   font-style:     italic
   line-height:    1.8
+  margin-top:     -1.8rem
+
+  fieldset > &
+    margin-top: -2.8rem
 
   a:hover
     text-decoration: none
 
-.form--fieldset-control-container
+.form--toolbar-item
   padding: 0 0.25rem
   background-color: inherit
 

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -61,6 +61,13 @@ $nm-color-success-background: #d8fdd1
   &.-with-dropdown .toolbar-item.drop-down
     position: relative
 
+  &.-minimum-title
+    .toolbar-items
+      flex-grow: 1
+
+    .title-container
+      flex-grow: 0
+
 // Align title and toolbar with flex
 .toolbar
   display: flex
@@ -79,6 +86,8 @@ $nm-color-success-background: #d8fdd1
   flex-wrap: wrap
   margin:  0 -10px 0 0
   padding: 0
+  // have a fixed height for all toolbars
+  height: 44px
 
   li
     list-style-type: none
@@ -91,6 +100,9 @@ $nm-color-success-background: #d8fdd1
     // hide right margin for e.g., conditional buttons
     &.-no-spacing
       margin-right: 0
+
+    &.-no-grow
+      flex-grow: 0
 
     .button
       width: 100%
@@ -194,6 +206,9 @@ $nm-color-success-background: #d8fdd1
   overflow: hidden
   white-space: nowrap
   margin-bottom: 10px // margin-bottom of toolbar buttons
+
+  &.-no-grow
+    flex-grow: 0
 
   h2
     @include text-shortener

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -373,9 +373,9 @@ module ApplicationHelper
   end
 
   def check_all_links(form_name)
-    link_to_function(l(:button_check_all), "checkAll('#{form_name}', true)") +
+    link_to_function(t(:button_check_all), "checkAll('#{form_name}', true)") +
       ' | ' +
-      link_to_function(l(:button_uncheck_all), "checkAll('#{form_name}', false)")
+      link_to_function(t(:button_uncheck_all), "checkAll('#{form_name}', false)")
   end
 
   def current_layout

--- a/app/helpers/toolbar_helper.rb
+++ b/app/helpers/toolbar_helper.rb
@@ -6,11 +6,12 @@ module ToolbarHelper
     classes = ['toolbar-container', html[:class]].compact.join(' ')
     content_tag :div, class: classes do
       toolbar = content_tag :div, class: 'toolbar' do
-        dom_title(title, link_to, title_class: title_class, title_extra: title_extra) + dom_toolbar {
+        dom_title(title, link_to, title_class: title_class, title_extra: title_extra) + dom_toolbar do
           yield if block_given?
-        }
+        end
       end
       next toolbar if subtitle.blank?
+
       toolbar + content_tag(:p, subtitle, class: 'subtitle')
     end
   end

--- a/app/views/project_settings/activities.html.erb
+++ b/app/views/project_settings/activities.html.erb
@@ -26,7 +26,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: l(:enumeration_activities) %>
+<%= toolbar title: t(:enumeration_activities), html: { class: '-minimum-title' } do -%>
+  <%= render partial: 'projects/form/toolbar', locals: { form_name: "edit_project_#{@project.id}" } %>
+<% end %>
 
 <% if TimeEntryActivity.any? %>
   <%= labelled_tabular_form_for @project,

--- a/app/views/project_settings/activities.html.erb
+++ b/app/views/project_settings/activities.html.erb
@@ -29,9 +29,9 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:enumeration_activities) %>
 
 <% if TimeEntryActivity.any? %>
-  <%= form_tag  project_time_entry_activities_path(@project),
-                method: :put,
-                class: "tabular" do %>
+  <%= labelled_tabular_form_for @project,
+                                url: project_time_entry_activities_path(@project),
+                                method: :put do %>
 
     <%= render partial: 'projects/form/activities', locals: { project: @project, withControlls: true } %>
   <% end %>

--- a/app/views/project_settings/categories.html.erb
+++ b/app/views/project_settings/categories.html.erb
@@ -27,7 +27,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= toolbar title: l(:label_work_package_category_plural) do %>
+<%= toolbar title: t(:label_work_package_category_plural) do -%>
   <% if current_user.allowed_to?(:manage_categories, @project)  %>
     <li class="toolbar-item">
       <%= link_to_if_authorized({ controller: '/categories', action: 'new', project_id: @project },

--- a/app/views/project_settings/custom_fields.html.erb
+++ b/app/views/project_settings/custom_fields.html.erb
@@ -27,9 +27,11 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= toolbar title: l(:label_custom_field_plural) do %>
+<%= toolbar title: t(:label_custom_field_plural) , html: { class: '-minimum-title' } do -%>
+  <%= render partial: 'projects/form/toolbar', locals: { form_name: "modules-form" } %>
+
   <% if current_user.admin? %>
-    <li class="toolbar-item">
+    <li class="toolbar-item -no-grow">
       <%= link_to new_custom_field_path(type: 'WorkPackageCustomField'),
                   { class: 'button -alt-highlight',
                     aria: {label: t(:label_custom_field_new)},

--- a/app/views/project_settings/modules.html.erb
+++ b/app/views/project_settings/modules.html.erb
@@ -26,10 +26,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: t(:label_module_plural) %>
+
+<%= toolbar title: t(:label_module_plural), html: { class: '-minimum-title' } do -%>
+  <%= render partial: 'projects/form/toolbar', locals: { form_name: "edit_project_#{@project.id}" } %>
+<% end %>
 
 <%= labelled_tabular_form_for @project,
-                              url: settings_modules_project_path(@project),
+                              url: modules_project_path(@project),
                               method: :put do |form| %>
 
   <%= render partial: "/projects/form/modules",

--- a/app/views/project_settings/modules.html.erb
+++ b/app/views/project_settings/modules.html.erb
@@ -26,10 +26,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: l(:label_module_plural) %>
+<%= toolbar title: t(:label_module_plural) %>
 
 <%= labelled_tabular_form_for @project,
-                              url: { controller: '/projects', action: 'modules', id: @project },
+                              url: settings_modules_project_path(@project),
                               method: :put do |form| %>
 
   <%= render partial: "/projects/form/modules",

--- a/app/views/project_settings/types.html.erb
+++ b/app/views/project_settings/types.html.erb
@@ -27,7 +27,9 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= toolbar title: l(:label_work_package_types) %>
+<%= toolbar title: t(:label_work_package_types), html: { class: '-minimum-title' } do -%>
+  <%= render partial: 'projects/form/toolbar', locals: { form_name: "types-form" } %>
+<% end %>
 
 <% if  Type.all.any? %>
   <%= form_for @project,

--- a/app/views/projects/form/_activities.html.erb
+++ b/app/views/projects/form/_activities.html.erb
@@ -27,6 +27,8 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
+<%= render partial: 'projects/form/toolbar', locals: { form_name: "edit_project_#{@project.id}" } %>
+
 <% TimeEntryActivity
    .includes(:time_entry_activities_projects)
    .order(:name)

--- a/app/views/projects/form/_activities.html.erb
+++ b/app/views/projects/form/_activities.html.erb
@@ -27,8 +27,6 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= render partial: 'projects/form/toolbar', locals: { form_name: "edit_project_#{@project.id}" } %>
-
 <% TimeEntryActivity
    .includes(:time_entry_activities_projects)
    .order(:name)

--- a/app/views/projects/form/_custom_fields.html.erb
+++ b/app/views/projects/form/_custom_fields.html.erb
@@ -27,6 +27,8 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
+<%= render partial: 'projects/form/toolbar', locals: { form_name: "modules-form" } %>
+
 <div class="generic-table--container">
   <div class="generic-table--results-container">
     <table class="generic-table">

--- a/app/views/projects/form/_custom_fields.html.erb
+++ b/app/views/projects/form/_custom_fields.html.erb
@@ -27,8 +27,6 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= render partial: 'projects/form/toolbar', locals: { form_name: "modules-form" } %>
-
 <div class="generic-table--container">
   <div class="generic-table--results-container">
     <table class="generic-table">

--- a/app/views/projects/form/_modules.html.erb
+++ b/app/views/projects/form/_modules.html.erb
@@ -27,6 +27,8 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
+<%= render partial: 'projects/form/toolbar', locals: { form_name: "edit_project_#{@project.id}" } %>
+
 <% sorted_modules = OpenProject::AccessControl.available_project_modules.sort_by { |name| l_or_humanize(name, prefix: "project_module_") } %>
 <% sorted_modules.each do |name| %>
   <div class="form--field">

--- a/app/views/projects/form/_modules.html.erb
+++ b/app/views/projects/form/_modules.html.erb
@@ -27,8 +27,6 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= render partial: 'projects/form/toolbar', locals: { form_name: "edit_project_#{@project.id}" } %>
-
 <% sorted_modules = OpenProject::AccessControl.available_project_modules.sort_by { |name| l_or_humanize(name, prefix: "project_module_") } %>
 <% sorted_modules.each do |name| %>
   <div class="form--field">

--- a/app/views/projects/form/_toolbar.html.erb
+++ b/app/views/projects/form/_toolbar.html.erb
@@ -27,8 +27,6 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<div class="form--toolbar">
-  <span class="form--toolbar-item">
-    <%= check_all_links form_name %>
-  </span>
-</div>
+<li class="form--toolbar-item -in-header">
+  (<%= check_all_links form_name %>)
+</li>

--- a/app/views/projects/form/_toolbar.html.erb
+++ b/app/views/projects/form/_toolbar.html.erb
@@ -27,35 +27,8 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<section class="form--section">
-  <div class="grid-block wrap">
-    <div class="grid-content small-12 large-6">
-      <% if @projects.any? %>
-      <fieldset class="form--fieldset" id="type_project_ids">
-        <legend class="form--fieldset-legend" >
-          <%= t('types.edit.enabled_projects') %>
-        </legend>
-        <div>
-          <div class="form--toolbar">
-            <span class="form--toolbar-item">
-              (<%= check_all_links 'type_project_ids' %>)
-            </span>
-          </div>
-          <%= project_nested_ul(@projects) do |p|
-            content_tag('label',
-              check_box_tag('type[project_ids][]', p.id, @type.projects.include?(p), id: nil) +
-                ' ' + h(p), class: 'form--label-with-check-box')
-          end %>
-          <%= hidden_field_tag('type[project_ids][]', '', id: nil) %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-</section>
-
-<div class="grid-block">
-  <div class="generic-table--action-buttons">
-  <%= styled_button_tag t(@type.new_record? ? :button_create : :button_save),
-      class: '-highlight -with-icon icon-checkmark' %>
-  </div>
+<div class="form--toolbar">
+  <span class="form--toolbar-item">
+    <%= check_all_links form_name %>
+  </span>
 </div>

--- a/app/views/projects/form/_types.html.erb
+++ b/app/views/projects/form/_types.html.erb
@@ -35,8 +35,6 @@ See docs/COPYRIGHT.rdoc for more details.
                          id: "types_flash_notice",
                          class: "ignored-by-flash-activation" %>
 
-<%= render partial: 'projects/form/toolbar', locals: { form_name: "types-form" } %>
-
 <div class="generic-table--container">
   <div class="generic-table--results-container">
     <table class="generic-table types">

--- a/app/views/projects/form/_types.html.erb
+++ b/app/views/projects/form/_types.html.erb
@@ -30,14 +30,16 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= javascript_include_tag 'types_checkboxes' %>
 
 <%= render_flash_message :notice,
-                         l(:notice_automatic_set_of_standard_type),
+                         t(:notice_automatic_set_of_standard_type),
                          style: "display:none;",
                          id: "types_flash_notice",
                          class: "ignored-by-flash-activation" %>
 
+<%= render partial: 'projects/form/toolbar', locals: { form_name: "types-form" } %>
+
 <div class="generic-table--container">
   <div class="generic-table--results-container">
-    <table class="generic-table types" id="types-form">
+    <table class="generic-table types">
       <colgroup>
         <col highlight-col>
         <col highlight-col>

--- a/app/views/roles/_permissions.html.erb
+++ b/app/views/roles/_permissions.html.erb
@@ -34,8 +34,8 @@ See docs/COPYRIGHT.rdoc for more details.
     <legend class="form--fieldset-legend">
       <%= mod.blank? ? Project.model_name.human : l_or_humanize(mod, prefix: 'project_module_') %>
     </legend>
-    <div class="form--fieldset-control">
-      <span class="form--fieldset-control-container">
+    <div class="form--toolbar">
+      <span class="form--toolbar-item">
         (<%= check_all_links module_name %>)
       </span>
     </div>

--- a/app/views/roles/report.html.erb
+++ b/app/views/roles/report.html.erb
@@ -44,8 +44,8 @@ See docs/COPYRIGHT.rdoc for more details.
       <legend class="form--fieldset-legend" >
         <%= mod.blank? ? I18n.t('attributes.project') : l_or_humanize(mod, prefix: 'project_module_') %>
       </legend>
-      <div class="form--fieldset-control">
-        <span class="form--fieldset-control-container">
+      <div class="form--toolbar">
+        <span class="form--toolbar-item">
           (<%= check_all_links module_name %>)
         </span>
       </div>

--- a/app/views/settings/_notifications.html.erb
+++ b/app/views/settings/_notifications.html.erb
@@ -38,8 +38,8 @@ See docs/COPYRIGHT.rdoc for more details.
       <legend class="form--fieldset-legend">
         <%= t(:text_select_mail_notifications) %>
       </legend>
-      <div class="form--fieldset-control">
-        <span class="form--fieldset-control-container">
+      <div class="form--toolbar">
+        <span class="form--toolbar-item">
           (<%= check_all_links 'notified_events' %>)
         </span>
       </div>

--- a/app/views/work_packages/reports/_report_category.html.erb
+++ b/app/views/work_packages/reports/_report_category.html.erb
@@ -29,8 +29,8 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <div class="form--fieldset">
   <div class="form--fieldset-legend"><%= WorkPackage.human_attribute_name(report.report_type) %></div>
-  <div class="form--fieldset-control">
-    <span class="form--fieldset-control-container">
+  <div class="form--toolbar">
+    <span class="form--toolbar-item">
     <%= link_to(icon_wrapper('icon icon-zoom-in',l(:text_analyze, subject: WorkPackage.human_attribute_name(report.report_type))),
                 {action: 'report_details', detail: report.report_type},
                 title: l(:text_analyze, subject: WorkPackage.human_attribute_name(report.report_type)),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1065,7 +1065,7 @@ en:
       project_filters:
         description_html: "Filtering and sorting on custom fields is an enterprise edition feature."
 
-  enumeration_activities: "Activities (time tracking)"
+  enumeration_activities: "Time tracking activities"
   enumeration_work_package_priorities: "Work package priorities"
   enumeration_reported_project_statuses: "Reported project status"
 

--- a/modules/backlogs/app/views/project_settings/backlogs_settings.html.erb
+++ b/modules/backlogs/app/views/project_settings/backlogs_settings.html.erb
@@ -29,7 +29,9 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <%= toolbar title: l('backlogs.definition_of_done') %>
 
-<%= styled_form_tag(controller: '/projects', action: "project_done_statuses", id: @project) do %>
+<%= render partial: 'projects/form/toolbar', locals: { form_name: "edit_project_#{@project.id}" } %>
+
+<%= styled_form_tag({controller: '/projects', action: "project_done_statuses", id: @project}, id: "edit_project_#{@project.id}") do %>
 
 <div class="generic-table--container">
   <div class="generic-table--results-container">

--- a/modules/backlogs/app/views/project_settings/backlogs_settings.html.erb
+++ b/modules/backlogs/app/views/project_settings/backlogs_settings.html.erb
@@ -27,9 +27,9 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= toolbar title: l('backlogs.definition_of_done') %>
-
-<%= render partial: 'projects/form/toolbar', locals: { form_name: "edit_project_#{@project.id}" } %>
+<%= toolbar title: t('backlogs.definition_of_done'), html: { class: '-minimum-title' } do -%>
+  <%= render partial: 'projects/form/toolbar', locals: { form_name: "edit_project_#{@project.id}" } %>
+<% end %>
 
 <%= styled_form_tag({controller: '/projects', action: "project_done_statuses", id: @project}, id: "edit_project_#{@project.id}") do %>
 

--- a/modules/webhooks/app/views/webhooks/outgoing/admin/_form.html.erb
+++ b/modules/webhooks/app/views/webhooks/outgoing/admin/_form.html.erb
@@ -36,8 +36,8 @@
   <legend class="form--fieldset-legend" title="<%= t 'webhooks.outgoing.form.events.title' %>">
       <%= t 'webhooks.outgoing.form.events.title' %>
   </legend>
-  <div class="form--fieldset-control">
-    <span class="form--fieldset-control-container">
+  <div class="form--toolbar">
+    <span class="form--toolbar-item">
         (<%= check_all_links 'webhooks-selected-events' %>)
     </span>
   </div>


### PR DESCRIPTION
During the restructuring of the project settings pages, the fieldsets that where there in abundance where removed. This also removed the "select all | unselect all" section.

https://community.openproject.com/projects/openproject/work_packages/32116/activity 