### PR TITLE
[32650] Usability bug: breadcrumbs do not follow usability best practices

### DIFF
--- a/app/assets/stylesheets/layout/_breadcrumb.sass
+++ b/app/assets/stylesheets/layout/_breadcrumb.sass
@@ -77,17 +77,6 @@ ul.breadcrumb
 
 #breadcrumb,
 .wp-breadcrumb
-  ul.breadcrumb li.first-breadcrumb-element
-    margin-left: 0
-    height: $breadcrumb-height
-    line-height: $breadcrumb-height
-    a
-      text-decoration: none
-      display: block
-      font-size: 12px
-
-#breadcrumb,
-.wp-breadcrumb
   ul.breadcrumb li
     float: left
     margin: 0 5px 0 0

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -30,12 +30,10 @@ See docs/COPYRIGHT.rdoc for more details.
 <%
   parent_node = admin_first_level_menu_entry
   if local_assigns[:additional_breadcrumb].nil?
-    breadcrumb_paths(t(:label_administration),
-                     parent_node.name == :root ? nil : parent_node.caption,
+    breadcrumb_paths(ActionController::Base.helpers.link_to(t(:label_administration), admin_index_path),
                      default_breadcrumb)
   else
-    breadcrumb_paths(t(:label_administration),
-                     parent_node.name == :root ? nil : parent_node.caption,
+    breadcrumb_paths(ActionController::Base.helpers.link_to(t(:label_administration), admin_index_path),
                      default_breadcrumb,
                      local_assigns[:additional_breadcrumb])
   end


### PR DESCRIPTION
Make every breadcrumb element (except current one) clickable.

https://community.openproject.com/projects/openproject/work_packages/32650/activity