### PR TITLE
Fix bim_filter_spec

### DIFF
--- a/modules/bim/spec/support/pages/ifc_models/show_default.rb
+++ b/modules/bim/spec/support/pages/ifc_models/show_default.rb
@@ -73,7 +73,7 @@ module Pages
       end
 
       def page_shows_a_filter_button(visible)
-        expect(page).to have_conditional_selector(visible, '.toolbar-item', 'Filter')
+        expect(page).to have_conditional_selector(visible, '.toolbar-item', text: 'Filter')
       end
 
       def switch_view(value)


### PR DESCRIPTION
I assume, that the attribute was missing. Because of that Capybara did not to know what to do with the "Filters" parameter. 
See: https://stackoverflow.com/a/37195989/8900797