### PR TITLE
[26684] Redirect to WP from search only with #ID match on enter

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -31,8 +31,7 @@ class SearchController < ApplicationController
   include Layout
 
   before_action :find_optional_project,
-                :prepare_tokens,
-                :quick_wp_id_redirect
+                :prepare_tokens
 
   LIMIT = 10
 
@@ -61,12 +60,6 @@ class SearchController < ApplicationController
 
     unless @tokens.any?
       @question = ''
-    end
-  end
-
-  def quick_wp_id_redirect
-    scan_work_package_reference @question do |id|
-      redirect_to work_package_path(id: id) if WorkPackage.visible.find_by(id: id)
     end
   end
 
@@ -106,10 +99,6 @@ class SearchController < ApplicationController
     tokens.slice! 5..-1 if tokens.size > 5
 
     tokens
-  end
-
-  def scan_work_package_reference(query, &blk)
-    query.match(/\A#?(\d+)\z/) && ((blk&.call($1.to_i)) || true)
   end
 
   def search_params

--- a/frontend/src/app/modules/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/modules/global_search/input/global-search-input.component.html
@@ -12,7 +12,8 @@
               id="global-search-input"
               placeholder="{{text.search_dots}}"
               accesskey="4"
-              [ngClass]="'top-menu-search--input'"
+              [ngClass]="{'top-menu-search--input': true, '-markable': markable }"
+              [(ngModel)]="selectedItem"
               [class.-expanded]="expanded"
               [openOnEnter]="false"
               [searchFn]="customSearchFn"
@@ -23,13 +24,13 @@
               (search)="search($event)"
               (open)="openCloseMenu(currentValue)"
               (close)="select.searchTerm = currentValue"
-              (change)="onChange($event)"
+              (change)="followSelectedItem()"
               (keydown.enter)="onEnterBeforeResultsLoaded()"
               (keydown.escape)="blur()"
               (clear)="clearSearch()">
         <ng-template ng-option-tmp let-item="item" let-index="index" let-search="searchTerm">
           <div *ngIf="!item.id; else workPackageItemTemplate">
-            <div tabindex="-1" class="global-search--option">
+            <div tabindex="-1" class="global-search--option"(click)="followItem(item)">
               <div class="global-search--option-wrapper">
                 <span class="global-search--search-term"> {{currentValue}} </span>
                 <span class="global-search--project-scope" title="{{item.projectScope}}"> {{item.text}} ↵ </span>
@@ -37,9 +38,8 @@
             </div>
           </div>
           <ng-template #workPackageItemTemplate>
-            <div tabindex="-1" class="global-search--option">
+            <div tabindex="-1" class="global-search--option" (click)="redirectToWp(item.id, $event)">
               <a class="global-search--option-wrapper"
-                 (click)="redirectToWp(item.id, $event)"
                  [href]="wpPath(item.id)">
                 <span class="global-search--wp-id"
                       title="{{item.status}}"

--- a/frontend/src/app/modules/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/modules/global_search/input/global-search-input.component.sass
@@ -75,25 +75,36 @@ $search-input-height: 30px
       input
         color: var(--header-search-field-font-color)
 
-      .scroll-host
-        @include styled-scroll-bar
-        max-height: 80vh
-        height: auto
+    .scroll-host
+      @include styled-scroll-bar
+      max-height: 80vh
+      height: auto
 
-        .ng-option
-          border-bottom: 1px solid #EAEAEA
-          white-space: normal
-          padding: 5px 10px
-          &:last-child
-            border-bottom: none
-          &.ng-option-marked
-            background-color: var(--drop-down-hover-bg-color)
-            color: var(--header-drop-down-item-font-hover-color)
-          &.ng-option-disabled
-            display: none
-          &.ng-option-selected
-            background-color: var(--drop-down-selected-bg-color)
-            color: var(--header-drop-down-item-font-hover-color)
+    .ng-option
+      border-bottom: 1px solid #EAEAEA
+      white-space: normal
+      padding: 5px 10px
+      // We do not want the default highlighting of ng-select to take place as
+      // it will highlight the element last hovered over/navigated to even
+      // though the selection might have changed in the meantime.
+      // We either want to mark the first element or, in case of a direct hit (by the wp id)
+      // we want to highlight that hit.
+      background-color: unset
+      &:last-child
+        border-bottom: none
+      &.ng-option-marked
+        color: var(--header-drop-down-item-font-hover-color)
+      &.ng-option-disabled
+        display: none
+      &.ng-option-selected
+        color: var(--header-drop-down-item-font-hover-color)
+
+    &.-markable
+      .ng-option
+        &.ng-option-marked
+          background-color: var(--drop-down-hover-bg-color)
+        &.ng-option-selected
+          background-color: var(--drop-down-selected-bg-color)
 
 .global-search--wp-id
   color: var(--gray-dark)

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -29,58 +29,58 @@
 require 'spec_helper'
 
 describe SearchController, type: :controller do
-  let!(:project) do
+  shared_let(:project) do
     FactoryBot.create(:project,
                       name: 'eCookbook')
   end
 
-  let!(:other_project) do
+  shared_let(:other_project) do
     FactoryBot.create(:project,
                       name: 'Other project')
   end
 
-  let!(:subproject) do
+  shared_let(:subproject) do
     FactoryBot.create(:project,
                       name: 'Child project',
                       parent: project)
   end
 
-  let(:role) do
+  shared_let(:role) do
     FactoryBot.create(:role, permissions: %i[view_wiki_pages view_work_packages])
   end
 
-  let(:user) do
+  shared_let(:user) do
     FactoryBot.create(:user,
                       member_in_projects: [project, subproject],
                       member_through_role: role)
   end
 
-  let!(:wiki_page) do
+  shared_let(:wiki_page) do
     FactoryBot.create(:wiki_page,
                       title: "How to solve an issue",
                       wiki: project.wiki)
   end
 
-  let!(:work_package_1) do
+  shared_let(:work_package_1) do
     FactoryBot.create(:work_package,
                       subject: 'This is a test issue',
                       project: project)
   end
 
-  let!(:work_package_2) do
+  shared_let(:work_package_2) do
     FactoryBot.create(:work_package,
                       subject: 'Issue test 2',
                       project: project,
                       status: FactoryBot.create(:closed_status))
   end
 
-  let!(:work_package_3) do
+  shared_let(:work_package_3) do
     FactoryBot.create(:work_package,
                       subject: 'Issue test 3',
                       project: subproject)
   end
 
-  let!(:work_package_4) do
+  shared_let(:work_package_4) do
     FactoryBot.create(:work_package,
                       subject: 'Issue test 4',
                       project: other_project)
@@ -107,14 +107,6 @@ describe SearchController, type: :controller do
         end
 
         it_behaves_like 'successful search'
-      end
-
-      context 'is a work package reference' do
-        let!(:work_package) { FactoryBot.create :work_package, project: project }
-
-        subject { get :index, params: { q: "##{work_package.id}" } }
-
-        it { is_expected.to redirect_to work_package }
       end
     end
   end
@@ -268,46 +260,6 @@ describe SearchController, type: :controller do
           let(:query) { 'hello "fallen world" something-hyphenated' }
 
           it { is_expected.to eq ['hello', 'fallen world', 'something-hyphenated'] }
-        end
-      end
-    end
-
-    describe '#scan_work_package_reference' do
-      subject { @controller.send(:scan_work_package_reference, query) }
-
-      context 'with normal query' do
-        let(:query) { 'lorem' }
-
-        it { is_expected.to be nil }
-      end
-
-      context 'with work package reference' do
-        let(:query) { '#4123' }
-
-        it { is_expected.not_to be nil }
-
-        describe 'captures' do
-          let!(:check_block) { Proc.new { |id| @work_package_id = id } }
-
-          it 'block gets called' do
-            # NOTE: this is how it is favored to do in RSpec3
-            # expect(check_block).to receive :call
-            # but we have only RSpec2 here, so:
-            expect(check_block).to receive :call
-            @controller.send(:scan_work_package_reference, query, &check_block)
-          end
-
-          it 'id inside of block is work package id' do
-            @controller.send(:scan_work_package_reference, query, &check_block)
-
-            expect(@work_package_id.to_i).to eq 4123
-          end
-        end
-
-        context 'and with additional text' do
-          let(:query) { '#4123 and some text' }
-
-          it { is_expected.to be nil }
         end
       end
     end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -75,6 +75,8 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
     end
   end
 
+  let(:global_search) { ::Components::GlobalSearch.new }
+
   let(:query) { 'Subject' }
 
   let(:params) { [project, { q: query }] }
@@ -100,49 +102,66 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
     let!(:other_work_package) { FactoryBot.create(:work_package, subject: 'Other work package', project: project) }
 
     it 'provides suggestions' do
-      suggestions = search_autocomplete(page.find('.top-menu-search--input'),
-                                        query: query)
+      global_search.search(query, submit: false)
+
       # Suggestions shall show latest WPs first.
-      expect(suggestions).to have_text('No. 11 WP', wait: 10)
+      global_search.expect_work_package_option(work_packages[11])
       #  and show maximum 10 suggestions.
-      expect(suggestions).to_not have_text('No. 1 WP')
+      global_search.expect_work_package_option(work_packages[2])
+      global_search.expect_no_work_package_option(work_packages[1])
       # and unrelated work packages shall not get suggested
-      expect(suggestions).to_not have_text(other_work_package.subject)
+      global_search.expect_no_work_package_option(other_work_package)
 
       target_work_package = work_packages.last
 
-      # Expect redirection when WP is selected from results
-      select_autocomplete(page.find('.top-menu-search--input'),
-                          query: target_work_package.subject,
-                          select_text: "##{target_work_package.id}")
+      # If no direct match is available, the first option is marked
+      global_search.expect_in_project_and_subproject_scope_marked
 
-      sleep 1
+      # Expect redirection when WP is selected from results
+      global_search.search(target_work_package.subject, submit: false)
+
+      # Even though there is a work package named the same, we did not search by id
+      # and thus the work package is not selected.
+      global_search.expect_in_project_and_subproject_scope_marked
+
+      # But we can open it by clicking
+      global_search.click_work_package(target_work_package)
+
+      expect(page)
+        .to have_selector('.subject', text: target_work_package.subject)
 
       expect(current_path).to eql project_work_package_path(target_work_package.project, target_work_package, state: 'activity')
 
       first_wp = work_packages.first
 
       # Typing a work package id shall find that work package
-      suggestions = search_autocomplete(page.find('.top-menu-search--input'),
-                                        query: first_wp.id.to_s)
-      expect(suggestions).to have_text('No. 1 WP', wait: 10)
+      global_search.search(first_wp.id.to_s, submit: false)
+
+      # And it shall be marked as the direct hit.
+      global_search.expect_work_package_marked(first_wp)
+
+      # And the direct hit is opened when enter is pressed
+      global_search.submit_with_enter
+
+      expect(page)
+        .to have_selector('.subject', text: first_wp.subject)
+
+      expect(current_path).to eql project_work_package_path(first_wp.project, first_wp, state: 'activity')
 
       # Typing a hash sign before an ID shall only suggest that work package and (no hits within the subject)
-      suggestions = search_autocomplete(page.find('.top-menu-search--input'),
-                                        query: "##{first_wp.id}")
-      expect(suggestions).to have_text("Subject", count: 1)
+      global_search.search("##{first_wp.id}", submit: false)
+
+      global_search.expect_work_package_marked(first_wp)
 
       # Expect to have 3 project scope selecting menu entries
-      expect(suggestions).to have_text('In this project ↵')
-      expect(suggestions).to have_text('In this project + subprojects ↵')
-      expect(suggestions).to have_text('In all projects ↵')
+      global_search.expect_scope('In this project ↵')
+      global_search.expect_scope('In this project + subprojects ↵')
+      global_search.expect_scope('In all projects ↵')
 
       # Selection project scope 'In all projects' redirects away from current project.
-      select_autocomplete(page.find('.top-menu-search--input'),
-                          query: query,
-                          select_text: "In all projects ↵")
+      global_search.submit_in_global_scope
       expect(current_path).to match(/\/search/)
-      expect(current_url).to match(/\/search\?q=#{query}&work_packages=1&scope=all$/)
+      expect(current_url).to match(/\/search\?q=#{"%23#{first_wp.id}"}&work_packages=1&scope=all$/)
     end
   end
 
@@ -197,7 +216,6 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
       let(:filters) { ::Components::WorkPackages::Filters.new }
       let(:columns) { ::Components::WorkPackages::Columns.new }
       let(:top_menu) { ::Components::Projects::TopMenu.new }
-      let(:global_search) { ::Components::GlobalSearch.new }
 
       it 'shows a work package table with correct results' do
         # Search without subprojects
@@ -254,7 +272,7 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
         expect(global_search.input.value).to eq query
 
         # Expect that a fresh global search will reset the advanced filters, i.e. that they are closed
-        global_search.search work_packages[6].subject, submit_with_enter: true
+        global_search.search work_packages[6].subject, submit: true
 
         expect(page).to have_text "Search for \"#{work_packages[6].subject}\" in #{project.name}"
 
@@ -268,7 +286,7 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
 
         # Expect that changing the search term without using the autocompleter will leave the project scope unchanged
         # at current_project.
-        global_search.search other_work_package.subject, submit_with_enter: true
+        global_search.search other_work_package.subject, submit: true
 
         expect(page).to have_text "Search for \"#{other_work_package.subject}\" in #{project.name}"
 
@@ -279,11 +297,11 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
 
         # Expect to find custom field values
         # ...for type: text
-        global_search.search custom_field_text_value, submit_with_enter: true
+        global_search.search custom_field_text_value, submit: true
         table.ensure_work_package_not_listed! work_packages[1]
         table.expect_work_package_subject(work_packages[0].subject)
         # ... for type: string
-        global_search.search custom_field_string_value, submit_with_enter: true
+        global_search.search custom_field_string_value, submit: true
         table.ensure_work_package_not_listed! work_packages[0]
         table.expect_work_package_subject(work_packages[1].subject)
 
@@ -361,7 +379,6 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
     let(:wp_2) { FactoryBot.create :work_package, subject: "Foo # Bar", project: project }
     let(:wp_3) { FactoryBot.create :work_package, subject: "Foo &# Bar", project: project }
     let!(:work_packages) { [wp_1, wp_2, wp_3] }
-    let(:global_search) { ::Components::GlobalSearch.new }
     let(:table) { Pages::EmbeddedWorkPackagesTable.new(find('.work-packages-embedded-view--container')) }
 
     let(:run_visit) { false }
@@ -375,6 +392,7 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
       # Bug in ng-select causes highlights to break up entities
       global_search.find_option "Foo &amp;&amp; Bar"
       global_search.find_option "Foo &amp;# Bar"
+      global_search.expect_global_scope_marked
       global_search.submit_in_global_scope
 
       table.ensure_work_package_not_listed! wp_2

--- a/spec/support/components/global_search.rb
+++ b/spec/support/components/global_search.rb
@@ -17,15 +17,19 @@ module Components
       container.find 'input'
     end
 
-    def search(query, submit_with_enter: false)
+    def search(query, submit: false)
       input.set ''
       input.hover
       input.click
       input.set query
 
-      if submit_with_enter
-        input.send_keys :enter
+      if submit
+        submit_with_enter
       end
+    end
+
+    def submit_with_enter
+      input.send_keys :enter
     end
 
     def expect_open
@@ -42,6 +46,40 @@ module Components
 
     def submit_in_global_scope
       page.find('.global-search--project-scope[title="all_projects"]', wait: 10).click
+    end
+
+    def expect_global_scope_marked
+      expect(page)
+        .to have_selector('.global-search--project-scope[title="all_projects"]', wait: 10)
+    end
+
+    def expect_in_project_and_subproject_scope_marked
+      expect(page)
+        .to have_selector('.global-search--project-scope[title="current_project_and_all_descendants"]', wait: 10)
+    end
+
+    def expect_scope(text)
+      expect(page)
+        .to have_selector('.global-search--project-scope', text: text, wait: 10)
+    end
+
+    def expect_work_package_marked(wp)
+      expect(page)
+        .to have_selector('.ng-option-marked', text: "##{wp.id} #{wp.subject}", wait: 10)
+    end
+
+    def expect_work_package_option(wp)
+      expect(page)
+        .to have_selector('.global-search--option', text: "##{wp.id} #{wp.subject}", wait: 10)
+    end
+
+    def expect_no_work_package_option(wp)
+      expect(page)
+        .not_to have_selector('.global-search--option', text: "##{wp.id} #{wp.subject}")
+    end
+
+    def click_work_package(wp)
+      find_work_package(wp).click
     end
 
     def find_work_package(wp)


### PR DESCRIPTION
Currently, the backend redirects to work packages whenever an ID is exactly matched with or without the `#` prefix. This means users cannot explicitly trigger a search through the "global" or "in this project" buttons.

If we remember the match in the frontend, we can redirect it _only_ when pressing enter. I also restricted the search to match with the `#` prefix only

https://community.openproject.com/wp/26684