### PR TITLE
[32590] Mobile issues with cards in Work Packages and BIM module

### DIFF
--- a/app/assets/stylesheets/layout/_base_mobile.sass
+++ b/app/assets/stylesheets/layout/_base_mobile.sass
@@ -57,7 +57,7 @@
     height: initial
   // ------------------- END CHANGED SCROLL BEHAVIOR
 
-  #main-menu ~ #content-wrapper
+  #content-wrapper
     padding: 15px
 
   #main

--- a/app/assets/stylesheets/layout/_toolbar.sass
+++ b/app/assets/stylesheets/layout/_toolbar.sass
@@ -201,11 +201,11 @@ $nm-color-success-background: #d8fdd1
 
 // Allow title container to grow
 .title-container
-  flex-grow: 1
-  flex-basis: auto
+  flex: 1 1
   overflow: hidden
   white-space: nowrap
   margin-bottom: 10px // margin-bottom of toolbar buttons
+  min-width: 33%
 
   &.-no-grow
     flex-grow: 0

--- a/app/assets/stylesheets/layout/_toolbar_mobile.sass
+++ b/app/assets/stylesheets/layout/_toolbar_mobile.sass
@@ -31,9 +31,6 @@
     .toolbar-container
       margin-top: 10px
 
-      .toolbar
-        flex-wrap: nowrap
-
       .title-container:not(editable-toolbar-title)
         margin-right: 10px
 

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -148,4 +148,3 @@
 
       .toolbar-container
         margin-left: 15px
-        margin-right: 15px

--- a/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.html
+++ b/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.html
@@ -26,7 +26,7 @@
     </div>
   </div>
 
-  <filter-container *ngIf="filterAllowed"></filter-container>
+  <filter-container></filter-container>
 
   <div class="work-packages-partitioned-page--content-container">
     <!-- Left content view -->

--- a/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
+++ b/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
@@ -32,3 +32,5 @@
     .work-packages-partitioned-page--content-left,
     .work-packages-partitioned-page--content-right
       min-width: initial
+      max-width: 100vw
+      max-height: 100%

--- a/frontend/src/app/modules/work_packages/routing/wp-list-view/wp-list-view.component.sass
+++ b/frontend/src/app/modules/work_packages/routing/wp-list-view/wp-list-view.component.sass
@@ -11,10 +11,11 @@
   padding-bottom: 5px
   @include styled-scroll-bar
 
-  &.-with-resizer
-    padding-left: 10px
+  @media screen and (min-width: 679px)
+    &.-with-resizer
+      padding-left: 10px
 
-  @media screen and (max-width: 659px)
+  @media screen and (max-width: 679px)
     // Ensure the WP cards span the complete width on mobile
     // --> Move scrollbar out of visible area
     min-width: calc(100vw + 10px)

--- a/modules/bim/app/assets/stylesheets/bim/ifc_viewer/generic.sass
+++ b/modules/bim/app/assets/stylesheets/bim/ifc_viewer/generic.sass
@@ -14,8 +14,6 @@
 // This is different to how we style #content else where.
 .controller-bim\/ifc_models\/ifc_viewer
   overflow: hidden
-  @include extended-content--right
-  @include extended-content--bottom
 
   &.action-show
     #content
@@ -23,8 +21,16 @@
 
   // Override default behavior to let the viewer span the whole height
   @media only screen and (max-width: 679px)
+    @include extended-content--right
+    @include extended-content--left
     #content-wrapper
       height: calc(100vh - 55px)
+
+    .work-packages-partitioned-page--content-container
+      flex-direction: column
+
+    .ifc-model-viewer--container
+      height: 33vh
 
 [data-name="bim"] .main-menu--children
   overflow-x: hidden !important


### PR DESCRIPTION
* Fix mobile style for BIM page.
  * Show little model viewer on split screen and the WP cards below
* Wrap toolbar if there is no other way to show all buttons.

https://community.openproject.com/projects/openproject/work_packages/32590/activity?query_id=2294