### PR TITLE
recent work packages tab on time entry autocompleter

### DIFF
--- a/app/assets/stylesheets/content/_tabs.lsg
+++ b/app/assets/stylesheets/content/_tabs.lsg
@@ -22,3 +22,28 @@
   </div>
 </div>
 ```
+
+The height of the tabs section can be reduced applying the `-narrow` modification class.
+
+```
+<div class="scrollable-tabs -narrow">
+  <ul class="tabrow"">
+    <li class="selected"
+        tab-id="tab_1">
+      <a href="#scrollable-tabs?tab=tab_1">Tab 1</a>
+    </li>
+    <li tab-id="tab_2">
+      <a href="#scrollable-tabs?tab=tab_2">Tab 2</a>
+    </li>
+    <li tab-id="tab_3">
+      <a href="#scrollable-tabs?tab=tab_3">Tab 3</a>
+    </li>
+  </ul>
+  <div hidden="true" class="scrollable-tabs--button -left">
+    <span class="icon-arrow-left2"></span>
+  </div>
+  <div hidden="true" class="scrollable-tabs--button -right">
+    <span class="icon-arrow-right2"></span>
+  </div>
+</div>
+```

--- a/app/assets/stylesheets/content/_tabs.sass
+++ b/app/assets/stylesheets/content/_tabs.sass
@@ -74,6 +74,7 @@ content-tabs
   height: 40px
   border-bottom: 1px solid #DDDDDD
   margin-bottom: 1rem
+
   .tabrow
     display: block
     overflow-x: auto
@@ -84,6 +85,18 @@ content-tabs
       padding-left: 1rem
       padding-right: 1rem
       font-size: 14px
+
+  &.-narrow
+    margin-bottom: 0
+    height: initial
+
+    .tabrow
+      height: initial
+      line-height: initial
+
+      li
+        line-height: initial
+        padding-bottom: 6px
 
 .scrollable-tabs--button
   display: block

--- a/app/models/queries/time_entries/orders/default_order.rb
+++ b/app/models/queries/time_entries/orders/default_order.rb
@@ -32,6 +32,6 @@ class Queries::TimeEntries::Orders::DefaultOrder < Queries::BaseOrder
   self.model = TimeEntry
 
   def self.key
-    /\A(id|hours|spent_on|created_on)\z/
+    /\A(id|hours|spent_on|created_on|updated_on)\z/
   end
 end

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -336,6 +336,7 @@ en:
     label_project_plural: "Projects"
     label_visibility_settings: "Visibility settings"
     label_quote_comment: "Quote this comment"
+    label_recent: "Recent"
     label_reset: "Reset"
     label_remove_column: "Remove column"
     label_remove_columns: "Remove selected columns"

--- a/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/create-autocompleter.component.ts
@@ -66,7 +66,7 @@ export class CreateAutocompleterComponent implements AfterViewInit {
 
   @ViewChild('ngSelectComponent', {static: false}) public ngSelectComponent:NgSelectComponent;
 
-  public text:any = {
+  public text:{ [key:string]:string } = {
     add_new_action: this.I18n.t('js.label_create'),
   };
 

--- a/frontend/src/app/modules/common/autocomplete/te-work-package-autocompleter.component.html
+++ b/frontend/src/app/modules/common/autocomplete/te-work-package-autocompleter.component.html
@@ -1,0 +1,43 @@
+<ng-select #ngSelectComponent
+           [(ngModel)]="model"
+           [items]="availableValues"
+           [ngClass]="classes"
+           [addTag]="createAllowed"
+           [virtualScroll]="true"
+           [required]="required"
+           [clearable]="!required"
+           [disabled]="disabled"
+           [typeahead]="typeahead"
+           [clearOnBackspace]="false"
+           [appendTo]="appendTo"
+           [hideSelected]="hideSelected"
+           [loading]="finishedLoading | async"
+           [id]="id"
+           (change)="changeModel($event)"
+           (open)="opened()"
+           (close)="closed()"
+           (keydown)="keyPressed($event)"
+           bindLabel="name">
+  <ng-template ng-header-tmp>
+    <div class="scrollable-tabs -narrow">
+      <ul class="tabrow">
+        <li [ngClass]="{'selected': mode === 'all'}"
+            (click)="setMode('all')">
+          <a href="#" [textContent]="text.all">
+          </a>
+        </li>
+        <li [ngClass]="{'selected': mode === 'recent'}"
+            (click)="setMode('recent')">
+          <a href="#" [textContent]="text.recent">
+          </a>
+        </li>
+      </ul>
+    </div>
+  </ng-template>
+  <ng-template ng-tag-tmp let-search="searchTerm">
+    <b [textContent]="text.add_new_action"></b>: {{search}}
+  </ng-template>
+  <ng-template ng-option-tmp let-item="item" let-search="searchTerm">
+    <div [ngOptionHighlight]="search" class="ng-option-label ellipsis">{{ item.name }}</div>
+  </ng-template>
+</ng-select>

--- a/frontend/src/app/modules/common/autocomplete/te-work-package-autocompleter.component.sass
+++ b/frontend/src/app/modules/common/autocomplete/te-work-package-autocompleter.component.sass
@@ -1,0 +1,2 @@
+.ng-dropdown-panel .ng-dropdown-header
+  padding-bottom: 0

--- a/frontend/src/app/modules/common/autocomplete/te-work-package-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/te-work-package-autocompleter.component.ts
@@ -1,0 +1,72 @@
+// -- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2015 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+// ++
+
+import {
+  AfterViewInit,
+  Component,
+ ViewEncapsulation,
+ Output,
+ EventEmitter,
+ ChangeDetectorRef,
+} from '@angular/core';
+import {WorkPackageAutocompleterComponent} from "core-app/modules/common/autocomplete/wp-autocompleter.component";
+import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {CurrentProjectService} from "core-components/projects/current-project.service";
+import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
+
+export type TimeEntryWorkPackageAutocompleterMode = 'all'|'recent';
+
+@Component({
+  templateUrl: './te-work-package-autocompleter.component.html',
+  styleUrls: ['./te-work-package-autocompleter.component.sass'],
+  selector: 'te-work-package-autocompleter',
+  encapsulation: ViewEncapsulation.None
+})
+export class TimeEntryWorkPackageAutocompleterComponent extends WorkPackageAutocompleterComponent implements AfterViewInit {
+  @Output() modeSwitch = new EventEmitter<TimeEntryWorkPackageAutocompleterMode>();
+
+  constructor(readonly I18n:I18nService,
+              readonly cdRef:ChangeDetectorRef,
+              readonly currentProject:CurrentProjectService,
+              readonly pathHelper:PathHelperService) {
+    super(I18n, cdRef, currentProject, pathHelper);
+
+    this.text['all'] = this.I18n.t('js.label_all');
+    this.text['recent'] = this.I18n.t('js.label_recent');
+  }
+
+  public loading:boolean = false;
+  public mode:TimeEntryWorkPackageAutocompleterMode = 'all';
+
+  public setMode(value:TimeEntryWorkPackageAutocompleterMode) {
+    if (value !== this.mode) {
+      this.modeSwitch.emit(value);
+    }
+    this.mode = value;
+  }
+}

--- a/frontend/src/app/modules/common/openproject-common.module.ts
+++ b/frontend/src/app/modules/common/openproject-common.module.ts
@@ -99,6 +99,7 @@ import {CurrentProjectService} from "core-components/projects/current-project.se
 import {CurrentUserService} from "core-components/user/current-user.service";
 import {WorkPackageAutocompleterComponent} from "core-app/modules/common/autocomplete/wp-autocompleter.component";
 import {ColorsService} from "core-app/modules/common/colors/colors.service";
+import {TimeEntryWorkPackageAutocompleterComponent} from "core-app/modules/common/autocomplete/te-work-package-autocompleter.component";
 
 export function bootstrapModule(injector:Injector) {
   return () => {
@@ -147,6 +148,7 @@ export function bootstrapModule(injector:Injector) {
     DynamicModule.withComponents([
       VersionAutocompleterComponent,
       WorkPackageAutocompleterComponent,
+      TimeEntryWorkPackageAutocompleterComponent,
       CreateAutocompleterComponent]),
   ],
   exports: [
@@ -281,6 +283,7 @@ export function bootstrapModule(injector:Injector) {
     CreateAutocompleterComponent,
     VersionAutocompleterComponent,
     WorkPackageAutocompleterComponent,
+    TimeEntryWorkPackageAutocompleterComponent,
 
     HomescreenNewFeaturesBlockComponent,
     BoardVideoTeaserModalComponent

--- a/frontend/src/app/modules/fields/edit/field-types/work-package-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/work-package-edit-field.component.html
@@ -6,7 +6,7 @@
                                    disabled: inFlight,
                                    typeahead: requests.input$,
                                    id: handler.htmlId,
-                                   finishedLoading: true,
+                                   finishedLoading: requests.loading$,
                                    hideSelected: true,
                                    classes: 'inline-edit--field ' + handler.fieldName }"
              [ndcDynamicOutputs]="referenceOutputs">

--- a/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
+++ b/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
@@ -175,13 +175,14 @@ describe 'My page time entries current user widget spec', type: :feature, js: tr
 
     spent_on_field.expect_value((Date.today.beginning_of_week(:sunday) + 3.days).strftime)
 
+    expect(page)
+      .not_to have_selector('.ng-spinner-loader')
+
     wp_field.input_element.click
     wp_field.set_value(other_work_package.subject)
 
     expect(page)
       .to have_no_content(I18n.t('js.time_entry.work_package_required'))
-
-    sleep(0.1)
 
     comments_field.set_value('Comment for new entry')
 
@@ -221,6 +222,11 @@ describe 'My page time entries current user widget spec', type: :feature, js: tr
     activity_field.set_value(other_activity.name)
 
     wp_field.input_element.click
+    # As the other_work_package now has time logged, it is now considered to be a
+    # recent work package.
+    within('.ng-dropdown-header') do
+      click_link(I18n.t('js.label_recent'))
+    end
     wp_field.set_value(other_work_package.subject)
 
     hours_field.set_value('6')


### PR DESCRIPTION
Adds tabs to the work package autocompleter for time entries. The first tab lists all work packages, the second one the work packages, for which the user logged time recently:

![image](https://user-images.githubusercontent.com/617519/74219385-f95e1580-4cac-11ea-86d6-b4d34337b192.png)

This should make it easier for users to log time as a lot of activities span more than a day and as such require a user to log time on multiple days.

Admittedly, the implementation is kind of a hack. It cannot guarantee a fixed number of recent work packages. But the functionality is worth having and implementing it in this way, was very efficient. The alternative would have been to add a specific filtering and sorting on work packages for those that have recently had time logged on them. No only would that have been way more work, it also strikes me as weird to have such a filter.