### PR TITLE
[32736] Pressing search keyboard shortcut in viewer causes weird effects

### DIFF
--- a/frontend/src/app/modules/a11y/keyboard-shortcut-service.ts
+++ b/frontend/src/app/modules/a11y/keyboard-shortcut-service.ts
@@ -102,7 +102,7 @@ export class KeyboardShortcutService {
       if (elem.is('input') || elem.attr('id') === 'global-search-input') {
         // timeout with delay so that the key is not
         // triggered on the input
-        setTimeout( () => this.FocusHelper.focus(elem), 0);
+        setTimeout( () => this.FocusHelper.focus(elem), 200);
       } else if (elem.is('[href]')) {
         this.clickLink(elem[0]);
       } else {


### PR DESCRIPTION
Delay the search opening to avoid that the BIM model viewer movement is triggered. To be honest, I have no idea why they interfere with each other anyway.

https://community.openproject.com/projects/openproject/work_packages/32736/activity