### PR TITLE
[32825] Cache external URLs for at max 604799 seconds …

### DIFF
--- a/lib/api/v3/attachments/attachments_api.rb
+++ b/lib/api/v3/attachments/attachments_api.rb
@@ -65,7 +65,9 @@ module API
               helpers ::API::Helpers::AttachmentRenderer
 
               get do
-                respond_with_attachment @attachment, cache_seconds: 1.year.to_i
+                # Cache that value at max 604799 seconds, which is the max
+                # allowed expiry time for AWS generated links
+                respond_with_attachment @attachment, cache_seconds: 604799
               end
             end
           end

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -277,13 +277,13 @@ shared_examples 'an APIv3 attachment resource', type: :request, content_type: :j
           expect(subject.headers['Content-Type'])
             .to eql mock_file.content_type
 
-          expect(subject.headers["Cache-Control"]).to eq "public, max-age=#{1.year.to_i}"
+          expect(subject.headers["Cache-Control"]).to eq "public, max-age=604799"
           expect(subject.headers["Expires"]).to be_present
 
           expires_time = Time.parse response.headers["Expires"]
 
-          expect(expires_time < Time.now.utc + 1.year.to_i).to be_truthy
-          expect(expires_time > Time.now.utc + 1.year.to_i - 60).to be_truthy
+          expect(expires_time < Time.now.utc + 604799).to be_truthy
+          expect(expires_time > Time.now.utc + 604799 - 60).to be_truthy
         end
 
         it 'sends the file in binary' do
@@ -332,13 +332,13 @@ shared_examples 'an APIv3 attachment resource', type: :request, content_type: :j
           expect(subject.headers['Location'])
             .to eql external_url
 
-          expect(subject.headers["Cache-Control"]).to eq "public, max-age=#{1.year.to_i}"
+          expect(subject.headers["Cache-Control"]).to eq "public, max-age=604799"
           expect(subject.headers["Expires"]).to be_present
 
           expires_time = Time.parse response.headers["Expires"]
 
-          expect(expires_time < Time.now.utc + 1.year.to_i).to be_truthy
-          expect(expires_time > Time.now.utc + 1.year.to_i - 60).to be_truthy
+          expect(expires_time < Time.now.utc + 604799).to be_truthy
+          expect(expires_time > Time.now.utc + 604799 - 60).to be_truthy
         end
       end
     end


### PR DESCRIPTION
Caching the redirect causes AWS links to be cached locally and then expire after some time.

https://community.openproject.com/wp/32825