### PR TITLE
increase tsv extracted check resilience

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -236,7 +236,11 @@ class Attachment < ActiveRecord::Base
       .pluck(:container_type)
       .compact
       .select do |container_class|
-      container_class.constantize.attachment_tsv_extracted?
+      klass = container_class.constantize
+
+      klass.respond_to?(:attachment_tsv_extracted?) && klass.attachment_tsv_extracted?
+    rescue NameError
+      false
     end
   end
 


### PR DESCRIPTION
The data in the attachments table might be corrupted e.g. when:
* A plugin was installed which had attachments defined
* Some container type was defined that never was attachable

In that case, the check now disregards those attachments on the check for whether they are tsv extracted.

https://community.openproject.com/projects/openproject/work_packages/32329