### PR TITLE
[32396] Drag placeholder in boards should look like on the project overview page

### DIFF
--- a/app/assets/stylesheets/content/drag_and_drop.sass
+++ b/app/assets/stylesheets/content/drag_and_drop.sass
@@ -31,8 +31,10 @@
 // there is also the 'modifying' grouping, which could serve as the basis for the two.
 
 @mixin modifying--placeholder
-  border: 1px dashed $primary-color
+  border: 1px dashed var(--primary-color)
   pointer-events: none
+  *
+    visibility: hidden
 
 @mixin d_n_d--preview
   box-shadow: 0 0 10px 5px rgba(0, 0, 0, 0.1)

--- a/frontend/src/app/components/wp-card-view/styles/wp-card-view.component.sass
+++ b/frontend/src/app/components/wp-card-view/styles/wp-card-view.component.sass
@@ -5,3 +5,4 @@
 
 .wp-inline-create--reference-container
   margin-bottom: 3rem
+  margin-top: 10px

--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -30,7 +30,11 @@
     margin-top: 10px
     // Take care that the shadow of the last element is still visible
     &:last-of-type
-      margin-bottom: 3px
+      margin-bottom: 5px
+
+  // Style shadow element while dragging
+  wp-single-card:host.gu-transit &
+    @include modifying--placeholder
 
 .wp-card--content:not(.-new)
   display: grid

--- a/frontend/src/app/modules/boards/board/board.component.sass
+++ b/frontend/src/app/modules/boards/board/board.component.sass
@@ -17,7 +17,6 @@ $board-list-max-width: 300px
   flex-grow: 1
 
   // Make it scrollable
-  padding-bottom: 5px
   overflow-y: auto
 
 
@@ -28,6 +27,9 @@ $board-list-max-width: 300px
 
   &:first-of-type
     margin-left: 5px
+
+  &.cdk-drag-placeholder
+    @include modifying--placeholder
 
 .board--header-container
   display: flex

--- a/frontend/src/assets/sass/_helpers.sass
+++ b/frontend/src/assets/sass/_helpers.sass
@@ -1,1 +1,2 @@
 @import "../../../../app/assets/stylesheets/openproject/_mixins"
+@import "../../../../app/assets/stylesheets/content/drag_and_drop"


### PR DESCRIPTION
Style shadowElements in boards (cards and lists) like on the project overview page.

https://community.openproject.com/projects/openproject/work_packages/32396/activity