### PR TITLE
add a log time button to the time logging widget

### DIFF
--- a/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.sass
+++ b/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.sass
@@ -90,3 +90,9 @@
     padding-right: 5px
     font-weight: bold
 
+.te-calendar--create-button
+  float: right
+  margin-right: 0
+  margin-top: 4px
+  height: 34px
+

--- a/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
@@ -83,6 +83,10 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
   protected memoizedTimeEntries:{start:Date, end:Date, entries:Promise<CollectionResource<TimeEntryResource>>};
   protected memoizedCreateAllowed:boolean = false;
 
+  public text = {
+    logTime: this.i18n.t('js.button_log_time')
+  };
+
   constructor(readonly states:States,
               readonly timeEntryDm:TimeEntryDmService,
               readonly $state:StateService,
@@ -309,6 +313,10 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
       .catch(() => {
         event.revert();
       });
+  }
+
+  public addEventToday() {
+    this.addEvent(moment(new Date()));
   }
 
   private addEvent(date:Moment) {

--- a/frontend/src/app/modules/calendar/te-calendar/te-calendar.template.html
+++ b/frontend/src/app/modules/calendar/te-calendar/te-calendar.template.html
@@ -2,6 +2,16 @@
 <div class="te-calendar--container loading-indicator--location"
      [attr.data-indicator-name]="'table'"
      style="position: relative">
+
+  <button class="button te-calendar--create-button"
+          [attr.aria-label]="text.logTime"
+          (click)="addEventToday()">
+    <op-icon icon-classes="button--icon icon-log_time"></op-icon>
+    <span class="button--text"
+          [textContent]="text.logTime"
+          aria-hidden="true"></span>
+  </button>
+
   <full-calendar #ucCalendar
                  [editable]="calendarEditable"
                  [eventLimit]="calendarEventLimit"


### PR DESCRIPTION
Unfortunately, fullcalendar does not support having icons and text on a button at the same time. Therefore the button is created outside of fullcalendar and then positioned to look as if it where part of it.

https://community.openproject.com/projects/openproject/work_packages/32128