### PR TITLE
Fix/show user link

### DIFF
--- a/frontend/src/app/components/user/user-link/user-link.component.spec.ts
+++ b/frontend/src/app/components/user/user-link/user-link.component.spec.ts
@@ -42,6 +42,11 @@ describe('UserLinkComponent component test', () => {
     t: (key:string, args:any) => `Author: ${args.user}`
   };
 
+  let app:UserLinkComponent;
+  let fixture:ComponentFixture<UserLinkComponent>;
+  let element:HTMLElement;
+  let user:UserResource;
+
   beforeEach(async(() => {
 
     // noinspection JSIgnoredPromiseFromCall
@@ -54,32 +59,50 @@ describe('UserLinkComponent component test', () => {
         { provide: PathHelperService, useValue: PathHelperStub },
       ]
     }).compileComponents();
+
+    fixture = TestBed.createComponent(UserLinkComponent);
+    app = fixture.debugElement.componentInstance;
+    element = fixture.elementRef.nativeElement;
   }));
 
   describe('inner element', function() {
-    let app:UserLinkComponent;
-    let fixture:ComponentFixture<UserLinkComponent>
-    let element:HTMLElement;
+    describe('with the uer having the showUserPath attribute', function() {
+      beforeEach(async(() => {
+        user = {
+          name: 'First Last',
+          showUserPath: '/users/1'
+        } as UserResource;
 
-    let user = {
-      name: 'First Last',
-      href: '/api/v3/users/1',
-      idFromLink: '1',
-    } as UserResource;
+        app.user = user;
+        fixture.detectChanges();
+      }));
 
-    it('should render an inner link with specified classes', function() {
-      fixture = TestBed.createComponent(UserLinkComponent);
-      app = fixture.debugElement.componentInstance;
-      element = fixture.elementRef.nativeElement;
+      it('should render an inner link with specified classes', function () {
+        const link = element.querySelector('a')!;
 
-      app.user = user;
-      fixture.detectChanges();
+        expect(link.textContent).toEqual('First Last');
+        expect(link.getAttribute('title')).toEqual('Author: First Last');
+        expect(link.getAttribute('href')).toEqual('/users/1');
+      });
+    });
 
-      const link = element.querySelector('a')!;
+    describe('with the user not having the showUserPath attribute', function() {
+      beforeEach(async(() => {
+        user = {
+          name: 'First Last',
+          showUserPath: null
+        } as UserResource;
 
-      expect(link.textContent).toEqual('First Last');
-      expect(link.getAttribute('title')).toEqual('Author: First Last');
-      expect(link.getAttribute('href')).toEqual('/users/1');
+        app.user = user;
+        fixture.detectChanges();
+      }));
+
+      it('renders only the name', function () {
+        const link = element.querySelector('a');
+
+        expect(link).toBeNull();
+        expect(element.textContent).toEqual(' First Last ');
+      });
     });
   });
 });

--- a/frontend/src/app/components/user/user-link/user-link.component.ts
+++ b/frontend/src/app/components/user/user-link/user-link.component.ts
@@ -26,7 +26,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {Component, Inject, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {UserResource} from 'core-app/modules/hal/resources/user-resource';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
@@ -34,26 +34,33 @@ import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper
 @Component({
   selector: 'user-link',
   template: `
-    <a [attr.href]="href"
+    <a *ngIf="href"
+       [attr.href]="href"
        [attr.title]="label"
-       [textContent]="user.name">
+       [textContent]="name">
     </a>
-  `
+    <ng-container *ngIf="!href">
+      {{ name }}
+    <ng-container>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class UserLinkComponent {
   @Input() user:UserResource;
-
-  public href:string;
-  public label:string;
-  public name:string;
 
   constructor(readonly pathHelper:PathHelperService,
               readonly I18n:I18nService) {
   }
 
-  ngOnInit() {
-    this.href = this.pathHelper.userPath(this.user.idFromLink);
-    this.name = this.user.name;
-    this.label = this.I18n.t('js.label_author', { user: this.name });
+  public get href() {
+    return this.user && this.user.showUserPath;
+  }
+
+  public get name() {
+    return this.user && this.user.name;
+  }
+
+  public get label() {
+    return this.I18n.t('js.label_author', { user: this.name });
   }
 }

--- a/frontend/src/app/components/user/user-link/user-link.component.ts
+++ b/frontend/src/app/components/user/user-link/user-link.component.ts
@@ -48,8 +48,7 @@ import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper
 export class UserLinkComponent {
   @Input() user:UserResource;
 
-  constructor(readonly pathHelper:PathHelperService,
-              readonly I18n:I18nService) {
+  constructor(readonly I18n:I18nService) {
   }
 
   public get href() {

--- a/frontend/src/app/components/wp-activity/user/user-activity.component.html
+++ b/frontend/src/app/components/wp-activity/user/user-activity.component.html
@@ -8,13 +8,9 @@
                data-class-list="avatar">
   </user-avatar>
 
-  <span class="user" *ngIf="userPath">
-    <a [attr.href]="userPath"
-       [attr.aria-label]="userLabel"
-       [textContent]="userName">
-    </a>
+  <span class="user">
+    <user-link [user]="user"></user-link>
   </span>
-  <span class="user" *ngIf="!userPath">{{ userName }}</span>
   <span class="date">
     {{ isInitial ? text.label_created_on : text.label_updated_on }}
     <op-date-time [dateTimeValue]="activity.createdAt"></op-date-time>

--- a/frontend/src/app/components/wp-activity/user/user-activity.component.html
+++ b/frontend/src/app/components/wp-activity/user/user-activity.component.html
@@ -8,13 +8,13 @@
                data-class-list="avatar">
   </user-avatar>
 
-  <span class="user" *ngIf="userActive">
+  <span class="user" *ngIf="userPath">
     <a [attr.href]="userPath"
        [attr.aria-label]="userLabel"
        [textContent]="userName">
     </a>
   </span>
-  <span class="user" *ngIf="!userActive">{{ userName }}</span>
+  <span class="user" *ngIf="!userPath">{{ userName }}</span>
   <span class="date">
     {{ isInitial ? text.label_created_on : text.label_updated_on }}
     <op-date-time [dateTimeValue]="activity.createdAt"></op-date-time>

--- a/frontend/src/app/components/wp-activity/user/user-activity.component.ts
+++ b/frontend/src/app/components/wp-activity/user/user-activity.component.ts
@@ -66,7 +66,6 @@ export class UserActivityComponent extends WorkPackageCommentFieldHandler implem
 
   public userId:string | number;
   public userName:string;
-  public userActive:boolean;
   public userPath:string | null;
   public userLabel:string;
   public userAvatar:string;
@@ -128,9 +127,10 @@ export class UserActivityComponent extends WorkPackageCommentFieldHandler implem
       .then((user:UserResource) => {
         this.userId = user.id!;
         this.userName = user.name;
-        this.userActive = user.isActive;
         this.userAvatar = user.avatar;
-        this.userPath = user.showUser.href;
+        if (user.showUser) {
+          this.userPath = user.showUser.href;
+        }
         this.userLabel = this.I18n.t('js.label_author', {user: this.userName});
         this.cdRef.detectChanges();
       });

--- a/frontend/src/app/components/wp-activity/user/user-activity.component.ts
+++ b/frontend/src/app/components/wp-activity/user/user-activity.component.ts
@@ -65,9 +65,8 @@ export class UserActivityComponent extends WorkPackageCommentFieldHandler implem
   public userCanQuote = false;
 
   public userId:string | number;
+  public user:UserResource;
   public userName:string;
-  public userPath:string | null;
-  public userLabel:string;
   public userAvatar:string;
   public details:any[] = [];
   public isComment:boolean;
@@ -125,13 +124,10 @@ export class UserActivityComponent extends WorkPackageCommentFieldHandler implem
     this.userCacheService
       .require(this.activity.user.idFromLink)
       .then((user:UserResource) => {
+        this.user = user;
         this.userId = user.id!;
         this.userName = user.name;
         this.userAvatar = user.avatar;
-        if (user.showUser) {
-          this.userPath = user.showUser.href;
-        }
-        this.userLabel = this.I18n.t('js.label_author', {user: this.userName});
         this.cdRef.detectChanges();
       });
   }

--- a/frontend/src/app/modules/hal/resources/user-resource.ts
+++ b/frontend/src/app/modules/hal/resources/user-resource.ts
@@ -55,7 +55,7 @@ export class UserResource extends HalResource {
   }
 
   public get showUserPath() {
-    return this.showUser.$link.href;
+    return this.showUser ? this.showUser.$link.href : null;
   }
 
   public get isActive() {

--- a/frontend/src/app/modules/work_packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-full-view/wp-full-view.component.ts
@@ -26,11 +26,9 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {UserResource} from 'core-app/modules/hal/resources/user-resource';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {WorkPackageViewFocusService} from 'core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-focus.service';
 import {StateService} from '@uirouter/core';
-import {TypeResource} from 'core-app/modules/hal/resources/type-resource';
 import {Component, Injector, OnInit} from '@angular/core';
 import {WorkPackageViewSelectionService} from 'core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-selection.service';
 import {States} from 'core-components/states.service';
@@ -51,13 +49,6 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
   public isWatched:boolean;
   public displayWatchButton:boolean;
   public watchers:any;
-
-  // Properties
-  public type:TypeResource;
-  public author:UserResource;
-  public authorPath:string;
-  public authorActive:boolean;
-  public attachments:any;
 
   // More menu
   public permittedActions:any;
@@ -109,16 +100,5 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
     if (wp.watchers) {
       this.watchers = (wp.watchers as any).elements;
     }
-
-    // Type
-    this.type = wp.type;
-
-    // Author
-    this.author = wp.author;
-    this.authorPath = this.author.showUserPath as string;
-    this.authorActive = this.author.isActive;
-
-    // Attachments
-    this.attachments = wp.attachments.elements;
   }
 }

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -48,6 +48,8 @@ module API
         self_link
 
         link :showUser do
+          next if represented.locked?
+
           {
             href: api_v3_paths.show_user(represented.id),
             type: 'text/html'

--- a/spec/lib/api/v3/users/user_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_representer_spec.rb
@@ -29,7 +29,8 @@
 require 'spec_helper'
 
 describe ::API::V3::Users::UserRepresenter do
-  let(:user) { FactoryBot.build_stubbed(:user, status: 1) }
+  let(:status) { Principal::STATUSES[:active] }
+  let(:user) { FactoryBot.build_stubbed(:user, status: status) }
   let(:current_user) { FactoryBot.build_stubbed(:user) }
   let(:representer) { described_class.new(user, current_user: current_user) }
 
@@ -150,9 +151,19 @@ describe ::API::V3::Users::UserRepresenter do
         expect(subject).to have_json_path('_links/self/href')
       end
 
-      it_behaves_like 'has an untitled link' do
-        let(:link) { 'showUser' }
-        let(:href) { "/users/#{user.id}" }
+      context 'showUser' do
+        it_behaves_like 'has an untitled link' do
+          let(:link) { 'showUser' }
+          let(:href) { "/users/#{user.id}" }
+        end
+
+        context 'with a locked user' do
+          let(:status) { Principal::STATUSES[:locked] }
+
+          it_behaves_like 'has no link' do
+            let(:link) { 'showUser' }
+          end
+        end
       end
 
       context 'when regular current_user' do


### PR DESCRIPTION
Fixes multiple bugs regarding user links on the wp page:
* The user activity displayed user names always as non links for non admins
* The author information right below the wp title would always be a link although the link led to a 404 if the user is locked.

To reduce the probability of further errors, all of the logic is now inside the user-link component and both places make use of that component.

https://community.openproject.com/projects/openproject/work_packages/32489