### PR TITLE
increase version check resilience

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -150,8 +150,9 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
   end
 
   def set_fixed_version_to_nil
-    unless work_package.fixed_version &&
-           work_package.project.shared_versions.include?(work_package.fixed_version)
+    if work_package.fixed_version &&
+       !(work_package.project &&
+         work_package.project.shared_versions.include?(work_package.fixed_version))
       work_package.fixed_version = nil
     end
   end


### PR DESCRIPTION
Do not fail with a "method on nil" error when no project is set