### PR TITLE
[32134] Blank Gantt chart when zooming out

### DIFF
--- a/frontend/src/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
+++ b/frontend/src/app/components/wp-table/timeline/container/wp-timeline-container.directive.ts
@@ -60,6 +60,7 @@ import {debugLog, timeOutput} from "core-app/helpers/debug_output";
 import {RenderedWorkPackage} from "core-app/modules/work_packages/render-info/rendered-work-package.type";
 import {HalEventsService} from "core-app/modules/hal/services/hal-events.service";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
+import {timelineHeaderSelector} from "core-components/wp-table/timeline/header/wp-timeline-header.directive";
 
 @Component({
   selector: 'wp-timeline-container',
@@ -237,8 +238,9 @@ export class WorkPackageTimelineTableController implements AfterViewInit, OnDest
       });
 
       // Calculate overflowing width to set to outer container
-      // required to match width in all child divs
-      const currentWidth = this.getParentScrollContainer().scrollWidth;
+      // required to match width in all child divs.
+      // The header is the only one reliable, as it already has the final width.
+      const currentWidth = this.$element.find(timelineHeaderSelector)[0].scrollWidth;
       this.outerContainer.width(currentWidth);
     });
   }

--- a/frontend/src/app/components/wp-table/timeline/header/wp-timeline-header.directive.ts
+++ b/frontend/src/app/components/wp-table/timeline/header/wp-timeline-header.directive.ts
@@ -37,9 +37,10 @@ import {WorkPackageViewTimelineService} from "core-app/modules/work_packages/rou
 
 
 export const timelineHeaderCSSClass = 'wp-timeline--header-element';
+export const timelineHeaderSelector = 'wp-timeline-header';
 
 @Component({
-  selector: 'wp-timeline-header',
+  selector: timelineHeaderSelector,
   templateUrl: './wp-timeline-header.html'
 })
 export class WorkPackageTimelineHeaderController implements OnInit {


### PR DESCRIPTION
When zooming out the width of the timeline is newly calculated. Therefore the `scrollWidth` of the timeline was taken. This is however misleading as the timeline bars still have the width they had at the zoom level before. So, as they are still long, the whole container gets too long. The width of the bars is only changed afterwards. Instead the width of the timeline is now based on the header, which width is already final.

https://community.openproject.com/projects/openproject/work_packages/32134/activity