### PR TITLE
[32486] Use error response for unauthenticated instead of warden

### DIFF
--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -66,9 +66,7 @@ module API
       end
 
       def authenticate
-        warden.authenticate! scope: authentication_scope
-
-        User.current = warden.user scope: authentication_scope
+        User.current = warden.authenticate! scope: authentication_scope
 
         if Setting.login_required? and not logged_in?
           raise ::API::Errors::Unauthenticated

--- a/lib/open_project/authentication/failure_app.rb
+++ b/lib/open_project/authentication/failure_app.rb
@@ -20,7 +20,7 @@ module OpenProject
             handle_failure warden
           end
         else
-          unauthorized
+          unauthorized env
         end
       end
 
@@ -32,8 +32,8 @@ module OpenProject
         [warden.status || 401, warden.headers, [warden.message]]
       end
 
-      def unauthorized
-        [401, {}, ['unauthorized']]
+      def unauthorized(env)
+        [401, unauthorized_header(env), ['unauthorized']]
       end
 
       def warden(env)
@@ -42,6 +42,13 @@ module OpenProject
 
       def warden_options(env)
         Hash(env['warden.options'])
+      end
+
+      def unauthorized_header(env)
+        header = OpenProject::Authentication::WWWAuthenticate
+          .response_header(scope: scope(env), request_headers: env)
+
+        { 'WWW-Authenticate' => header }
       end
 
       def scope(env)

--- a/lib/open_project/authentication/strategies/warden/anonymous_fallback.rb
+++ b/lib/open_project/authentication/strategies/warden/anonymous_fallback.rb
@@ -26,7 +26,7 @@ module OpenProject
           ##
           # Always valid unless session based. We are using it as a fallback after all.
           def valid?
-            !session
+            session&.id.nil?
           end
 
           def authenticate_user(_username, _password)

--- a/spec/requests/api/v3/authentication_spec.rb
+++ b/spec/requests/api/v3/authentication_spec.rb
@@ -109,6 +109,32 @@ describe API::V3, type: :request do
           end
         end
 
+        context 'with no credentials' do
+          let(:expected_message) { 'You need to be authenticated to access this resource.' }
+
+          before do
+            post '/api/v3/time_entries/form'
+          end
+
+          it 'should return 401 unauthorized' do
+            expect(last_response.status).to eq 401
+          end
+
+          it 'should return the correct JSON response' do
+            expect(JSON.parse(last_response.body)).to eq response_401
+          end
+
+          it 'should return the correct content type header' do
+            expect(last_response.headers['Content-Type']).to eq 'application/hal+json; charset=utf-8'
+          end
+
+
+          it 'should return the WWW-Authenticate header' do
+            expect(last_response.header['WWW-Authenticate'])
+              .to include 'Basic realm="OpenProject API"'
+          end
+        end
+
         context 'with invalid credentials an X-Authentication-Scheme "Session"' do
           let(:expected_message) { 'You did not provide the correct credentials.' }
 


### PR DESCRIPTION
Instead of warden responding with 401 "unauthorized", use our own error response that correctly sets the `WWWW-Authenticate` header.
