### PR TITLE
Stabilize bim_filter_spec

### DIFF
--- a/modules/bim/spec/features/bim_filter_spec.rb
+++ b/modules/bim/spec/features/bim_filter_spec.rb
@@ -84,13 +84,8 @@ describe 'BIM filter spec', type: :feature, js: true do
       filters.set_operator('Status', 'closed', nil)
       filters.expect_filter_count 1
 
-      # Otherwise the check for the loading indicator is done
-      # before it is even shown and the next steps will fail
-      sleep 0.5
-      loading_indicator_saveguard
-
-      card_view.expect_work_package_not_listed wp1
       card_view.expect_work_package_listed wp2
+      card_view.expect_work_package_not_listed wp1
 
       # Using the browser back will reload the filter and the work packages
       page.go_back
@@ -109,25 +104,19 @@ describe 'BIM filter spec', type: :feature, js: true do
       filters.set_operator('Status', 'closed', nil)
       filters.expect_filter_count 1
 
-      # Otherwise the check for the loading indicator is done
-      # before it is even shown and the next steps will fail
-      sleep 0.5
-      loading_indicator_saveguard
-
-      card_view.expect_work_package_not_listed wp1
       card_view.expect_work_package_listed wp2
+      card_view.expect_work_package_not_listed wp1
 
       # Reload and the filter is still correctly applied
       page.driver.browser.navigate.refresh
-      loading_indicator_saveguard
 
       filters.expect_loaded
       filters.expect_filter_count 1
       filters.open
       filters.expect_filter_by('Status', 'closed', nil)
 
-      card_view.expect_work_package_not_listed wp1
       card_view.expect_work_package_listed wp2
+      card_view.expect_work_package_not_listed wp1
     end
   end
 end

--- a/spec/support/pages/work_packages/work_package_cards.rb
+++ b/spec/support/pages/work_packages/work_package_cards.rb
@@ -39,7 +39,7 @@ module Pages
 
     def expect_work_package_listed(*work_packages)
       work_packages.each do |wp|
-        expect(page).to have_selector("wp-single-card[data-work-package-id='#{wp.id}']")
+        expect(page).to have_selector("wp-single-card[data-work-package-id='#{wp.id}']", wait: 10)
       end
     end
 


### PR DESCRIPTION
The loading indicator sometimes did not even start yet, when the `loading_indicator_saveguard` check was made. Thus the following checks were made too early. This is avoided by a `wait` in the check for the correct cards.