### PR TITLE
[31472] Copy all messages in project forum, faster using pluck_all

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,10 @@ gem 'htmldiff'
 # Generate url slugs with #to_url and other string niceties
 gem 'stringex', '~> 2.8.5'
 
+# Faster pluck to hash to avoid Rails object initialization
+# when bulk selecting
+gem 'pluck_all', '~> 2.0.4'
+
 # CommonMark markdown parser with GFM extension
 gem 'commonmarker', '~> 0.21.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -675,6 +675,8 @@ GEM
       activesupport (> 2.2.1)
       nokogiri (~> 1.10, >= 1.10.4)
       rubyzip (~> 1.3.0)
+    pluck_all (2.0.4)
+      activesupport (>= 3.0.0)
     posix-spawn (0.3.13)
     prawn (2.2.2)
       pdf-core (~> 0.7.0)
@@ -1056,6 +1058,7 @@ DEPENDENCIES
   passenger (~> 6.0.1)
   pg (~> 1.2.2)
   plaintext (~> 0.3.2)
+  pluck_all (~> 2.0.4)
   posix-spawn (~> 0.3.13)
   prawn (~> 2.2)
   prawn-markup (~> 0.2.1)
@@ -1125,4 +1128,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/spec/models/project/copy_spec.rb
+++ b/spec/models/project/copy_spec.rb
@@ -561,9 +561,9 @@ describe Project::Copy, type: :model, with_mail: false do
           copy.save
         end
 
-        it 'should copy topics without replies' do
+        it 'should copy topics WITH replies' do
           expect(copy.forums.first.topics.count).to eq(project.forums.first.topics.count)
-          expect(copy.forums.first.messages.count).not_to eq(project.forums.first.messages.count)
+          expect(copy.forums.first.messages.count).to eq(project.forums.first.messages.count)
         end
       end
     end


### PR DESCRIPTION
Only the topics, not the messages where copied. We can do all that in a single query with `pluck_all` fetching only raw data, not initializing any objects until saving.


https://community.openproject.com/wp/31472