### PR TITLE
[32141] OpenProject logo in light theme is hard to see

### DIFF
--- a/app/controllers/custom_styles_controller.rb
+++ b/app/controllers/custom_styles_controller.rb
@@ -96,8 +96,12 @@ class CustomStylesController < ApplicationController
   end
 
   def update_themes
-    variable_params = OpenProject::CustomStyles::ColorThemes::THEMES.find { |theme| theme[:name] == params[:theme] }[:colors]
-    set_colors(variable_params)
+    theme = OpenProject::CustomStyles::ColorThemes::THEMES.find { |t| t[:name] == params[:theme] }
+    color_params = theme[:colors]
+    logo = theme[:logo]
+
+    set_logo(logo)
+    set_colors(color_params)
     set_theme(params)
 
     redirect_to action: :show
@@ -114,6 +118,10 @@ class CustomStylesController < ApplicationController
     options << [t('admin.custom_styles.color_theme_custom'), '', disabled: true] if @current_theme.empty?
 
     options
+  end
+
+  def set_logo(logo)
+    CustomStyle.current.update(theme_logo: logo)
   end
 
   def set_colors(variable_params)

--- a/app/views/custom_styles/_inline_css.erb
+++ b/app/views/custom_styles/_inline_css.erb
@@ -32,6 +32,10 @@ See docs/COPYRIGHT.rdoc for more details.
     #logo .home-link {
       background-image: url("<%= custom_style_logo_path(digest: CustomStyle.current.digest, filename: CustomStyle.current.logo_identifier) %>");
     }
+  <% elsif CustomStyle.current.theme_logo %>
+    #logo .home-link {
+      background-image: url("<%= asset_path(CustomStyle.current.theme_logo) %>");
+    }
   <% end %>
 
   :root {

--- a/db/migrate/20200206101135_add_theme_logo_to_custom_style.rb
+++ b/db/migrate/20200206101135_add_theme_logo_to_custom_style.rb
@@ -1,0 +1,5 @@
+class AddThemeLogoToCustomStyle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :custom_styles, :theme_logo, :string, default: nil
+  end
+end

--- a/lib/open_project/custom_styles/color_themes.rb
+++ b/lib/open_project/custom_styles/color_themes.rb
@@ -70,7 +70,8 @@ module OpenProject::CustomStyles
           'main-menu-hover-font-color'                           => "#000000",
           'main-menu-selected-font-color'                        => "#000000",
           'main-menu-border-color'                               => "#EAEAEA"
-        }
+        },
+        logo:                                                   'logo_openproject.png'
       },
       {
         name:                                                   'OpenProject Dark',


### PR DESCRIPTION
Allow themes to define a logo (dark vs. light) which is only shown when there is no custom logo defined.

https://community.openproject.com/projects/openproject/work_packages/32141/activity