### PR TITLE
[33092] Ensure to check for existing WPs in manual sort

### DIFF
--- a/spec/services/queries/create_service_spec.rb
+++ b/spec/services/queries/create_service_spec.rb
@@ -28,33 +28,27 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::CreateService < Queries::BaseService
-  def initialize(**args)
-    super(**args)
-    self.contract_class = Queries::CreateContract
-  end
+require 'spec_helper'
 
-  def call(query)
-    remove_invalid_order(query)
-    super
-  end
+describe Queries::CreateService do
+  let(:user) { FactoryBot.build_stubbed(:admin) }
+  let(:query) { FactoryBot.build(:query, user: user) }
 
+  let(:instance) { described_class.new(user: user) }
+  subject { instance.call(query).result }
 
-  private
+  describe 'ordered work packages' do
+    let!(:work_package) { FactoryBot.create :work_package }
 
-  def remove_invalid_order(query)
-    # Check which of the work package IDs exist
-    ids = query.ordered_work_packages.map(&:work_package_id)
-    existent_wps = WorkPackage.where(id: ids).pluck(:id).to_set
-
-    query.ordered_work_packages = query.ordered_work_packages.select do |order_item|
-      existent_wps.include?(order_item.work_package_id)
+    before do
+      query.ordered_work_packages.build(work_package_id: work_package.id, position: 0)
+      query.ordered_work_packages.build(work_package_id: 99999, position: 1)
     end
-  end
 
-  def service_result(result, errors, query)
-    query.update user: user
-
-    super
+    it 'removes items for which work packages do not exist' do
+      expect(subject).to be_valid
+      expect(subject.ordered_work_packages.length).to eq 1
+      expect(subject.ordered_work_packages.first.work_package_id).to eq work_package.id
+    end
   end
 end


### PR DESCRIPTION
Saving a query with ordered work packages does not check whether the IDs exist, but a foreign key check is in place to ensure they exist.

This can happen when creating a query with positions while a work package has been destroyed in the meantime.

https://community.openproject.com/wp/33092