### PR TITLE
Feature/disable bcf creation when lacking permission

### DIFF
--- a/frontend/src/app/modules/bim/bcf/api/extensions/bcf-extension.paths.ts
+++ b/frontend/src/app/modules/bim/bcf/api/extensions/bcf-extension.paths.ts
@@ -1,0 +1,12 @@
+import {BcfResourcePath} from "core-app/modules/bim/bcf/api/bcf-path-resources";
+import {BcfApiRequestService} from "core-app/modules/bim/bcf/api/bcf-api-request.service";
+import {HTTPClientHeaders, HTTPClientParamMap} from "core-app/modules/hal/http/http.interfaces";
+import {BcfExtensionResource} from "core-app/modules/bim/bcf/api/extensions/bcf-extension.resource";
+
+export class BcfExtensionPaths extends BcfResourcePath {
+  readonly bcfExtensionService = new BcfApiRequestService(this.injector, BcfExtensionResource);
+
+  get(params:HTTPClientParamMap = {}, headers:HTTPClientHeaders = {}) {
+    return this.bcfExtensionService.get(this.toPath(), params, headers);
+  }
+}

--- a/frontend/src/app/modules/bim/bcf/api/extensions/bcf-extension.resource.ts
+++ b/frontend/src/app/modules/bim/bcf/api/extensions/bcf-extension.resource.ts
@@ -1,0 +1,14 @@
+import {jsonArrayMember, jsonObject} from "typedjson";
+
+@jsonObject
+export class BcfExtensionResource {
+
+  @jsonArrayMember(String)
+  topic_actions:string[];
+
+  @jsonArrayMember(String)
+  project_actions:string[];
+
+  @jsonArrayMember(String)
+  comment_actions:string[];
+}

--- a/frontend/src/app/modules/bim/bcf/api/projects/bcf-project.paths.ts
+++ b/frontend/src/app/modules/bim/bcf/api/projects/bcf-project.paths.ts
@@ -3,12 +3,15 @@ import {BcfApiRequestService} from "core-app/modules/bim/bcf/api/bcf-api-request
 import {BcfProjectResource} from "core-app/modules/bim/bcf/api/projects/bcf-project.resource";
 import {HTTPClientHeaders, HTTPClientParamMap} from "core-app/modules/hal/http/http.interfaces";
 import {BcfTopicCollectionPath} from "core-app/modules/bim/bcf/api/topics/bcf-viewpoint-collection.paths";
+import {BcfExtensionPaths} from "core-app/modules/bim/bcf/api/extensions/bcf-extension.paths";
 
 export class BcfProjectPaths extends BcfResourcePath {
   readonly bcfProjectService = new BcfApiRequestService(this.injector, BcfProjectResource);
 
   /** /topics */
   public readonly topics = new BcfTopicCollectionPath(this.injector, this.path, 'topics');
+
+  public readonly extensions = new BcfExtensionPaths(this.injector, this.path, 'extensions');
 
   get(params:HTTPClientParamMap = {}, headers:HTTPClientHeaders = {}) {
     return this.bcfProjectService.get(this.toPath(), params, headers);

--- a/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.html
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.html
@@ -17,7 +17,7 @@
       </ngx-gallery>
     </div>
 
-    <a *ngIf="viewerVisible"
+    <a *ngIf="viewerVisible && createAllowed"
        [title]="text.add_viewpoint"
        class="button"
        (click)="saveCurrentAsViewpoint()">

--- a/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.ts
@@ -22,6 +22,7 @@ import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixi
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
 import {BcfViewpointInterface} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.interface";
 import {WorkPackageCreateService} from "core-components/wp-new/wp-create.service";
+import {BcfExtensionResource} from "core-app/modules/bim/bcf/api/extensions/bcf-extension.resource";
 
 export interface ViewpointItem {
   /** The URL of the viewpoint, if persisted */
@@ -216,20 +217,20 @@ export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements
   }
 
   // Poor mans caching to avoid repeatedly fetching from the backend.
-  protected createAllowedMemoize = {};
+  protected createAllowedMemoize:{[key:string]:Promise<BcfExtensionResource>} = {};
 
   protected fetchCreateAllowed() {
-    if (!this.createAllowedMemoize[this.workPackage.project.idFromLink]) {
-      this.createAllowedMemoize[this.workPackage.project.idFromLink] = this.bcfApi
-        .projects.id(this.workPackage.project.idFromLink)
+    if (!this.createAllowedMemoize[this.wpProjectId]) {
+      this.createAllowedMemoize[this.wpProjectId] = this.bcfApi
+        .projects.id(this.wpProjectId)
         .extensions
         .get()
         .toPromise();
     }
 
-    this.createAllowedMemoize[this.workPackage.project.idFromLink]
+    this.createAllowedMemoize[this.wpProjectId]
       .then(resource => {
-        this.createAllowed = resource.topic_actions && resource.topic_actions.includes('createViewpoint')
+        this.createAllowed = resource.topic_actions && resource.topic_actions.includes('createViewpoint');
         this.cdRef.detectChanges();
       });
   }
@@ -238,7 +239,7 @@ export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements
     this.topicUUID = this.topicUUID || await this.createBcfTopic();
 
     return this.bcfApi
-      .projects.id(this.workPackage.project.idFromLink)
+      .projects.id(this.wpProjectId)
       .topics.id(this.topicUUID)
       .viewpoints
       .post(viewpoint)
@@ -265,7 +266,7 @@ export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements
 
   protected async createBcfTopic():Promise<string> {
     return this.bcfApi
-      .projects.id(this.workPackage.project.idFromLink)
+      .projects.id(this.wpProjectId)
       .topics
       .post(this.workPackage.convertBCF.payload)
       .toPromise()
@@ -320,5 +321,9 @@ export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements
         titleText: this.text.delete_viewpoint
       }
     ];
+  }
+
+  protected get wpProjectId() {
+    return this.workPackage.project.idFromLink;
   }
 }

--- a/lib/api/caching/cached_representer.rb
+++ b/lib/api/caching/cached_representer.rb
@@ -139,7 +139,7 @@ module API
         # to remove the cache_if option which would otherwise
         # be visible in the output
         def prepare_link_for(href, options)
-          super(href, options.except(:cache_if))
+          super(href, options.except(:cache_if, :uncacheable))
         end
 
         # Overriding Roar::Hypbermedia#combile_links_for

--- a/lib/api/decorators/linked_resource.rb
+++ b/lib/api/decorators/linked_resource.rb
@@ -46,6 +46,7 @@ module API
 
         representable_attrs.find_all do |dfn|
           next unless dfn[:linked_resource]
+
           name = dfn[:as] ? dfn[:as].(nil) : dfn.name
           fragment = copied_hash['_links'].delete(name)
           next unless fragment

--- a/modules/bim/spec/features/bcf/create_spec.rb
+++ b/modules/bim/spec/features/bcf/create_spec.rb
@@ -8,7 +8,7 @@ describe 'Create BCF', type: :feature, js: true, with_mail: false do
                       work_package_custom_fields: [integer_cf])
   end
   let(:index_page) { Pages::IfcModels::ShowDefault.new(project) }
-  let(:permissions) { %i[view_ifc_models manage_ifc_models view_linked_issues manage_bcf add_work_packages edit_work_packages view_work_packages] }
+  let(:permissions) { %i[view_ifc_models view_linked_issues manage_bcf add_work_packages edit_work_packages view_work_packages] }
   let!(:status) { FactoryBot.create(:default_status) }
   let!(:priority) { FactoryBot.create :priority, is_default: true }
 
@@ -32,7 +32,7 @@ describe 'Create BCF', type: :feature, js: true, with_mail: false do
   end
 
   shared_examples 'bcf details creation' do |with_viewpoints|
-    it 'can create a new bcf work package' do
+    it "can create a new #{with_viewpoints ? 'bcf' : 'plain' } work package" do
       create_page = index_page.create_wp_by_button(type)
       create_page.view_route = view_route
 
@@ -56,6 +56,8 @@ describe 'Create BCF', type: :feature, js: true, with_mail: false do
         # Expect no confirm dialog to be present
         create_page.delete_current_viewpoint
         create_page.expect_viewpoint_count 2
+      else
+        create_page.expect_no_viewpoint_addable
       end
 
       # switch the type
@@ -138,12 +140,12 @@ describe 'Create BCF', type: :feature, js: true, with_mail: false do
         expect(page).to have_current_path /\/bcf\/split\/details/, ignore_query: true
       end
 
-      it_behaves_like 'bcf details creation'
+      it_behaves_like 'bcf details creation', true
     end
   end
 
-  context 'without create work package permission' do
-    let(:permissions) { %i[view_ifc_models manage_ifc_models view_work_packages] }
+  context 'without add_work_packages permission' do
+    let(:permissions) { %i[view_ifc_models manage_bcf view_work_packages] }
 
     it 'has the create button disabled' do
       index_page.visit!

--- a/modules/bim/spec/features/bcf/create_spec.rb
+++ b/modules/bim/spec/features/bcf/create_spec.rb
@@ -32,7 +32,7 @@ describe 'Create BCF', type: :feature, js: true, with_mail: false do
   end
 
   shared_examples 'bcf details creation' do |with_viewpoints|
-    it "can create a new #{with_viewpoints ? 'bcf' : 'plain' } work package" do
+    it "can create a new #{with_viewpoints ? 'bcf' : 'plain'} work package" do
       create_page = index_page.create_wp_by_button(type)
       create_page.view_route = view_route
 

--- a/modules/bim/spec/features/bcf/create_spec.rb
+++ b/modules/bim/spec/features/bcf/create_spec.rb
@@ -152,4 +152,17 @@ describe 'Create BCF', type: :feature, js: true, with_mail: false do
       index_page.expect_wp_create_button_disabled
     end
   end
+
+  context 'with add_work_packages but without manage_bcf permission' do
+    let(:permissions) { %i[view_ifc_models view_work_packages add_work_packages] }
+
+    context 'on the split page' do
+      let(:view_route) { 'split' }
+      before do
+        index_page.visit!
+      end
+
+      it_behaves_like 'bcf details creation', false
+    end
+  end
 end

--- a/modules/bim/spec/support/components/bcf_details_viewpoints.rb
+++ b/modules/bim/spec/support/components/bcf_details_viewpoints.rb
@@ -28,9 +28,12 @@
 
 module Components
   module BcfDetailsViewpoints
-
     def expect_viewpoint_count(number)
       expect(page).to have_selector('.ngx-gallery-thumbnail', visible: :all, count: number, wait: 20)
+    end
+
+    def expect_no_viewpoint_addable
+      expect(page).to have_no_selector('a.button', text: 'Viewpoint')
     end
 
     def next_viewpoint


### PR DESCRIPTION
Introduces the extensions resource of the BCF API and employs it to check the users permission before displaying the "+ Viewpoint" button. 

Right now only the button is hidden but we might want to hide the whole section at least on create. But the same would apply to existing work packages without viewpoints which would result in an empty "BCF" attribute group. 

https://community.openproject.com/wp/32600 