### PR TITLE
[32670] Adding child work packages not possible

### DIFF
--- a/frontend/src/app/modules/work_packages/routing/split-view-routes.template.ts
+++ b/frontend/src/app/modules/work_packages/routing/split-view-routes.template.ts
@@ -116,7 +116,7 @@ export function makeSplitViewRoutes(baseRoute:string,
     // Split create route
     {
       name: baseRoute + '.new',
-      url: '/create_new?{type:[0-9]+}',
+      url: '/create_new?{type:[0-9]+}&{parent_id:[0-9]+}',
       reloadOnSearch: false,
       data: {
         partition: '-split',

--- a/spec/features/work_packages/table/context_menu_spec.rb
+++ b/spec/features/work_packages/table/context_menu_spec.rb
@@ -71,6 +71,7 @@ describe 'Work package table context menu', js: true do
         menu.choose('Create new child')
         expect(page).to have_selector('.inline-edit--container.subject input')
         expect(page).to have_selector('.inline-edit--field.type')
+        expect(current_url).to match(/.*\/create_new\?.*(\&)*parent_id=#{work_package.id.to_s}/)
 
         find('#work-packages--edit-actions-cancel').click
         expect(page).to have_no_selector('.inline-edit--container.subject input')


### PR DESCRIPTION
Add `parent_id` parameter to the create route again, to allow setting the parent directly.

https://community.openproject.com/projects/openproject/work_packages/32670/activity
