### PR TITLE
default timestamps for documents

### DIFF
--- a/frontend/src/app/modules/grids/widgets/documents/documents.component.ts
+++ b/frontend/src/app/modules/grids/widgets/documents/documents.component.ts
@@ -65,7 +65,7 @@ export class WidgetDocumentsComponent extends AbstractWidgetComponent implements
   }
 
   public get documentsUrl() {
-    let orders = JSON.stringify([['created_on', 'desc']]);
+    let orders = JSON.stringify([['updated_at', 'desc']]);
 
     let url = `${this.pathHelper.api.v3.apiV3Base}/documents?sortBy=${orders}&pageSize=10`;
 

--- a/modules/dashboards/spec/features/docments_spec.rb
+++ b/modules/dashboards/spec/features/docments_spec.rb
@@ -76,7 +76,7 @@ describe 'Documents widget on dashboard', type: :feature, js: true do
       expect(page)
         .to have_content visible_document.description
       expect(page)
-        .to have_content visible_document.created_on.strftime('%m/%d/%Y')
+        .to have_content visible_document.created_at.strftime('%m/%d/%Y')
 
       expect(page)
         .to have_no_content invisible_document.title

--- a/modules/documents/app/models/queries/documents/orders/default_order.rb
+++ b/modules/documents/app/models/queries/documents/orders/default_order.rb
@@ -32,6 +32,6 @@ class Queries::Documents::Orders::DefaultOrder < Queries::BaseOrder
   self.model = Document
 
   def self.key
-    /\A(id|created_on)\z/
+    /\A(id|created_at|updated_at)\z/
   end
 end

--- a/modules/documents/app/views/documents/show.html.erb
+++ b/modules/documents/app/views/documents/show.html.erb
@@ -29,7 +29,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <% html_title h(@document.title) -%>
 <%= toolbar title: @document.title,
-            subtitle: "#{@document.category.name} - #{format_date @document.created_on}" do %>
+            subtitle: "#{@document.category.name} - #{format_date @document.created_at}" do %>
   <% if authorize_for(:documents, :edit) %>
     <li class="toolbar-item">
       <%= link_to({controller: '/documents', action: 'edit', id: @document}, class: 'button', accesskey: accesskey(:edit)) do %>

--- a/modules/documents/app/views/my/blocks/_documents.html.erb
+++ b/modules/documents/app/views/my/blocks/_documents.html.erb
@@ -40,6 +40,6 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= render(partial: 'documents/document',
            collection:  Document
                         .limit(10)
-                        .order("#{Document.table_name}.created_on DESC")
+                        .order("#{Document.table_name}.created_at DESC")
                         .where("#{Document.table_name}.project_id in (#{project_ids.join(',')})")
                         .includes(:project)) unless project_ids.empty? %>

--- a/modules/documents/app/views/my_projects_overviews/blocks/_documents.html.erb
+++ b/modules/documents/app/views/my_projects_overviews/blocks/_documents.html.erb
@@ -39,5 +39,5 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <% if current_user.allowed_to?(:view_documents, @project)%>
     <%= render(:partial => 'documents/document',
-               :collection => Document.where(project_id: @project.id).limit(10).order("created_on DESC")) %>
+               :collection => Document.where(project_id: @project.id).limit(10).order("created_at DESC")) %>
 <% end %>

--- a/modules/documents/db/migrate/20180323140208_to_v710_aggregated_documents_migrations.rb
+++ b/modules/documents/db/migrate/20180323140208_to_v710_aggregated_documents_migrations.rb
@@ -26,10 +26,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-require Rails.root.join("db","migrate","migration_utils","migration_squasher").to_s
+require Rails.root.join("db", "migrate", "migration_utils", "migration_squasher").to_s
 # This migration aggregates the migrations detailed in MIGRATION_FILES
 class ToV710AggregatedDocumentsMigrations < ActiveRecord::Migration[5.1]
-
   MIGRATION_FILES = <<-MIGRATIONS
     20130807085604_create_document_journals.rb
     20130814131242_create_documents_tables.rb
@@ -39,21 +38,21 @@ class ToV710AggregatedDocumentsMigrations < ActiveRecord::Migration[5.1]
   def up
     Migration::MigrationSquasher.squash(migrations) do
       create_table "documents", id: :integer do |t|
-        t.integer  "project_id",                :default => 0,  :null => false
-        t.integer  "category_id",               :default => 0,  :null => false
-        t.string   "title",       :limit => 60, :default => "", :null => false
+        t.integer  "project_id", default: 0, null: false
+        t.integer  "category_id", default: 0, null: false
+        t.string   "title", limit: 60, default: "", null: false
         t.text     "description"
         t.datetime "created_on"
       end
-      add_index "documents", ["category_id"], :name => "index_documents_on_category_id"
-      add_index "documents", ["created_on"], :name => "index_documents_on_created_on"
-      add_index "documents", ["project_id"], :name => "documents_project_id"
+      add_index "documents", ["category_id"], name: "index_documents_on_category_id"
+      add_index "documents", ["created_on"], name: "index_documents_on_created_on"
+      add_index "documents", ["project_id"], name: "documents_project_id"
 
       create_table :document_journals, id: :integer do |t|
-        t.integer  :journal_id,                                :null => false
-        t.integer  :project_id,                :default => 0,  :null => false
-        t.integer  :category_id,               :default => 0,  :null => false
-        t.string   :title,       :limit => 60, :default => "", :null => false
+        t.integer  :journal_id, null: false
+        t.integer  :project_id, default: 0,  null: false
+        t.integer  :category_id, default: 0,  null: false
+        t.string   :title, limit: 60, default: "", null: false
         t.text     :description
         t.datetime :created_on
       end

--- a/modules/documents/db/migrate/20200217090016_document_timestamps.rb
+++ b/modules/documents/db/migrate/20200217090016_document_timestamps.rb
@@ -1,0 +1,12 @@
+class DocumentTimestamps < ActiveRecord::Migration[6.0]
+  def change
+    add_column :documents, :updated_at, :datetime
+    rename_column :documents, :created_on, :created_at
+    # We do not need the timestamp on the data table, as we already have it on the journals table.
+    remove_column :document_journals, :created_on, :datetime
+
+    reversible do |change|
+      change.up { Document.update_all("updated_at = created_at") }
+    end
+  end
+end

--- a/modules/documents/lib/api/v3/documents/document_representer.rb
+++ b/modules/documents/lib/api/v3/documents/document_representer.rb
@@ -47,8 +47,8 @@ module API
 
         formattable_property :description
 
-        date_time_property :created_on,
-                           as: 'createdAt'
+        date_time_property :created_at
+        date_time_property :updated_at
 
         associated_resource :project,
                             link: ->(*) do

--- a/modules/documents/spec/api/v3/documents/document_representer_rendering_spec.rb
+++ b/modules/documents/spec/api/v3/documents/document_representer_rendering_spec.rb
@@ -33,7 +33,6 @@ describe ::API::V3::Documents::DocumentRepresenter, 'rendering' do
 
   let(:document) do
     FactoryBot.build_stubbed(:document,
-                             created_on: Time.now,
                              description: 'Some description') do |document|
       allow(document)
         .to receive(:project)
@@ -97,8 +96,13 @@ describe ::API::V3::Documents::DocumentRepresenter, 'rendering' do
     end
 
     it_behaves_like 'has UTC ISO 8601 date and time' do
-      let(:date) { document.created_on }
+      let(:date) { document.created_at }
       let(:json_path) { 'createdAt' }
+    end
+
+    it_behaves_like 'has UTC ISO 8601 date and time' do
+      let(:date) { document.updated_at }
+      let(:json_path) { 'updatedAt' }
     end
 
     it_behaves_like 'API V3 formattable', 'description' do
@@ -112,7 +116,7 @@ describe ::API::V3::Documents::DocumentRepresenter, 'rendering' do
     it 'has project embedded' do
       expect(subject)
         .to be_json_eql(project.name.to_json)
-              .at_path('_embedded/project/name')
+        .at_path('_embedded/project/name')
     end
   end
 end

--- a/modules/documents/spec/models/document_spec.rb
+++ b/modules/documents/spec/models/document_spec.rb
@@ -98,16 +98,16 @@ describe Document do
     it "without attachments, the updated-on-date is taken from the document's date" do
       document = FactoryBot.create(:document, project: project)
       expect(document.attachments).to be_empty
-      expect(document.created_on).to eql document.updated_on
+      expect(document.created_at).to eql document.updated_at
     end
   end
 
   describe "acts as event" do
     let(:now) { Time.zone.now }
-    let(:document) {
+    let(:document) do
       FactoryBot.build(:document,
-                                       created_on: now)
-    }
+                       created_at: now)
+    end
 
     it { expect(document.event_datetime.to_i).to eq(now.to_i) }
   end

--- a/modules/my_page/spec/features/my/documents_spec.rb
+++ b/modules/my_page/spec/features/my/documents_spec.rb
@@ -72,7 +72,7 @@ describe 'My page documents widget', type: :feature, js: true do
     expect(page)
       .to have_content visible_document.description
     expect(page)
-      .to have_content visible_document.created_on.strftime('%m/%d/%Y')
+      .to have_content visible_document.created_at.strftime('%m/%d/%Y')
 
     expect(page)
       .to have_no_content invisible_document.title


### PR DESCRIPTION
Adds an updated_at and renames the created_on to created_at column. By that, representer caching works and 

https://community.openproject.com/projects/openproject/work_packages/32221

is fixed.