### PR TITLE
[32235] Fix missing news timestamp updated_at

### DIFF
--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -41,11 +41,12 @@ class News < ActiveRecord::Base
   acts_as_journalized
 
   acts_as_event url: Proc.new { |o| { controller: '/news', action: 'show', id: o.id } },
-                datetime: :created_on
+                datetime: :created_at
 
   acts_as_searchable columns: ["#{table_name}.title", "#{table_name}.summary", "#{table_name}.description"],
                      include: :project,
-                     references: :projects
+                     references: :projects,
+                     date_column: "#{table_name}.created_at"
 
   acts_as_watchable
 
@@ -85,7 +86,7 @@ class News < ActiveRecord::Base
 
   # table_name shouldn't be needed :(
   def self.newest_first
-    order "#{table_name}.created_on DESC"
+    order "#{table_name}.created_at DESC"
   end
 
   def new_comment(attributes = {})

--- a/app/models/queries/news/orders/default_order.rb
+++ b/app/models/queries/news/orders/default_order.rb
@@ -32,6 +32,6 @@ class Queries::News::Orders::DefaultOrder < Queries::BaseOrder
   self.model = News
 
   def self.key
-    /\A(id|created_on)\z/
+    /\A(id|created_at|updated_at)\z/
   end
 end

--- a/app/views/homescreen/blocks/_news.html.erb
+++ b/app/views/homescreen/blocks/_news.html.erb
@@ -9,7 +9,7 @@
         <%= link_to_project(news.project) + ': ' %>
         <%= link_to h(news.title), news_path(news) %>
         <br/>
-        <span class="additional-information"><%= authoring news.created_on, news.author %></span>
+        <span class="additional-information"><%= authoring news.created_at, news.author %></span>
       </div>
     </li>
   <% end %>

--- a/app/views/news/_news.html.erb
+++ b/app/views/news/_news.html.erb
@@ -29,7 +29,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <div class="news">
   <%= link_to_project(news.project) + ': ' unless @project %>
   <h4 class='overview'><%= link_to h(news.title), news_path(news) %></h4>
-  <p class="author additional-information"><%= authoring news.created_on, news.author %></p>
+  <p class="author additional-information"><%= authoring news.created_at, news.author %></p>
   <div class="comment">
     <% if news.summary.present? %>
       <div class="summary">

--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -52,7 +52,7 @@ See docs/COPYRIGHT.rdoc for more details.
     <h3 class="news--header"><%= avatar(news.author) %><%= link_to_project(news.project) + ': ' unless news.project == @project %>
       <%= link_to h(news.title), news_path(news) %>
       <%= "(#{l(:label_x_comments, count: news.comments_count)})" if news.comments_count > 0 %></h3>
-    <p class="author additional-information"><%= authoring news.created_on, news.author %></p>
+    <p class="author additional-information"><%= authoring news.created_at, news.author %></p>
     <div class="wiki">
       <%= format_text(news.summary.present? ? news.summary : truncate(news.description, length: 150, escape: false), object: news) %>
     </div>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -69,7 +69,7 @@ See docs/COPYRIGHT.rdoc for more details.
     <%= format_text(@news.summary, object: @news) %>
   </div>
 <% end %>
-  <p class="author additional-information"><%= authoring @news.created_on, @news.author %></p>
+  <p class="author additional-information"><%= authoring @news.created_at, @news.author %></p>
 <div class="wiki">
   <%= format_text(@news.description, object: @news) %>
 </div>

--- a/config/initializers/activity.rb
+++ b/config/initializers/activity.rb
@@ -40,11 +40,13 @@ Redmine::Activity.map do |activity|
                                    default: false
 end
 
+# TODO: replace by string based references to avoid stale
+# objects when reloading in dev mode.
 Project.register_latest_project_activity on: WorkPackage,
                                          attribute: :updated_at
 
 Project.register_latest_project_activity on: News,
-                                         attribute: :created_on
+                                         attribute: :updated_at
 
 Project.register_latest_project_activity on: Changeset,
                                          chain: Repository,

--- a/db/migrate/20200217061622_add_timestamp_to_news.rb
+++ b/db/migrate/20200217061622_add_timestamp_to_news.rb
@@ -1,9 +1,10 @@
 class AddTimestampToNews < ActiveRecord::Migration[6.0]
   def change
-    add_column :news, :updated_on, :datetime
+    add_column :news, :updated_at, :datetime
+    rename_column :news, :created_on, :created_at
 
     reversible do |change|
-      change.up { News.update_all("updated_on = created_on") }
+      change.up { News.update_all("updated_at = created_at") }
     end
   end
 end

--- a/db/migrate/20200217061622_add_timestamp_to_news.rb
+++ b/db/migrate/20200217061622_add_timestamp_to_news.rb
@@ -1,0 +1,9 @@
+class AddTimestampToNews < ActiveRecord::Migration[6.0]
+  def change
+    add_column :news, :updated_on, :datetime
+
+    reversible do |change|
+      change.up { News.update_all("updated_on = created_on") }
+    end
+  end
+end

--- a/frontend/src/app/modules/grids/widgets/news/news.component.ts
+++ b/frontend/src/app/modules/grids/widgets/news/news.component.ts
@@ -98,7 +98,7 @@ export class WidgetNewsComponent extends AbstractWidgetComponent implements OnIn
   }
 
   private get newsDmParams() {
-    let params:DmListParameter = { sortBy: [['created_on', 'desc']],
+    let params:DmListParameter = { sortBy: [['created_at', 'desc']],
                                    pageSize: 3 };
 
     if (this.currentProject.id) {

--- a/lib/api/v3/news/news_representer.rb
+++ b/lib/api/v3/news/news_representer.rb
@@ -48,8 +48,8 @@ module API
 
         formattable_property :description
 
-        date_time_property :created_on,
-                           as: :createdAt
+        date_time_property :created_at
+        date_time_property :updated_at
 
         associated_resource :project,
                             link: ->(*) do

--- a/modules/dashboards/spec/features/news_spec.rb
+++ b/modules/dashboards/spec/features/news_spec.rb
@@ -79,7 +79,7 @@ describe 'News widget on dashboard', type: :feature, js: true do
       expect(page)
         .to have_content visible_news.project.name
       expect(page)
-        .to have_content visible_news.created_on.strftime('%m/%d/%Y')
+        .to have_content visible_news.created_at.strftime('%m/%d/%Y')
 
       expect(page)
         .to have_no_content invisible_news.title

--- a/modules/my_page/spec/features/my/news_spec.rb
+++ b/modules/my_page/spec/features/my/news_spec.rb
@@ -75,7 +75,7 @@ describe 'My page news widget spec', type: :feature, js: true do
     expect(page)
       .to have_content visible_news.project.name
     expect(page)
-      .to have_content visible_news.created_on.strftime('%m/%d/%Y')
+      .to have_content visible_news.created_at.strftime('%m/%d/%Y')
 
     expect(page)
       .to have_no_content invisible_news.title

--- a/spec/controllers/homescreen_controller_spec.rb
+++ b/spec/controllers/homescreen_controller_spec.rb
@@ -70,7 +70,7 @@ describe HomescreenController, type: :controller do
 
       it 'shows the news when available' do
         expect(News).to receive(:latest).with(any_args)
-          .and_return(FactoryBot.build_stubbed_list(:news, 5, created_on: Time.now))
+          .and_return(FactoryBot.build_stubbed_list(:news, 5, created_at: Time.now))
 
         get :index
         expect(response).to render_template(partial: 'homescreen/blocks/_news')

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -33,13 +33,13 @@ describe NewsController, type: :controller do
 
   include BecomeMember
 
-  let(:user) {
+  let(:user) do
     user = FactoryBot.create(:admin)
 
-    FactoryBot.create(:user_preference, user: user, others: {no_self_notified: false})
+    FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
 
     user
-  }
+  end
   let(:project) { FactoryBot.create(:project) }
   let(:news) { FactoryBot.create(:news) }
 
@@ -59,7 +59,7 @@ describe NewsController, type: :controller do
     end
 
     it 'renders index with project' do
-      get :index, params: {project_id: project.id}
+      get :index, params: { project_id: project.id }
 
       expect(response).to be_successful
       expect(response).to render_template 'index'
@@ -69,7 +69,7 @@ describe NewsController, type: :controller do
 
   describe '#show' do
     it 'renders show' do
-      get :show, params: {id: news.id}
+      get :show, params: { id: news.id }
 
       expect(response).to be_successful
       expect(response).to render_template 'show'
@@ -78,7 +78,7 @@ describe NewsController, type: :controller do
     end
 
     it 'renders show with slug' do
-      get :show, params: {id: "#{news.id}-some-news-title"}
+      get :show, params: { id: "#{news.id}-some-news-title" }
 
       expect(response).to be_successful
       expect(response).to render_template 'show'
@@ -87,7 +87,7 @@ describe NewsController, type: :controller do
     end
 
     it 'renders error if news item is not found' do
-      get :show, params: {id: -1}
+      get :show, params: { id: -1 }
 
       expect(response).to be_not_found
     end
@@ -95,7 +95,7 @@ describe NewsController, type: :controller do
 
   describe '#new' do
     it 'renders new' do
-      get :new, params: {project_id: project.id}
+      get :new, params: { project_id: project.id }
 
       expect(response).to be_successful
       expect(response).to render_template 'new'
@@ -104,7 +104,7 @@ describe NewsController, type: :controller do
 
   describe '#create' do
     context 'with news_added notifications',
-            with_settings: {notified_events: %w(news_added)} do
+            with_settings: { notified_events: %w(news_added) } do
       it 'persists a news item and delivers email notifications' do
         become_member_with_permissions(project, user)
 
@@ -154,7 +154,7 @@ describe NewsController, type: :controller do
 
   describe '#edit' do
     it 'renders edit' do
-      get :edit, params: {id: news.id}
+      get :edit, params: { id: news.id }
       expect(response).to be_successful
       expect(response).to render_template 'edit'
     end
@@ -163,7 +163,7 @@ describe NewsController, type: :controller do
   describe '#update' do
     it 'updates the news element' do
       put :update,
-          params: {id: news.id, news: {description: 'Description changed by test_post_edit'}}
+          params: { id: news.id, news: { description: 'Description changed by test_post_edit' } }
 
       expect(response).to redirect_to news_path(news)
 
@@ -174,7 +174,7 @@ describe NewsController, type: :controller do
 
   describe '#destroy' do
     it 'deletes the news element and redirects to the news overview page' do
-      delete :destroy, params: {id: news.id}
+      delete :destroy, params: { id: news.id }
 
       expect(response).to redirect_to project_news_index_path(news.project)
       expect { news.reload }.to raise_error ActiveRecord::RecordNotFound

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -168,7 +168,7 @@ describe 'Projects index page',
           expect(page)
             .to have_selector('th', text: 'LATEST ACTIVITY AT')
           expect(page)
-            .to have_selector('td', text: news.created_on.strftime('%m/%d/%Y'))
+            .to have_selector('td', text: news.created_at.strftime('%m/%d/%Y'))
         end
       end
 
@@ -802,7 +802,7 @@ describe 'Projects index page',
         expect(page)
           .to have_no_selector('th', text: 'LATEST ACTIVITY AT')
         expect(page)
-          .to have_no_selector('td', text: news.created_on.strftime('%m/%d/%Y'))
+          .to have_no_selector('td', text: news.created_at.strftime('%m/%d/%Y'))
       end
     end
   end

--- a/spec/lib/api/v3/news/news_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/news/news_representer_rendering_spec.rb
@@ -34,7 +34,6 @@ describe ::API::V3::News::NewsRepresenter, 'rendering' do
   let(:news) do
     FactoryBot.build_stubbed(:news,
                              project: project,
-                             created_on: Time.now,
                              author: user)
   end
   let(:project) { FactoryBot.build_stubbed(:project) }
@@ -85,8 +84,13 @@ describe ::API::V3::News::NewsRepresenter, 'rendering' do
     end
 
     it_behaves_like 'has UTC ISO 8601 date and time' do
-      let(:date) { news.created_on }
+      let(:date) { news.created_at }
       let(:json_path) { 'createdAt' }
+    end
+
+    it_behaves_like 'has UTC ISO 8601 date and time' do
+      let(:date) { news.updated_at }
+      let(:json_path) { 'updatedAt' }
     end
 
     it_behaves_like 'API V3 formattable', 'description' do

--- a/spec/models/project/activity_spec.rb
+++ b/spec/models/project/activity_spec.rb
@@ -141,12 +141,12 @@ describe Project::Activity, type: :model do
     end
 
     it 'is the latest news update' do
-      news.update_attribute(:created_on, initial_time - 10.seconds)
-      news2.update_attribute(:created_on, initial_time - 20.seconds)
+      news.update_attribute(:updated_at, initial_time - 10.seconds)
+      news2.update_attribute(:updated_at, initial_time - 20.seconds)
       news.reload
       news2.reload
 
-      expect(latest_activity).to eql news.created_on
+      expect(latest_activity).to eql news.updated_at
     end
 
     it 'is the latest changeset update' do
@@ -180,7 +180,7 @@ describe Project::Activity, type: :model do
     it 'takes the time stamp of the latest activity across models' do
       work_package.update_attribute(:updated_at, initial_time - 10.seconds)
       wiki_content.update_attribute(:updated_on, initial_time - 20.seconds)
-      news.update_attribute(:created_on, initial_time - 30.seconds)
+      news.update_attribute(:updated_at, initial_time - 30.seconds)
       changeset.update_attribute(:committed_on, initial_time - 40.seconds)
       message.update_attribute(:updated_on, initial_time - 50.seconds)
 
@@ -219,9 +219,9 @@ describe Project::Activity, type: :model do
       # work_package
       # wiki_content
 
-      expect(latest_activity).to eql news.created_on
+      expect(latest_activity).to eql news.updated_at
 
-      news.update_attribute(:created_on, wiki_content.updated_on - 10.seconds)
+      news.update_attribute(:updated_at, wiki_content.updated_on - 10.seconds)
 
       # Order:
       # changeset
@@ -232,7 +232,7 @@ describe Project::Activity, type: :model do
 
       expect(latest_activity).to eql changeset.committed_on
 
-      changeset.update_attribute(:committed_on, news.created_on - 10.seconds)
+      changeset.update_attribute(:committed_on, news.updated_at - 10.seconds)
 
       # Order:
       # message

--- a/spec_legacy/fixtures/news.yml
+++ b/spec_legacy/fixtures/news.yml
@@ -28,7 +28,8 @@
 
 ---
 news_001:
-  created_on: 2006-07-19 22:40:26 +02:00
+  created_at: 2006-07-19 22:40:26 +02:00
+  updated_at: 2006-07-19 22:40:26 +02:00
   project_id: 1
   title: eCookbook first release !
   id: 1
@@ -40,7 +41,8 @@ news_001:
   author_id: 2
   comments_count: 1
 news_002:
-  created_on: 2006-07-19 22:42:58 +02:00
+  created_at: 2006-07-19 22:42:58 +02:00
+  updated_at: 2006-07-19 22:42:58 +02:00
   project_id: 1
   title: 100,000 downloads for eCookbook
   id: 2
@@ -49,7 +51,8 @@ news_002:
   author_id: 2
   comments_count: 0
 news_003:
-  created_on: 2006-07-19 22:42:58 +02:00
+  created_at: 2006-07-19 22:42:58 +02:00
+  updated_at: 2006-07-19 22:42:58 +02:00
   project_id: 2
   title: News on a private project
   id: 3


### PR DESCRIPTION
https://community.openproject.com/wp/32235

This will also fix the latest activity scope for news, in case a news is updated.