### PR TITLE
[32814] Main menu state is not stored on page reload

### DIFF
--- a/frontend/src/app/components/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/components/main-menu/main-menu-toggle.service.ts
@@ -26,12 +26,11 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Injectable} from '@angular/core';
-import {BehaviorSubject, fromEvent, Observable, Subscription} from 'rxjs';
+import {Injectable, Injector} from '@angular/core';
+import {BehaviorSubject} from 'rxjs';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {DeviceService} from "app/modules/common/browser/device.service";
-import {Injector} from "@angular/core";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 
 @Injectable({ providedIn: 'root' })
@@ -40,6 +39,7 @@ export class MainMenuToggleService {
 
   private elementWidth:number;
   private readonly localStorageKey:string = 'openProject-mainMenuWidth';
+  private readonly localStorageStateKey:string = 'openProject-mainMenuCollapsed';
   private readonly defaultWidth:number = 230;
 
   @InjectField() currentProject:CurrentProjectService;
@@ -57,9 +57,6 @@ export class MainMenuToggleService {
   private changeData = new BehaviorSubject<any>({});
   public changeData$ = this.changeData.asObservable();
 
-  private resizeObservable$:Observable<Event>;
-  private resizeSubscription$:Subscription;
-
   constructor(protected I18n:I18nService,
               public injector:Injector,
               readonly deviceService:DeviceService) {
@@ -69,10 +66,14 @@ export class MainMenuToggleService {
     if (!this.mainMenu) { return; }
 
     this.elementWidth = parseInt(window.OpenProject.guardedLocalStorage(this.localStorageKey) as string);
+    const menuCollapsed = window.OpenProject.guardedLocalStorage(this.localStorageStateKey) as string;
 
     if (!this.elementWidth) {
       this.saveWidth(this.mainMenu.offsetWidth);
-    } else {
+    } else if (menuCollapsed && JSON.parse(menuCollapsed)) {
+      this.closeMenu();
+    }
+    else {
       this.setWidth();
     }
 
@@ -82,9 +83,7 @@ export class MainMenuToggleService {
     }
 
     // mobile version default: hide menu on initialization
-    if (this.deviceService.isMobile) {
-      this.closeMenu();
-    }
+    this.closeWhenOnMobile();
   }
 
   // click on arrow or hamburger icon
@@ -104,8 +103,6 @@ export class MainMenuToggleService {
       this.closeMenu();
     }
 
-    this.toggleClassHidden();
-    this.setToggleTitle();
     // Set focus on first visible main menu item.
     // This needs to be called after AngularJS has rendered the menu, which happens some when after(!) we leave this
     // method here. So we need to set the focus after a timeout.
@@ -116,13 +113,55 @@ export class MainMenuToggleService {
 
   public closeMenu():void {
     this.setWidth(0);
-    this.hideElements.addClass('hidden-navigation');
+    window.OpenProject.guardedLocalStorage(this.localStorageStateKey, 'true');
     jQuery('.wp-query-menu--search-input').blur();
   }
 
   public closeWhenOnMobile():void {
     if (this.deviceService.isMobile) {
       this.closeMenu();
+      window.OpenProject.guardedLocalStorage(this.localStorageStateKey, 'false');
+    }
+  }
+  public saveWidth(width?:number):void {
+    this.setWidth(width);
+    window.OpenProject.guardedLocalStorage(this.localStorageKey, String(this.elementWidth));
+    window.OpenProject.guardedLocalStorage(this.localStorageStateKey, String(this.elementWidth === 0));
+  }
+
+  public setWidth(width?:any):void {
+    if (width !== undefined) {
+      // Leave a minimum amount of space for space fot the content
+      let maxMenuWidth = this.deviceService.isMobile ? window.innerWidth - 120 : window.innerWidth - 520;
+      if (width > maxMenuWidth) {
+        this.elementWidth = maxMenuWidth;
+      } else {
+        this.elementWidth = width as number;
+      }
+    }
+
+    this.snapBack();
+    this.setToggleTitle();
+    this.toggleClassHidden();
+
+    this.global.showNavigation = this.showNavigation;
+    this.htmlNode.style.setProperty("--main-menu-width", this.elementWidth + 'px');
+
+    // Send change event when size of menu is changing (menu toggled or resized)
+    // Event should only be fired, when transition is finished
+    let changeEvent = jQuery.Event("change");
+    jQuery('#content-wrapper').on('transitionend webkitTransitionEnd oTransitionEnd otransitionend MSTransitionEnd', () => {
+      this.changeData.next(changeEvent);
+    });
+  }
+
+  public get showNavigation():boolean {
+    return (this.elementWidth > 10);
+  }
+
+  private snapBack():void {
+    if (this.elementWidth <= 10) {
+      this.elementWidth = 0;
     }
   }
 
@@ -137,57 +176,5 @@ export class MainMenuToggleService {
 
   private toggleClassHidden():void {
     this.hideElements.toggleClass('hidden-navigation', !this.showNavigation);
-  }
-
-  public saveWidth(width?:number):void {
-    // Leave a minimum amount of space for space fot the content
-    let maxMenuWidth = window.innerWidth - 520;
-
-    if (width !== undefined && width > maxMenuWidth) {
-      width = maxMenuWidth;
-    }
-
-    this.setWidth(width);
-    window.OpenProject.guardedLocalStorage(this.localStorageKey, String(this.elementWidth));
-    this.setToggleTitle();
-    // Send change event when size of menu is changing (menu toggled or resized)
-    // Event should only be fired, when transition is finished
-    let changeEvent = jQuery.Event("change");
-    jQuery('#content-wrapper').on('transitionend webkitTransitionEnd oTransitionEnd otransitionend MSTransitionEnd', () => {
-      this.changeData.next(changeEvent);
-    });
-  }
-
-  public setWidth(width?:any):void {
-    if (width !== undefined) {
-      this.elementWidth = width as number;
-    }
-    this.snapBack();
-    this.ensureContentVisibility();
-
-    this.global.showNavigation = this.showNavigation;
-    this.toggleClassHidden();
-    this.htmlNode.style.setProperty("--main-menu-width", this.elementWidth + 'px');
-  }
-
-  private snapBack():void {
-    if (this.elementWidth <= 10) {
-      this.elementWidth = 0;
-    }
-  }
-
-  private ensureContentVisibility():void {
-    let viewportWidth = document.documentElement!.clientWidth;
-    if (this.elementWidth >= viewportWidth - 150) {
-      this.elementWidth = viewportWidth - 150;
-    }
-  }
-
-  public get showNavigation():boolean {
-    return (this.elementWidth > 10);
-  }
-
-  private get isGlobalPage():boolean {
-    return this.currentProject.id ? false : true;
   }
 }


### PR DESCRIPTION
Introduce a second variable for the mainMenuToggler to store the collapsed state of the menu. By storing the width and the state separately we can restore the state correctly on reload. At the same time we can expand the menu to the last used width when toggling the menu again.

https://community.openproject.com/projects/openproject/work_packages/32814/activity