### PR TITLE
[32799] Missing demo data: Teaser image and "Getting started" box for Demo project and Scrum project

### DIFF
--- a/app/seeders/demo_data_seeder.rb
+++ b/app/seeders/demo_data_seeder.rb
@@ -31,7 +31,8 @@ class DemoDataSeeder < CompositeSeeder
       DemoData::GroupSeeder,
       DemoData::AttributeHelpTextSeeder,
       DemoData::GlobalQuerySeeder,
-      DemoData::ProjectSeeder
+      DemoData::ProjectSeeder,
+      DemoData::OverviewSeeder
     ]
   end
 


### PR DESCRIPTION
Include overview seeder again into demo data seeder. Actually for all projects the overview seeding was not performed (BIM and core).

https://community.openproject.com/projects/openproject/work_packages/32799/activity