### PR TITLE
Fix/attachment race condition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -289,6 +289,10 @@ platforms :mri, :mingw, :x64_mingw do
 
   # Support application loading when no database exists yet.
   gem 'activerecord-nulldb-adapter', '~> 0.4.0'
+
+  # Have application level locks on the database to have a mutex shared between workers/hosts.
+  # We e.g. emply this to safeguard the creation of journals.
+  gem 'with_advisory_lock', '~> 4.6.0'
 end
 
 group :opf_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -962,6 +962,8 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
     will_paginate (3.1.8)
+    with_advisory_lock (4.6.0)
+      activerecord (>= 4.2)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.2.2)
@@ -1133,6 +1135,7 @@ DEPENDENCIES
   webdrivers (~> 4.2.0)
   webmock (~> 3.7.2)
   will_paginate (~> 3.1.7)
+  with_advisory_lock (~> 4.6.0)
 
 RUBY VERSION
    ruby 2.6.5p114

--- a/app/contracts/attachments/delete_contract.rb
+++ b/app/contracts/attachments/delete_contract.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH
@@ -26,34 +28,10 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module BaseServices
-  class Delete < BaseContracted
-    attr_accessor :model
-
-    def initialize(user:, model:, contract_class: nil, contract_options: {})
-      self.model = model
-      super(user: user, contract_class: contract_class, contract_options: contract_options)
-    end
-
-    def persist(service_result)
-      service_result = super(service_result)
-
-      unless destroy(service_result.result)
-        service_result.errors = service_result.result.errors
-        service_result.success = false
-      end
-
-      service_result
-    end
-
-    def destroy(object)
-      object.destroy
-    end
-
-    protected
-
-    def default_contract_class
-      "#{namespace}::DeleteContract".constantize
-    end
+module Attachments
+  class DeleteContract < ::DeleteContract
+    delete_permission -> {
+      model.deletable?(user)
+    }
   end
 end

--- a/app/contracts/messages/base_contract.rb
+++ b/app/contracts/messages/base_contract.rb
@@ -28,26 +28,20 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Attachments
-  module SetReplacements
-    extend ActiveSupport::Concern
+module Messages
+  class BaseContract < ::ModelContract
+    include Attachments::ValidateReplacements
 
-    included do
-      private
-
-      def set_attributes(attributes)
-        set_attachments_attributes(attributes)
-
-        super
-      end
-
-      def set_attachments_attributes(attributes)
-        attachment_ids = attributes.delete(:attachment_ids)
-
-        return unless attachment_ids
-
-        model.attachments_replacements = Attachment.where(id: attachment_ids)
-      end
+    def self.model
+      Message
     end
+
+    attribute :forum_id
+    attribute :parent_id
+    attribute :subject
+    attribute :content
+    attribute :last_reply
+    attribute :locked
+    attribute :sticky
   end
 end

--- a/app/contracts/messages/create_contract.rb
+++ b/app/contracts/messages/create_contract.rb
@@ -28,26 +28,8 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Attachments
-  module SetReplacements
-    extend ActiveSupport::Concern
-
-    included do
-      private
-
-      def set_attributes(attributes)
-        set_attachments_attributes(attributes)
-
-        super
-      end
-
-      def set_attachments_attributes(attributes)
-        attachment_ids = attributes.delete(:attachment_ids)
-
-        return unless attachment_ids
-
-        model.attachments_replacements = Attachment.where(id: attachment_ids)
-      end
-    end
+# TODO: This is but a stub
+module Messages
+  class CreateContract < BaseContract
   end
 end

--- a/app/contracts/messages/update_contract.rb
+++ b/app/contracts/messages/update_contract.rb
@@ -28,26 +28,8 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Attachments
-  module SetReplacements
-    extend ActiveSupport::Concern
-
-    included do
-      private
-
-      def set_attributes(attributes)
-        set_attachments_attributes(attributes)
-
-        super
-      end
-
-      def set_attachments_attributes(attributes)
-        attachment_ids = attributes.delete(:attachment_ids)
-
-        return unless attachment_ids
-
-        model.attachments_replacements = Attachment.where(id: attachment_ids)
-      end
-    end
+# TODO: This is but a stub
+module Messages
+  class UpdateContract < BaseContract
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -523,14 +523,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Renders a warning flash if obj has unsaved attachments
-  def render_attachment_warning_if_needed(obj)
-    unsaved_attachments = obj.attachments.select(&:new_record?)
-    if unsaved_attachments.any?
-      flash[:warning] = l(:warning_attachments_not_saved, unsaved_attachments.size)
-    end
-  end
-
   # Converts the errors on an ActiveRecord object into a common JSON format
   def object_errors_to_json(object)
     object.errors.map do |attribute, error|

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -92,8 +92,6 @@ class MessagesController < ApplicationController
     @reply = call.result
 
     if call.success?
-      #@topic.children << @reply
-
       call_hook(:controller_messages_reply_after_save, params: params, message: @reply)
     end
     redirect_to topic_path(@topic, r: @reply)

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -115,7 +115,6 @@ class WikiController < ApplicationController
     @page.attach_files(permitted_params.attachments.to_h)
 
     if @page.save
-      render_attachment_warning_if_needed(@page)
       call_hook(:controller_wiki_edit_after_save, params: params, page: @page)
       flash[:notice] = l(:notice_successful_create)
       redirect_to_show
@@ -192,7 +191,6 @@ class WikiController < ApplicationController
     @content.add_journal User.current, params['content']['comments']
 
     if @page.save_with_content
-      render_attachment_warning_if_needed(@page)
       call_hook(:controller_wiki_edit_after_save, params: params, page: @page)
       flash[:notice] = l(:notice_successful_update)
       redirect_to_show

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/models/journal_manager.rb
+++ b/app/models/journal_manager.rb
@@ -45,14 +45,6 @@ class JournalManager
       @send_notification = true
     end
 
-    def with_advisory_lock_transaction(container)
-      ActiveRecord::Base.transaction do
-        container.class.with_advisory_lock("create_journal_on_#{container.class.name}_#{container.id}") do
-          yield
-        end
-      end
-    end
-
     private
 
     def merge_reference_journals_by_id(new_journals, old_journals, id_key, value)
@@ -261,6 +253,7 @@ class JournalManager
     journable.journals.select(&:new_record?)
 
     journal.save!
+
     journal
   end
 

--- a/app/models/journal_manager.rb
+++ b/app/models/journal_manager.rb
@@ -45,6 +45,14 @@ class JournalManager
       @send_notification = true
     end
 
+    def with_advisory_lock_transaction(container)
+      ActiveRecord::Base.transaction do
+        container.class.with_advisory_lock("create_journal_on_#{container.class.name}_#{container.id}") do
+          yield
+        end
+      end
+    end
+
     private
 
     def merge_reference_journals_by_id(new_journals, old_journals, id_key, value)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -97,10 +97,13 @@ class Message < ActiveRecord::Base
                       end
   end
 
+  # TODO: move into create contract
   def update_last_reply_in_parent
     if parent
-      parent.reload.update_attribute(:last_reply_id, id)
+      parent.reload
+      parent.update_attribute(:last_reply_id, id)
     end
+
     forum.reset_counters!
   end
 

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -339,8 +339,9 @@ class PermittedParams
   # `params.fetch` and not `require` because the update controller action associated
   # with this is doing multiple things, therefore not requiring a message hash
   # all the time.
-  def message(instance = nil)
-    if instance && current_user.allowed_to?(:edit_messages, instance.project)
+  def message(project = nil)
+    # TODO: Move this distinction into the contract where it belongs
+    if project && current_user.allowed_to?(:edit_messages, project)
       params.fetch(:message, {}).permit(:subject, :content, :forum_id, :locked, :sticky)
     else
       params.fetch(:message, {}).permit(:subject, :content, :forum_id)
@@ -367,6 +368,7 @@ class PermittedParams
             # We rely on enum being an integer, an id that is. This will blow up
             # otherwise, which is fine.
             next if params[:enumerations][enum][param].nil?
+
             whitelist[enum][param] = params[:enumerations][enum][param]
           end
         end

--- a/app/services/attachments/create_service.rb
+++ b/app/services/attachments/create_service.rb
@@ -26,7 +26,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class AddAttachmentService
+class Attachments::CreateService
   attr_reader :container, :author
 
   def initialize(container, author:)
@@ -39,7 +39,7 @@ class AddAttachmentService
   # In case the container supports it, a journal will be written.
   #
   # An ActiveRecord::RecordInvalid error is raised if any record can't be saved.
-  def add_attachment(uploaded_file:, description:)
+  def call(uploaded_file:, description:)
     attachment = Attachment.new(file: uploaded_file,
                                 container: container,
                                 description: description,

--- a/app/services/attachments/delete_service.rb
+++ b/app/services/attachments/delete_service.rb
@@ -26,34 +26,20 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module BaseServices
-  class Delete < BaseContracted
-    attr_accessor :model
-
-    def initialize(user:, model:, contract_class: nil, contract_options: {})
-      self.model = model
-      super(user: user, contract_class: contract_class, contract_options: contract_options)
+class Attachments::DeleteService < ::BaseServices::Delete
+  def call(params = nil)
+    in_context(model.container || model) do
+      perform(params)
     end
+  end
 
-    def persist(service_result)
-      service_result = super(service_result)
+  private
 
-      unless destroy(service_result.result)
-        service_result.errors = service_result.result.errors
-        service_result.success = false
-      end
-
-      service_result
-    end
-
-    def destroy(object)
-      object.destroy
-    end
-
-    protected
-
-    def default_contract_class
-      "#{namespace}::DeleteContract".constantize
+  def destroy(attachment)
+    if attachment.container
+      attachment.container.attachments.delete(attachment)
+    else
+      super
     end
   end
 end

--- a/app/services/attachments/replace_attachments.rb
+++ b/app/services/attachments/replace_attachments.rb
@@ -29,24 +29,20 @@
 #++
 
 module Attachments
-  module SetReplacements
+  module ReplaceAttachments
     extend ActiveSupport::Concern
 
     included do
       private
 
       def set_attributes(attributes)
-        set_attachments_attributes(attributes)
+        call = super
 
-        super
-      end
+        if call.success?
+          call.result.attachments = call.result.attachments_replacements if call.result.attachments_replacements
+        end
 
-      def set_attachments_attributes(attributes)
-        attachment_ids = attributes.delete(:attachment_ids)
-
-        return unless attachment_ids
-
-        model.attachments_replacements = Attachment.where(id: attachment_ids)
+        call
       end
     end
   end

--- a/app/services/base_services/base_contracted.rb
+++ b/app/services/base_services/base_contracted.rb
@@ -42,7 +42,7 @@ module BaseServices
     end
 
     def call(params = nil)
-      in_context(false) do
+      in_context(model, true) do
         perform(params)
       end
     end

--- a/app/services/base_services/create.rb
+++ b/app/services/base_services/create.rb
@@ -30,6 +30,12 @@
 
 module BaseServices
   class Create < Write
+    def call(params = nil)
+      in_user_context(true) do
+        perform(params)
+      end
+    end
+
     private
 
     def instance(_params)

--- a/app/services/messages/create_service.rb
+++ b/app/services/messages/create_service.rb
@@ -28,26 +28,6 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Attachments
-  module SetReplacements
-    extend ActiveSupport::Concern
-
-    included do
-      private
-
-      def set_attributes(attributes)
-        set_attachments_attributes(attributes)
-
-        super
-      end
-
-      def set_attachments_attributes(attributes)
-        attachment_ids = attributes.delete(:attachment_ids)
-
-        return unless attachment_ids
-
-        model.attachments_replacements = Attachment.where(id: attachment_ids)
-      end
-    end
-  end
+class Messages::CreateService < ::BaseServices::Create
+  include Attachments::ReplaceAttachments
 end

--- a/app/services/messages/set_attributes_service.rb
+++ b/app/services/messages/set_attributes_service.rb
@@ -28,25 +28,20 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Attachments
-  module SetReplacements
-    extend ActiveSupport::Concern
+# TODO: This is but a stub
+module Messages
+  class SetAttributesService < ::BaseServices::SetAttributes
+    include Attachments::SetReplacements
 
-    included do
-      private
+    private
 
-      def set_attributes(attributes)
-        set_attachments_attributes(attributes)
+    def set_default_attributes(*)
+      set_default_author
+    end
 
-        super
-      end
-
-      def set_attachments_attributes(attributes)
-        attachment_ids = attributes.delete(:attachment_ids)
-
-        return unless attachment_ids
-
-        model.attachments_replacements = Attachment.where(id: attachment_ids)
+    def set_default_author
+      change_by_system do
+        model.author = user
       end
     end
   end

--- a/app/services/messages/update_service.rb
+++ b/app/services/messages/update_service.rb
@@ -28,26 +28,6 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Attachments
-  module SetReplacements
-    extend ActiveSupport::Concern
-
-    included do
-      private
-
-      def set_attributes(attributes)
-        set_attachments_attributes(attributes)
-
-        super
-      end
-
-      def set_attachments_attributes(attributes)
-        attachment_ids = attributes.delete(:attachment_ids)
-
-        return unless attachment_ids
-
-        model.attachments_replacements = Attachment.where(id: attachment_ids)
-      end
-    end
-  end
+class Messages::UpdateService < ::BaseServices::Update
+  include Attachments::ReplaceAttachments
 end

--- a/app/services/relations/create_service.rb
+++ b/app/services/relations/create_service.rb
@@ -35,7 +35,7 @@ class Relations::CreateService < Relations::BaseService
   end
 
   def call(relation, send_notifications: true)
-    in_context(send_notifications) do
+    in_user_context(send_notifications) do
       update_relation relation, {}
     end
   end

--- a/app/services/shared/service_context.rb
+++ b/app/services/shared/service_context.rb
@@ -32,7 +32,7 @@ module Shared
   module ServiceContext
     private
 
-    def in_context(model, send_notifications, &block)
+    def in_context(model, send_notifications = true, &block)
       if model
         in_mutex_context(model, send_notifications, &block)
       else
@@ -40,13 +40,13 @@ module Shared
       end
     end
 
-    def in_mutex_context(model, send_notifications, &block)
+    def in_mutex_context(model, send_notifications = true, &block)
       OpenProject::Mutex.with_advisory_lock_transaction(model) do
         in_user_context(send_notifications, &block)
       end
     end
 
-    def in_user_context(send_notifications)
+    def in_user_context(send_notifications = true)
       result = nil
 
       ActiveRecord::Base.transaction do

--- a/app/services/time_entries/create_service.rb
+++ b/app/services/time_entries/create_service.rb
@@ -29,7 +29,6 @@
 #++
 
 class TimeEntries::CreateService < ::BaseServices::Create
-
   def after_perform(call)
     OpenProject::Notifications.send(
       OpenProject::Events::NEW_TIME_ENTRY_CREATED,

--- a/app/services/work_packages/bulk/update_service.rb
+++ b/app/services/work_packages/bulk/update_service.rb
@@ -43,7 +43,7 @@ module WorkPackages
 
       def call(params:)
         self.permitted_params = PermittedParams.new(params, user)
-        in_context(true) do
+        in_user_context do
           bulk_update(params)
         end
       end

--- a/app/services/work_packages/copy_service.rb
+++ b/app/services/work_packages/copy_service.rb
@@ -43,7 +43,7 @@ class WorkPackages::CopyService
   end
 
   def call(send_notifications: true, **attributes)
-    in_context(send_notifications) do
+    in_context(work_package) do
       copy(attributes, send_notifications)
     end
   end

--- a/app/services/work_packages/create_service.rb
+++ b/app/services/work_packages/create_service.rb
@@ -43,7 +43,7 @@ class WorkPackages::CreateService
   def call(work_package: WorkPackage.new,
            send_notifications: true,
            **attributes)
-    in_context(send_notifications) do
+    in_user_context(send_notifications) do
       create(attributes, work_package)
     end
   end

--- a/app/services/work_packages/reschedule_service.rb
+++ b/app/services/work_packages/reschedule_service.rb
@@ -40,7 +40,7 @@ class WorkPackages::RescheduleService
   end
 
   def call(date)
-    in_context(true) do
+    in_context(work_package) do
       return if date.nil?
 
       update(date)

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -43,7 +43,7 @@ class WorkPackages::UpdateService
   end
 
   def call(send_notifications: true, **attributes)
-    in_context(send_notifications) do
+    in_context(model, send_notifications) do
       update(attributes)
     end
   end

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -28,6 +28,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
+# TODO: use default update base class
 class WorkPackages::UpdateService
   include ::WorkPackages::Shared::UpdateAncestors
   include ::Shared::ServiceContext

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -28,11 +28,7 @@ See docs/COPYRIGHT.rdoc for more details.
 ++#%>
 <%= error_messages_for 'message' %>
 <% replying ||= false %>
-<% representer_object = if replying
-                          f.object.parent
-                        else
-                          f.object
-                        end %>
+<% representer_object = f.object %>
 <% resource = message_attachment_representer(representer_object) %>
 
 <div class="form--field -required">

--- a/config/initializers/register_renderer.rb
+++ b/config/initializers/register_renderer.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1196,6 +1196,9 @@ en:
       forums: "Community forum"
       newsletter: "Security alerts / Newsletter"
 
+  journals:
+    changes_retracted: "The changes where retracted."
+
   links:
     configuration_guide: 'Configuration guide'
 
@@ -2681,6 +2684,7 @@ en:
 
   query_menu_item_for: "Menu item for query \"%{title}\""
 
+  # TODO: merge with work_packages top level key
   work_package:
     updated_automatically_by_child_changes: |
         _Updated automatically by changing values within child work package %{child}_

--- a/db/migrate/20200302100431_fix_attachable_journals.rb
+++ b/db/migrate/20200302100431_fix_attachable_journals.rb
@@ -1,0 +1,49 @@
+class FixAttachableJournals < ActiveRecord::Migration[6.0]
+  # Adds attachable_journals to all journals where the
+  # attachment was created before the journal as long as there
+  # is no attachable_journal associated to the journal yet.
+  #
+  # This does not fix journals where the attachment has been deleted in the meantime as
+  # we no longer have the necessary information to recreate the journals.
+  def up
+    statement = <<~SQL
+      WITH
+        existing_attachments AS (
+          SELECT
+            id,
+            created_at,
+            file,
+            container_id,
+            container_type,
+            author_id
+          FROM attachments),
+        existing_attachable_journals AS (
+          SELECT
+            journals.id journal_id,
+            attachable_journals.attachment_id
+          FROM journals
+          LEFT OUTER JOIN attachable_journals ON journals.id = attachable_journals.journal_id
+          LEFT OUTER JOIN attachments ON attachable_journals.attachment_id = attachments.id)
+
+      INSERT INTO attachable_journals (journal_id, attachment_id, filename)
+      SELECT
+        journals.id journal_id,
+        existing_attachments.id attachment_id,
+        existing_attachments.file filename
+      FROM journals
+      JOIN existing_attachments
+        ON journals.created_at >= existing_attachments.created_at
+        AND journals.user_id = existing_attachments.author_id
+        AND journals.journable_id = existing_attachments.container_id
+        AND journals.journable_type = existing_attachments.container_type
+      LEFT OUTER JOIN existing_attachable_journals
+        ON existing_attachments.id = existing_attachable_journals.attachment_id
+        AND journals.id = existing_attachable_journals.journal_id
+      WHERE attachment_id IS NULL
+    SQL
+
+    ActiveRecord::Base.connection.execute statement
+  end
+
+  # Does not require a down statement as a bug is fixed.
+end

--- a/frontend/src/app/modules/attachments/attachment-list/attachment-list-item.html
+++ b/frontend/src/app/modules/attachments/attachment-list/attachment-list-item.html
@@ -29,5 +29,5 @@
              [icon-title]="text.removeFile({fileName: attachment.fileName})"></op-icon>
   </a>
 
-  <input type="hidden" name="attachments[{{index}}][id]" value="{{attachment.id}}" *ngIf="!attachment.container">
+  <input type="hidden" name="attachments[{{index}}][id]" value="{{attachment.id}}">
 </li>

--- a/frontend/src/app/modules/common/notifications/notification.component.html
+++ b/frontend/src/app/modules/common/notifications/notification.component.html
@@ -20,7 +20,7 @@
           </a>
           <span [textContent]="uploadText"></span>
         </div>
-        <div *ngIf="show || !canBeHidden()">
+        <div [ngClass]="{ '-hidden': !show && canBeHidden() }">
           <ul class="notification-box--uploads" *ngIf="data && data.length > 0">
             <notifications-upload-progress
                 *ngFor="let upload of data"

--- a/frontend/src/app/modules/common/notifications/notification.component.ts
+++ b/frontend/src/app/modules/common/notifications/notification.component.ts
@@ -44,7 +44,7 @@ export class NotificationComponent implements OnInit {
 
   public text = {
     close_popup: this.I18n.t('js.close_popup_title'),
-  }
+  };
 
   public type:NotificationType;
   public uploadCount = 0;

--- a/lib/api/helpers/attachment_renderer.rb
+++ b/lib/api/helpers/attachment_renderer.rb
@@ -49,7 +49,7 @@ module API
           content_type attachment.content_type
           header['Content-Disposition'] = "#{attachment.content_disposition}; filename=#{attachment.filename}"
           env['api.format'] = :binary
-          file attachment.diskfile
+          file attachment.diskfile.path
         end
       end
 

--- a/lib/api/v3/attachments/attachments_api.rb
+++ b/lib/api/v3/attachments/attachments_api.rb
@@ -59,17 +59,7 @@ module API
               AttachmentRepresenter.new(@attachment, embed_links: true, current_user: current_user)
             end
 
-            delete do
-              raise API::Errors::Unauthorized unless @attachment.deletable?(current_user)
-
-              if @attachment.container
-                @attachment.container.attachments.delete(@attachment)
-              else
-                @attachment.destroy
-              end
-
-              status 204
-            end
+            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Attachment).mount
 
             namespace :content do
               helpers ::API::Helpers::AttachmentRenderer

--- a/lib/api/v3/attachments/attachments_by_container_api.rb
+++ b/lib/api/v3/attachments/attachments_by_container_api.rb
@@ -79,7 +79,7 @@ module API
                                                                    file[:type],
                                                                    file_name: metadata.file_name.to_s
 
-            service = Attachments::CreateService.new(container, author: current_user)
+            service = ::Attachments::CreateService.new(container, author: current_user)
 
             with_handled_create_errors do
               service.call uploaded_file: uploaded_file,

--- a/lib/api/v3/attachments/attachments_by_container_api.rb
+++ b/lib/api/v3/attachments/attachments_by_container_api.rb
@@ -79,11 +79,11 @@ module API
                                                                    file[:type],
                                                                    file_name: metadata.file_name.to_s
 
-            service = AddAttachmentService.new(container, author: current_user)
+            service = Attachments::CreateService.new(container, author: current_user)
 
             with_handled_create_errors do
-              service.add_attachment uploaded_file: uploaded_file,
-                                     description: metadata.description
+              service.call uploaded_file: uploaded_file,
+                           description: metadata.description
             end
           end
 

--- a/lib/open_project/info.rb
+++ b/lib/open_project/info.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/lib/open_project/mutex.rb
+++ b/lib/open_project/mutex.rb
@@ -1,0 +1,89 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject
+  module Mutex
+    module_function
+
+    # Adds a mutex on database level via advisory locks:
+    # https://www.postgresql.org/docs/12/explicit-locking.html
+    # employing the with_advisory_lock gem.
+    # This leads to requests received in parallel by two different workers, which might be in different OS processes
+    # on different hosts, to be executed sequentially.
+    # The locks are, from an abstract perspective, on row level as the entry's id is taken to create the lock.
+    # Other entries of the same class can still be created/updated.
+    # Relying on explicit row level locking (e.g. ROW EXCLUSIVE FOR UPDATE) would not work, I believe, as it would still
+    # allow reading. Allowing reading is desirable in some cases, e.g. when fetching for the work package list, but would not
+    # prevent the creation of journals. The journals transaction could not be committed, but the faulty view of the entries
+    # current state could be committed anyway afterwards. See below for details.
+    #
+    # We in particular have to wait until the transaction is complete.
+    # Otherwise the following is e.g. possible:
+    # Action 1 writes an attachment and releases the lock.
+    # Action 2, running in parallel, writes an attachment and releases the lock.
+    # Action 3 updates something, some time later.
+    # Both have not yet committed their transaction so, given that we have the "READ COMMITTED" transaction level,
+    # the two actions cannot yet see the attachment added by the respective other action.
+    # Both actions now proceed to write their journals, which will create attachable journals based on the attachments
+    # at that time. But given that both do not see the attachment added by the other action yet, they only add
+    # attachable journals for the attachment added by themselves. To the user this will look as if one of the actions
+    # deleted the other attachment. The next action, Action 3,  will then seem to have readded the attachment,
+    # seemingly removed before.
+    def with_advisory_lock_transaction(entry, &block)
+      ActiveRecord::Base.transaction do
+        with_advisory_lock(entry, &block)
+      end
+    end
+
+    def with_advisory_lock(entry)
+      lock_name = "mutex_on_#{entry.class.name}_#{entry.id}"
+
+      debug_log("Attempting to fetched advisory lock", lock_name)
+      result = entry.class.with_advisory_lock(lock_name, transaction: true) do
+        debug_log("Fetched advisory lock", lock_name)
+        yield
+      end
+      debug_log("Released advisory lock", lock_name)
+
+      result
+    end
+
+    def debug_log(action, lock_name)
+      message = <<~MESSAGE
+        #{action}:
+          * lockname: #{lock_name}
+          * thread:  #{Thread.current.object_id}
+          * held locks: #{WithAdvisoryLock::Base.lock_stack.map(&:name).join(', ')}
+      MESSAGE
+
+      Rails.logger.debug { message }
+    end
+  end
+end

--- a/lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb
+++ b/lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb
@@ -157,6 +157,8 @@ module Redmine
               (persisted? && allowed_to_on_attachment?(user, self.class.attachable_options[:add_on_persisted_permission]))
           end
 
+          # TODO: Check if we can remove this.
+          # If the attachments where only added via the Attachments::CreateService, it would be thread safe.
           # Bulk attaches a set of files to an object
           def attach_files(attachments)
             return unless attachments&.is_a?(Hash)

--- a/lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb
+++ b/lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb
@@ -29,8 +29,10 @@
 module Redmine
   module Acts
     module Attachable
-      def self.included(base)
-        base.extend ClassMethods
+      extend ActiveSupport::Concern
+
+      included do
+        extend ClassMethods
       end
 
       def self.attachables
@@ -51,6 +53,8 @@ module Redmine
           attr_accessor :attachments_replacements,
                         :attachments_claimed
           send :include, Redmine::Acts::Attachable::InstanceMethods
+
+          OpenProject::Deprecation.deprecate_method self, :attach_files
         end
 
         private
@@ -157,9 +161,10 @@ module Redmine
               (persisted? && allowed_to_on_attachment?(user, self.class.attachable_options[:add_on_persisted_permission]))
           end
 
-          # TODO: Check if we can remove this.
-          # If the attachments where only added via the Attachments::CreateService, it would be thread safe.
           # Bulk attaches a set of files to an object
+          # @deprecated
+          # Either use the already existing Attachments::CreateService or
+          # write/extend Services for the attached to object.
           def attach_files(attachments)
             return unless attachments&.is_a?(Hash)
 

--- a/lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb
+++ b/lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb
@@ -165,6 +165,10 @@ module Redmine
           # @deprecated
           # Either use the already existing Attachments::CreateService or
           # write/extend Services for the attached to object.
+          # The service should rely on the attachments_replacements variable.
+          # See:
+          # * app/services/attachments/set_replacements.rb
+          # * app/services/attachments/replace_attachments.rb
           def attach_files(attachments)
             return unless attachments&.is_a?(Hash)
 
@@ -216,7 +220,8 @@ module Redmine
 
           def memoize_attachment_for_claiming(attachment_hash)
             self.attachments_claimed ||= []
-            self.attachments_claimed << Attachment.find(attachment_hash['id'])
+            attachment = Attachment.find(attachment_hash['id'])
+            self.attachments_claimed << attachment unless id && attachment.container_id == id
           end
 
           def validate_attachments_claimable

--- a/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/save_hooks.rb
+++ b/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/save_hooks.rb
@@ -74,9 +74,9 @@ module Redmine::Acts::Journalized
 
       add_journal = journals.empty? || JournalManager.changed?(self) || !@journal_notes.empty?
 
-      journal = JournalManager.add_journal! self, @journal_user, @journal_notes if add_journal
-
       if add_journal
+        journal = JournalManager.add_journal!(self, @journal_user, @journal_notes)
+
         OpenProject::Notifications.send('journal_created',
                                         journal: journal,
                                         send_notification: JournalManager.send_notification)

--- a/modules/costs/app/controllers/cost_objects_controller.rb
+++ b/modules/costs/app/controllers/cost_objects_controller.rb
@@ -126,22 +126,19 @@ class CostObjectsController < ApplicationController
     @cost_object.project_id = @project.id
 
     # fixed_date must be set before material_budget_items and labor_budget_items
-    if params[:cost_object] && params[:cost_object][:fixed_date]
-      @cost_object.fixed_date = params[:cost_object].delete(:fixed_date)
-    else
-      @cost_object.fixed_date = Date.today
-    end
+    @cost_object.fixed_date = if params[:cost_object] && params[:cost_object][:fixed_date]
+                                params[:cost_object].delete(:fixed_date)
+                              else
+                                Date.today
+                              end
 
     @cost_object.attributes = permitted_params.cost_object
     @cost_object.attach_files(permitted_params.attachments.to_h)
 
     if @cost_object.save
-      render_attachment_warning_if_needed(@cost_object)
-
       flash[:notice] = t(:notice_successful_create)
       redirect_to(params[:continue] ? { action: 'new' } :
                       { action: 'show', id: @cost_object })
-      return
     else
       render action: 'new', layout: !request.xhr?
     end
@@ -172,8 +169,6 @@ class CostObjectsController < ApplicationController
     @cost_object.attach_files(permitted_params.attachments.to_h)
 
     if @cost_object.save
-      render_attachment_warning_if_needed(@cost_object)
-
       flash[:notice] = t(:notice_successful_update)
       redirect_to(params[:back_to] || { action: 'show', id: @cost_object })
     else

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -68,7 +68,6 @@ class DocumentsController < ApplicationController
     @document.attach_files(permitted_params.attachments.to_h)
 
     if @document.save
-      render_attachment_warning_if_needed(@document)
       flash[:notice] = l(:notice_successful_create)
       redirect_to project_documents_path(@project)
     else
@@ -85,7 +84,6 @@ class DocumentsController < ApplicationController
     @document.attach_files(permitted_params.attachments.to_h)
 
     if @document.save
-      render_attachment_warning_if_needed(@document)
       flash[:notice] = l(:notice_successful_update)
       redirect_to action: 'show', id: @document
     else
@@ -103,9 +101,8 @@ class DocumentsController < ApplicationController
     attachments = @document.attachments.select(&:new_record?)
 
     @document.save
-    render_attachment_warning_if_needed(@document)
-
     saved_attachments = attachments.select(&:persisted?)
+
     if saved_attachments.present? && Setting.notified_events.include?('document_added')
       users = saved_attachments.first.container.recipients
       users.each do |user|

--- a/modules/meeting/app/controllers/meeting_contents_controller.rb
+++ b/modules/meeting/app/controllers/meeting_contents_controller.rb
@@ -67,7 +67,6 @@ class MeetingContentsController < ApplicationController
     if @content.save
       flash[:notice] = l(:notice_successful_update)
       redirect_back_or_default controller: '/meetings', action: 'show', id: @meeting
-    else
     end
   rescue ActiveRecord::StaleObjectError
     # Optimistic locking exception

--- a/spec/contracts/messages/create_contract_spec.rb
+++ b/spec/contracts/messages/create_contract_spec.rb
@@ -28,26 +28,25 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Attachments
-  module SetReplacements
-    extend ActiveSupport::Concern
+require 'spec_helper'
+require_relative './shared_contract_examples'
 
-    included do
-      private
+describe Messages::CreateContract do
+  it_behaves_like 'message contract' do
+    let(:message) do
+      Message.new(forum: message_forum,
+                  parent: message_parent,
+                  subject: message_subject,
+                  content: message_content,
+                  author: message_author,
+                  last_reply: message_last_reply,
+                  locked: message_locked,
+                  sticky: message_sticky)
+    end
+    let(:changed_by_system) { %w(author_id) }
 
-      def set_attributes(attributes)
-        set_attachments_attributes(attributes)
-
-        super
-      end
-
-      def set_attachments_attributes(attributes)
-        attachment_ids = attributes.delete(:attachment_ids)
-
-        return unless attachment_ids
-
-        model.attachments_replacements = Attachment.where(id: attachment_ids)
-      end
+    subject(:contract) do
+      described_class.new(message, current_user, options: { changed_by_system: changed_by_system })
     end
   end
 end

--- a/spec/contracts/messages/shared_contract_examples.rb
+++ b/spec/contracts/messages/shared_contract_examples.rb
@@ -28,26 +28,44 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Attachments
-  module SetReplacements
-    extend ActiveSupport::Concern
+require 'spec_helper'
 
-    included do
-      private
-
-      def set_attributes(attributes)
-        set_attachments_attributes(attributes)
-
-        super
-      end
-
-      def set_attachments_attributes(attributes)
-        attachment_ids = attributes.delete(:attachment_ids)
-
-        return unless attachment_ids
-
-        model.attachments_replacements = Attachment.where(id: attachment_ids)
+shared_examples_for 'message contract' do
+  let(:current_user) do
+    FactoryBot.build_stubbed(:user) do |user|
+      allow(user)
+        .to receive(:allowed_to?) do |permission, permission_project|
+        permissions.include?(permission) && message_project == permission_project
       end
     end
   end
+  let(:reply_message) { FactoryBot.build_stubbed(:message) }
+  let(:other_user) { FactoryBot.build_stubbed(:user) }
+  let(:message_forum) do
+    FactoryBot.build_stubbed(:forum)
+  end
+  let(:message_project) { FactoryBot.build_stubbed(:project) }
+  let(:message_parent) { FactoryBot.build_stubbed(:message) }
+  let(:message_subject) { "Subject" }
+  let(:message_content) { "A content" }
+  let(:message_author) { other_user }
+  let(:message_last_reply) { reply_message }
+  let(:message_locked) { true }
+  let(:message_sticky) { true }
+
+  def expect_valid(valid, symbols = {})
+    expect(contract.validate).to eq(valid)
+
+    symbols.each do |key, arr|
+      expect(contract.errors.symbols_for(key)).to match_array arr
+    end
+  end
+
+  shared_examples 'is valid' do
+    it 'is valid' do
+      expect_valid(true)
+    end
+  end
+
+  it_behaves_like 'is valid'
 end

--- a/spec/contracts/messages/update_contract_spec.rb
+++ b/spec/contracts/messages/update_contract_spec.rb
@@ -28,25 +28,28 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Attachments
-  module SetReplacements
-    extend ActiveSupport::Concern
+require 'spec_helper'
+require_relative './shared_contract_examples'
 
-    included do
-      private
-
-      def set_attributes(attributes)
-        set_attachments_attributes(attributes)
-
-        super
+describe Messages::UpdateContract do
+  it_behaves_like 'message contract' do
+    let(:message) do
+      FactoryBot.build_stubbed(:message).tap do |message|
+        message.forum = message_forum
+        message.parent = message_parent
+        message.subject = message_subject
+        message.content = message_content
+        message.last_reply = message_last_reply
+        message.locked = message_locked
+        message.sticky = message_sticky
       end
+    end
+    subject(:contract) { described_class.new(message, current_user) }
 
-      def set_attachments_attributes(attributes)
-        attachment_ids = attributes.delete(:attachment_ids)
-
-        return unless attachment_ids
-
-        model.attachments_replacements = Attachment.where(id: attachment_ids)
+    context 'if the author is changed' do
+      it 'is invalid' do
+        message.author = other_user
+        expect_valid(false, author_id: %i(error_readonly))
       end
     end
   end

--- a/spec/contracts/time_entries/create_contract_spec.rb
+++ b/spec/contracts/time_entries/create_contract_spec.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/contracts/time_entries/delete_contract_spec.rb
+++ b/spec/contracts/time_entries/delete_contract_spec.rb
@@ -54,13 +54,13 @@ describe TimeEntries::DeleteContract do
 
   let(:time_entry) do
     FactoryBot.build_stubbed(:time_entry,
-                              project: time_entry_project,
-                              work_package: time_entry_work_package,
-                              user: time_entry_user,
-                              activity: time_entry_activity,
-                              spent_on: time_entry_spent_on,
-                              hours: time_entry_hours,
-                              comments: time_entry_comments)
+                             project: time_entry_project,
+                             work_package: time_entry_work_package,
+                             user: time_entry_user,
+                             activity: time_entry_activity,
+                             spent_on: time_entry_spent_on,
+                             hours: time_entry_hours,
+                             comments: time_entry_comments)
   end
 
   before do

--- a/spec/contracts/time_entries/update_contract_spec.rb
+++ b/spec/contracts/time_entries/update_contract_spec.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/factories/journal_factory.rb
+++ b/spec/factories/journal_factory.rb
@@ -30,12 +30,16 @@ FactoryBot.define do
   factory :journal do
     user factory: :user
     created_at { Time.now }
-    sequence(:version) do |n| n + 1 end
+    sequence(:version) { |n| n + 1 }
 
     factory :work_package_journal, class: Journal do
       journable_type { 'WorkPackage' }
       activity_type { 'work_packages' }
       data { FactoryBot.build(:journal_work_package_journal) }
+
+      callback(:after_stub) do |journal, options|
+        journal.journable ||= options.journable || FactoryBot.build_stubbed(:work_package)
+      end
     end
 
     factory :wiki_content_journal, class: Journal do

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -240,6 +240,7 @@ describe PermittedParams, type: :model do
 
     context 'with instance passed' do
       let(:instance) { double('message', project: double('project')) }
+      let(:project) { double('project') }
       let(:allowed_params) do
         { 'subject' => 'value',
           'content' => 'value',
@@ -253,10 +254,10 @@ describe PermittedParams, type: :model do
       end
 
       before do
-        allow(user).to receive(:allowed_to?).with(:edit_messages, instance.project).and_return(true)
+        allow(user).to receive(:allowed_to?).with(:edit_messages, project).and_return(true)
       end
 
-      subject { PermittedParams.new(hash, user).message(instance).to_h }
+      subject { PermittedParams.new(hash, user).message(project).to_h }
 
       it do
         expect(subject).to eq(allowed_params)

--- a/spec/services/attachments/create_service_spec.rb
+++ b/spec/services/attachments/create_service_spec.rb
@@ -34,7 +34,7 @@ describe Attachments::CreateService do
   let(:container) { work_package }
   let(:description) { 'a fancy description' }
 
-  subject { described_class.new(work_package, author: user) }
+  subject { described_class.new(container, author: user) }
 
   describe '#call' do
     def call_tested_method
@@ -50,12 +50,12 @@ describe Attachments::CreateService do
       end
 
       it 'adds the attachment to the WP' do
-        work_package.reload
-        expect(work_package.attachments).to include Attachment.first
+        container.reload
+        expect(container.attachments).to include Attachment.first
       end
 
       it 'adds a journal entry on the WP' do
-        expect(work_package.journals.count).to eq 2 # 1 for WP creation + 1 for the attachment
+        expect(container.journals.count).to eq 2 # 1 for WP creation + 1 for the attachment
       end
     end
 
@@ -76,6 +76,20 @@ describe Attachments::CreateService do
       end
 
       it_behaves_like 'successful creation'
+    end
+
+    context "uncontainered" do
+      let(:container) { nil }
+
+      before do
+        call_tested_method
+      end
+
+      it 'saves the attachment' do
+        attachment = Attachment.first
+        expect(attachment.filename).to eq 'foobar.txt'
+        expect(attachment.description).to eq description
+      end
     end
 
     context 'invalid attachment', with_settings: { attachment_max_size: 0 } do

--- a/spec/services/attachments/create_service_spec.rb
+++ b/spec/services/attachments/create_service_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe AddAttachmentService do
+describe Attachments::CreateService do
   let(:user) { FactoryBot.create(:user) }
   let(:work_package) { FactoryBot.create(:work_package) }
   let(:container) { work_package }
@@ -36,10 +36,10 @@ describe AddAttachmentService do
 
   subject { described_class.new(work_package, author: user) }
 
-  describe '#add_attachment' do
+  describe '#call' do
     def call_tested_method
-      subject.add_attachment uploaded_file: FileHelpers.mock_uploaded_file(name: 'foobar.txt'),
-                             description: description
+      subject.call uploaded_file: FileHelpers.mock_uploaded_file(name: 'foobar.txt'),
+                   description: description
     end
 
     shared_examples 'successful creation' do

--- a/spec/services/messages/create_service_spec.rb
+++ b/spec/services/messages/create_service_spec.rb
@@ -1,0 +1,149 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Messages::CreateService, type: :model do
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:contract_class) do
+    double('contract_class', '<=': true)
+  end
+  let(:message_valid) { true }
+  let(:instance) do
+    described_class.new(user: user,
+                        contract_class: contract_class)
+  end
+  let(:call_attributes) { { name: 'Some name', identifier: 'Some identifier' } }
+  let(:set_attributes_success) do
+    true
+  end
+  let(:set_attributes_errors) do
+    double('set_attributes_errors')
+  end
+  let(:set_attributes_result) do
+    ServiceResult.new result: created_message,
+                      success: set_attributes_success,
+                      errors: set_attributes_errors
+  end
+  let!(:created_message) do
+    message = FactoryBot.build_stubbed(:message)
+
+    allow(Message)
+      .to receive(:new)
+      .and_return(message)
+
+    allow(message)
+      .to receive(:save)
+      .and_return(message_valid)
+
+    message
+  end
+  let!(:set_attributes_service) do
+    service = double('set_attributes_service_instance')
+
+    allow(Messages::SetAttributesService)
+      .to receive(:new)
+      .with(user: user,
+            model: created_message,
+            contract_class: contract_class)
+      .and_return(service)
+
+    allow(service)
+      .to receive(:call)
+      .and_return(set_attributes_result)
+  end
+  let(:new_project_role) { FactoryBot.build_stubbed(:role) }
+
+  describe 'call' do
+    subject { instance.call(call_attributes) }
+
+    it 'is successful' do
+      expect(subject.success?).to be_truthy
+    end
+
+    it 'returns the result of the SetAttributesService' do
+      expect(subject)
+        .to eql set_attributes_result
+    end
+
+    it 'persists the message' do
+      expect(created_message)
+        .to receive(:save)
+        .and_return(message_valid)
+
+      subject
+    end
+
+    it 'creates a message' do
+      expect(subject.result)
+        .to eql created_message
+    end
+
+    context 'if the SetAttributeService is unsuccessful' do
+      let(:set_attributes_success) { false }
+
+      it 'is unsuccessful' do
+        expect(subject.success?).to be_falsey
+      end
+
+      it 'returns the result of the SetAttributesService' do
+        expect(subject)
+          .to eql set_attributes_result
+      end
+
+      it 'does not persist the changes' do
+        expect(created_message)
+          .to_not receive(:save)
+
+        subject
+      end
+
+      it "exposes the contract's errors" do
+        subject
+
+        expect(subject.errors).to eql set_attributes_errors
+      end
+    end
+
+    context 'when the message is invalid' do
+      let(:message_valid) { false }
+
+      it 'is unsuccessful' do
+        expect(subject.success?).to be_falsey
+      end
+
+      it "exposes the message's errors" do
+        subject
+
+        expect(subject.errors).to eql created_message.errors
+      end
+    end
+  end
+end

--- a/spec/services/messages/set_attributes_service_spec.rb
+++ b/spec/services/messages/set_attributes_service_spec.rb
@@ -1,0 +1,141 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Messages::SetAttributesService, type: :model do
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:forum) { FactoryBot.build_stubbed(:forum) }
+  let(:contract_instance) do
+    contract = double('contract_instance')
+    allow(contract)
+      .to receive(:validate)
+      .and_return(contract_valid)
+    allow(contract)
+      .to receive(:errors)
+      .and_return(contract_errors)
+    contract
+  end
+
+  let(:contract_errors) { double('contract_errors') }
+  let(:contract_valid) { true }
+  let(:time_entry_valid) { true }
+
+  let(:instance) do
+    described_class.new(user: user,
+                        model: message_instance,
+                        contract_class: contract_class)
+  end
+  let(:message_instance) { Message.new }
+  let(:contract_class) do
+    allow(Messages::CreateContract)
+      .to receive(:new)
+      .with(message_instance, user, options: { changed_by_system: ["author_id"] })
+      .and_return(contract_instance)
+
+    Messages::CreateContract
+  end
+
+  let(:params) { {} }
+
+  before do
+    allow(message_instance)
+      .to receive(:valid?)
+      .and_return(time_entry_valid)
+  end
+
+  subject { instance.call(params) }
+
+  it 'returns the message instance as the result' do
+    expect(subject.result)
+      .to eql message_instance
+  end
+
+  it 'is a success' do
+    is_expected
+      .to be_success
+  end
+
+  it "has the service's user assigned as author" do
+    subject
+
+    expect(message_instance.author)
+      .to eql user
+  end
+
+  it 'notes the author to be system changed' do
+    subject
+
+    expect(instance.changed_by_system)
+      .to include('author_id')
+  end
+
+  context 'with params' do
+    let(:params) do
+      {
+        forum: forum
+      }
+    end
+
+    let(:expected) do
+      {
+        author_id: user.id,
+        forum_id: forum.id
+      }.with_indifferent_access
+    end
+
+    it 'assigns the params' do
+      subject
+
+      attributes_of_interest = message_instance
+                                 .attributes
+                                 .slice(*expected.keys)
+
+      expect(attributes_of_interest)
+        .to eql(expected)
+    end
+  end
+
+  context 'with an invalid contract' do
+    let(:contract_valid) { false }
+    let(:expect_time_instance_save) do
+      expect(message_instance)
+        .not_to receive(:save)
+    end
+
+    it 'returns failure' do
+      is_expected
+        .not_to be_success
+    end
+
+    it "returns the contract's errors" do
+      expect(subject.errors)
+        .to eql(contract_errors)
+    end
+  end
+end

--- a/spec/services/messages/update_service_spec.rb
+++ b/spec/services/messages/update_service_spec.rb
@@ -1,0 +1,150 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Messages::UpdateService, type: :model do
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:contract_class) do
+    double('contract_class', "<=": true)
+  end
+  let(:message_valid) { true }
+  let(:instance) do
+    described_class.new(user: user,
+                        model: message,
+                        contract_class: contract_class)
+  end
+  let(:call_attributes) { {} }
+  let(:set_attributes_success) do
+    true
+  end
+  let(:set_attributes_errors) do
+    double('set_attributes_errors')
+  end
+  let(:set_attributes_result) do
+    ServiceResult.new result: message,
+                      success: set_attributes_success,
+                      errors: set_attributes_errors
+  end
+  let!(:message) do
+    message = FactoryBot.build_stubbed(:message)
+
+    allow(message)
+      .to receive(:save)
+      .and_return(message_valid)
+
+    message
+  end
+  let!(:set_attributes_service) do
+    service = double('set_attributes_service_instance')
+
+    allow(Messages::SetAttributesService)
+      .to receive(:new)
+      .with(user: user,
+            model: message,
+            contract_class: contract_class)
+      .and_return(service)
+
+    allow(service)
+      .to receive(:call)
+            .and_return(set_attributes_result)
+
+    service
+  end
+
+  describe 'call' do
+    shared_examples_for 'service call' do
+      subject { instance.call(call_attributes) }
+
+      it 'is successful' do
+        expect(subject.success?).to be_truthy
+      end
+
+      it 'returns the result of the SetAttributesService' do
+        expect(subject)
+          .to eql set_attributes_result
+      end
+
+      it 'persists the message' do
+        expect(message)
+          .to receive(:save)
+                .and_return(message_valid)
+
+        subject
+      end
+
+      context 'when the SetAttributeService is unsuccessful' do
+        let(:set_attributes_success) { false }
+
+        it 'is unsuccessful' do
+          expect(subject.success?).to be_falsey
+        end
+
+        it 'returns the result of the SetAttributesService' do
+          expect(subject)
+            .to eql set_attributes_result
+        end
+
+        it 'does not persist the changes' do
+          expect(message)
+            .to_not receive(:save)
+
+          subject
+        end
+
+        it "exposes the contract's errors" do
+          subject
+
+          expect(subject.errors).to eql set_attributes_errors
+        end
+      end
+
+      context 'when the message is invalid' do
+        let(:message_valid) { false }
+
+        it 'is unsuccessful' do
+          expect(subject.success?).to be_falsey
+        end
+
+        it "exposes the message's errors" do
+          subject
+
+          expect(subject.errors).to eql message.errors
+        end
+      end
+    end
+
+    context 'with parameters' do
+      let(:call_attributes) { { sticky: true } }
+
+      it_behaves_like 'service call'
+    end
+  end
+end


### PR DESCRIPTION
Prevent interloping updates to entries, e.g. work packages that might end up in having inconsistent journals.

The easiest way of reproducing the problem is to bulk upload attachments. But other scenarios, e.g. uploading in one session while manipulating the work package in another might also cause the problem.

See https://github.com/opf/openproject/compare/fix/attachment_race_condition?expand=1#diff-0eacebd92347a467eeb5186c50fe28cdR35-R58 for a detailed scenario description.

### ToDos

* [x] Safeguard attachment deletion
* [x] Check other places where services are not yet used and which also upload attachments (we might rule the risk to be bearable)
* [x] Check whether already corrupted journals can be fixed
* [x] **Backport to 10.4** Developing on that branch is hampered by having to restart the server consistently.

https://community.openproject.com/work_packages/32302

