### PR TITLE
[32665] Work package details view cut off on smaller screen

### DIFF
--- a/app/assets/stylesheets/layout/work_packages/_details_view.sass
+++ b/app/assets/stylesheets/layout/work_packages/_details_view.sass
@@ -32,8 +32,7 @@ body.router--work-packages-partitioned-split-view-details,
 body.router--work-packages-partitioned-split-view-new
 
   .work-packages-partitioned-page--content-right
-    overflow-x: hidden
-    overflow-y: auto
+    overflow: auto
     position: relative
     border-left: 2px solid #eee
     border-top: 2px solid #eee

--- a/app/assets/stylesheets/layout/work_packages/_mobile.sass
+++ b/app/assets/stylesheets/layout/work_packages/_mobile.sass
@@ -72,9 +72,6 @@
 @include breakpoint(1248px down)
   .router--work-packages-base
     // --------------- ALL WP VIEWS ---------------
-    .work-packages-tabletimeline--table-side
-      contain: none
-
     .toolbar-container
       padding-right: 0
 

--- a/app/assets/stylesheets/layout/work_packages/_table.sass
+++ b/app/assets/stylesheets/layout/work_packages/_table.sass
@@ -168,6 +168,9 @@
   #content
     height: 100%
 
+  .work-packages-partitioned-page--content-left
+    overflow: hidden
+
   .icon-button, .sort-header, .action-icon
     cursor: pointer
 

--- a/frontend/src/app/components/wp-card-view/styles/wp-card-view-horizontal.sass
+++ b/frontend/src/app/components/wp-card-view/styles/wp-card-view-horizontal.sass
@@ -1,6 +1,6 @@
 .wp-cards-container.-horizontal
   display: grid
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr))
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr))
   grid-column-gap: 10px
   grid-row-gap: 10px
   margin-right: 5px

--- a/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
+++ b/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
@@ -23,7 +23,6 @@
   .work-packages-partitioned-page--content-left,
   .work-packages-partitioned-page--content-right
     position: relative
-    min-width: 580px
 
   .work-packages-partitioned-page--content-left
     flex: 1

--- a/modules/bim/app/assets/stylesheets/bim/ifc_viewer/generic.sass
+++ b/modules/bim/app/assets/stylesheets/bim/ifc_viewer/generic.sass
@@ -56,6 +56,7 @@
   width: 100%
   height: 100%
   padding-bottom: 10px
+  min-width: 400px
 
 .ifc-model-viewer--model-canvas
   width: 100%


### PR DESCRIPTION
Remove `min-width` for generic left part of partitioned page. Thus the table can shrink as much as its want and the split screen is always visible. 
Since we don't want that for the model viewer, I added a `min-width` there that fits all toolbar buttons. In case the screen is smaller than the minimum width of viewer and split screen, there is  a scrollbar to reach the content.

https://community.openproject.com/projects/openproject/work_packages/32665/activity