### PR TITLE
[32525] Split screen content not reachable on medium screen sizes

### DIFF
--- a/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
+++ b/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
@@ -1,3 +1,5 @@
+@import "helpers"
+
 .work-packages-partitioned-query-space--container
   height: 100%
   overflow: hidden
@@ -15,6 +17,8 @@
 
   .work-packages-partitioned-page--content-container
     display: flex
+    overflow: auto
+    @include styled-scroll-bar
 
   .work-packages-partitioned-page--content-left,
   .work-packages-partitioned-page--content-right


### PR DESCRIPTION
Add a scrollbar when the screen is too small to fit both parts of the partitioned view. 
This PR adds one scrollbar for both sides instead of one for each side. In my opinion this is better, because independent scrollbars would lead to the left side expanding to its minimum width (580px), while the right side has to shrink massively. In this case the content is not perceivable even with scrollbar.

https://community.openproject.com/projects/openproject/work_packages/32525/activity