### PR TITLE
Use text pattern for float number fields

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -458,6 +458,7 @@ en:
       subject: 'Enter subject here'
       selection: 'Please select'
       relation_description: 'Click to add description for this relation'
+      float: 'Enter decimal number'
 
     project:
       required_outside_context: >


### PR DESCRIPTION
The number pattern doesnt correctly respect the lang field in all browsers it appears. Using text field with custom parsing/formatters with validations for the numbers, we can avoid the number field.

We however need to listen for keydown events to emulate a number field and disable inputting any other fields. This will probably break for some keys.

https://community.openproject.com/projects/openproject/work_packages/details/32232