### PR TITLE
avoid double submit of form configuration

### DIFF
--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -136,7 +136,6 @@ module Type::AttributeGroups
     self.attribute_groups_objects = nil
   end
 
-
   private
 
   def write_attribute_groups_objects

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -104,7 +104,6 @@ class BaseTypeService
 
   def transform_attribute_groups(groups)
     groups.map do |group|
-
       if group['type'] == 'query'
         transform_query_group(group)
       else

--- a/app/views/types/form/_form_configuration.html.erb
+++ b/app/views/types/form/_form_configuration.html.erb
@@ -89,6 +89,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <div class="grid-block">
   <div class="generic-table--action-buttons">
     <%= styled_button_tag t(@type.new_record? ? :button_create : :button_save),
+                          data: { disable_with: t(@type.new_record? ? :button_create : :button_save) },
                           class: 'form-configuration--save -highlight -with-icon icon-checkmark' %>
   </div>
 </div>

--- a/frontend/src/app/modules/admin/types/type-form-configuration.component.ts
+++ b/frontend/src/app/modules/admin/types/type-form-configuration.component.ts
@@ -79,9 +79,22 @@ export class TypeFormConfigurationComponent implements OnInit, OnDestroy {
     this.form = jQuery(this.element).closest('form');
     this.submit = this.form.find('.form-configuration--save');
 
+    // In the following we are triggering the form submit ourselves to work around
+    // a firefox shortcoming. But to avoid double submits which are sometimes not canceled fast
+    // enough, we need to memoize whether we have already submitted.
+    let submitted = false;
+
+    this.form.on('submit', (event) => {
+      submitted = true;
+    });
+
     // Capture mousedown on button because firefox breaks blur on click
     this.submit.on('mousedown', (event) => {
-      setTimeout(() => this.form.trigger('submit'), 50);
+      setTimeout(() => {
+        if (!submitted) {
+          this.form.trigger('submit');
+        }
+      }, 50);
       return true;
     });
 


### PR DESCRIPTION
The form configuration used to be submitted at least twice. In most cases, the first submit was canceled fast enough to not reach the backend. But if it was not canceled fast enough, the duplicate post lead to some errors when e.g. the referenced queries where already deleted.

https://community.openproject.com/projects/openproject/work_packages/32459