### PR TITLE
POC for fetching attachments from seafile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem 'omniauth', git: 'https://github.com/opf/omniauth', ref: 'fe862f986b2e846e29
 gem 'doorkeeper', '~> 5.3.1'
 gem 'request_store', '~> 1.5.0'
 
+gem 'rails-reverse-proxy'
+
 gem 'warden', '~> 1.2'
 gem 'warden-basic_auth', '~> 0.2.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -727,6 +727,8 @@ GEM
       rack
     rack-protection (2.0.8.1)
       rack
+    rack-proxy (0.6.5)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rack_session_access (0.2.0)
@@ -759,6 +761,11 @@ GEM
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 7)
+    rails-reverse-proxy (0.9.1)
+      addressable
+      rack
+      rack-proxy
+      rails
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -1088,6 +1095,7 @@ DEPENDENCIES
   rails (~> 6.0.2)
   rails-controller-testing (~> 1.0.2)
   rails-i18n (~> 6.0.0)
+  rails-reverse-proxy
   rails_12factor
   rdoc (>= 2.4.2)
   reform (~> 2.2.0)

--- a/app/controllers/seafile_controller.rb
+++ b/app/controllers/seafile_controller.rb
@@ -1,0 +1,8 @@
+class SeafileController < ApplicationController
+  include ReverseProxy::Controller
+
+  def index
+    reverse_proxy "https://seafile-demo.de", headers: { "Authorization" => "Token eea2fc92262ea156d8bf3bec8e945e854b5e608f" } do
+    end
+  end
+end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -24,7 +24,7 @@ SecureHeaders::Configuration.default do |config|
   default_src = %w('self')
 
   # Allow requests to CLI in dev mode
-  connect_src = default_src
+  connect_src = default_src + %w(https://seafile-demo.de)
 
   if OpenProject::Configuration.sentry_dsn.present?
     connect_src += [OpenProject::Configuration.sentry_host]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,8 @@ OpenProject::Application.routes.draw do
   get '/auth/:provider', to: proc { [404, {}, ['']] }, as: 'omniauth_start'
   match '/auth/:provider/callback', to: 'account#omniauth_login', as: 'omniauth_login', via: %i[get post]
 
+  match 'api2/*path' => 'seafile#index', via: [:get, :post, :put, :patch, :delete]
+
   # In case assets are actually delivered by a node server (e.g. in test env)
   # forward requests to the proxy
   if FrontendAssetHelper.assets_proxied?

--- a/frontend/src/app/modules/attachments/attachment-list/attachment-list-item.html
+++ b/frontend/src/app/modules/attachments/attachment-list/attachment-list-item.html
@@ -12,22 +12,9 @@
         rel="noopener"
         [attr.href]="downloadPath || '#'">
 
-      {{ attachment.fileName || attachment.customName || attachment.name }}
-
-      <authoring class="work-package--attachments--info"
-                 [createdOn]="attachment.createdAt"
-                 [author]="attachment.author"
-                 [showAuthorAsLink]="false"></authoring>
+      {{ attachment.name }}
     </a>
   </span>
-  <a
-      href=""
-      class="form--selected-value--remover work-package--atachments--delete-button"
-      *ngIf="!!attachment.$links.delete"
-      (click)="confirmRemoveAttachment($event)">
-    <op-icon icon-classes="icon-delete"
-             [icon-title]="text.removeFile({fileName: attachment.fileName})"></op-icon>
-  </a>
 
   <input type="hidden" name="attachments[{{index}}][id]" value="{{attachment.id}}">
 </li>

--- a/frontend/src/app/modules/attachments/attachment-list/attachment-list.component.ts
+++ b/frontend/src/app/modules/attachments/attachment-list/attachment-list.component.ts
@@ -33,6 +33,7 @@ import {filter} from "rxjs/operators";
 import {States} from "core-components/states.service";
 import {AngularTrackingHelpers} from "core-components/angular/tracking-functions";
 import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import { HttpClient } from '@angular/common/http';
 
 @Component({
   selector: 'attachment-list',
@@ -44,7 +45,7 @@ export class AttachmentListComponent extends UntilDestroyedMixin implements OnIn
 
   trackByHref = AngularTrackingHelpers.trackByHref;
 
-  attachments:HalResource[] = [];
+  attachments:any[] = [];
   deletedAttachments:HalResource[] = [];
 
   public $element:JQuery;
@@ -53,7 +54,8 @@ export class AttachmentListComponent extends UntilDestroyedMixin implements OnIn
   constructor(protected elementRef:ElementRef,
               protected states:States,
               protected cdRef:ChangeDetectorRef,
-              protected halResourceService:HalResourceService) {
+              protected halResourceService:HalResourceService,
+              protected httpClient:HttpClient) {
     super();
   }
 
@@ -122,17 +124,17 @@ export class AttachmentListComponent extends UntilDestroyedMixin implements OnIn
   }
 
   private updateAttachments() {
-    if (!this.attachmentsUpdatable) {
-      this.attachments = this.resource.attachments.elements;
-      return;
-    }
+    //if (!this.attachmentsUpdatable) {
+    //  this.attachments = this.resource.attachments.elements;
+    //  return;
+    //}
 
     this
-      .resource
-      .attachments
-      .updateElements()
-      .then(() => {
-        this.attachments = this.resource.attachments.elements;
+      .httpClient
+      .get(`/api2/repos/aacd0f98-ba4d-4fee-bc64-fea5a93dc433/dir/?p=${this.resource.id}/`)
+      .toPromise()
+      .then((attachments:any) => {
+        this.attachments = attachments;
         this.cdRef.detectChanges();
       });
   }


### PR DESCRIPTION
⚠️ not intended for merging ⚠️ 

This is just a POC for fetching attachments from Seafile instead of from the OpenProject backend.

The functionality is currently rather limited: Files are fetched from the Seafile instance:
https://https://seafile-demo.de/
always using the same user (myself) account.
Uploading attachments, removing work packages and the like is not supported.

In order for the front end to pick up the attachments, new attachments have to be placed inside a folder within the OpenProject library: https://seafile-demo.de/library/aacd0f98-ba4d-4fee-bc64-fea5a93dc433/OpenProject/

The folder name is to be the id of the work package the attachments are uploaded for.