### PR TITLE
Highlight correct error field in EE trial form

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -200,6 +200,8 @@ en:
             label_starts_at: "Starts at"
             label_expires_at: "Expires at"
             receive_newsletter: I want to receive the OpenProject <a target="_blank" href="%{link}">newsletter</a>.
+            taken_domain: There can only be one active trial per domain.
+            taken_email: Each user can only create one trial.
           email_not_received: "You did not receive an email? You can resend the email with the link on the right."
           try_another_email: "Or try it with another email address."
           try_another_email_hint: "Please be aware that your previous email address gets invalid if you try again with a new one."

--- a/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.html
+++ b/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.html
@@ -36,14 +36,14 @@
     <label class="form--label" for="trial-email">{{ text.label_email }}</label>
     <div class="form--field-container">
       <div class="form--text-field-container"
-           [ngClass]="{ '-required-highlighting' : eeTrialService.emailTaken }">
+           [ngClass]="{ '-required-highlighting' : eeTrialService.emailError }">
         <input type="email"
                class="form--text-field"
                id="trial-email"
                formControlName="email" (blur)="checkMailField()">
       </div>
     </div>
-    <div *ngIf="eeTrialService.emailTaken" class="form--field-instructions">{{ eeTrialService.errorMsg }}</div>
+    <div *ngIf="eeTrialService.emailError" class="form--field-instructions">{{ eeTrialService.errorMsg }}</div>
   </div>
   <div class="form--field -wide-label -required">
     <label class="form--label" for="trial-domain-name">{{ text.label_domain }}</label>

--- a/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.html
+++ b/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.html
@@ -32,29 +32,31 @@
       </div>
     </div>
   </div>
-  <div class="form--field -wide-label -required" [ngClass]="{ '-error': eeTrialService.errorMsg }">
+  <div class="form--field -wide-label -required">
     <label class="form--label" for="trial-email">{{ text.label_email }}</label>
     <div class="form--field-container">
       <div class="form--text-field-container"
-           [ngClass]="{ '-required-highlighting' : eeTrialService.errorMsg }">
+           [ngClass]="{ '-required-highlighting' : eeTrialService.emailTaken }">
         <input type="email"
                class="form--text-field"
                id="trial-email"
                formControlName="email" (blur)="checkMailField()">
       </div>
     </div>
-    <div *ngIf="eeTrialService.errorMsg" class="form--field-instructions">{{ eeTrialService.errorMsg }}</div>
+    <div *ngIf="eeTrialService.emailTaken" class="form--field-instructions">{{ eeTrialService.errorMsg }}</div>
   </div>
   <div class="form--field -wide-label -required">
     <label class="form--label" for="trial-domain-name">{{ text.label_domain }}</label>
     <div class="form--field-container">
-      <div class="form--text-field-container">
+      <div class="form--text-field-container"
+           [ngClass]="{ '-required-highlighting' : eeTrialService.domainTaken }">
         <input type="text"
                id="trial-domain-name"
                class="form--text-field"
                formControlName="domain">
       </div>
     </div>
+    <div *ngIf="eeTrialService.domainTaken" class="form--field-instructions">{{ eeTrialService.errorMsg }}</div>
   </div>
   <div class="form--field -required">
     <div class="form--field-container">

--- a/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.ts
+++ b/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.ts
@@ -90,6 +90,7 @@ export class EETrialFormComponent {
     if (this.trialForm.value.email !== '' && this.trialForm.controls.email.errors) {
       this.eeTrialService.emailInvalid = true;
     } else {
+      this.eeTrialService.emailInvalid = false;
       this.eeTrialService.error = undefined;
     }
   }

--- a/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.ts
+++ b/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.ts
@@ -65,7 +65,6 @@ export class EETrialFormComponent {
         de: 'https://www.openproject.org/de/datenschutz/'
       })
     }),
-    invalid_email: this.I18n.t('js.admin.enterprise.trial.form.invalid_email'),
     label_test_ee: this.I18n.t('js.admin.enterprise.trial.form.test_ee'),
     label_company: this.I18n.t('js.admin.enterprise.trial.form.label_company'),
     label_first_name: this.I18n.t('js.admin.enterprise.trial.form.label_first_name'),
@@ -89,9 +88,9 @@ export class EETrialFormComponent {
   // displays message for user
   public checkMailField() {
     if (this.trialForm.value.email !== '' && this.trialForm.controls.email.errors) {
-      this.eeTrialService.errorMsg = this.text.invalid_email;
+      this.eeTrialService.emailInvalid = true;
     } else {
-      this.eeTrialService.errorMsg = undefined;
+      this.eeTrialService.error = undefined;
     }
   }
 }

--- a/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial.modal.ts
+++ b/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial.modal.ts
@@ -48,7 +48,6 @@ export class EnterpriseTrialModal extends OpModalComponent implements AfterViewI
   @Input() public opReferrer:string;
 
   public trialForm:FormGroup;
-  public errorMsg:string|undefined;
 
   // modal configuration
   public showClose = true;

--- a/frontend/src/app/components/enterprise/enterprise-trial.service.ts
+++ b/frontend/src/app/components/enterprise/enterprise-trial.service.ts
@@ -55,12 +55,12 @@ export class EnterpriseTrialService {
   // send POST request with form object
   // receive an enterprise trial link to access a token
   public sendForm(form:FormGroup) {
-    this.userData$.putValue(form.value);
-
-    this.cancelled = false;
     this.http.post(this.baseUrlAugur + '/public/v1/trials', form.value)
       .toPromise()
       .then((enterpriseTrial:any) => {
+        this.userData$.putValue(form.value);
+        this.cancelled = false;
+
         this.trialLink = enterpriseTrial._links.self.href;
         this.saveTrialKey(this.trialLink);
 

--- a/frontend/src/app/components/enterprise/enterprise-trial.service.ts
+++ b/frontend/src/app/components/enterprise/enterprise-trial.service.ts
@@ -32,7 +32,11 @@ export class EnterpriseTrialService {
   public confirmed:boolean;
   public cancelled = false;
   public status:'mailSubmitted'|'startTrial'|undefined;
-  public errorMsg:string|undefined;
+  public error:HttpErrorResponse|undefined;
+  public emailInvalid:boolean = false;
+  public text = {
+    invalid_email: this.I18n.t('js.admin.enterprise.trial.form.invalid_email')
+  };
 
   constructor(readonly I18n:I18nService,
               protected http:HttpClient,
@@ -63,7 +67,7 @@ export class EnterpriseTrialService {
       .catch((error:HttpErrorResponse) => {
         // mail is invalid or user already created a trial
         if (error.status === 422 || error.status === 400) {
-          this.errorMsg = error.error.description;
+          this.error = error;
         } else {
           this.notificationsService.addWarning(error.error.description || I18n.t('js.error.internal'));
         }
@@ -171,5 +175,24 @@ export class EnterpriseTrialService {
 
   public get mailSubmitted():boolean {
     return this.status === 'mailSubmitted';
+  }
+
+  public get domainTaken():boolean {
+    return this.error ? this.error.error.identifier === 'domain_taken' : false;
+
+  }
+
+  public get emailTaken():boolean {
+    return this.error ? this.error.error.identifier === 'user_already_created_trial' : false;
+  }
+
+  public get errorMsg() {
+    if (this.emailInvalid) {
+      return this.text.invalid_email;
+    } else if (this.error) {
+      return this.error.error.description;
+    } else {
+      return undefined;
+    }
   }
 }

--- a/frontend/src/app/components/enterprise/enterprise-trial.service.ts
+++ b/frontend/src/app/components/enterprise/enterprise-trial.service.ts
@@ -179,11 +179,16 @@ export class EnterpriseTrialService {
 
   public get domainTaken():boolean {
     return this.error ? this.error.error.identifier === 'domain_taken' : false;
-
   }
 
-  public get emailTaken():boolean {
-    return this.error ? this.error.error.identifier === 'user_already_created_trial' : false;
+  public get emailError():boolean {
+    if (this.emailInvalid) {
+      return true;
+    } else if (this.error) {
+      return this.error.error.identifier === 'user_already_created_trial';
+    } else {
+      return false;
+    }
   }
 
   public get errorMsg() {

--- a/frontend/src/app/components/enterprise/enterprise-trial.service.ts
+++ b/frontend/src/app/components/enterprise/enterprise-trial.service.ts
@@ -35,7 +35,9 @@ export class EnterpriseTrialService {
   public error:HttpErrorResponse|undefined;
   public emailInvalid:boolean = false;
   public text = {
-    invalid_email: this.I18n.t('js.admin.enterprise.trial.form.invalid_email')
+    invalid_email: this.I18n.t('js.admin.enterprise.trial.form.invalid_email'),
+    taken_email: this.I18n.t('js.admin.enterprise.trial.form.taken_email'),
+    taken_domain: this.I18n.t('js.admin.enterprise.trial.form.taken_domain'),
   };
 
   constructor(readonly I18n:I18nService,
@@ -181,23 +183,30 @@ export class EnterpriseTrialService {
     return this.error ? this.error.error.identifier === 'domain_taken' : false;
   }
 
+  public get emailTaken():boolean {
+    return this.error ? this.error.error.identifier === 'user_already_created_trial' : false;
+  }
+
   public get emailError():boolean {
     if (this.emailInvalid) {
       return true;
     } else if (this.error) {
-      return this.error.error.identifier === 'user_already_created_trial';
+      return this.emailTaken;
     } else {
       return false;
     }
   }
 
   public get errorMsg() {
+    let error:string = '';
     if (this.emailInvalid) {
-      return this.text.invalid_email;
-    } else if (this.error) {
-      return this.error.error.description;
-    } else {
-      return undefined;
+      error = this.text.invalid_email;
+    } else if (this.domainTaken) {
+      error = this.text.taken_domain;
+    } else if (this.emailTaken) {
+      error = this.text.taken_email;
     }
+
+    return error;
   }
 }


### PR DESCRIPTION
Depending on the error (invalid email, taken email or taken domain) the according field in the form should be highlighted with a red border and the according message should be shown.