### PR TITLE
no mail on empty wp update

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -121,6 +121,10 @@ class Journal < ActiveRecord::Base
     predecessor
   end
 
+  def noop?
+    (!notes || notes&.empty?) && get_changes.empty?
+  end
+
   private
 
   def save_data

--- a/app/models/journal/aggregated_journal.rb
+++ b/app/models/journal/aggregated_journal.rb
@@ -346,6 +346,7 @@ class Journal::AggregatedJournal
            :project,
            :data,
            :data=,
+           :noop?,
            to: :journal
 
   # Initializes a new AggregatedJournal. Allows to explicitly set a predecessor, if it is already

--- a/app/services/notifications/journal_wp_mail_service.rb
+++ b/app/services/notifications/journal_wp_mail_service.rb
@@ -39,7 +39,7 @@ class Notifications::JournalWPMailService
     private
 
     def journal_complete_mail(journal, send_mails)
-      return nil unless send_mail?(journal, send_mails)
+      return nil if abort_sending?(journal, send_mails)
 
       author = User.find_by(id: journal.user_id) || DeletedUser.first
 
@@ -128,6 +128,10 @@ class Notifications::JournalWPMailService
 
     def notification_enabled?(name)
       Setting.notified_events.include?(name)
+    end
+
+    def abort_sending?(journal, send_mails)
+      !send_mail?(journal, send_mails) || journal.noop?
     end
   end
 end

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -70,7 +70,7 @@ module API
         formattable_property :notes,
                              as: :comment,
                              getter: ->(*) {
-                               text = if empty?
+                               text = if represented.noop?
                                         "_#{I18n.t(:'journals.changes_retracted')}_"
                                       else
                                         represented.notes
@@ -97,7 +97,7 @@ module API
         date_time_property :created_at
 
         def _type
-          if empty? || represented.notes.present?
+          if represented.noop? || represented.notes.present?
             'Activity::Comment'
           else
             'Activity'
@@ -116,10 +116,6 @@ module API
 
         def render_details(journal, no_html: false)
           journal.details.map { |d| journal.render_detail(d, no_html: no_html) }
-        end
-
-        def empty?
-          represented.get_changes.empty? && represented.notes.empty?
         end
       end
     end

--- a/spec/services/notifications/journal_wp_mail_service_spec.rb
+++ b/spec/services/notifications/journal_wp_mail_service_spec.rb
@@ -333,6 +333,19 @@ describe Notifications::JournalWPMailService do
       it_behaves_like 'mentioned'
     end
   end
+
+  context 'aggregated journal is empty' do
+    let(:journal) { journal_2_empty_change }
+    let(:journal_2_empty_change) do
+      work_package.add_journal(author, 'temp')
+      work_package.save(validate: false)
+      work_package.journals.last.tap do |j|
+        j.update_column(:notes, nil)
+      end
+    end
+
+    it_behaves_like 'sends no mail'
+  end
 end
 
 describe 'initialization' do


### PR DESCRIPTION
Do not send out a mail in case the aggregated journal is empty e.g. when the user undid the change.

https://community.openproject.com/projects/openproject/work_packages/21816