### PR TITLE
[33111] Always assign query_props to change persisted queries

### DIFF
--- a/app/models/work_package/pdf_export/common.rb
+++ b/app/models/work_package/pdf_export/common.rb
@@ -59,7 +59,7 @@ module WorkPackage::PDFExport::Common
   end
 
   def error(message)
-    WorkPackage::Exporter::Error.new message
+    WorkPackage::Exporter::Result::Error.new message
   end
 
   def cell_padding

--- a/app/services/work_packages/exports/schedule_service.rb
+++ b/app/services/work_packages/exports/schedule_service.rb
@@ -48,16 +48,21 @@ class WorkPackages::Exports::ScheduleService
     WorkPackages::Exports::ExportJob.perform_later(export: export_storage,
                                                    mime_type: mime_type,
                                                    options: params,
-                                                   query: serialize_query(query))
+                                                   query: serialize_query(query),
+                                                   query_attributes: serialize_query_props(query))
   end
 
+  ##
+  # Pass the query to the job if it was saved
   def serialize_query(query)
     if query.persisted?
       query
-    else
-      query.attributes.tap do |attributes|
-        attributes['filters'] = Queries::WorkPackages::FilterSerializer.dump(query.attributes['filters'])
-      end
+    end
+  end
+
+  def serialize_query_props(query)
+    query.attributes.tap do |attributes|
+      attributes['filters'] = Queries::WorkPackages::FilterSerializer.dump(query.attributes['filters'])
     end
   end
 end

--- a/modules/bim/spec/workers/work_packages/exports/export_job_spec.rb
+++ b/modules/bim/spec/workers/work_packages/exports/export_job_spec.rb
@@ -43,7 +43,8 @@ describe WorkPackages::Exports::ExportJob do
     instance.perform(export: export,
                      mime_type: mime_type,
                      options: options,
-                     query: query)
+                     query: query,
+                     query_attributes: {})
   end
 
   describe '#perform' do

--- a/spec/workers/work_packages/exports/export_job_spec.rb
+++ b/spec/workers/work_packages/exports/export_job_spec.rb
@@ -36,6 +36,7 @@ describe WorkPackages::Exports::ExportJob do
     FactoryBot.build_stubbed(:work_packages_export, user: user)
   end
   let(:query) { FactoryBot.build_stubbed(:query) }
+  let(:query_attributes) { {} }
 
   let(:instance) { described_class.new }
   let(:options) { {} }
@@ -43,7 +44,8 @@ describe WorkPackages::Exports::ExportJob do
     instance.perform(export: export,
                      mime_type: mime_type,
                      options: options,
-                     query: query)
+                     query: query,
+                     query_attributes: query_attributes)
   end
 
   shared_examples_for 'exporter returning string' do
@@ -79,6 +81,22 @@ describe WorkPackages::Exports::ExportJob do
         .and_yield(result)
 
       subject
+    end
+  end
+
+  describe 'query passing' do
+    context 'passing in group_by through attributes' do
+      let(:query_attributes) { { group_by: 'assigned_to' }}
+      let(:mime_type) { :pdf }
+
+      it 'updates the query from attributes' do
+        expect("WorkPackage::Exporter::#{mime_type.upcase}".constantize)
+          .to receive(:list) do |query, _options|
+          expect(query.group_by).to eq 'assigned_to'
+        end
+
+        subject
+      end
     end
   end
 


### PR DESCRIPTION
In case of a persisted query, the export job only received that query without any (unsaved) query_props, resulting in changes to it never being applied.

Since a saved query is only passed for manual sorting, the problem only occurs there.

https://community.openproject.com/wp/33111