### PR TITLE
[31920] Wiki tables not responsive

### DIFF
--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -63,7 +63,10 @@ div.wiki
 
     td, th
       border: 1px solid #bbb
-      padding: 4px
+
+    th
+      background: rgba(0, 0, 0, 0.05)
+      padding: 10px
 
   // ------------------- LISTINGS -------------------
   ul.toc
@@ -141,12 +144,16 @@ h1:hover, h2:hover, h3:hover
     max-width: 100%
 
 .wiki.wiki-content
+  overflow: auto
   overflow-wrap: break-word
   word-wrap: break-word
+  @include styled-scroll-bar
 
 .wiki--content--attribute
   .form--field-container
     max-width: 100%
+  .form--text-area-container
+    overflow: hidden
 
 #wiki_page_parent_id
   overflow: auto


### PR DESCRIPTION
* Style wiki table headers to look more like in the editor
* Make the wiki editor content scrollable when the table is long
* Make the wiki page content scrollable when the table is long

https://community.openproject.com/projects/openproject/work_packages/31920/activity