### PR TITLE
[32870] Don't set cache headers for own avatar

### DIFF
--- a/modules/avatars/lib/api/v3/users/user_avatar_api.rb
+++ b/modules/avatars/lib/api/v3/users/user_avatar_api.rb
@@ -40,7 +40,7 @@ module API
           if (local_avatar = local_avatar?(@user))
             respond_with_attachment(local_avatar, cache_seconds: cache_seconds)
           elsif avatar_manager.gravatar_enabled?
-            set_cache_headers!(cache_seconds)
+            set_cache_headers!(cache_seconds) unless cache_seconds.nil?
 
             redirect build_gravatar_image_url(@user)
           else


### PR DESCRIPTION
The empty seconds end up to `CacheControl: public,max-age=` which means
indefinite caching on outer load balancers

https://community.openproject.com/wp/32870