### PR TITLE
wp-resizer fixes and improvements

### DIFF
--- a/app/assets/stylesheets/openproject/_generic.sass
+++ b/app/assets/stylesheets/openproject/_generic.sass
@@ -118,4 +118,4 @@
   z-index: 0 !important
 
 .-error
-  color: $content-form-error-color
+  color: $content-form-error-color !important

--- a/app/assets/stylesheets/openproject/_generic.sass
+++ b/app/assets/stylesheets/openproject/_generic.sass
@@ -116,3 +116,6 @@
 
 .-no-z-index
   z-index: 0 !important
+
+.-error
+  color: $content-form-error-color

--- a/frontend/src/app/components/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/components/resizer/wp-resizer.component.ts
@@ -146,9 +146,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
     const event = new Event(this.resizeEvent);
     window.dispatchEvent(event);
 
-    if (this.resizer.classList.contains('-error')) {
-      this.resizer.classList.remove('-error');
-    }
+    this.manageErrorClass(false);
   }
 
   resizeMove(deltas:ResizeDelta) {
@@ -164,15 +162,11 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
       newValue = this.elementMinWidth;
 
       // Show the resizer red when it reaches its limit (min-width)
-      if (!this.resizer.classList.contains('-error')) {
-        this.resizer.classList.add('-error');
-      }
+      this.manageErrorClass(true);
     } else {
       newValue = this.elementWidth;
 
-      if (this.resizer.classList.contains('-error')) {
-        this.resizer.classList.remove('-error');
-      }
+      this.manageErrorClass(false);
     }
 
     // Store item in local storage
@@ -217,5 +211,15 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
   private toggleFullscreenColumns() {
     let fullScreenLeftView = jQuery('.work-packages-full-view--split-left')[0];
     this.toggleColumns(fullScreenLeftView);
+  }
+
+  private manageErrorClass(shouldBePresent:boolean) {
+    if (shouldBePresent && !this.resizer.classList.contains('-error')) {
+       this.resizer.classList.add('-error');
+    }
+
+    if (!shouldBePresent && this.resizer.classList.contains('-error')) {
+      this.resizer.classList.remove('-error');
+    }
   }
 }

--- a/modules/bim/app/assets/stylesheets/bim/ifc_viewer/generic.sass
+++ b/modules/bim/app/assets/stylesheets/bim/ifc_viewer/generic.sass
@@ -1,6 +1,7 @@
 // -------------------------- GENERIC --------------------------
 @import "openproject/variables"
 @import "openproject/mixins"
+@import "openproject/generic"
 @import "fonts/openproject_icon_definitions"
 @import "fonts/openproject_icon_font"
 

--- a/modules/bim/app/assets/stylesheets/bim/ifc_viewer/generic.sass
+++ b/modules/bim/app/assets/stylesheets/bim/ifc_viewer/generic.sass
@@ -1,7 +1,6 @@
 // -------------------------- GENERIC --------------------------
 @import "openproject/variables"
 @import "openproject/mixins"
-@import "openproject/generic"
 @import "fonts/openproject_icon_definitions"
 @import "fonts/openproject_icon_font"
 


### PR DESCRIPTION
https://community.openproject.com/wp/33120

wp-resizer fixes:
- [x] default min-width and
- [x] avoid text selection while the user is dragging.

wp-resizer improvements: 
- [x] show the resizer in red color when the min-width has been reached.