### PR TITLE
Feature/wp export status

### DIFF
--- a/app/controllers/work_packages/exports_controller.rb
+++ b/app/controllers/work_packages/exports_controller.rb
@@ -35,10 +35,21 @@ class WorkPackages::ExportsController < ApplicationController
                 :authorize_current_user
 
   def show
-    if @export.attachments.first
+    if @export.ready?
       redirect_to attachment_content_path
     else
+      headers['Link'] = "<#{status_work_packages_export_path(@export.id)}> rel=\"status\""
       head 202
+    end
+  end
+
+  def status
+    if @export.ready?
+      headers['Link'] = "<#{attachment_content_path}> rel=\"download\""
+
+      render plain: 'Completed'
+    else
+      render plain: 'Processing'
     end
   end
 

--- a/app/models/work_packages/export.rb
+++ b/app/models/work_packages/export.rb
@@ -11,4 +11,8 @@ class WorkPackages::Export < ApplicationRecord
   def visible?(user)
     user_id == user.id
   end
+
+  def ready?
+    attachments.any?
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -409,7 +409,9 @@ OpenProject::Application.routes.draw do
 
   namespace :work_packages do
     match 'auto_complete' => 'auto_completes#index', via: %i[get post]
-    resources :exports, only: [:show]
+    resources :exports, only: [:show] do
+      get 'status', action: :status, on: :member
+    end
     resources :calendar, controller: 'calendars', only: [:index]
     resource :bulk, controller: 'bulk', only: %i[edit update destroy]
     # FIXME: this is kind of evil!! We need to remove this soonest and

--- a/spec/routing/work_packages/exports_spec.rb
+++ b/spec/routing/work_packages/exports_spec.rb
@@ -32,4 +32,8 @@ describe 'work_package exports routes', type: :routing do
   it '/work_packages/exports/:id GET routes to work_packages/exports#show' do
     expect(get('/work_packages/exports/5')).to route_to('work_packages/exports#show', id: "5")
   end
+
+  it '/work_packages/exports/:id/status GET routes to work_packages/exports#status' do
+    expect(get('/work_packages/exports/5/status')).to route_to('work_packages/exports#status', id: "5")
+  end
 end


### PR DESCRIPTION
Uses a dedicated export status action instead of relying solely on redirecting. Redirecting fails in scenarios where S3 is used as the backend (because of CSP).

The status actions is quite simple for now but could later on be expanded to return the progress or error messages.

https://community.openproject.com/wp/33093