### PR TITLE
[32296] Also ensure versions are sorted by name

### DIFF
--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -97,7 +97,7 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
     },
     fixed_version: {
       association: 'fixed_version',
-      sortable: %w(start_date effective_date),
+      sortable: %w(start_date effective_date name),
       default_order: 'DESC',
       null_handling: 'NULLS LAST',
       groupable: "#{WorkPackage.table_name}.fixed_version_id"

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -60,7 +60,8 @@ class Version < ActiveRecord::Base
 
   scope :order_by_newest_date, -> {
     reorder Arel.sql("#{Version.table_name}.start_date DESC NULLS LAST,
-                    #{Version.table_name}.effective_date DESC NULLS LAST")
+                    #{Version.table_name}.effective_date DESC NULLS LAST,
+                    #{Version.table_name}.name ASC")
   }
 
   def self.with_status_open

--- a/spec/models/query/sort_criteria_spec.rb
+++ b/spec/models/query/sort_criteria_spec.rb
@@ -77,7 +77,8 @@ describe ::Query::SortCriteria, type: :model, with_mail: false do
 
       it 'adds the order handling' do
         expect(subject.length).to eq 2
-        expect(subject.first).to eq ['start_date DESC NULLS LAST', 'effective_date DESC NULLS LAST']
+        expect(subject.first)
+          .to eq ['start_date DESC NULLS LAST', 'effective_date DESC NULLS LAST', 'name DESC NULLS LAST']
         expect(subject.last).to eq ['work_packages.start_date NULLS LAST']
       end
     end


### PR DESCRIPTION
If versions are sorted by date, the default work_packages.id sort will break up grouped versions if they have no date.

https://community.openproject.com/wp/32296