### PR TITLE
[32779] Disable possibility to change the user name when login via Google

### DIFF
--- a/app/views/my/account.html.erb
+++ b/app/views/my/account.html.erb
@@ -48,8 +48,19 @@ See docs/COPYRIGHT.rdoc for more details.
         <%= @user.login %>
       </div>
     </div>
-    <div class="form--field -required"><%= f.text_field :firstname, required: true, container_class: '-middle' %></div>
-    <div class="form--field -required"><%= f.text_field :lastname, required: true, container_class: '-middle' %></div>
+    <% login_via_provider = !!@user.identity_url %>
+    <div class="form--field -required">
+      <%= f.text_field :firstname, required: true, container_class: '-middle', disabled: login_via_provider %>
+      <% if login_via_provider %>
+        <span class="form--field-instructions"><%= t('user.text_change_disabled_for_provider_login') %></span>
+      <% end %>
+    </div>
+    <div class="form--field -required">
+      <%= f.text_field :lastname, required: true, container_class: '-middle', disabled: login_via_provider %>
+      <% if login_via_provider %>
+        <span class="form--field-instructions"><%= t('user.text_change_disabled_for_provider_login') %></span>
+      <% end %>
+    </div>
     <div class="form--field -required"><%= f.text_field :mail, required: true, container_class: '-middle' %></div>
 
     <%= fields_for :pref, @user.pref, builder: TabularFormBuilder, lang: current_language do |pref_fields| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2631,6 +2631,7 @@ en:
       mail_self_notified: "I want to be notified of changes that I make myself"
     status_user_and_brute_force: "%{user} and %{brute_force}"
     status_change: "Status change"
+    text_change_disabled_for_provider_login: "The name is set by your login provider and can thus not be changed."
     unlock: "Unlock"
     unlock_and_reset_failed_logins: "Unlock and reset failed logins"
 


### PR DESCRIPTION
When logged in via a login provider, changing the name is not allowed any more as it would be overwritten anyways.

https://community.openproject.com/projects/openproject/work_packages/32779/activity