### PR TITLE
Dynamically set the deployURL that loads webpack assets

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -15,7 +15,6 @@
             "preserveSymlinks": true,
             "aot": true,
             "outputPath": "../public/assets/frontend/",
-            "deployUrl": "/assets/frontend/",
             "index": "src/index2.html",
             "main": "src/main.ts",
             "tsConfig": "src/tsconfig.app.json",

--- a/frontend/src/app/init-globals.ts
+++ b/frontend/src/app/init-globals.ts
@@ -30,6 +30,11 @@ import {whenDebugging} from 'core-app/helpers/debug_output';
 import {enableReactiveStatesLogging} from "reactivestates";
 import 'hammerjs';
 
+// Ensure we set the correct dynamic frontend path
+// based on the RAILS_RELATIVE_URL_ROOT setting
+// https://webpack.js.org/guides/public-path/
+const ASSET_BASE_PATH = '/assets/frontend/';
+
 // Global scripts previously part of the application.js
 // Avoid require.context since that crashes angular regularly
 require('./globals/augmenting/modal-wrapper.augment.service');
@@ -38,7 +43,12 @@ require('./globals/global-listeners');
 require('./globals/openproject');
 require('./globals/tree-menu');
 
+// Sets the relative base path
 window.appBasePath = jQuery('meta[name=app_base_path]').attr('content') || '';
+
+// Ensure to set the asset base for dynamic code loading
+// https://webpack.js.org/guides/public-path/
+__webpack_public_path__ = window.appBasePath + ASSET_BASE_PATH;
 
 const meta = jQuery('meta[name=openproject_initializer]');
 I18n.locale = meta.data('defaultLocale');


### PR DESCRIPTION
Webpack allows us to set the prefix that dynamically loaded code stems from. Previously we set this statically, but this fails for users with `RAILS_RELATIVE_URL_ROOT` set and those that did not recompile angular assets. This wasn't an issue up until we removed node from the packages to drastically reduce size. This means users cannot easily recompile angular (or would have to install the node dependencies first).

Steps to reproduce locally:

- Compile assets for production with `SECRET_TOKEN=foobar SECRET_KEY_BASE=foobar RAILS_ENV=production bundle exec rake assets:precompile`

- Change the `rails_relative_url_root` in configuration.yml or through ENV to e.g., `/foobar`

- Recompile for rails (this is what happens with packager after setting a relative URL root) `RECOMPILE_RAILS_ASSETS=true RECOMPILE_ANGULAR_ASSETS=false SECRET_TOKEN=foobar SECRET_KEY_BASE=foobar RAILS_ENV=production bundle exec rake assets:precompile`

- Start the rails server in production: ` RAILS_MIN_THREADS=8 RAILS_MAX_THREADS=8 RAILS_LOG_TO_STDOUT=true OPENPROJECT_LOG__LEVEL=debug RAILS_SERVE_STATIC_FILES=true SECRET_TOKEN=foobar SECRET_KEY_BASE=foobar RAILS_ENV=production bundle exec rails s`

- Go to the wiki page and try to add a code block. Observe the error in the console

https://community.openproject.com/projects/openproject/work_packages/29010