### PR TITLE
Fix/time entry active scope

### DIFF
--- a/app/models/time_entry_activity.rb
+++ b/app/models/time_entry_activity.rb
@@ -50,18 +50,28 @@ class TimeEntryActivity < Enumeration
 
   def active_in_project?(project)
     teap = if time_entry_activities_projects.loaded?
-             time_entry_activities_projects.detect { |t| t.project_id == project.id }&.active?
+             detect_project_time_entry_activity_active_state(project)
            else
-             time_entry_activities_projects
-               .where(project_id: project.id)
-               .pluck(:active)
-               .first
+             pluck_project_time_entry_activity_active_state(project)
            end
 
-    teap.present? && teap
+    !teap.nil? && teap || teap.nil? && active?
   end
 
   def activated_projects
     Project::Scopes::ActivatedTimeActivity.fetch(self)
+  end
+
+  private
+
+  def detect_project_time_entry_activity_active_state(project)
+    time_entry_activities_projects.detect { |t| t.project_id == project.id }&.active?
+  end
+
+  def pluck_project_time_entry_activity_active_state(project)
+    time_entry_activities_projects
+      .where(project_id: project.id)
+      .pluck(:active)
+      .first
   end
 end

--- a/app/models/time_entry_activity/scopes/active_in_project.rb
+++ b/app/models/time_entry_activity/scopes/active_in_project.rb
@@ -30,13 +30,31 @@
 
 module TimeEntryActivity::Scopes
   class ActiveInProject
-    def self.fetch(project)
-      scope = TimeEntryActivity.includes(time_entry_activities_projects: :activity)
+    class << self
+      def fetch(project)
+        being_active_in_project(project)
+          .or(being_not_inactive_in_project(project))
+      end
 
-      scope
-        .where(time_entry_activities_projects: { project_id: project.id, active: true })
-        .or(scope.where.not(time_entry_activities_projects: { project_id: project.id }).where(enumerations: { active: true }))
-        .or(scope.where(time_entry_activities_projects: { project_id: nil }, enumerations: { active: true }))
+      private
+
+      # All activities, that have a specific setting for the project to be active.
+      # The global active state has no effect in that case.
+      def being_active_in_project(project)
+        TimeEntryActivity
+          .where(id: of_project(project).where(active: true))
+      end
+
+      # All activities that are active and do not have a project specific setting stating
+      # the activity to be inactive. So there could either be no project specific setting (for that project) or
+      # a project specific setting that is active.
+      def being_not_inactive_in_project(project)
+        TimeEntryActivity.where(active: true).where.not(id: of_project(project).where(active: false))
+      end
+
+      def of_project(project)
+        TimeEntryActivitiesProject.where(project_id: project.id).select(:activity_id)
+      end
     end
   end
 end

--- a/spec/models/time_entry_activity/scopes/active_in_project_spec.rb
+++ b/spec/models/time_entry_activity/scopes/active_in_project_spec.rb
@@ -31,7 +31,8 @@
 require 'spec_helper'
 
 describe TimeEntryActivity::Scopes::ActiveInProject, type: :model do
-  let(:activity) { FactoryBot.create(:time_entry_activity) }
+  let!(:activity) { FactoryBot.create(:time_entry_activity) }
+  let!(:other_activity) { FactoryBot.create(:time_entry_activity) }
   let(:project) { FactoryBot.create(:project) }
   let(:other_project) { FactoryBot.create(:project) }
 
@@ -42,7 +43,7 @@ describe TimeEntryActivity::Scopes::ActiveInProject, type: :model do
       context 'with the activity being active' do
         it 'includes the activity' do
           is_expected
-            .to match_array [activity]
+            .to match_array [activity, other_activity]
         end
       end
 
@@ -53,7 +54,7 @@ describe TimeEntryActivity::Scopes::ActiveInProject, type: :model do
 
         it 'excludes the activity' do
           is_expected
-            .to be_empty
+            .to match_array([other_activity])
         end
       end
     end
@@ -65,7 +66,7 @@ describe TimeEntryActivity::Scopes::ActiveInProject, type: :model do
 
       it 'includes the activity' do
         is_expected
-          .to match_array [activity]
+          .to match_array [activity, other_activity]
       end
 
       context 'with the activity being inactive' do
@@ -75,7 +76,7 @@ describe TimeEntryActivity::Scopes::ActiveInProject, type: :model do
 
         it 'includes the activity' do
           is_expected
-            .to match_array [activity]
+            .to match_array [activity, other_activity]
         end
       end
     end
@@ -87,7 +88,7 @@ describe TimeEntryActivity::Scopes::ActiveInProject, type: :model do
 
       it 'includes the activity' do
         is_expected
-          .to match_array [activity]
+          .to match_array [activity, other_activity]
       end
     end
 
@@ -98,7 +99,18 @@ describe TimeEntryActivity::Scopes::ActiveInProject, type: :model do
 
       it 'excludes the activity' do
         is_expected
-          .to be_empty
+          .to match_array [other_activity]
+      end
+
+      context 'with a project configuration configured to true but for a different project' do
+        before do
+          activity.time_entry_activities_projects.create(project: other_project, active: true)
+        end
+
+        it 'excludes the activity' do
+          is_expected
+            .to match_array [other_activity]
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes both:
* The scope to fetch all time entry activities active in a project from the database.
* The check within each time entry to determine whether it is active in a project.

https://community.openproject.com/projects/openproject/work_packages/32358