### PR TITLE
Correctly load groups trough hrefs

### DIFF
--- a/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-action.service.ts
@@ -8,19 +8,21 @@ import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {FilterOperator} from "core-components/api/api-v3/api-v3-filter-builder";
 import {CreateAutocompleterComponent} from "core-app/modules/common/autocomplete/create-autocompleter.component";
 import {OpContextMenuItem} from "core-components/op-context-menu/op-context-menu.types";
-import {UserCacheService} from 'core-app/components/user/user-cache.service';
 import {UserResource} from 'core-app/modules/hal/resources/user-resource';
 import {CurrentProjectService} from 'core-app/components/projects/current-project.service';
 import {CollectionResource} from 'core-app/modules/hal/resources/collection-resource';
 import {HalResourceService} from 'core-app/modules/hal/services/hal-resource.service';
 import {AssigneeBoardHeaderComponent} from "core-app/modules/boards/board/board-actions/assignee/assignee-board-header.component";
+import {input} from "reactivestates";
+import {take} from "rxjs/operators";
 
 @Injectable()
 export class BoardAssigneeActionService implements BoardActionService {
 
+  private assignees = input<HalResource[]>();
+
   constructor(protected boardListsService:BoardListsService,
               protected I18n:I18nService,
-              protected userCache:UserCacheService,
               protected halResourceService:HalResourceService,
               protected currentProject:CurrentProjectService
   ) {
@@ -49,15 +51,16 @@ export class BoardAssigneeActionService implements BoardActionService {
    * Returns the loaded assignee
    * @param query
    */
-  public getLoadedFilterValue(query:QueryResource):Promise<undefined|UserResource> {
+  public getLoadedFilterValue(query:QueryResource):Promise<undefined|HalResource> {
     const href = this.getFilterHref(query);
 
-    if (href) {
-      const id = HalResource.idFromLink(href);
-      return this.userCache.require(id);
-    } else {
+    if (!href) {
       return Promise.resolve(undefined);
     }
+
+    return this
+      .getAssignees()
+      .then(collection => collection.find(resource => resource.href === href));
   }
 
   public canAddToQuery(query:QueryResource):Promise<boolean> {
@@ -95,7 +98,8 @@ export class BoardAssigneeActionService implements BoardActionService {
       queries.map(query => this.getFilterHref(query))
     );
 
-    return this.getAssignees(board)
+    return this
+      .getAssignees()
       .then(results =>
         results.filter(assignee => !active.has(assignee.href!))
       );
@@ -117,17 +121,23 @@ export class BoardAssigneeActionService implements BoardActionService {
     return AssigneeBoardHeaderComponent;
   }
 
-  public disabledAddButtonPlaceholder(assignee:UserResource) {
+  public disabledAddButtonPlaceholder(assignee:HalResource) {
     return undefined;
   }
 
-  private getAssignees(board:Board):Promise<UserResource[]> {
+  private getAssignees():Promise<HalResource[]> {
     const projectIdentifier = this.currentProject.identifier!;
-    let myData = this.halResourceService.get('/api/v3/projects/' + projectIdentifier + '/available_assignees').toPromise();
+    this.assignees.putFromPromiseIfPristine(() =>
+      this.halResourceService
+        .get('/api/v3/projects/' + projectIdentifier + '/available_assignees')
+        .toPromise()
+        .then((collection:CollectionResource<UserResource>) => collection.elements)
+    );
 
-
-    return myData
-      .then((collection:CollectionResource<UserResource>) => collection.elements);
+    return this.assignees
+      .values$()
+      .pipe(take(1))
+      .toPromise();
   }
 
 }

--- a/frontend/src/app/modules/hal/resources/group-resource.ts
+++ b/frontend/src/app/modules/hal/resources/group-resource.ts
@@ -1,0 +1,33 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2020 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+//++
+
+import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
+
+export class GroupResource extends HalResource {
+  public name:string;
+}

--- a/frontend/src/app/modules/hal/services/hal-resource.config.ts
+++ b/frontend/src/app/modules/hal/services/hal-resource.config.ts
@@ -48,7 +48,6 @@ import {
   HalResourceFactoryConfigInterface,
   HalResourceService
 } from 'core-app/modules/hal/services/hal-resource.service';
-import {Injectable} from '@angular/core';
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
 import {WikiPageResource} from "core-app/modules/hal/resources/wiki-page-resource";
 import {MeetingContentResource} from "core-app/modules/hal/resources/meeting-content-resource";
@@ -63,6 +62,7 @@ import {VersionResource} from "core-app/modules/hal/resources/version-resource";
 import {MembershipResource} from "core-app/modules/hal/resources/membership-resource";
 import {RoleResource} from "core-app/modules/hal/resources/role-resource";
 import {ProjectResource} from "core-app/modules/hal/resources/project-resource";
+import {GroupResource} from "core-app/modules/hal/resources/group-resource";
 
 const halResourceDefaultConfig:{ [typeName:string]:HalResourceFactoryConfigInterface } = {
   WorkPackage: {
@@ -119,6 +119,9 @@ const halResourceDefaultConfig:{ [typeName:string]:HalResourceFactoryConfigInter
   },
   User: {
     cls: UserResource
+  },
+  Group: {
+    cls: GroupResource
   },
   Collection: {
     cls: CollectionResource

--- a/modules/boards/spec/features/support/board_index_page.rb
+++ b/modules/boards/spec/features/support/board_index_page.rb
@@ -66,7 +66,10 @@ module Pages
         find('.button', text: 'Action board').click
       end
 
-      unless expect_empty
+      if expect_empty
+        expect(page).to have_selector('.boards-list--add-item-text', wait: 10)
+        expect(page).to have_no_selector('.boards-list--item')
+      else
         expect(page).to have_selector('.boards-list--item', wait: 10)
       end
 


### PR DESCRIPTION
We used the user service which does not allow loading groups. Instead we can simply use the "allowed assignees" query we load anyway to get the loaded values.

https://community.openproject.com/wp/33072