### PR TITLE
[32156] Use backlogs sorting of versions date for work packages

### DIFF
--- a/app/models/queries/columns/base.rb
+++ b/app/models/queries/columns/base.rb
@@ -36,6 +36,7 @@ class Queries::Columns::Base
   attr_accessor :name,
                 :sortable_join,
                 :summable,
+                :null_handling,
                 :default_order
 
   alias_method :summable?, :summable
@@ -48,6 +49,7 @@ class Queries::Columns::Base
        groupable
        summable
        association
+       null_handling
        default_order).each do |attribute|
       send("#{attribute}=", options[attribute])
     end

--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -73,23 +73,17 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
     },
     author: {
       association: 'author',
-      sortable: ["lastname",
-                 "firstname",
-                 "id"],
+      sortable: %w(lastname firstname id),
       groupable: "#{WorkPackage.table_name}.author_id"
     },
     assigned_to: {
       association: 'assigned_to',
-      sortable: ["lastname",
-                 "firstname",
-                 "id"],
+      sortable: %w(lastname firstname id),
       groupable: "#{WorkPackage.table_name}.assigned_to_id"
     },
     responsible: {
       association: 'responsible',
-      sortable: ["lastname",
-                 "firstname",
-                 "id"],
+      sortable: %w(lastname firstname id),
       groupable: "#{WorkPackage.table_name}.responsible_id"
     },
     updated_at: {
@@ -103,24 +97,19 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
     },
     fixed_version: {
       association: 'fixed_version',
-      sortable: ["name"],
-      default_order: 'desc',
+      sortable: %w(start_date effective_date),
+      default_order: 'DESC',
+      null_handling: 'NULLS LAST',
       groupable: "#{WorkPackage.table_name}.fixed_version_id"
     },
     start_date: {
-      # Put empty start_dates in the far future rather than in the far past
-      sortable: ["CASE WHEN #{WorkPackage.table_name}.start_date IS NULL
-                  THEN 1
-                  ELSE 0 END",
-                 "#{WorkPackage.table_name}.start_date"]
+      sortable: "#{WorkPackage.table_name}.start_date",
+      null_handling: 'NULLS LAST'
     },
     due_date: {
       highlightable: true,
-      # Put empty due_dates in the far future rather than in the far past
-      sortable: ["CASE WHEN #{WorkPackage.table_name}.due_date IS NULL
-                  THEN 1
-                  ELSE 0 END",
-                 "#{WorkPackage.table_name}.due_date"]
+      sortable: "#{WorkPackage.table_name}.due_date",
+      null_handling: 'NULLS LAST'
     },
     estimated_hours: {
       sortable: "#{WorkPackage.table_name}.estimated_hours",

--- a/app/models/queries/work_packages/filter/version_filter.rb
+++ b/app/models/queries/work_packages/filter/version_filter.rb
@@ -33,7 +33,7 @@ class Queries::WorkPackages::Filter::VersionFilter <
 
   def allowed_values
     @allowed_values ||= begin
-      versions.map { |s| ["#{s.project.name} - #{s.name}", s.id.to_s] }
+      versions.order_by_newest_date.map { |s| ["#{s.project.name} - #{s.name}", s.id.to_s] }
     end
   end
 

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -331,11 +331,13 @@ class Query < ActiveRecord::Base
       .map do |attribute, direction|
         attribute = attribute.to_sym
 
-        column = sortable_columns
-                 .detect { |candidate| candidate.name == attribute }
-
-        [column, direction]
+        [sort_criteria_column(attribute), direction]
       end
+  end
+
+  def sort_criteria_column(attribute)
+    sortable_columns
+      .detect { |candidate| candidate.name == attribute }
   end
 
   def sorted?

--- a/app/models/query/group_by.rb
+++ b/app/models/query/group_by.rb
@@ -176,6 +176,12 @@ module ::Query::Grouping
   # IF it occurs in the sort criteria
   def order_for_group_by(column)
     sort_entry = query.sort_criteria.detect { |column, _dir| column == query.group_by }
-    sort_entry&.last || column.default_order
+    order = sort_entry&.last || column.default_order
+
+    if column.null_handling
+      "#{order} #{column.null_handling}"
+    else
+      order
+    end
   end
 end

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -142,7 +142,7 @@ class ::Query::Results
   end
 
   def sort_criteria_array
-    criteria = SortHelper::SortCriteria.new
+    criteria = ::Query::SortCriteria.new query.sortable_columns
     criteria.available_criteria = aliased_sorting_by_column_name
     criteria.criteria = query.sort_criteria
     criteria.map_each { |criteria| criteria.map { |raw| Arel.sql raw } }

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -29,6 +29,10 @@
 #++
 
 class Version < ActiveRecord::Base
+  default_scope do
+    order Arel.sql("#{Version.table_name}.start_date DESC NULLS LAST,
+                    #{Version.table_name}.effective_date DESC NULLS LAST")
+  end
   include Version::ProjectSharing
 
   belongs_to :project

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -29,10 +29,6 @@
 #++
 
 class Version < ActiveRecord::Base
-  default_scope do
-    order Arel.sql("#{Version.table_name}.start_date DESC NULLS LAST,
-                    #{Version.table_name}.effective_date DESC NULLS LAST")
-  end
   include Version::ProjectSharing
 
   belongs_to :project
@@ -61,6 +57,11 @@ class Version < ActiveRecord::Base
   scope :systemwide, -> { where(sharing: 'system') }
 
   scope :order_by_name, -> { order(Arel.sql("LOWER(#{Version.table_name}.name)")) }
+
+  scope :order_by_newest_date, -> {
+    reorder Arel.sql("#{Version.table_name}.start_date DESC NULLS LAST,
+                    #{Version.table_name}.effective_date DESC NULLS LAST")
+  }
 
   def self.with_status_open
     where(status: 'open')

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -265,7 +265,7 @@ class WorkPackage < ActiveRecord::Base
   def assignable_versions
     @assignable_versions ||= begin
       current_version = fixed_version_id_changed? ? Version.find_by(id: fixed_version_id_was) : fixed_version
-      ((project&.assignable_versions || []) + [current_version]).compact.uniq.sort
+      ((project&.assignable_versions || []) + [current_version]).compact.uniq
     end
   end
 

--- a/app/views/project_settings/versions.html.erb
+++ b/app/views/project_settings/versions.html.erb
@@ -124,7 +124,7 @@ See docs/COPYRIGHT.rdoc for more details.
           </tr>
         </thead>
         <tbody>
-          <% for version in @project.shared_versions.sort %>
+        <% @project.shared_versions.order_by_newest_date.each do |version| %>
             <tr class="version <%= 'shared' if version.project != @project %>">
               <td class="name <%=h version.status %><%= ' icon-context icon-link' if version.project != @project %>">
                 <%= link_to_version version %>

--- a/modules/backlogs/app/models/sprint.rb
+++ b/modules/backlogs/app/models/sprint.rb
@@ -31,12 +31,12 @@ require 'date'
 class Sprint < Version
   scope :open_sprints, lambda { |project|
     where(["versions.status = 'open' and versions.project_id = ?", project.id])
-      .order(Arel.sql("COALESCE(start_date, CAST('4000-12-30' as date)) ASC, COALESCE(effective_date, CAST('4000-12-30' as date)) ASC"))
+      .order_by_date
   }
 
   # null last ordering
   scope :order_by_date, -> {
-    order Arel.sql("COALESCE(start_date, CAST('4000-12-30' as date)) ASC, COALESCE(effective_date, CAST('4000-12-30' as date)) ASC")
+    reorder(Arel.sql("start_date ASC NULLS LAST, effective_date ASC NULLS LAST"))
   }
   scope :order_by_name, -> {
     order Arel.sql("#{Version.table_name}.name ASC")

--- a/modules/backlogs/app/views/project_settings/versions.html.erb
+++ b/modules/backlogs/app/views/project_settings/versions.html.erb
@@ -123,7 +123,7 @@ See docs/COPYRIGHT.rdoc for more details.
           </tr>
         </thead>
         <tbody>
-          <% for version in @project.shared_versions.sort %>
+          <% @project.shared_versions.order_by_newest_date.each do |version| %>
             <tr class="version <%= 'shared' if version.project != @project %>">
               <td class="name <%=h version.status %><%= ' icon-context icon-link' if version.project != @project %>">
                 <%= link_to_version version %>

--- a/modules/backlogs/spec/models/sprint_spec.rb
+++ b/modules/backlogs/spec/models/sprint_spec.rb
@@ -200,9 +200,12 @@ describe Sprint, type: :model do
         @sprint3 = FactoryBot.create(:sprint, name: 'sprint3', project: project, start_date: Date.today + 1.day, effective_date: Date.today + 2.days)
       end
 
-      it { expect(Sprint.order_by_date[0]).to eql @sprint3 }
-      it { expect(Sprint.order_by_date[1]).to eql @sprint2 }
-      it { expect(Sprint.order_by_date[2]).to eql @sprint1 }
+      it 'sorts the dates correctly', :aggregate_failures do
+        expect(Sprint.order_by_date[0]).to eql @sprint3
+        expect(Sprint.order_by_date[1]).to eql @sprint2
+        expect(Sprint.order_by_date[2]).to eql @sprint1
+      end
+
     end
 
     describe '#apply_to' do

--- a/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
+++ b/spec/features/work_packages/details/inplace_editor/version_editor_spec.rb
@@ -11,20 +11,29 @@ describe 'subject inplace editor', js: true, selenium: true do
 
   let!(:version) do
     FactoryBot.create(:version,
+                      name: 'Old version',
                       status: 'open',
                       sharing: 'tree',
+                      start_date: '2019-02-02',
+                      effective_date: '2019-02-03',
                       project: project)
   end
   let!(:version2) do
     FactoryBot.create(:version,
                       status: 'open',
                       sharing: 'tree',
+                      name: 'New version',
+                      start_date: '2020-02-02',
+                      effective_date: '2020-02-03',
                       project: subproject1)
   end
   let!(:version3) do
     FactoryBot.create(:version,
                       status: 'open',
                       sharing: 'tree',
+                      start_date: nil,
+                      effective_date: nil,
+                      name: 'No date version',
                       project: subproject2)
   end
 
@@ -59,6 +68,10 @@ describe 'subject inplace editor', js: true, selenium: true do
       expect(page).to have_selector('.ng-option-label', text: version3.name)
       expect(page).to have_selector('.ng-option-label', text: version2.name)
       expect(page).to have_selector('.ng-option-label', text: version.name)
+
+      # Expect the order to be descending by version date
+      labels = page.all('.ng-option-label').map { |el| el.text.strip }
+      expect(labels).to eq ['-', 'New version', 'Old version', 'No date version']
 
       page.find('.ng-option-label', text: version3.name).select_option
       field.expect_state_text(version3.name)

--- a/spec/models/queries/work_packages/filter/version_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/version_filter_spec.rb
@@ -40,11 +40,11 @@ describe Queries::WorkPackages::Filter::VersionFilter, type: :model do
     before do
       if project
         allow(project)
-          .to receive_message_chain(:shared_versions)
+          .to receive_message_chain(:shared_versions, :order_by_newest_date)
           .and_return [version]
       else
         allow(Version)
-          .to receive_message_chain(:visible, :systemwide)
+          .to receive_message_chain(:visible, :systemwide, :order_by_newest_date)
           .and_return [version]
       end
     end
@@ -57,7 +57,7 @@ describe Queries::WorkPackages::Filter::VersionFilter, type: :model do
 
         it 'is false if the value does not exist as a version' do
           allow(project)
-            .to receive_message_chain(:shared_versions)
+            .to receive_message_chain(:shared_versions, :order_by_newest_date)
             .and_return []
 
           expect(instance).to_not be_valid
@@ -73,7 +73,7 @@ describe Queries::WorkPackages::Filter::VersionFilter, type: :model do
 
         it 'is false if the value does not exist as a version' do
           allow(Version)
-            .to receive_message_chain(:visible, :systemwide)
+            .to receive_message_chain(:visible, :systemwide, :order_by_newest_date)
             .and_return []
 
           expect(instance).to_not be_valid

--- a/spec/models/query/results_version_integration_spec.rb
+++ b/spec/models/query/results_version_integration_spec.rb
@@ -1,0 +1,139 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::Query::Results, 'Grouping and sorting for version', type: :model, with_mail: false do
+  let(:query_results) do
+    ::Query::Results.new query
+  end
+  let(:project_1) { FactoryBot.create :project }
+  let(:role_dev) do
+    FactoryBot.create(:role,
+                      permissions: [:view_work_packages])
+  end
+  let(:user_1) do
+    FactoryBot.create(:user,
+                      firstname: 'user',
+                      lastname: '1',
+                      member_in_project: project_1,
+                      member_through_role: [role_dev])
+  end
+
+  let(:old_version) do
+    FactoryBot.create(:version, name: 'Old version',
+                      project: project_1,
+                      start_date: '2019-02-02',
+                      effective_date: '2019-02-03')
+  end
+
+  let(:new_version) do
+    FactoryBot.create(:version,
+                      name: 'New version',
+                      project: project_1,
+                      start_date: '2020-02-02',
+                      effective_date: '2020-02-03')
+  end
+
+  let(:no_date_version) do
+    FactoryBot.create(:version,
+                      name: 'No date',
+                      project: project_1,
+                      start_date: nil,
+                      effective_date: nil)
+  end
+
+
+  let!(:oldest_version_wp) do
+    FactoryBot.create(:work_package,
+                      fixed_version: old_version,
+                      project: project_1)
+  end
+  let!(:newest_version_wp) do
+    FactoryBot.create(:work_package,
+                      fixed_version: new_version,
+                      project: project_1)
+  end
+  let!(:no_date_version_wp) do
+    FactoryBot.create(:work_package,
+                      fixed_version: no_date_version,
+                      project: project_1)
+  end
+
+  before do
+    login_as(user_1)
+  end
+
+  describe 'grouping by fixed_version' do
+    let(:query) do
+      FactoryBot.build :query,
+                       show_hierarchies: false,
+                       group_by: 'fixed_version',
+                       project: project_1
+    end
+
+
+    it 'returns the correct sorted grouped result' do
+      expect(query_results.work_package_count_by_group)
+        .to eql(old_version => 1, new_version => 1, no_date_version => 1)
+
+      expect(query_results.sorted_work_packages)
+        .to match [newest_version_wp, oldest_version_wp, no_date_version_wp]
+    end
+  end
+
+  describe 'sorting ASC by version' do
+    let(:query) do
+      query = FactoryBot.build(:query, user: user_1, project: project_1)
+
+      query.filters.clear
+      query.sort_criteria = [['fixed_version', 'asc']]
+      query
+    end
+
+    it 'returns the correct sorted result' do
+      expect(query_results.sorted_work_packages.pluck(:id))
+        .to match [oldest_version_wp, newest_version_wp, no_date_version_wp].map(&:id)
+    end
+  end
+
+  describe 'sorting ASC by version' do
+    let(:query) do
+      query = FactoryBot.build(:query, user: user_1, project: project_1)
+
+      query.filters.clear
+      query.sort_criteria = [['fixed_version', 'desc']]
+      query
+    end
+
+    it 'returns the correct sorted result' do
+      expect(query_results.sorted_work_packages.pluck(:id))
+        .to match [newest_version_wp, oldest_version_wp, no_date_version_wp].map(&:id)
+    end
+  end
+end

--- a/spec/models/query/sort_criteria_spec.rb
+++ b/spec/models/query/sort_criteria_spec.rb
@@ -1,0 +1,85 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::Query::SortCriteria, type: :model, with_mail: false do
+  let(:query) do
+    FactoryBot.build :query,
+                     show_hierarchies: false
+  end
+
+  let(:available_criteria) { query.sortable_key_by_column_name }
+
+  let(:instance) { described_class.new query.sortable_columns }
+  subject { instance.to_a }
+
+  before do
+    instance.criteria = sort_criteria
+    instance.available_criteria = available_criteria
+  end
+
+  describe 'ordered handling' do
+    context 'with sort_criteria with order handling and no order statement' do
+      let(:sort_criteria) { [['start_date']] }
+
+      it 'adds the order handling' do
+        expect(subject.length).to eq 1
+        expect(subject.first).to eq ['work_packages.start_date NULLS LAST']
+      end
+    end
+
+    context 'with sort_criteria with order handling and ASC order statement' do
+      let(:sort_criteria) { [['start_date', 'asc']] }
+
+      it 'adds the order handling' do
+        expect(subject.length).to eq 1
+        expect(subject.first).to eq ['work_packages.start_date NULLS LAST']
+      end
+    end
+
+    context 'with sort_criteria with order handling and DESC order statement' do
+      let(:sort_criteria) { [['start_date', 'desc']] }
+
+      it 'adds the order handling' do
+        expect(subject.length).to eq 1
+        expect(subject.first).to eq ['work_packages.start_date DESC NULLS LAST']
+      end
+    end
+
+    context 'with multiple sort_criteria with order handling and misc order statement' do
+      let(:sort_criteria) { [['fixed_version', 'desc'], ['start_date', 'asc']] }
+
+      it 'adds the order handling' do
+        expect(subject.length).to eq 2
+        expect(subject.first).to eq ['start_date DESC NULLS LAST', 'effective_date DESC NULLS LAST']
+        expect(subject.last).to eq ['work_packages.start_date NULLS LAST']
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Adds a null_handling option to the property columns to allow `NULLS FIRST/LAST` to be handled
- Adds a query specific SortCriteria that can work with null_handling 
- Fixes sorting of allowed_versions to reuse that sort order

https://community.openproject.com/wp/32156