### PR TITLE
Fix/watcher filter reset

### DIFF
--- a/frontend/src/app/components/api/api-v3/api-v3-filter-builder.ts
+++ b/frontend/src/app/components/api/api-v3/api-v3-filter-builder.ts
@@ -58,8 +58,20 @@ export class ApiV3FilterBuilder {
       return this.serializeFilter(filter);
     });
 
-    let params = { filters: `[${transformedFilters.join(",")}]`, ...mergeParams }
+    let params = { filters: `[${transformedFilters.join(",")}]`, ...mergeParams };
     return new URLSearchParams(params).toString();
+  }
+
+  public clone() {
+    let newFilters = new ApiV3FilterBuilder();
+
+    this.filters.forEach(filter => {
+      Object.keys(filter).forEach(name => {
+        newFilters.add(name, filter[name].operator, filter[name].values);
+      });
+    });
+
+    return newFilters;
   }
 
   private serializeFilter(filter:ApiV3Filter) {

--- a/frontend/src/app/modules/common/autocomplete/user-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/user-autocompleter.component.ts
@@ -116,7 +116,9 @@ export class UserAutocompleterComponent implements OnInit {
   }
 
   public onFocus() {
-    this.requests.input$.next('');
+    if (!this.requests.lastRequestedValue) {
+      this.requests.input$.next('');
+    }
   }
 
   public onModelChange(user:any) {

--- a/frontend/src/app/modules/common/autocomplete/user-autocompleter.component.ts
+++ b/frontend/src/app/modules/common/autocomplete/user-autocompleter.component.ts
@@ -135,9 +135,11 @@ export class UserAutocompleterComponent implements OnInit {
   }
 
   private getAvailableUsers(url:string, searchTerm:any):Observable<{[key:string]:string|null}[]> {
-    let searchFilters = this.inputFilters;
+    // Need to clone the filters to not add additional filters on every
+    // search term being processed.
+    let searchFilters = this.inputFilters.clone();
 
-    if (searchTerm) {
+    if (searchTerm && searchTerm.length) {
       searchFilters.add('name', '~', [searchTerm]);
     }
 


### PR DESCRIPTION
The same filter instance was reused every time an input for the watchers autocompleter (or any user_autocompleter powered field) was processed. Now we clone the filters so that the problem no longer occurs.

https://community.openproject.com/wp/32666