### PR TITLE
Fix/zeitwerk for gems

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -63,7 +63,7 @@ if db_adapter&.start_with? 'mysql'
   warn <<~ERROR
     ======= INCOMPATIBLE DATABASE DETECTED =======
     Your database is set up for use with a MySQL or MySQL-compatible variant.
-    This installation of OpenProject 10.0. no longer supports these variants.
+    This installation of OpenProject no longer supports these variants.
 
     The following guides provide extensive documentation for migrating
     your installation to a PostgreSQL database:

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -1,7 +1,8 @@
 require Rails.root.join('config/constants/open_project/inflector')
 
 OpenProject::Inflector.rule do |_, abspath|
-  if abspath.match?(/open_project\/version(\.rb)?\z/)
+  if abspath.match?(/open_project\/version(\.rb)?\z/) ||
+    abspath.match?(/lib\/open_project\/\w+\/version(\.rb)?\z/)
     "VERSION"
   end
 end
@@ -34,6 +35,16 @@ OpenProject::Inflector.rule do |basename, abspath|
   end
 end
 
+# Instruct zeitwerk to 'ignore' all the engine gems' lib initialization files.
+# As it is complicated to return all the paths where such an initialization file might exist,
+# we simply return the general OpenProject namespace for such files.
+OpenProject::Inflector.rule do |_basename, abspath|
+  if abspath =~ /openproject-\w+\/lib\/openproject-\w+.rb\z/ ||
+    abspath =~ /modules\/\w+\/lib\/openproject-\w+.rb\z/
+    'OpenProject'
+  end
+end
+
 OpenProject::Inflector.inflection(
   'api' => 'API',
   'rss' => 'RSS',
@@ -52,9 +63,6 @@ Rails.autoloaders.each do |autoloader|
   autoloader.inflector = OpenProject::Inflector.new(__FILE__)
 end
 
-# Instruct zeitwerk to ignore all the engine gems' lib initialization files
-Rails.autoloaders.main.ignore(Rails.root.join('modules/*/lib/openproject-*.rb'))
-Rails.autoloaders.main.ignore(Rails.root.join('vendor/plugins/*/lib/openproject-*.rb'))
 Rails.autoloaders.main.ignore(Rails.root.join('lib/plugins'))
 Rails.autoloaders.main.ignore(Rails.root.join('lib/open_project/patches'))
 Rails.autoloaders.main.ignore(Rails.root.join('lib/generators'))


### PR DESCRIPTION
Gems need to have a file following the pattern `lib/<gemname>.rb` which in the case of our plugin gems only contains a require statement. And as our plugins follow the naming convention `openproject-<whatever it does>`, it is not possible to simply add a class/module to that file (e.g. `openproject-csv_export` would require a module named `Openproject-csvExport` which is an invalid module name.

Zeitwerk thus needs to ignore those files. Before, all the files in certain directories where ignored. But as the gems can also be bundled by path, this does not always work. Therefore, such files are now inflected to the generic `OpenProject` namespace which however is also provided elsewhere. Admittedly, this is a hack. But it works.