### PR TITLE
[33097] Fix: alignment of labels displayed on the left side in the gantt chart

### DIFF
--- a/app/assets/stylesheets/content/work_packages/timelines/elements/_labels.sass
+++ b/app/assets/stylesheets/content/work_packages/timelines/elements/_labels.sass
@@ -1,8 +1,10 @@
 @mixin timeline-label
+  display: flex
+  align-items: center
   height: 16px
   min-width: 20px
+  width: max-content
   font-size: 14px
-  display: inline-block
   white-space: nowrap
   vertical-align: middle
   pointer-events: none
@@ -33,7 +35,7 @@
     left: 0px
     top: 0px
     // Then translate by its own width + some margin
-    transform: translateX(calc(-100% - 10px))
+    transform: translateX(calc(-100% - 15px))
     // Ensure line-height is normal
     line-height: 1
 


### PR DESCRIPTION
#### Changes
- vertical align all labels shown in the gantt view
- adapt margin of left containers to the margin on the other side

See ticket: https://community.openproject.com/projects/openproject/work_packages/33097