### PR TITLE
Set asset path in service configuration

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -63,6 +63,7 @@
           "options": {
             "browserTarget": "OpenProject:build",
             "proxyConfig": "cli_to_rails_proxy.js",
+            "deployUrl": "/assets/frontend/",
             "aot": true
           },
           "configurations": {


### PR DESCRIPTION
The webpack server no longer has a static deployUrl, so the assets were
just under `/` in develoment mode. If we set the deployUrl in serve
only, the path is identitical in both cases