### PR TITLE
resilient grid text textile conversion

### DIFF
--- a/modules/overviews/lib/overviews/patches/textile_converter_patch.rb
+++ b/modules/overviews/lib/overviews/patches/textile_converter_patch.rb
@@ -12,6 +12,9 @@ module Overviews::Patches
 
     module Patch
       def convert_custom_text_widgets
+        # If the table does not exist yet, there is nothing to convert
+        return unless Grids::Overview.table_exists?
+
         print Grids::Overview.name
 
         text_widgets_to_convert


### PR DESCRIPTION
In case the Grids::Overview table does not exist yet, the textile converion can simply ignore them.

https://community.openproject.com/projects/openproject/work_packages/31567