### PR TITLE
[32030] Multiple Work Package Widgets on MyPage - Groups can't be reduced independently

### DIFF
--- a/frontend/src/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/modes/grouped/grouped-rows-builder.ts
@@ -87,7 +87,8 @@ export class GroupedRowsBuilder extends RowsBuilder {
       }
 
       // Set expansion state of contained rows
-      const affected = jQuery(`.${groupedRowClassName(groupIndex)}`);
+      const affected = jQuery(this.workPackageTable.tableAndTimelineContainer)
+                        .find(`.${groupedRowClassName(groupIndex)}`);;
       affected.toggleClass(collapsedRowClass, !!group.collapsed);
 
       // Update the hidden section of the rendered state


### PR DESCRIPTION
Collapse table rows only within the current table.

https://community.openproject.com/projects/openproject/work_packages/32030/activity