### PR TITLE
[33090] Rename continue button to add in boards modal

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -48,6 +48,7 @@ en:
     close_form_title: "Close form"
 
     button_add_watcher: "Add watcher"
+    button_add: "Add"
     button_back: "Back"
     button_back_to_list_view: "Back to list view"
     button_cancel: "Cancel"

--- a/frontend/src/app/modules/boards/board/add-list-modal/add-list-modal.component.ts
+++ b/frontend/src/app/modules/boards/board/add-list-modal/add-list-modal.component.ts
@@ -75,7 +75,7 @@ export class AddListModalComponent extends OpModalComponent implements OnInit {
 
   public text:any = {
     title: this.I18n.t('js.boards.add_list'),
-    button_continue: this.I18n.t('js.button_continue'),
+    button_add: this.I18n.t('js.button_add'),
     button_cancel: this.I18n.t('js.button_cancel'),
     close_popup: this.I18n.t('js.close_popup_title'),
 

--- a/frontend/src/app/modules/boards/board/add-list-modal/add-list-modal.html
+++ b/frontend/src/app/modules/boards/board/add-list-modal/add-list-modal.html
@@ -34,8 +34,8 @@
       <button class="button -highlight"
               (click)="create()"
               [disabled]="!this.selectedAttribute || inFlight"
-              [textContent]="text.button_continue"
-              [attr.title]="text.button_continue">
+              [textContent]="text.button_add"
+              [attr.title]="text.button_add">
       </button>
       <button class="confirm-form-submit--cancel button"
               (click)="closeMe($event)"

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -181,7 +181,7 @@ module Pages
       else
         open_and_fill_add_list_modal option
         page.find('.ng-option-label', text: option, wait: 10).click
-        click_on 'Continue'
+        click_on 'Add'
       end
     end
 


### PR DESCRIPTION
https://community.openproject.com/wp/33090

:warning: adds a new string