### PR TITLE
[32190] Switch filter requires/required for queries

### DIFF
--- a/app/models/queries/work_packages/filter/required_filter.rb
+++ b/app/models/queries/work_packages/filter/required_filter.rb
@@ -42,10 +42,10 @@ class Queries::WorkPackages::Filter::RequiredFilter <
   private
 
   def relation_filter
-    { to_id: values }
+    { from_id: values }
   end
 
   def relation_select
-    :from_id
+    :to_id
   end
 end

--- a/app/models/queries/work_packages/filter/requires_filter.rb
+++ b/app/models/queries/work_packages/filter/requires_filter.rb
@@ -42,10 +42,10 @@ class Queries::WorkPackages::Filter::RequiresFilter <
   private
 
   def relation_filter
-    { from_id: values }
+    { to_id: values }
   end
 
   def relation_select
-    :to_id
+    :from_id
   end
 end

--- a/frontend/src/app/components/wp-relations/wp-relations.service.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations.service.ts
@@ -128,6 +128,7 @@ export class WorkPackageRelationsService extends StateCacheService<RelationsStat
       },
       type: relationType
     };
+
     const path = this.PathHelper.api.v3.work_packages.id(fromId).relations.toString();
     return this.halResource
       .post<RelationResource>(path, params)

--- a/spec/models/queries/work_packages/filter/required_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/required_filter_spec.rb
@@ -33,7 +33,7 @@ describe Queries::WorkPackages::Filter::RequiredFilter, type: :model do
     let(:class_key) { :required }
 
     it_behaves_like 'filter for relation' do
-      let(:relation_type) { :requires }
+      let(:relation_type) { :required_by }
     end
   end
 end

--- a/spec/models/queries/work_packages/filter/requires_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/requires_filter_spec.rb
@@ -33,7 +33,7 @@ describe Queries::WorkPackages::Filter::RequiresFilter, type: :model do
     let(:class_key) { :requires }
 
     it_behaves_like 'filter for relation' do
-      let(:relation_type) { :required_by }
+      let(:relation_type) { :requires }
     end
   end
 end


### PR DESCRIPTION
It was the wrong way around, causing required work packages to be found in the requires filter and vice versa.

https://community.openproject.com/wp/32190