### PR TITLE
filter instance variable might not have been set first

### DIFF
--- a/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
+++ b/frontend/src/app/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
@@ -53,8 +53,6 @@ export class WorkPackageFilterByTextInputComponent implements OnDestroy {
     placeholder: this.I18n.t('js.work_packages.placeholder_filter_by_text')
   };
 
-  private filter:QueryFilterInstanceResource;
-
   /** Observable to the current search filter term */
   public searchTerm = input<string>('');
 
@@ -95,13 +93,13 @@ export class WorkPackageFilterByTextInputComponent implements OnDestroy {
           this.wpTableFilters.replace('search', filter => {
             filter.operator = filter.findOperator('**')!;
             filter.values = [term];
-
-            this.filter = filter;
           });
         } else {
-          this.wpTableFilters.remove(this.filter);
+          let filter = this.wpTableFilters.find('search');
 
-          this.deactivateFilter.emit(this.filter);
+          this.wpTableFilters.remove(filter!);
+
+          this.deactivateFilter.emit(filter);
         }
       });
   }


### PR DESCRIPTION
In case the search filter is cleared so fast, that the debounce does not take place, the instance variable `filter` (now removed) was never set. We now get the filter from the service directly and do not store it ourselves.

https://community.openproject.com/wp/32500