### PR TITLE
register api patches immediately and raise when too late

### DIFF
--- a/config/constants/api_patch_registry.rb
+++ b/config/constants/api_patch_registry.rb
@@ -34,6 +34,11 @@ module Constants
         patch_map = patch_maps_by_class[class_name]
 
         path = ":#{path}" if path.is_a?(Symbol)
+
+        if Object.const_defined?(class_name)
+          raise "Adding patch #{block} to #{class_name} after it is already loaded has no effect."
+        end
+
         patch_map[path] = [] unless patch_map[path]
         patch_map[path] << block
       end

--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -225,13 +225,11 @@ module OpenProject::Plugins
       end
 
       def add_api_endpoint(base_endpoint, path = nil, &block)
-        config.to_prepare do
-          # we are expecting the base_endpoint as string for two reasons:
-          # 1. it does not seem possible to pass it as constant (auto loader not ready yet)
-          # 2. we can't constantize it here, because that would evaluate
-          #    the API before it can be patched
-          ::Constants::APIPatchRegistry.add_patch base_endpoint, path, &block
-        end
+        # we are expecting the base_endpoint as string for two reasons:
+        # 1. it does not seem possible to pass it as constant (auto loader not ready yet)
+        # 2. we can't constantize it here, because that would evaluate
+        #    the API before it can be patched
+        ::Constants::APIPatchRegistry.add_patch base_endpoint, path, &block
       end
 
       def extend_api_response(*args, &block)


### PR DESCRIPTION
New API patches can only be registered within an engine which is only read when booting.

Before the patch, the actual registration took place on to_prepare.

But the patching only takes place when the patched class is read.

If the class is initialized, before the patch is registered, it is never applied. There was no warning given.

With the change, the registration happens at once and an error is raised if a patch is registered after the class is already defined.