### PR TITLE
[32180] Fix invalid version diff number

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -211,8 +211,7 @@ class UserMailer < BaseMailer
                              action:     :diff,
                              project_id: wiki_content.project,
                              id:         wiki_content.page.slug,
-                             # using wiki_content.version + 1 because at this point the journal is not saved yet
-                             version:    wiki_content.version + 1)
+                             version:    wiki_content.version)
 
     open_project_headers 'Project'      => @wiki_content.project.identifier,
                          'Wiki-Page-Id' => @wiki_content.page.id,

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -174,7 +174,7 @@ describe UserMailer, type: :mailer do
     it_behaves_like 'mail is sent'
 
     it 'should link to the latest version diff page' do
-      expect(ActionMailer::Base.deliveries.first.body.encoded).to include 'diff/2'
+      expect(ActionMailer::Base.deliveries.first.body.encoded).to include 'diff/1'
     end
 
     it_behaves_like 'does only send mails to author if permitted'


### PR DESCRIPTION
The version number is no longer incorrect in the mailer since we delay them

https://community.openproject.com/wp/32180