### PR TITLE
Fix/search filter not removed

### DIFF
--- a/frontend/src/app/components/filters/query-filters/query-filters.component.html
+++ b/frontend/src/app/components/filters/query-filters/query-filters.component.html
@@ -17,7 +17,8 @@
       </label>
 
       <div class="advanced-filters--filter-value">
-        <wp-filter-by-text-input (filterChanged)="filtersChanged.emit($event)">
+        <wp-filter-by-text-input
+          (deactivateFilter)="deactivateFilter($event)">
         </wp-filter-by-text-input>
       </div>
     </li>


### PR DESCRIPTION
Although the search filter is cleared, its original (searched by) value is still transmitted to the back end for searching which leads to work packages unexpectedly not being found.

https://community.openproject.com/projects/openproject/work_packages/32500