### PR TITLE
[32754] Scroll correct container in forums and remove toggle link

### DIFF
--- a/app/assets/javascripts/forums.js
+++ b/app/assets/javascripts/forums.js
@@ -44,7 +44,7 @@
 
       reply.slideDown();
 
-      $('html, body').animate({
+      $('#content-wrapper').animate({
         scrollTop: focusElement.offset().top
       }, 1000);
     }
@@ -60,4 +60,4 @@
     });
   });
 
-}(jQuery))
+}(jQuery));

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -93,13 +93,6 @@ module ApplicationHelper
     t "status_#{user.status_name}"
   end
 
-  def toggle_link(name, id, options = {}, html_options = {})
-    onclick = "jQuery('##{id}').toggle(); "
-    onclick << (options[:focus] ? "jQuery('##{options[:focus]}').focus(); " : 'this.blur(); ')
-    onclick << 'return false;'
-    link_to_function(name, onclick, html_options)
-  end
-
   def delete_link(url, options = {})
     options = {
       method: :delete,

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -117,11 +117,7 @@ See docs/COPYRIGHT.rdoc for more details.
   <% end %>
 
   <% if !@topic.locked? && authorize_for('messages', 'reply') %>
-    <div class="form--space">
-      <%= toggle_link t(:button_reply), "reply", {focus: 'reply_content'}, {class: 'button -highlight'} %>
-    </div>
-
-    <div id="reply" style="display:none;">
+    <div id="reply">
 
       <hr class="form--separator" />
 
@@ -136,7 +132,6 @@ See docs/COPYRIGHT.rdoc for more details.
         <hr class="form--separator" />
 
         <%= f.button t(:button_submit), class: 'button -highlight -highlight -with-icon icon-checkmark' %>
-        <%= toggle_link t(:button_cancel), "reply", {}, { class: 'button' } %>
       <% end %>
       <div id="preview"></div>
     </div>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -94,8 +94,7 @@ See docs/COPYRIGHT.rdoc for more details.
     <% end %>
   </div>
   <% if authorize_for 'news/comments', 'create' %>
-    <p><%= toggle_link l(:label_comment_add), "add_comment_form", focus: "comment_comments" %></p>
-    <%= form_for([@news, Comment.new], html: { id: "add_comment_form", style: "display:none;" }) do %>
+    <%= form_for([@news, Comment.new], html: { id: "add_comment_form" }) do %>
       <div>
         <%= label_tag 'comment_comments', Journal.human_attribute_name(:notes), class: 'hidden-for-sighted' %>
         <%= text_area 'comment',
@@ -104,8 +103,7 @@ See docs/COPYRIGHT.rdoc for more details.
         <%= wikitoolbar_for 'comment_comments', preview_context: preview_context(@news) %>
       </div>
       <p>
-        <%= submit_tag l(:button_add), class: 'button -highlight' %>
-        <%= toggle_link t(:button_cancel), "add_comment_form", {}, { class: 'button' } %>
+        <%= submit_tag l(:button_add_comment), class: 'button -highlight' %>
       </p>
     <% end %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -812,6 +812,7 @@ en:
     work_package: "Work package"
 
   button_add: "Add"
+  button_add_comment: "Add comment"
   button_add_member: Add member
   button_add_watcher: "Add watcher"
   button_annotate: "Annotate"

--- a/spec/support/pages/messages/show.rb
+++ b/spec/support/pages/messages/show.rb
@@ -53,8 +53,6 @@ module Pages::Messages
     end
 
     def reply(text)
-      click_on 'Reply'
-
       find('.ck-content').base.send_keys text
 
       click_button 'Submit'


### PR DESCRIPTION
Simply always shows the reply form, no sense in hiding it if allowed.

https://community.openproject.com/wp/32754