### PR TITLE
Fix/wp budget assignment

### DIFF
--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -27,6 +27,10 @@
 #++
 
 require 'open_project/plugins'
+require_relative './patches/api/work_package_representer'
+require_relative './patches/api/work_package_schema_representer'
+require_relative './patches/api/work_package_sums_representer'
+require_relative './patches/api/work_package_sums_schema_representer'
 
 module OpenProject::Backlogs
   class Engine < ::Rails::Engine
@@ -133,100 +137,25 @@ module OpenProject::Backlogs
     patch_with_namespace :WorkPackages, :BaseContract
 
     config.to_prepare do
-      next if Versions::BaseContract.included_modules.include?(OpenProject::Backlogs::Patches::VersionBaseContractPatch)
+      next if Versions::BaseContract.included_modules.include?(OpenProject::Backlogs::Patches::Versions::BaseContractPatch)
 
-      Versions::BaseContract.prepend(OpenProject::Backlogs::Patches::VersionBaseContractPatch)
+      Versions::BaseContract.prepend(OpenProject::Backlogs::Patches::Versions::BaseContractPatch)
     end
 
-    extend_api_response(:v3, :work_packages, :work_package) do
-      property :position,
-               render_nil: true,
-               skip_render: ->(*) { !(backlogs_enabled? && type && type.passes_attribute_constraint?(:position)) }
+    extend_api_response(:v3, :work_packages, :work_package,
+                        &::OpenProject::Backlogs::Patches::API::WorkPackageRepresenter.extension)
 
-      property :story_points,
-               render_nil: true,
-               skip_render: ->(*) { !(backlogs_enabled? && type && type.passes_attribute_constraint?(:story_points)) }
+    extend_api_response(:v3, :work_packages, :work_package_payload,
+                        &::OpenProject::Backlogs::Patches::API::WorkPackageRepresenter.extension)
 
-      property :remaining_time,
-               exec_context: :decorator,
-               render_nil: true,
-               skip_render: ->(represented:, **) { !represented.backlogs_enabled? }
+    extend_api_response(:v3, :work_packages, :schema, :work_package_schema,
+                        &::OpenProject::Backlogs::Patches::API::WorkPackageSchemaRepresenter.extension)
 
-      # cannot use def here as it wouldn't define the method on the representer
-      define_method :remaining_time do
-        datetime_formatter.format_duration_from_hours(represented.remaining_hours,
-                                                      allow_nil: true)
-      end
+    extend_api_response(:v3, :work_packages, :schema, :work_package_sums_schema,
+                        &::OpenProject::Backlogs::Patches::API::WorkPackageSumsSchemaRepresenter.extension)
 
-      define_method :remaining_time= do |value|
-        remaining = datetime_formatter.parse_duration_to_hours(value,
-                                                               'remainingTime',
-                                                               allow_nil: true)
-        represented.remaining_hours = remaining
-      end
-    end
-
-    extend_api_response(:v3, :work_packages, :schema, :work_package_schema) do
-      schema :position,
-             type: 'Integer',
-             required: false,
-             writable: false,
-             show_if: ->(*) {
-               represented.project && represented.project.backlogs_enabled? &&
-                 (!represented.type || represented.type.passes_attribute_constraint?(:position))
-             }
-
-      schema :story_points,
-             type: 'Integer',
-             required: false,
-             show_if: ->(*) {
-               represented.project && represented.project.backlogs_enabled? &&
-                 (!represented.type || represented.type.passes_attribute_constraint?(:story_points))
-             }
-
-      schema :remaining_time,
-             type: 'Duration',
-             name_source: :remaining_hours,
-             required: false,
-             show_if: ->(*) { represented.project && represented.project.backlogs_enabled? }
-    end
-
-    extend_api_response(:v3, :work_packages, :schema, :work_package_sums_schema) do
-      schema :story_points,
-             type: 'Integer',
-             required: false,
-             show_if: ->(*) {
-               ::Setting.work_package_list_summable_columns.include?('story_points')
-             }
-
-      schema :remaining_time,
-             type: 'Duration',
-             name_source: :remaining_hours,
-             required: false,
-             writable: false,
-             show_if: ->(*) {
-               ::Setting.work_package_list_summable_columns.include?('remaining_hours')
-             }
-    end
-
-    extend_api_response(:v3, :work_packages, :work_package_sums) do
-      property :story_points,
-               render_nil: true,
-               if: ->(*) {
-                 ::Setting.work_package_list_summable_columns.include?('story_points')
-               }
-
-      property :remaining_time,
-               render_nil: true,
-               exec_context: :decorator,
-               getter: ->(*) {
-                 datetime_formatter.format_duration_from_hours(represented.remaining_hours,
-                                                               allow_nil: true)
-               },
-               if: ->(*) {
-                 ::Setting.work_package_list_summable_columns.include?('remaining_hours')
-               }
-    end
+    extend_api_response(:v3, :work_packages, :work_package_sums,
+                        &::OpenProject::Backlogs::Patches::API::WorkPackageSumsRepresenter.extension)
 
     add_api_attribute on: :work_package, ar_name: :story_points
     add_api_attribute on: :work_package, ar_name: :remaining_hours, writeable: ->(*) { model.leaf? }

--- a/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_representer.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_representer.rb
@@ -1,0 +1,69 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject::Backlogs
+  module Patches
+    module API
+      module WorkPackageRepresenter
+        module_function
+
+        # rubocop:disable Metrics/AbcSize
+        def extension
+          ->(*) do
+            property :position,
+                     render_nil: true,
+                     skip_render: ->(*) { !(backlogs_enabled? && type && type.passes_attribute_constraint?(:position)) }
+
+            property :story_points,
+                     render_nil: true,
+                     skip_render: ->(*) { !(backlogs_enabled? && type && type.passes_attribute_constraint?(:story_points)) }
+
+            property :remaining_time,
+                     exec_context: :decorator,
+                     render_nil: true,
+                     skip_render: ->(represented:, **) { !represented.backlogs_enabled? }
+
+            # cannot use def here as it wouldn't define the method on the representer
+            define_method :remaining_time do
+              datetime_formatter.format_duration_from_hours(represented.remaining_hours,
+                                                            allow_nil: true)
+            end
+
+            define_method :remaining_time= do |value|
+              remaining = datetime_formatter.parse_duration_to_hours(value,
+                                                                     'remainingTime',
+                                                                     allow_nil: true)
+              represented.remaining_hours = remaining
+            end
+          end
+        end
+        # rubocop:enable Metrics/AbcSize
+      end
+    end
+  end
+end

--- a/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_schema_representer.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_schema_representer.rb
@@ -1,0 +1,69 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject::Backlogs
+  module Patches
+    module API
+      module WorkPackageSchemaRepresenter
+        module_function
+
+        # rubocop:disable Metrics/AbcSize
+        def extension
+          ->(*) do
+            schema :position,
+                   type: 'Integer',
+                   required: false,
+                   writable: false,
+                   show_if: ->(*) {
+                     backlogs_constraint_passed?(:position)
+                   }
+
+            schema :story_points,
+                   type: 'Integer',
+                   required: false,
+                   show_if: ->(*) {
+                     backlogs_constraint_passed?(:story_points)
+                   }
+
+            schema :remaining_time,
+                   type: 'Duration',
+                   name_source: :remaining_hours,
+                   required: false,
+                   show_if: ->(*) { represented.project && represented.project.backlogs_enabled? }
+
+            define_method :backlogs_constraint_passed? do |attribute|
+              represented.project&.backlogs_enabled? &&
+                (!represented.type || represented.type.passes_attribute_constraint?(attribute))
+            end
+          end
+        end
+        # rubocop:enable Metrics/AbcSize
+      end
+    end
+  end
+end

--- a/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_sums_schema_representer.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_sums_schema_representer.rb
@@ -1,0 +1,57 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject::Backlogs
+  module Patches
+    module API
+      module WorkPackageSumsSchemaRepresenter
+        module_function
+
+        def extension
+          ->(*) do
+            schema :story_points,
+                   type: 'Integer',
+                   required: false,
+                   show_if: ->(*) {
+                     ::Setting.work_package_list_summable_columns.include?('story_points')
+                   }
+
+            schema :remaining_time,
+                   type: 'Duration',
+                   name_source: :remaining_hours,
+                   required: false,
+                   writable: false,
+                   show_if: ->(*) {
+                     ::Setting.work_package_list_summable_columns.include?('remaining_hours')
+                   }
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/backlogs/lib/open_project/backlogs/patches/versions/base_contract_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/versions/base_contract_patch.rb
@@ -1,0 +1,45 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject::Backlogs::Patches::Versions::BaseContractPatch
+  private
+
+  def user_allowed_to_manage
+    changed_settings = model.version_settings.select(&:changed?)
+
+    super unless !model.changed? && changed_settings.any?
+
+    # Make sure the version_settings (column=left|right|none) can only be stored
+    # for projects the user has the :manage_versions permission in.
+    changed_settings.each do |version_setting|
+      unless user.allowed_to?(:manage_versions, Project.find_by(id: version_setting.project_id))
+        errors.add :base, :error_unauthorized
+      end
+    end
+  end
+end

--- a/modules/costs/lib/open_project/costs/engine.rb
+++ b/modules/costs/lib/open_project/costs/engine.rb
@@ -242,6 +242,19 @@ module OpenProject::Costs
       end
     end
 
+    # This should not be necessary as the payload representer inherits
+    # from the work package representer. The patching probably happens after
+    # the payload representer is already evaluated.
+    extend_api_response(:v3, :work_packages, :work_package_payload) do
+      prepend API::V3::CostsApiUserPermissionCheck
+
+      associated_resource :cost_object,
+                          v3_path: :budget,
+                          link_title_attribute: :subject,
+                          representer: ::API::V3::Budgets::BudgetRepresenter,
+                          skip_render: ->(*) { !cost_object_visible? }
+    end
+
     extend_api_response(:v3, :work_packages, :schema, :work_package_schema) do
       # N.B. in the long term we should have a type like "Currency", but that requires a proper
       # format and not a string like "10 EUR"

--- a/modules/costs/lib/open_project/costs/engine.rb
+++ b/modules/costs/lib/open_project/costs/engine.rb
@@ -43,33 +43,32 @@ module OpenProject::Costs
                menu_item: :costs_setting
              },
              name: 'OpenProject Costs' do
-
       project_module :costs_module do
         permission :view_own_hourly_rate, {}
         permission :view_hourly_rates, {}
 
-        permission :edit_own_hourly_rate, { hourly_rates: [:set_rate, :edit, :update] },
+        permission :edit_own_hourly_rate, { hourly_rates: %i[set_rate edit update] },
                    require: :member
-        permission :edit_hourly_rates, { hourly_rates: [:set_rate, :edit, :update] },
+        permission :edit_hourly_rates, { hourly_rates: %i[set_rate edit update] },
                    require: :member
         permission :view_cost_rates, {} # cost item values
 
-        permission :log_own_costs, { costlog: [:new, :create] },
+        permission :log_own_costs, { costlog: %i[new create] },
                    require: :loggedin
-        permission :log_costs, { costlog: [:new, :create] },
+        permission :log_costs, { costlog: %i[new create] },
                    require: :member
 
-        permission :edit_own_cost_entries, { costlog: [:edit, :update, :destroy] },
+        permission :edit_own_cost_entries, { costlog: %i[edit update destroy] },
                    require: :loggedin
-        permission :edit_cost_entries, { costlog: [:edit, :update, :destroy] },
+        permission :edit_cost_entries, { costlog: %i[edit update destroy] },
                    require: :member
 
-        permission :view_cost_objects, { cost_objects: [:index, :show] }
+        permission :view_cost_objects, { cost_objects: %i[index show] }
 
-        permission :view_cost_entries, { cost_objects: [:index, :show], costlog: [:index] }
-        permission :view_own_cost_entries, { cost_objects: [:index, :show], costlog: [:index] }
+        permission :view_cost_entries, { cost_objects: %i[index show], costlog: [:index] }
+        permission :view_own_cost_entries, { cost_objects: %i[index show], costlog: [:index] }
 
-        permission :edit_cost_objects, { cost_objects: [:index, :show, :edit, :update, :destroy, :new, :create, :copy] }
+        permission :edit_cost_objects, { cost_objects: %i[index show edit update destroy new create copy] }
       end
 
       # Menu extensions
@@ -92,8 +91,7 @@ module OpenProject::Costs
       end
     end
 
-    patches [:Project, :User, :TimeEntry, :PermittedParams,
-             :ProjectsController, :ApplicationHelper]
+    patches %i[Project User TimeEntry PermittedParams ProjectsController ApplicationHelper]
     patch_with_namespace :WorkPackages, :BaseContract
     patch_with_namespace :API, :V3, :WorkPackages, :Schema, :SpecificWorkPackageSchema
     patch_with_namespace :BasicData, :RoleSeeder
@@ -162,7 +160,8 @@ module OpenProject::Costs
       link :logCosts,
            cache_if: -> {
              current_user_allowed_to(:log_costs, context: represented.project) ||
-               current_user_allowed_to(:log_own_costs, context: represented.project) } do
+               current_user_allowed_to(:log_own_costs, context: represented.project)
+           } do
         next unless represented.costs_enabled? && represented.persisted?
 
         {
@@ -173,8 +172,10 @@ module OpenProject::Costs
       end
 
       link :showCosts,
-           cache_if: -> { current_user_allowed_to(:view_cost_entries, context: represented.project) ||
-                          current_user_allowed_to(:view_own_cost_entries, context: represented.project) } do
+           cache_if: -> {
+             current_user_allowed_to(:view_cost_entries, context: represented.project) ||
+               current_user_allowed_to(:view_own_cost_entries, context: represented.project)
+           } do
         next unless represented.cost_reporting_enabled? && represented.persisted?
 
         {

--- a/modules/costs/spec/features/costs_edit_fields_spec.rb
+++ b/modules/costs/spec/features/costs_edit_fields_spec.rb
@@ -32,34 +32,36 @@ describe 'Work Package cost fields', type: :feature, js: true do
   let(:type_task) { FactoryBot.create(:type_task) }
   let!(:status) { FactoryBot.create(:status, is_default: true) }
   let!(:priority) { FactoryBot.create(:priority, is_default: true) }
-  let!(:project) {
-    FactoryBot.create(:project, types: [type_task])
-  }
+  let!(:project) { FactoryBot.create(:project, types: [type_task]) }
   let(:user) { FactoryBot.create :admin }
-  let(:budget) { FactoryBot.create :cost_object, author: user, project: project }
+  let!(:budget) { FactoryBot.create :cost_object, author: user, project: project }
 
-  let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
-  let(:split_create) { ::Pages::SplitWorkPackageCreate.new(project: project) }
+  let(:create_page) { ::Pages::FullWorkPackageCreate.new(project: project) }
+  let(:view_page) { ::Pages::FullWorkPackage.new(project: project) }
 
   before do
-    budget
     login_as(user)
   end
 
-  it 'does not show read-only fields' do
-    wp_table.visit!
-    wp_table.expect_no_work_package_listed
-
-    split_create.click_create_wp_button type_task
-    split_create.expect_fully_loaded
+  it 'does not show read-only fields and allows setting the cost object' do
+    create_page.visit!
 
     expect(page).to have_selector('.inline-edit--container.costObject')
     expect(page).to have_no_selector('.inline-edit--container.laborCosts')
     expect(page).to have_no_selector('.inline-edit--container.materialCosts')
     expect(page).to have_no_selector('.inline-edit--container.overallCosts')
 
-    field = split_create.edit_field(:costObject)
-    field.openSelectField
+    field = create_page.edit_field(:costObject)
     field.set_value budget.name
+    page.find('.ng-dropdown-panel .ng-option', text: budget.name).click
+
+    field = create_page.edit_field(:subject)
+    field.set_value 'Some subject'
+
+    create_page.save!
+
+    view_page.expect_notification(message: "Successful creation.")
+
+    view_page.edit_field(:costObject).expect_display_value budget.name
   end
 end

--- a/modules/costs/spec/lib/api/v3/work_packages/work_package_payload_representer_rendering_spec.rb
+++ b/modules/costs/spec/lib/api/v3/work_packages/work_package_payload_representer_rendering_spec.rb
@@ -1,0 +1,90 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter, 'rendering' do
+  include API::V3::Utilities::PathHelper
+
+  let(:work_package) do
+    FactoryBot.build_stubbed(:stubbed_work_package,
+                             start_date: Date.today.to_datetime,
+                             due_date: Date.today.to_datetime,
+                             created_at: DateTime.now,
+                             updated_at: DateTime.now,
+                             cost_object: cost_object,
+                             type: FactoryBot.build_stubbed(:type)) do |wp|
+    end
+  end
+
+  let(:cost_object) { FactoryBot.build_stubbed(:cost_object) }
+
+  let(:permissions) { %i(view_cost_objects edit_work_packages) }
+
+  let(:project) { work_package.project }
+
+  include_context 'user with stubbed permissions'
+
+  let(:representer) do
+    ::API::V3::WorkPackages::WorkPackagePayloadRepresenter
+      .create(work_package, current_user: user)
+  end
+
+  subject(:generated) { representer.to_json }
+
+  describe '_links' do
+    describe 'costObject' do
+      context 'without a cost object assigned' do
+        let(:cost_object) { nil }
+
+        it 'has an empty href' do
+          expect(subject)
+            .to be_json_eql(nil.to_json)
+            .at_path '_links/costObject/href'
+        end
+      end
+
+      context 'with a cost object assigned' do
+        it 'has an href to the cost object' do
+          expect(subject)
+            .to be_json_eql(api_v3_paths.budget(cost_object.id).to_json)
+            .at_path '_links/costObject/href'
+        end
+      end
+
+      context 'without necessary permissions' do
+        let(:permissions) { %i(edit_work_packages) }
+
+        it 'has no href' do
+          expect(subject)
+            .not_to have_json_path('_links/costObject')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Readd a costObject link to the wp payload representer. Without it, the frontend will no know where to place an assigned budget and will treat is as a property. This then fails.

https://community.openproject.com/wp/32732 