### PR TITLE
[31298] Missing warning message when reopening agenda

### DIFF
--- a/modules/meeting/app/helpers/meeting_contents_helper.rb
+++ b/modules/meeting/app/helpers/meeting_contents_helper.rb
@@ -96,7 +96,7 @@ module MeetingContentsHelper
                                 meeting_id: meeting },
                               method: :put,
                               class: 'button',
-                              confirm: l(:text_meeting_agenda_open_are_you_sure)) do
+                              data: { confirm: l(:text_meeting_agenda_open_are_you_sure) }) do
           op_icon('button--icon icon-unlocked') +
           content_tag('span', l(:label_meeting_open), class: 'button--text')
         end

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -94,7 +94,7 @@ en:
   text_in_hours: "in hours"
   text_meeting_agenda_for_meeting: 'agenda for the meeting "%{meeting}"'
   text_meeting_closing_are_you_sure: "Are you sure you want to close the meeting?"
-  text_meeting_agenda_open_are_you_sure: "Unsaved content in the minutes will be lost! Continue?"
+  text_meeting_agenda_open_are_you_sure: "This will overwrite all changes in the minutes! Do you want to continue?"
   text_meeting_minutes_for_meeting: 'minutes for the meeting "%{meeting}"'
   text_review_meeting_agenda: "%{author} has put the %{link} up for review."
   text_review_meeting_minutes: "%{author} has put the %{link} up for review."

--- a/modules/meeting/spec/features/meetings_close_spec.rb
+++ b/modules/meeting/spec/features/meetings_close_spec.rb
@@ -75,6 +75,7 @@ describe 'Meetings close', type: :feature do
       # Go back to agenda, expect we can open it again
       find('.tabrow a', text: 'AGENDA').click
       find('.button', text: 'Open').click
+      page.accept_confirm
       expect(page).to have_selector('.button', text: 'Close')
     end
   end


### PR DESCRIPTION
Correctly show warning when reopen meeting agenda and change text a bit

https://community.openproject.com/projects/openproject/work_packages/31598/activity