### PR TITLE
Fix/time entry autocompleter typeahead

### DIFF
--- a/frontend/src/app/modules/fields/edit/field-types/te-work-package-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/te-work-package-edit-field.component.ts
@@ -52,6 +52,7 @@ export class TimeEntryWorkPackageEditFieldComponent extends WorkPackageEditField
     // existing values.
     if (this.referenceOutputs) {
       this.referenceOutputs['modeSwitch'] = (mode:TimeEntryWorkPackageAutocompleterMode) => {
+        this.valuesLoaded = false;
         let lastValue = this.requests.lastRequestedValue!;
 
         // Hack to provide a new value to "reset" the input.

--- a/frontend/src/app/modules/fields/edit/field-types/work-package-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/work-package-edit-field.component.html
@@ -4,7 +4,7 @@
                                    model: selectedOption ? selectedOption : '',
                                    required: required,
                                    disabled: inFlight,
-                                   typeahead: requests.input$,
+                                   typeahead: typeahead,
                                    id: handler.htmlId,
                                    finishedLoading: requests.loading$,
                                    hideSelected: true,

--- a/frontend/src/app/modules/fields/edit/field-types/work-package-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/work-package-edit-field.component.ts
@@ -57,6 +57,14 @@ export class WorkPackageEditFieldComponent extends SelectEditFieldComponent {
     });
   }
 
+  public get typeahead() {
+    if (this.valuesLoaded) {
+      return false;
+    } else {
+      return this.requests.input$;
+    }
+  }
+
   protected allowedValuesFilter(query?:string):{} {
     let filterParams = super.allowedValuesFilter(query);
 


### PR DESCRIPTION
https://community.openproject.com/wp/32578

In case less than the max page size of work packages exist as valid time entry targets, the front end has an optimization to not load the available values from the backend again. But for that to work, we have to instruct the front end to not work as a typeahead in such cases. 

Additionally, we have to reset the memoization on mode switches as we the user might not have a lot of values in one mode, e.g. on the "recent" tab, but might have way more values in the other, e.g. "all" tab.