### PR TITLE
[32354] Correctly escape filters in frontend to avoid unescape

### DIFF
--- a/app/services/api/v3/parse_query_params_service.rb
+++ b/app/services/api/v3/parse_query_params_service.rb
@@ -126,7 +126,7 @@ module API
       def filter_from_params(filter)
         attribute = filter.keys.first # there should only be one attribute per filter
         operator =  filter[attribute]['operator']
-        values = Array(filter[attribute]['values']).map { |v| CGI.unescape(v.to_s) }
+        values = Array(filter[attribute]['values'])
         ar_attribute = convert_filter_attribute attribute, append_id: true
 
         { field: ar_attribute,

--- a/frontend/src/app/components/api/api-v3/api-v3-filter-builder.ts
+++ b/frontend/src/app/components/api/api-v3/api-v3-filter-builder.ts
@@ -51,14 +51,15 @@ export class ApiV3FilterBuilder {
     return JSON.stringify(this.filters);
   }
 
-  public toParams():string {
+  public toParams(mergeParams:{[key:string]:string} = {}):string {
     let transformedFilters:string[] = [];
 
     transformedFilters = this.filters.map((filter:ApiV3Filter) => {
       return this.serializeFilter(filter);
     });
 
-    return `filters=${encodeURI(`[${transformedFilters.join(',')}]`)}`;
+    let params = { filters: `[${transformedFilters.join(",")}]`, ...mergeParams }
+    return new URLSearchParams(params).toString();
   }
 
   private serializeFilter(filter:ApiV3Filter) {

--- a/frontend/src/app/modules/common/path-helper/apiv3/apiv3-paths.ts
+++ b/frontend/src/app/modules/common/path-helper/apiv3/apiv3-paths.ts
@@ -157,7 +157,10 @@ export class ApiV3Paths {
       // Containing the that substring:
       filters.add('name', '~', [term]);
     }
-    return this.apiV3Base + '/principals' + '?' + filters.toParams() + encodeURI('&sortBy=[["name","asc"]]&offset=1&pageSize=10');
+
+    return this.apiV3Base +
+      '/principals?' +
+      filters.toParams({ sortBy: '[["name","asc"]]', offset: '1', pageSize: '10' });
   }
 
   public wpBySubjectOrId(term:string, idOnly:boolean = false) {
@@ -169,6 +172,8 @@ export class ApiV3Paths {
       filters.add('subjectOrId', '**', [term]);
     }
 
-    return this.apiV3Base + '/work_packages' + '?' + filters.toParams() + encodeURI('&sortBy=[["updatedAt","desc"]]&offset=1&pageSize=10');
+    return this.apiV3Base +
+      '/work_packages?' +
+      filters.toParams({ sortBy: '[["updatedAt","desc"]]', offset: '1', pageSize: '10' });
   }
 }

--- a/frontend/src/app/modules/common/path-helper/path-helper.service.spec.ts
+++ b/frontend/src/app/modules/common/path-helper/path-helper.service.spec.ts
@@ -31,6 +31,10 @@ import {PathHelperService} from './path-helper.service';
 describe('PathHelper', function() {
   var PathHelper:PathHelperService = new PathHelperService();
 
+  function encodeParams(object:any) {
+    return new URLSearchParams(object).toString();
+  }
+
   describe('apiV3', function() {
     var projectIdentifier = 'majora';
 
@@ -42,18 +46,39 @@ describe('PathHelper', function() {
       var projectId = '1';
       var term = 'Maria';
 
+      let params = {
+        filters: '[{"status":{"operator":"!","values":["3"]}},{"member":{"operator":"=","values":["1"]}},{"type":{"operator":"=","values":["User","Group"]}},{"id":{"operator":"!","values":["me"]}},{"name":{"operator":"~","values":["Maria"]}}]',
+        sortBy: '[["name","asc"]]',
+        offset: '1',
+        pageSize: '10'
+      };
+
       expect(
         PathHelper.api.v3.principals(projectId, term)
-      ).toEqual('/api/v3/principals?filters=' +  encodeURI('[{"status":{"operator":"!","values":["3"]}},{"member":{"operator":"=","values":["1"]}},{"type":{"operator":"=","values":["User","Group"]}},{"id":{"operator":"!","values":["me"]}},{"name":{"operator":"~","values":["Maria"]}}]&sortBy=[["name","asc"]]&offset=1&pageSize=10'));
+      ).toEqual('/api/v3/principals?' +  encodeParams(params));
     });
 
     it('should provide a path to work package query on subject or ID ', function() {
+      let params = {
+        filters: '[{"subjectOrId":{"operator":"**","values":["bogus"]}}]',
+        sortBy: '[["updatedAt","desc"]]',
+        offset: '1',
+        pageSize: '10'
+      };
+
       expect(
         PathHelper.api.v3.wpBySubjectOrId("bogus")
-      ).toEqual('/api/v3/work_packages?filters=' +  encodeURI('[{"subjectOrId":{"operator":"**","values":["bogus"]}}]&sortBy=[["updatedAt","desc"]]&offset=1&pageSize=10'));
+      ).toEqual('/api/v3/work_packages?' +  encodeParams(params));
+
+      params = {
+        filters: '[{"id":{"operator":"=","values":["1234"]}}]',
+        sortBy: '[["updatedAt","desc"]]',
+        offset: '1',
+        pageSize: '10'
+      };
       expect(
         PathHelper.api.v3.wpBySubjectOrId("1234", true)
-      ).toEqual('/api/v3/work_packages?filters=' +  encodeURI('[{"id":{"operator":"=","values":["1234"]}}]&sortBy=[["updatedAt","desc"]]&offset=1&pageSize=10'));
+      ).toEqual('/api/v3/work_packages?' +  encodeParams(params));
     });
   });
 });

--- a/frontend/src/app/modules/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/modules/global_search/input/global-search-input.component.ts
@@ -216,7 +216,6 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
     return Highlighting.inlineClass('status', statusId);
   }
 
-
   // return all project scope items and all items which contain the search term
   public customSearchFn(term:string, item:any):boolean {
     return item.id === undefined || item.subject.toLowerCase().indexOf(term.toLowerCase()) !== -1;
@@ -233,8 +232,6 @@ export class GlobalSearchInputComponent implements OnInit, OnDestroy {
       query = query.replace(/^#/, '');
       idOnly = true;
     }
-
-    query = encodeURIComponent(query);
 
     let href:string = this.PathHelperService.api.v3.wpBySubjectOrId(query, idOnly);
 

--- a/spec/services/api/v3/parse_query_params_service_spec.rb
+++ b/spec/services/api/v3/parse_query_params_service_spec.rb
@@ -232,16 +232,6 @@ describe ::API::V3::ParseQueryParamsService,
 
           it_behaves_like 'transforms' do
             let(:params) do
-              { filters: JSON::dump([{ 'subprojectId' => { 'operator' => '=',
-                                                           'values' => %w(a%26%23b 2) } }]) }
-            end
-            let(:expected) do
-              { filters: [{ field: 'subproject_id', operator: '=', values: %w(a&#b 2) }] }
-            end
-          end
-
-          it_behaves_like 'transforms' do
-            let(:params) do
               { filters: JSON::dump([{ 'watcher' => { 'operator' => '=',
                                                       'values' => %w(1 2) } }]) }
             end


### PR DESCRIPTION
The filters were not correctly escaped in the frontend, causing special
query characters such as & to break to search.

https://community.openproject.com/wp/32354