### PR TITLE
[32179] Reload list when deleting work package

### DIFF
--- a/frontend/src/app/components/modals/wp-destroy-modal/wp-destroy.modal.ts
+++ b/frontend/src/app/components/modals/wp-destroy-modal/wp-destroy.modal.ts
@@ -144,7 +144,7 @@ export class WpDestroyModal extends OpModalComponent implements OnInit {
          * since the WP in view (split/full) does not exist any more.
          */
         if (this.$state.current.name !== 'work-packages.list') {
-          this.backRoutingService.goBack(true);
+          this.backRoutingService.goBack(true, { reload: true });
         }
       })
       .catch(() => {

--- a/frontend/src/app/modules/common/back-routing/back-routing.service.ts
+++ b/frontend/src/app/modules/common/back-routing/back-routing.service.ts
@@ -29,6 +29,7 @@
 import {Injectable, Injector} from '@angular/core';
 import {StateService, Transition} from "@uirouter/core";
 import {KeepTabService} from "core-components/wp-single-view-tabs/keep-tab/keep-tab.service";
+import {TransitionOptions} from "@uirouter/core/lib/transition/interface";
 
 interface BackRouteOptions {
   name:string;
@@ -45,20 +46,20 @@ export class BackRoutingService {
   constructor(protected injector:Injector) {
   }
 
-  public goBack(preferListOverSplit:boolean = false) {
+  public goBack(preferListOverSplit:boolean = false, opts:Partial<TransitionOptions> = {}) {
     // Default: back to list
     // When coming from a deep link or a create form
     if (!this.backRoute || this.backRoute.name.includes('new')) {
-      this.$state.go('work-packages.list', this.$state.params);
+      this.$state.go('work-packages.list', this.$state.params, opts);
     } else {
       if (this.keepTab.isDetailsState(this.backRoute.parent)) {
-        if(preferListOverSplit) {
-          this.$state.go('work-packages.list', this.$state.params);
+        if (preferListOverSplit) {
+          this.$state.go('work-packages.list', this.$state.params, opts);
         } else {
-          this.$state.go(this.keepTab.currentDetailsState, this.$state.params);
+          this.$state.go(this.keepTab.currentDetailsState, this.$state.params, opts);
         }
       } else {
-        this.$state.go(this.backRoute.name, this.backRoute.params);
+        this.$state.go(this.backRoute.name, this.backRoute.params, opts);
       }
     }
   }


### PR DESCRIPTION
We have the halEventsService to notify other (active!) views about changes to resources such
as deletion.

However in the full view, the list view is destroyed and does not listen to these changes, thus going back to the list after deletion with a loaded query does nothing currently and renders the old list.

The easiest solution for this is to simply reload the list in this case through ui-router.

https://community.openproject.com/wp/32179