### PR TITLE
Fix/edit newly created time entry

### DIFF
--- a/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
@@ -397,6 +397,7 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
           collection.elements.splice(foundIndex, 1);
           break;
         case 'create':
+          this.timeEntryCache.updateValue(event.id!, event);
           collection.elements.push(event);
           break;
       }

--- a/frontend/src/app/modules/time_entries/form/form.component.html
+++ b/frontend/src/app/modules/time_entries/form/form.component.html
@@ -5,7 +5,10 @@
   (onSaved)="signalModifiedEntry($event)">
   <div class="attributes-map">
 
-    <div class="attributes-map--key -required" [textContent]="text.attributes.spentOn"></div>
+    <div class="attributes-map--key"
+               [ngClass]="{'-required': isRequired('spentOn')}"
+               [textContent]="text.attributes.spentOn">
+    </div>
     <div class="attributes-map--value">
       <editable-attribute-field [resource]="entry"
                                 [wrapperClasses]="'-tiny'"
@@ -13,7 +16,10 @@
       </editable-attribute-field>
     </div>
 
-    <div class="attributes-map--key -required" [textContent]="text.attributes.hours"></div>
+    <div class="attributes-map--key"
+         [ngClass]="{'-required': isRequired('hours')}"
+         [textContent]="text.attributes.hours">
+    </div>
     <div class="attributes-map--value">
       <editable-attribute-field [resource]="entry"
                                 [wrapperClasses]="'-tiny'"
@@ -21,14 +27,20 @@
       </editable-attribute-field>
     </div>
 
-    <div class="attributes-map--key -required" [textContent]="text.attributes.workPackage"></div>
+    <div class="attributes-map--key"
+         [ngClass]="{'-required': isRequired('workPackage')}"
+         [textContent]="text.attributes.workPackage">
+    </div>
     <div class="attributes-map--value">
       <editable-attribute-field [resource]="entry"
                                 [fieldName]="'workPackage'">
       </editable-attribute-field>
     </div>
 
-    <div class="attributes-map--key -required" [textContent]="text.attributes.activity"></div>
+    <div class="attributes-map--key"
+         [ngClass]="{'-required': isRequired('activity')}"
+         [textContent]="text.attributes.activity">
+    </div>
     <div class="attributes-map--value">
       <editable-attribute-field *ngIf="workPackageSelected"
                                 [resource]="entry"
@@ -39,7 +51,10 @@
       </i>
     </div>
 
-    <div class="attributes-map--key" [textContent]="text.attributes.comment"></div>
+    <div class="attributes-map--key"
+         [ngClass]="{'-required': isRequired('comment')}"
+         [textContent]="text.attributes.comment">
+    </div>
     <div class="attributes-map--value">
       <editable-attribute-field [resource]="entry"
                                 [fieldName]="'comment'">
@@ -47,7 +62,10 @@
     </div>
 
     <ng-container *ngFor="let cf of customFields">
-      <div class="attributes-map--key" [textContent]="cf.label"></div>
+      <div class="attributes-map--key"
+           [ngClass]="{'-required': isRequired(cf.key)}"
+           [textContent]="cf.label">
+      </div>
       <div class="attributes-map--value">
         <editable-attribute-field [resource]="entry"
                                   [fieldName]="cf.key">

--- a/frontend/src/app/modules/time_entries/form/form.component.ts
+++ b/frontend/src/app/modules/time_entries/form/form.component.ts
@@ -72,6 +72,16 @@ export class TimeEntryFormComponent implements OnInit, OnDestroy {
     return this.entry.isNew;
   }
 
+  public isRequired(field:string) {
+    // Other than defined in the schema, we consider the work package to be required.
+    // Remove once the schema requires it explicitly.
+    if (field === 'workPackage') {
+      return true;
+    } else {
+      return this.entry.schema[field].required;
+    }
+  }
+
   private setCustomFields(schema:SchemaResource) {
     Object.entries(schema).forEach(([key, keySchema]) => {
       if (key.match(/customField\d+/)) {


### PR DESCRIPTION
Push newly created time entries to the timeEntryCache so that they can subsequently be edited. This is done in the TimeEntryCalendar component for now. Ideally, we would move this and similar calls to the DataMapper layer so that components unrelated components can get updated whenever newer information is available. From what I have seen, it is too easy to forget to do it right now.

https://community.openproject.com/work_packages/32206

It also builds on #8027 and extends it to also include the custom fields.