### PR TITLE
[32509] Rename module in left menu from "BIM" to "BCF"

### DIFF
--- a/modules/bim/config/locales/en.yml
+++ b/modules/bim/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
     bcf_thumbnail: "BCF snapshot"
 
   project_module_bcf: "BCF"
+  project_module_bim: "BCF"
   permission_view_linked_issues: "View BCF issues"
   permission_manage_bcf: "Import and manage BCF issues"
 

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -70,10 +70,10 @@ module OpenProject::Bim
       ::Redmine::MenuManager.map(:project_menu) do |menu|
         menu.push(:ifc_models,
                   { controller: '/bim/ifc_models/ifc_models', action: 'defaults' },
-                  caption: :'bim.label_bim',
+                  caption: :'bcf.label_bcf',
                   param: :project_id,
                   after: :work_packages,
-                  icon: 'icon2 icon-ifc',
+                  icon: 'icon2 icon-bcf',
                   badge: :label_new)
 
         menu.push :ifc_viewer_panels,


### PR DESCRIPTION
Rename "BIM" module to "BCF" for the user in the sidebar and the settings. 
Internally the module is still named `bim` as this is the name we chose for everything BIM related.

https://community.openproject.com/projects/openproject/work_packages/32509/activity