### PR TITLE
[31968] Single click in WP list sets view in IFC Viewer according to first viewpoint

### DIFF
--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.html
@@ -14,7 +14,7 @@
       <op-icon icon-classes="icon icon-close"></op-icon>
     </a>
 
-    <a class="-no-decoration"
+    <a class="wp-card--details-button -no-decoration"
        *ngIf="!workPackage.isNew && showInfoButton"
        [title]="text.detailsView"
        (accessibleClick)="openSplitScreen(workPackage)">

--- a/frontend/src/app/modules/bim/ifc_models/ifc-base-view/event-handler/bcf-click-handler.ts
+++ b/frontend/src/app/modules/bim/ifc_models/ifc-base-view/event-handler/bcf-click-handler.ts
@@ -1,12 +1,33 @@
 import {CardClickHandler} from "core-components/wp-card-view/event-handler/click-handler";
+import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
+import {States} from "core-components/states.service";
+import {IFCViewerService} from "core-app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.service";
+import {BcfApiService} from "core-app/modules/bim/bcf/api/bcf-api.service";
+import {BcfViewpointPaths} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.paths";
 
 export class BcfClickHandler extends CardClickHandler {
+  @InjectField() viewer:IFCViewerService;
+  @InjectField() states:States;
+  @InjectField() bcfApi:BcfApiService;
 
-  protected handleWorkPackage(wpId:any, element:JQuery<HTMLElement>, evt:JQuery.TriggeredEvent) {
+  protected handleWorkPackage(wpId:string, element:JQuery<HTMLElement>, evt:JQuery.TriggeredEvent) {
     this.setSelection(wpId, element, evt);
+    const wp = this.states.workPackages.get(wpId).value!;
+
+    const current = this.viewer.saveBCFViewpoint() as any;
+    delete current.snapshot;
+    console.warn(JSON.stringify(current));
+
 
     // Open the viewpoint if any
-    // ...
+    if (this.viewer.viewerVisible() && wp.bcfViewpoints) {
+      const first = wp.bcfViewpoints[0].href;
+      const resource = this.bcfApi.parse(first) as BcfViewpointPaths;
+      resource
+        .get()
+        .subscribe((viewpoint) => {
+          this.viewer.loadBCFViewpoint(viewpoint);
+        });
+    }
   }
-
 }

--- a/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
+++ b/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@angular/core';
+import {Injectable} from '@angular/core';
 import {XeokitServer} from "core-app/modules/bim/ifc_models/xeokit/xeokit-server";
+import {BcfViewpointInterface} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.interface";
 
 export interface XeokitElements {
   canvasElement:HTMLElement;
@@ -10,9 +11,15 @@ export interface XeokitElements {
 }
 
 export interface BCFCreationOptions {
-  spacesVisible:boolean;
-  spaceBoundariesVisible:boolean;
-  openingsVisible:boolean;
+  spacesVisible?:boolean;
+  spaceBoundariesVisible?:boolean;
+  openingsVisible?:boolean;
+}
+
+export interface BCFLoadOptions {
+  rayCast?:boolean;
+  immediate?:boolean;
+  duration?:number;
 }
 
 @Injectable()
@@ -51,9 +58,18 @@ export class IFCViewerService {
     }
 
     this.viewer.viewer.scene.destroy();
+    this.viewer = undefined;
   }
 
-  public saveBCFViewpoint(options:BCFCreationOptions):JSON {
+  public saveBCFViewpoint(options:BCFCreationOptions = {}):BcfViewpointInterface {
     return this.viewer.saveBCFViewpoint(options);
+  }
+
+  public loadBCFViewpoint(viewpoint:BcfViewpointInterface, options:BCFLoadOptions = {}) {
+    this.viewer.loadBCFViewpoint(viewpoint, options);
+  }
+
+  public viewerVisible():boolean {
+    return !!this.viewer;
   }
 }

--- a/modules/bim/spec/factories/ifc_model_factory.rb
+++ b/modules/bim/spec/factories/ifc_model_factory.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
       )
     end
 
-    factory :ifc_model_converted do
+    factory :ifc_model_minimal_converted do
       sequence(:title) { |n| "Converted IFC model #{n}" }
       project factory: :project
       uploader factory: :user

--- a/modules/bim/spec/features/bcf/create_spec.rb
+++ b/modules/bim/spec/features/bcf/create_spec.rb
@@ -19,7 +19,7 @@ describe 'Create BCF', type: :feature, js: true, with_mail: false do
   end
 
   let!(:model) do
-    FactoryBot.create(:ifc_model_converted,
+    FactoryBot.create(:ifc_model_minimal_converted,
                       project: project,
                       uploader: user)
   end

--- a/modules/bim/spec/features/bcf/export_spec.rb
+++ b/modules/bim/spec/features/bcf/export_spec.rb
@@ -41,7 +41,7 @@ describe 'bcf export', type: :feature, js: true do
   let(:current_user) { FactoryBot.create :admin }
 
   let!(:model) do
-    FactoryBot.create(:ifc_model_converted,
+    FactoryBot.create(:ifc_model_minimal_converted,
                       project: project,
                       uploader: current_user)
   end

--- a/modules/bim/spec/features/bim_filter_spec.rb
+++ b/modules/bim/spec/features/bim_filter_spec.rb
@@ -42,7 +42,7 @@ describe 'BIM filter spec', type: :feature, js: true do
   let(:admin) { FactoryBot.create :admin }
 
   let!(:model) do
-    FactoryBot.create(:ifc_model_converted,
+    FactoryBot.create(:ifc_model_minimal_converted,
                       project: project,
                       uploader: admin)
   end

--- a/modules/bim/spec/features/bim_navigation_spec.rb
+++ b/modules/bim/spec/features/bim_navigation_spec.rb
@@ -44,7 +44,7 @@ describe 'BIM navigation spec', type: :feature, js: true do
   end
 
   let!(:model) do
-    FactoryBot.create(:ifc_model_converted,
+    FactoryBot.create(:ifc_model_minimal_converted,
                       project: project,
                       uploader: user)
   end

--- a/modules/bim/spec/features/bim_navigation_spec.rb
+++ b/modules/bim/spec/features/bim_navigation_spec.rb
@@ -77,7 +77,7 @@ describe 'BIM navigation spec', type: :feature, js: true do
         card_view.expect_work_package_listed work_package
 
         # Go to single view
-        card_view.open_full_screen_by_doubleclick(work_package)
+        card_view.open_full_screen_by_details(work_package)
 
         details_view.ensure_page_loaded
         details_view.expect_subject
@@ -100,7 +100,7 @@ describe 'BIM navigation spec', type: :feature, js: true do
         card_view.expect_work_package_listed work_package
 
         # Go to single view
-        card_view.open_full_screen_by_doubleclick(work_package)
+        card_view.open_full_screen_by_details(work_package)
 
         details_view.ensure_page_loaded
         details_view.expect_subject

--- a/modules/bim/spec/features/bim_navigation_spec.rb
+++ b/modules/bim/spec/features/bim_navigation_spec.rb
@@ -77,8 +77,7 @@ describe 'BIM navigation spec', type: :feature, js: true do
         card_view.expect_work_package_listed work_package
 
         # Go to single view
-        wp_card = card_view.card(work_package)
-        page.driver.browser.action.double_click(wp_card.native).perform
+        card_view.open_full_screen_by_doubleclick(work_package)
 
         details_view.ensure_page_loaded
         details_view.expect_subject
@@ -101,8 +100,7 @@ describe 'BIM navigation spec', type: :feature, js: true do
         card_view.expect_work_package_listed work_package
 
         # Go to single view
-        wp_card = card_view.card(work_package)
-        page.driver.browser.action.double_click(wp_card.native).perform
+        card_view.open_full_screen_by_doubleclick(work_package)
 
         details_view.ensure_page_loaded
         details_view.expect_subject

--- a/modules/bim/spec/features/model_management_spec.rb
+++ b/modules/bim/spec/features/model_management_spec.rb
@@ -42,13 +42,13 @@ describe 'model management', type: :feature, js: true do
   end
 
   let(:model) do
-    FactoryBot.create(:ifc_model_converted,
+    FactoryBot.create(:ifc_model_minimal_converted,
                       project: project,
                       uploader: user)
   end
 
   let(:model2) do
-    FactoryBot.create(:ifc_model_converted,
+    FactoryBot.create(:ifc_model_minimal_converted,
                       project: project,
                       uploader: user)
   end

--- a/modules/bim/spec/features/model_viewer_spec.rb
+++ b/modules/bim/spec/features/model_viewer_spec.rb
@@ -33,6 +33,7 @@ require_relative '../support/pages/ifc_models/show_default'
 
 describe 'model viewer', type: :feature, js: true do
   let(:project) { FactoryBot.create :project, enabled_module_names: [:bim, :work_package_tracking] }
+  # TODO: Add empty viewpoint and stub method to load viewpoints once defined
   let(:work_package) { FactoryBot.create(:work_package, project: project) }
   let(:role) { FactoryBot.create(:role, permissions: %i[view_ifc_models manage_ifc_models view_work_packages]) }
 
@@ -43,7 +44,7 @@ describe 'model viewer', type: :feature, js: true do
   end
 
   let(:model) do
-    FactoryBot.create(:ifc_model_converted,
+    FactoryBot.create(:ifc_model_minimal_converted,
                       project: project,
                       uploader: user)
   end

--- a/modules/bim/spec/features/show_default_spec.rb
+++ b/modules/bim/spec/features/show_default_spec.rb
@@ -44,7 +44,7 @@ describe 'show default model', type: :feature, js: true do
   end
 
   let(:model) do
-    FactoryBot.create(:ifc_model_converted,
+    FactoryBot.create(:ifc_model_minimal_converted,
                       is_default: model_is_default,
                       project: project,
                       uploader: user)

--- a/modules/bim/spec/features/viewer/show_viewpoint_spec.rb
+++ b/modules/bim/spec/features/viewer/show_viewpoint_spec.rb
@@ -1,0 +1,76 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+require_relative '../../support/pages/ifc_models/show_default'
+
+describe 'Show viewpoint in model viewer', type: :feature, js: true do
+  let(:project) { FactoryBot.create :project, enabled_module_names: [:bim, :work_package_tracking] }
+  let(:user) { FactoryBot.create :admin }
+
+  let!(:work_package) { FactoryBot.create(:work_package, project: project) }
+  let!(:bcf) { FactoryBot.create :bcf_issue, work_package: work_package }
+  let!(:viewpoint) { FactoryBot.create :bcf_viewpoint, issue: bcf, viewpoint_name: 'minimal_hidden_except_one' }
+
+  let!(:model) do
+    FactoryBot.create(:ifc_model_minimal_converted,
+                      title: 'minimal',
+                      project: project,
+                      uploader: user)
+  end
+
+  let(:show_model_page) { Pages::IfcModels::ShowDefault.new(project) }
+  let(:card_view) { ::Pages::WorkPackageCards.new(project) }
+
+  before do
+    login_as(user)
+    show_model_page.visit!
+    show_model_page.finished_loading
+  end
+
+  it 'loads the viewpoint in the viewer when clicking on the wp card' do
+    card_view.expect_work_package_listed work_package
+    card_view.select_work_package work_package
+
+    card_view.expect_work_package_selected work_package, true
+
+    # Idea: Check whether the storeys are correctly set and thus the viewpoint correctly loaded
+    # For convenience only, our viewpoint selected nothing, so no Storey should be selected
+    show_model_page.select_sidebar_tab 'Objects'
+    show_model_page.expand_tree
+    show_model_page.expect_checked 'minimal'
+    show_model_page.all_checkboxes.each do |label, checkbox|
+      if label.text == 'minimal' || label.text == 'LUB_Segment_new:S_WHG_Ess:7243035'
+        expect(checkbox.checked?).to eq(true)
+      else
+        expect(checkbox.checked?).to eq(false)
+      end
+    end
+  end
+end

--- a/modules/bim/spec/fixtures/files/minimal.json
+++ b/modules/bim/spec/fixtures/files/minimal.json
@@ -12,19 +12,19 @@
       "id": "0hOGUplITAJP95dJaHmSyS",
       "name": "Default",
       "type": "IfcSite",
-      "parent": "0hOGUplITAJP95dJaHmSyU"
+      "parent": null
     },
     {
       "id": "0hOGUplITAJP95dJaHmSyV",
       "name": "",
       "type": "IfcBuilding",
-      "parent": "0hOGUplITAJP95dJaHmSyS"
+      "parent": null
     },
     {
       "id": "0hOGUplITAJP95dJdkAGth",
       "name": "0EG",
       "type": "IfcBuildingStorey",
-      "parent": "0hOGUplITAJP95dJaHmSyV"
+      "parent": null
     },
     {
       "id": "2mWJQJFvvAGPIr4kdVXqdT",
@@ -288,7 +288,7 @@
       "id": "0hOGUplITAJP95dJdkNbUT",
       "name": "1OG",
       "type": "IfcBuildingStorey",
-      "parent": "0hOGUplITAJP95dJaHmSyV"
+      "parent": null
     },
     {
       "id": "2I3GeLg8z6SuvsKrNeG9TS",
@@ -552,7 +552,7 @@
       "id": "0hOGUplITAJP95dJdkKB2G",
       "name": "2OG",
       "type": "IfcBuildingStorey",
-      "parent": "0hOGUplITAJP95dJaHmSyV"
+      "parent": null
     },
     {
       "id": "2I3GeLg8z6SuvsKrNeG9UH",
@@ -816,7 +816,7 @@
       "id": "0hOGUplITAJP95dJdkKB1h",
       "name": "3OG",
       "type": "IfcBuildingStorey",
-      "parent": "0hOGUplITAJP95dJaHmSyV"
+      "parent": null
     },
     {
       "id": "2I3GeLg8z6SuvsKrNeG9VF",
@@ -1080,7 +1080,7 @@
       "id": "0hOGUplITAJP95dJdkKB1Y",
       "name": "4OG",
       "type": "IfcBuildingStorey",
-      "parent": "0hOGUplITAJP95dJaHmSyV"
+      "parent": null
     },
     {
       "id": "2I3GeLg8z6SuvsKrNeG9Oz",

--- a/modules/bim/spec/fixtures/viewpoints/minimal_hidden_except_one.json
+++ b/modules/bim/spec/fixtures/viewpoints/minimal_hidden_except_one.json
@@ -1,0 +1,40 @@
+{
+  "guid": "{{UUID}}",
+  "perspective_camera": {
+    "camera_view_point": {
+      "x": -20.054248809814453,
+      "y": -23.360965728759766,
+      "z": 25.947437286376953
+    },
+    "camera_direction": {
+      "x": -0.5773502588272095,
+      "y": 0.5773502588272095,
+      "z": -0.5773502588272095
+    },
+    "camera_up_vector": {
+      "x": -1,
+      "y": 1,
+      "z": 1
+    },
+    "field_of_view": 60
+  },
+  "lines": [],
+  "bitmaps": [],
+  "clipping_planes": [],
+  "components": {
+    "visibility": {
+      "view_setup_hints": {
+        "spaces_visible": false,
+        "space_boundaries_visible": false,
+        "openings_visible": false
+      },
+      "exceptions": [{
+        "ifc_guid": "2I3GeLg8z6SuvsKrNeG9Oz",
+        "originating_system": "xeokit.io",
+        "authoring_tool_id": "xeokit.io"
+      }],
+      "default_visibility": false
+    },
+    "selection": []
+  }
+}

--- a/modules/bim/spec/models/ifc_model_spec.rb
+++ b/modules/bim/spec/models/ifc_model_spec.rb
@@ -17,7 +17,7 @@ describe ::Bim::IfcModels::IfcModel, type: :model do
   end
 
   describe 'ifc_attachment=' do
-    subject { FactoryBot.create :ifc_model_converted, project: FactoryBot.create(:project) }
+    subject { FactoryBot.create :ifc_model_minimal_converted, project: FactoryBot.create(:project) }
     let(:ifc_attachment) { subject.ifc_attachment }
     let(:new_attachment) do
       FileHelpers.mock_uploaded_file name: "model.ifc", content_type: 'application/binary', binary: true

--- a/modules/bim/spec/support/pages/ifc_models/show_default.rb
+++ b/modules/bim/spec/support/pages/ifc_models/show_default.rb
@@ -75,6 +75,38 @@ module Pages
         end
       end
 
+      def select_sidebar_tab(tab)
+        selector = '.xeokit-tab'
+        page.find(selector, text: tab).click
+      end
+
+      def expand_tree
+        page.all('.xeokit-tree-panel a.plus').map(&:click)
+      end
+
+      def expect_checked(label)
+        page
+          .find('.xeokit-tree-panel li span', text: label, wait: 10)
+          .sibling('input[type=checkbox]:checked')
+      end
+
+      def all_checkboxes
+        page
+          .all('.xeokit-tree-panel li span')
+          .map { |item| [item, item.sibling('input[type=checkbox]')] }
+      end
+
+      def expect_tree_panel_selected(selected, tab = 'Models')
+        within (".xeokit-#{tab.downcase}.xeokit-tree-panel") do
+          if selected
+            expect(page.find('input', match: :first)).to be_checked
+          else
+            expect(page.find('input', match: :first)).not_to be_checked
+          end
+
+        end
+      end
+
       def page_shows_a_toolbar(visible)
         toolbar_items.each do |button|
           element_visible? visible, '.toolbar-item', button

--- a/spec/support/pages/work_packages/work_package_cards.rb
+++ b/spec/support/pages/work_packages/work_package_cards.rb
@@ -60,8 +60,13 @@ module Pages
     end
 
     def open_full_screen_by_doubleclick(work_package)
-      loading_indicator_saveguard
-      page.driver.browser.action.double_click(card(work_package).native).perform
+      retry_block do
+        loading_indicator_saveguard
+        page.driver.browser.action.double_click(card(work_package).native).perform
+
+        # Ensure we show the subject field
+        page.find('.work-packages--subject-type-row')
+      end
 
       Pages::FullWorkPackage.new(work_package, project)
     end

--- a/spec/support/pages/work_packages/work_package_cards.rb
+++ b/spec/support/pages/work_packages/work_package_cards.rb
@@ -71,6 +71,13 @@ module Pages
       Pages::FullWorkPackage.new(work_package, project)
     end
 
+    def open_full_screen_by_details(work_package)
+      element = card(work_package)
+      scroll_to_element(element)
+      element.hover
+      element.find('.wp-card--details-button').click
+    end
+
     def select_work_package(work_package)
       card(work_package).click
     end


### PR DESCRIPTION
### ToDo

- [x] Show attached viewpoint on click on a card. 
- [x] If there is no viewpoint attached, simply select the card.
- [x] Add a test case (Since we cannot test the actual viewer, we will check via the sidebar menu whether the correct viewpoint is loaded.)
