### PR TITLE
Feature/bcf in work package

### DIFF
--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
@@ -71,7 +71,7 @@
     </div>
   </div>
 
-  <div *ngIf="workPackage.bcf">
+  <div *ngIf="workPackage.bcfTopic">
     <bcf-wp-single-view [workPackage]="workPackage"></bcf-wp-single-view>
   </div>
 

--- a/frontend/src/app/components/wp-activity/user/user-activity.component.html
+++ b/frontend/src/app/components/wp-activity/user/user-activity.component.html
@@ -38,8 +38,8 @@
       </accessible-by-keyboard>
     </div>
   </div>
-  <img *ngIf="bcfSnapshot"
-       [src]="PathHelper.attachmentDownloadPath(bcfSnapshot.id, bcfSnapshot.file_name)"
+  <img *ngIf="bcfSnapshotUrl"
+       [src]="bcfSnapshotUrl"
        class="activity-thumbnail">
   <div class="user-comment" >
     <div *ngIf="active" class="inplace-edit">

--- a/frontend/src/app/components/wp-activity/user/user-activity.component.ts
+++ b/frontend/src/app/components/wp-activity/user/user-activity.component.ts
@@ -73,8 +73,6 @@ export class UserActivityComponent extends WorkPackageCommentFieldHandler implem
   public isComment:boolean;
   public isBcfComment:boolean;
   public postedComment:SafeHtml;
-  // TODO: turn into HalResource
-  public bcfSnapshot:any;
 
   public focused = false;
 
@@ -107,9 +105,6 @@ export class UserActivityComponent extends WorkPackageCommentFieldHandler implem
     this.updateCommentText();
     this.isComment = this.activity._type === 'Activity::Comment';
     this.isBcfComment = this.activity._type === 'Activity::BcfComment';
-    if (this.isBcfComment && _.get(this.activity.bcfComment,  'viewpoint.snapshot')) {
-      this.bcfSnapshot = _.get(this.activity.bcfComment,  'viewpoint.snapshot');
-    }
 
     this.$element = jQuery(this.elementRef.nativeElement);
     this.reset();
@@ -160,6 +155,14 @@ export class UserActivityComponent extends WorkPackageCommentFieldHandler implem
 
   public quoteComment() {
     this.commentService.quoteEvents.next(this.quotedText(this.activity.comment.raw));
+  }
+
+  public get bcfSnapshotUrl() {
+    if (_.get(this.activity, 'bcfViewpoints[0]')) {
+      return `${_.get(this.activity, 'bcfViewpoints[0]').href}/snapshot`;
+    } else {
+      return null;
+    }
   }
 
   public async updateComment() {

--- a/frontend/src/app/components/wp-activity/user/user-activity.component.ts
+++ b/frontend/src/app/components/wp-activity/user/user-activity.component.ts
@@ -46,7 +46,6 @@ import {UserCacheService} from "core-components/user/user-cache.service";
 import {CommentService} from "core-components/wp-activity/comment-service";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {WorkPackageCommentFieldHandler} from "core-components/work-packages/work-package-comment/work-package-comment-field-handler";
-import {ViewPointOriginal} from "core-app/modules/bim/bcf/bcf-wp-single-view/bcf-wp-single-view.component";
 import {DomSanitizer, SafeHtml} from "@angular/platform-browser";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 
@@ -74,7 +73,8 @@ export class UserActivityComponent extends WorkPackageCommentFieldHandler implem
   public isComment:boolean;
   public isBcfComment:boolean;
   public postedComment:SafeHtml;
-  public bcfSnapshot:ViewPointOriginal;
+  // TODO: turn into HalResource
+  public bcfSnapshot:any;
 
   public focused = false;
 

--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.ts
@@ -111,12 +111,8 @@ export class WorkPackageSingleCardComponent implements OnDestroy, OnInit {
   }
 
   public bcfSnapshotPath(wp:WorkPackageResource) {
-    let vp = _.get(wp, 'bcf.viewpoints[0]');
-    if (vp) {
-      return this.pathHelper.attachmentDownloadPath(vp.id, vp.file_name);
-    } else {
-      return null;
-    }
+    let vp = _.get(wp, 'bcfViewpoints[0]');
+    return vp ? `${vp.href}/snapshot` : null;
   }
 
   private isSelected(wp:WorkPackageResource):boolean {

--- a/frontend/src/app/modules/bim/bcf/bcf-wp-single-view/bcf-wp-single-view.component.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-single-view/bcf-wp-single-view.component.ts
@@ -4,10 +4,10 @@ import {StateService} from "@uirouter/core";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 import { NgxGalleryOptions, NgxGalleryImage, NgxGalleryAnimation } from 'ngx-gallery';
+import {HalLink} from "core-app/modules/hal/hal-link/hal-link";
 
 
-export type ViewPointOriginal = { id:string, file_name:string };
-export type ViewPoint = { id:string, fileName:string, fullPath:string };
+export type ViewPoint = { fullPath:string };
 
 @Component({
   selector: 'bcf-wp-single-view',
@@ -18,7 +18,46 @@ export type ViewPoint = { id:string, fileName:string, fullPath:string };
 export class BcfWpSingleViewComponent implements OnInit, OnDestroy {
   @Input() workPackage:WorkPackageResource;
 
-  galleryOptions:NgxGalleryOptions[];
+  galleryOptions:NgxGalleryOptions[] = [
+    {
+      width: '100%',
+      height: '400px',
+      thumbnailsColumns: 4,
+      imageAnimation: '',
+      previewAnimation: false,
+      previewCloseOnEsc: true,
+      previewKeyboardNavigation: true,
+      imageSize: 'contain',
+      imageArrowsAutoHide: true,
+      thumbnailsArrowsAutoHide: true,
+      thumbnailsAutoHide: true,
+      thumbnailsMargin: 5,
+      thumbnailMargin: 5,
+      previewDownload: true,
+      arrowPrevIcon: 'icon-arrow-left2',
+      arrowNextIcon: 'icon-arrow-right2',
+      closeIcon: 'icon-close',
+      downloadIcon: 'icon-download',
+      previewCloseOnClick: true,
+    },
+    // max-width 800
+    {
+      breakpoint: 800,
+      width: '100%',
+      height: '300px',
+      imagePercent: 80,
+      thumbnailsPercent: 20,
+      thumbnailsMargin: 5,
+      thumbnailMargin: 5,
+      imageSize: 'contain',
+    },
+    // max-width 400
+    {
+      breakpoint: 400,
+      height: '200px',
+    }
+  ];
+
   galleryImages:NgxGalleryImage[];
 
   private _viewpoints:ViewPoint[];
@@ -41,53 +80,11 @@ export class BcfWpSingleViewComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit():void {
-    this.viewpoints = this.workPackage.bcf.viewpoints.map((vp:ViewPointOriginal):ViewPoint => {
+    this.viewpoints = this.workPackage.bcfViewpoints.map((vp:HalLink):ViewPoint => {
       return {
-        id:       vp.id,
-        fileName: vp.file_name,
-        fullPath: this.pathHelper.attachmentDownloadPath(vp.id, vp.file_name)
+        fullPath: `${vp.href}/snapshot`
       };
     });
-
-    this.galleryOptions = [
-      {
-        width: '100%',
-        height: '400px',
-        thumbnailsColumns: 4,
-        imageAnimation: '',
-        previewAnimation: false,
-        previewCloseOnEsc: true,
-        previewKeyboardNavigation: true,
-        imageSize: 'contain',
-        imageArrowsAutoHide: true,
-        thumbnailsArrowsAutoHide: true,
-        thumbnailsAutoHide: true,
-        thumbnailsMargin: 5,
-        thumbnailMargin: 5,
-        previewDownload: true,
-        arrowPrevIcon: 'icon-arrow-left2',
-        arrowNextIcon: 'icon-arrow-right2',
-        closeIcon: 'icon-close',
-        downloadIcon: 'icon-download',
-        previewCloseOnClick: true,
-      },
-      // max-width 800
-      {
-        breakpoint: 800,
-        width: '100%',
-        height: '300px',
-        imagePercent: 80,
-        thumbnailsPercent: 20,
-        thumbnailsMargin: 5,
-        thumbnailMargin: 5,
-        imageSize: 'contain',
-      },
-      // max-width 400
-      {
-        breakpoint: 400,
-        height: '200px',
-      }
-    ];
 
     this.galleryImages = this.viewpoints.map((vp:ViewPoint) => {
       return {
@@ -99,12 +96,10 @@ export class BcfWpSingleViewComponent implements OnInit, OnDestroy {
   }
 
   public galleryPreviewOpen():void {
-    console.log("preview open");
     jQuery('#top-menu')[0].style.zIndex = '10';
   }
 
   public galleryPreviewClose():void {
-    console.log("preview close");
     jQuery('#top-menu')[0].style.zIndex = '';
   }
 

--- a/frontend/src/app/modules/bim/bcf/bcf-wp-single-view/bcf-wp-single-view.component.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-single-view/bcf-wp-single-view.component.ts
@@ -1,13 +1,8 @@
-import {Component, Injector, Input, OnDestroy, OnInit} from "@angular/core";
-import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {Component, Input, OnDestroy, OnInit} from "@angular/core";
 import {StateService} from "@uirouter/core";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
-import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
-import { NgxGalleryOptions, NgxGalleryImage, NgxGalleryAnimation } from 'ngx-gallery';
+import { NgxGalleryOptions, NgxGalleryImage } from 'ngx-gallery';
 import {HalLink} from "core-app/modules/hal/hal-link/hal-link";
-
-
-export type ViewPoint = { fullPath:string };
 
 @Component({
   selector: 'bcf-wp-single-view',
@@ -60,37 +55,32 @@ export class BcfWpSingleViewComponent implements OnInit, OnDestroy {
 
   galleryImages:NgxGalleryImage[];
 
-  private _viewpoints:ViewPoint[];
+  private _viewpointUrls:string[];
 
-  public get viewpoints():ViewPoint[] {
-    return this._viewpoints;
+  public get viewpoints():string[] {
+    return this._viewpointUrls;
   }
 
-  public set viewpoints(viewPoints:ViewPoint[]) {
-    this._viewpoints = viewPoints;
+  public set viewpoints(viewPoints:string[]) {
+    this._viewpointUrls = viewPoints;
   }
 
   public text = {
   };
 
-  constructor(public readonly state:StateService,
-              private readonly I18n:I18nService,
-              private readonly injector:Injector,
-              private readonly pathHelper:PathHelperService) {
+  constructor(public readonly state:StateService) {
   }
 
   ngOnInit():void {
-    this.viewpoints = this.workPackage.bcfViewpoints.map((vp:HalLink):ViewPoint => {
-      return {
-        fullPath: `${vp.href}/snapshot`
-      };
+    this.viewpoints = this.workPackage.bcfViewpoints.map((vp:HalLink) => {
+      return `${vp.href}/snapshot`;
     });
 
-    this.galleryImages = this.viewpoints.map((vp:ViewPoint) => {
+    this.galleryImages = this.viewpoints.map(url => {
       return {
-        small:  vp.fullPath,
-        medium: vp.fullPath,
-        big:    vp.fullPath,
+        small:  url,
+        medium: url,
+        big:    url,
       };
     });
   }

--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -80,7 +80,7 @@ module API
       class_attribute :to_eager_load
       class_attribute :checked_permissions
 
-      def current_user_allowed_to(permission, context:)
+      def current_user_allowed_to(permission, context: represented.respond_to?(:project) ? represented.project : nil)
         current_user.allowed_to?(permission, context)
       end
 

--- a/lib/api/v3/attachments/attachments_api.rb
+++ b/lib/api/v3/attachments/attachments_api.rb
@@ -65,7 +65,7 @@ module API
               helpers ::API::Helpers::AttachmentRenderer
 
               get do
-                respond_with_attachment @attachment
+                respond_with_attachment @attachment, cache_seconds: 1.year.to_i
               end
             end
           end

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -104,7 +104,6 @@ module API
 
         link :copy,
              cache_if: -> { current_user_allowed_to(:add_work_packages, context: represented.project) } do
-
           next if represented.new_record?
 
           {

--- a/modules/avatars/lib/api/v3/users/user_avatar_api.rb
+++ b/modules/avatars/lib/api/v3/users/user_avatar_api.rb
@@ -34,21 +34,14 @@ module API
         helpers ::AvatarHelper
         helpers ::API::Helpers::AttachmentRenderer
 
-        helpers do
-          def set_cache_headers!
-            return if @user == current_user
-
-            header "Cache-Control", "public, max-age=#{avatar_link_expiry_seconds}"
-            header "Expires", CGI.rfc1123_date(Time.now.utc + avatar_link_expiry_seconds)
-          end
-        end
-
         get '/avatar' do
-          set_cache_headers!
+          cache_seconds = @user == current_user ? nil : avatar_link_expires_in
 
           if (local_avatar = local_avatar?(@user))
-            respond_with_attachment(local_avatar, external_link_expires_in: avatar_link_expires_in)
+            respond_with_attachment(local_avatar, cache_seconds: cache_seconds)
           elsif avatar_manager.gravatar_enabled?
+            set_cache_headers!(cache_seconds)
+
             redirect build_gravatar_image_url(@user)
           else
             status 404

--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/viewpoints/api.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/viewpoints/api.rb
@@ -28,7 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
+# rubocop:disable Naming/ClassAndModuleCamelCase
 module Bim::Bcf::API::V2_1
+  # rubocop:enable Naming/ClassAndModuleCamelCase
   module Viewpoints
     class API < ::API::OpenProjectAPI
       # Avoid oj parsing numbers into BigDecimal
@@ -79,7 +81,7 @@ module Bim::Bcf::API::V2_1
             get do
               viewpoint = @issue.viewpoints.find_by!(uuid: params[:viewpoint_uuid])
               if snapshot = viewpoint.snapshot
-                respond_with_attachment snapshot
+                respond_with_attachment snapshot, cache_seconds: 1.year.to_i
               else
                 raise ActiveRecord::RecordNotFound
               end

--- a/modules/bim/app/models/bim/bcf/viewpoint.rb
+++ b/modules/bim/app/models/bim/bcf/viewpoint.rb
@@ -24,7 +24,11 @@ module Bim::Bcf
     end
 
     def snapshot
-      attachments.find_by_description('snapshot')
+      if attachments.loaded?
+        attachments.detect { |a| a.description == 'snapshot' }
+      else
+        attachments.find_by_description('snapshot')
+      end
     end
 
     def snapshot=(file)

--- a/modules/bim/lib/api/bim/utilities/path_helper.rb
+++ b/modules/bim/lib/api/bim/utilities/path_helper.rb
@@ -1,3 +1,4 @@
+#-- encoding: UTF-8
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH
@@ -26,15 +27,43 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-require_dependency 'work_package'
+module API
+  module Bim
+    module Utilities
+      module PathHelper
+        include API::Utilities::UrlHelper
 
-module OpenProject::Bim::Patches::WorkPackagePatch
-  def self.included(base)
-    base.class_eval do
-      has_one :bcf_issue, class_name: '::Bim::Bcf::Issue', foreign_key: 'work_package_id'
+        # rubocop:disable Naming/ClassAndModuleCamelCase
+        class BCF2_1Path
+          extend API::Utilities::UrlHelper
 
-      def bcf_issue?
-        bcf_issue.present?
+          # Determining the root_path on every url we want to render is
+          # expensive. As the root_path will not change within a
+          # request, we can cache the first response on each request.
+          def self.root_path
+            RequestStore.store[:cached_root_path] ||= super
+          end
+
+          def self.root
+            "#{root_path}api/bcf/2.1/"
+          end
+
+          def self.project(identifier)
+            "#{root}projects/#{identifier}"
+          end
+
+          def self.topic(project_identifier, uuid)
+            "#{project(project_identifier)}/topics/#{uuid}"
+          end
+
+          def self.viewpoint(project_identifier, topic_uuid, viewpoint_topic)
+            "#{topic(project_identifier, topic_uuid)}/viewpoints/#{viewpoint_topic}"
+          end
+        end
+
+        def bcf_v2_1_paths
+          BCF2_1Path
+        end
       end
     end
   end

--- a/modules/bim/lib/api/bim/utilities/path_helper.rb
+++ b/modules/bim/lib/api/bim/utilities/path_helper.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH
@@ -35,6 +36,7 @@ module API
 
         # rubocop:disable Naming/ClassAndModuleCamelCase
         class BCF2_1Path
+          # rubocop:enable Naming/ClassAndModuleCamelCase
           extend API::Utilities::UrlHelper
 
           # Determining the root_path on every url we want to render is

--- a/modules/bim/lib/api/bim/utilities/path_helper.rb
+++ b/modules/bim/lib/api/bim/utilities/path_helper.rb
@@ -54,8 +54,12 @@ module API
             "#{root}projects/#{identifier}"
           end
 
+          def self.topics(project_identifier)
+            "#{project(project_identifier)}/topics"
+          end
+
           def self.topic(project_identifier, uuid)
-            "#{project(project_identifier)}/topics/#{uuid}"
+            "#{topics(project_identifier)}/#{uuid}"
           end
 
           def self.viewpoint(project_identifier, topic_uuid, viewpoint_topic)

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -105,23 +105,6 @@ module OpenProject::Bim
     extend_api_response(:v3, :work_packages, :work_package) do
       include API::Bim::Utilities::PathHelper
 
-      property :bcf,
-               exec_context: :decorator,
-               getter: ->(*) {
-                 issue = represented.bcf_issue
-                 bcf = {}
-                 bcf[:viewpoints] = issue.viewpoints.map do |viewpoint|
-                   {
-                     id: viewpoint.snapshot.id,
-                     file_name: viewpoint.snapshot.filename
-                   }
-                 end
-                 bcf
-               },
-               if: ->(*) {
-                 represented.bcf_issue.present?
-               }
-
       link :bcfTopic,
            cache_if: -> { current_user_allowed_to(:view_linked_issues) } do
         next unless represented.bcf_issue?

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -116,7 +116,7 @@ module OpenProject::Bim
 
       link :convertBCF,
            cache_if: -> { current_user_allowed_to(:manage_bcf) } do
-        next if represented.bcf_issue?
+        next if represented.bcf_issue? || represented.project.nil?
 
         {
           href: bcf_v2_1_paths.topics(represented.project.identifier),

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -103,6 +103,8 @@ module OpenProject::Bim
     patch_with_namespace :DemoData, :WorkPackageBoardSeeder
 
     extend_api_response(:v3, :work_packages, :work_package) do
+      include API::Bim::Utilities::PathHelper
+
       property :bcf,
                exec_context: :decorator,
                getter: ->(*) {
@@ -119,6 +121,26 @@ module OpenProject::Bim
                if: ->(*) {
                  represented.bcf_issue.present?
                }
+
+      link :bcfTopic,
+           cache_if: -> { current_user_allowed_to(:view_linked_issues) } do
+        next unless represented.bcf_issue?
+
+        {
+          href: bcf_v2_1_paths.topic(represented.project.identifier, represented.bcf_issue.uuid)
+        }
+      end
+
+      links :bcfViewpoints,
+            cache_if: -> { current_user_allowed_to(:view_linked_issues) } do
+        next unless represented.bcf_issue?
+
+        represented.bcf_issue.viewpoints.map do |viewpoint|
+          {
+            href: bcf_v2_1_paths.viewpoint(represented.project.identifier, represented.bcf_issue.uuid, viewpoint.uuid)
+          }
+        end
+      end
     end
 
     extend_api_response(:v3, :work_packages, :work_package_collection) do

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -114,6 +114,18 @@ module OpenProject::Bim
         }
       end
 
+      link :convertBCF,
+           cache_if: -> { current_user_allowed_to(:manage_bcf) } do
+        next if represented.bcf_issue?
+
+        {
+          href: bcf_v2_1_paths.topics(represented.project.identifier),
+          title: 'Convert to BCF',
+          payload: { reference_links: [api_v3_paths.work_package(represented.id)] },
+          method: :post
+        }
+      end
+
       links :bcfViewpoints,
             cache_if: -> { current_user_allowed_to(:view_linked_issues) } do
         next unless represented.bcf_issue?

--- a/modules/bim/spec/api/v3/activities/activity_representer_spec.rb
+++ b/modules/bim/spec/api/v3/activities/activity_representer_spec.rb
@@ -1,0 +1,135 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Activities::ActivityRepresenter do
+  include API::Bim::Utilities::PathHelper
+
+  let(:current_user) do
+    FactoryBot.build_stubbed(:user).tap do |u|
+      allow(u)
+        .to receive(:allowed_to?) do |checked_permission, project|
+        project == work_package.project && permissions.include?(checked_permission)
+      end
+    end
+  end
+  let(:other_user) { FactoryBot.build_stubbed(:user) }
+  let(:work_package) do
+    journal.journable.tap do |wp|
+      allow(wp)
+        .to receive(:bcf_issue)
+        .and_return(bcf_topic)
+    end
+  end
+  let(:journal) do
+    FactoryBot.build_stubbed(:work_package_journal).tap do |journal|
+      allow(journal)
+        .to receive(:notes_id)
+        .and_return(journal.id)
+      allow(journal)
+        .to receive(:get_changes)
+        .and_return(changes)
+      allow(journal)
+        .to receive(:bcf_comment)
+        .and_return(bcf_comment)
+    end
+  end
+  let(:changes) { { subject: ["first subject", "second subject"] } }
+  let(:bcf_topic) do
+    FactoryBot.build_stubbed(:bcf_issue_with_comment)
+  end
+  let(:bcf_comment) { bcf_topic.comments.first }
+  let(:permissions) { %i(edit_work_package_notes view_linked_issues) }
+  let(:representer) { described_class.new(journal, current_user: current_user) }
+
+  before do
+    login_as(current_user)
+  end
+
+  subject(:generated) { representer.to_json }
+
+  describe 'type' do
+    context 'if a bcf_comment is present' do
+      let(:notes) { '' }
+      it 'is Activity::BcfComment' do
+        is_expected
+          .to be_json_eql('Activity::BcfComment'.to_json)
+          .at_path('_type')
+      end
+    end
+  end
+
+  describe '_links' do
+    describe 'bcfViewpoints' do
+      context 'if a viewpoint is present' do
+        it_behaves_like 'has a link collection' do
+          let(:link) { 'bcfViewpoints' }
+          let(:hrefs) do
+            [
+              {
+                href: bcf_v2_1_paths.viewpoint(work_package.project.identifier, bcf_topic.uuid, bcf_topic.viewpoints[0].uuid)
+              }
+            ]
+          end
+        end
+
+        context 'if no comment is present' do
+          let(:bcf_comment) { nil }
+
+          it_behaves_like 'has no link' do
+            let(:link) { 'bcfViewpoints' }
+          end
+        end
+
+        context 'if no viewpoint is linked' do
+          before do
+            allow(bcf_comment)
+              .to receive(:viewpoint)
+              .and_return nil
+          end
+
+          it_behaves_like 'has a link collection' do
+            let(:link) { 'bcfViewpoints' }
+            let(:hrefs) do
+              []
+            end
+          end
+        end
+
+        context 'if permission is lacking' do
+          let(:permissions) { %i[] }
+
+          it_behaves_like 'has no link' do
+            let(:link) { 'bcfViewpoints' }
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/bim/spec/api/v3/work_packages/work_package_representer_spec.rb
+++ b/modules/bim/spec/api/v3/work_packages/work_package_representer_spec.rb
@@ -65,19 +65,6 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
 
   include_context 'eager loaded work package representer'
 
-  describe 'with BCF issues' do
-    it "contains viewpoints" do
-      is_expected.to be_json_eql([
-        {
-          file_name: bcf_topic.viewpoints.first.attachments.first.filename,
-          id: bcf_topic.viewpoints.first.attachments.first.id
-        }
-      ].to_json)
-        .including('id')
-        .at_path('bcf/viewpoints/')
-    end
-  end
-
   describe '_links' do
     describe 'bcfTopic' do
       context 'if a topic is present' do

--- a/modules/bim/spec/api/v3/work_packages/work_package_representer_spec.rb
+++ b/modules/bim/spec/api/v3/work_packages/work_package_representer_spec.rb
@@ -35,7 +35,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
   let(:project) do
     work_package.project
   end
-  let(:permissions) { %i[view_linked_issues view_work_packages] }
+  let(:permissions) { %i[view_linked_issues view_work_packages manage_bcf] }
   let(:user) do
     FactoryBot.build_stubbed(:user).tap do |u|
       allow(u)
@@ -134,6 +134,36 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
             let(:link) { 'bcfViewpoints' }
           end
         end
+      end
+    end
+
+    describe 'convertBCF' do
+      let(:link) { 'convertBCF' }
+
+      context 'if no bcf issue is assigned yet' do
+        let(:bcf_topic) { nil }
+
+        it_behaves_like 'has a titled link' do
+          let(:title) { 'Convert to BCF' }
+          let(:href) { "/api/bcf/2.1/projects/#{project.identifier}/topics" }
+        end
+
+        it 'signalizes the payload' do
+          is_expected
+            .to be_json_eql({ "reference_links": ["/api/v3/work_packages/#{work_package.id}"] }.to_json)
+            .at_path('_links/convertBCF/payload')
+        end
+      end
+
+      context 'if a bcf issue is assigned' do
+        it_behaves_like 'has no link'
+      end
+
+      context 'if no bcf issue iss assigned but the user lacks permission' do
+        let(:bcf_topic) { nil }
+        let(:permissions) { %i[view_linked_issues view_work_packages] }
+
+        it_behaves_like 'has no link'
       end
     end
   end

--- a/modules/bim/spec/factories/bcf_issue_factory.rb
+++ b/modules/bim/spec/factories/bcf_issue_factory.rb
@@ -120,6 +120,18 @@ FactoryBot.define do
     end
 
     factory :bcf_issue_with_comment do
+      after(:stub) do |issue|
+        old_id = issue.id
+        issue.id = nil
+
+        attachment = FactoryBot.build_stubbed(:attachment, description: 'snapshot')
+        viewpoint = build_stubbed(:bcf_viewpoint, issue: issue, attachments: [attachment])
+
+        issue.viewpoints = [viewpoint]
+        issue.comments = [build_stubbed(:bcf_comment, issue: issue, viewpoint: viewpoint)]
+        issue.id = old_id
+      end
+
       after(:create) do |issue|
         viewpoint = create(:bcf_viewpoint, issue: issue)
         create(:bcf_comment, issue: issue, viewpoint: viewpoint)

--- a/modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb
@@ -200,9 +200,17 @@ describe 'BCF 2.1 viewpoints resource', type: :request, content_type: :json, wit
         get path
       end
 
-      it 'responds with the attachment' do
+      it 'responds with the attachment with the appropriate content type and cache headers' do
         expect(subject.status).to eq 200
         expect(subject.headers['Content-Type']).to eq 'image/jpeg'
+
+        expect(subject.headers["Cache-Control"]).to eq "public, max-age=#{1.year.to_i}"
+        expect(subject.headers["Expires"]).to be_present
+
+        expires_time = Time.parse response.headers["Expires"]
+
+        expect(expires_time < Time.now.utc + 1.year.to_i).to be_truthy
+        expect(expires_time > Time.now.utc + 1.year.to_i - 60).to be_truthy
       end
     end
 

--- a/spec/lib/api/v3/activities/activity_representer_spec.rb
+++ b/spec/lib/api/v3/activities/activity_representer_spec.rb
@@ -51,9 +51,6 @@ describe ::API::V3::Activities::ActivityRepresenter do
     end
   end
   let(:changes) { { subject: ["first subject", "second subject"] } }
-  let(:aggregated_journal) do
-    Journal::AggregatedJournal.new(journal)
-  end
   let(:permissions) { %i(edit_work_package_notes) }
   let(:representer) { described_class.new(journal, current_user: current_user) }
 

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -78,7 +78,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
   let(:available_custom_fields) { [] }
 
   before(:each) do
-    allow(User).to receive(:current).and_return current_user
+    login_as current_user
 
     allow(current_user)
       .to receive(:allowed_to?) do |permission, _context|

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -270,12 +270,20 @@ shared_examples 'an APIv3 attachment resource', type: :request, content_type: :j
           expect(subject.status).to eq 200
         end
 
-        it 'has the necessary headers' do
+        it 'has the necessary headers for content and caching' do
           expect(subject.headers['Content-Disposition'])
             .to eql content_disposition
 
           expect(subject.headers['Content-Type'])
             .to eql mock_file.content_type
+
+          expect(subject.headers["Cache-Control"]).to eq "public, max-age=#{1.year.to_i}"
+          expect(subject.headers["Expires"]).to be_present
+
+          expires_time = Time.parse response.headers["Expires"]
+
+          expect(expires_time < Time.now.utc + 1.year.to_i).to be_truthy
+          expect(expires_time > Time.now.utc + 1.year.to_i - 60).to be_truthy
         end
 
         it 'sends the file in binary' do
@@ -323,6 +331,14 @@ shared_examples 'an APIv3 attachment resource', type: :request, content_type: :j
           expect(subject.status).to eq 302
           expect(subject.headers['Location'])
             .to eql external_url
+
+          expect(subject.headers["Cache-Control"]).to eq "public, max-age=#{1.year.to_i}"
+          expect(subject.headers["Expires"]).to be_present
+
+          expires_time = Time.parse response.headers["Expires"]
+
+          expect(expires_time < Time.now.utc + 1.year.to_i).to be_truthy
+          expect(expires_time > Time.now.utc + 1.year.to_i - 60).to be_truthy
         end
       end
     end


### PR DESCRIPTION
Links from the work package to the bcf topic. It also replaces the bcf dictionary already existing inside the representer by an implementation more in line with the V3 paradigms (i.e. HAL)

### TODO

* [x] Add a bcfTopic link to the work package representer
* [x] Add a viewpoint link collection to the work package representer
* [x] Check performance impacts of those added links
* [x] Add link to the work package representer to signal the user being able to turn the work package into a bcf issue
* [x] Check if we can provide cache headers for the viewpoint snapshot in the bcf api as they are immutable
* [x] Check if we can provide cache headers for the attachments content in the v3 api as they are immutable
* [x] Also adapt the activities to follow the v3 paradigms 

https://community.openproject.com/projects/openproject/work_packages/32465