### PR TITLE
no backlogs settings menu if backlogs is disabled

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -371,6 +371,7 @@ Redmine::MenuManager.map :project_menu do |menu|
     menu.push :"settings_#{node[:name]}",
               node[:action],
               caption: node[:label],
-              parent: :settings
+              parent: :settings,
+              if: node[:if]
   end
 end

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -65,7 +65,6 @@ module OpenProject::Backlogs
         edit.actions << 'rb_impediments/update'
       end
 
-
       project_module :backlogs do
         # SYNTAX: permission :name_of_permission, { :controller_name => [:action1, :action2] }
 

--- a/modules/backlogs/lib/open_project/backlogs/patches/project_settings_helper_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/project_settings_helper_patch.rb
@@ -38,7 +38,8 @@ module OpenProject::Backlogs::Patches::ProjectSettingsHelperPatch
           settings << {
             name: :backlogs,
             action: { controller: '/backlogs_settings', action: 'show' },
-            label: :'backlogs.backlog_settings'
+            label: :'backlogs.backlog_settings',
+            if: ->(p) { p.module_enabled?('backlogs') }
           }
         end
       end


### PR DESCRIPTION
Relying on the permissions does not work here as backlogs_settings is tied to the edit_project permission which will always be present in the project (if the user has it).

https://community.openproject.com/projects/openproject/work_packages/32184