### PR TITLE
Remove links to wp queries from release notes

### DIFF
--- a/docs/release-notes/3-0-0/README.md
+++ b/docs/release-notes/3-0-0/README.md
@@ -102,5 +102,4 @@ notes](https://www.ruby-lang.org/en/news/2013/12/25/ruby-2-1-0-is-released/)
 notes](http://guides.rubyonrails.org/v3.2.14/3_2_release_notes.html)
 
 If you have an older version of OpenProject, please follow the
-[migration
-guideline](http://openproject.org/projects/openproject/wiki/Migration_24_to_30).
+[migration guideline](https://docs.openproject.org/installation-and-operations/operation/upgrading/).

--- a/docs/release-notes/3-0-0/README.md
+++ b/docs/release-notes/3-0-0/README.md
@@ -9,8 +9,6 @@
 
 # OpenProject 3.0.0
 
- 
-
 ## New Design
 
   - Use of icon fonts
@@ -18,10 +16,6 @@
   - Contractible side navigation
   - New work package form
   - Design customization via Themes
-
-
-
- 
 
 ## Major Accessibility Improvements
 
@@ -31,18 +25,10 @@
   - Form elements linked to their labels
   - Screen reader support for multiple languages (English, German)
 
-
-
- 
-
 ## Keyboard Shortcuts for Power Users
 
   -  Implementation of keyboard shortcuts for power users
   - Shortcuts can be accessed by pressing “?” on the keyboard
-
-
-
- 
 
 ## Adaptive Timeline Reports
 
@@ -56,10 +42,6 @@
     longer supported)
   - Performance improvements
 
-
-
- 
-
 ## Improved Work Package Functionality
 
   - Auto-completion for work packages
@@ -68,19 +50,11 @@
   - Responible can be assigned via context menu and bulk edit
   - Easier navigation to work packages through shorter URL
 
-
-
- 
-
 ## Add work package queries as menu items to sidebar
 
   -  Frequently used work package queries can be added to the side
     navigation
   - Subsequently, query pages can be renamed or deleted
-
-
-
- 
 
 ## Copy projects based on Templates
 
@@ -88,18 +62,10 @@
     templates
   - Select different project settings to be copied (e.g. work packages)
 
-
-
- 
-
 ## Improved Project Settings
 
   - Improved member configuration
   - Improved and extended type configuration
-
-
-
- 
 
 ## Additional Account Security Features
 
@@ -111,16 +77,11 @@
     attempts
   - Automated logout on inactivity
 
-
-
  
 
 ## Substantial Number of Bug Fixes
 
 Many bugs have been fixed with the release of OpenProject 3.0.  
-For an extensive overview of bug fixes please refer to the [following
-list](http://openproject.org/projects/openproject/work_packages?query_id=236)
-
  
 
 ## Migration to Ruby 2.1 and Rails 3.2
@@ -143,5 +104,3 @@ notes](http://guides.rubyonrails.org/v3.2.14/3_2_release_notes.html)
 If you have an older version of OpenProject, please follow the
 [migration
 guideline](http://openproject.org/projects/openproject/wiki/Migration_24_to_30).
-
-

--- a/docs/release-notes/3-0-8/README.md
+++ b/docs/release-notes/3-0-8/README.md
@@ -22,7 +22,7 @@ will still answer while large projects are copied. Please bear in mind
 that for this to happen you need to have [delayed job
 running](https://github.com/collectiveidea/delayed_job).
 
-For a complete list of changes to OpenProject, please refere to the
+For a complete list of changes to OpenProject, please refer to the
 [version’s
 packages](https://community.openproject.com/projects/openproject/roadmap).
 
@@ -39,9 +39,6 @@ number. We therefore encourage you to always update OpenProject and
 installed plugins to the same release in synch. The most easy way of
 doing this is to follow the stable branches for every plugin and
 OpenProject.
-
-The complete list of changes you can benefit from can be [found in this
-query](http://openproject.org/projects/openproject/work_packages?query_id=350).
 
 We are aware that this change in versioning has some weird side effects.
 The most noticeable is the [costs

--- a/docs/release-notes/4-0-0/README.md
+++ b/docs/release-notes/4-0-0/README.md
@@ -23,10 +23,6 @@ easy integration with OmniAuth strategy providers such as Google.
   - Multiple authentication provider can be integrated and are shown in
     the login screen
 
-
-
- 
-
 ## Integrated toolbar on work package page
 
 OpenProject 4.0 replaces the old filter and options section on the work
@@ -45,10 +41,6 @@ more intuitive.
   - Two different views: Work package table and split-screen
   - Create new queries based on existing ones (Save as)
 
-
-
- 
-
 ## Integrated query title on work package page
 
 The query selection is now integrated in the work package title. Queries
@@ -57,10 +49,6 @@ are being persisted.
   - Title includes query selection
   - Auto-completion of queries is supported
   - Selected query is persisted
-
-
-
- 
 
 ## Column header functions in work package table
 
@@ -73,10 +61,6 @@ package table right on a column header.
   - Group by column attribute
   - Hide / Remove column
   - Add new column
-
-
-
- 
 
 ## Split screen mode added to work package page
 
@@ -95,10 +79,6 @@ allowing users to see the most important information at a glance.
   - “Watchers” tab to follow work package
   - “Attachments” tab showing attached documents
 
-
-
- 
-
 ## Improved design
 
 Several design changes have been made to improve the readability and
@@ -111,10 +91,6 @@ overall usability of OpenProject.
   - Changed headlines
   - Round avatars
 
-
-
- 
-
 ## Many accessibility improvements
 
 Numerous accessibility improvements – especially in the work package
@@ -125,10 +101,6 @@ page.
     work package split screen
   - Keyboard shortcuts and access key fully functional in work package
     page
-
-
-
- 
 
 ## New plugins released
 
@@ -145,8 +117,3 @@ page.
 
 A large number of bugs have been fixed with the release of OpenProject
 4.0.
-
-For an extensive overview of bug fixes please refer to the [following
-list](https://community.openproject.org/projects/openproject/work_packages?query_id=479).
-
-

--- a/docs/release-notes/4-2-0/README.md
+++ b/docs/release-notes/4-2-0/README.md
@@ -103,7 +103,4 @@ Please note that the API v3 is still a draft.
 A large number of bugs have been fixed with the release of OpenProject
 4.2.
 
-For an extensive overview of bug fixes please refer to the [following
-list](https://community.openproject.org/projects/openproject/work_packages?query_id=763).
-
 

--- a/docs/release-notes/4-2-0/README.md
+++ b/docs/release-notes/4-2-0/README.md
@@ -102,5 +102,3 @@ Please note that the API v3 is still a draft.
 
 A large number of bugs have been fixed with the release of OpenProject
 4.2.
-
-

--- a/docs/release-notes/5-0-0/README.md
+++ b/docs/release-notes/5-0-0/README.md
@@ -239,7 +239,4 @@ OpenProject Packager edition.
 A large number of bugs have been fixed with the release of OpenProject
 5.0.
 
-For an extensive overview of bug fixes please refer to the [following
-list](https://community.openproject.com/projects/openproject/work_packages?query_id=730&query_props=%7B%22c%22:%5B%22id%22,%22subject%22,%22type%22,%22status%22,%22assignee%22%5D,%22p%22:%22openproject%22,%22g%22:%22project%22,%22t%22:%22parent:desc%22,%22f%22:%5B%7B%22n%22:%22version%22,%22o%22:%22%253D%22,%22t%22:%22list_optional%22,%22v%22:%5B%22548%22%5D%7D,%7B%22n%22:%22subprojectId%22,%22o%22:%22*%22,%22t%22:%22list_subprojects%22%7D,%7B%22n%22:%22type%22,%22o%22:%22%253D%22,%22t%22:%22list_model%22,%22v%22:%5B%221%22%5D%7D%5D,%22pa%22:1,%22pp%22:20%7D).
-
 


### PR DESCRIPTION
[skip ci]

We currently have a large number of public work package queries. We link to some of them from our release notes:

https://github.com/opf/openproject/search?l=Markdown&q=work_packages%3Fquery_id%3D

We need a consistent solution for this.



