### PR TITLE
Improve design of EE page

### DIFF
--- a/app/assets/stylesheets/content/_enterprise.sass
+++ b/app/assets/stylesheets/content/_enterprise.sass
@@ -11,14 +11,17 @@
   .upsale--feature-reference
     padding-bottom: 2rem
 
-.token-form textarea
-  font-family: "Lucida Console", Monaco, monospace
-  max-width: 560px
-
-.upsale--actions
+.upsale-actions
   display: flex
   flex-wrap: wrap
   align-items: baseline
 
   .openproject--static-link
     margin-left: 1rem
+
+.upsale--information-container
+  margin-bottom: 40px
+
+.token-form textarea
+  font-family: "Lucida Console", Monaco, monospace
+  max-width: 560px

--- a/app/views/enterprises/_info.html.erb
+++ b/app/views/enterprises/_info.html.erb
@@ -32,31 +32,32 @@ See docs/COPYRIGHT.rdoc for more details.
   </script>
 <% end %>
 
-<enterprise-base></enterprise-base>
+<div class="upsale--information-container">
+  <div class='upsale-information'>
+    <enterprise-base></enterprise-base>
+  </div>
 
-<div class='upsale--actions'>
-  <a href="#"
-     class="button -highlight"
-     data-cb-type="checkout"
-     data-cb-plan-id="enterprise-edition---annual-user-license">
-    <%= t('admin.enterprise.book_now') %>
-  </a>
+  <div class='upsale-actions'>
+    <a href="#"
+       class="button -highlight-inverted"
+       data-cb-type="checkout"
+       data-cb-plan-id="enterprise-edition---annual-user-license">
+      <%= t('admin.enterprise.book_now') %>
+    </a>
 
-  <% quote_link = OpenProject::Static::Links.links.fetch :upsale_get_quote %>
-  <%= link_to t(quote_link[:label]),
-              quote_link[:href],
-              target: '_blank',
-              class: 'button -highlight'%>
+    <% quote_link = OpenProject::Static::Links.links.fetch :upsale_get_quote %>
+    <%= link_to t(quote_link[:label]),
+                quote_link[:href],
+                target: '_blank',
+                class: 'button -highlight-inverted'%>
+  </div>
 
   <%= static_link_to :contact %>
 </div>
 
-<p>
-  <b><%= t('js.admin.enterprise.upsale.confidence') %></b>
-</p>
-
 <div class="info-boxes upsale-benefits">
   <h3 class="info-boxes--title -no-border"><%= t('js.admin.enterprise.upsale.benefits.description') %></h3>
+
   <div class="info-boxes--container">
     <div class="info-boxes--item">
       <%= image_tag "installation_alerts.svg",

--- a/app/views/homescreen/blocks/_upsale.html.erb
+++ b/app/views/homescreen/blocks/_upsale.html.erb
@@ -13,7 +13,7 @@
   <% end  %>
 
   <%= link_to "#{OpenProject::Static::Links.links[:upsale][:href]}/?utm_source=unknown&utm_medium=community-edition&utm_campaign=home-screen",
-        { class: 'button -highlight',
+        { class: 'button -highlight-inverted',
           aria: {label: t('homescreen.blocks.upsale.more_info')},
           target: '_blank',
           title: t('homescreen.blocks.upsale.more_info')} do %>

--- a/frontend/src/app/components/enterprise/enterprise-base.component.html
+++ b/frontend/src/app/components/enterprise/enterprise-base.component.html
@@ -1,10 +1,9 @@
 <div *ngIf="noTrialRequested; else alreadyRequested">
+  <p>{{ text.enterprise_edition }}</p>
+  <p class="-bold">{{ text.confidence }}</p>
   <p>
-    <b>{{ text.text }}</b>
-  </p>
-  <p>
-    <b>{{ text.become_hero }}</b><br>
-    {{ text.you_contribute }}
+    <span class="-bold">{{ text.become_hero }}</span><br>
+    <span>{{ text.you_contribute }}</span>
   </p>
   <button class="button -alt-highlight" (click)="openTrialModal()">
     {{ text.button_trial }}

--- a/frontend/src/app/components/enterprise/enterprise-base.component.ts
+++ b/frontend/src/app/components/enterprise/enterprise-base.component.ts
@@ -48,7 +48,8 @@ export class EnterpriseBaseComponent {
     become_hero: this.I18n.t('js.admin.enterprise.upsale.become_hero'),
     you_contribute: this.I18n.t('js.admin.enterprise.upsale.you_contribute'),
     email_not_received: this.I18n.t('js.admin.enterprise.trial.email_not_received'),
-    text: this.I18n.t('js.admin.enterprise.upsale.text'),
+    enterprise_edition: this.I18n.t('js.admin.enterprise.upsale.text'),
+    confidence: this.I18n.t('js.admin.enterprise.upsale.confidence'),
     try_another_email: this.I18n.t('js.admin.enterprise.trial.try_another_email')
   };
 


### PR DESCRIPTION
A quick fix attempt to make the EE page when having no token more structured/cleaned up without changing the texts.

#### Before
<img width="1550" alt="Bildschirmfoto 2020-04-21 um 13 48 02" src="https://user-images.githubusercontent.com/7457313/79871308-7233c900-83e4-11ea-9402-d3fa8eb0d528.png">

#### After
<img width="1551" alt="Bildschirmfoto 2020-04-21 um 13 47 32" src="https://user-images.githubusercontent.com/7457313/79871320-76f87d00-83e4-11ea-8059-79bada393de2.png">
