### PR TITLE
[32118] Correctly pass highlighted attributes to query backend

### DIFF
--- a/frontend/src/app/components/wp-query/url-params-helper.spec.ts
+++ b/frontend/src/app/components/wp-query/url-params-helper.spec.ts
@@ -193,6 +193,7 @@ describe('UrlParamsHelper', function() {
         timelineZoomLevel: 0,
         timelineLabels: { left: 'foo', right: 'bar', farRight: 'asdf' },
         highlightingMode: 'inline',
+        highlightedAttributes: [{href: 'a'}, {href: 'b'}],
         sums: true,
         columns: [{ id: 'type' }, { id: 'status' }, { id: 'soße' }],
         groupBy: {
@@ -238,6 +239,7 @@ describe('UrlParamsHelper', function() {
         timelineVisible: false,
         showHierarchies: false,
         highlightingMode: 'inline',
+        'highlightedAttributes[]': ['a', 'b'],
         offset: 10,
         pageSize: 100
       };

--- a/frontend/src/app/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/components/wp-query/url-params-helper.ts
@@ -263,7 +263,7 @@ export class UrlParamsHelperService {
     }
 
     if (query.highlightedAttributes && query.highlightingMode === 'inline') {
-      queryData.highlightedAttributes = query.highlightedAttributes.map(el => el.href);
+      queryData['highlightedAttributes[]'] = query.highlightedAttributes.map(el => el.href);
     }
 
     if (query.displayRepresentation) {


### PR DESCRIPTION
When using params without `[]` suffix, only the last param is parsed by Rails/Grape. Then the returned query only has one highlighted attribute and the queryProps correctly change

https://community.openproject.com/wp/32118