### PR TITLE
Avoid trying to log time for missing changeset user

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -240,6 +240,11 @@ class Changeset < ActiveRecord::Base
   end
 
   def log_time(work_package, hours)
+    unless user.present?
+      Rails.logger.warn("TimeEntry could not be created by changeset #{id}: #{committer} does not map to user")
+      return
+    end
+
     Changesets::LogTimeService
       .new(user: user, changeset: self)
       .call(work_package, hours)


### PR DESCRIPTION
A change in https://github.com/opf/openproject/commit/08a7ee52b35b336cd0528cb8efd0259b35026b16#diff-1d816c3a4f881298dd46a9f489418b4d caused an internal error when the user is not present (comitter could not be mapped to an OpenProject user)

https://community.openproject.com/wp/32038