### PR TITLE
Bim/fix/33122 hide keyboard icon when no IFCviewer

### DIFF
--- a/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.component.html
+++ b/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.component.html
@@ -16,7 +16,7 @@
   </div>
 
   <div class="ifc-model-viewer--container xeokit-busy-modal-backdrop">
-    <div *ngIf="!keyboardEnabled"
+    <div *ngIf="modelCount && !keyboardEnabled"
          class="ifc-model-viewer--focus-warning">
       <a class="ifc-model-viewer--keyboard-disabled-icon icon-no-color icon-input-disabled"
          (mousedown)="enableFromIcon($event)"

--- a/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.component.ts
@@ -63,7 +63,7 @@ export class IFCViewerComponent implements OnInit, OnDestroy {
 
   constructor(private I18n:I18nService,
               private elementRef:ElementRef,
-              private ifcData:IfcModelsDataService,
+              public ifcData:IfcModelsDataService,
               private ifcViewer:IFCViewerService) {
   }
 

--- a/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.component.ts
@@ -47,9 +47,7 @@ import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 })
 export class IFCViewerComponent implements OnInit, OnDestroy {
   private viewerUI:any;
-
-  modelCount = this.ifcData.models.length;
-
+  modelCount:number;
   canManage = this.ifcData.allowed('manage_ifc_models');
 
   text = {
@@ -70,6 +68,8 @@ export class IFCViewerComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit():void {
+    this.modelCount = this.ifcData.models.length;
+
     if (this.modelCount === 0) {
       return;
     }
@@ -94,13 +94,15 @@ export class IFCViewerComponent implements OnInit, OnDestroy {
 
   @HostListener('mousedown')
   enableKeyBoard() {
-    this.keyboardEnabled = true;
-    this.ifcViewer.setKeyboardEnabled(true);
+    if (this.modelCount) {
+      this.keyboardEnabled = true;
+      this.ifcViewer.setKeyboardEnabled(true);
+    }
   }
 
   @HostListener('window:mousedown', ['$event.target'])
   disableKeyboard(target:Element) {
-    if (!this.outerContainer.nativeElement!.contains(target)) {
+    if (this.modelCount && !this.outerContainer.nativeElement!.contains(target)) {
       this.keyboardEnabled = false;
       this.ifcViewer.setKeyboardEnabled(false);
     }


### PR DESCRIPTION
https://community.openproject.com/projects/bim/work_packages/details/33122/overview

Ifc-viewer.component:

- [x] Hide ifc-model-viewer--keyboard-disabled-icon when there are no models and so there is no IFCViewer loaded.

- [x] Remove Typescript error because a private variable was used on the template.