### PR TITLE
Allow other event handlers to be injected into card view

### DIFF
--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -4,10 +4,10 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
-  EventEmitter,
+  EventEmitter, Inject,
   Injector,
   Input,
-  OnInit,
+  OnInit, Optional,
   Output,
   ViewChild
 } from "@angular/core";
@@ -29,11 +29,18 @@ import {PathHelperService} from "core-app/modules/common/path-helper/path-helper
 import {filter, withLatestFrom} from 'rxjs/operators';
 import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
 import {WorkPackageViewSelectionService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-selection.service";
-import {CardViewHandlerRegistry} from "core-components/wp-card-view/event-handler/card-view-handler-registry";
+import {
+  CardEventHandler,
+  CardViewHandlerRegistry
+} from "core-components/wp-card-view/event-handler/card-view-handler-registry";
 import {WorkPackageCardViewService} from "core-components/wp-card-view/services/wp-card-view.service";
 import {WorkPackageCardDragAndDropService} from "core-components/wp-card-view/services/wp-card-drag-and-drop.service";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
 import {DeviceService} from "core-app/modules/common/browser/device.service";
+import {
+  WorkPackageViewHandlerClass,
+  WorkPackageViewHandlerToken
+} from "core-app/modules/work_packages/routing/wp-view-base/event-handling/event-handler-registry";
 
 export type CardViewOrientation = 'horizontal'|'vertical';
 
@@ -143,7 +150,8 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
     }
 
     // Register event handlers for the cards
-    new CardViewHandlerRegistry(this.injector).attachTo(this);
+    let registry = this.injector.get<any>(WorkPackageViewHandlerToken, CardViewHandlerRegistry);
+    new registry(this.injector).attachTo(this);
     this.wpTableSelection.registerSelectAllListener(() => { return this.cardView.renderedCards; });
     this.wpTableSelection.registerDeselectAllListener();
   }

--- a/frontend/src/app/modules/ifc_models/ifc-base-view/event-handler/bcf-card-view-handler-registry.ts
+++ b/frontend/src/app/modules/ifc_models/ifc-base-view/event-handler/bcf-card-view-handler-registry.ts
@@ -1,0 +1,16 @@
+import {WorkPackageCardViewComponent} from "core-components/wp-card-view/wp-card-view.component";
+import {
+  CardEventHandler,
+  CardViewHandlerRegistry
+} from "core-components/wp-card-view/event-handler/card-view-handler-registry";
+import {BcfClickHandler} from "core-app/modules/ifc_models/ifc-base-view/event-handler/bcf-click-handler";
+
+
+export class BcfCardViewHandlerRegistry extends CardViewHandlerRegistry {
+
+  protected eventHandlers:((c:WorkPackageCardViewComponent) => CardEventHandler)[] = [
+    // Clicking on the card (not within a cell)
+    c => new BcfClickHandler(this.injector, c),
+  ];
+}
+

--- a/frontend/src/app/modules/ifc_models/ifc-base-view/event-handler/bcf-click-handler.ts
+++ b/frontend/src/app/modules/ifc_models/ifc-base-view/event-handler/bcf-click-handler.ts
@@ -1,0 +1,45 @@
+import {Injector} from '@angular/core';
+import {CardEventHandler} from "core-components/wp-card-view/event-handler/card-view-handler-registry";
+import {WorkPackageCardViewComponent} from "core-components/wp-card-view/wp-card-view.component";
+import {WorkPackageViewSelectionService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-selection.service";
+import {WorkPackageViewFocusService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-focus.service";
+import {WorkPackageCardViewService} from "core-components/wp-card-view/services/wp-card-view.service";
+import {StateService} from "@uirouter/core";
+import {DeviceService} from "core-app/modules/common/browser/device.service";
+import {CardClickHandler} from "core-components/wp-card-view/event-handler/click-handler";
+
+export class BcfClickHandler extends CardClickHandler {
+
+  public get EVENT() {
+    return 'click.cardView.card';
+  }
+
+  public get SELECTOR() {
+    return `.wp-card`;
+  }
+
+  public eventScope(card:WorkPackageCardViewComponent) {
+    return jQuery(card.container.nativeElement);
+  }
+
+  public handleEvent(card:WorkPackageCardViewComponent, evt:JQuery.TriggeredEvent) {
+    let target = jQuery(evt.target);
+
+    // Ignore links
+    if (target.is('a') || target.parent().is('a')) {
+      return true;
+    }
+
+    // Locate the card from event
+    let element = target.closest('wp-single-card');
+    let wpId = element.data('workPackageId');
+
+    if (!wpId) {
+      return true;
+    }
+
+    console.log("Clicked on " + wpId);
+
+    return false;
+  }
+}

--- a/frontend/src/app/modules/ifc_models/ifc-base-view/ifc-base-view.component.ts
+++ b/frontend/src/app/modules/ifc_models/ifc-base-view/ifc-base-view.component.ts
@@ -29,12 +29,17 @@
 import {ChangeDetectionStrategy, Component} from "@angular/core";
 import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
 import {WorkPackageTableConfigurationObject} from "core-components/wp-table/wp-table-configuration";
+import {WorkPackageViewHandlerToken} from "core-app/modules/work_packages/routing/wp-view-base/event-handling/event-handler-registry";
+import {BcfCardViewHandlerRegistry} from "core-app/modules/ifc_models/ifc-base-view/event-handler/bcf-card-view-handler-registry";
 
 @Component({
   templateUrl: './ifc-base-view.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'ifc-base-view',
-  styleUrls: ['./ifc-base-view.component.sass']
+  styleUrls: ['./ifc-base-view.component.sass'],
+  providers: [
+    { provide: WorkPackageViewHandlerToken, useValue: BcfCardViewHandlerRegistry }
+  ]
 })
 export class IfcBaseViewComponent {
   public queryProps:{ [key:string]:any };

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/event-handling/event-handler-registry.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/event-handling/event-handler-registry.ts
@@ -1,4 +1,4 @@
-import {Injector} from '@angular/core';
+import {InjectionToken, Injector} from '@angular/core';
 
 export interface WorkPackageViewEventHandler<T> {
   /** Event name to register **/
@@ -13,6 +13,12 @@ export interface WorkPackageViewEventHandler<T> {
   /** Event scope method */
   eventScope(view:T):JQuery;
 }
+
+export interface WorkPackageViewHandlerClass<T> {
+  new(injector:Injector):WorkPackageViewEventHandler<any>;
+}
+
+export const WorkPackageViewHandlerToken = new InjectionToken<WorkPackageViewEventHandler<any>>('CardEventHandler');
 
 /**
  * Abstract view handler registry for globally handling arbitrary event on the


### PR DESCRIPTION
This allows to have other actions on click, dblclick or basically any events that the registry handles

- [x] check that injection approach works
- [ ] Build for single click
- [ ] Build for double click