### PR TITLE
[32218] Unnecessary dots displayed in subject column

### DIFF
--- a/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
+++ b/app/assets/stylesheets/content/work_packages/_table_hierarchy.sass
@@ -24,7 +24,6 @@
   text-align: right
   display: block
   float: left
-  margin-left: 5px
   padding-right: 8px
   height: 1rem
   // width calculation done in js code


### PR DESCRIPTION
Remove unnecessary margin which blows up the column as the margin is not part of the [width calculation](https://github.com/opf/openproject/blob/dev/frontend/src/app/components/wp-fast-table/builders/modes/hierarchy/single-hierarchy-row-builder.ts#L131).

https://community.openproject.com/projects/openproject/work_packages/32218/activity?query_id=2294