### PR TITLE
[32129] Add icon "Log time" close to spent time attribute in work packages details view

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -572,7 +572,7 @@ en:
       duration: 'Duration'
       spent_on: 'Date'
       hours: 'Hours'
-      label: 'Time entry'
+      title: 'Log time'
 
     two_factor_authentication:
       label_two_factor_authentication: 'Two-factor authentication'

--- a/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -33,7 +33,6 @@ import { ProjectResource } from "core-app/modules/hal/resources/project-resource
 import { InjectField } from "core-app/helpers/angular/inject-field.decorator";
 import * as URI from 'urijs';
 import { TimeEntryCreateService } from 'core-app/modules/time_entries/create/create.service';
-import {TimeEntryDmService} from "core-app/modules/hal/dm-services/time-entry-dm.service";
 
 export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
   public text = {
@@ -44,7 +43,6 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
   @InjectField() PathHelper:PathHelperService;
   @InjectField() projectCacheService:ProjectCacheService;
   @InjectField() timeEntryCreateService:TimeEntryCreateService;
-  @InjectField() timeEntryDm:TimeEntryDmService;
 
   public render(element:HTMLElement, displayText:string):void {
     if (!this.value) {
@@ -75,23 +73,18 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
   }
 
   private appendTimelogLink(element:HTMLElement) {
-    this
-      .timeEntryDm
-      .list({ pageSize: 1 })
-      .then(collection => {
-        if (!!collection.createTimeEntry) {
-          const timelogElement = document.createElement('a');
-          timelogElement.setAttribute('class','icon icon-time');
-          timelogElement.textContent = this.text.logTime;
+    if (this.resource.logTime) {
+      const timelogElement = document.createElement('a');
+      timelogElement.setAttribute('class','icon icon-time');
+      timelogElement.textContent = this.text.logTime;
 
-          element.appendChild(timelogElement);
+      element.appendChild(timelogElement);
 
-          let classContext = this;
-          timelogElement.addEventListener('click', function() {
-            classContext.showTimelogWidget();
-          });
-        }
+      let classContext = this;
+      timelogElement.addEventListener('click', function() {
+        classContext.showTimelogWidget();
       });
+    }
   }
 
   private showTimelogWidget() {

--- a/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -95,6 +95,10 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
   }
 
   private showTimelogWidget() {
-    this.timeEntryCreateService.create(moment(new Date()), this.resource, false);
+    this.timeEntryCreateService
+      .create(moment(new Date()), this.resource, false)
+      .catch(() => {
+        // do nothing, the user closed without changes
+      });
   }
 }

--- a/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -33,6 +33,7 @@ import { ProjectResource } from "core-app/modules/hal/resources/project-resource
 import { InjectField } from "core-app/helpers/angular/inject-field.decorator";
 import * as URI from 'urijs';
 import { TimeEntryCreateService } from 'core-app/modules/time_entries/create/create.service';
+import {TimeEntryDmService} from "core-app/modules/hal/dm-services/time-entry-dm.service";
 
 export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
   public text = {
@@ -43,6 +44,7 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
   @InjectField() PathHelper:PathHelperService;
   @InjectField() projectCacheService:ProjectCacheService;
   @InjectField() timeEntryCreateService:TimeEntryCreateService;
+  @InjectField() timeEntryDm:TimeEntryDmService;
 
   public render(element:HTMLElement, displayText:string):void {
     if (!this.value) {
@@ -66,19 +68,30 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
         });
     }
 
-
-    const timelogLogo = document.createElement('a');
-    timelogLogo.setAttribute('class', 'icon icon-time');
-    timelogLogo.textContent = this.text.logTime;
-
     element.innerHTML = '';
     element.appendChild(link);
-    element.appendChild(timelogLogo);
 
-    let classContext = this;
-    timelogLogo.addEventListener('click', function () {
-      classContext.showTimelogWidget();
-    });
+    this.appendTimelogLink(element);
+  }
+
+  private appendTimelogLink(element:HTMLElement) {
+    this
+      .timeEntryDm
+      .list({ pageSize: 1 })
+      .then(collection => {
+        if (!!collection.createTimeEntry) {
+          const timelogElement = document.createElement('a');
+          timelogElement.setAttribute('class','icon icon-time');
+          timelogElement.textContent = this.text.logTime;
+
+          element.appendChild(timelogElement);
+
+          let classContext = this;
+          timelogElement.addEventListener('click', function() {
+            classContext.showTimelogWidget();
+          });
+        }
+      });
   }
 
   private showTimelogWidget() {

--- a/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -95,6 +95,6 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
   }
 
   private showTimelogWidget() {
-    this.timeEntryCreateService.create(moment(new Date()), this.resource);
+    this.timeEntryCreateService.create(moment(new Date()), this.resource, false);
   }
 }

--- a/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -26,11 +26,11 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {DurationDisplayField} from './duration-display-field.module';
-import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
-import {ProjectCacheService} from "core-components/projects/project-cache.service";
-import {ProjectResource} from "core-app/modules/hal/resources/project-resource";
-import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
+import { DurationDisplayField } from './duration-display-field.module';
+import { PathHelperService } from 'core-app/modules/common/path-helper/path-helper.service';
+import { ProjectCacheService } from "core-components/projects/project-cache.service";
+import { ProjectResource } from "core-app/modules/hal/resources/project-resource";
+import { InjectField } from "core-app/helpers/angular/inject-field.decorator";
 import * as URI from 'urijs';
 import { TimeEntryCreateService } from 'core-app/modules/time_entries/create/create.service';
 
@@ -59,16 +59,16 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
         .require(this.resource.project.idFromLink)
         .then((project:ProjectResource) => {
           const href = URI(this.PathHelper.projectTimeEntriesPath(project.identifier))
-            .search({work_package_id: wpID})
+            .search({ work_package_id: wpID })
             .toString();
 
           link.href = href;
         });
     }
 
-    
+
     const timelogLogo = document.createElement('a');
-    timelogLogo.setAttribute('class','icon icon-time');
+    timelogLogo.setAttribute('class', 'icon icon-time');
     timelogLogo.textContent = this.text.logTime;
 
     element.innerHTML = '';
@@ -76,12 +76,12 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
     element.appendChild(timelogLogo);
 
     let classContext = this;
-    timelogLogo.addEventListener('click', function() {
+    timelogLogo.addEventListener('click', function () {
       classContext.showTimelogWidget();
     });
   }
 
-  private showTimelogWidget(){
+  private showTimelogWidget() {
     this.timeEntryCreateService.create(moment(new Date()), this.resource);
-  } 
+  }
 }

--- a/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -35,7 +35,8 @@ import * as URI from 'urijs';
 
 export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
   public text = {
-    linkTitle: this.I18n.t('js.work_packages.message_view_spent_time')
+    linkTitle: this.I18n.t('js.work_packages.message_view_spent_time'),
+    logTime: this.I18n.t('js.button_log_time')
   };
 
   @InjectField() PathHelper:PathHelperService;
@@ -63,7 +64,13 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
         });
     }
 
+    
+    const timelogLogo= document.createElement('a');
+    timelogLogo.setAttribute('class','icon icon-time');
+    timelogLogo.textContent = this.text.logTime;
+
     element.innerHTML = '';
     element.appendChild(link);
+    element.appendChild(timelogLogo);
   }
 }

--- a/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -32,6 +32,7 @@ import {ProjectCacheService} from "core-components/projects/project-cache.servic
 import {ProjectResource} from "core-app/modules/hal/resources/project-resource";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 import * as URI from 'urijs';
+import { TimeEntryCreateService } from 'core-app/modules/time_entries/create/create.service';
 
 export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
   public text = {
@@ -41,6 +42,7 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
 
   @InjectField() PathHelper:PathHelperService;
   @InjectField() projectCacheService:ProjectCacheService;
+  @InjectField() timeEntryCreateService:TimeEntryCreateService;
 
   public render(element:HTMLElement, displayText:string):void {
     if (!this.value) {
@@ -51,6 +53,7 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
     link.textContent = displayText;
     link.setAttribute('title', this.text.linkTitle);
 
+    
     if (this.resource.project) {
       const wpID = this.resource.id.toString();
       this.projectCacheService
@@ -64,7 +67,8 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
         });
     }
 
-    
+
+
     const timelogLogo= document.createElement('a');
     timelogLogo.setAttribute('class','icon icon-time');
     timelogLogo.textContent = this.text.logTime;
@@ -72,5 +76,10 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
     element.innerHTML = '';
     element.appendChild(link);
     element.appendChild(timelogLogo);
+
+    let that = this;
+    timelogLogo.addEventListener('click', function() {
+      that.timeEntryCreateService.create(moment(new Date()), that.resource);
+    });
   }
 }

--- a/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -53,7 +53,6 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
     link.textContent = displayText;
     link.setAttribute('title', this.text.linkTitle);
 
-    
     if (this.resource.project) {
       const wpID = this.resource.id.toString();
       this.projectCacheService
@@ -67,9 +66,8 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
         });
     }
 
-
-
-    const timelogLogo= document.createElement('a');
+    
+    const timelogLogo = document.createElement('a');
     timelogLogo.setAttribute('class','icon icon-time');
     timelogLogo.textContent = this.text.logTime;
 
@@ -77,9 +75,13 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
     element.appendChild(link);
     element.appendChild(timelogLogo);
 
-    let that = this;
+    let classContext = this;
     timelogLogo.addEventListener('click', function() {
-      that.timeEntryCreateService.create(moment(new Date()), that.resource);
+      classContext.showTimelogWidget();
     });
   }
+
+  private showTimelogWidget(){
+    this.timeEntryCreateService.create(moment(new Date()), this.resource);
+  } 
 }

--- a/frontend/src/app/modules/fields/openproject-fields.module.ts
+++ b/frontend/src/app/modules/fields/openproject-fields.module.ts
@@ -54,8 +54,6 @@ import {ProjectStatusEditFieldComponent} from "core-app/modules/fields/edit/fiel
 import {PortalCleanupService} from "core-app/modules/fields/display/display-portal/portal-cleanup.service";
 import {PlainFormattableEditFieldComponent} from "core-app/modules/fields/edit/field-types/plain-formattable-edit-field.component";
 import {TimeEntryWorkPackageEditFieldComponent} from "core-app/modules/fields/edit/field-types/te-work-package-edit-field.component";
-import { TimeEntryCreateService } from '../time_entries/create/create.service';
-import { HalResourceEditingService } from './edit/services/hal-resource-editing.service';
 
 @NgModule({
   imports: [
@@ -84,8 +82,6 @@ import { HalResourceEditingService } from './edit/services/hal-resource-editing.
       deps: [DisplayFieldService],
       multi: true
     },
-    TimeEntryCreateService,
-    HalResourceEditingService,
   ],
   declarations: [
     EditFormPortalComponent,

--- a/frontend/src/app/modules/fields/openproject-fields.module.ts
+++ b/frontend/src/app/modules/fields/openproject-fields.module.ts
@@ -54,6 +54,8 @@ import {ProjectStatusEditFieldComponent} from "core-app/modules/fields/edit/fiel
 import {PortalCleanupService} from "core-app/modules/fields/display/display-portal/portal-cleanup.service";
 import {PlainFormattableEditFieldComponent} from "core-app/modules/fields/edit/field-types/plain-formattable-edit-field.component";
 import {TimeEntryWorkPackageEditFieldComponent} from "core-app/modules/fields/edit/field-types/te-work-package-edit-field.component";
+import { TimeEntryCreateService } from '../time_entries/create/create.service';
+import { HalResourceEditingService } from './edit/services/hal-resource-editing.service';
 
 @NgModule({
   imports: [
@@ -82,6 +84,8 @@ import {TimeEntryWorkPackageEditFieldComponent} from "core-app/modules/fields/ed
       deps: [DisplayFieldService],
       multi: true
     },
+    TimeEntryCreateService,
+    HalResourceEditingService,
   ],
   declarations: [
     EditFormPortalComponent,

--- a/frontend/src/app/modules/time_entries/create/create.service.ts
+++ b/frontend/src/app/modules/time_entries/create/create.service.ts
@@ -1,30 +1,30 @@
-import {Injectable, Injector} from "@angular/core";
-import {OpModalService} from "app/components/op-modals/op-modal.service";
-import {HalResourceService} from "app/modules/hal/services/hal-resource.service";
-import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import { Injectable, Injector } from "@angular/core";
+import { OpModalService } from "app/components/op-modals/op-modal.service";
+import { HalResourceService } from "app/modules/hal/services/hal-resource.service";
+import { I18nService } from "core-app/modules/common/i18n/i18n.service";
 import { TimeEntryResource } from 'core-app/modules/hal/resources/time-entry-resource';
 import { take } from 'rxjs/operators';
-import {FormResource} from "core-app/modules/hal/resources/form-resource";
-import {TimeEntryDmService} from "core-app/modules/hal/dm-services/time-entry-dm.service";
-import {ResourceChangeset} from "core-app/modules/fields/changeset/resource-changeset";
-import {HalResourceEditingService} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
+import { FormResource } from "core-app/modules/hal/resources/form-resource";
+import { TimeEntryDmService } from "core-app/modules/hal/dm-services/time-entry-dm.service";
+import { ResourceChangeset } from "core-app/modules/fields/changeset/resource-changeset";
+import { HalResourceEditingService } from "core-app/modules/fields/edit/services/hal-resource-editing.service";
 import { Moment } from 'moment';
-import {TimeEntryCreateModal} from "core-app/modules/time_entries/create/create.modal";
+import { TimeEntryCreateModal } from "core-app/modules/time_entries/create/create.modal";
 import { WorkPackageResource } from 'core-app/modules/hal/resources/work-package-resource';
 
 @Injectable()
 export class TimeEntryCreateService {
 
   constructor(readonly opModalService:OpModalService,
-              readonly injector:Injector,
-              readonly halResource:HalResourceService,
-              readonly timeEntryDm:TimeEntryDmService,
-              protected halEditing:HalResourceEditingService,
-              readonly i18n:I18nService) {
+    readonly injector:Injector,
+    readonly halResource:HalResourceService,
+    readonly timeEntryDm:TimeEntryDmService,
+    protected halEditing:HalResourceEditingService,
+    readonly i18n:I18nService) {
   }
 
   public create(date:Moment, wp?:WorkPackageResource) {
-    return new Promise<{entry:TimeEntryResource, action:'create'}>((resolve, reject) => {
+    return new Promise<{ entry:TimeEntryResource, action:'create' }>((resolve, reject) => {
       this
         .createNewTimeEntry(date, wp)
         .then(changeset => {
@@ -35,7 +35,7 @@ export class TimeEntryCreateService {
             .pipe(take(1))
             .subscribe(() => {
               if (modal.createdEntry) {
-                resolve({entry: modal.createdEntry, action: 'create'});
+                resolve({ entry: modal.createdEntry, action: 'create' });
               } else {
                 reject();
               }
@@ -50,7 +50,7 @@ export class TimeEntryCreateService {
       spentOn: date.format('YYYY-MM-DD')
     };
 
-    if(wp) { 
+    if (wp) {
       payload['_links'] = {
         workPackage: {
           href: wp.href

--- a/frontend/src/app/modules/time_entries/create/create.service.ts
+++ b/frontend/src/app/modules/time_entries/create/create.service.ts
@@ -50,14 +50,14 @@ export class TimeEntryCreateService {
       spentOn: date.format('YYYY-MM-DD')
     };
 
-    if(wp) {  
+    if(wp) { 
       payload['_links'] = {
         workPackage: {
           href: wp.href
         }
       };
     }
-    
+
     return this.timeEntryDm.createForm(payload).then(form => {
       return this.fromCreateForm(form);
     });

--- a/frontend/src/app/modules/time_entries/create/create.service.ts
+++ b/frontend/src/app/modules/time_entries/create/create.service.ts
@@ -10,6 +10,7 @@ import {ResourceChangeset} from "core-app/modules/fields/changeset/resource-chan
 import {HalResourceEditingService} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
 import { Moment } from 'moment';
 import {TimeEntryCreateModal} from "core-app/modules/time_entries/create/create.modal";
+import { WorkPackageResource } from 'core-app/modules/hal/resources/work-package-resource';
 
 @Injectable()
 export class TimeEntryCreateService {
@@ -22,10 +23,10 @@ export class TimeEntryCreateService {
               readonly i18n:I18nService) {
   }
 
-  public create(date:Moment) {
+  public create(date:Moment, wp?:WorkPackageResource) {
     return new Promise<{entry:TimeEntryResource, action:'create'}>((resolve, reject) => {
       this
-        .createNewTimeEntry(date)
+        .createNewTimeEntry(date, wp)
         .then(changeset => {
           const modal = this.opModalService.show(TimeEntryCreateModal, this.injector, { entry: changeset.pristineResource });
 
@@ -44,8 +45,19 @@ export class TimeEntryCreateService {
     });
   }
 
-  public createNewTimeEntry(date:Moment) {
-    return this.timeEntryDm.createForm({ spentOn: date.format('YYYY-MM-DD') }).then(form => {
+  public createNewTimeEntry(date:Moment, wp?:WorkPackageResource) {
+    // Todo handle case that wp is not given
+    let payload = {
+      spentOn: date.format('YYYY-MM-DD'),
+      '_links': {
+        'workPackage': {
+          'href': wp!.href
+        }
+      }
+    }
+
+    
+    return this.timeEntryDm.createForm(payload).then(form => {
       return this.fromCreateForm(form);
     });
   }

--- a/frontend/src/app/modules/time_entries/create/create.service.ts
+++ b/frontend/src/app/modules/time_entries/create/create.service.ts
@@ -23,12 +23,12 @@ export class TimeEntryCreateService {
     readonly i18n:I18nService) {
   }
 
-  public create(date:Moment, wp?:WorkPackageResource) {
+  public create(date:Moment, wp?:WorkPackageResource, showWorkPackageField:boolean = true) {
     return new Promise<{ entry:TimeEntryResource, action:'create' }>((resolve, reject) => {
       this
         .createNewTimeEntry(date, wp)
         .then(changeset => {
-          const modal = this.opModalService.show(TimeEntryCreateModal, this.injector, { entry: changeset.pristineResource });
+          const modal = this.opModalService.show(TimeEntryCreateModal, this.injector, { entry: changeset.pristineResource, showWorkPackageField: showWorkPackageField });
 
           modal
             .closingEvent

--- a/frontend/src/app/modules/time_entries/create/create.service.ts
+++ b/frontend/src/app/modules/time_entries/create/create.service.ts
@@ -46,16 +46,17 @@ export class TimeEntryCreateService {
   }
 
   public createNewTimeEntry(date:Moment, wp?:WorkPackageResource) {
-    // Todo handle case that wp is not given
-    let payload = {
-      spentOn: date.format('YYYY-MM-DD'),
-      '_links': {
-        'workPackage': {
-          'href': wp!.href
-        }
-      }
-    }
+    let payload:any = {
+      spentOn: date.format('YYYY-MM-DD')
+    };
 
+    if(wp) {  
+      payload['_links'] = {
+        workPackage: {
+          href: wp.href
+        }
+      };
+    }
     
     return this.timeEntryDm.createForm(payload).then(form => {
       return this.fromCreateForm(form);

--- a/frontend/src/app/modules/time_entries/form/form.component.html
+++ b/frontend/src/app/modules/time_entries/form/form.component.html
@@ -27,12 +27,12 @@
       </editable-attribute-field>
     </div>
 
-    <div *ngIf="!entry.workPackage" 
+    <div *ngIf="showWorkPackageField"
          class="attributes-map--key"
          [ngClass]="{'-required': isRequired('workPackage')}"
          [textContent]="text.attributes.workPackage">
     </div>
-    <div *ngIf="!entry.workPackage" 
+    <div *ngIf="showWorkPackageField"
          class="attributes-map--value">
       <editable-attribute-field [resource]="entry"
                                 [fieldName]="'workPackage'">

--- a/frontend/src/app/modules/time_entries/form/form.component.html
+++ b/frontend/src/app/modules/time_entries/form/form.component.html
@@ -27,11 +27,13 @@
       </editable-attribute-field>
     </div>
 
-    <div class="attributes-map--key"
+    <div *ngIf="!entry.workPackage" 
+         class="attributes-map--key"
          [ngClass]="{'-required': isRequired('workPackage')}"
          [textContent]="text.attributes.workPackage">
     </div>
-    <div class="attributes-map--value">
+    <div *ngIf="!entry.workPackage" 
+         class="attributes-map--value">
       <editable-attribute-field [resource]="entry"
                                 [fieldName]="'workPackage'">
       </editable-attribute-field>

--- a/frontend/src/app/modules/time_entries/form/form.component.ts
+++ b/frontend/src/app/modules/time_entries/form/form.component.ts
@@ -26,6 +26,7 @@ import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixi
 })
 export class TimeEntryFormComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
   @Input() entry:TimeEntryResource;
+  @Input() showWorkPackageField:boolean = true;
 
   @Output() modifiedEntry = new EventEmitter<{ savedResource:TimeEntryResource, isInital:boolean }>();
 

--- a/frontend/src/app/modules/time_entries/shared/modal/base.modal.html
+++ b/frontend/src/app/modules/time_entries/shared/modal/base.modal.html
@@ -16,6 +16,7 @@
     <div class="ngdialog-body op-modal--modal-body">
       <te-form #editForm
                [entry]="entry"
+               [showWorkPackageField]="showWorkPackageField"
                (modifiedEntry)="setModifiedEntry($event)">
       </te-form>
     </div>

--- a/frontend/src/app/modules/time_entries/shared/modal/base.modal.ts
+++ b/frontend/src/app/modules/time_entries/shared/modal/base.modal.ts
@@ -1,10 +1,12 @@
-import { ElementRef, Inject, ChangeDetectorRef, ViewChild, Directive } from "@angular/core";
+import { ElementRef, Inject, ChangeDetectorRef, ViewChild, Directive, Injector } from "@angular/core";
 import {OpModalComponent} from "app/components/op-modals/op-modal.component";
 import {OpModalLocalsToken} from "app/components/op-modals/op-modal.service";
 import {OpModalLocalsMap} from "app/components/op-modals/op-modal.types";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {TimeEntryFormComponent} from "core-app/modules/time_entries/form/form.component";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
+import { InjectField } from 'core-app/helpers/angular/inject-field.decorator';
+import { WorkPackageCacheService } from 'core-app/components/work-packages/work-package-cache.service';
 
 @Directive()
 export abstract class TimeEntryBaseModal extends OpModalComponent {
@@ -21,10 +23,13 @@ export abstract class TimeEntryBaseModal extends OpModalComponent {
   public closeOnEscape = false;
   public closeOnOutsideClick = false;
 
+  @InjectField() workPackageCacheService:WorkPackageCacheService;
+
   constructor(readonly elementRef:ElementRef,
               @Inject(OpModalLocalsToken) readonly locals:OpModalLocalsMap,
               readonly cdRef:ChangeDetectorRef,
-              readonly i18n:I18nService) {
+              readonly i18n:I18nService,
+              readonly injector:Injector) {
     super(locals, cdRef, elementRef);
   }
 
@@ -37,6 +42,8 @@ export abstract class TimeEntryBaseModal extends OpModalComponent {
   public saveEntry() {
     this.editForm.save()
       .then(() => {
+        // reload workPackage
+        this.workPackageCacheService.require(this.entry.workPackage.id, true);
         this.service.close();
       });
   }

--- a/frontend/src/app/modules/time_entries/shared/modal/base.modal.ts
+++ b/frontend/src/app/modules/time_entries/shared/modal/base.modal.ts
@@ -13,7 +13,7 @@ export abstract class TimeEntryBaseModal extends OpModalComponent {
   @ViewChild('editForm', { static: true }) editForm:TimeEntryFormComponent;
 
   public text:{ [key:string]:string } = {
-    title: this.i18n.t('js.time_entry.label'),
+    title: this.i18n.t('js.time_entry.title'),
     cancel: this.i18n.t('js.button_cancel'),
     close: this.i18n.t('js.button_close'),
     delete: this.i18n.t('js.button_delete'),

--- a/frontend/src/app/modules/time_entries/shared/modal/base.modal.ts
+++ b/frontend/src/app/modules/time_entries/shared/modal/base.modal.ts
@@ -39,11 +39,17 @@ export abstract class TimeEntryBaseModal extends OpModalComponent {
     return this.locals.entry;
   }
 
+  public get showWorkPackageField() {
+    return this.locals.showWorkPackageField !== undefined ? this.locals.showWorkPackageField : true;
+  }
+
   public saveEntry() {
     this.editForm.save()
       .then(() => {
         // reload workPackage
-        this.workPackageCacheService.require(this.entry.workPackage.id, true);
+        if (this.entry.workPackage) {
+          this.workPackageCacheService.require(this.entry.workPackage.id, true);
+        }
         this.service.close();
       });
   }

--- a/frontend/src/app/modules/work_packages/query-space/wp-isolated-query-space.directive.ts
+++ b/frontend/src/app/modules/work_packages/query-space/wp-isolated-query-space.directive.ts
@@ -65,6 +65,7 @@ import {WorkPackageViewDisplayRepresentationService} from "core-app/modules/work
 import {WorkPackageViewHierarchyIdentationService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-hierarchy-indentation.service";
 import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
+import {TimeEntryCreateService} from "core-app/modules/time_entries/create/create.service";
 
 /**
  * Directive to open a work package query 'space', an isolated injector hierarchy
@@ -118,6 +119,7 @@ import {WorkPackageNotificationService} from "core-app/modules/work_packages/not
     WorkPackageCardViewService,
 
     HalResourceEditingService,
+    TimeEntryCreateService,
     WorkPackageCreateService,
 
     WorkPackageStatesInitializationService,

--- a/spec/features/support/components/time_logging_modal.rb
+++ b/spec/features/support/components/time_logging_modal.rb
@@ -1,0 +1,143 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Components
+  class TimeLoggingModal
+    include Capybara::DSL
+    include RSpec::Matchers
+
+    attr_reader :activity_field,
+                :comment_field,
+                :hours_field,
+                :spent_on_field,
+                :work_package_field
+
+    def initialize
+      @activity_field = EditField.new(page, 'activity')
+      @comment_field = EditField.new(page, 'comment')
+      @hours_field = EditField.new(page, 'hours')
+      @spent_on_field = EditField.new(page, 'spentOn')
+      @work_package_field = EditField.new(page, 'workPackage')
+    end
+
+    def is_visible(visible)
+      if visible
+        within modal_container do
+          expect(page)
+            .to have_content(I18n.t('js.button_log_time'))
+        end
+      else
+        expect(page).to have_no_selector '.op-modal--modal-container'
+      end
+    end
+
+    def has_field_with_value(field, value)
+      within modal_container do
+        expect(page).to have_field field_identifier(field), with: value
+      end
+    end
+
+    def shows_field(field, visible)
+      within modal_container do
+        if visible
+          expect(page).to have_selector "##{field_identifier(field)}"
+        else
+          expect(page).to have_no_selector "##{field_identifier(field)}"
+        end
+      end
+    end
+
+    def update_field(field_name, value)
+      field = field_object field_name
+      field.input_element.click
+      field.set_value value
+    end
+
+    def update_work_package_field(value, recent = false)
+      work_package_field.input_element.click
+
+      if recent
+        within('.ng-dropdown-header') do
+          click_link(I18n.t('js.label_recent'))
+        end
+      end
+
+      work_package_field.set_value(value)
+    end
+
+    def perform_action(action)
+      within modal_container do
+        click_button action
+      end
+    end
+
+    def work_package_is_missing(missing)
+      if missing
+        expect(page)
+          .to have_content(I18n.t('js.time_entry.work_package_required'))
+      else
+        expect(page)
+          .to have_no_content(I18n.t('js.time_entry.work_package_required'))
+      end
+    end
+
+    private
+
+    def field_identifier(field_name)
+      case field_name
+      when 'spent_on'
+        'wp-new-inline-edit--field-spentOn'
+      when 'work_package'
+        'wp-new-inline-edit--field-workPackage'
+      else
+        nil
+      end
+    end
+
+    def field_object(field_name)
+      case field_name
+      when 'activity'
+        activity_field
+      when 'hours'
+        hours_field
+      when 'spent_on'
+        spent_on_field
+      when 'comment'
+        comment_field
+      when 'work_package'
+        work_package_field
+      else
+        nil
+      end
+    end
+
+    def modal_container
+      page.find('.op-modal--modal-container')
+    end
+  end
+end

--- a/spec/features/work_packages/spent_time_display_spec.rb
+++ b/spec/features/work_packages/spent_time_display_spec.rb
@@ -1,0 +1,89 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Logging time within the work package view', type: :feature, js: true do
+  let(:project) { FactoryBot.create :project }
+  let(:admin) { FactoryBot.create :admin }
+  let(:user_without_permissions) do
+    FactoryBot.create(:user,
+                      member_in_project: project,
+                      member_with_permissions: %i[view_time_entries view_work_packages edit_work_packages])
+  end
+
+  let!(:activity) { FactoryBot.create :time_entry_activity, project: project }
+  let(:spent_time_field) { ::SpentTimeEditField.new(page, 'spentTime') }
+  let(:time_logging_modal) { ::Components::TimeLoggingModal.new }
+
+  let(:work_package) { FactoryBot.create :work_package, project: project }
+  let(:wp_page) { Pages::FullWorkPackage.new(work_package, project) }
+
+
+  context 'as an admin' do
+    before do
+      login_as(admin)
+      wp_page.visit!
+      loading_indicator_saveguard
+    end
+
+    it 'shows a logging button within the display field and can log time via a modal' do
+      spent_time_field.timeLogIconVisible true
+
+      # click on button opens modal
+      spent_time_field.openTimeLogModal
+      time_logging_modal.is_visible true
+
+      # the fields are visible
+      time_logging_modal.has_field_with_value 'spent_on', Date.today.strftime("%Y-%m-%d")
+      time_logging_modal.shows_field 'work_package', false
+
+      time_logging_modal.update_field 'activity', activity.name
+
+      # a click on save creates a time entry
+      time_logging_modal.perform_action 'Create'
+      wp_page.expect_and_dismiss_notification message: 'Successful creation.'
+
+      # the value is updated automatically
+      spent_time_field.expect_display_value '1 h'
+    end
+  end
+
+  context 'as a user who cannot log time' do
+    before do
+      login_as(user_without_permissions)
+      wp_page.visit!
+      loading_indicator_saveguard
+    end
+
+    it 'shows no logging button within the display field' do
+      spent_time_field.timeLogIconVisible false
+      spent_time_field.expect_display_value '-'
+    end
+  end
+end

--- a/spec/support/edit_fields/spent_time_edit_field.rb
+++ b/spec/support/edit_fields/spent_time_edit_field.rb
@@ -1,0 +1,21 @@
+require_relative './edit_field'
+
+class SpentTimeEditField < EditField
+  def timeLogIconVisible(visible)
+    if visible
+      expect(page).to have_selector("#{@selector} #{display_selector} #{icon}")
+    else
+      expect(page).to have_no_selector("#{@selector} #{display_selector} #{icon}")
+    end
+  end
+
+  def openTimeLogModal
+    page.find("#{@selector} #{display_selector} #{icon}").click
+  end
+
+  private
+
+  def icon
+    '.icon-time'
+  end
+end


### PR DESCRIPTION
### Todo

- [x] Show icon next to display field in work package view
  - [x] Do not show the icon, if the user does not have the permission to log time
- [x] A click on the icon, opens the time logging widget
   - [x] The work package is preselected (in the data)
   - [x] The work package select field should be hidden
- [x] When logging new time, the Work Package is updated accordingly
- [x] Add test
