### PR TITLE
Fix/filters inline label

### DIFF
--- a/app/assets/stylesheets/content/_advanced_filters.sass
+++ b/app/assets/stylesheets/content/_advanced_filters.sass
@@ -60,7 +60,7 @@ $advanced-filters--grid-gap: 10px
     // Filters will not span the whole width,
     // but have an orientation to the left side
     grid-template-columns: $advanced-filters--label-size $advanced-filters--operator-size $advanced-filters--values-size $advanced-filters--close-icon-size
-    grid-grap: $advanced-filters--grid-gap
+    grid-gap: $advanced-filters--grid-gap
     align-items: center
     margin-bottom: 10px
 

--- a/app/assets/stylesheets/vendor/foundation-apps/scss/components/_forms.scss
+++ b/app/assets/stylesheets/vendor/foundation-apps/scss/components/_forms.scss
@@ -180,7 +180,7 @@ input[type="checkbox"], input[type="radio"] {
 
   // Inputs stretch all the way out
   > input, > select {
-    flex: 1;
+    flex: 1 1 auto;
     margin: 0;
   }
 


### PR DESCRIPTION
Firefox seems to need the explicit `flex-basis: auto` to take the container's width into account. I don't fully understand why as the `flex-shrink: 1` should have already enabled it to scale down if not enough space is available.

https://community.openproject.com/projects/openproject/work_packages/32135 