### PR TITLE
do not fail pdf export on unpermitted image url

### DIFF
--- a/app/models/work_package/pdf_export/common.rb
+++ b/app/models/work_package/pdf_export/common.rb
@@ -66,6 +66,19 @@ module WorkPackage::PdfExport::Common
     @cell_padding ||= [2, 5, 2, 5]
   end
 
+  def configure_markup
+    # Do not attempt to fetch images.
+    # Fetching images can cause errors e.g. a 403 is returned when attempting to fetch from aws with
+    # a no longer valid token.
+    # Such an error would cause the whole export to error.
+    pdf.markup_options = {
+      image: {
+        loader: ->(_src) { nil },
+        placeholder: "<i>[#{I18n.t('export.image.omitted')}]</i>"
+      }
+    }
+  end
+
   ##
   # Writes the formatted work package description into the document.
   #

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -42,6 +42,11 @@ class WorkPackage::PdfExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
 
     self.pdf = get_pdf(current_language)
 
+    configure_page_size
+    configure_markup
+  end
+
+  def configure_page_size
     pdf.options[:page_size] = 'EXECUTIVE'
     pdf.options[:page_layout] = :landscape
   end
@@ -119,7 +124,7 @@ class WorkPackage::PdfExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
 
   def text_column?(column)
     column.is_a?(Queries::WorkPackages::Columns::CustomFieldColumn) &&
-      ['string', 'text'].include?(column.custom_field.field_format)
+      %w(string text).include?(column.custom_field.field_format)
   end
 
   def write_headers!

--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -38,6 +38,8 @@ class WorkPackage::PdfExport::WorkPackageToPdf < WorkPackage::Exporter::Base
     super
 
     self.pdf = get_pdf(current_language)
+
+    configure_markup
   end
 
   def render!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1141,6 +1141,8 @@ en:
       pdf_with_descriptions: "PDF with descriptions"
       pdf_with_descriptions_and_attachments: "PDF with descriptions and attachments"
       pdf_with_attachments: "PDF with attachments"
+    image:
+      omitted: "Image not exported."
 
   extraction:
     available:

--- a/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
@@ -107,12 +107,12 @@ module OpenProject::TextFormatting::Matchers
           anchor = $5
           link_to h("#{matcher.project_prefix}#{matcher.prefix}:#{oid}"),
                   named_route(:entry_revision_project_repository,
-                                   action: 'entry',
-                                   project_id: project.identifier,
-                                   repo_path: path.to_s,
-                                   rev: rev,
-                                   anchor: anchor,
-                                   format: (matcher.prefix == 'export' ? 'raw' : nil)),
+                              action: 'entry',
+                              project_id: project.identifier,
+                              repo_path: path.to_s,
+                              rev: rev,
+                              anchor: anchor,
+                              format: (matcher.prefix == 'export' ? 'raw' : nil)),
                   class: (matcher.prefix == 'export' ? 'source download' : 'source')
         end
       end


### PR DESCRIPTION
In case the description contains an image, prawn_markup attempts to download the image to embed it in the html turned pdf. But in case of errors, the gem does not seem to them thouroughly. E.g. a 403 when fetching the image, causes the whole export to fail. It might be worthwile to further invest in the area to display certain images, but for the time being, we simply do not fetch the images any longer.

A description contents for testing is e.g.: 
```
"![](https://openproject-edge-com-data.s3-eu-west-1.amazonaws.com/qa/attachment/file/479/test.jpg?X-Amz-Expires=600&X-Amz-Date=20180817T065159Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIEUPDBQ7SZPYD4TA/20180817/eu-west-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=0db134e1a52ae7d9a87c1e5c8fddc3ffb2f64f1de44da468df94a397e00b5d5d)"
```

https://community.openproject.com/projects/openproject/work_packages/32142