### PR TITLE
[32216] Wrong query displayed after going to full screen view 

### DIFF
--- a/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
+++ b/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
@@ -432,15 +432,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
   // On click of a menu item, load requested query
   private loadQuery(item:IAutocompleteItem) {
     const params = this.getQueryParams(item);
-    const currentId = _.toString(this.$state.params.query_id);
-    let opts = {reload: false};
-
-    const isSameItem = params.query_id && params.query_id === currentId.toString();
-
-    // Ensure we're reloading the query
-    if (isSameItem) {
-      opts.reload = true;
-    }
+    const opts = {reload: true};
 
     this.$state.go(
       'work-packages.list',


### PR DESCRIPTION
Always enforce a query reload when clicking on the main menu entry

https://community.openproject.com/projects/openproject/work_packages/32216/activity