### PR TITLE
Handle missing viewpoint_names and make snapshot filename unique

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -153,6 +153,13 @@ class Attachment < ActiveRecord::Base
     attributes['file']
   end
 
+  ##
+  # Returns the file extension name,
+  # if any (with leading dot)
+  def extension
+    File.extname filename
+  end
+
   def file=(file)
     super.tap do
       set_file_size file

--- a/modules/bim/lib/open_project/bim/bcf_xml/exporter.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/exporter.rb
@@ -127,8 +127,8 @@ module OpenProject::Bim::BcfXml
     def viewpoints_for(issue_dir, issue)
       [].tap do |files|
         issue.viewpoints.find_each do |vp|
-          vp_file = File.join(issue_dir, vp.viewpoint_name)
-          snapshot_file = File.join(issue_dir, vp.snapshot.filename)
+          vp_file = File.join(issue_dir, "#{vp.uuid}.xml")
+          snapshot_file = File.join(issue_dir, "#{vp.uuid}#{vp.snapshot.extension}")
 
           # Copy the files
           dump_file vp_file, ViewpointWriter.new(vp).to_xml


### PR DESCRIPTION
Frontend created snapshots may not have a `viewpoint_name` property, which is currently being used in the XML exporter.

It's better to export viewpoints with a unique name however, so I suggest we use the viewpoint UUID + .xml for the XML data, and UUID + .png (or whatever extension) for the associated snapshot.