### PR TITLE
Test new pullpreview action

### DIFF
--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -1,0 +1,27 @@
+name: PullPreview
+on:
+  push:
+  pull_request:
+    types: [labeled, unlabeled, closed]
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v2
+    - name: Generate .env.pullpreview file
+      run: |
+        echo "OP_ADMIN_USER_SEEDER_FORCE_PASSWORD_CHANGE=off" > .env.pullpreview
+        echo "OPENPROJECT_SHOW__SETTING__MISMATCH__WARNING=false" >> .env.pullpreview
+    - uses: pullpreview/action@master
+      with:
+        admins: crohr,HDinger,machisuji,oliverguenther,ulferts,wielinde
+        always_on: master
+        compose_files: docker-compose.pullpreview.yml
+        instance_type: medium_2_0
+      env:
+        AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+        AWS_REGION: eu-central-1

--- a/docker-compose.pullpreview.yml
+++ b/docker-compose.pullpreview.yml
@@ -5,8 +5,7 @@ db:
     POSTGRES_PASSWORD: p4ssw0rd
     POSTGRES_DB: app
   volumes:
-    - ./export/db:/var/lib/postgresql/data
-  memory: 64
+    - /var/lib/postgresql/data
   expose:
     - '5432'
 
@@ -20,12 +19,10 @@ web:
     - "SECRET_KEY_BASE=d4e74f017910ac56c6ebad01165b7e1b37f4c9c02e9716836f8670cdc8d65a231e64e4f6416b19c8"
     - "RAILS_ENV=production"
     - "HEROKU=true"
-    - "OP_ADMIN_USER_SEEDER_FORCE_PASSWORD_CHANGE=off"
-    - "OPENPROJECT_SHOW__SETTING__MISMATCH__WARNING=false"
+  env_file: ./.env.pullpreview
   ports:
     - "80:8080"
   command: "./docker/web"
-  memory: 1024
   volumes:
     - "/var/openproject/assets"
 
@@ -39,8 +36,7 @@ worker:
     - "SECRET_KEY_BASE=d4e74f017910ac56c6ebad01165b7e1b37f4c9c02e9716836f8670cdc8d65a231e64e4f6416b19c8"
     - "RAILS_ENV=production"
     - "HEROKU=true"
-    - "OP_ADMIN_USER_SEEDER_FORCE_PASSWORD_CHANGE=off"
+  env_file: ./.env.pullpreview
   command: "./docker/worker --seed --set attachment_max_size=262144"
-  memory: 384
   volumes_from:
     - web


### PR DESCRIPTION
PullPreview.com is going to switch to GitHub Actions as the mean of deployment.

This allows better visibility into failures and logs, as well as having the environment URL directly accessible. Selected users also have SSH access into the instance for debugging purposes. It also supports all versions of compose files.

Preview envs can be started and destroyed by adding/removing the `pullpreview` label on the PR.

Let me know if you see anything that you might miss from the original version (vanity domain names are on the roadmap for feature parity).