### PR TITLE
disable oj for viewpoint body parsing

### DIFF
--- a/lib/api/utilities/json_gem_parser.rb
+++ b/lib/api/utilities/json_gem_parser.rb
@@ -1,0 +1,11 @@
+# Forces using the classic json gem when parsing.
+# This might be beneficial in cases where other parsers, orchestrated by MultiJson misbehave.
+# This is e.g. the case with oj which sometimes turns numbers into BigDecimal values.
+module API::Utilities::JsonGemParser
+  def self.call(object, _)
+    ::Grape::Json.load(object, adapter: :json_gem)
+  rescue ::Grape::Json::ParseError
+    # handle JSON parsing errors via the rescue handlers or provide error message
+    raise Grape::Exceptions::InvalidMessageBody, 'application/json'
+  end
+end

--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/viewpoints/api.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/viewpoints/api.rb
@@ -31,6 +31,9 @@
 module Bim::Bcf::API::V2_1
   module Viewpoints
     class API < ::API::OpenProjectAPI
+      # Avoid oj parsing numbers into BigDecimal
+      parser :json, ::API::Utilities::JsonGemParser
+
       resources :viewpoints do
         get do
           @issue

--- a/modules/bim/spec/representers/bcf/api/v2_1/viewpoints/single_representers_parsing_spec.rb
+++ b/modules/bim/spec/representers/bcf/api/v2_1/viewpoints/single_representers_parsing_spec.rb
@@ -60,7 +60,25 @@ describe Bim::Bcf::API::V2_1::Viewpoints::SingleRepresenter, 'rendering' do
               "z" => 0.990215996212637
             },
             "field_of_view" => 60.0
-          }
+          },
+        "perspective_camera" => {
+          "camera_view_point" => {
+            "x" => 183.31539916992188,
+            "y" => -183.31539916992188,
+            "z" => 183.31539916992188
+          },
+          "camera_direction" => {
+            "x" => -0.5773502588272095,
+            "y" => 0.5773502588272095,
+            "z" => -0.5773502588272095
+          },
+          "camera_up_vector" => {
+            "x" => -1,
+            "y" => 1,
+            "z" => 1
+          },
+          "field_of_view" => 60
+        }
       )
   end
   let(:representer) { described_class.new(struct) }

--- a/modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb
@@ -282,6 +282,49 @@ describe 'BCF 2.1 viewpoints resource', type: :request, content_type: :json, wit
       it_behaves_like 'bcf api not allowed response'
     end
 
+    context 'providing a number for a perspective that might be transformed into a BigDecimal (by the Oj gem)' do
+      let(:params) do
+        FactoryBot
+          .attributes_for(:bcf_viewpoint)[:json_viewpoint]
+          .merge(
+            "perspective_camera" => {
+              "camera_view_point" => {
+                "x" => 183.31539916992188,
+                "y" => -183.31539916992188,
+                "z" => 183.31539916992188
+              },
+              "camera_direction" => {
+                "x" => -0.5773502588272095,
+                "y" => 0.5773502588272095,
+                "z" => -0.5773502588272095
+              },
+              "camera_up_vector" => {
+                "x" => -1,
+                "y" => 1,
+                "z" => 1
+              },
+              "field_of_view" => 60
+            }
+          ).except('bitmaps')
+      end
+
+      it_behaves_like 'bcf api successful response' do
+        let(:expected_body) do
+          new_viewpoint = Bim::Bcf::Viewpoint.last
+
+          params
+            .merge(guid: new_viewpoint.uuid)
+        end
+
+        let(:expected_status) { 201 }
+      end
+
+      it 'creates the viewpoint with an attachment for the snapshot' do
+        expect(Bim::Bcf::Viewpoint.count)
+          .to eql 2
+      end
+    end
+
     context 'providing an invalid viewpoint json by having an invalid snapshot type' do
       let(:params) do
         FactoryBot


### PR DESCRIPTION
oj in rails mode sometimes parses numbers to BigDecimal. Those then are
serialized to strings when assigned to a JSONB column of an AR model,
e.g. viewpoint's json_viewpoint attribute. The classic json gem does not
behave in the same way so we use it for viewpoint parsing.