### PR TITLE
introduce a persisted status for delayed jobs

### DIFF
--- a/app/models/delayed/job/status.rb
+++ b/app/models/delayed/job/status.rb
@@ -1,0 +1,20 @@
+module Delayed
+  class Job
+    class Status < ApplicationRecord
+      self.table_name = 'delayed_job_statuses'
+
+      belongs_to :reference, polymorphic: true
+      belongs_to :job, class_name: '::Delayed::Job'
+
+      enum status: { in_queue: 'in_queue',
+                     error: 'error',
+                     in_process: 'in_process',
+                     success: 'success',
+                     failure: 'failure' }
+
+      def self.of_reference(reference)
+        where(reference: reference)
+      end
+    end
+  end
+end

--- a/app/models/work_package/pdf_export/common.rb
+++ b/app/models/work_package/pdf_export/common.rb
@@ -59,7 +59,7 @@ module WorkPackage::PDFExport::Common
   end
 
   def error(message)
-    WorkPackage::Exporter::Error.new message
+    WorkPackage::Exporter::Result::Error.new message
   end
 
   def cell_padding

--- a/app/workers/application_job.rb
+++ b/app/workers/application_job.rb
@@ -29,7 +29,6 @@
 require 'active_job'
 
 class ApplicationJob < ::ActiveJob::Base
-
   ##
   # Return a priority number on the given payload
   def self.priority_number(prio = :default)
@@ -55,6 +54,14 @@ class ApplicationJob < ::ActiveJob::Base
 
   def self.inherited(child)
     child.prepend Setup
+  end
+
+  # Delayed jobs can have a status:
+  # Delayed::Job::Status
+  # which is related to the job via a reference which is an AR model instance.
+  # If no such reference is defined, there is no status stored in the db.
+  def status_reference
+    nil
   end
 
   module Setup

--- a/app/workers/cron/clear_old_job_status_job.rb
+++ b/app/workers/cron/clear_old_job_status_job.rb
@@ -1,0 +1,44 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Cron
+  class ClearOldJobStatusJob < CronJob
+    # runs at 4:15 nightly
+    self.cron_expression = '15 4 * * *'
+
+    RETENTION_PERIOD = 2.days.freeze
+
+    def perform
+      Delayed::Job::Status
+        .where(Delayed::Job::Status.arel_table[:updated_at].lteq(Time.now - RETENTION_PERIOD))
+        .destroy_all
+    end
+  end
+end

--- a/app/workers/work_packages/exports/export_job.rb
+++ b/app/workers/work_packages/exports/export_job.rb
@@ -9,6 +9,10 @@ module WorkPackages
         end
       end
 
+      def status_reference
+        arguments.first[:export]
+      end
+
       private
 
       def export_work_packages(export, mime_type, query_props, options)

--- a/config/initializers/cronjobs.rb
+++ b/config/initializers/cronjobs.rb
@@ -4,6 +4,7 @@ OpenProject::Application.configure do |application|
   application.config.to_prepare do
     ::Cron::CronJob.register! ::Cron::ClearOldSessionsJob,
                               ::Cron::ClearTmpCacheJob,
-                              ::Cron::ClearUploadedFilesJob
+                              ::Cron::ClearUploadedFilesJob,
+                              ::Cron::ClearOldJobStatusJob
   end
 end

--- a/config/initializers/job_status.rb
+++ b/config/initializers/job_status.rb
@@ -1,0 +1,77 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+# Extends the ActiveJob adapter in use (DelayedJob) by a Status which lives
+# indenpendently from the job itself (which is deleted once successful or after max attempts).
+# That way, the result of a background job is available even after the original job is gone.
+
+ActiveSupport::Notifications.subscribe "perform.active_job" do |job:, exception_object: nil, **_args|
+  next unless job.status_reference
+
+  # job.provider_job_id is not filled at this point as
+  # the ActiveJob adapter for DelayedJob is only setting it
+  # on enqueue and enqueue_at.
+  if exception_object
+    dj_job_attempts = Delayed::Job.where(id: Delayed::Job::Status.of_reference(job.status_reference).select(:job_id))
+                      .pluck(:attempts)
+                      .first || 1
+
+    new_status = if dj_job_attempts + 1 >= Delayed::Worker.max_attempts
+                   :failure
+                 else
+                   :error
+                 end
+
+    Delayed::Job::Status
+      .of_reference(job.status_reference)
+      .update(status: new_status,
+              message: exception_object)
+  else
+    Delayed::Job::Status
+      .of_reference(job.status_reference)
+      .update(status: :success)
+  end
+end
+
+ActiveSupport::Notifications.subscribe "enqueue.active_job" do |job:, **_args|
+  if job.status_reference
+    Delayed::Job::Status.create(status: :in_queue,
+                                reference: job.status_reference,
+                                job_id: job.provider_job_id)
+  end
+end
+
+ActiveSupport::Notifications.subscribe "enqueue_at.active_job" do |job:, **_args|
+  if job.status_reference
+    Delayed::Job::Status.create(status: :in_queue,
+                                reference: job.status_reference,
+                                job_id: job.provider_job_id)
+  end
+end

--- a/db/migrate/20200422105623_add_job_status.rb
+++ b/db/migrate/20200422105623_add_job_status.rb
@@ -1,0 +1,25 @@
+class AddJobStatus < ActiveRecord::Migration[6.0]
+  def up
+    execute <<-SQL
+      CREATE TYPE delayed_job_status AS ENUM ('in_queue', 'error', 'in_process', 'success', 'failure');
+    SQL
+
+    create_table :delayed_job_statuses do |t|
+      t.references :job
+      t.references :reference, polymorphic: true, index: { unique: true }
+      t.string :message
+
+      t.timestamps
+    end
+
+    add_column :delayed_job_statuses, :status, :delayed_job_status, default: 'in_queue'
+  end
+
+  def down
+    drop_table :delayed_job_statuses
+
+    execute <<-SQL
+      DROP TYPE delayed_job_status;
+    SQL
+  end
+end

--- a/spec/factories/delayed_job_status_factory.rb
+++ b/spec/factories/delayed_job_status_factory.rb
@@ -1,0 +1,33 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+FactoryBot.define do
+  factory :delayed_job_status, class: Delayed::Job::Status do
+
+  end
+end

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -58,143 +58,180 @@ describe 'work package export', type: :feature do
     login_as(current_user)
   end
 
+  let(:export_type) { 'CSV' }
   subject { DownloadedFile.download_content }
 
-  def export!
+  def export!(wait_for_downloads = true)
     DownloadedFile::clear_downloads
 
     work_packages_page.ensure_loaded
 
     settings_menu.open_and_choose 'Export ...'
-    click_on 'CSV'
+    click_on export_type
 
-    perform_enqueued_jobs
-    # Wait for the file to download
-    ::DownloadedFile.wait_for_download
-    ::DownloadedFile.wait_for_download_content
+    begin
+      perform_enqueued_jobs
+    rescue
+      # nothing
+    end
+
+
+    if wait_for_downloads
+      # Wait for the file to download
+      ::DownloadedFile.wait_for_download
+      ::DownloadedFile.wait_for_download_content
+    end
   end
-
-  #before do
-  #  # render the CSV as plain text so we can run expectations against the output
-  #  expect_any_instance_of(WorkPackagesController)
-  #    .to receive(:send_data) do |receiver, serialized_work_packages, _opts|
-  #    receiver.render plain: serialized_work_packages
-  #  end
-  #end
 
   after do
     DownloadedFile::clear_downloads
   end
 
-  context 'with default filter' do
-    before do
-      work_packages_page.visit_index
-      filters.expect_filter_count 1
-      filters.open
+  context 'CSV export' do
+    context 'with default filter' do
+      before do
+        work_packages_page.visit_index
+        filters.expect_filter_count 1
+        filters.open
+      end
+
+      it 'shows all work packages with the default filters', js: true, retry: 2 do
+        export!
+
+        expect(subject).to have_text(wp_1.description)
+        expect(subject).to have_text(wp_2.description)
+        expect(subject).to have_text(wp_3.description)
+        expect(subject).to have_text(wp_4.description)
+
+        # results are ordered by ID (asc) and not grouped by type
+        expect(subject.scan(/Type (A|B)/).flatten).to eq %w(A A B A)
+      end
+
+      it 'shows all work packages grouped by ', js: true, retry: 2 do
+        group_by.enable_via_menu 'Type'
+
+        wp_table.expect_work_package_listed(wp_1)
+        wp_table.expect_work_package_listed(wp_2)
+        wp_table.expect_work_package_listed(wp_3)
+        wp_table.expect_work_package_listed(wp_4)
+
+        export!
+
+        expect(subject).to have_text(wp_1.description)
+        expect(subject).to have_text(wp_2.description)
+        expect(subject).to have_text(wp_3.description)
+        expect(subject).to have_text(wp_4.description)
+
+        # grouped by type
+        expect(subject.scan(/Type (A|B)/).flatten).to eq %w(A A A B)
+      end
+
+      it 'shows only the work package with the right progress if filtered this way',
+         js: true, retry: 2 do
+        filters.add_filter_by 'Progress (%)', 'is', ['25'], 'percentageDone'
+
+        sleep 1
+        loading_indicator_saveguard
+
+        wp_table.expect_work_package_listed(wp_1)
+        wp_table.ensure_work_package_not_listed!(wp_2, wp_3)
+
+        export!
+
+        expect(subject).to have_text(wp_1.description)
+        expect(subject).not_to have_text(wp_2.description)
+        expect(subject).not_to have_text(wp_3.description)
+      end
+
+      it 'shows only work packages of the filtered type', js: true, retry: 2 do
+        filters.add_filter_by 'Type', 'is', wp_3.type.name
+
+        expect(page).to have_no_content(wp_2.description) # safeguard
+
+        export!
+
+        expect(subject).not_to have_text(wp_1.description)
+        expect(subject).not_to have_text(wp_2.description)
+        expect(subject).to have_text(wp_3.description)
+      end
+
+      it 'exports selected columns', js: true, retry: 2 do
+        columns.add 'Progress (%)'
+
+        export!
+
+        expect(subject).to have_text('Progress (%)')
+        expect(subject).to have_text('25')
+      end
     end
 
-    it 'shows all work packages with the default filters', js: true, retry: 2 do
-      export!
+    describe 'with a manually sorted query', js: true do
+      let(:query) do
+        FactoryBot.create :query,
+                          user: current_user,
+                          project: project
+      end
 
-      expect(subject).to have_text(wp_1.description)
-      expect(subject).to have_text(wp_2.description)
-      expect(subject).to have_text(wp_3.description)
-      expect(subject).to have_text(wp_4.description)
+      before do
+        ::OrderedWorkPackage.create(query: query, work_package: wp_4, position: 0)
+        ::OrderedWorkPackage.create(query: query, work_package: wp_1, position: 1)
+        ::OrderedWorkPackage.create(query: query, work_package: wp_2, position: 2)
+        ::OrderedWorkPackage.create(query: query, work_package: wp_3, position: 3)
 
-      # results are ordered by ID (asc) and not grouped by type
-      expect(subject.scan(/Type (A|B)/).flatten).to eq %w(A A B A)
-    end
+        query.add_filter('manual_sort', 'ow', [])
+        query.sort_criteria = [[:manual_sorting, 'asc']]
+        query.save!
+      end
 
-    it 'shows all work packages grouped by ', js: true, retry: 2 do
-      group_by.enable_via_menu 'Type'
+      it 'returns the correct number of work packages' do
+        wp_table.visit_query query
+        wp_table.expect_work_package_listed(wp_1, wp_2, wp_3, wp_4)
+        wp_table.expect_work_package_order(wp_4, wp_1, wp_2, wp_3)
 
-      wp_table.expect_work_package_listed(wp_1)
-      wp_table.expect_work_package_listed(wp_2)
-      wp_table.expect_work_package_listed(wp_3)
-      wp_table.expect_work_package_listed(wp_4)
+        export!
 
-      export!
+        expect(subject).to have_text(wp_1.description)
+        expect(subject).to have_text(wp_2.description)
+        expect(subject).to have_text(wp_3.description)
+        expect(subject).to have_text(wp_4.description)
 
-      expect(subject).to have_text(wp_1.description)
-      expect(subject).to have_text(wp_2.description)
-      expect(subject).to have_text(wp_3.description)
-      expect(subject).to have_text(wp_4.description)
-
-      # grouped by type
-      expect(subject.scan(/Type (A|B)/).flatten).to eq %w(A A A B)
-    end
-
-    it 'shows only the work package with the right progress if filtered this way',
-       js: true, retry: 2 do
-      filters.add_filter_by 'Progress (%)', 'is', ['25'], 'percentageDone'
-
-      sleep 1
-      loading_indicator_saveguard
-
-      wp_table.expect_work_package_listed(wp_1)
-      wp_table.ensure_work_package_not_listed!(wp_2, wp_3)
-
-      export!
-
-      expect(subject).to have_text(wp_1.description)
-      expect(subject).not_to have_text(wp_2.description)
-      expect(subject).not_to have_text(wp_3.description)
-    end
-
-    it 'shows only work packages of the filtered type', js: true, retry: 2 do
-      filters.add_filter_by 'Type', 'is', wp_3.type.name
-
-      expect(page).to have_no_content(wp_2.description) # safeguard
-
-      export!
-
-      expect(subject).not_to have_text(wp_1.description)
-      expect(subject).not_to have_text(wp_2.description)
-      expect(subject).to have_text(wp_3.description)
-    end
-
-    it 'exports selected columns', js: true, retry: 2 do
-      columns.add 'Progress (%)'
-
-      export!
-
-      expect(subject).to have_text('Progress (%)')
-      expect(subject).to have_text('25')
+        # results are ordered by ID (asc) and not grouped by type
+        expect(subject.scan(/WorkPackage No\. \d+,/)).to eq [wp_4, wp_1, wp_2, wp_3].map { |wp| wp.subject + ',' }
+      end
     end
   end
 
-  describe 'with a manually sorted query', js: true do
+  context 'PDF export', js: true do
+    let(:export_type) { 'PDF' }
     let(:query) do
       FactoryBot.create :query,
                         user: current_user,
                         project: project
     end
 
-    before do
-      ::OrderedWorkPackage.create(query: query, work_package: wp_4, position: 0)
-      ::OrderedWorkPackage.create(query: query, work_package: wp_1, position: 1)
-      ::OrderedWorkPackage.create(query: query, work_package: wp_2, position: 2)
-      ::OrderedWorkPackage.create(query: query, work_package: wp_3, position: 3)
+    context 'with many columns' do
+      before do
+        query.column_names = query.available_columns.map { |c| c.name.to_s } - ['bcf_thumbnail']
+        query.save!
 
-      query.add_filter('manual_sort', 'ow', [])
-      query.sort_criteria = [[:manual_sorting, 'asc']]
-      query.save!
-    end
+        # Despite attempts to provoke the error by having a lot of columns, the pdf
+        # is still being drawn successfully. We thus have to fake the error.
+        allow_any_instance_of(WorkPackage::PDFExport::WorkPackageListToPdf)
+          .to receive(:render!)
+          .and_return(WorkPackage::Exporter::Result::Error.new(I18n.t(:error_pdf_export_too_many_columns)))
+      end
 
-    it 'returns the correct number of work packages' do
-      wp_table.visit_query query
-      wp_table.expect_work_package_listed(wp_1, wp_2, wp_3, wp_4)
-      wp_table.expect_work_package_order(wp_4, wp_1, wp_2, wp_3)
+      it 'returns the error' do
+        wp_table.visit_query query
 
-      export!
+        export!(false)
 
-      expect(subject).to have_text(wp_1.description)
-      expect(subject).to have_text(wp_2.description)
-      expect(subject).to have_text(wp_3.description)
-      expect(subject).to have_text(wp_4.description)
+        expect(page)
+          .not_to have_content I18n.t('js.label_export_preparing')
 
-      # results are ordered by ID (asc) and not grouped by type
-      expect(subject.scan(/WorkPackage No\. \d+,/)).to eq [wp_4, wp_1, wp_2, wp_3].map { |wp| wp.subject + ',' }
+        expect(page)
+          .to have_content I18n.t(:error_pdf_export_too_many_columns)
+      end
     end
   end
 end


### PR DESCRIPTION
This is currently only employed for work package export jobs but is intended to be used more broadly, e.g. to signal the status of copying a project.

For now, the functionality is rather basic: Whenever an ActiveJob is scheduled, the id of the DelayedJob employed behind the scene is noted in a Delayed::Job::Status object. But the job_id is not the only reference the status object has. As the DelayedJob may be deleted (because it is finished or failed too often) and as the id of the DelayedJob is tough to get on the level of ActiveJob, a polymorphic reference is maintained. I

n the use case the PR aims at, the reference object is the `WorkPackages::Export` that is currently processed. It could just as well be a `Journal` or a `Project`. To avoid the reference not being a unique key, a unique index is applied on the table. This works for the export and will work for other cases as well but chances are high that we will need to adapt the pattern once multiple jobs can have run within the retention period of the job status list. 

The retention period is currently set to two days. A setting would make sense to allow the user to control the period. 

It would also make sense to introduce a generic, non work package export focused, end point to query for the status of jobs, but that is out of scope of the PR. So is extracting the functionality into an aspect. It is simply too late before the release to do more just now.   

https://community.openproject.com/wp/33110