### PR TITLE
Github Integration: document current GET parameter for the API key

### DIFF
--- a/docs/system-admin-guide/github-integration/README.md
+++ b/docs/system-admin-guide/github-integration/README.md
@@ -64,10 +64,11 @@ You need to configure just two things in the webhook.
 The **Content Type** has to be `application/json`.
 The **Payload URL** must point to your OpenProject server's github webhook endpoint (`/webhooks/github`).
 
-Now you need the API key you copied earlier. Append it to the *Payload URL* as a simple GET parameter named `api_key`. In the end the URL should look something like this:
+Now you need the API key you copied earlier. Append it to the *Payload URL* as a simple GET parameter named `key`. In the end the URL should look something like this:
 
 ```
-https://myopenproject.com/webhooks/github?api_key=42
+https://myopenproject.com/webhooks/github?key=42
 ```
+_Earlier version may have used the `api_key` parameter. In OpenProject 10.4, it is `key`._
 
 Now the integration is set up on both sides and you can use it.


### PR DESCRIPTION
this parameter may have been `api_key` in earlier releases, but it `key` in 10.4