### PR TITLE
Introduce base mixin for observing until component destroyed

### DIFF
--- a/frontend/npm-shrinkwrap.json
+++ b/frontend/npm-shrinkwrap.json
@@ -3186,6 +3186,14 @@
       "resolved": "https://registry.npmjs.org/@uirouter/rx/-/rx-0.6.5.tgz",
       "integrity": "sha512-srGdX+BAVTfpZ1Kl7tvdEN1ss8yctKO4YrGyy9E/4s80bGFp4KMe9Qf2L3UHn0iugBZlX7Nbmp305AQSzWXYrw=="
     },
+    "@w11k/ngx-componentdestroyed": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@w11k/ngx-componentdestroyed/-/ngx-componentdestroyed-5.0.2.tgz",
+      "integrity": "sha512-njpK7h6hSpF8LQp2bayb47T7rTxOwx7745TOiUP88y8YAT2JOY5OeJpYqlK2WrQQBeD7CT+DxozD6yNBN283dA==",
+      "requires": {
+        "rxjs": ">=6.5.0"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -4148,9 +4156,9 @@
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001033",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001033.tgz",
-          "integrity": "sha512-8Ibzxee6ibc5q88cM1usPsMpJOG5CTq0s/dKOmlekPbDGKt+UrnOOTPSjQz3kVo6yL7N4SB5xd+FGLHQmbzh6A=="
+          "version": "1.0.30001035",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
+          "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ=="
         }
       }
     },
@@ -5876,9 +5884,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.375",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.375.tgz",
-      "integrity": "sha512-zmaFnYVBtfpF8bGRYxgPeVAlXB7N3On8rjBE2ROc6wOpTPpzRWaiHo6KkbJMvlH07CH33uks/TEb6kuMMn8q6A=="
+      "version": "1.3.376",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.376.tgz",
+      "integrity": "sha512-cv/PYVz5szeMz192ngilmezyPNFkUjuynuL2vNdiqIrio440nfTDdc0JJU0TS2KHLSVCs9gBbt4CFqM+HcBnjw=="
     },
     "elliptic": {
       "version": "6.5.2",
@@ -9487,14 +9495,6 @@
           "resolved": "https://registry.npmjs.org/@types/dragula/-/dragula-2.1.35.tgz",
           "integrity": "sha512-kh0O22j8QVh7xU0P6Penwext6xVMNldVEzvtOAHU1/AzdluYstc9pe2nUL3fS6IZRyzSoSGvdR/u8zP2iIZmnA=="
         }
-      }
-    },
-    "ng2-rx-componentdestroyed": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ng2-rx-componentdestroyed/-/ng2-rx-componentdestroyed-3.0.1.tgz",
-      "integrity": "sha512-dc+A05w+FXb2FaOe6XWmE9+KBWYDM/+aksFT4oXP/2EHQjyozXy6RcG2a+E39WzNuLIpjN+bHHqxT3evHcjBnA==",
-      "requires": {
-        "rxjs": "^6.0.0"
       }
     },
     "ngtemplate-loader": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,9 +70,9 @@
     "@uirouter/angular": "^6.0.1",
     "@uirouter/core": "^6.0.4",
     "@uirouter/rx": "^0.6.5",
+    "@w11k/ngx-componentdestroyed": "^5.0.2",
     "@xeokit/xeokit-sdk": "^0.8.8",
     "@xeokit/xeokit-viewer": "^1.6.4",
-    "urijs": "^1.19.2",
     "amdefine": "^1.0.0",
     "angular-dragula": "^1.2.8",
     "atoa": "^1.0.0",
@@ -112,7 +112,6 @@
     "ng-dynamic-component": "^6.0.0",
     "ng2-charts": "^2.3.0",
     "ng2-dragula": "^2.1.1",
-    "ng2-rx-componentdestroyed": "3.0.1",
     "ngtemplate-loader": "^2.0.1",
     "node-sass": "^4.13.1",
     "observable-array": "0.0.4",
@@ -127,6 +126,7 @@
     "typescript": "3.7.5",
     "uglifyjs-webpack-plugin": "^2.2.0",
     "ui-select": "~0.19.6",
+    "urijs": "^1.19.2",
     "zone.js": "~0.10.2"
   },
   "scripts": {

--- a/frontend/src/app/ckeditor/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/ckeditor/ckeditor-augmented-textarea.component.ts
@@ -26,18 +26,19 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, ElementRef, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {Component, ElementRef, OnInit, ViewChild} from '@angular/core';
 import {ConfigurationService} from 'core-app/modules/common/config/configuration.service';
 import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
 import {HalResourceService} from 'core-app/modules/hal/services/hal-resource.service';
 import {States} from 'core-components/states.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
 import {filter, takeUntil} from 'rxjs/operators';
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {ICKEditorContext, ICKEditorInstance} from "core-app/modules/common/ckeditor/ckeditor-setup.service";
 import {OpCkeditorComponent} from "core-app/modules/common/ckeditor/op-ckeditor.component";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 
 export const ckeditorAugmentedTextareaSelector = 'ckeditor-augmented-textarea';
@@ -46,7 +47,7 @@ export const ckeditorAugmentedTextareaSelector = 'ckeditor-augmented-textarea';
   selector: ckeditorAugmentedTextareaSelector,
   templateUrl: './ckeditor-augmented-textarea.html'
 })
-export class CkeditorAugmentedTextareaComponent implements OnInit, OnDestroy {
+export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin implements OnInit {
   public textareaSelector:string;
   public previewContext:string;
 
@@ -79,6 +80,7 @@ export class CkeditorAugmentedTextareaComponent implements OnInit, OnDestroy {
               protected I18n:I18nService,
               protected states:States,
               protected ConfigurationService:ConfigurationService) {
+    super();
   }
 
   ngOnInit() {
@@ -109,6 +111,7 @@ export class CkeditorAugmentedTextareaComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    super.ngOnDestroy();
     this.formElement.off('submit.ckeditor');
   }
 
@@ -164,8 +167,8 @@ export class CkeditorAugmentedTextareaComponent implements OnInit, OnDestroy {
         filter(resource => !!resource)
       ).subscribe(resource => {
       let missingAttachments = _.differenceBy(this.attachments,
-                                              resource!.attachments.elements,
-                                              (attachment:HalResource) => attachment.id);
+        resource!.attachments.elements,
+        (attachment:HalResource) => attachment.id);
 
       let removedUrls = missingAttachments.map(attachment => attachment.downloadLocation.$href);
 

--- a/frontend/src/app/components/angular/debounced-event-emitter.ts
+++ b/frontend/src/app/components/angular/debounced-event-emitter.ts
@@ -7,7 +7,7 @@ export class DebouncedEventEmitter<T> {
   private emitter = new EventEmitter<T>();
   private debouncer:Subject<T>;
 
-  constructor(takeUntil$:Observable<true>, debounceTimeInMs:number = 250) {
+  constructor(takeUntil$:Observable<unknown>, debounceTimeInMs:number = 250) {
     this.debouncer = new Subject<T>();
     this.debouncer
       .pipe(

--- a/frontend/src/app/components/filters/abstract-filter-date-time-value/abstract-filter-date-time-value.controller.ts
+++ b/frontend/src/app/components/filters/abstract-filter-date-time-value/abstract-filter-date-time-value.controller.ts
@@ -31,12 +31,14 @@ import {QueryFilterInstanceResource} from 'core-app/modules/hal/resources/query-
 import {TimezoneService} from 'core-components/datetime/timezone.service';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {OnInit} from '@angular/core';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
-export abstract class AbstractDateTimeValueController implements OnInit {
+export abstract class AbstractDateTimeValueController extends UntilDestroyedMixin implements OnInit {
   public filter:QueryFilterInstanceResource;
 
   constructor(protected I18n:I18nService,
               protected timezoneService:TimezoneService) {
+    super();
   }
 
   ngOnInit() {
@@ -44,6 +46,7 @@ export abstract class AbstractDateTimeValueController implements OnInit {
   }
 
   public abstract get lowerBoundary():Moment|null;
+
   public abstract get upperBoundary():Moment|null;
 
   public isoDateParser(data:any) {
@@ -68,22 +71,24 @@ export abstract class AbstractDateTimeValueController implements OnInit {
     if (!value) {
       return false;
     } else {
-      return value.hours() !== 0 || value.minutes() !== 0;
+      return value.hours() !== 0 || value.minutes() !== 0;
     }
   }
 
   public get timeZoneText() {
     if (this.lowerBoundary && this.upperBoundary) {
       return this.I18n.t('js.filter.time_zone_converted.two_values',
-                         { from: this.lowerBoundary.format('YYYY-MM-DD HH:mm'),
-                           to: this.upperBoundary.format('YYYY-MM-DD HH:mm') });
+        {
+          from: this.lowerBoundary.format('YYYY-MM-DD HH:mm'),
+          to: this.upperBoundary.format('YYYY-MM-DD HH:mm')
+        });
     } else if (this.upperBoundary) {
       return this.I18n.t('js.filter.time_zone_converted.only_end',
-                         { to: this.upperBoundary.format('YYYY-MM-DD HH:mm') });
+        { to: this.upperBoundary.format('YYYY-MM-DD HH:mm') });
 
-    } else if(this.lowerBoundary) {
+    } else if (this.lowerBoundary) {
       return this.I18n.t('js.filter.time_zone_converted.only_start',
-                         { from: this.lowerBoundary.format('YYYY-MM-DD HH:mm') });
+        { from: this.lowerBoundary.format('YYYY-MM-DD HH:mm') });
 
     }
 

--- a/frontend/src/app/components/filters/filter-container/filter-container.directive.ts
+++ b/frontend/src/app/components/filters/filter-container/filter-container.directive.ts
@@ -28,19 +28,19 @@
 
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, OnInit, Output} from '@angular/core';
 import {WorkPackageViewFiltersService} from 'core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service';
-import {componentDestroyed, untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {WorkPackageFiltersService} from 'core-components/filters/wp-filters/wp-filters.service';
 import {DebouncedEventEmitter} from "core-components/angular/debounced-event-emitter";
 import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-filter-instance-resource";
 import {Observable} from "rxjs";
-import {takeUntil} from "rxjs/operators";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 @Component({
   templateUrl: './filter-container.directive.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'filter-container',
 })
-export class WorkPackageFilterContainerComponent implements OnInit, OnDestroy {
+export class WorkPackageFilterContainerComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
   @Input('showFilterButton') showFilterButton:boolean = false;
   @Input('filterButtonText') filterButtonText:string = I18n.t('js.button_filter');
   @Output() public filtersChanged = new DebouncedEventEmitter<QueryFilterInstanceResource[]>(componentDestroyed(this));
@@ -52,6 +52,7 @@ export class WorkPackageFilterContainerComponent implements OnInit, OnDestroy {
   constructor(readonly wpTableFilters:WorkPackageViewFiltersService,
               readonly cdRef:ChangeDetectorRef,
               readonly wpFiltersService:WorkPackageFiltersService) {
+    super();
     this.visible$ = this.wpFiltersService.observeUntil(componentDestroyed(this));
   }
 
@@ -59,17 +60,13 @@ export class WorkPackageFilterContainerComponent implements OnInit, OnDestroy {
     this.wpTableFilters
       .pristine$()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(() => {
         this.filters = this.wpTableFilters.current;
         this.loaded = true;
         this.cdRef.detectChanges();
       });
-  }
-
-  ngOnDestroy() {
-    // Nothing to do, added for interface compatibility
   }
 
   public replaceIfComplete(filters:QueryFilterInstanceResource[]) {

--- a/frontend/src/app/components/filters/filter-date-time-value/filter-date-time-value.component.ts
+++ b/frontend/src/app/components/filters/filter-date-time-value/filter-date-time-value.component.ts
@@ -26,22 +26,21 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {Component, Input, OnDestroy, Output} from '@angular/core';
+import {Component, Input, OnInit, Output} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
 import {QueryFilterInstanceResource} from 'core-app/modules/hal/resources/query-filter-instance-resource';
 import {DebouncedEventEmitter} from 'core-components/angular/debounced-event-emitter';
 import {TimezoneService} from 'core-components/datetime/timezone.service';
 import {Moment} from 'moment';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
 import {AbstractDateTimeValueController} from '../abstract-filter-date-time-value/abstract-filter-date-time-value.controller';
-import {OnInit} from '@angular/core';
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 @Component({
   selector: 'filter-date-time-value',
   templateUrl: './filter-date-time-value.component.html'
 })
-export class FilterDateTimeValueComponent extends AbstractDateTimeValueController implements OnInit, OnDestroy {
+export class FilterDateTimeValueComponent extends AbstractDateTimeValueController implements OnInit {
   @Input() public shouldFocus:boolean = false;
   @Input() public filter:QueryFilterInstanceResource;
   @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource>(componentDestroyed(this));
@@ -51,11 +50,7 @@ export class FilterDateTimeValueComponent extends AbstractDateTimeValueControlle
     super(I18n, timezoneService);
   }
 
-  ngOnDestroy() {
-    // Nothing to do, added for interface compatibility
-  }
-
-  public get value():HalResource | string {
+  public get value():HalResource|string {
     return this.filter.values[0];
   }
 
@@ -68,7 +63,7 @@ export class FilterDateTimeValueComponent extends AbstractDateTimeValueControlle
     this.filterChanged.emit(this.filter);
   }
 
-  public get lowerBoundary():Moment | null {
+  public get lowerBoundary():Moment|null {
     if (this.value && this.timezoneService.isValidISODateTime(this.valueString)) {
       return this.timezoneService.parseDatetime(this.valueString);
     }
@@ -76,7 +71,7 @@ export class FilterDateTimeValueComponent extends AbstractDateTimeValueControlle
     return null;
   }
 
-  public get upperBoundary():Moment | null {
+  public get upperBoundary():Moment|null {
     if (this.value && this.timezoneService.isValidISODateTime(this.valueString)) {
       return this.timezoneService.parseDatetime(this.valueString).add(24, 'hours');
     }

--- a/frontend/src/app/components/filters/filter-date-times-value/filter-date-times-value.component.ts
+++ b/frontend/src/app/components/filters/filter-date-times-value/filter-date-times-value.component.ts
@@ -29,19 +29,18 @@
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
 import {QueryFilterInstanceResource} from 'core-app/modules/hal/resources/query-filter-instance-resource';
 import {Moment} from 'moment';
-import {AbstractDateTimeValueController} from '../abstract-filter-date-time-value/abstract-filter-date-time-value.controller'
-import {Component, Inject, Input, OnDestroy, Output} from '@angular/core';
+import {AbstractDateTimeValueController} from '../abstract-filter-date-time-value/abstract-filter-date-time-value.controller'
+import {Component, Input, OnInit, Output} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {DebouncedEventEmitter} from 'core-components/angular/debounced-event-emitter';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
 import {TimezoneService} from 'core-components/datetime/timezone.service';
-import {OnInit} from '@angular/core';
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 @Component({
   selector: 'filter-date-times-value',
   templateUrl: './filter-date-times-value.component.html'
 })
-export class FilterDateTimesValueComponent extends AbstractDateTimeValueController implements OnInit, OnDestroy {
+export class FilterDateTimesValueComponent extends AbstractDateTimeValueController implements OnInit {
   @Input() public shouldFocus:boolean = false;
   @Input() public filter:QueryFilterInstanceResource;
   @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource>(componentDestroyed(this));
@@ -53,10 +52,6 @@ export class FilterDateTimesValueComponent extends AbstractDateTimeValueControll
   constructor(readonly I18n:I18nService,
               readonly timezoneService:TimezoneService) {
     super(I18n, timezoneService);
-  }
-
-  ngOnDestroy() {
-    // Nothing to do, added for interface compatibility
   }
 
   public get begin():HalResource|string {

--- a/frontend/src/app/components/filters/filter-date-value/filter-date-value.component.ts
+++ b/frontend/src/app/components/filters/filter-date-value/filter-date-value.component.ts
@@ -26,32 +26,30 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {Component, Input, OnDestroy, Output} from '@angular/core';
+import {Component, Input, Output} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
 import {QueryFilterInstanceResource} from 'core-app/modules/hal/resources/query-filter-instance-resource';
 import {DebouncedEventEmitter} from 'core-components/angular/debounced-event-emitter';
 import {TimezoneService} from 'core-components/datetime/timezone.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 @Component({
   selector: 'filter-date-value',
   templateUrl: './filter-date-value.component.html'
 })
-export class FilterDateValueComponent implements OnDestroy {
+export class FilterDateValueComponent extends UntilDestroyedMixin {
   @Input() public shouldFocus:boolean = false;
   @Input() public filter:QueryFilterInstanceResource;
   @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource>(componentDestroyed(this));
 
   constructor(readonly timezoneService:TimezoneService,
               readonly I18n:I18nService) {
+    super();
   }
 
-  ngOnDestroy() {
-    // Nothing to do, added for interface compatibility
-  }
-
-  public get value():HalResource | string {
+  public get value():HalResource|string {
     return this.filter.values[0];
   }
 

--- a/frontend/src/app/components/filters/filter-dates-value/filter-dates-value.component.ts
+++ b/frontend/src/app/components/filters/filter-dates-value/filter-dates-value.component.ts
@@ -28,18 +28,19 @@
 
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
 import {QueryFilterInstanceResource} from 'core-app/modules/hal/resources/query-filter-instance-resource';
-import {Component, Inject, Input, OnDestroy, Output} from '@angular/core';
+import {Component, Input, Output} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
 import {DebouncedEventEmitter} from 'core-components/angular/debounced-event-emitter';
 import {TimezoneService} from 'core-components/datetime/timezone.service';
 import * as moment from 'moment';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 @Component({
   selector: 'filter-dates-value',
   templateUrl: './filter-dates-value.component.html'
 })
-export class FilterDatesValueComponent implements OnDestroy {
+export class FilterDatesValueComponent extends UntilDestroyedMixin {
   @Input() public shouldFocus:boolean = false;
   @Input() public filter:QueryFilterInstanceResource;
   @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource>(componentDestroyed(this));
@@ -50,10 +51,7 @@ export class FilterDatesValueComponent implements OnDestroy {
 
   constructor(readonly timezoneService:TimezoneService,
               readonly I18n:I18nService) {
-  }
-
-  ngOnDestroy() {
-    // Nothing to do, added for interface compatibility
+    super();
   }
 
   public get begin():any {

--- a/frontend/src/app/components/filters/filter-integer-value/filter-integer-value.component.ts
+++ b/frontend/src/app/components/filters/filter-integer-value/filter-integer-value.component.ts
@@ -29,25 +29,23 @@
 
 import {QueryFilterResource} from 'core-app/modules/hal/resources/query-filter-resource';
 import {QueryFilterInstanceResource} from 'core-app/modules/hal/resources/query-filter-instance-resource';
-import {Component, EventEmitter, Inject, Input, OnDestroy, Output} from '@angular/core';
+import {Component, Input, Output} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {DebouncedEventEmitter} from 'core-components/angular/debounced-event-emitter';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 @Component({
   selector: 'filter-integer-value',
   templateUrl: './filter-integer-value.component.html'
 })
-export class FilterIntegerValueComponent implements OnDestroy {
+export class FilterIntegerValueComponent extends UntilDestroyedMixin {
   @Input() public shouldFocus:boolean = false;
   @Input() public filter:QueryFilterInstanceResource;
   @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource>(componentDestroyed(this));
 
   constructor(readonly I18n:I18nService) {
-  }
-
-  ngOnDestroy() {
-    // Nothing to do, added for interface compatibility
+    super();
   }
 
   public get value() {
@@ -55,7 +53,7 @@ export class FilterIntegerValueComponent implements OnDestroy {
   }
 
   public set value(val) {
-    if (typeof(val) === 'number') {
+    if (typeof (val) === 'number') {
       this.filter.values = [val.toString()];
     } else {
       this.filter.values = [];

--- a/frontend/src/app/components/filters/filter-string-value/filter-string-value.component.ts
+++ b/frontend/src/app/components/filters/filter-string-value/filter-string-value.component.ts
@@ -26,18 +26,19 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {Component, Input, OnDestroy, Output} from '@angular/core';
+import {Component, Input, Output} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
 import {QueryFilterInstanceResource} from 'core-app/modules/hal/resources/query-filter-instance-resource';
 import {DebouncedEventEmitter} from 'core-components/angular/debounced-event-emitter';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 @Component({
   selector: 'filter-string-value',
   templateUrl: './filter-string-value.component.html'
 })
-export class FilterStringValueComponent implements OnDestroy {
+export class FilterStringValueComponent extends UntilDestroyedMixin {
   @Input() public shouldFocus:boolean = false;
   @Input() public filter:QueryFilterInstanceResource;
   @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource>(componentDestroyed(this));
@@ -47,10 +48,7 @@ export class FilterStringValueComponent implements OnDestroy {
   };
 
   constructor(readonly I18n:I18nService) {
-  }
-
-  ngOnDestroy() {
-    // Nothing to do, added for interface compatibility
+    super();
   }
 
   public get value():HalResource|string {

--- a/frontend/src/app/components/filters/query-filter/query-filter.component.ts
+++ b/frontend/src/app/components/filters/query-filter/query-filter.component.ts
@@ -26,7 +26,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {WorkPackageFiltersService} from 'core-components/filters/wp-filters/wp-filters.service';
 import {QueryFilterResource} from 'core-app/modules/hal/resources/query-filter-resource';
@@ -39,7 +39,7 @@ import {WorkPackageViewFiltersService} from "core-app/modules/work_packages/rout
   selector: '[query-filter]',
   templateUrl: './query-filter.component.html'
 })
-export class QueryFilterComponent implements OnInit, OnDestroy {
+export class QueryFilterComponent implements OnInit {
   @Input() public shouldFocus:boolean = false;
   @Input() public filter:QueryFilterInstanceResource;
   @Output() public filterChanged = new EventEmitter<QueryFilterResource>();
@@ -88,9 +88,5 @@ export class QueryFilterComponent implements OnInit, OnDestroy {
     this.eeShowBanners = this.bannerService.eeShowBanners;
     this.availableOperators = this.filter.schema.availableOperators;
     this.showValuesInput = this.filter.currentSchema!.isValueRequired();
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 }

--- a/frontend/src/app/components/filters/query-filters/query-filters.component.ts
+++ b/frontend/src/app/components/filters/query-filters/query-filters.component.ts
@@ -26,19 +26,9 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  Output,
-  ViewChild
-} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, OnChanges, OnInit, Output, ViewChild} from '@angular/core';
 import {QueryFilterInstanceResource} from 'core-app/modules/hal/resources/query-filter-instance-resource';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
 import {QueryFilterResource} from 'core-app/modules/hal/resources/query-filter-resource';
 import {DebouncedEventEmitter} from 'core-components/angular/debounced-event-emitter';
 import {AngularTrackingHelpers} from "core-components/angular/tracking-functions";
@@ -46,6 +36,8 @@ import {BannersService} from "core-app/modules/common/enterprise/banners.service
 import {NgSelectComponent} from "@ng-select/ng-select";
 import {WorkPackageViewFiltersService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service";
 import {WorkPackageFiltersService} from "core-components/filters/wp-filters/wp-filters.service";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 const ADD_FILTER_SELECT_INDEX = -1;
 
@@ -55,7 +47,7 @@ const ADD_FILTER_SELECT_INDEX = -1;
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './query-filters.component.html'
 })
-export class QueryFiltersComponent implements OnInit, OnChanges, OnDestroy {
+export class QueryFiltersComponent extends UntilDestroyedMixin implements OnInit, OnChanges {
 
   @ViewChild(NgSelectComponent) public ngSelectComponent:NgSelectComponent;
   @Input() public filters:QueryFilterInstanceResource[];
@@ -85,14 +77,11 @@ export class QueryFiltersComponent implements OnInit, OnChanges, OnDestroy {
               readonly wpFiltersService:WorkPackageFiltersService,
               readonly I18n:I18nService,
               readonly bannerService:BannersService) {
+    super();
   }
 
   ngOnInit() {
     this.eeShowBanners = this.bannerService.eeShowBanners;
-  }
-
-  ngOnDestroy() {
-    // Nothing to do.
   }
 
   ngOnChanges() {

--- a/frontend/src/app/components/main-menu/main-menu-toggle.component.ts
+++ b/frontend/src/app/components/main-menu/main-menu-toggle.component.ts
@@ -26,13 +26,13 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnInit} from '@angular/core';
 import {MainMenuToggleService} from './main-menu-toggle.service';
 import {distinctUntilChanged} from 'rxjs/operators';
-import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {DeviceService} from "app/modules/common/browser/device.service";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 export const mainMenuToggleSelector = 'main-menu-toggle';
 
@@ -52,7 +52,7 @@ export const mainMenuToggleSelector = 'main-menu-toggle';
   `
 })
 
-export class MainMenuToggleComponent implements OnInit, OnDestroy {
+export class MainMenuToggleComponent extends UntilDestroyedMixin implements OnInit {
   toggleTitle:string = "";
   @InjectField() currentProject:CurrentProjectService;
 
@@ -60,6 +60,7 @@ export class MainMenuToggleComponent implements OnInit, OnDestroy {
               readonly cdRef:ChangeDetectorRef,
               readonly deviceService:DeviceService,
               readonly injector:Injector) {
+    super();
   }
 
   ngOnInit() {
@@ -68,16 +69,12 @@ export class MainMenuToggleComponent implements OnInit, OnDestroy {
     this.toggleService.titleData$
       .pipe(
         distinctUntilChanged(),
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(setToggleTitle => {
         this.toggleTitle = setToggleTitle;
         this.cdRef.detectChanges();
       });
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 }
 

--- a/frontend/src/app/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
@@ -26,15 +26,13 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {Directive, ElementRef, Injector, Input, OnDestroy} from '@angular/core';
+import {Directive, ElementRef, Injector, Input} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {AuthorisationService} from 'core-app/modules/common/model-auth/model-auth.service';
 import {OpContextMenuTrigger} from 'core-components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import {OPContextMenuService} from 'core-components/op-context-menu/op-context-menu.service';
 import {States} from 'core-components/states.service';
 import {WorkPackagesListService} from 'core-components/wp-list/wp-list.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {takeUntil} from 'rxjs/operators';
 import {QueryFormResource} from 'core-app/modules/hal/resources/query-form-resource';
 import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
 import {OpModalService} from "core-components/op-modals/op-modal.service";
@@ -51,7 +49,7 @@ import {
 @Directive({
   selector: '[opSettingsContextMenu]'
 })
-export class OpSettingsMenuDirective extends OpContextMenuTrigger implements OnDestroy {
+export class OpSettingsMenuDirective extends OpContextMenuTrigger {
   @Input('opSettingsContextMenu-query') public query:QueryResource;
   private form:QueryFormResource;
   private loadingPromise:PromiseLike<any>;
@@ -70,16 +68,12 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger implements OnD
     super(elementRef, opContextMenu);
   }
 
-  ngOnDestroy():void {
-    // Nothing to do
-  }
-
   ngAfterViewInit():void {
     super.ngAfterViewInit();
 
     this.querySpace.query.values$()
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       )
       .subscribe(queryUpdate => {
         this.query = queryUpdate;
@@ -89,7 +83,7 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger implements OnD
 
     this.querySpace.queryForm.values$()
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       )
       .subscribe(formUpdate => {
         this.form = formUpdate;

--- a/frontend/src/app/components/op-context-menu/op-context-menu-handler.ts
+++ b/frontend/src/app/components/op-context-menu/op-context-menu-handler.ts
@@ -1,15 +1,17 @@
 import {OPContextMenuService} from 'core-components/op-context-menu/op-context-menu.service';
 import {OpContextMenuItem} from 'core-components/op-context-menu/op-context-menu.types';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 /**
  * Interface passed to CM service to open a particular context menu.
  * This will often be a trigger component, but does not have to be.
  */
-export abstract class OpContextMenuHandler {
+export abstract class OpContextMenuHandler extends UntilDestroyedMixin {
   protected $element:JQuery;
   protected items:OpContextMenuItem[] = [];
 
   constructor(readonly opContextMenu:OPContextMenuService) {
+    super();
   }
 
   /**

--- a/frontend/src/app/components/table-pagination/table-pagination.component.ts
+++ b/frontend/src/app/components/table-pagination/table-pagination.component.ts
@@ -39,13 +39,14 @@ import {
   Output
 } from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   selector: '[tablePagination]',
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './table-pagination.component.html'
 })
-export class TablePaginationComponent implements OnInit {
+export class TablePaginationComponent extends UntilDestroyedMixin implements OnInit {
   @Input() totalEntries:string;
   @Input() hideForSinglePageResults:boolean = false;
   @Input() showPerPage:boolean = true;
@@ -70,6 +71,7 @@ export class TablePaginationComponent implements OnInit {
   constructor(protected paginationService:PaginationService,
               protected cdRef:ChangeDetectorRef,
               protected I18n:I18nService) {
+    super();
   }
 
   ngOnInit():void {
@@ -155,10 +157,9 @@ export class TablePaginationComponent implements OnInit {
 
       // This avoids a truncation when there are not enough elements to truncate for the first elements
       var startingDiff = currentPage - 2 * truncSize;
-      if ( 0 <= startingDiff && startingDiff <= 1 ) {
+      if (0 <= startingDiff && startingDiff <= 1) {
         this.postPageNumbers = this.truncatePageNums(pageNumbers, pageNumbers.length >= maxVisible + (truncSize * 2), maxVisible + truncSize, pageNumbers.length, 0);
-      }
-      else {
+      } else {
         this.prePageNumbers = this.truncatePageNums(pageNumbers, currentPage >= maxVisible, 0, Math.min(currentPage - Math.ceil(maxVisible / 2), pageNumbers.length - maxVisible), truncSize);
         this.postPageNumbers = this.truncatePageNums(pageNumbers, pageNumbers.length >= maxVisible + (truncSize * 2), maxVisible, pageNumbers.length, 0);
       }
@@ -169,8 +170,8 @@ export class TablePaginationComponent implements OnInit {
 
   public showPerPageOptions() {
     return this.showPerPage &&
-           this.perPageOptions.length > 0 &&
-           this.pagination.total > this.perPageOptions[0];
+      this.perPageOptions.length > 0 &&
+      this.pagination.total > this.perPageOptions[0];
   }
 
   private truncatePageNums(pageNumbers:any, perform:any, disectFrom:any, disectLength:any, truncateFrom:any) {

--- a/frontend/src/app/components/work-packages/work-package-comment/work-package-comment.component.ts
+++ b/frontend/src/app/components/work-packages/work-package-comment/work-package-comment.component.ts
@@ -28,7 +28,6 @@
 
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {ErrorResource} from 'core-app/modules/hal/resources/error-resource';
-import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
 import {WorkPackageCacheService} from '../work-package-cache.service';
 import {WorkPackagesActivityService} from 'core-components/wp-single-view-tabs/activity-panel/wp-activity.service';
 import {LoadingIndicatorService} from "core-app/modules/common/loading-indicator/loading-indicator.service";
@@ -49,7 +48,6 @@ import {
 import {ConfigurationService} from "core-app/modules/common/config/configuration.service";
 
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {WorkPackageCommentFieldHandler} from "core-components/work-packages/work-package-comment/work-package-comment-field-handler";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
@@ -99,7 +97,7 @@ export class WorkPackageCommentComponent extends WorkPackageCommentFieldHandler 
 
     this.commentService.quoteEvents
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe((quote:string) => {
         this.activate(quote);
@@ -117,11 +115,6 @@ export class WorkPackageCommentComponent extends WorkPackageCommentFieldHandler 
 
     event.preventDefault();
     return false;
-  }
-
-
-  public ngOnDestroy() {
-    // Nothing to do.
   }
 
   public get htmlId() {
@@ -166,8 +159,7 @@ export class WorkPackageCommentComponent extends WorkPackageCommentFieldHandler 
         this.inFlight = false;
         if (error instanceof ErrorResource) {
           this.workPackageNotificationService.showError(error, this.workPackage);
-        }
-        else {
+        } else {
           this.NotificationsService.addError(this.I18n.t('js.work_packages.comment_send_failed'));
         }
       });
@@ -176,7 +168,9 @@ export class WorkPackageCommentComponent extends WorkPackageCommentFieldHandler 
   scrollToBottom():void {
     const scrollableContainer = jQuery(this.elementRef.nativeElement).scrollParent()[0];
     if (scrollableContainer) {
-      setTimeout(() => { scrollableContainer.scrollTop = scrollableContainer.scrollHeight; }, 400);
+      setTimeout(() => {
+        scrollableContainer.scrollTop = scrollableContainer.scrollHeight;
+      }, 400);
     }
   }
 

--- a/frontend/src/app/components/work-packages/wp-relations-count/wp-watchers-count.component.ts
+++ b/frontend/src/app/components/work-packages/wp-relations-count/wp-watchers-count.component.ts
@@ -1,29 +1,25 @@
-import {Component, Input, OnDestroy, OnInit} from '@angular/core';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {takeUntil} from 'rxjs/operators';
+import {Component, Input, OnInit} from '@angular/core';
 import {WorkPackageCacheService} from '../../work-packages/work-package-cache.service';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   templateUrl: './wp-relations-count.html',
   selector: 'wp-watchers-count',
 })
-export class WorkPackageWatchersCountComponent implements OnInit, OnDestroy {
+export class WorkPackageWatchersCountComponent extends UntilDestroyedMixin implements OnInit {
   @Input('wpId') wpId:string;
   public count:number = 0;
 
   constructor(protected wpCacheService:WorkPackageCacheService) {
+    super();
   }
 
   ngOnInit():void {
     this.wpCacheService.loadWorkPackage(this.wpId.toString()).values$()
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       ).subscribe((workPackage) => {
-        this.count =  _.size(workPackage.watchers.elements);
-      });
-}
-
-  ngOnDestroy():void {
-    // Nothing to do
+      this.count = _.size(workPackage.watchers.elements);
+    });
   }
 }

--- a/frontend/src/app/components/work-packages/wp-subject/wp-subject.component.ts
+++ b/frontend/src/app/components/work-packages/wp-subject/wp-subject.component.ts
@@ -26,29 +26,25 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 import {UIRouterGlobals} from '@uirouter/core';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {takeUntil} from 'rxjs/operators';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {WorkPackageCacheService} from '../work-package-cache.service';
 import {randomString} from "core-app/helpers/random-string";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   selector: 'wp-subject',
   templateUrl: './wp-subject.html'
 })
-export class WorkPackageSubjectComponent implements OnInit, OnDestroy {
+export class WorkPackageSubjectComponent extends UntilDestroyedMixin implements OnInit {
   @Input('workPackage') workPackage:WorkPackageResource;
 
   public readonly uniqueElementIdentifier = `work-packages--subject-type-row-${randomString(16)}`;
 
   constructor(protected uiRouterGlobals:UIRouterGlobals,
               protected wpCacheService:WorkPackageCacheService) {
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
+    super();
   }
 
   ngOnInit() {
@@ -56,7 +52,7 @@ export class WorkPackageSubjectComponent implements OnInit, OnDestroy {
       this.wpCacheService.loadWorkPackage(this.uiRouterGlobals.params['workPackageId'])
         .values$()
         .pipe(
-          takeUntil(componentDestroyed(this))
+          this.untilDestroyed()
         )
         .subscribe((wp:WorkPackageResource) => {
           this.workPackage = wp;

--- a/frontend/src/app/components/work-packages/wp-watcher-button/wp-watcher-button.component.ts
+++ b/frontend/src/app/components/work-packages/wp-watcher-button/wp-watcher-button.component.ts
@@ -28,17 +28,16 @@
 
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {WorkPackageCacheService} from '../work-package-cache.service';
-import {Component, Inject, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {takeUntil} from 'rxjs/operators';
 import {WorkPackageWatchersService} from 'core-components/wp-single-view-tabs/watchers-tab/wp-watchers.service';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   selector: 'wp-watcher-button',
   templateUrl: './wp-watcher-button.html'
 })
-export class WorkPackageWatcherButtonComponent implements OnInit,  OnDestroy {
+export class WorkPackageWatcherButtonComponent extends UntilDestroyedMixin implements OnInit {
   @Input('workPackage') public workPackage:WorkPackageResource;
   @Input('showText') public showText:boolean = false;
   @Input('disabled') public disabled:boolean = false;
@@ -52,22 +51,19 @@ export class WorkPackageWatcherButtonComponent implements OnInit,  OnDestroy {
   constructor(readonly I18n:I18nService,
               readonly wpWatchersService:WorkPackageWatchersService,
               readonly wpCacheService:WorkPackageCacheService) {
+    super();
   }
 
   ngOnInit() {
     this.wpCacheService.loadWorkPackage(this.workPackage.id!)
       .values$()
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       )
       .subscribe((wp:WorkPackageResource) => {
         this.workPackage = wp;
         this.setWatchStatus();
       });
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 
   public get isWatched() {

--- a/frontend/src/app/components/wp-buttons/wp-buttons.module.ts
+++ b/frontend/src/app/components/wp-buttons/wp-buttons.module.ts
@@ -27,6 +27,7 @@
 // ++
 
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 export interface ButtonControllerText {
   activate:string;
@@ -35,7 +36,7 @@ export interface ButtonControllerText {
   buttonText:string;
 }
 
-export abstract class AbstractWorkPackageButtonComponent {
+export abstract class AbstractWorkPackageButtonComponent extends UntilDestroyedMixin {
   public disabled:boolean;
   public buttonId:string;
   public iconClass:string;
@@ -46,6 +47,8 @@ export abstract class AbstractWorkPackageButtonComponent {
   protected text:ButtonControllerText;
 
   constructor(public I18n:I18nService) {
+    super();
+
     this.text = {
       activate: this.I18n.t('js.label_activate'),
       deactivate: this.I18n.t('js.label_deactivate'),

--- a/frontend/src/app/components/wp-buttons/wp-create-button/wp-create-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-create-button/wp-create-button.component.ts
@@ -31,15 +31,16 @@ import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy,
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {AuthorisationService} from "core-app/modules/common/model-auth/model-auth.service";
-import {componentDestroyed} from "ng2-rx-componentdestroyed";
 import {Observable} from "rxjs";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 @Component({
   selector: 'wp-create-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './wp-create-button.html'
 })
-export class WorkPackageCreateButtonComponent implements OnInit, OnDestroy {
+export class WorkPackageCreateButtonComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
   @Input('allowed') allowedWhen:string[];
   @Input('stateName$') stateName$:Observable<string>;
 
@@ -61,11 +62,11 @@ export class WorkPackageCreateButtonComponent implements OnInit, OnDestroy {
               readonly transition:TransitionService,
               readonly I18n:I18nService,
               readonly cdRef:ChangeDetectorRef) {
+    super();
   }
 
   ngOnInit() {
     this.projectIdentifier = this.currentProject.identifier;
-    // Created for interface compliance
 
     // Find the first permission that is allowed
     this.authorisationService
@@ -86,6 +87,7 @@ export class WorkPackageCreateButtonComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy():void {
+    super.ngOnDestroy();
     this.transitionUnregisterFn();
   }
 

--- a/frontend/src/app/components/wp-buttons/wp-details-view-button/wp-details-view-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-details-view-button/wp-details-view-button.component.ts
@@ -73,6 +73,7 @@ export class WorkPackageDetailsViewButtonComponent extends AbstractWorkPackageBu
   }
 
   public ngOnDestroy() {
+    super.ngOnDestroy();
     this.transitionListener();
   }
 

--- a/frontend/src/app/components/wp-buttons/wp-filter-button/wp-filter-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-filter-button/wp-filter-button.component.ts
@@ -28,17 +28,17 @@
 
 import {AbstractWorkPackageButtonComponent} from 'core-components/wp-buttons/wp-buttons.module';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from '@angular/core';
 import {WorkPackageFiltersService} from 'core-components/filters/wp-filters/wp-filters.service';
-import {componentDestroyed, untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {WorkPackageViewFiltersService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 @Component({
   selector: 'wp-filter-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './wp-filter-button.html'
 })
-export class WorkPackageFilterButtonComponent extends AbstractWorkPackageButtonComponent implements OnInit, OnDestroy  {
+export class WorkPackageFilterButtonComponent extends AbstractWorkPackageButtonComponent implements OnInit {
   public count:number;
   public initialized:boolean = false;
 
@@ -54,10 +54,6 @@ export class WorkPackageFilterButtonComponent extends AbstractWorkPackageButtonC
 
   ngOnInit():void {
     this.setupObserver();
-  }
-
-  ngOnDestroy():void {
-    // Empty
   }
 
   public get labelKey():string {
@@ -88,13 +84,13 @@ export class WorkPackageFilterButtonComponent extends AbstractWorkPackageButtonC
     this.wpTableFilters
       .live$()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(() => {
-      this.count = this.wpTableFilters.currentlyVisibleFilters.length;
-      this.initialized = true;
-      this.cdRef.detectChanges();
-    });
+        this.count = this.wpTableFilters.currentlyVisibleFilters.length;
+        this.initialized = true;
+        this.cdRef.detectChanges();
+      });
 
     this.wpFiltersService
       .observeUntil(componentDestroyed(this))

--- a/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.component.ts
@@ -29,20 +29,19 @@
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 
 import {HalResourceEditingService} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
-import {ChangeDetectorRef, Component, Inject, Input, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Component, Input, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {Highlighting} from "core-components/wp-fast-table/builders/highlighting/highlighting.functions";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {WorkPackageCacheService} from "core-components/work-packages/work-package-cache.service";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
-import {SchemaCacheService} from "core-components/schemas/schema-cache.service";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   selector: 'wp-status-button',
   styleUrls: ['./wp-status-button.component.sass'],
   templateUrl: './wp-status-button.html'
 })
-export class WorkPackageStatusButtonComponent implements OnInit, OnDestroy {
+export class WorkPackageStatusButtonComponent extends UntilDestroyedMixin implements OnInit {
   @Input('workPackage') public workPackage:WorkPackageResource;
   @Input('containerClass') public containerClass:string;
 
@@ -56,6 +55,7 @@ export class WorkPackageStatusButtonComponent implements OnInit, OnDestroy {
               readonly cdRef:ChangeDetectorRef,
               readonly wpCacheService:WorkPackageCacheService,
               readonly halEditing:HalResourceEditingService) {
+    super();
   }
 
   ngOnInit() {
@@ -63,7 +63,7 @@ export class WorkPackageStatusButtonComponent implements OnInit, OnDestroy {
       .temporaryEditResource(this.workPackage)
       .values$()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe((wp) => {
         this.workPackage = wp;
@@ -73,10 +73,6 @@ export class WorkPackageStatusButtonComponent implements OnInit, OnDestroy {
           this.workPackage.status.$load();
         }
       });
-  }
-
-  ngOnDestroy():void {
-    // Nothing to do
   }
 
   public get buttonTitle() {

--- a/frontend/src/app/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component.ts
@@ -27,10 +27,9 @@
 // ++
 
 import {AbstractWorkPackageButtonComponent, ButtonControllerText} from '../wp-buttons.module';
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {TimelineZoomLevel} from 'core-app/modules/hal/resources/query-resource';
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {WorkPackageViewTimelineService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-timeline.service";
 
 export interface TimelineButtonText extends ButtonControllerText {
@@ -45,7 +44,7 @@ export interface TimelineButtonText extends ButtonControllerText {
   selector: 'wp-timeline-toggle-button',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class WorkPackageTimelineButtonComponent extends AbstractWorkPackageButtonComponent implements OnInit, OnDestroy {
+export class WorkPackageTimelineButtonComponent extends AbstractWorkPackageButtonComponent implements OnInit {
   public buttonId:string = 'work-packages-timeline-toggle-button';
   public iconClass:string = 'icon-view-timeline';
 
@@ -79,7 +78,7 @@ export class WorkPackageTimelineButtonComponent extends AbstractWorkPackageButto
     this.wpTableTimeline
       .live$()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(() => {
         this.isAutoZoom = this.wpTableTimeline.isAutoZoom();
@@ -91,17 +90,13 @@ export class WorkPackageTimelineButtonComponent extends AbstractWorkPackageButto
       .appliedZoomLevel$
       .values$()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe((current) => {
         this.isMaxLevel = current === this.maxZoomLevel;
         this.isMinLevel = current === this.minZoomLevel;
         this.cdRef.detectChanges();
       });
-  }
-
-  ngOnDestroy():void {
-    // Nothing to do
   }
 
   public get label():string {

--- a/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
+++ b/frontend/src/app/components/wp-buttons/wp-view-toggle-button/work-package-view-toggle-button.component.ts
@@ -26,36 +26,35 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
-import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
 import {
   WorkPackageViewDisplayRepresentationService,
   wpDisplayCardRepresentation,
-  wpDisplayListRepresentation, wpDisplayRepresentation
+  wpDisplayListRepresentation
 } from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-display-representation.service";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {WorkPackageViewTimelineService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-timeline.service";
 import {combineLatest} from "rxjs";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 
 @Component({
   template: `
-      <button class="button"
-              id="wp-view-toggle-button"
-              wpViewDropdown>
-        <op-icon icon-classes="button--icon icon-view-{{view}}"></op-icon>
-        <span class="button--text"
-              aria-hidden="true"
-              [textContent]="text[view]">
+    <button class="button"
+            id="wp-view-toggle-button"
+            wpViewDropdown>
+      <op-icon icon-classes="button--icon icon-view-{{view}}"></op-icon>
+      <span class="button--text"
+            aria-hidden="true"
+            [textContent]="text[view]">
         </span>
-        <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
-      </button>
-`,
+      <op-icon icon-classes="button--icon icon-small icon-pulldown"></op-icon>
+    </button>
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'wp-view-toggle-button',
 })
-export class WorkPackageViewToggleButton implements OnInit, OnDestroy {
+export class WorkPackageViewToggleButton extends UntilDestroyedMixin implements OnInit {
   public view:string;
 
   public text:any = {
@@ -68,6 +67,7 @@ export class WorkPackageViewToggleButton implements OnInit, OnDestroy {
               readonly cdRef:ChangeDetectorRef,
               readonly wpDisplayRepresentationService:WorkPackageViewDisplayRepresentationService,
               readonly wpTableTimeline:WorkPackageViewTimelineService) {
+    super();
   }
 
   ngOnInit() {
@@ -77,15 +77,11 @@ export class WorkPackageViewToggleButton implements OnInit, OnDestroy {
     ]);
 
     statesCombined.pipe(
-      untilComponentDestroyed(this)
+      this.untilDestroyed()
     ).subscribe(([display, timelines]) => {
       this.detectView(display, timelines.visible);
       this.cdRef.detectChanges();
     });
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 
   public detectView(display:string|null, timelineVisible:boolean) {

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -4,16 +4,15 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
-  EventEmitter, Inject,
+  EventEmitter,
   Injector,
   Input,
-  OnInit, Optional,
+  OnInit,
   Output,
   ViewChild
 } from "@angular/core";
 import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
-import {componentDestroyed, untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {QueryColumn} from "app/components/wp-query/query-column";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
@@ -29,18 +28,14 @@ import {PathHelperService} from "core-app/modules/common/path-helper/path-helper
 import {filter, withLatestFrom} from 'rxjs/operators';
 import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
 import {WorkPackageViewSelectionService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-selection.service";
-import {
-  CardEventHandler,
-  CardViewHandlerRegistry
-} from "core-components/wp-card-view/event-handler/card-view-handler-registry";
+import {CardViewHandlerRegistry} from "core-components/wp-card-view/event-handler/card-view-handler-registry";
 import {WorkPackageCardViewService} from "core-components/wp-card-view/services/wp-card-view.service";
 import {WorkPackageCardDragAndDropService} from "core-components/wp-card-view/services/wp-card-drag-and-drop.service";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
 import {DeviceService} from "core-app/modules/common/browser/device.service";
-import {
-  WorkPackageViewHandlerClass,
-  WorkPackageViewHandlerToken
-} from "core-app/modules/work_packages/routing/wp-view-base/event-handling/event-handler-registry";
+import {WorkPackageViewHandlerToken} from "core-app/modules/work_packages/routing/wp-view-base/event-handling/event-handler-registry";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 export type CardViewOrientation = 'horizontal'|'vertical';
 
@@ -50,7 +45,7 @@ export type CardViewOrientation = 'horizontal'|'vertical';
   templateUrl: './wp-card-view.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
+export class WorkPackageCardViewComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit {
   @Input('dragOutOfHandler') public canDragOutOf:(wp:WorkPackageResource) => boolean;
   @Input() public dragInto:boolean;
   @Input() public highlightingMode:CardHighlightingMode;
@@ -76,7 +71,7 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
   public columns:QueryColumn[];
   public text = {
     removeCard: this.I18n.t('js.card.remove_from_list'),
-    addNewCard:  this.I18n.t('js.card.add_new'),
+    addNewCard: this.I18n.t('js.card.add_new'),
     noResults: {
       title: this.I18n.t('js.work_packages.no_results.title'),
       description: this.I18n.t('js.work_packages.no_results.description')
@@ -112,6 +107,7 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
               readonly cardView:WorkPackageCardViewService,
               readonly cardDragDrop:WorkPackageCardDragAndDropService,
               readonly deviceService:DeviceService) {
+    super();
   }
 
   ngOnInit() {
@@ -127,12 +123,12 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
       });
 
     this.querySpace.results
-    .values$()
-    .pipe(
-      withLatestFrom(this.querySpace.query.values$()),
-      untilComponentDestroyed(this),
-      filter(([results, query]) => results && !this.causedUpdates.includes(query))
-    ).subscribe(([results, query]) => {
+      .values$()
+      .pipe(
+        withLatestFrom(this.querySpace.query.values$()),
+        this.untilDestroyed(),
+        filter(([results, query]) => results && !this.causedUpdates.includes(query))
+      ).subscribe(([results, query]) => {
       this.query = query;
       this.workPackages = this.wpViewOrder.orderedWorkPackages();
       this.cardView.updateRenderedCardsValues(this.workPackages);
@@ -152,12 +148,15 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
     // Register event handlers for the cards
     let registry = this.injector.get<any>(WorkPackageViewHandlerToken, CardViewHandlerRegistry);
     new registry(this.injector).attachTo(this);
-    this.wpTableSelection.registerSelectAllListener(() => { return this.cardView.renderedCards; });
+    this.wpTableSelection.registerSelectAllListener(() => {
+      return this.cardView.renderedCards;
+    });
     this.wpTableSelection.registerDeselectAllListener();
   }
 
   ngOnDestroy():void {
-      this.cardDragDrop.destroy();
+    super.ngOnDestroy();
+    this.cardDragDrop.destroy();
   }
 
   public get workPackages():WorkPackageResource[] {
@@ -192,6 +191,7 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
 
     return classes;
   }
+
   /**
    * Listen to newly created work packages to detect whether the WP is the one we created,
    * and properly reset inline create in this case
@@ -199,7 +199,9 @@ export class WorkPackageCardViewComponent  implements OnInit, AfterViewInit {
   private registerCreationCallback() {
     this.wpCreate
       .onNewWorkPackage()
-      .pipe(untilComponentDestroyed(this))
+      .pipe(
+        this.untilDestroyed()
+      )
       .subscribe(async (wp:WorkPackageResource) => {
         this.onCardSaved(wp);
       });

--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.ts
@@ -4,7 +4,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  OnDestroy,
   OnInit,
   Output
 } from "@angular/core";
@@ -18,7 +17,7 @@ import {WorkPackageCardViewService} from "core-components/wp-card-view/services/
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {CardHighlightingMode} from "core-components/wp-fast-table/builders/highlighting/highlighting-mode.const";
 import {CardViewOrientation} from "core-components/wp-card-view/wp-card-view.component";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 
 @Component({
@@ -27,7 +26,7 @@ import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
   templateUrl: './wp-single-card.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class WorkPackageSingleCardComponent implements OnDestroy, OnInit {
+export class WorkPackageSingleCardComponent extends UntilDestroyedMixin implements OnInit {
   @Input() public workPackage:WorkPackageResource;
   @Input() public showInfoButton:boolean = false;
   @Input() public showStatusButton:boolean = true;
@@ -52,20 +51,18 @@ export class WorkPackageSingleCardComponent implements OnDestroy, OnInit {
               readonly wpTableSelection:WorkPackageViewSelectionService,
               readonly cardView:WorkPackageCardViewService,
               readonly cdRef:ChangeDetectorRef) {
+    super();
   }
 
   ngOnInit():void {
     // Update selection state
     this.wpTableSelection.selection$()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(() => {
         this.cdRef.detectChanges();
       });
-  }
-
-  ngOnDestroy():void {
   }
 
   public classIdentifier(wp:WorkPackageResource) {
@@ -77,7 +74,7 @@ export class WorkPackageSingleCardComponent implements OnDestroy, OnInit {
     this.wpTableSelection.setSelection(wp.id!, this.cardView.findRenderedCard(classIdentifier));
     this.$state.go(
       '.details',
-      {workPackageId: wp.id!}
+      { workPackageId: wp.id! }
     );
   }
 

--- a/frontend/src/app/components/wp-copy/wp-copy.controller.ts
+++ b/frontend/src/app/components/wp-copy/wp-copy.controller.ts
@@ -30,7 +30,6 @@ import {take} from 'rxjs/operators';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {WorkPackageCreateComponent} from 'core-components/wp-new/wp-create.component';
 import {WorkPackageRelationsService} from "core-components/wp-relations/wp-relations.service";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 
 import {HalResourceEditingService} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
 import {WorkPackageChangeset} from "core-components/wp-edit/work-package-changeset";
@@ -53,7 +52,7 @@ export class WorkPackageCopyController extends WorkPackageCreateComponent {
 
     this.wpCreate.onNewWorkPackage()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe((wp:WorkPackageResource) => {
         if (wp.__initialized_at === this.__initialized_at) {

--- a/frontend/src/app/components/wp-grid/wp-grid.component.ts
+++ b/frontend/src/app/components/wp-grid/wp-grid.component.ts
@@ -76,7 +76,9 @@ export class WorkPackagesGridComponent {
 
   ngOnInit() {
     this.dragInto = this.configuration.dragAndDropEnabled;
-    this.canDragOutOf = () => { return this.configuration.dragAndDropEnabled; };
+    this.canDragOutOf = () => {
+      return this.configuration.dragAndDropEnabled;
+    };
 
     this.wpTableHighlight
       .updates$()
@@ -89,10 +91,6 @@ export class WorkPackagesGridComponent {
         this.cdRef.detectChanges();
       });
 
-  }
-
-  ngOnDestroy():void {
-    // Nothing to do
   }
 
   public switchToManualSorting() {

--- a/frontend/src/app/components/wp-new/wp-create.service.ts
+++ b/frontend/src/app/components/wp-new/wp-create.service.ts
@@ -26,7 +26,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Injectable, Injector, OnDestroy} from '@angular/core';
+import {Injectable, Injector} from '@angular/core';
 import {WorkPackageCacheService} from '../work-packages/work-package-cache.service';
 import {Observable, Subject} from 'rxjs';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
@@ -39,19 +39,18 @@ import {
   ResourceChangesetCommit
 } from "core-app/modules/fields/edit/services/hal-resource-editing.service";
 import {WorkPackageChangeset} from "core-components/wp-edit/work-package-changeset";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {filter} from "rxjs/operators";
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {WorkPackageDmService} from "core-app/modules/hal/dm-services/work-package-dm.service";
 import {FormResource} from "core-app/modules/hal/resources/form-resource";
 import {HalEventsService} from "core-app/modules/hal/services/hal-events.service";
-import {ResourceChangeset} from "core-app/modules/fields/changeset/resource-changeset";
 import {AuthorisationService} from "core-app/modules/common/model-auth/model-auth.service";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 export const newWorkPackageHref = '/api/v3/work_packages/new';
 
 @Injectable()
-export class WorkPackageCreateService implements OnDestroy {
+export class WorkPackageCreateService extends UntilDestroyedMixin {
   protected form:Promise<FormResource>|undefined;
 
   // Allow callbacks to happen on newly created work packages
@@ -66,30 +65,27 @@ export class WorkPackageCreateService implements OnDestroy {
               protected halEditing:HalResourceEditingService,
               protected workPackageDmService:WorkPackageDmService,
               protected halEvents:HalEventsService) {
+    super();
 
-  this.halEditing
+    this.halEditing
       .comittedChanges
       .pipe(
-        untilComponentDestroyed(this),
+        this.untilDestroyed(),
         filter(commit => commit.resource._type === 'WorkPackage' && commit.wasNew)
       )
       .subscribe((commit:ResourceChangesetCommit<WorkPackageResource>) => {
         this.newWorkPackageCreated(commit.resource);
       });
 
-  this.halEditing
-    .changes$(newWorkPackageHref)
-    .pipe(
-      untilComponentDestroyed(this),
-      filter(changeset => !changeset)
-    )
-    .subscribe(() => {
-      this.reset();
-    });
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
+    this.halEditing
+      .changes$(newWorkPackageHref)
+      .pipe(
+        this.untilDestroyed(),
+        filter(changeset => !changeset)
+      )
+      .subscribe(() => {
+        this.reset();
+      });
   }
 
   protected newWorkPackageCreated(wp:WorkPackageResource) {

--- a/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
+++ b/frontend/src/app/components/wp-query-select/wp-query-select-dropdown.component.ts
@@ -29,29 +29,21 @@
 import {CollectionResource} from 'core-app/modules/hal/resources/collection-resource';
 import {States} from '../states.service';
 import {StateService, TransitionService} from '@uirouter/core';
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  OnDestroy,
-  OnInit,
-  ViewChild
-} from "@angular/core";
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit, ViewChild} from "@angular/core";
 import {QueryDmService} from 'core-app/modules/hal/dm-services/query-dm.service';
 import {LoadingIndicatorService} from "core-app/modules/common/loading-indicator/loading-indicator.service";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
 import {WorkPackageStaticQueriesService} from 'core-components/wp-query-select/wp-static-queries.service';
-import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
 import {LinkHandling} from "core-app/modules/common/link-handling/link-handling";
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {keyCodes} from 'core-app/modules/common/keyCodes.enum';
 import {MainMenuToggleService} from "core-components/main-menu/main-menu-toggle.service";
 import {MainMenuNavigationService} from "core-components/main-menu/main-menu-navigation.service";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
-export type QueryCategory = 'starred' | 'public' | 'private' | 'default';
+export type QueryCategory = 'starred'|'public'|'private'|'default';
 
 export interface IAutocompleteItem {
   // Some optional identifier
@@ -81,7 +73,7 @@ export const wpQuerySelectSelector = 'wp-query-select';
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './wp-query-select.template.html',
 })
-export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestroy {
+export class WorkPackageQuerySelectDropdownComponent extends UntilDestroyedMixin implements OnInit {
   @ViewChild('wpQueryMenuSearchInput', { static: true }) _wpQueryMenuSearchInput:ElementRef;
   @ViewChild('queryResultsContainer', { static: true }) _queryResultsContainerElement:ElementRef;
 
@@ -99,7 +91,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
   };
   private unregisterTransitionListener:Function;
 
-  private projectIdentifier:string | null;
+  private projectIdentifier:string|null;
 
   private hiddenCategories:any = [];
 
@@ -127,6 +119,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
               readonly mainMenuService:MainMenuNavigationService,
               readonly toggleService:MainMenuToggleService,
               readonly cdRef:ChangeDetectorRef) {
+    super();
   }
 
   public ngOnInit() {
@@ -145,6 +138,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
   }
 
   ngOnDestroy() {
+    super.ngOnDestroy();
     this.unregisterTransitionListener();
   }
 
@@ -165,7 +159,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
   private transformQueries(collection:CollectionResource<QueryResource>) {
     let loadedQueries:IAutocompleteItem[] = collection.elements
       .map(query => {
-        return {label: query.name, query: query, query_props: null};
+        return { label: query.name, query: query, query_props: null };
       });
 
     // Add to the loaded set of queries the fixed set of queries for the current project context
@@ -229,22 +223,22 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
       .listNonHidden(this.CurrentProject.identifier)
       .then(collection => {
 
-      // Update the complete collection
-      this.searchInput.querycomplete("option", {source: this.transformQueries(collection)});
+        // Update the complete collection
+        this.searchInput.querycomplete("option", { source: this.transformQueries(collection) });
 
-      // To visibly show the changes, we need to search again
-      this.searchInput.querycomplete("search", this.searchInput.val());
+        // To visibly show the changes, we need to search again
+        this.searchInput.querycomplete("search", this.searchInput.val());
 
-      // To search an empty string would expand all categories again every time
-      // Remember all previously hidden categories and set them again after updating the menu
-      _.each(this.hiddenCategories, category => {
-        let thisCategory:string = jQuery(category).attr("category")!;
-        this.expandCollapseCategory(thisCategory);
+        // To search an empty string would expand all categories again every time
+        // Remember all previously hidden categories and set them again after updating the menu
+        _.each(this.hiddenCategories, category => {
+          let thisCategory:string = jQuery(category).attr("category")!;
+          this.expandCollapseCategory(thisCategory);
+        });
+
+        // Update view
+        this.ref.detectChanges();
       });
-
-      // Update view
-      this.ref.detectChanges();
-    });
   }
 
   private set loadingPromise(promise:Promise<any>) {
@@ -313,12 +307,12 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
     let thisComponent = this;
 
     jQuery.widget('custom.querycomplete', jQuery.ui.autocomplete, {
-      _create: function(this:any) {
+      _create: function (this:any) {
         this._super();
         this.widget().menu('option', 'items', '.wp-query-menu--item');
         this._search('');
       },
-      _renderItem: function(this:{}, ul:any, item:IAutocompleteItem) {
+      _renderItem: function (this:{}, ul:any, item:IAutocompleteItem) {
         const link = jQuery('<a>')
           .addClass('wp-query-menu--item-link')
           .attr('href', thisComponent.buildQueryItemUrl(item))
@@ -336,7 +330,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
 
         return li;
       },
-      _renderMenu: function(this:any, ul:any, items:IAutocompleteItem[]) {
+      _renderMenu: function (this:any, ul:any, items:IAutocompleteItem[]) {
         let currentCategory:QueryCategory;
 
         _.each(items, option => {
@@ -361,7 +355,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
         if (thisComponent.searchInput.val() === '') {
           let selected = thisComponent.queryResultsContainer.find('.wp-query-menu--item.selected');
           if (selected.length > 0) {
-            setTimeout(() => selected[0].scrollIntoView({behavior: 'auto', block: 'center'}), 20);
+            setTimeout(() => selected[0].scrollIntoView({ behavior: 'auto', block: 'center' }), 20);
           }
         }
       }
@@ -416,7 +410,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
   private updateMenuOnChanges() {
     this.states.changes.queries
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(() => this.loadQueries());
   }
@@ -432,7 +426,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
   // On click of a menu item, load requested query
   private loadQuery(item:IAutocompleteItem) {
     const params = this.getQueryParams(item);
-    const opts = {reload: true};
+    const opts = { reload: true };
 
     this.$state.go(
       'work-packages.partitioned.list',
@@ -444,7 +438,7 @@ export class WorkPackageQuerySelectDropdownComponent implements OnInit, OnDestro
   }
 
   private getQueryParams(item:IAutocompleteItem) {
-    let val:{ query_id:string | null, query_props:string | null, projects?:string, projectPath?:string } = {
+    let val:{ query_id:string|null, query_props:string|null, projects?:string, projectPath?:string } = {
       query_id: item.query ? _.toString(item.query.id) : null,
       query_props: item.query ? null : item.query_props,
     };

--- a/frontend/src/app/components/wp-relations/embedded/children/wp-children-inline-create.service.ts
+++ b/frontend/src/app/components/wp-relations/embedded/children/wp-children-inline-create.service.ts
@@ -26,7 +26,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Injectable, Injector, OnDestroy} from '@angular/core';
+import {Injectable, Injector} from '@angular/core';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {WorkPackageRelationsHierarchyService} from "core-components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service";
 import {WorkPackageInlineCreateService} from "core-components/wp-inline-create/wp-inline-create.service";
@@ -34,7 +34,7 @@ import {WpRelationInlineCreateServiceInterface} from "core-components/wp-relatio
 import {WpRelationInlineAddExistingComponent} from "core-components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component";
 
 @Injectable()
-export class WpChildrenInlineCreateService extends WorkPackageInlineCreateService implements WpRelationInlineCreateServiceInterface, OnDestroy {
+export class WpChildrenInlineCreateService extends WorkPackageInlineCreateService implements WpRelationInlineCreateServiceInterface {
 
   constructor(readonly injector:Injector,
               protected readonly wpRelationsHierarchyService:WorkPackageRelationsHierarchyService) {
@@ -90,12 +90,4 @@ export class WpChildrenInlineCreateService extends WorkPackageInlineCreateServic
     reference: this.I18n.t('js.relation_buttons.add_existing_child'),
     create: this.I18n.t('js.relation_buttons.add_new_child')
   };
-
-  /**
-   * Ensure hierarchical injected versions of this service correctly unregister
-   */
-  ngOnDestroy() {
-    super.ngOnDestroy();
-  }
-
 }

--- a/frontend/src/app/components/wp-relations/embedded/children/wp-children-query.component.ts
+++ b/frontend/src/app/components/wp-relations/embedded/children/wp-children-query.component.ts
@@ -26,17 +26,15 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {Component, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {UrlParamsHelperService} from 'core-components/wp-query/url-params-helper';
 import {WorkPackageRelationsHierarchyService} from 'core-components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service';
-import {WorkPackageEmbeddedTableComponent} from 'core-components/wp-table/embedded/wp-embedded-table.component';
 import {OpUnlinkTableAction} from 'core-components/wp-table/table-actions/actions/unlink-table-action';
 import {OpTableActionFactory} from 'core-components/wp-table/table-actions/table-action';
 import {WorkPackageInlineCreateService} from "core-components/wp-inline-create/wp-inline-create.service";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {WorkPackageRelationQueryBase} from "core-components/wp-relations/embedded/wp-relation-query.base";
 import {WpChildrenInlineCreateService} from "core-components/wp-relations/embedded/children/wp-children-inline-create.service";
 import {WorkPackageCacheService} from "core-components/work-packages/work-package-cache.service";
@@ -52,7 +50,7 @@ import {HalEventsService} from "core-app/modules/hal/services/hal-events.service
     { provide: WorkPackageInlineCreateService, useClass: WpChildrenInlineCreateService }
   ]
 })
-export class WorkPackageChildrenQueryComponent extends WorkPackageRelationQueryBase implements OnInit, OnDestroy {
+export class WorkPackageChildrenQueryComponent extends WorkPackageRelationQueryBase implements OnInit {
   @Input() public workPackage:WorkPackageResource;
   @Input() public query:QueryResource;
 
@@ -90,7 +88,9 @@ export class WorkPackageChildrenQueryComponent extends WorkPackageRelationQueryB
 
     // Fire event that children were added
     this.wpInlineCreate.newInlineWorkPackageCreated
-      .pipe(untilComponentDestroyed(this))
+      .pipe(
+        this.untilDestroyed()
+      )
       .subscribe((toId:string) => {
         this.halEvents.push(this.workPackage, {
           eventType: 'association',
@@ -104,12 +104,8 @@ export class WorkPackageChildrenQueryComponent extends WorkPackageRelationQueryB
       .observe(this.workPackage.id!)
       .pipe(
         filter(() => this.embeddedTable && this.embeddedTable.isInitialized),
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(() => this.refreshTable());
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 }

--- a/frontend/src/app/components/wp-relations/embedded/relations/wp-relation-inline-create.service.ts
+++ b/frontend/src/app/components/wp-relations/embedded/relations/wp-relation-inline-create.service.ts
@@ -30,9 +30,7 @@ import {Injectable, Injector, OnDestroy} from '@angular/core';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {WorkPackageInlineCreateService} from "core-components/wp-inline-create/wp-inline-create.service";
 import {WpRelationInlineAddExistingComponent} from "core-components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component";
-import {WorkPackageRelationsHierarchyService} from "core-components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service";
 import {WorkPackageRelationsService} from "core-components/wp-relations/wp-relations.service";
-import {RelationResource} from "core-app/modules/hal/resources/relation-resource";
 import {WpRelationInlineCreateServiceInterface} from "core-components/wp-relations/embedded/wp-relation-inline-create.service.interface";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 
@@ -96,12 +94,4 @@ export class WpRelationInlineCreateService extends WorkPackageInlineCreateServic
     reference: this.I18n.t('js.relation_buttons.add_existing'),
     create: this.I18n.t('js.relation_buttons.create_new')
   };
-
-  /**
-   * Ensure hierarchical injected versions of this service correctly unregister
-   */
-  ngOnDestroy() {
-    super.ngOnDestroy();
-  }
-
 }

--- a/frontend/src/app/components/wp-relations/embedded/relations/wp-relation-query.component.ts
+++ b/frontend/src/app/components/wp-relations/embedded/relations/wp-relation-query.component.ts
@@ -26,7 +26,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {Component, Inject, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, Inject, Input, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
@@ -34,7 +34,6 @@ import {UrlParamsHelperService} from 'core-components/wp-query/url-params-helper
 import {OpUnlinkTableAction} from 'core-components/wp-table/table-actions/actions/unlink-table-action';
 import {OpTableActionFactory} from 'core-components/wp-table/table-actions/table-action';
 import {WorkPackageInlineCreateService} from "core-components/wp-inline-create/wp-inline-create.service";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {WorkPackageRelationQueryBase} from "core-components/wp-relations/embedded/wp-relation-query.base";
 import {WpRelationInlineCreateService} from "core-components/wp-relations/embedded/relations/wp-relation-inline-create.service";
 import {WorkPackageRelationsService} from "core-components/wp-relations/wp-relations.service";
@@ -51,7 +50,7 @@ import {WorkPackageNotificationService} from "core-app/modules/work_packages/not
     { provide: WorkPackageInlineCreateService, useClass: WpRelationInlineCreateService }
   ]
 })
-export class WorkPackageRelationQueryComponent extends WorkPackageRelationQueryBase implements OnInit, OnDestroy {
+export class WorkPackageRelationQueryComponent extends WorkPackageRelationQueryBase implements OnInit {
   @Input() public workPackage:WorkPackageResource;
 
   @Input() public query:QueryResource;
@@ -93,20 +92,18 @@ export class WorkPackageRelationQueryComponent extends WorkPackageRelationQueryB
 
     // Wire the successful saving of a new addition to refreshing the embedded table
     this.wpInlineCreate.newInlineWorkPackageCreated
-      .pipe(untilComponentDestroyed(this))
+      .pipe(
+        this.untilDestroyed()
+      )
       .subscribe((toId:string) => this.addRelation(toId));
 
     // When relations have changed, refresh this table
     this.wpRelations.observe(this.workPackage.id!)
       .pipe(
         filter(val => !_.isEmpty(val)),
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(() => this.refreshTable());
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 
   private addRelation(toId:string) {

--- a/frontend/src/app/components/wp-relations/embedded/wp-relation-query.base.ts
+++ b/frontend/src/app/components/wp-relations/embedded/wp-relation-query.base.ts
@@ -27,16 +27,14 @@
 //++
 
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
-import { ViewChild, Directive } from "@angular/core";
+import {Directive, ViewChild} from "@angular/core";
 import {WorkPackageEmbeddedTableComponent} from "core-components/wp-table/embedded/wp-embedded-table.component";
 import {QueryResource} from "core-app/modules/hal/resources/query-resource";
 import {UrlParamsHelperService} from "core-components/wp-query/url-params-helper";
-import {ErrorResource} from "core-app/modules/hal/resources/error-resource";
-import {query} from "@angular/animations";
-import {HalResource} from "core-app/modules/hal/resources/hal-resource";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Directive()
-export abstract class WorkPackageRelationQueryBase {
+export abstract class WorkPackageRelationQueryBase extends UntilDestroyedMixin {
   public workPackage:WorkPackageResource;
 
   /** Input is either a query resource, or directly query props */
@@ -52,6 +50,7 @@ export abstract class WorkPackageRelationQueryBase {
   @ViewChild('embeddedTable') protected embeddedTable:WorkPackageEmbeddedTableComponent;
 
   constructor(protected queryUrlParamsHelper:UrlParamsHelperService) {
+    super();
   }
 
   /**

--- a/frontend/src/app/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
+++ b/frontend/src/app/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
@@ -1,21 +1,20 @@
 import {WorkPackageCacheService} from '../../work-packages/work-package-cache.service';
-import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {WorkPackageRelationsService} from '../wp-relations.service';
 import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
 import {RelationResource} from 'core-app/modules/hal/resources/relation-resource';
-import {ChangeDetectorRef, Component, ElementRef, Input, OnDestroy, OnInit, ViewChild} from "@angular/core";
+import {ChangeDetectorRef, Component, ElementRef, Input, OnInit, ViewChild} from "@angular/core";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {HalEventsService} from "core-app/modules/hal/services/hal-events.service";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 
 @Component({
   selector: 'wp-relation-row',
   templateUrl: './wp-relation-row.template.html'
 })
-export class WorkPackageRelationRowComponent implements OnInit, OnDestroy {
+export class WorkPackageRelationRowComponent extends UntilDestroyedMixin implements OnInit {
   @Input() public workPackage:WorkPackageResource;
   @Input() public relatedWorkPackage:WorkPackageResource;
   @Input() public groupByWorkPackageType:boolean;
@@ -63,6 +62,7 @@ export class WorkPackageRelationRowComponent implements OnInit, OnDestroy {
               protected I18n:I18nService,
               protected cdRef:ChangeDetectorRef,
               protected PathHelper:PathHelperService) {
+    super();
   }
 
   ngOnInit() {
@@ -71,19 +71,15 @@ export class WorkPackageRelationRowComponent implements OnInit, OnDestroy {
     this.userInputs.newRelationText = this.relation.description || '';
     this.availableRelationTypes = RelationResource.LOCALIZED_RELATION_TYPES(false);
     this.selectedRelationType = _.find(this.availableRelationTypes,
-      {'name': this.relation.normalizedType(this.workPackage)})!;
+      { 'name': this.relation.normalizedType(this.workPackage) })!;
 
     this.wpCacheService
       .observe(this.relatedWorkPackage.id!)
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       ).subscribe((wp) => {
       this.relatedWorkPackage = wp;
     });
-  }
-
-  ngOnDestroy():void {
-    // Nothing to do
   }
 
   /**
@@ -126,7 +122,7 @@ export class WorkPackageRelationRowComponent implements OnInit, OnDestroy {
   public saveDescription() {
     this.wpRelations.updateRelation(
       this.relation,
-      {description: this.userInputs.newRelationText})
+      { description: this.userInputs.newRelationText })
       .then((savedRelation:RelationResource) => {
         this.relation = savedRelation;
         this.relatedWorkPackage.relatedBy = savedRelation;

--- a/frontend/src/app/components/wp-relations/wp-relations.component.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations.component.ts
@@ -26,17 +26,18 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {RelationResource} from 'core-app/modules/hal/resources/relation-resource';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
 import {Observable, zip} from 'rxjs';
 import {take, takeUntil} from 'rxjs/operators';
 import {WorkPackageCacheService} from '../work-packages/work-package-cache.service';
 import {RelatedWorkPackagesGroup} from './wp-relations.interfaces';
 import {RelationsStateValue, WorkPackageRelationsService} from './wp-relations.service';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 
 @Component({
@@ -44,7 +45,7 @@ import {RelationsStateValue, WorkPackageRelationsService} from './wp-relations.s
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './wp-relations.template.html'
 })
-export class WorkPackageRelationsComponent implements OnInit, OnDestroy {
+export class WorkPackageRelationsComponent extends UntilDestroyedMixin implements OnInit {
   @Input() public workPackage:WorkPackageResource;
   public relationGroups:RelatedWorkPackagesGroup = {};
   public relationGroupKeys:string[] = [];
@@ -63,6 +64,7 @@ export class WorkPackageRelationsComponent implements OnInit, OnDestroy {
               private wpRelations:WorkPackageRelationsService,
               private cdRef:ChangeDetectorRef,
               private wpCacheService:WorkPackageCacheService) {
+    super();
   }
 
   ngOnInit() {
@@ -86,10 +88,6 @@ export class WorkPackageRelationsComponent implements OnInit, OnDestroy {
       .subscribe((wp:WorkPackageResource) => {
         this.workPackage = wp;
       });
-  }
-
-  ngOnDestroy() {
-    // Nothing to do, interface compliance.
   }
 
   private getRelatedWorkPackages(workPackageIds:string[]):Observable<WorkPackageResource[]> {

--- a/frontend/src/app/components/wp-single-view-tabs/activity-panel/activity-base.controller.ts
+++ b/frontend/src/app/components/wp-single-view-tabs/activity-panel/activity-base.controller.ts
@@ -26,19 +26,18 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import { ChangeDetectorRef, OnDestroy, OnInit, Directive } from '@angular/core';
+import {ChangeDetectorRef, Directive, OnInit} from '@angular/core';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
 import {ActivityEntryInfo} from 'core-components/wp-single-view-tabs/activity-panel/activity-entry-info';
 import {WorkPackagesActivityService} from 'core-components/wp-single-view-tabs/activity-panel/wp-activity.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {takeUntil} from 'rxjs/operators';
 import {WorkPackageCacheService} from '../../work-packages/work-package-cache.service';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {Transition} from "@uirouter/core";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Directive()
-export class ActivityPanelBaseController implements OnInit, OnDestroy {
+export class ActivityPanelBaseController extends UntilDestroyedMixin implements OnInit {
   public workPackage:WorkPackageResource;
   public workPackageId:string;
 
@@ -63,6 +62,7 @@ export class ActivityPanelBaseController implements OnInit, OnDestroy {
               readonly cdRef:ChangeDetectorRef,
               readonly $transition:Transition,
               readonly wpActivity:WorkPackagesActivityService) {
+    super();
 
     this.reverse = wpActivity.isReversed;
     this.togglerText = this.text.commentsOnly;
@@ -72,7 +72,7 @@ export class ActivityPanelBaseController implements OnInit, OnDestroy {
     this.wpCacheService
       .observe(this.workPackageId)
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       )
       .subscribe((wp:WorkPackageResource) => {
         this.workPackage = wp;
@@ -81,10 +81,6 @@ export class ActivityPanelBaseController implements OnInit, OnDestroy {
           this.cdRef.detectChanges();
         });
       });
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 
   protected updateActivities(activities:HalResource[]) {

--- a/frontend/src/app/components/wp-single-view-tabs/activity-panel/activity-tab.component.ts
+++ b/frontend/src/app/components/wp-single-view-tabs/activity-panel/activity-tab.component.ts
@@ -26,20 +26,16 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, Inject, OnDestroy} from '@angular/core';
-import {Transition} from '@uirouter/core';
-import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
-import {WorkPackageCacheService} from 'core-components/work-packages/work-package-cache.service';
+import {Component} from '@angular/core';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {ActivityPanelBaseController} from 'core-components/wp-single-view-tabs/activity-panel/activity-base.controller';
-import {WorkPackagesActivityService} from 'core-components/wp-single-view-tabs/activity-panel/wp-activity.service';
 import {AngularTrackingHelpers} from "core-components/angular/tracking-functions";
 
 @Component({
   templateUrl: './activity-tab.html',
   selector: 'wp-activity-tab',
 })
-export class WorkPackageActivityTabComponent extends ActivityPanelBaseController implements OnDestroy {
+export class WorkPackageActivityTabComponent extends ActivityPanelBaseController {
   public workPackage:WorkPackageResource;
   public tabName = this.I18n.t('js.work_packages.tabs.activity');
   public trackByHref = AngularTrackingHelpers.trackByHrefAndProperty('version');
@@ -47,10 +43,5 @@ export class WorkPackageActivityTabComponent extends ActivityPanelBaseController
   ngOnInit() {
     this.workPackageId = this.$transition.params('to').workPackageId;
     super.ngOnInit();
-  }
-
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 }

--- a/frontend/src/app/components/wp-single-view-tabs/overview-tab/overview-tab.component.ts
+++ b/frontend/src/app/components/wp-single-view-tabs/overview-tab/overview-tab.component.ts
@@ -26,19 +26,18 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, Inject, OnDestroy} from '@angular/core';
-import {StateService, Transition} from '@uirouter/core';
+import {Component} from '@angular/core';
+import {StateService} from '@uirouter/core';
 import {WorkPackageCacheService} from 'core-components/work-packages/work-package-cache.service';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {takeUntil} from 'rxjs/operators';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   templateUrl: './overview-tab.html',
   selector: 'wp-overview-tab',
 })
-export class WorkPackageOverviewTabComponent implements OnDestroy {
+export class WorkPackageOverviewTabComponent extends UntilDestroyedMixin {
   public workPackageId:string;
   public workPackage:WorkPackageResource;
   public tabName = this.I18n.t('js.label_latest_activity');
@@ -46,17 +45,14 @@ export class WorkPackageOverviewTabComponent implements OnDestroy {
   public constructor(readonly I18n:I18nService,
                      readonly $state:StateService,
                      readonly wpCacheService:WorkPackageCacheService) {
+    super();
 
     this.workPackageId = this.$state.params.workPackageId;
     wpCacheService.loadWorkPackage(this.workPackageId)
       .values$()
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       )
       .subscribe((wp) => this.workPackage = wp);
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 }

--- a/frontend/src/app/components/wp-single-view-tabs/relations-tab/relations-tab.component.ts
+++ b/frontend/src/app/components/wp-single-view-tabs/relations-tab/relations-tab.component.ts
@@ -28,23 +28,23 @@
 
 import {Transition} from '@uirouter/core';
 import {WorkPackageCacheService} from 'core-components/work-packages/work-package-cache.service';
-import {Component, Inject, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {takeUntil} from 'rxjs/operators';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   templateUrl: './relations-tab.html',
   selector: 'wp-relations-tab',
 })
-export class WorkPackageRelationsTabComponent implements OnInit, OnDestroy {
+export class WorkPackageRelationsTabComponent extends UntilDestroyedMixin implements OnInit {
   @Input() public workPackageId?:string;
   public workPackage:WorkPackageResource;
 
   public constructor(readonly I18n:I18nService,
                      readonly $transition:Transition,
                      readonly wpCacheService:WorkPackageCacheService) {
+    super();
   }
 
   ngOnInit() {
@@ -52,15 +52,12 @@ export class WorkPackageRelationsTabComponent implements OnInit, OnDestroy {
     this.wpCacheService.loadWorkPackage(wpId)
       .values$()
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       )
       .subscribe((wp) => {
-          this.workPackageId = wp.id!;
-          this.workPackage = wp;
-        });
+        this.workPackageId = wp.id!;
+        this.workPackage = wp;
+      });
   }
 
-  ngOnDestroy() {
-    // Nothing to do
-  }
 }

--- a/frontend/src/app/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
+++ b/frontend/src/app/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
@@ -26,27 +26,25 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit} from '@angular/core';
 import {Transition} from '@uirouter/core';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
 import {LoadingIndicatorService} from 'core-app/modules/common/loading-indicator/loading-indicator.service';
 import {WorkPackageCacheService} from 'core-components/work-packages/work-package-cache.service';
-import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {takeUntil} from 'rxjs/operators';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {WorkPackageWatchersService} from 'core-components/wp-single-view-tabs/watchers-tab/wp-watchers.service';
 import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 import {AngularTrackingHelpers} from "core-components/angular/tracking-functions";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   templateUrl: './watchers-tab.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'wp-watchers-tab',
 })
-export class WorkPackageWatchersTabComponent implements OnInit, OnDestroy {
+export class WorkPackageWatchersTabComponent extends UntilDestroyedMixin implements OnInit {
   public workPackageId:string;
   public workPackage:WorkPackageResource;
   public trackByHref = AngularTrackingHelpers.trackByHref;
@@ -77,6 +75,7 @@ export class WorkPackageWatchersTabComponent implements OnInit, OnDestroy {
                      readonly wpCacheService:WorkPackageCacheService,
                      readonly cdRef:ChangeDetectorRef,
                      readonly pathHelper:PathHelperService) {
+    super();
   }
 
   public ngOnInit() {
@@ -86,7 +85,7 @@ export class WorkPackageWatchersTabComponent implements OnInit, OnDestroy {
     this.wpCacheService.loadWorkPackage(this.workPackageId)
       .values$()
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       )
       .subscribe((wp:WorkPackageResource) => {
         this.workPackage = wp;
@@ -123,7 +122,7 @@ export class WorkPackageWatchersTabComponent implements OnInit, OnDestroy {
 
 
   public addWatcher(user:any) {
-    this.loadingPromise = this.workPackage.addWatcher.$link.$fetch({user: {href: user.href}})
+    this.loadingPromise = this.workPackage.addWatcher.$link.$fetch({ user: { href: user.href } })
       .then(() => {
         // Forcefully reload the resource to update the watch/unwatch links
         // should the current user have been added
@@ -135,7 +134,7 @@ export class WorkPackageWatchersTabComponent implements OnInit, OnDestroy {
   }
 
   public removeWatcher(watcher:any) {
-    this.workPackage.removeWatcher.$link.$prepare({user_id: watcher.id})()
+    this.workPackage.removeWatcher.$link.$prepare({ user_id: watcher.id })()
       .then(() => {
         _.remove(this.watching, (other:HalResource) => {
           return other.href === watcher.href;
@@ -148,9 +147,5 @@ export class WorkPackageWatchersTabComponent implements OnInit, OnDestroy {
         this.cdRef.detectChanges();
       })
       .catch((error:any) => this.notificationService.showError(error, this.workPackage));
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 }

--- a/frontend/src/app/components/wp-table/embedded/wp-embedded-base.component.ts
+++ b/frontend/src/app/components/wp-table/embedded/wp-embedded-base.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectorRef, Input, SimpleChanges, Directive } from '@angular/core';
+import {AfterViewInit, ChangeDetectorRef, Directive, Input, SimpleChanges} from '@angular/core';
 import {CurrentProjectService} from '../../projects/current-project.service';
 import {WorkPackageStatesInitializationService} from '../../wp-list/wp-states-initialization.service';
 import {
@@ -48,10 +48,6 @@ export abstract class WorkPackageEmbeddedBaseComponent extends WorkPackagesViewB
   ngAfterViewInit():void {
     // Load initially
     this.loadQuery(true, false);
-  }
-
-  ngOnDestroy():void {
-    super.ngOnDestroy();
   }
 
   ngOnChanges(changes:SimpleChanges) {

--- a/frontend/src/app/components/wp-table/embedded/wp-embedded-table.component.ts
+++ b/frontend/src/app/components/wp-table/embedded/wp-embedded-table.component.ts
@@ -10,8 +10,7 @@ import {OpModalService} from 'core-components/op-modals/op-modal.service';
 import {WorkPackageEmbeddedBaseComponent} from "core-components/wp-table/embedded/wp-embedded-base.component";
 import {QueryFormResource} from "core-app/modules/hal/resources/query-form-resource";
 import {QueryFormDmService} from "core-app/modules/hal/dm-services/query-form-dm.service";
-import {distinctUntilChanged, take, withLatestFrom, map} from "rxjs/operators";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {distinctUntilChanged, map, take, withLatestFrom} from "rxjs/operators";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 
 @Component({
@@ -66,7 +65,7 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
       .pipe(
         map(pagination => [pagination.page, pagination.perPage]),
         distinctUntilChanged(),
-        untilComponentDestroyed(this),
+        this.untilDestroyed(),
         withLatestFrom(this.querySpace.query.values$())
       ).subscribe(([_, query]) => {
       this.loadingIndicator = this.QueryDm
@@ -105,7 +104,7 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
 
         // Disable compact mode when timeline active
         if (this.wpTableTimeline.isVisible) {
-          this.configuration = {...this.configuration, compactTableStyle: false};
+          this.configuration = { ...this.configuration, compactTableStyle: false };
         }
       });
   }
@@ -161,7 +160,7 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
       .catch((error) => {
         this.error = this.I18n.t(
           'js.error.embedded_table_loading',
-          {message: _.get(error, 'message', error)}
+          { message: _.get(error, 'message', error) }
         );
         this.onError.emit(error);
       });

--- a/frontend/src/app/components/wp-table/sort-header/sort-header.directive.ts
+++ b/frontend/src/app/components/wp-table/sort-header/sort-header.directive.ts
@@ -26,24 +26,24 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, OnDestroy} from '@angular/core';
+import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {RelationQueryColumn, TypeRelationQueryColumn} from 'core-components/wp-query/query-column';
-import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {WorkPackageTable} from 'core-components/wp-fast-table/wp-fast-table';
 import {QUERY_SORT_BY_ASC, QUERY_SORT_BY_DESC} from 'core-app/modules/hal/resources/query-sort-by-resource';
 import {WorkPackageViewHierarchiesService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-hierarchy.service";
 import {WorkPackageViewSortByService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-sort-by.service";
 import {WorkPackageViewGroupByService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-group-by.service";
 import {WorkPackageViewRelationColumnsService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-relation-columns.service";
-import {combineLatest, merge} from "rxjs";
+import {combineLatest} from "rxjs";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 
 @Component({
   selector: 'sortHeader',
   templateUrl: './sort-header.directive.html'
 })
-export class SortHeaderDirective implements OnDestroy, AfterViewInit {
+export class SortHeaderDirective extends UntilDestroyedMixin implements AfterViewInit {
 
   @Input() headerColumn:any;
 
@@ -63,7 +63,7 @@ export class SortHeaderDirective implements OnDestroy, AfterViewInit {
 
   isHierarchyColumn:boolean;
 
-  columnType:'hierarchy' | 'relation' | 'sort';
+  columnType:'hierarchy'|'relation'|'sort';
 
   columnName:string;
 
@@ -82,10 +82,7 @@ export class SortHeaderDirective implements OnDestroy, AfterViewInit {
               private elementRef:ElementRef,
               private cdRef:ChangeDetectorRef,
               private I18n:I18nService) {
-  }
-
-  // noinspection TsLint
-  ngOnDestroy():void {
+    super();
   }
 
   ngAfterViewInit() {
@@ -100,7 +97,7 @@ export class SortHeaderDirective implements OnDestroy, AfterViewInit {
       this.wpTableSortBy.live$()
     ])
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(() => {
         let latestSortElement = this.wpTableSortBy.current[0];
@@ -144,7 +141,7 @@ export class SortHeaderDirective implements OnDestroy, AfterViewInit {
       this.wpTableGroupBy
         .live$()
         .pipe(
-          untilComponentDestroyed(this)
+          this.untilDestroyed()
         )
         .subscribe(() => {
           this.isHierarchyDisabled = this.wpTableGroupBy.isEnabled;
@@ -155,7 +152,7 @@ export class SortHeaderDirective implements OnDestroy, AfterViewInit {
       this.wpTableHierarchies
         .live$()
         .pipe(
-          untilComponentDestroyed(this)
+          this.untilDestroyed()
         )
         .subscribe(() => {
           this.setHierarchyIcon();
@@ -192,8 +189,7 @@ export class SortHeaderDirective implements OnDestroy, AfterViewInit {
     if (this.wpTableHierarchies.isEnabled) {
       this.text.toggleHierarchy = I18n.t('js.work_packages.hierarchy.hide');
       this.hierarchyIcon = 'icon-hierarchy';
-    }
-    else {
+    } else {
       this.text.toggleHierarchy = I18n.t('js.work_packages.hierarchy.show');
       this.hierarchyIcon = 'icon-no-hierarchy';
     }

--- a/frontend/src/app/components/wp-table/table-pagination/wp-table-pagination.component.ts
+++ b/frontend/src/app/components/wp-table/table-pagination/wp-table-pagination.component.ts
@@ -27,16 +27,14 @@
 // ++
 
 import {TablePaginationComponent} from 'core-components/table-pagination/table-pagination.component';
-import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {IPaginationOptions, PaginationService} from 'core-components/table-pagination/pagination-service';
 import {WorkPackageViewPaginationService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-pagination.service";
 import {WorkPackageViewPagination} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-table-pagination";
 import {WorkPackageViewSortByService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-sort-by.service";
-import {wpDisplayCardRepresentation} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-display-representation.service";
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
-import { combineLatest } from 'rxjs';
+import {combineLatest} from 'rxjs';
 import {WorkPackageCollectionResource} from "core-app/modules/hal/resources/wp-collection-resource";
 
 @Component({
@@ -67,19 +65,19 @@ export class WorkPackageTablePaginationComponent extends TablePaginationComponen
     this.wpTablePagination
       .live$()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe((wpPagination:WorkPackageViewPagination) => {
         this.pagination = wpPagination.current;
         this.update();
-    });
+      });
 
     // hide/show pagination options depending on the sort mode
     combineLatest([
       this.querySpace.query.values$(),
       this.wpTableSortBy.live$()
     ]).pipe(
-      untilComponentDestroyed(this)
+      this.untilDestroyed()
     ).subscribe(([query, sort]) => {
       this.showPerPage = this.showPageSelections = !this.isManualSortingMode;
       this.infoText = this.paginationInfoText(query.results);
@@ -88,17 +86,13 @@ export class WorkPackageTablePaginationComponent extends TablePaginationComponen
     });
   }
 
-  ngOnDestroy():void {
-    // Nothing to do
-  }
-
   public selectPerPage(perPage:number) {
     this.paginationService.setPerPage(perPage);
-    this.wpTablePagination.updateFromObject({page: 1, perPage: perPage});
- }
+    this.wpTablePagination.updateFromObject({ page: 1, perPage: perPage });
+  }
 
   public showPage(pageNumber:number) {
-    this.wpTablePagination.updateFromObject({page: pageNumber});
+    this.wpTablePagination.updateFromObject({ page: pageNumber });
   }
 
   private get isManualSortingMode() {
@@ -108,7 +102,7 @@ export class WorkPackageTablePaginationComponent extends TablePaginationComponen
   public paginationInfoText(work_packages:WorkPackageCollectionResource) {
     if (this.isManualSortingMode && (work_packages.count < work_packages.total)) {
       return I18n.t('js.work_packages.limited_results',
-        {count: work_packages.count});
+        { count: work_packages.count });
     } else {
       return undefined;
     }

--- a/frontend/src/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
+++ b/frontend/src/app/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
@@ -26,23 +26,20 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, ElementRef, Injector, OnDestroy, OnInit} from '@angular/core';
+import {Component, ElementRef, Injector, OnInit} from '@angular/core';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
 import {State} from 'reactivestates';
 import {combineLatest} from 'rxjs';
-import {filter, map, take, takeUntil} from 'rxjs/operators';
+import {filter, map, take} from 'rxjs/operators';
 import {States} from '../../../states.service';
-import {
-  RelationsStateValue,
-  WorkPackageRelationsService
-} from '../../../wp-relations/wp-relations.service';
+import {RelationsStateValue, WorkPackageRelationsService} from '../../../wp-relations/wp-relations.service';
 import {WorkPackageTimelineCell} from '../cells/wp-timeline-cell';
 import {WorkPackageTimelineTableController} from '../container/wp-timeline-container.directive';
 import {timelineElementCssClass, TimelineViewParameters} from '../wp-timeline';
 import {TimelineRelationElement, workPackagePrefix} from './timeline-relation-element';
 import {WorkPackageViewTimelineService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-timeline.service";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 const DEBUG_DRAW_RELATION_LINES_WITH_COLOR = false;
 
@@ -81,7 +78,7 @@ function newSegment(vp:TimelineViewParameters,
   selector: 'wp-timeline-relations',
   template: '<div class="wp-table-timeline--relations"></div>'
 })
-export class WorkPackageTableTimelineRelations implements OnInit, OnDestroy {
+export class WorkPackageTableTimelineRelations extends UntilDestroyedMixin implements OnInit {
 
   @InjectField() querySpace:IsolatedQuerySpace;
 
@@ -95,7 +92,7 @@ export class WorkPackageTableTimelineRelations implements OnInit, OnDestroy {
               public workPackageTimelineTableController:WorkPackageTimelineTableController,
               public wpTableTimeline:WorkPackageViewTimelineService,
               public wpRelations:WorkPackageRelationsService) {
-
+    super();
   }
 
   ngOnInit() {
@@ -105,10 +102,6 @@ export class WorkPackageTableTimelineRelations implements OnInit, OnDestroy {
       .onRefreshRequested('relations', (vp:TimelineViewParameters) => this.refreshView());
 
     this.setupRelationSubscription();
-  }
-
-  ngOnDestroy() {
-    // empty
   }
 
   private refreshView() {
@@ -130,7 +123,7 @@ export class WorkPackageTableTimelineRelations implements OnInit, OnDestroy {
     ])
       .pipe(
         filter(([_, timeline]) => timeline.visible),
-        takeUntil(componentDestroyed(this)),
+        this.untilDestroyed(),
         map(([rendered, _]) => rendered)
       )
       .subscribe(list => {
@@ -156,7 +149,7 @@ export class WorkPackageTableTimelineRelations implements OnInit, OnDestroy {
     // When a WorkPackage changes, redraw the corresponding relations
     this.states.workPackages.observeChange()
       .pipe(
-        takeUntil(componentDestroyed(this)),
+        this.untilDestroyed(),
         filter(() => this.wpTableTimeline.isVisible)
       )
       .subscribe(([workPackageId]) => {

--- a/frontend/src/app/components/wp-table/wp-table.directive.ts
+++ b/frontend/src/app/components/wp-table/wp-table.directive.ts
@@ -34,7 +34,6 @@ import {
   Injector,
   Input,
   NgZone,
-  OnDestroy,
   OnInit,
   ViewEncapsulation
 } from '@angular/core';
@@ -43,7 +42,6 @@ import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {TableHandlerRegistry} from 'core-components/wp-fast-table/handlers/table-handler-registry';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
-import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {combineLatest} from 'rxjs';
 import {States} from '../states.service';
 import {
@@ -61,7 +59,7 @@ import {WpTableHoverSync} from "core-components/wp-table/wp-table-hover-sync";
 import {WorkPackageTimelineTableController} from "core-components/wp-table/timeline/container/wp-timeline-container.directive";
 import {WorkPackageTable} from "core-components/wp-fast-table/wp-fast-table";
 import {WorkPackageViewTimelineService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-timeline.service";
-import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   templateUrl: './wp-table.directive.html',
@@ -70,7 +68,7 @@ import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'wp-table',
 })
-export class WorkPackagesTableController implements OnInit, OnDestroy {
+export class WorkPackagesTableController extends UntilDestroyedMixin implements OnInit {
 
   @Input() projectIdentifier:string;
   @Input('configuration') configurationObject:WorkPackageTableConfigurationObject;
@@ -101,7 +99,7 @@ export class WorkPackagesTableController implements OnInit, OnDestroy {
 
   public results:WorkPackageCollectionResource;
 
-  public groupBy:QueryGroupByResource | null;
+  public groupBy:QueryGroupByResource|null;
 
   public columns:QueryColumn[];
 
@@ -124,6 +122,7 @@ export class WorkPackagesTableController implements OnInit, OnDestroy {
               readonly wpTableTimeline:WorkPackageViewTimelineService,
               readonly wpTableColumns:WorkPackageViewColumnsService,
               readonly wpTableSortBy:WorkPackageViewSortByService) {
+    super();
   }
 
   ngOnInit():void {
@@ -161,7 +160,7 @@ export class WorkPackagesTableController implements OnInit, OnDestroy {
     ]);
 
     statesCombined.pipe(
-      untilComponentDestroyed(this)
+      this.untilDestroyed()
     ).subscribe(([results, groupBy, columns, timelines, sort]) => {
       this.query = this.querySpace.query.value!;
       this.results = results;
@@ -187,6 +186,7 @@ export class WorkPackagesTableController implements OnInit, OnDestroy {
   }
 
   public ngOnDestroy():void {
+    super.ngOnDestroy();
     this.wpTableHoverSync.deactivate();
   }
 

--- a/frontend/src/app/helpers/angular/until-destroyed.mixin.ts
+++ b/frontend/src/app/helpers/angular/until-destroyed.mixin.ts
@@ -1,0 +1,25 @@
+import {OnDestroyMixin, untilComponentDestroyed} from "@w11k/ngx-componentdestroyed";
+import {OnDestroy} from "@angular/core";
+import {Observable} from "rxjs";
+
+/**
+ * Mixin function to provide access to observable and flags
+ * whether this component has been destroyed.
+ *
+ * Use for rxjs with .pipe(this.untilDestroyed)
+ */
+export class UntilDestroyedMixin extends OnDestroyMixin implements OnDestroy {
+  public componentDestroyed = false;
+
+  ngOnDestroy():void {
+    this.componentDestroyed = true;
+    super.ngOnDestroy();
+  }
+
+  /**
+   * Helper function to access `untilComponentDestroyed`
+   */
+  protected untilDestroyed<T>():(source:Observable<T>) => Observable<T> {
+    return untilComponentDestroyed(this);
+  }
+}

--- a/frontend/src/app/modules/admin/types/type-form-configuration.component.ts
+++ b/frontend/src/app/modules/admin/types/type-form-configuration.component.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, OnDestroy, OnInit} from '@angular/core';
+import {Component, ElementRef, OnInit} from '@angular/core';
 import {TypeBannerService} from 'core-app/modules/admin/types/type-banner.service';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {NotificationsService} from 'core-app/modules/common/notifications/notifications.service';
@@ -8,8 +8,7 @@ import {DragulaService} from 'ng2-dragula';
 import {ConfirmDialogService} from 'core-components/modals/confirm-dialog/confirm-dialog.service';
 import {Drake} from 'dragula';
 import {GonService} from "core-app/modules/common/gon/gon.service";
-import {takeUntil} from "rxjs/operators";
-import {componentDestroyed} from "ng2-rx-componentdestroyed";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 export type TypeGroupType = 'attribute'|'query';
 
@@ -38,7 +37,7 @@ export const adminTypeFormConfigurationSelector = 'admin-type-form-configuration
     TypeBannerService,
   ]
 })
-export class TypeFormConfigurationComponent implements OnInit, OnDestroy {
+export class TypeFormConfigurationComponent extends UntilDestroyedMixin implements OnInit {
 
   public text = {
     drag_to_activate: this.I18n.t('js.admin.type_form.drag_to_activate'),
@@ -71,6 +70,7 @@ export class TypeFormConfigurationComponent implements OnInit, OnDestroy {
               private confirmDialog:ConfirmDialogService,
               private notificationsService:NotificationsService,
               private externalRelationQuery:ExternalRelationQueryConfigurationService) {
+    super();
   }
 
   ngOnInit():void {
@@ -104,7 +104,7 @@ export class TypeFormConfigurationComponent implements OnInit, OnDestroy {
 
     this.dragula.dropModel("attributes")
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       )
       .subscribe((event) => {
         console.log(event);
@@ -130,10 +130,6 @@ export class TypeFormConfigurationComponent implements OnInit, OnDestroy {
           return this.down && (groups || attributes);
         }
       });
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 
   public deactivateAttribute(attribute:TypeFormAttribute) {
@@ -192,12 +188,12 @@ export class TypeFormConfigurationComponent implements OnInit, OnDestroy {
         }
       })
       .then(() => {
-      this.form.find('input#type_attribute_groups').val(JSON.stringify([]));
+        this.form.find('input#type_attribute_groups').val(JSON.stringify([]));
 
-      // Disable our form handler that updates the attribute groups
-      this.form.off('submit.typeformupdater');
-      this.form.trigger('submit');
-    });
+        // Disable our form handler that updates the attribute groups
+        this.form.off('submit.typeformupdater');
+        this.form.trigger('submit');
+      });
 
     $event.preventDefault();
     return false;

--- a/frontend/src/app/modules/attachments/attachments.component.ts
+++ b/frontend/src/app/modules/attachments/attachments.component.ts
@@ -26,15 +26,13 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {Component, Input, OnInit, OnDestroy} from '@angular/core';
+import {Component, ElementRef, Input, OnInit} from '@angular/core';
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
-import {DynamicBootstrapper} from 'core-app/globals/dynamic-bootstrapper';
-import {ElementRef} from '@angular/core';
 import {HalResourceService} from 'core-app/modules/hal/services/hal-resource.service';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {States} from 'core-components/states.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {filter, takeUntil} from 'rxjs/operators';
+import {filter} from 'rxjs/operators';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 export const attachmentsSelector = 'attachments';
 
@@ -42,7 +40,7 @@ export const attachmentsSelector = 'attachments';
   selector: attachmentsSelector,
   templateUrl: './attachments.html'
 })
-export class AttachmentsComponent implements OnInit, OnDestroy {
+export class AttachmentsComponent extends UntilDestroyedMixin implements OnInit {
   @Input('resource') public resource:HalResource;
 
   public $element:JQuery;
@@ -54,6 +52,7 @@ export class AttachmentsComponent implements OnInit, OnDestroy {
               protected I18n:I18nService,
               protected states:States,
               protected halResourceService:HalResourceService) {
+    super();
 
     this.text = {
       attachments: this.I18n.t('js.label_attachments'),
@@ -80,14 +79,10 @@ export class AttachmentsComponent implements OnInit, OnDestroy {
     this.setupResourceUpdateListener();
   }
 
-  ngOnDestroy():void {
-    // nothing to do
-  }
-
   public setupResourceUpdateListener() {
     this.states.forResource(this.resource)!.changes$()
       .pipe(
-        takeUntil(componentDestroyed(this)),
+        this.untilDestroyed(),
         filter(newResource => !!newResource)
       )
       .subscribe((newResource:HalResource) => {

--- a/frontend/src/app/modules/bim/bcf/bcf-wp-single-view/bcf-wp-single-view.component.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-single-view/bcf-wp-single-view.component.ts
@@ -18,7 +18,7 @@ import {CurrentProjectService} from "core-components/projects/current-project.se
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {ViewerBridgeService} from "core-app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service";
 import {WorkPackageCacheService} from "core-components/work-packages/work-package-cache.service";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
 
 export type ViewPoint = { snapshotId:string, snapshotFullPath:string };
@@ -29,7 +29,7 @@ export type ViewPoint = { snapshotId:string, snapshotFullPath:string };
   styleUrls: ['./bcf-wp-single-view.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BcfWpSingleViewComponent implements AfterViewInit, OnDestroy {
+export class BcfWpSingleViewComponent extends UntilDestroyedMixin implements AfterViewInit, OnDestroy {
   @Input() workPackage:WorkPackageResource;
 
   @ViewChild(NgxGalleryComponent) gallery:NgxGalleryComponent;
@@ -121,13 +121,14 @@ export class BcfWpSingleViewComponent implements AfterViewInit, OnDestroy {
               readonly notifications:NotificationsService,
               readonly cdRef:ChangeDetectorRef,
               readonly I18n:I18nService) {
+    super();
   }
 
   ngAfterViewInit():void {
     this.wpCache
       .observe(this.workPackage.id!)
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(wp => {
         this.workPackage = wp;
@@ -137,10 +138,6 @@ export class BcfWpSingleViewComponent implements AfterViewInit, OnDestroy {
           this.cdRef.detectChanges();
         }
       });
-  }
-
-  ngOnDestroy():void {
-    // Nothing to do.
   }
 
   showViewpoint(event:Event, index:number) {

--- a/frontend/src/app/modules/bim/ifc_models/bcf/list-container/bcf-list-container.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/bcf/list-container/bcf-list-container.component.ts
@@ -9,9 +9,9 @@ import {QueryParamListenerService} from "core-components/wp-query/query-param-li
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 import {WorkPackagesListService} from "core-components/wp-list/wp-list.service";
 import {UrlParamsHelperService} from "core-components/wp-query/url-params-helper";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {WorkPackageViewHandlerToken} from "core-app/modules/work_packages/routing/wp-view-base/event-handling/event-handler-registry";
 import {BcfCardViewHandlerRegistry} from "core-app/modules/bim/ifc_models/ifc-base-view/event-handler/bcf-card-view-handler-registry";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   templateUrl: './bcf-list-container.component.html',
@@ -20,7 +20,7 @@ import {BcfCardViewHandlerRegistry} from "core-app/modules/bim/ifc_models/ifc-ba
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BcfListContainerComponent implements OnInit, OnDestroy {
+export class BcfListContainerComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
   @InjectField() public queryParamListener:QueryParamListenerService;
   @InjectField() public wpListService:WorkPackagesListService;
   @InjectField() public urlParamsHelper:UrlParamsHelperService;
@@ -44,6 +44,7 @@ export class BcfListContainerComponent implements OnInit, OnDestroy {
               readonly gon:GonService,
               readonly injector:Injector,
               readonly cdRef:ChangeDetectorRef) {
+    super();
   }
 
   ngOnInit():void {
@@ -52,13 +53,14 @@ export class BcfListContainerComponent implements OnInit, OnDestroy {
     this.queryParamListener
       .observe$
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       ).subscribe((queryProps) => {
-        this.refresh(this.urlParamsHelper.buildV3GetQueryFromJsonParams(queryProps));
-      });
+      this.refresh(this.urlParamsHelper.buildV3GetQueryFromJsonParams(queryProps));
+    });
   }
 
   ngOnDestroy():void {
+    super.ngOnDestroy();
     this.queryParamListener.removeQueryChangeListener();
   }
 

--- a/frontend/src/app/modules/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
@@ -6,7 +6,6 @@ import {
 } from "core-app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component";
 import {WorkPackageFilterButtonComponent} from "core-components/wp-buttons/wp-filter-button/wp-filter-button.component";
 import {ZenModeButtonComponent} from "core-components/wp-buttons/zen-mode-toggle-button/zen-mode-toggle-button.component";
-import {componentDestroyed} from "ng2-rx-componentdestroyed";
 import {
   bimListViewIdentifier,
   bimViewerViewIdentifier,
@@ -24,6 +23,7 @@ import {BcfImportButtonComponent} from "core-app/modules/bim/ifc_models/toolbar/
 import {BcfExportButtonComponent} from "core-app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component";
 import {viewerBridgeServiceFactory} from "core-app/modules/bim/bcf/openproject-bcf.module";
 import {ViewerBridgeService} from "core-app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 @Component({
   templateUrl: '/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.html',
@@ -110,10 +110,6 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent {
     this.transitionUnsubscribeFn = this.transition.onSuccess({}, () => {
       this.newRoute$.next(this.state.current.data.newRoute);
     });
-  }
-
-  ngOnDestroy():void {
-    super.ngOnDestroy();
   }
 
   /**

--- a/frontend/src/app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component.ts
@@ -30,11 +30,11 @@ import {Component, OnDestroy, OnInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {BcfPathHelperService} from "core-app/modules/bim/bcf/helper/bcf-path-helper.service";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {QueryResource} from "core-app/modules/hal/resources/query-resource";
 import {UrlParamsHelperService} from "core-components/wp-query/url-params-helper";
 import {StateService} from "@uirouter/core";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   template: `
@@ -48,7 +48,7 @@ import {StateService} from "@uirouter/core";
   `,
   selector: 'bcf-export-button',
 })
-export class BcfExportButtonComponent implements OnInit, OnDestroy {
+export class BcfExportButtonComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
   public text = {
     export: this.I18n.t('js.bcf.export')
   };
@@ -61,13 +61,14 @@ export class BcfExportButtonComponent implements OnInit, OnDestroy {
               readonly querySpace:IsolatedQuerySpace,
               readonly queryUrlParamsHelper:UrlParamsHelperService,
               readonly state:StateService) {
+    super();
   }
 
   ngOnInit() {
     this.querySpace.query
       .values$()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe((query) => {
         this.query = query;
@@ -79,9 +80,5 @@ export class BcfExportButtonComponent implements OnInit, OnDestroy {
           JSON.stringify(filters)
         );
       });
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 }

--- a/frontend/src/app/modules/boards/board/add-card-dropdown/add-card-dropdown-menu.directive.ts
+++ b/frontend/src/app/modules/boards/board/add-card-dropdown/add-card-dropdown-menu.directive.ts
@@ -26,37 +26,13 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {
-  ChangeDetectorRef,
-  Directive,
-  ElementRef,
-  EventEmitter,
-  Injector,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output
-} from '@angular/core';
+import {ChangeDetectorRef, Directive, ElementRef, Injector} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {AuthorisationService} from 'core-app/modules/common/model-auth/model-auth.service';
 import {OpContextMenuTrigger} from 'core-components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import {OPContextMenuService} from 'core-components/op-context-menu/op-context-menu.service';
-import {States} from 'core-components/states.service';
-import {WorkPackagesListService} from 'core-components/wp-list/wp-list.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {takeUntil} from 'rxjs/operators';
-import {QueryFormResource} from 'core-app/modules/hal/resources/query-form-resource';
-import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
 import {OpModalService} from "core-components/op-modals/op-modal.service";
-import {WpTableExportModal} from "core-components/modals/export-modal/wp-table-export.modal";
-import {SaveQueryModal} from "core-components/modals/save-modal/save-query.modal";
-import {QuerySharingModal} from "core-components/modals/share-modal/query-sharing.modal";
-import {WpTableConfigurationModalComponent} from 'core-components/wp-table/configuration-modal/wp-table-configuration.modal';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
-import {
-  selectableTitleIdentifier,
-  triggerEditingEvent
-} from "core-app/modules/common/editable-toolbar-title/editable-toolbar-title.component";
 import {WorkPackageInlineCreateService} from "core-components/wp-inline-create/wp-inline-create.service";
 import {BoardListComponent} from "core-app/modules/boards/board/board-list/board-list.component";
 

--- a/frontend/src/app/modules/boards/board/board-list/board-inline-create.service.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-inline-create.service.ts
@@ -26,7 +26,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Injectable, Injector, OnDestroy} from '@angular/core';
+import {Injectable, Injector} from '@angular/core';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {WorkPackageRelationsHierarchyService} from "core-components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service";
 import {WorkPackageInlineCreateService} from "core-components/wp-inline-create/wp-inline-create.service";
@@ -37,7 +37,7 @@ import {BoardInlineAddAutocompleterComponent} from "core-app/modules/boards/boar
 import {GonService} from "core-app/modules/common/gon/gon.service";
 
 @Injectable()
-export class BoardInlineCreateService extends WorkPackageInlineCreateService implements OnDestroy {
+export class BoardInlineCreateService extends WorkPackageInlineCreateService {
 
   constructor(readonly injector:Injector,
               protected readonly querySpace:IsolatedQuerySpace,
@@ -73,12 +73,4 @@ export class BoardInlineCreateService extends WorkPackageInlineCreateService imp
     reference: this.I18n.t('js.relation_buttons.add_existing_child'),
     create: this.I18n.t('js.relation_buttons.add_new_child')
   };
-
-  /**
-   * Ensure hierarchical injected versions of this service correctly unregister
-   */
-  ngOnDestroy() {
-    super.ngOnDestroy();
-  }
-
 }

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -2,7 +2,6 @@ import {
   Component,
   ElementRef,
   EventEmitter,
-  Inject,
   Injector,
   Input,
   OnChanges,
@@ -18,7 +17,6 @@ import {
   withLoadingIndicator
 } from "core-app/modules/common/loading-indicator/loading-indicator.service";
 import {QueryResource} from "core-app/modules/hal/resources/query-resource";
-import {componentDestroyed, untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {WorkPackageInlineCreateService} from "core-components/wp-inline-create/wp-inline-create.service";
 import {BoardInlineCreateService} from "core-app/modules/boards/board/board-list/board-inline-create.service";
 import {AbstractWidgetComponent} from "core-app/modules/grids/widgets/abstract-widget.component";
@@ -49,6 +47,7 @@ import {BoardListMenuComponent} from "core-app/modules/boards/board/board-list/b
 import {debugLog} from "core-app/helpers/debug_output";
 import {WorkPackageCardDragAndDropService} from "core-components/wp-card-view/services/wp-card-drag-and-drop.service";
 import {WorkPackageChangeset} from "core-components/wp-edit/work-package-changeset";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 export interface DisabledButtonPlaceholder {
   text:string;
@@ -60,7 +59,7 @@ export interface DisabledButtonPlaceholder {
   templateUrl: './board-list.component.html',
   styleUrls: ['./board-list.component.sass'],
   providers: [
-    {provide: WorkPackageInlineCreateService, useClass: BoardInlineCreateService},
+    { provide: WorkPackageInlineCreateService, useClass: BoardInlineCreateService },
     BoardListMenuComponent,
     WorkPackageCardDragAndDropService
   ]
@@ -159,7 +158,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     this.querySpace.query
       .values$()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe((query) => {
         this.query = query;
@@ -168,10 +167,6 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
       });
 
     this.updateQuery();
-  }
-
-  ngOnDestroy():void {
-    // Interface compatibility
   }
 
   ngOnChanges(changes:SimpleChanges) {
@@ -209,8 +204,8 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
   public get canRename() {
     return this.canManage &&
-           !!this.query.updateImmediately &&
-           this.board.isFree;
+      !!this.query.updateImmediately &&
+      this.board.isFree;
   }
 
   public addReferenceCard() {
@@ -237,7 +232,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     this.inFlight = true;
     this.query.name = value;
     this.QueryDm
-      .patch(this.query.id!, {name: value})
+      .patch(this.query.id!, { name: value })
       .toPromise()
       .then(() => {
         this.inFlight = false;
@@ -324,7 +319,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     if (actionAttribute && !changeset.isWritable(actionAttribute)) {
       throw this.I18n.t(
         'js.boards.error_attribute_not_writable',
-        { attribute: changeset.humanName(actionAttribute)}
+        { attribute: changeset.humanName(actionAttribute) }
       );
     }
 

--- a/frontend/src/app/modules/boards/board/board.component.ts
+++ b/frontend/src/app/modules/boards/board/board.component.ts
@@ -15,7 +15,6 @@ import {BoardListsService} from "core-app/modules/boards/board/board-list/board-
 import {BoardCacheService} from "core-app/modules/boards/board/board-cache.service";
 import {BoardService} from "core-app/modules/boards/board/board.service";
 import {Board} from "core-app/modules/boards/board/board";
-import {componentDestroyed, untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {StateService} from "@uirouter/core";
 import {GridWidgetResource} from "core-app/modules/hal/resources/grid-widget-resource";
 import {CdkDragDrop, moveItemInArray} from "@angular/cdk/drag-drop";
@@ -31,6 +30,8 @@ import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-
 import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and-drop.service";
 import {QueryUpdatedService} from "core-app/modules/boards/board/query-updated/query-updated.service";
 import {QueryResource} from "core-app/modules/hal/resources/query-resource";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   selector: 'board',
@@ -42,7 +43,7 @@ import {QueryResource} from "core-app/modules/hal/resources/query-resource";
     DragAndDropService,
   ]
 })
-export class BoardComponent implements OnInit, OnDestroy {
+export class BoardComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
 
   /** Reference all query children to extract current actions */
   @ViewChildren(BoardListComponent) lists:QueryList<BoardListComponent>;
@@ -131,6 +132,7 @@ export class BoardComponent implements OnInit, OnDestroy {
               private readonly Banner:BannersService,
               private readonly Drag:DragAndDropService,
               private readonly QueryUpdated:QueryUpdatedService) {
+    super();
   }
 
   goBack() {
@@ -156,7 +158,7 @@ export class BoardComponent implements OnInit, OnDestroy {
     this.BoardCache
       .observe(id)
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(board => {
         this.board = board;
@@ -167,16 +169,12 @@ export class BoardComponent implements OnInit, OnDestroy {
       });
   }
 
-  ngOnDestroy():void {
-    // Nothing to do.
-  }
-
   saveWithNameAndFilters(board:Board, newName:string) {
     board.name = newName;
     board.filters = this.filters;
 
     let params = { isNew: false, query_props: null };
-    this.state.go('.', params, {custom: {notify: false}});
+    this.state.go('.', params, { custom: { notify: false } });
 
     this.saveBoard(board);
   }
@@ -192,7 +190,7 @@ export class BoardComponent implements OnInit, OnDestroy {
   addList(board:Board):any {
     if (board.isFree) {
       return this.BoardList
-        .addFreeQuery(board, { name: this.text.unnamed_list})
+        .addFreeQuery(board, { name: this.text.unnamed_list })
         .then(board => this.Boards.save(board))
         .then(saved => {
           this.BoardCache.update(saved);
@@ -238,12 +236,12 @@ export class BoardComponent implements OnInit, OnDestroy {
     }
 
     this.currentQueryUpdatedMonitoring = this
-                                         .QueryUpdated
-                                         .monitor(this.board.queries.map((widget) => widget.options.queryId as string))
-                                         .pipe(
-                                           untilComponentDestroyed(this)
-                                         )
-                                         .subscribe((collection) => this.requestRefreshOfUpdatedLists(collection.elements));
+      .QueryUpdated
+      .monitor(this.board.queries.map((widget) => widget.options.queryId as string))
+      .pipe(
+        this.untilDestroyed()
+      )
+      .subscribe((collection) => this.requestRefreshOfUpdatedLists(collection.elements));
   }
 
   private requestRefreshOfUpdatedLists(queries:QueryResource[]) {
@@ -252,7 +250,7 @@ export class BoardComponent implements OnInit, OnDestroy {
         .lists
         .filter((listComponent) => {
           const id = query.id!.toString();
-          const listId = (listComponent.resource.options.queryId as string|number).toString() ;
+          const listId = (listComponent.resource.options.queryId as string|number).toString();
 
           return id === listId;
         })

--- a/frontend/src/app/modules/boards/board/toolbar-menu/boards-toolbar-menu.directive.ts
+++ b/frontend/src/app/modules/boards/board/toolbar-menu/boards-toolbar-menu.directive.ts
@@ -26,7 +26,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {Directive, ElementRef, Injector, Input, OnDestroy} from '@angular/core';
+import {Directive, ElementRef, Injector, Input} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {OpContextMenuTrigger} from 'core-components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import {OPContextMenuService} from 'core-components/op-context-menu/op-context-menu.service';
@@ -37,15 +37,12 @@ import {BoardService} from "core-app/modules/boards/board/board.service";
 import {StateService} from "@uirouter/core";
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
 import {BoardCacheService} from "core-app/modules/boards/board/board-cache.service";
-import {
-  selectableTitleIdentifier,
-  triggerEditingEvent
-} from "core-app/modules/common/editable-toolbar-title/editable-toolbar-title.component";
+import {triggerEditingEvent} from "core-app/modules/common/editable-toolbar-title/editable-toolbar-title.component";
 
 @Directive({
   selector: '[boardsToolbarMenu]'
 })
-export class BoardsToolbarMenuDirective extends OpContextMenuTrigger implements OnDestroy {
+export class BoardsToolbarMenuDirective extends OpContextMenuTrigger {
   @Input('boardsToolbarMenu-resource') public board:Board;
 
   public text = {
@@ -63,10 +60,6 @@ export class BoardsToolbarMenuDirective extends OpContextMenuTrigger implements 
               readonly I18n:I18nService) {
 
     super(elementRef, opContextMenu);
-  }
-
-  ngOnDestroy():void {
-    // Nothing to do
   }
 
   public get locals() {
@@ -117,7 +110,7 @@ export class BoardsToolbarMenuDirective extends OpContextMenuTrigger implements 
               .delete(this.board)
               .then(() => {
                 this.BoardCache.clearSome(this.board.id!);
-                this.State.go('^', { flash_message: { type: 'success', message: this.text.deleteSuccessful }});
+                this.State.go('^', { flash_message: { type: 'success', message: this.text.deleteSuccessful } });
               });
           }
 

--- a/frontend/src/app/modules/boards/index-page/boards-index-page.component.ts
+++ b/frontend/src/app/modules/boards/index-page/boards-index-page.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, Injector, OnDestroy, OnInit} from "@angular/core";
+import {AfterViewInit, Component, Injector, OnInit} from "@angular/core";
 import {Observable} from "rxjs";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {BoardService} from "core-app/modules/boards/board/board.service";
@@ -10,16 +10,17 @@ import {NewBoardModalComponent} from "core-app/modules/boards/new-board-modal/ne
 import {BannersService} from "core-app/modules/common/enterprise/banners.service";
 import {LoadingIndicatorService} from "core-app/modules/common/loading-indicator/loading-indicator.service";
 import {AuthorisationService} from "core-app/modules/common/model-auth/model-auth.service";
-import {componentDestroyed} from "ng2-rx-componentdestroyed";
 import {enterpriseDemoUrl, enterpriseEditionUrl} from "core-app/globals/constants.const";
 import {DomSanitizer} from "@angular/platform-browser";
 import {boardTeaserVideoURL} from "core-app/modules/boards/board-constants.const";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
 
 @Component({
   templateUrl: './boards-index-page.component.html',
   styleUrls: ['./boards-index-page.component.sass']
 })
-export class BoardsIndexPageComponent implements OnInit, OnDestroy, AfterViewInit {
+export class BoardsIndexPageComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit {
 
   public text = {
     name: this.I18n.t('js.modals.label_name'),
@@ -28,7 +29,7 @@ export class BoardsIndexPageComponent implements OnInit, OnDestroy, AfterViewIni
     type: this.I18n.t('js.boards.label_board_type'),
     type_free: this.I18n.t('js.boards.board_type.free'),
     action_by_attribute: (attr:string) => this.I18n.t('js.boards.board_type.action_by_attribute',
-      {attribute: attr}),
+      { attribute: attr }),
     createdAt: this.I18n.t('js.label_created_on'),
     delete: this.I18n.t('js.button_delete'),
     areYouSure: this.I18n.t('js.text_are_you_sure'),
@@ -55,6 +56,7 @@ export class BoardsIndexPageComponent implements OnInit, OnDestroy, AfterViewIni
               private readonly injector:Injector,
               private readonly bannerService:BannersService,
               private readonly domSanitizer:DomSanitizer) {
+    super();
   }
 
   ngOnInit():void {
@@ -63,10 +65,6 @@ export class BoardsIndexPageComponent implements OnInit, OnDestroy, AfterViewIni
       .subscribe(() => {
         this.canAdd = this.authorisationService.can('boards', 'create');
       });
-  }
-
-  ngOnDestroy():void {
-    // Nothing to do
   }
 
   ngAfterViewInit():void {

--- a/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/modules/calendar/te-calendar/te-calendar.component.ts
@@ -1,15 +1,28 @@
-import {Component, ElementRef, Input, OnDestroy, OnInit, SecurityContext, ViewChild, AfterViewInit, Output, EventEmitter, Injector, ViewEncapsulation, ChangeDetectionStrategy} from "@angular/core";
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Injector,
+  Input,
+  OnInit,
+  Output,
+  SecurityContext,
+  ViewChild,
+  ViewEncapsulation
+} from "@angular/core";
 import {FullCalendarComponent} from '@fullcalendar/angular';
 import {States} from "core-components/states.service";
 import * as moment from "moment";
-import { Moment } from 'moment';
+import {Moment} from "moment";
 import {StateService} from "@uirouter/core";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {DomSanitizer} from "@angular/platform-browser";
 import timeGrid from '@fullcalendar/timegrid';
-import { EventInput, EventApi, Duration, View } from '@fullcalendar/core';
-import { EventSourceError } from '@fullcalendar/core/structs/event-source';
-import { ToolbarInput } from '@fullcalendar/core/types/input-types';
+import {Duration, EventApi, EventInput, View} from '@fullcalendar/core';
+import {EventSourceError} from '@fullcalendar/core/structs/event-source';
+import {ToolbarInput} from '@fullcalendar/core/types/input-types';
 import {ConfigurationService} from "core-app/modules/common/config/configuration.service";
 import {TimeEntryDmService} from "core-app/modules/hal/dm-services/time-entry-dm.service";
 import {FilterOperator} from "core-components/api/api-v3/api-v3-filter-builder";
@@ -23,7 +36,7 @@ import {TimeEntryEditService} from "core-app/modules/time_entries/edit/edit.serv
 import {TimeEntryCreateService} from "core-app/modules/time_entries/create/create.service";
 import {ColorsService} from "core-app/modules/common/colors/colors.service";
 import {BrowserDetector} from "core-app/modules/common/browser/browser-detector.service";
-import { HalResourceNotificationService } from 'core-app/modules/hal/services/hal-resource-notification.service';
+import {HalResourceNotificationService} from 'core-app/modules/hal/services/hal-resource-notification.service';
 
 interface CalendarViewEvent {
   el:HTMLElement;
@@ -59,7 +72,7 @@ const ADD_ENTRY_PROHIBITED_CLASS_NAME = '-prohibited';
     HalResourceEditingService
   ]
 })
-export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewInit {
+export class TimeEntryCalendarComponent implements OnInit, AfterViewInit {
   @ViewChild(FullCalendarComponent) ucCalendar:FullCalendarComponent;
   @Input() projectIdentifier:string;
   @Input() static:boolean = false;
@@ -89,7 +102,7 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
   public calendarMaxTime = `${this.maxHour}:00:00`;
   public calendarEventOverlap = (stillEvent:any) => !stillEvent.classNames.includes(TIME_ENTRY_CLASS_NAME);
 
-  protected memoizedTimeEntries:{start:Date, end:Date, entries:Promise<CollectionResource<TimeEntryResource>>};
+  protected memoizedTimeEntries:{ start:Date, end:Date, entries:Promise<CollectionResource<TimeEntryResource>> };
   protected memoizedCreateAllowed:boolean = false;
 
   public text = {
@@ -110,29 +123,34 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
               private timeEntryCreate:TimeEntryCreateService,
               private timeEntryCache:TimeEntryCacheService,
               private colors:ColorsService,
-              private browserDetector:BrowserDetector) { }
+              private browserDetector:BrowserDetector) {
+  }
 
   ngOnInit() {
     this.initializeCalendar();
-  }
-
-  ngOnDestroy() {
-    // nothing to do
   }
 
   ngAfterViewInit() {
     // The full-calendar component's outputs do not seem to work
     // see: https://github.com/fullcalendar/fullcalendar-angular/issues/228#issuecomment-523505044
     // Therefore, setting the outputs via the underlying API
-    this.ucCalendar.getApi().setOption('eventRender', (event:CalendarViewEvent) => { this.alterEventEntry(event); });
-    this.ucCalendar.getApi().setOption('eventDestroy', (event:CalendarViewEvent) => { this.beforeEventRemove(event); });
-    this.ucCalendar.getApi().setOption('eventClick', (event:CalendarViewEvent) => { this.dispatchEventClick(event); });
-    this.ucCalendar.getApi().setOption('eventDrop', (event:CalendarMoveEvent) => { this.moveEvent(event); });
+    this.ucCalendar.getApi().setOption('eventRender', (event:CalendarViewEvent) => {
+      this.alterEventEntry(event);
+    });
+    this.ucCalendar.getApi().setOption('eventDestroy', (event:CalendarViewEvent) => {
+      this.beforeEventRemove(event);
+    });
+    this.ucCalendar.getApi().setOption('eventClick', (event:CalendarViewEvent) => {
+      this.dispatchEventClick(event);
+    });
+    this.ucCalendar.getApi().setOption('eventDrop', (event:CalendarMoveEvent) => {
+      this.moveEvent(event);
+    });
   }
 
   public calendarEventsFunction(fetchInfo:{ start:Date, end:Date },
                                 successCallback:(events:EventInput[]) => void,
-                                failureCallback:(error:EventSourceError) => void ):void | PromiseLike<EventInput[]> {
+                                failureCallback:(error:EventSourceError) => void):void|PromiseLike<EventInput[]> {
 
     this.fetchTimeEntries(fetchInfo.start, fetchInfo.end)
       .then((collection) => {
@@ -144,8 +162,8 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
 
   protected fetchTimeEntries(start:Date, end:Date) {
     if (!this.memoizedTimeEntries ||
-        this.memoizedTimeEntries.start.getTime() !== start.getTime() ||
-        this.memoizedTimeEntries.end.getTime() !== end.getTime()) {
+      this.memoizedTimeEntries.start.getTime() !== start.getTime() ||
+      this.memoizedTimeEntries.end.getTime() !== end.getTime()) {
       let promise = this
         .timeEntryDm
         .list({ filters: this.dmFilters(start, end), pageSize: 500 })
@@ -283,7 +301,7 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
     let classNames = [ADD_ENTRY_CLASS_NAME];
 
     if (duration >= 24) {
-       classNames.push(ADD_ENTRY_PROHIBITED_CLASS_NAME);
+      classNames.push(ADD_ENTRY_PROHIBITED_CLASS_NAME);
     }
 
     return {
@@ -298,7 +316,7 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
     let startDate = moment(start).format('YYYY-MM-DD');
     let endDate = moment(end).subtract(1, 'd').format('YYYY-MM-DD');
     return [['spentOn', '<>d', [startDate, endDate]] as [string, FilterOperator, string[]],
-           ['user_id', '=', ['me']] as [string, FilterOperator, [string]]];
+      ['user_id', '=', ['me']] as [string, FilterOperator, [string]]];
   }
 
   private initializeCalendar() {
@@ -441,13 +459,15 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
 
   private addTooltip(event:CalendarViewEvent) {
     if (this.browserDetector.isMobile) {
-     return;
+      return;
     }
 
     jQuery(event.el).tooltip({
       content: this.tooltipContentString(event.event.extendedProps.entry),
       items: '.fc-event',
-      close: function () { jQuery(".ui-helper-hidden-accessible").remove(); },
+      close: function () {
+        jQuery(".ui-helper-hidden-accessible").remove();
+      },
       track: true
     });
   }
@@ -507,7 +527,7 @@ export class TimeEntryCalendarComponent implements OnInit, OnDestroy, AfterViewI
   private entryName(entry:TimeEntryResource) {
     let name = entry.project.name;
     if (entry.workPackage) {
-      name +=  ` - ${this.workPackageName(entry)}`;
+      name += ` - ${this.workPackageName(entry)}`;
     }
 
     return name || '-';

--- a/frontend/src/app/modules/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/modules/calendar/wp-calendar/wp-calendar.component.ts
@@ -1,8 +1,7 @@
-import {Component, ElementRef, Input, OnDestroy, OnInit, SecurityContext, ViewChild, AfterViewInit} from "@angular/core";
+import {AfterViewInit, Component, ElementRef, Input, OnInit, SecurityContext, ViewChild} from "@angular/core";
 import {FullCalendarComponent} from '@fullcalendar/angular';
 import {States} from "core-components/states.service";
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {WorkPackageCollectionResource} from "core-app/modules/hal/resources/wp-collection-resource";
 import {WorkPackageViewFiltersService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service";
@@ -15,11 +14,12 @@ import {DomSanitizer} from "@angular/platform-browser";
 import {WorkPackagesListChecksumService} from "core-components/wp-list/wp-list-checksum.service";
 import {OpTitleService} from "core-components/html/op-title.service";
 import dayGridPlugin from '@fullcalendar/daygrid';
-import { EventInput, EventApi } from '@fullcalendar/core';
-import { EventSourceError } from '@fullcalendar/core/structs/event-source';
-import { take } from 'rxjs/operators';
-import { ToolbarInput } from '@fullcalendar/core/types/input-types';
+import {EventApi, EventInput} from '@fullcalendar/core';
+import {EventSourceError} from '@fullcalendar/core/structs/event-source';
+import {take} from 'rxjs/operators';
+import {ToolbarInput} from '@fullcalendar/core/types/input-types';
 import {ConfigurationService} from "core-app/modules/common/config/configuration.service";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 interface CalendarViewEvent {
   el:HTMLElement;
@@ -32,7 +32,7 @@ interface CalendarViewEvent {
   styleUrls: ['./wp-calendar.sass'],
   selector: 'wp-calendar',
 })
-export class WorkPackagesCalendarController implements OnInit, OnDestroy, AfterViewInit {
+export class WorkPackagesCalendarController extends UntilDestroyedMixin implements OnInit, AfterViewInit {
   @ViewChild(FullCalendarComponent) ucCalendar:FullCalendarComponent;
   @Input() projectIdentifier:string;
   @Input() static:boolean = false;
@@ -58,7 +58,9 @@ export class WorkPackagesCalendarController implements OnInit, OnDestroy, AfterV
               readonly i18n:I18nService,
               readonly notificationsService:NotificationsService,
               private sanitizer:DomSanitizer,
-              private configuration:ConfigurationService) { }
+              private configuration:ConfigurationService) {
+    super();
+  }
 
   ngOnInit() {
     // Clear any old subscribers
@@ -69,21 +71,21 @@ export class WorkPackagesCalendarController implements OnInit, OnDestroy, AfterV
     this.initializeCalendar();
   }
 
-  ngOnDestroy() {
-    // nothing to do
-  }
-
   ngAfterViewInit() {
     // The full-calendar component's outputs do not seem to work
     // see: https://github.com/fullcalendar/fullcalendar-angular/issues/228#issuecomment-523505044
     // Therefore, setting the outputs via the underlying API
-    this.ucCalendar.getApi().setOption('eventRender', (event:CalendarViewEvent) => { this.addTooltip(event); });
-    this.ucCalendar.getApi().setOption('eventClick', (event:CalendarViewEvent) => { this.toWPFullView(event); });
+    this.ucCalendar.getApi().setOption('eventRender', (event:CalendarViewEvent) => {
+      this.addTooltip(event);
+    });
+    this.ucCalendar.getApi().setOption('eventClick', (event:CalendarViewEvent) => {
+      this.toWPFullView(event);
+    });
   }
 
   public calendarEventsFunction(fetchInfo:{ start:Date, end:Date, timeZone:string },
-                        successCallback:(events:EventInput[]) => void,
-                        failureCallback:(error:EventSourceError) => void ):void | PromiseLike<EventInput[]> {
+                                successCallback:(events:EventInput[]) => void,
+                                failureCallback:(error:EventSourceError) => void):void|PromiseLike<EventInput[]> {
     if (this.alreadyLoaded) {
       this.alreadyLoaded = false;
       let events = this.updateResults(this.querySpace.results.value!);
@@ -140,7 +142,9 @@ export class WorkPackagesCalendarController implements OnInit, OnDestroy, AfterV
     jQuery(event.el).tooltip({
       content: this.tooltipContentString(event.event.extendedProps.workPackage),
       items: '.fc-event',
-      close: function () { jQuery(".ui-helper-hidden-accessible").remove(); },
+      close: function () {
+        jQuery(".ui-helper-hidden-accessible").remove();
+      },
       track: true
     });
   }
@@ -237,7 +241,7 @@ export class WorkPackagesCalendarController implements OnInit, OnDestroy, AfterV
       return;
     }
 
-    let datesIntervalFilter = _.find(query.filters || [], {'id': 'datesInterval'}) as any;
+    let datesIntervalFilter = _.find(query.filters || [], { 'id': 'datesInterval' }) as any;
 
     let calendarDate:any = null;
     let calendarUnit = 'dayGridMonth';
@@ -263,7 +267,7 @@ export class WorkPackagesCalendarController implements OnInit, OnDestroy, AfterV
 
   private setupWorkPackagesListener() {
     this.querySpace.results.values$().pipe(
-      untilComponentDestroyed(this)
+      this.untilDestroyed()
     ).subscribe((collection:WorkPackageCollectionResource) => {
       this.alreadyLoaded = true;
       this.setCalendarsDate();
@@ -315,12 +319,14 @@ export class WorkPackagesCalendarController implements OnInit, OnDestroy, AfterV
   }
 
   private defaultQueryProps(startDate:string, endDate:string) {
-    let props = { "c": ["id"],
-                  "t":
-                  "id:asc",
-                  "f": [{ "n": "status", "o": "o", "v": [] },
-                        { "n": "datesInterval", "o": "<>d", "v": [startDate, endDate] }],
-                  "pp": WorkPackagesCalendarController.MAX_DISPLAYED };
+    let props = {
+      "c": ["id"],
+      "t":
+        "id:asc",
+      "f": [{ "n": "status", "o": "o", "v": [] },
+        { "n": "datesInterval", "o": "<>d", "v": [startDate, endDate] }],
+      "pp": WorkPackagesCalendarController.MAX_DISPLAYED
+    };
 
     return JSON.stringify(props);
   }
@@ -376,7 +382,9 @@ export class WorkPackagesCalendarController implements OnInit, OnDestroy, AfterV
   private removeTooltip(element:HTMLElement) {
     // deactivate tooltip so that it is not displayed on the wp show page
     jQuery(element).tooltip({
-      close: function () { jQuery(".ui-helper-hidden-accessible").remove(); },
+      close: function () {
+        jQuery(".ui-helper-hidden-accessible").remove();
+      },
       disabled: true
     });
   }

--- a/frontend/src/app/modules/common/ckeditor/op-ckeditor.component.ts
+++ b/frontend/src/app/modules/common/ckeditor/op-ckeditor.component.ts
@@ -26,7 +26,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild} from '@angular/core';
+import {Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild} from '@angular/core';
 import {
   CKEditorSetupService,
   ICKEditorContext,
@@ -45,8 +45,8 @@ const manualModeLocalStorageKey = 'op-ckeditor-uses-manual-mode';
   templateUrl: './op-ckeditor.html',
   styleUrls: ['./op-ckeditor.sass']
 })
-export class OpCkeditorComponent implements OnInit, OnDestroy {
-  @Input() ckEditorType:'full' | 'constrained' = 'full';
+export class OpCkeditorComponent implements OnInit {
+  @Input() ckEditorType:'full'|'constrained' = 'full';
   @Input() context:ICKEditorContext;
   @Input('content') _content:string;
 
@@ -65,7 +65,7 @@ export class OpCkeditorComponent implements OnInit, OnDestroy {
 
   // CKEditor instance once initialized
   public ckEditorInstance:ICKEditorInstance;
-  public error:string | null = null;
+  public error:string|null = null;
   public allowManualMode = false;
   public manualMode = false;
 
@@ -74,7 +74,7 @@ export class OpCkeditorComponent implements OnInit, OnDestroy {
   };
 
   // Codemirror instance, initialized lazily when running source mode
-  public codeMirrorInstance:undefined | any;
+  public codeMirrorInstance:undefined|any;
 
   // Debounce change listener for both CKE and codemirror
   // to read back changes as they happen
@@ -86,7 +86,7 @@ export class OpCkeditorComponent implements OnInit, OnDestroy {
         });
     },
     1000,
-    {leading: true}
+    { leading: true }
   );
 
   private $element:JQuery;
@@ -126,7 +126,7 @@ export class OpCkeditorComponent implements OnInit, OnDestroy {
         console.error(`Failed to save CKEditor content: ${e}.`);
         let error = this.I18n.t(
           'js.editor.error_saving_failed',
-          {error: e || this.I18n.t('js.error.internal')}
+          { error: e || this.I18n.t('js.error.internal') }
         );
 
         if (notificationOnError) {
@@ -158,10 +158,6 @@ export class OpCkeditorComponent implements OnInit, OnDestroy {
     return this.ckEditorInstance !== undefined;
   }
 
-  ngOnDestroy() {
-    // Nothing to do.
-  }
-
   ngOnInit() {
     try {
       this.initializeEditor();
@@ -175,7 +171,7 @@ export class OpCkeditorComponent implements OnInit, OnDestroy {
     }
   }
 
-  private initializeEditor()  {
+  private initializeEditor() {
     this.$element = jQuery(this.elementRef.nativeElement);
 
     const editorPromise = this.ckEditorSetup

--- a/frontend/src/app/modules/common/hide-section/add-section-dropdown/add-section-dropdown.component.ts
+++ b/frontend/src/app/modules/common/hide-section/add-section-dropdown/add-section-dropdown.component.ts
@@ -27,10 +27,10 @@
 // ++
 
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
-import {Component, ElementRef, OnDestroy, OnInit, ViewChild} from "@angular/core";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {Component, ElementRef, OnInit, ViewChild} from "@angular/core";
 import {HideSectionDefinition, HideSectionService} from "core-app/modules/common/hide-section/hide-section.service";
 import {AngularTrackingHelpers} from "core-components/angular/tracking-functions";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 export const addSectionDropdownSelector = 'add-section-dropdown';
 
@@ -38,7 +38,7 @@ export const addSectionDropdownSelector = 'add-section-dropdown';
   selector: addSectionDropdownSelector,
   templateUrl: './add-section-dropdown.component.html'
 })
-export class AddSectionDropdownComponent implements OnInit, OnDestroy {
+export class AddSectionDropdownComponent extends UntilDestroyedMixin implements OnInit {
   @ViewChild('fallbackOption', { static: true }) private option:ElementRef;
 
   trackByKey = AngularTrackingHelpers.trackByProperty('key');
@@ -52,6 +52,7 @@ export class AddSectionDropdownComponent implements OnInit, OnDestroy {
   constructor(protected hideSectionService:HideSectionService,
               protected elementRef:ElementRef,
               protected I18n:I18nService) {
+    super();
   }
 
   ngOnInit():void {
@@ -61,18 +62,14 @@ export class AddSectionDropdownComponent implements OnInit, OnDestroy {
       .displayed
       .values$()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       ).subscribe(displayed => {
-        this.selectable = this.hideSectionService.all
-          .filter(el => displayed.indexOf(el.key) === -1)
-          .sort((a, b) => a.label.localeCompare(b.label));
+      this.selectable = this.hideSectionService.all
+        .filter(el => displayed.indexOf(el.key) === -1)
+        .sort((a, b) => a.label.localeCompare(b.label));
 
-        (this.option.nativeElement as HTMLOptionElement).selected = true;
+      (this.option.nativeElement as HTMLOptionElement).selected = true;
     });
-  }
-
-  ngOnDestroy():void {
-    // Nothing to do
   }
 
   show(value:string) {

--- a/frontend/src/app/modules/common/notifications/notifications-container.component.ts
+++ b/frontend/src/app/modules/common/notifications/notifications-container.component.ts
@@ -26,11 +26,9 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from '@angular/core';
 import {INotification, NotificationsService} from 'core-app/modules/common/notifications/notifications.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {takeUntil} from 'rxjs/operators';
-import {DynamicBootstrapper} from "core-app/globals/dynamic-bootstrapper";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 export const notificationsContainerSelector = 'notifications-container';
 
@@ -45,12 +43,13 @@ export const notificationsContainerSelector = 'notifications-container';
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: notificationsContainerSelector
 })
-export class NotificationsContainerComponent implements OnInit, OnDestroy {
+export class NotificationsContainerComponent extends UntilDestroyedMixin implements OnInit {
 
   public stack:INotification[] = [];
 
   constructor(readonly notificationsService:NotificationsService,
               readonly cdRef:ChangeDetectorRef) {
+    super();
   }
 
   ngOnInit():void {
@@ -58,16 +57,12 @@ export class NotificationsContainerComponent implements OnInit, OnDestroy {
       .current
       .values$('Subscribing to changes in the notification stack')
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       )
       .subscribe(stack => {
         this.stack = stack;
         this.cdRef.detectChanges();
       });
-  }
-
-  ngOnDestroy() {
-    // Nothing to do, interface compliance only.
   }
 }
 

--- a/frontend/src/app/modules/common/notifications/upload-progress.component.ts
+++ b/frontend/src/app/modules/common/notifications/upload-progress.component.ts
@@ -26,16 +26,12 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
-import {
-  UploadFile,
-  UploadHttpEvent,
-  UploadInProgress
-} from "core-components/api/op-file-upload/op-file-upload.service";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {UploadFile, UploadHttpEvent, UploadInProgress} from "core-components/api/op-file-upload/op-file-upload.service";
 import {HttpErrorResponse, HttpEventType, HttpProgressEvent} from "@angular/common/http";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {debugLog} from "core-app/helpers/debug_output";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   selector: 'notifications-upload-progress',
@@ -50,7 +46,7 @@ import {debugLog} from "core-app/helpers/debug_output";
     </li>
   `
 })
-export class UploadProgressComponent implements OnInit, OnDestroy {
+export class UploadProgressComponent extends UntilDestroyedMixin implements OnInit {
   @Input() public upload:UploadInProgress;
   @Output() public onError = new EventEmitter<HttpErrorResponse>();
   @Output() public onSuccess = new EventEmitter<undefined>();
@@ -61,6 +57,7 @@ export class UploadProgressComponent implements OnInit, OnDestroy {
   public completed = false;
 
   constructor(protected readonly I18n:I18nService) {
+    super();
   }
 
   ngOnInit() {
@@ -69,7 +66,7 @@ export class UploadProgressComponent implements OnInit, OnDestroy {
 
     observable
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(
         (evt:UploadHttpEvent) => {
@@ -96,11 +93,7 @@ export class UploadProgressComponent implements OnInit, OnDestroy {
       );
   }
 
-  ngOnDestroy() {
-    // Nothing to do.
-  }
-
-  public get fileName():string | undefined {
+  public get fileName():string|undefined {
     return this.file && this.file.name;
   }
 

--- a/frontend/src/app/modules/fields/edit/edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/edit-field.component.ts
@@ -26,10 +26,18 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import { ChangeDetectorRef, ElementRef, Inject, InjectionToken, Injector, OnDestroy, OnInit, Directive } from "@angular/core";
+import {
+  ChangeDetectorRef,
+  Directive,
+  ElementRef,
+  Inject,
+  InjectionToken,
+  Injector,
+  OnDestroy,
+  OnInit
+} from "@angular/core";
 import {EditFieldHandler} from "core-app/modules/fields/edit/editing-portal/edit-field-handler";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {Field, IFieldSchema} from "core-app/modules/fields/field.base";
 import {ResourceChangeset} from "core-app/modules/fields/changeset/resource-changeset";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
@@ -65,7 +73,7 @@ export abstract class EditFieldComponent extends Field implements OnInit, OnDest
       this.change.state
         .values$()
         .pipe(
-          untilComponentDestroyed(this)
+          this.untilDestroyed()
         )
         .subscribe((change) => {
           const fieldSchema = change.schema[this.name];
@@ -85,10 +93,6 @@ export abstract class EditFieldComponent extends Field implements OnInit, OnDest
   ngOnInit():void {
     this.$element = jQuery(this.elementRef.nativeElement);
     this.initialize();
-  }
-
-  ngOnDestroy() {
-    // Nothing to do
   }
 
   public get overflowingSelector() {

--- a/frontend/src/app/modules/fields/edit/editing-portal/edit-field-handler.ts
+++ b/frontend/src/app/modules/fields/edit/editing-portal/edit-field-handler.ts
@@ -28,8 +28,9 @@
 
 import {Subject} from 'rxjs';
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
-export abstract class EditFieldHandler {
+export abstract class EditFieldHandler extends UntilDestroyedMixin {
   /**
    * Whether the handler belongs to a larger edit mode form
    * e.g., WP-create

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -33,7 +33,6 @@ import {Component, OnInit, ViewChild} from "@angular/core";
 import {EditFieldComponent} from "core-app/modules/fields/edit/edit-field.component";
 import {ValueOption} from "core-app/modules/fields/edit/field-types/select-edit-field.component";
 import {NgSelectComponent} from "@ng-select/ng-select";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 
 @Component({
@@ -68,7 +67,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
     this.handler
       .$onUserActivate
       .pipe(
-        untilComponentDestroyed(this),
+        this.untilDestroyed()
       )
       .subscribe(() => {
         this.requestFocus = this.availableOptions.length === 0;
@@ -213,8 +212,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
           return _.some(this.availableOptions, (option) => (option.$href === value.$href))
         }))
       );
-    }
-    else {
+    } else {
       // If no value but required
       this.currentValueInvalid = !!this.schema.required;
     }

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field.component.ts
@@ -31,11 +31,10 @@ import {HalResourceSortingService} from "core-app/modules/hal/services/hal-resou
 import {CollectionResource} from "core-app/modules/hal/resources/collection-resource";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {EditFieldComponent} from "../edit-field.component";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {CreateAutocompleterComponent} from "core-app/modules/common/autocomplete/create-autocompleter.component";
 import {SelectAutocompleterRegisterService} from "app/modules/fields/edit/field-types/select-autocompleter-register.service";
 import {from} from 'rxjs';
-import {tap, map} from 'rxjs/operators';
+import {map, tap} from 'rxjs/operators';
 import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 
@@ -100,7 +99,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
     this.handler
       .$onUserActivate
       .pipe(
-        untilComponentDestroyed(this),
+        this.untilDestroyed()
       )
       .subscribe(() => {
         loadingPromise.then(() => {
@@ -176,7 +175,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
 
   private addValue(val:HalResource) {
     this.availableOptions.push(val);
-    this.valueOptions.push({name: val.name, $href: val.$href});
+    this.valueOptions.push({ name: val.name, $href: val.$href });
   }
 
   public get currentValueInvalid():boolean {
@@ -189,7 +188,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
 
   public onCreate(newElement:HalResource) {
     this.addValue(newElement);
-    this.selectedOption = {name: newElement.name, $href: newElement.$href};
+    this.selectedOption = { name: newElement.name, $href: newElement.$href };
     this.handler.handleUserSubmit();
   }
 
@@ -205,7 +204,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
 
   public onChange(value:HalResource|undefined) {
     if (value !== undefined) {
-      this.selectedOption = {name: value.name, $href: value.$href};
+      this.selectedOption = { name: value.name, $href: value.$href };
       this.handler.handleUserSubmit();
       return;
     }
@@ -244,7 +243,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   }
 
   protected mapAllowedValue(value:HalResource):ValueOption {
-    return {name: value.name, $href: value.$href};
+    return { name: value.name, $href: value.$href };
   }
 
   // Subclasses shall be able to override the filters with which the

--- a/frontend/src/app/modules/fields/edit/field/editable-attribute-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field/editable-attribute-field.component.ts
@@ -55,16 +55,16 @@ import {NotificationsService} from 'core-app/modules/common/notifications/notifi
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {IFieldSchema} from "core-app/modules/fields/field.base";
 import {ClickPositionMapper} from "core-app/modules/common/set-click-position/set-click-position";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
 import {EditFormComponent} from "core-app/modules/fields/edit/edit-form/edit-form.component";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   selector: 'editable-attribute-field',
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './editable-attribute-field.component.html'
 })
-export class EditableAttributeFieldComponent implements OnInit, OnDestroy {
+export class EditableAttributeFieldComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
   @Input('fieldName') public fieldName:string;
   @Input('resource') public resource:HalResource;
   @Input('wrapperClasses') public wrapperClasses?:string;
@@ -95,12 +95,12 @@ export class EditableAttributeFieldComponent implements OnInit, OnDestroy {
               protected NotificationsService:NotificationsService,
               protected cdRef:ChangeDetectorRef,
               protected I18n:I18nService) {
-
+    super();
   }
 
   public setActive(active:boolean = true) {
     this.active = active;
-    if (!this.destroyed) {
+    if (!this.componentDestroyed) {
       this.cdRef.detectChanges();
     }
   }
@@ -114,16 +114,12 @@ export class EditableAttributeFieldComponent implements OnInit, OnDestroy {
       .temporaryEditResource(this.resource)
       .values$()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(resource => {
         this.resource = resource;
         this.render();
       });
-  }
-
-  public ngOnDestroy() {
-    this.destroyed = true;
   }
 
   // Open the field when its closed and relay drag & drop events to it.

--- a/frontend/src/app/modules/fields/field.base.ts
+++ b/frontend/src/app/modules/fields/field.base.ts
@@ -26,8 +26,8 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Injector} from '@angular/core';
 import {DisplayFieldContext} from "core-app/modules/fields/display/display-field.service";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 export interface IFieldSchema {
   type:string;
@@ -39,7 +39,7 @@ export interface IFieldSchema {
   options?:any;
 }
 
-export class Field {
+export class Field extends UntilDestroyedMixin {
   public static type:string;
   public resource:any;
   public name:string;

--- a/frontend/src/app/modules/global_search/global-search-work-packages.component.ts
+++ b/frontend/src/app/modules/global_search/global-search-work-packages.component.ts
@@ -26,46 +26,33 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {
-  AfterViewInit,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  OnDestroy,
-  OnInit,
-  Query,
-  Renderer2
-} from '@angular/core';
+import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit, Renderer2} from '@angular/core';
 import {FocusHelperService} from 'app/modules/common/focus/focus-helper';
 import {I18nService} from 'app/modules/common/i18n/i18n.service';
-import {DynamicBootstrapper} from "app/globals/dynamic-bootstrapper";
 import {HalResourceService} from "app/modules/hal/services/hal-resource.service";
 import {GlobalSearchService} from "core-app/modules/global_search/services/global-search.service";
-import {untilComponentDestroyed} from "ng2-rx-componentdestroyed";
-import {QueryResource} from "app/modules/hal/resources/query-resource";
 import {WorkPackageFiltersService} from "app/components/filters/wp-filters/wp-filters.service";
 import {UrlParamsHelperService} from "app/components/wp-query/url-params-helper";
 import {WorkPackageTableConfigurationObject} from "core-components/wp-table/wp-table-configuration";
-import {cloneHalResource} from "core-app/modules/hal/helpers/hal-resource-builder";
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
-import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-filter-instance-resource";
 import {WorkPackageViewFiltersService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service";
 import {debounceTime, distinctUntilChanged, skip} from "rxjs/operators";
 import {combineLatest} from "rxjs";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 export const globalSearchWorkPackagesSelector = 'global-search-work-packages';
 
 @Component({
   selector: globalSearchWorkPackagesSelector,
   template: `
-   <wp-embedded-table *ngIf="!resultsHidden"
-                      [queryProps]="queryProps"
-                      [configuration]="tableConfiguration">
+    <wp-embedded-table *ngIf="!resultsHidden"
+                       [queryProps]="queryProps"
+                       [configuration]="tableConfiguration">
     </wp-embedded-table>
   `
 })
 
-export class GlobalSearchWorkPackagesComponent implements OnInit, OnDestroy, AfterViewInit {
+export class GlobalSearchWorkPackagesComponent extends UntilDestroyedMixin implements OnInit, OnDestroy, AfterViewInit {
   public queryProps:{ [key:string]:any };
   public resultsHidden = false;
 
@@ -90,27 +77,29 @@ export class GlobalSearchWorkPackagesComponent implements OnInit, OnDestroy, Aft
               readonly wpFilters:WorkPackageFiltersService,
               readonly cdRef:ChangeDetectorRef,
               private UrlParamsHelper:UrlParamsHelperService) {
+    super();
   }
 
   ngAfterViewInit() {
-    combineLatest(
+    combineLatest([
       this.globalSearchService.searchTerm$,
       this.globalSearchService.projectScope$
-    ).pipe(
-      skip(1),
-      distinctUntilChanged(),
-      debounceTime(10),
-      untilComponentDestroyed(this)
-    )
-    .subscribe(([newSearchTerm, newProjectScope]) => {
-      this.wpFilters.visible = false;
-      this.setQueryProps();
-    });
+    ])
+      .pipe(
+        skip(1),
+        distinctUntilChanged(),
+        debounceTime(10),
+        this.untilDestroyed()
+      )
+      .subscribe(([newSearchTerm, newProjectScope]) => {
+        this.wpFilters.visible = false;
+        this.setQueryProps();
+      });
 
     this.globalSearchService
       .resultsHidden$
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe((resultsHidden:boolean) => this.resultsHidden = resultsHidden);
   }
@@ -119,31 +108,36 @@ export class GlobalSearchWorkPackagesComponent implements OnInit, OnDestroy, Aft
     this.setQueryProps();
   }
 
-  ngOnDestroy():void {
-    // Nothing to do
-  }
-
   private setQueryProps():void {
     let filters:any[] = [];
     let columns = ['id', 'project', 'subject', 'type', 'status', 'updatedAt'];
 
     if (this.globalSearchService.searchTerm.length > 0) {
-      filters.push({ search: {
+      filters.push({
+        search: {
           operator: '**',
-          values: [this.globalSearchService.searchTerm] }});
+          values: [this.globalSearchService.searchTerm]
+        }
+      });
     }
 
     if (this.globalSearchService.projectScope === 'current_project') {
-      filters.push({ subprojectId: {
+      filters.push({
+        subprojectId: {
           operator: '!*',
-          values: [] }});
+          values: []
+        }
+      });
       columns = ['id', 'subject', 'type', 'status', 'updatedAt'];
     }
 
     if (this.globalSearchService.projectScope === '') {
-      filters.push({ subprojectId: {
+      filters.push({
+        subprojectId: {
           operator: '*',
-          values: [] }});
+          values: []
+        }
+      });
     }
 
     this.queryProps = {

--- a/frontend/src/app/modules/grids/widgets/abstract-widget.component.ts
+++ b/frontend/src/app/modules/grids/widgets/abstract-widget.component.ts
@@ -1,10 +1,11 @@
-import { HostBinding, Input, EventEmitter, Output, HostListener, Injector, Directive } from "@angular/core";
+import {Directive, EventEmitter, HostBinding, Injector, Input, Output} from "@angular/core";
 import {GridWidgetResource} from "app/modules/hal/resources/grid-widget-resource";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {WidgetChangeset} from "core-app/modules/grids/widgets/widget-changeset";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Directive()
-export abstract class AbstractWidgetComponent {
+export abstract class AbstractWidgetComponent extends UntilDestroyedMixin {
   @HostBinding('style.grid-column-start') gridColumnStart:number;
   @HostBinding('style.grid-column-end') gridColumnEnd:number;
   @HostBinding('style.grid-row-start') gridRowStart:number;
@@ -44,7 +45,9 @@ export abstract class AbstractWidgetComponent {
   }
 
   constructor(protected i18n:I18nService,
-              protected injector:Injector) { }
+              protected injector:Injector) {
+    super();
+  }
 
   protected setChangesetOptions(values:{ [key:string]:unknown; }) {
     let changeset = new WidgetChangeset(this.resource);

--- a/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.ts
+++ b/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.ts
@@ -1,12 +1,22 @@
 import {AbstractWidgetComponent} from "core-app/modules/grids/widgets/abstract-widget.component";
-import {Component, ChangeDetectionStrategy, Injector, OnInit, OnDestroy, SimpleChanges, ChangeDetectorRef, ElementRef, ViewChild} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Injector,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
 import {CustomTextEditFieldService} from "core-app/modules/grids/widgets/custom-text/custom-text-edit-field.service";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
-import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 import {filter} from 'rxjs/operators';
 import {GridAreaService} from "core-app/modules/grids/grid/area.service";
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
 
 @Component({
   templateUrl: './custom-text.component.html',
@@ -15,18 +25,18 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
     CustomTextEditFieldService
   ]
 })
-export class WidgetCustomTextComponent extends AbstractWidgetComponent implements OnInit, OnDestroy {
+export class WidgetCustomTextComponent extends AbstractWidgetComponent implements OnInit, OnChanges, OnDestroy {
   protected currentRawText:string;
   public customText:SafeHtml;
 
   @ViewChild('displayContainer') readonly displayContainer:ElementRef;
 
-  constructor (protected i18n:I18nService,
-               protected injector:Injector,
-               public handler:CustomTextEditFieldService,
-               protected cdr:ChangeDetectorRef,
-               readonly sanitization:DomSanitizer,
-               protected layout:GridAreaService) {
+  constructor(protected i18n:I18nService,
+              protected injector:Injector,
+              public handler:CustomTextEditFieldService,
+              protected cdr:ChangeDetectorRef,
+              readonly sanitization:DomSanitizer,
+              protected layout:GridAreaService) {
     super(i18n, injector);
   }
 
@@ -37,16 +47,12 @@ export class WidgetCustomTextComponent extends AbstractWidgetComponent implement
       .handler
       .valueChanged$
       .pipe(
-        untilComponentDestroyed(this),
+        this.untilDestroyed(),
         filter(value => value !== this.resource.options['text'])
       ).subscribe(newText => {
-        let changeset = this.setChangesetOptions({ text: { raw: newText } });
-        this.resourceChanged.emit(changeset);
-      });
-  }
-
-  ngOnDestroy():void {
-    // comply to interface
+      let changeset = this.setChangesetOptions({ text: { raw: newText } });
+      this.resourceChanged.emit(changeset);
+    });
   }
 
   ngOnChanges(changes:SimpleChanges):void {

--- a/frontend/src/app/modules/grids/widgets/wp-graph/wp-graph.component.ts
+++ b/frontend/src/app/modules/grids/widgets/wp-graph/wp-graph.component.ts
@@ -1,9 +1,8 @@
-import {Component, OnDestroy, OnInit, Injector, ChangeDetectionStrategy, ChangeDetectorRef} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnDestroy, OnInit} from '@angular/core';
 import {WorkPackageEmbeddedGraphDataset} from "core-app/modules/work-package-graphs/embedded/wp-embedded-graph.component";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
-import {UrlParamsHelperService} from "core-components/wp-query/url-params-helper";
 import {AbstractWidgetComponent} from "core-app/modules/grids/widgets/abstract-widget.component";
-import {ChartType, ChartOptions} from 'chart.js';
+import {ChartOptions, ChartType} from 'chart.js';
 import {WpGraphConfigurationService} from "core-app/modules/work-package-graphs/configuration/wp-graph-configuration.service";
 import {WpGraphConfiguration} from "core-app/modules/work-package-graphs/configuration/wp-graph-configuration";
 
@@ -27,10 +26,6 @@ export class WidgetWpGraphComponent extends AbstractWidgetComponent implements O
   ngOnInit() {
     this.initializeConfiguration();
     this.loadQueriesInitially();
-  }
-
-  ngOnDestroy() {
-    // nothing to do
   }
 
   public set chartType(type:ChartType) {
@@ -58,12 +53,12 @@ export class WidgetWpGraphComponent extends AbstractWidgetComponent implements O
   protected initializeConfiguration() {
     let ids = [];
     if (this.resource.options.queryId) {
-      ids.push({id: this.resource.options.queryId as string});
+      ids.push({ id: this.resource.options.queryId as string });
     }
 
     this.graphConfiguration.configuration = new WpGraphConfiguration(ids,
-                                                                     this.resource.options.chartOptions as ChartOptions,
-                                                                     this.resource.options.chartType as ChartType);
+      this.resource.options.chartOptions as ChartOptions,
+      this.resource.options.chartType as ChartType);
   }
 
   protected loadQueriesInitially() {

--- a/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.ts
+++ b/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.ts
@@ -1,4 +1,4 @@
-import {Component, Injector, ChangeDetectionStrategy} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Injector} from '@angular/core';
 import {AbstractWidgetComponent} from "core-app/modules/grids/widgets/abstract-widget.component";
 import {QueryFormResource} from "core-app/modules/hal/resources/query-form-resource";
 import {QueryResource} from "core-app/modules/hal/resources/query-resource";
@@ -11,7 +11,6 @@ import {QueryDmService} from "core-app/modules/hal/dm-services/query-dm.service"
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {StateService} from '@uirouter/core';
 import {skip} from 'rxjs/operators';
-import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
 
 @Component({
   selector: 'widget-wp-table',
@@ -65,7 +64,7 @@ export class WidgetWpTableComponent extends AbstractWidgetComponent {
       .pipe(
         // 2 because ... well it is a magic number and works
         skip(2),
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       ).subscribe((query) => {
       this.ensureFormAndSaveQuery(query);
     });
@@ -77,10 +76,6 @@ export class WidgetWpTableComponent extends AbstractWidgetComponent {
 
   public static get identifier():string {
     return 'work_packages_table';
-  }
-
-  ngOnDestroy() {
-    // nothing to do
   }
 
   private ensureFormAndSaveQuery(query:QueryResource) {
@@ -111,7 +106,7 @@ export class WidgetWpTableComponent extends AbstractWidgetComponent {
   private createInitial():Promise<QueryResource> {
     const projectIdentifier = this.state.params['projectPath'];
     let initializationProps = this.resource.options.queryProps;
-    let queryProps = Object.assign({pageSize: 0}, initializationProps);
+    let queryProps = Object.assign({ pageSize: 0 }, initializationProps);
 
     return this.queryFormDm
       .loadWithParams(

--- a/frontend/src/app/modules/time_entries/form/form.component.ts
+++ b/frontend/src/app/modules/time_entries/form/form.component.ts
@@ -1,11 +1,22 @@
 import {HalResourceEditingService} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
 import {TimeEntryResource} from "core-app/modules/hal/resources/time-entry-resource";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
-import { ViewEncapsulation, Component, Input, EventEmitter, Output, OnInit, OnDestroy, ViewChild, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
-import { untilComponentDestroyed } from 'ng2-rx-componentdestroyed';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewChild,
+  ViewEncapsulation
+} from '@angular/core';
 import {SchemaResource} from "core-app/modules/hal/resources/schema-resource";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
-import { EditFormComponent } from 'core-app/modules/fields/edit/edit-form/edit-form.component';
+import {EditFormComponent} from 'core-app/modules/fields/edit/edit-form/edit-form.component';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   templateUrl: './form.component.html',
@@ -13,10 +24,10 @@ import { EditFormComponent } from 'core-app/modules/fields/edit/edit-form/edit-f
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TimeEntryFormComponent implements OnInit, OnDestroy {
+export class TimeEntryFormComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
   @Input() entry:TimeEntryResource;
 
-  @Output() modifiedEntry = new EventEmitter<{savedResource:TimeEntryResource, isInital:boolean}>();
+  @Output() modifiedEntry = new EventEmitter<{ savedResource:TimeEntryResource, isInital:boolean }>();
 
   @ViewChild('editForm', { static: true }) editForm:EditFormComponent;
 
@@ -32,11 +43,12 @@ export class TimeEntryFormComponent implements OnInit, OnDestroy {
   };
 
   public workPackageSelected:boolean = false;
-  public customFields:{key:string, label:string}[] = [];
+  public customFields:{ key:string, label:string }[] = [];
 
   constructor(readonly halEditing:HalResourceEditingService,
               readonly cdRef:ChangeDetectorRef,
               readonly i18n:I18nService) {
+    super();
   }
 
   ngOnInit() {
@@ -44,7 +56,7 @@ export class TimeEntryFormComponent implements OnInit, OnDestroy {
       .temporaryEditResource(this.entry)
       .values$()
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       )
       .subscribe(changeset => {
         if (changeset && changeset.workPackage) {
@@ -57,12 +69,8 @@ export class TimeEntryFormComponent implements OnInit, OnDestroy {
     this.cdRef.detectChanges();
   }
 
-  ngOnDestroy() {
-    // nothing to do
-  }
-
-  public signalModifiedEntry($event:{savedResource:HalResource, isInital:boolean}) {
-    this.modifiedEntry.emit($event as {savedResource:TimeEntryResource, isInital:boolean});
+  public signalModifiedEntry($event:{ savedResource:HalResource, isInital:boolean }) {
+    this.modifiedEntry.emit($event as { savedResource:TimeEntryResource, isInital:boolean });
   }
 
   public save() {
@@ -88,7 +96,7 @@ export class TimeEntryFormComponent implements OnInit, OnDestroy {
   private setCustomFields(schema:SchemaResource) {
     Object.entries(schema).forEach(([key, keySchema]) => {
       if (key.match(/customField\d+/)) {
-        this.customFields.push({key: key, label: keySchema.name });
+        this.customFields.push({ key: key, label: keySchema.name });
       }
     });
   }

--- a/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.ts
@@ -26,17 +26,11 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {ChangeDetectionStrategy, Component, ComponentRef, HostBinding, OnDestroy, OnInit} from "@angular/core";
-import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
+import {ChangeDetectionStrategy, Component, OnDestroy, OnInit} from "@angular/core";
 import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
 import {OpTitleService} from "core-components/html/op-title.service";
 import {WorkPackagesViewBase} from "core-app/modules/work_packages/routing/wp-view-base/work-packages-view.base";
 import {take} from "rxjs/operators";
-import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
-import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and-drop.service";
-import {BcfDetectorService} from "core-app/modules/bim/bcf/helper/bcf-detector.service";
-import {wpDisplayCardRepresentation} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-display-representation.service";
-import {WorkPackageTableConfigurationObject} from "core-components/wp-table/wp-table-configuration";
 import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
 import {QueryParamListenerService} from "core-components/wp-query/query-param-listener.service";
@@ -48,8 +42,8 @@ export interface ToolbarButtonComponentDefinition {
   component:ComponentType<any>;
   containerClasses?:string;
   show?:() => boolean;
-  inputs?:{[inputName:string]:any};
-  outputs?:{[outputName:string]:Function};
+  inputs?:{ [inputName:string]:any };
+  outputs?:{ [outputName:string]:Function };
 }
 
 export type ViewPartitionState = '-split'|'-left-only'|'-right-only';
@@ -61,7 +55,7 @@ export type ViewPartitionState = '-split'|'-left-only'|'-right-only';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     /** We need to provide the wpNotification service here to get correct save notifications for WP resources */
-    {provide: HalResourceNotificationService, useClass: WorkPackageNotificationService},
+    { provide: HalResourceNotificationService, useClass: WorkPackageNotificationService },
     QueryParamListenerService
   ]
 })
@@ -69,7 +63,7 @@ export class PartitionedQuerySpacePageComponent extends WorkPackagesViewBase imp
   @InjectField() titleService:OpTitleService;
   @InjectField() queryParamListener:QueryParamListenerService;
 
-  text:{[key:string]:string} = {
+  text:{ [key:string]:string } = {
     'jump_to_pagination': this.I18n.t('js.work_packages.jump_marks.pagination'),
     'text_jump_to_pagination': this.I18n.t('js.work_packages.jump_marks.label_pagination'),
   };
@@ -126,18 +120,18 @@ export class PartitionedQuerySpacePageComponent extends WorkPackagesViewBase imp
     this.queryParamListener
       .observe$
       .pipe(
-        untilComponentDestroyed(this)
+        this.untilDestroyed()
       ).subscribe(() => {
-        this.refresh(true, true);
-      });
+      this.refresh(true, true);
+    });
 
     // Update title on entering this state
-    this.unRegisterTitleListener = this.$transitions.onSuccess( {}, () => {
+    this.unRegisterTitleListener = this.$transitions.onSuccess({}, () => {
       this.updateTitle(this.querySpace.query.value);
     });
 
     this.querySpace.query.values$().pipe(
-      untilComponentDestroyed(this)
+      this.untilDestroyed()
     ).subscribe((query) => {
       this.onQueryUpdated(query);
     });

--- a/frontend/src/app/modules/work_packages/routing/wp-list-view/wp-list-view.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list-view/wp-list-view.component.ts
@@ -26,23 +26,10 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  HostBinding,
-  Input,
-  OnDestroy,
-  OnInit
-} from "@angular/core";
-import {untilComponentDestroyed} from 'ng2-rx-componentdestroyed';
-import {QueryResource} from 'core-app/modules/hal/resources/query-resource';
-import {OpTitleService} from "core-components/html/op-title.service";
-import {WorkPackagesViewBase} from "core-app/modules/work_packages/routing/wp-view-base/work-packages-view.base";
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from "@angular/core";
 import {take} from "rxjs/operators";
 import {CausedUpdatesService} from "core-app/modules/boards/board/caused-updates/caused-updates.service";
 import {DragAndDropService} from "core-app/modules/common/drag-and-drop/drag-and-drop.service";
-import {BcfDetectorService} from "core-app/modules/bim/bcf/helper/bcf-detector.service";
 import {
   WorkPackageViewDisplayRepresentationService,
   wpDisplayCardRepresentation
@@ -50,14 +37,12 @@ import {
 import {WorkPackageTableConfigurationObject} from "core-components/wp-table/wp-table-configuration";
 import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
-import {QueryParamListenerService} from "core-components/wp-query/query-param-listener.service";
-import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {DeviceService} from "core-app/modules/common/browser/device.service";
-import {WorkPackageViewPageComponent} from "core-app/modules/work_packages/routing/wp-view-page/wp-view-page.component";
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {WorkPackageViewFiltersService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
 @Component({
   selector: 'wp-list-view',
@@ -71,7 +56,7 @@ import {WorkPackageViewFiltersService} from "core-app/modules/work_packages/rout
     CausedUpdatesService
   ]
 })
-export class WorkPackageListViewComponent implements OnInit, OnDestroy {
+export class WorkPackageListViewComponent extends UntilDestroyedMixin implements OnInit {
 
   text = {
     'jump_to_pagination': this.I18n.t('js.work_packages.jump_marks.pagination'),
@@ -100,6 +85,7 @@ export class WorkPackageListViewComponent implements OnInit, OnDestroy {
               private CurrentProject:CurrentProjectService,
               private wpDisplayRepresentation:WorkPackageViewDisplayRepresentationService,
               private cdRef:ChangeDetectorRef) {
+    super();
   }
 
   ngOnInit() {
@@ -107,7 +93,7 @@ export class WorkPackageListViewComponent implements OnInit, OnDestroy {
     this.setupInformationLoadedListener();
 
     this.querySpace.query.values$().pipe(
-      untilComponentDestroyed(this)
+      this.untilDestroyed()
     ).subscribe((query) => {
       // Update the visible representation
       this.showListView = !(this.deviceService.isMobile || this.wpDisplayRepresentation.valueFromQuery(query) === wpDisplayCardRepresentation);
@@ -115,9 +101,6 @@ export class WorkPackageListViewComponent implements OnInit, OnDestroy {
     });
   }
 
-  ngOnDestroy():void {
-    // Nothing to do
-  }
   protected setupInformationLoadedListener() {
     this
       .querySpace

--- a/frontend/src/app/modules/work_packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-split-view/wp-split-view.component.ts
@@ -29,8 +29,6 @@
 import {ChangeDetectionStrategy, Component, Injector, OnInit} from '@angular/core';
 import {StateService} from '@uirouter/core';
 import {WorkPackageViewFocusService} from 'core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-focus.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {takeUntil} from 'rxjs/operators';
 import {States} from "core-components/states.service";
 import {FirstRouteService} from "core-app/modules/router/first-route-service";
 import {KeepTabService} from "core-components/wp-single-view-tabs/keep-tab/keep-tab.service";
@@ -83,14 +81,14 @@ export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase imp
 
     this.wpTableFocus.whenChanged()
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       )
       .subscribe(newId => {
         const idSame = wpId.toString() === newId.toString();
         if (!idSame && this.$state.includes(`${this.baseRoute}.details.overview`)) {
           this.$state.go(
             (this.$state.current.name as string),
-            {workPackageId: newId, focus: false}
+            { workPackageId: newId, focus: false }
           );
         }
       });

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/work-package-single-view.base.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/work-package-single-view.base.ts
@@ -26,12 +26,10 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {ChangeDetectorRef, Injector, OnDestroy} from '@angular/core';
+import {ChangeDetectorRef, Injector} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
 import {WorkPackageViewFocusService} from 'core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-focus.service';
-import {componentDestroyed} from 'ng2-rx-componentdestroyed';
-import {takeUntil} from 'rxjs/operators';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {ProjectCacheService} from 'core-components/projects/project-cache.service';
 import {OpTitleService} from 'core-components/html/op-title.service';
@@ -41,11 +39,11 @@ import {States} from "core-components/states.service";
 import {KeepTabService} from "core-components/wp-single-view-tabs/keep-tab/keep-tab.service";
 
 import {HalResourceEditingService} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
-import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 
-export class WorkPackageSingleViewBase implements OnDestroy {
+export class WorkPackageSingleViewBase extends UntilDestroyedMixin {
 
   @InjectField() wpCacheService:WorkPackageCacheService;
   @InjectField() states:States;
@@ -72,11 +70,8 @@ export class WorkPackageSingleViewBase implements OnDestroy {
   @InjectField() readonly titleService:OpTitleService;
 
   constructor(public injector:Injector, protected workPackageId:string) {
+    super();
     this.initializeTexts();
-  }
-
-  ngOnDestroy():void {
-    // Created for interface compliance
   }
 
   /**
@@ -92,7 +87,7 @@ export class WorkPackageSingleViewBase implements OnDestroy {
     this.wpCacheService.state(this.workPackageId)
       .values$()
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       )
       .subscribe((wp:WorkPackageResource) => {
         this.workPackage = wp;
@@ -134,7 +129,7 @@ export class WorkPackageSingleViewBase implements OnDestroy {
     // Listen to tab changes to update the tab label
     this.keepTab.observable
       .pipe(
-        takeUntil(componentDestroyed(this))
+        this.untilDestroyed()
       )
       .subscribe((tabs:any) => {
         this.updateFocusAnchorLabel(tabs.active);


### PR DESCRIPTION
Ivy introduces changes that break the previous version of `untilComponentDestroyed(this)` for when a base class is involved.

To mitigate this, we need to use the following pattern from now on:

- Extend the class from our helper class `UntilDestroyedMixin`
- Call super() in the constructor
- Replace `untilComponentDestroyed(this)` with `this.untilDestroyed()`
- Remove empty `ngOnDestroy` functions, as they are defined in the mixin
- If ngOnDestroy is not empty, **make sure you call** `super.ngOnDestroy()`
- You no longer have to use `implements OnDestroy` in these components