### PR TITLE
Add --clean option to pg-restore

### DIFF
--- a/docs/installation-and-operations/misc/migration/README.md
+++ b/docs/installation-and-operations/misc/migration/README.md
@@ -60,7 +60,7 @@ First the dump has to be extracted (unzipped) and then restored. The command use
 
 ```
 # Restore the PostgreSQL dump
-pg_restore -h <dbhost> -u <dbuser> -W <dbname> postgresql-dump-20180408095521.pgdump
+pg_restore -h <dbhost> -u <dbuser> -W <dbname> --clean postgresql-dump-20180408095521.pgdump
 ```
 
 


### PR DESCRIPTION
This page guides the user to a complete re-install of the database.

If due to some error (an example ERROR: invalid byte sequence for encoding "UTF8") you have to repeat the operation, it is frequent to come across the problem of the contents already present in the database, with different errors, for example:
 - could not execute query: ERROR: relation "..." already exists
 - could not execute query: ERROR: constraint "..." already exists

The use of the "clean" option allows to operate avoiding these errors.

From the guide of pg-restore:
--clean
 Clean (drop) database objects before recreating them. (Unless --if-exists is used, this might generate some harmless error messages, if any objects were not present in the destination database.)

Thank you,
Riccardo