### PR TITLE
Move split screen on ifc page also to the screen right/bottom

### DIFF
--- a/app/assets/stylesheets/layout/work_packages/_table_embedded.sass
+++ b/app/assets/stylesheets/layout/work_packages/_table_embedded.sass
@@ -66,9 +66,6 @@ $table-timeline--compact-row-height: 28px
     height: 100%
     overflow: auto
     @include styled-scroll-bar
-
-    .work-packages-partitioned-page--content-right &
-      margin-right: -14px
     
     .wp-cards-container.-horizontal
       grid-template-columns: repeat(auto-fit, minmax(200px, 1fr))
@@ -115,9 +112,6 @@ $table-timeline--compact-row-height: 28px
   .work-packages-tabletimeline--table-side.-timeline-visible
     max-width: 50%
     overflow-x: scroll
-
-  .pagination
-    padding-bottom: 0
 
 wp-query-group .wp-relations-create-button
   margin-left: -6px

--- a/modules/bim/app/assets/stylesheets/bim/ifc_viewer/generic.sass
+++ b/modules/bim/app/assets/stylesheets/bim/ifc_viewer/generic.sass
@@ -14,6 +14,8 @@
 // This is different to how we style #content else where.
 .controller-bim\/ifc_models\/ifc_viewer
   overflow: hidden
+  @include extended-content--right
+  @include extended-content--bottom
 
   &.action-show
     #content
@@ -47,6 +49,7 @@
   position: relative
   width: 100%
   height: 100%
+  padding-bottom: 10px
 
 .ifc-model-viewer--model-canvas
   width: 100%


### PR DESCRIPTION
Similar to the WP page, the split screen should be directly appended to the screens right / bottom side.