### PR TITLE
Change wording of relation queries

### DIFF
--- a/app/assets/stylesheets/content/_tabs.sass
+++ b/app/assets/stylesheets/content/_tabs.sass
@@ -41,6 +41,7 @@
     text-decoration: none
     &:hover
       text-decoration: none
+
   li.tab-icon
     width: 5%
     .icon-context:before
@@ -62,6 +63,13 @@
     @include varprop(border-bottom-color, content-link-color)
   li:hover
     border-bottom-color: #DDDDDD
+
+  li.-disabled
+    cursor: default
+    pointer-events: none
+    border-bottom-width: 0
+    a
+      color: $tabs-font-color-disabled
 
 content-tabs
   min-height: 73px

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -484,19 +484,6 @@ en:
         upgrade_to_ee_text: "Wow! If you need this feature you are a super pro! Would you mind supporting us OpenSource developers by becoming an Enterprise Edition client?"
         more_information: "More information"
         nevermind: "Nevermind"
-        filter_types:
-          parent: "being child of"
-          precedes: "preceding"
-          follows: "following"
-          relates: "relating to"
-          duplicates: "duplicating"
-          duplicated: "duplicated by"
-          blocks: "blocking"
-          blocked: "blocked by"
-          partof: "being part of"
-          includes: "including"
-          requires: "requiring"
-          required: "required by"
       edit:
         form_configuration: "Form Configuration"
         projects: "Projects"
@@ -850,8 +837,7 @@ en:
           relation_columns: 'Need to see relations in the work package list?'
           check_out_link: 'Check out the Enterprise Edition.'
         relation_filters:
-          first_part: "Show all work packages"
-          second_part: "the current work package"
+          filter_work_packages_by_relation_type: 'Filter work packages by relation type'
       tabs:
         overview: Overview
         activity: Activity

--- a/frontend/src/app/components/wp-table/configuration-modal/wp-table-configuration-relation-selector.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/wp-table-configuration-relation-selector.html
@@ -1,6 +1,6 @@
 <div class="relation-filter-selector">
   <h5>
-    <span [textContent]="text.first_part"></span>
+    <span [textContent]="text.filter_work_packages_by_relation_type"></span>
     &ngsp;
     <select class="form--select form--inline-select"
             id=""
@@ -12,7 +12,5 @@
               [ngValue]="filter">
       </option>
     </select>
-    &ngsp;
-    <span [textContent]="text.second_part"></span>
   </h5>
 </div>

--- a/frontend/src/app/components/wp-table/configuration-modal/wp-table-configuration-relation-selector.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/wp-table-configuration-relation-selector.ts
@@ -35,21 +35,22 @@ export class WpTableConfigurationRelationSelectorComponent implements OnInit  {
   public selectedRelationFilter:QueryFilterResource|undefined = undefined;
 
   public text = {
+    filter_work_packages_by_relation_type: this.I18n.t('js.work_packages.table_configuration.relation_filters.filter_work_packages_by_relation_type'),
     please_select: this.I18n.t('js.placeholders.selection'),
-    first_part:    this.I18n.t('js.work_packages.table_configuration.relation_filters.first_part'),
-    second_part:   this.I18n.t('js.work_packages.table_configuration.relation_filters.second_part'),
-    parent:        this.I18n.t('js.types.attribute_groups.filter_types.parent'),
-    precedes:      this.I18n.t('js.types.attribute_groups.filter_types.precedes'),
-    follows:       this.I18n.t('js.types.attribute_groups.filter_types.follows'),
-    relates:     this.I18n.t('js.types.attribute_groups.filter_types.relates'),
-    duplicates:    this.I18n.t('js.types.attribute_groups.filter_types.duplicates'),
-    duplicated:  this.I18n.t('js.types.attribute_groups.filter_types.duplicated'),
-    blocks:        this.I18n.t('js.types.attribute_groups.filter_types.blocks'),
-    blocked:     this.I18n.t('js.types.attribute_groups.filter_types.blocked'),
-    requires:      this.I18n.t('js.types.attribute_groups.filter_types.requires'),
-    required:    this.I18n.t('js.types.attribute_groups.filter_types.required'),
-    partof:        this.I18n.t('js.types.attribute_groups.filter_types.partof'),
-    includes:      this.I18n.t('js.types.attribute_groups.filter_types.includes')
+    // We need to inverse the translation strings, as the filters's are named the other way around than what
+    // a user knows from the relations tab:
+    parent:        this.I18n.t('js.relation_labels.children'),
+    precedes:      this.I18n.t('js.relation_labels.follows'),
+    follows:       this.I18n.t('js.relation_labels.precedes'),
+    relates:     this.I18n.t('js.relation_labels.relates'),
+    duplicates:    this.I18n.t('js.relation_labels.duplicated'),
+    duplicated:  this.I18n.t('js.relation_labels.duplicates'),
+    blocks:        this.I18n.t('js.relation_labels.blocked'),
+    blocked:     this.I18n.t('js.relation_labels.blocks'),
+    requires:      this.I18n.t('js.relation_labels.required'),
+    required:    this.I18n.t('js.relation_labels.requires'),
+    partof:        this.I18n.t('js.relation_labels.includes'),
+    includes:      this.I18n.t('js.relation_labels.partof')
   };
 
   constructor(readonly injector:Injector,

--- a/frontend/src/app/components/wp-table/configuration-modal/wp-table-configuration.modal.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/wp-table-configuration.modal.html
@@ -22,10 +22,10 @@
          class="content--tabs scrollable-tabs">
       <ul class="tabrow">
         <li *ngFor="let tab of availableTabs"
-            [ngClass]="{ 'selected': currentTab && tab.name === currentTab.name }">
+            [ngClass]="{ 'selected': currentTab && tab.name === currentTab.name, '-disabled': tab.disableBecause != null }">
           <a class="tab-show"
              role="button"
-             [ngClass]="{ '-disabled': tab.disableBecause != null, 'selected': currentTab && tab.name === currentTab.name }"
+             [ngClass]="{ 'selected': currentTab && tab.name === currentTab.name }"
              [attr.title]="tab.disableBecause || tab.title"
              [textContent]="tab.title"
              (click)="switchTo(tab.name)"

--- a/frontend/src/app/modules/admin/types/group-edit-in-place.component.ts
+++ b/frontend/src/app/modules/admin/types/group-edit-in-place.component.ts
@@ -26,7 +26,15 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output
+} from '@angular/core';
 import {TypeBannerService} from 'core-app/modules/admin/types/type-banner.service';
 
 @Component({
@@ -44,7 +52,8 @@ export class GroupEditInPlaceComponent implements OnInit {
 
   public editedName:string;
 
-  constructor(private bannerService:TypeBannerService) {
+  constructor(private bannerService:TypeBannerService,
+              protected readonly cdRef:ChangeDetectorRef) {
   }
 
   ngOnInit():void {
@@ -68,6 +77,8 @@ export class GroupEditInPlaceComponent implements OnInit {
   saveEdition(event:KeyboardEvent) {
     this.leaveEditingMode();
     this.name = this.editedName.trim();
+
+    this.cdRef.detectChanges();
 
     if (this.name !== '') {
       this.onValueChange.emit(this.name);

--- a/frontend/src/app/modules/admin/types/group-edit-in-place.component.ts
+++ b/frontend/src/app/modules/admin/types/group-edit-in-place.component.ts
@@ -74,7 +74,7 @@ export class GroupEditInPlaceComponent implements OnInit {
     );
   }
 
-  saveEdition(event:KeyboardEvent) {
+  saveEdition(event:FocusEvent) {
     this.leaveEditingMode();
     this.name = this.editedName.trim();
 

--- a/frontend/src/app/modules/admin/types/group-edit-in-place.html
+++ b/frontend/src/app/modules/admin/types/group-edit-in-place.html
@@ -11,6 +11,6 @@
     autoFocus
     [(ngModel)]="editedName"
     [attr.placeholder]="placeholder"
-    (focusout)="saveEdition($event)"
+    (blur)="saveEdition($event)"
     (keydown.escape)="reset()"
     (keydown.enter)="saveEdition($event)">

--- a/frontend/src/app/modules/admin/types/type-form-configuration.component.ts
+++ b/frontend/src/app/modules/admin/types/type-form-configuration.component.ts
@@ -7,8 +7,6 @@ import {DomAutoscrollService} from 'core-app/modules/common/drag-and-drop/dom-au
 import {DragulaService} from 'ng2-dragula';
 import {ConfirmDialogService} from 'core-components/modals/confirm-dialog/confirm-dialog.service';
 import {Drake} from 'dragula';
-
-import {randomString} from 'core-app/helpers/random-string';
 import {GonService} from "core-app/modules/common/gon/gon.service";
 import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
 import {takeUntil} from "rxjs/operators";
@@ -55,6 +53,7 @@ export class TypeFormConfigurationComponent implements OnInit, OnDestroy {
   private autoscroll:any;
   private element:HTMLElement;
   private form:JQuery;
+  private submit:JQuery;
 
   public groups:TypeGroup[] = [];
   public inactives:TypeFormAttribute[] = [];
@@ -78,6 +77,15 @@ export class TypeFormConfigurationComponent implements OnInit, OnDestroy {
     this.element = this.elementRef.nativeElement;
     this.no_filter_query = this.element.dataset.noFilterQuery!;
     this.form = jQuery(this.element).closest('form');
+    this.submit = this.form.find('.form-configuration--save');
+
+    // Capture mousedown on button because firefox breaks blur on click
+    this.submit.on('mousedown', (event) => {
+      setTimeout(() => this.form.trigger('submit'), 50);
+      return true;
+    });
+
+    // Capture regular form submit
     this.form.on('submit.typeformupdater', () => {
       this.updateHiddenFields();
       return true;

--- a/lib/open_project/custom_styles/design.rb
+++ b/lib/open_project/custom_styles/design.rb
@@ -174,6 +174,7 @@ module OpenProject
       'table-row-hierarchies-row-font-color'                 => "#6C7A89",
       'table-header-border-color'                            => "#D7D7D7",
       'table-header-shadow-color'                            => "#DDDDDD",
+      'tabs-font-color-disabled'                             => "$gray-dark",
       'loading-indicator-bg-color'                           => "$body-background",
       'loading-indicator-bg-opacity'                         => "0.8",
       'loading-indicator-spinner-color'                      => "$primary-color",

--- a/spec/features/types/form_configuration_query_spec.rb
+++ b/spec/features/types/form_configuration_query_spec.rb
@@ -37,23 +37,21 @@ describe 'form query configuration', type: :feature, js: true do
   let(:other_project) { FactoryBot.create :project, types: [type_task] }
   let!(:work_package) do
     FactoryBot.create :work_package,
-                      project: project,
-                      type: type_bug
+                      new_relation.merge(
+                        project: project,
+                        type: type_bug
+                      )
   end
-  let(:wp_relation_type) { :parent }
+  let(:wp_relation_type) { :children }
   let(:frontend_relation_type) { wp_relation_type }
-  let(:relation_target) { work_package }
+  let(:relation_target) { related_task }
   let(:new_relation) do
     relation = Hash.new
-    relation[wp_relation_type] = relation_target
+    relation[wp_relation_type] = [related_bug, related_task, related_task_other_project]
     relation
   end
   let!(:related_task) do
-    FactoryBot.create :work_package,
-                      new_relation.merge(
-                        project: project,
-                        type: type_task
-                      )
+    FactoryBot.create :work_package, project: project, type: type_task
   end
   let!(:unrelated_task) do
     FactoryBot.create :work_package, subject: 'Unrelated task', type: type_task, project: project
@@ -62,18 +60,10 @@ describe 'form query configuration', type: :feature, js: true do
     FactoryBot.create :work_package, subject: 'Unrelated bug', type: type_bug, project: project
   end
   let!(:related_task_other_project) do
-    FactoryBot.create :work_package,
-                      new_relation.merge(
-                        project: other_project,
-                        type: type_task
-                      )
+    FactoryBot.create :work_package, project: other_project, type: type_task
   end
   let!(:related_bug) do
-    FactoryBot.create :work_package,
-                      new_relation.merge(
-                        project: project,
-                        type: type_bug
-                      )
+    FactoryBot.create :work_package, project: project, type: type_bug
   end
 
   let(:wp_page) { Pages::FullWorkPackage.new(work_package) }
@@ -91,18 +81,18 @@ describe 'form query configuration', type: :feature, js: true do
     end
 
     it 'can save an empty query group' do
-      form.add_query_group('Empty test', :parent)
+      form.add_query_group('Empty test', :children)
       form.save_changes
       expect(page).to have_selector('.flash.notice', text: 'Successful update.', wait: 10)
       type_bug.reload
 
-      query_group = type_bug.attribute_groups.detect{ |x| x.is_a?(Type::QueryGroup) }
+      query_group = type_bug.attribute_groups.detect { |x| x.is_a?(Type::QueryGroup) }
       expect(query_group.attributes).to be_kind_of(::Query)
       expect(query_group.key).to eq('Empty test')
     end
 
     it 'loads the children from the table split view (Regression #28490)' do
-      form.add_query_group('Subtasks', :parent)
+      form.add_query_group('Subtasks', :children)
       # Save changed query
       form.save_changes
       expect(page).to have_selector('.flash.notice', text: 'Successful update.', wait: 10)
@@ -129,7 +119,7 @@ describe 'form query configuration', type: :feature, js: true do
       let(:wp_page) { Pages::FullWorkPackageCreate.new }
 
       it 'does not show a subgroup (Regression #29582)' do
-        form.add_query_group('Subtasks', :parent)
+        form.add_query_group('Subtasks', :children)
         # Save changed query
         form.save_changes
         expect(page).to have_selector('.flash.notice', text: 'Successful update.', wait: 10)
@@ -143,7 +133,7 @@ describe 'form query configuration', type: :feature, js: true do
     end
 
     it 'can modify and keep changed columns (Regression #27604)' do
-      form.add_query_group('Columns Test', :parent)
+      form.add_query_group('Columns Test', :children)
       form.edit_query_group('Columns Test')
 
       # Restrict filters to type_task
@@ -166,7 +156,7 @@ describe 'form query configuration', type: :feature, js: true do
       column_names = query.attributes.columns.map(&:name).sort
       expect(column_names).to eq %i[id subject]
 
-      form.add_query_group('Second query', :parent)
+      form.add_query_group('Second query', :children)
       form.edit_query_group('Second query')
 
       # Restrict filters to type_task

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -23,6 +23,8 @@ def register_chrome_headless(language)
       options.add_argument('--disable-gpu')
     end
 
+    options.add_argument("--remote-debugging-port=9222")
+
     options.add_argument('--no-sandbox')
     options.add_argument('--disable-gpu')
     options.add_argument('--disable-popup-blocking')

--- a/spec/support/components/admin/type_configuration_form.rb
+++ b/spec/support/components/admin/type_configuration_form.rb
@@ -130,11 +130,11 @@ module Components
         modal = ::Components::WorkPackages::TableConfigurationModal.new
 
         within find('.relation-filter-selector') do
-          select I18n.t("js.types.attribute_groups.filter_types.#{relation_filter}")
+          select I18n.t("js.relation_labels.#{relation_filter}")
 
           # While we are here, let's check that all relation filters are present.
           option_labels = %w[
-            parent
+            children
             precedes
             follows
             relates
@@ -146,7 +146,7 @@ module Components
             includes
             requires
             required
-          ].map { |filter_name| I18n.t("js.types.attribute_groups.filter_types.#{filter_name}") }
+          ].map { |filter_name| I18n.t("js.relation_labels.#{filter_name}") }
 
           option_labels.each do |label|
             expect(page).to have_text(label)

--- a/spec/support/components/work_packages/table_configuration_modal.rb
+++ b/spec/support/components/work_packages/table_configuration_modal.rb
@@ -88,7 +88,7 @@ module Components
       end
 
       def expect_disabled_tab(name)
-        expect(page).to have_selector("#{selector} .tab-show.-disabled", text: name.upcase)
+        expect(page).to have_selector("#{selector} li.-disabled", text: name.upcase)
       end
 
       def selected_tab(name)

--- a/spec/support/local_storage_cleanup.rb
+++ b/spec/support/local_storage_cleanup.rb
@@ -28,6 +28,6 @@
 
 RSpec.configure do |config|
   config.after(:each, js: true) do
-    Capybara.current_session.driver.execute_script('window.localStorage.clear()')
+    Capybara.current_session.driver.execute_script('window.localStorage.clear()') rescue nil
   end
 end


### PR DESCRIPTION
Multiple fixes and improvements for form configuration
- [x] Fix old dev and make old feature specs pass
- [x] Add styles for disabled tabs, which got lost when updating the styles for tabs
- [x] Change layout and wording when adding a relation filter to a query
- [x] Save form group names on form save even when the edit in place field still is open https://community.openproject.com/wp/32189