### PR TITLE
remove currency separator duplicity

### DIFF
--- a/modules/costs/app/controllers/cost_objects_controller.rb
+++ b/modules/costs/app/controllers/cost_objects_controller.rb
@@ -196,7 +196,7 @@ class CostObjectsController < ApplicationController
     cost_type = CostType.where(id: params[:cost_type_id]).first
 
     if cost_type && params[:units].present?
-      volume = BigDecimal(Rate.clean_currency(params[:units])) rescue 0.0
+      volume = Rate.parse_number_string_to_number(params[:units])
       @costs = (volume * cost_type.rate_at(params[:fixed_date]).rate rescue 0.0)
       @unit = volume == 1.0 ? cost_type.unit : cost_type.unit_plural
     else

--- a/modules/costs/app/controllers/cost_types_controller.rb
+++ b/modules/costs/app/controllers/cost_types_controller.rb
@@ -129,7 +129,7 @@ class CostTypesController < ApplicationController
       cr.valid_from = today
     end
 
-    rate.rate = clean_currency(params[:rate])
+    rate.rate = parse_number_string_to_number(params[:rate])
     if rate.save
       flash[:notice] = t(:notice_successful_update)
       redirect_to action: 'index'

--- a/modules/costs/app/controllers/hourly_rates_controller.rb
+++ b/modules/costs/app/controllers/hourly_rates_controller.rb
@@ -134,7 +134,7 @@ class HourlyRatesController < ApplicationController
       hr.project    = @project
       hr.user       = @user
       hr.valid_from = today
-      hr.rate = clean_currency(params[:rate])
+      hr.rate = parse_number_string_to_number(params[:rate])
     end
 
     if rate.save

--- a/modules/costs/app/helpers/costlog_helper.rb
+++ b/modules/costs/app/helpers/costlog_helper.rb
@@ -51,19 +51,4 @@ module CostlogHelper
     done = 100.0 - ((100.0 / pcts) * 100).round
     progress_bar([closed, done], options)
   end
-
-  def clean_currency(value)
-    return nil if value.nil? || value == ''
-
-    value = value.strip
-    value.gsub!(t(:currency_delimiter), '') if value.include?(t(:currency_delimiter)) && value.include?(t(:currency_separator))
-    value.gsub(',', '.')
-    BigDecimal(value)
-  end
-
-  def to_currency_with_empty(rate)
-    rate.nil? ?
-      '0.0' :
-      number_to_currency(rate.rate)
-  end
 end

--- a/modules/costs/app/models/cost_entry.rb
+++ b/modules/costs/app/models/cost_entry.rb
@@ -82,11 +82,11 @@ class CostEntry < ActiveRecord::Base
   end
 
   def overwritten_costs=(costs)
-    write_attribute(:overwritten_costs, CostRate.clean_currency(costs))
+    write_attribute(:overwritten_costs, CostRate.parse_number_string_to_number(costs))
   end
 
   def units=(units)
-    write_attribute(:units, CostRate.clean_currency(units))
+    write_attribute(:units, CostRate.parse_number_string(units))
   end
 
   # tyear, tmonth, tweek assigned where setting spent_on attributes

--- a/modules/costs/app/models/cost_type.rb
+++ b/modules/costs/app/models/cost_type.rb
@@ -73,7 +73,7 @@ class CostType < ActiveRecord::Base
 
   def new_rate_attributes=(rate_attributes)
     rate_attributes.each do |_index, attributes|
-      attributes[:rate] = Rate.clean_currency(attributes[:rate])
+      attributes[:rate] = Rate.parse_number_string(attributes[:rate])
       rates.build(attributes)
     end
   end
@@ -84,7 +84,7 @@ class CostType < ActiveRecord::Base
 
       has_rate = false
       if attributes && attributes[:rate].present?
-        attributes[:rate] = Rate.clean_currency(attributes[:rate])
+        attributes[:rate] = Rate.parse_number_string(attributes[:rate])
         has_rate = true
       end
 

--- a/modules/costs/app/models/variable_cost_object.rb
+++ b/modules/costs/app/models/variable_cost_object.rb
@@ -112,7 +112,7 @@ class VariableCostObject < CostObject
 
       if User.current.allowed_to? :edit_cost_objects, material_budget_item.cost_object.project
         if attributes && attributes[:units].to_i > 0
-          attributes[:budget] = Rate.clean_currency(attributes[:budget])
+          attributes[:budget] = Rate.parse_number_string(attributes[:budget])
           material_budget_item.attributes = attributes
         else
           material_budget_items.delete(material_budget_item)
@@ -144,7 +144,7 @@ class VariableCostObject < CostObject
       attributes = labor_budget_item_attributes[labor_budget_item.id.to_s]
       if User.current.allowed_to? :edit_cost_objects, labor_budget_item.cost_object.project
         if attributes && attributes[:hours].to_i > 0 && attributes[:user_id].to_i > 0 && project.possible_assignees.map(&:id).include?(attributes[:user_id].to_i)
-          attributes[:budget] = Rate.clean_currency(attributes[:budget])
+          attributes[:budget] = Rate.parse_number_string(attributes[:budget])
           labor_budget_item.attributes = attributes
         else
           labor_budget_items.delete(labor_budget_item)

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -113,9 +113,6 @@ en:
   caption_set_rate: "Set current rate"
   caption_show_locked: "Show locked types"
   cost_objects_title: "Budgets"
-  label_cost_type_plural: "Cost types"
-  currency_delimiter: ","
-  currency_separator: "."
 
   description_date_for_new_rate: "Date for new rate"
 

--- a/modules/costs/lib/open_project/costs/patches/user_patch.rb
+++ b/modules/costs/lib/open_project/costs/patches/user_patch.rb
@@ -74,7 +74,7 @@ module OpenProject::Costs::Patches::UserPatch
       return unless rate_attributes
 
       rate_attributes.each do |_index, attributes|
-        attributes[:rate] = Rate.clean_currency(attributes[:rate])
+        attributes[:rate] = Rate.parse_number_string(attributes[:rate])
 
         if project.nil?
           default_rates.build(attributes)
@@ -107,7 +107,7 @@ module OpenProject::Costs::Patches::UserPatch
 
     def update_rate(rate, attributes, project_rate = true)
       if attributes && attributes[:rate].present?
-        attributes[:rate] = Rate.clean_currency(attributes[:rate])
+        attributes[:rate] = Rate.parse_number_string(attributes[:rate])
         rate.attributes = attributes
       else
         # TODO: this is surprising

--- a/modules/costs/spec/helpers/costs/number_helper_spec.rb
+++ b/modules/costs/spec/helpers/costs/number_helper_spec.rb
@@ -1,0 +1,142 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require File.dirname(__FILE__) + '/../../spec_helper'
+
+describe Costs::NumberHelper, type: :helper do
+  describe '#parse_number_string' do
+    context 'for a german local' do
+      it 'parses a string with delimiter and separator correctly' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("123.456,78"))
+            .to eql "123456.78"
+        end
+      end
+
+      it 'parses a string with space delimiter and separator correctly' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("123 456,78"))
+            .to eql "123456.78"
+        end
+      end
+
+      it 'parses a string without delimiter and separator correctly' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("12345678"))
+            .to eql "12345678"
+        end
+      end
+
+      it 'parses a string without delimiter and with separator correctly' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("123456,78"))
+            .to eql "123456.78"
+        end
+      end
+
+      it 'parses a string with delimiter and without separator correctly' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("12.345.678"))
+            .to eql "12345678"
+        end
+      end
+
+      it 'parses a string with space delimiter and without separator correctly' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("12 345 678"))
+            .to eql "12345678"
+        end
+      end
+
+      it 'returns alphabetical values instead of a delimiter unchanged' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("123456a78"))
+            .to eql "123456a78"
+        end
+      end
+    end
+
+    context 'for an english local' do
+      it 'parses a string with delimiter and separator correctly' do
+        I18n.with_locale(:en) do
+          expect(helper.parse_number_string("123,456.78"))
+            .to eql "123456.78"
+        end
+      end
+
+      it 'parses a string with space delimiter and separator correctly' do
+        I18n.with_locale(:en) do
+          expect(helper.parse_number_string("123 456.78"))
+            .to eql "123456.78"
+        end
+      end
+
+      it 'parses a string without delimiter and separator correctly' do
+        I18n.with_locale(:en) do
+          expect(helper.parse_number_string("12345678"))
+            .to eql "12345678"
+        end
+      end
+
+      it 'parses a string without delimiter and with separator correctly' do
+        I18n.with_locale(:en) do
+          expect(helper.parse_number_string("123456.78"))
+            .to eql "123456.78"
+        end
+      end
+
+      it 'parses a string with delimiter and without separator correctly' do
+        I18n.with_locale(:en) do
+          expect(helper.parse_number_string("12,345,678"))
+            .to eql "12345678"
+        end
+      end
+
+      it 'parses a string with space delimiter and without separator correctly' do
+        I18n.with_locale(:en) do
+          expect(helper.parse_number_string("12 345 678"))
+            .to eql "12345678"
+        end
+      end
+
+      it 'returns alphabetical values instead of a delimiter unchanged' do
+        I18n.with_locale(:en) do
+          expect(helper.parse_number_string("123456a78"))
+            .to eql "123456a78"
+        end
+      end
+    end
+
+    context 'for nil' do
+      it 'is nil' do
+        expect(helper.parse_number_string(nil))
+          .to be_nil
+      end
+    end
+  end
+end

--- a/modules/reporting_engine/lib/report/operator.rb
+++ b/modules/reporting_engine/lib/report/operator.rb
@@ -175,7 +175,7 @@ class Report::Operator
 
     new '=n', label: :label_equals do
       def modify(query, field, value)
-        query.where "#{field} = #{clean_currency(value)}"
+        query.where "#{field} = #{parse_number_string(value)}"
         query
       end
     end

--- a/modules/reporting_engine/lib/report/query_utils.rb
+++ b/modules/reporting_engine/lib/report/query_utils.rb
@@ -35,6 +35,8 @@ module Report::QueryUtils
   delegate :quoted_false, :quoted_true, to: 'engine.reporting_connection'
   attr_writer :engine
 
+  include Costs::NumberHelper
+
   module PropagationHook
     include Report::QueryUtils
 
@@ -166,17 +168,6 @@ module Report::QueryUtils
   # @return [String] Sanitized statement.
   def sanitize_sql_for_conditions(statement)
     engine.send :sanitize_sql_for_conditions, statement
-  end
-
-  ##
-  # FIXME: This is redmine
-  # Generates string representation for a currency.
-  #
-  # @see CostRate.clean_currency
-  # @param [BigDecimal] value
-  # @return [String]
-  def clean_currency(value)
-    CostRate.clean_currency(value).to_f.to_s
   end
 
   ##


### PR DESCRIPTION
I18n already defines keys for number delimitors and separators. They are also to be used for currencies.