### PR TITLE
[31524] Overlapping menus on WP page

### DIFF
--- a/app/assets/javascripts/top_menu.js
+++ b/app/assets/javascripts/top_menu.js
@@ -36,11 +36,10 @@
 
   TopMenu.prototype = $.extend(TopMenu.prototype, {
     setup: function () {
-      var self = this;
       this.hover = false;
       this.menuIsOpen = false;
       this.withHeadingFoldOutAtBorder();
-      this.setupDropdownHoverAndClick();
+      this.setupDropdownClick();
       this.registerEventHandlers();
       this.closeOnBodyClick();
       this.accessibility();
@@ -97,11 +96,11 @@
 
     closeOnBodyClick: function () {
       var self = this;
-      $('html').click(function() {
-        if (self.menuIsOpen) {
+      document.getElementById('wrapper').addEventListener('click', function (evt) {
+        if (self.menuIsOpen && !self.openDropdowns()[0].contains(evt.target)) {
           self.closing();
         }
-      });
+      },  true);
     },
 
     openDropdowns: function () {
@@ -125,7 +124,7 @@
       }
     },
 
-    setupDropdownHoverAndClick: function () {
+    setupDropdownClick: function () {
       var self = this;
       this.dropdowns().each(function (ix, it) {
         $(it).click(function () {

--- a/frontend/src/app/components/op-context-menu/op-context-menu.service.ts
+++ b/frontend/src/app/components/op-context-menu/op-context-menu.service.ts
@@ -49,11 +49,12 @@ export class OPContextMenuService {
     });
 
     // Listen to any click and close the active context menu
-    jQuery(window).on('click', (evt:JQuery.TriggeredEvent) => {
-      if (this.active && evt.button !== 2 && !this.portalHostElement.contains(evt.target as Element)) {
-        this.close();
+    const that = this;
+    document.getElementById('wrapper')!.addEventListener('click', function(evt:Event) {
+      if (that.active &&  !that.portalHostElement.contains(evt.target as Element)) {
+        that.close();
       }
-    });
+    },  true);
   }
 
   /**


### PR DESCRIPTION
Use capturing event to close menus to be sure, that they are really always closed on a click outside.
The bubbling event was often catched by other elements and the propagation stopped.

https://community.openproject.com/projects/openproject/work_packages/31524/activity