### PR TITLE
[33127] Work package template text form is too small

### DIFF
--- a/app/assets/stylesheets/content/editor/_ckeditor.sass
+++ b/app/assets/stylesheets/content/editor/_ckeditor.sass
@@ -101,6 +101,10 @@ ckeditor-augmented-textarea .op-ckeditor--wrapper
     border-top-left-radius: 0
     border-top-right-radius: 0
 
+    .document-editor__editable
+      .-large-height &
+        min-height: 250px
+
   .ck-editor__editable
     padding: 1cm 2cm 2cm
     border: 1px hsl( 0,0%,82.7% ) solid

--- a/app/views/types/form/_settings.html.erb
+++ b/app/views/types/form/_settings.html.erb
@@ -56,7 +56,7 @@ See docs/COPYRIGHT.rdoc for more details.
       </div>
     <% end %>
 
-    <div class="form--field">
+    <div class="form--field -wide-label -large-height">
       <%= f.text_area :description,
                       class: 'wiki-edit wiki-toolbar',
                       container_class: '-xxwide',


### PR DESCRIPTION
Provide minimal height for the default text field of WP types.

https://community.openproject.com/projects/openproject/work_packages/33127/activity