### PR TITLE
Show warning for edge versions < 18

### DIFF
--- a/app/helpers/browser_helper.rb
+++ b/app/helpers/browser_helper.rb
@@ -20,6 +20,9 @@ module BrowserHelper
       # Older version of safari
       return true if browser.safari? && version < 12
 
+      # Older version of EDGE
+      return true if browser.edge? && version < 18
+
       false
     end
   end


### PR DESCRIPTION
We're getting errors on sentry with Edge versions 16 due to `URLSearchParams` (https://url.spec.whatwg.org/#urlsearchparams) which is only available since 17, but we only support the last version anyway