### PR TITLE
[32908] Styling changes to the confirm-dialog modal

### DIFF
--- a/frontend/src/app/components/modals/confirm-dialog/confirm-dialog.modal.html
+++ b/frontend/src/app/components/modals/confirm-dialog/confirm-dialog.modal.html
@@ -17,16 +17,17 @@
       <p [textContent]="text.text"></p>
     </div>
     <div class="op-modal--modal-footer">
-      <button class="confirm-form-submit--cancel button"
-              (click)="closeMe($event)"
-              [textContent]="text.button_cancel"
-              [attr.title]="text.button_cancel">
-      </button>
       <button class="confirm-form-submit--continue button -highlight"
               (click)="confirmAndClose($event)"
               [textContent]="text.button_continue"
               [attr.title]="text.button_continue">
       </button>
+      <button class="confirm-form-submit--cancel button"
+              (click)="closeMe($event)"
+              [textContent]="text.button_cancel"
+              [attr.title]="text.button_cancel">
+      </button>
+      
     </div>
   </div>
 </div>

--- a/frontend/src/app/components/modals/confirm-dialog/confirm-dialog.modal.sass
+++ b/frontend/src/app/components/modals/confirm-dialog/confirm-dialog.modal.sass
@@ -1,0 +1,8 @@
+
+.op-modal--modal-close-button
+  right: 1.75rem
+  top: unset
+
+.op-modal--modal-container
+  padding-bottom: 0
+   

--- a/frontend/src/app/components/modals/confirm-dialog/confirm-dialog.modal.sass
+++ b/frontend/src/app/components/modals/confirm-dialog/confirm-dialog.modal.sass
@@ -1,7 +1,7 @@
 
 .op-modal--modal-close-button
   right: 1.75rem
-  top: unset
+  top: 1.6rem
 
 .op-modal--modal-container
   padding-bottom: 0

--- a/frontend/src/app/components/modals/confirm-dialog/confirm-dialog.modal.ts
+++ b/frontend/src/app/components/modals/confirm-dialog/confirm-dialog.modal.ts
@@ -45,7 +45,8 @@ export interface ConfirmDialogOptions {
 }
 
 @Component({
-  templateUrl: './confirm-dialog.modal.html'
+  templateUrl: './confirm-dialog.modal.html',
+  styleUrls:['./confirm-dialog.modal.sass']
 })
 export class ConfirmDialogModal extends OpModalComponent {
 


### PR DESCRIPTION
Updated the close button to be correctly positioned in the EE destroy modal.

https://community.openproject.com/work_packages/32908/activity