### PR TITLE
no movement on time entry drop

### DIFF
--- a/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.sass
+++ b/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.sass
@@ -60,7 +60,7 @@
       transition: opacity 1s ease
       background: #EAEAEA
 
-    .fc-content
+    .te-calendar--add-icon
       color: black
       width: 100%
       font-weight: normal
@@ -68,6 +68,9 @@
 
     &.-prohibited
       cursor: not-allowed
+
+      .te-calendar--add-icon
+        display: none
 
   .te-calendar--time-entry
     .fc-content

--- a/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.sass
+++ b/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.sass
@@ -7,7 +7,7 @@
   .fc-head
     display: table-footer-group
 
-  .fc-event
+  .fc-event, .fc-bgevent
     border-radius: 0
     margin-right: 8px
     margin-left: 8px
@@ -39,12 +39,10 @@
     background-color: initial
     color: #000000
     text-align: center
-    font-size: 1em
+    font-size: 0.875em
     font-weight: bold
-
-    .fc-title
-      // as this is the height of the day sum element
-      line-height: 22px
+    line-height: 22px
+    opacity: 1
 
   .te-calendar--add-entry
     text-align: center

--- a/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
@@ -44,6 +44,7 @@ interface CalendarMoveEvent {
 const TIME_ENTRY_CLASS_NAME = 'te-calendar--time-entry';
 const DAY_SUM_CLASS_NAME = 'te-calendar--day-sum';
 const ADD_ENTRY_CLASS_NAME = 'te-calendar--add-entry';
+const ADD_ICON_CLASS_NAME = 'te-calendar--add-icon';
 const ADD_ENTRY_PROHIBITED_CLASS_NAME = '-prohibited';
 
 @Component({
@@ -279,17 +280,15 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
 
   protected addEntry(date:Moment, duration:number) {
     let classNames = [ADD_ENTRY_CLASS_NAME];
-    let title = '+';
 
     if (duration >= 24) {
        classNames.push(ADD_ENTRY_PROHIBITED_CLASS_NAME);
-       title = '';
     }
 
     return {
-      title: title,
       start: date.clone().format(),
       end: date.clone().add(this.maxHour - Math.min(duration * this.scaleRatio, this.maxHour - 1) - 0.5, 'h').format(),
+      rendering: "background" as 'background',
       classNames: classNames
     };
   }
@@ -406,6 +405,8 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
   }
 
   private alterEventEntry(event:CalendarViewEvent) {
+    this.appendAddIcon(event);
+
     if (!event.event.extendedProps.entry) {
       return;
     }
@@ -413,6 +414,17 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
     this.addTooltip(event);
     this.prependDuration(event);
     this.appendFadeout(event);
+  }
+
+  private appendAddIcon(event:CalendarViewEvent) {
+    if (!event.el.classList.contains(ADD_ENTRY_CLASS_NAME)) {
+      return;
+    }
+
+    let addIcon = document.createElement('div');
+    addIcon.classList.add(ADD_ICON_CLASS_NAME);
+    addIcon.innerText = '+';
+    event.el.append(addIcon);
   }
 
   private addTooltip(event:CalendarViewEvent) {

--- a/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
@@ -5,7 +5,6 @@ import * as moment from "moment";
 import { Moment } from 'moment';
 import {StateService} from "@uirouter/core";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
-import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
 import {DomSanitizer} from "@angular/platform-browser";
 import timeGrid from '@fullcalendar/timegrid';
 import { EventInput, EventApi, Duration, View } from '@fullcalendar/core';
@@ -24,6 +23,7 @@ import {TimeEntryEditService} from "core-app/modules/time_entries/edit/edit.serv
 import {TimeEntryCreateService} from "core-app/modules/time_entries/create/create.service";
 import {ColorsService} from "core-app/modules/common/colors/colors.service";
 import {BrowserDetector} from "core-app/modules/common/browser/browser-detector.service";
+import { HalResourceNotificationService } from 'core-app/modules/hal/services/hal-resource-notification.service';
 
 interface CalendarViewEvent {
   el:HTMLElement;
@@ -102,7 +102,7 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
               private element:ElementRef,
               readonly i18n:I18nService,
               readonly injector:Injector,
-              readonly notificationsService:NotificationsService,
+              readonly notifications:HalResourceNotificationService,
               private sanitizer:DomSanitizer,
               private configuration:ConfigurationService,
               private timezone:TimezoneService,
@@ -360,7 +360,8 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
       .then(event => {
         this.updateEventSet(event, 'update');
       })
-      .catch(() => {
+      .catch((e) => {
+        this.notifications.handleRawError(e);
         event.revert();
       });
   }

--- a/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
@@ -271,10 +271,11 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
 
   protected sumEntry(date:Moment, duration:number) {
     return {
-      title: this.i18n.t('js.units.hour', { count: this.formatNumber(duration) }),
       start: date.clone().add(this.maxHour - Math.min(duration * this.scaleRatio, this.maxHour - 0.5) - 0.5, 'h').format(),
       end: date.clone().add(this.maxHour - Math.min(((duration + 0.05) * this.scaleRatio), this.maxHour - 0.5), 'h').format(),
-      classNames: DAY_SUM_CLASS_NAME
+      classNames: DAY_SUM_CLASS_NAME,
+      rendering: 'background' as 'background',
+      sum: this.i18n.t('js.units.hour', { count: this.formatNumber(duration) })
     };
   }
 
@@ -406,6 +407,7 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
 
   private alterEventEntry(event:CalendarViewEvent) {
     this.appendAddIcon(event);
+    this.appendSum(event);
 
     if (!event.event.extendedProps.entry) {
       return;
@@ -425,6 +427,12 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
     addIcon.classList.add(ADD_ICON_CLASS_NAME);
     addIcon.innerText = '+';
     event.el.append(addIcon);
+  }
+
+  private appendSum(event:CalendarViewEvent) {
+    if (event.event.extendedProps.sum) {
+      event.el.append(event.event.extendedProps.sum);
+    }
   }
 
   private addTooltip(event:CalendarViewEvent) {

--- a/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
@@ -352,7 +352,9 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
   private moveEvent(event:CalendarMoveEvent) {
     let entry = event.event.extendedProps.entry;
 
-    entry.spentOn = moment(event.event.start!).format('YYYY-MM-DD');
+    // Use end instead of start as when dragging, the event might be too long and would thus be start
+    // on the day before by fullcalendar.
+    entry.spentOn = moment(event.event.end!).format('YYYY-MM-DD');
 
     this
       .timeEntryDm

--- a/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
+++ b/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
@@ -167,7 +167,7 @@ describe 'My page time entries current user widget spec', type: :feature, js: tr
 
     # The add time entry event is invisible
     within entries_area.area do
-      find(".fc-content-skeleton td:nth-of-type(5) .fc-event-container .te-calendar--add-entry", visible: false).click
+      find(".fc-content-skeleton td:nth-of-type(5) .te-calendar--add-entry", visible: false).click
     end
 
     expect(page)


### PR DESCRIPTION
By turning the "add entry" events into background events, an event dropped where the "add entry" is already present will no longer be squished to the side before being rendered correctly. It will also prevent dragging and resizing of the add entry events.

https://community.openproject.com/projects/openproject/work_packages/32206