### PR TITLE
use integer instead of enum type for job status

### DIFF
--- a/app/models/delayed/job/status.rb
+++ b/app/models/delayed/job/status.rb
@@ -6,11 +6,11 @@ module Delayed
       belongs_to :reference, polymorphic: true
       belongs_to :job, class_name: '::Delayed::Job'
 
-      enum status: { in_queue: 'in_queue',
-                     error: 'error',
-                     in_process: 'in_process',
-                     success: 'success',
-                     failure: 'failure' }
+      enum status: { in_queue: 0,
+                     in_process: 1,
+                     error: 2,
+                     success: 3,
+                     failure: 4 }
 
       def self.of_reference(reference)
         where(reference: reference)

--- a/db/migrate/20200424142608_job_status_without_enum.rb
+++ b/db/migrate/20200424142608_job_status_without_enum.rb
@@ -1,0 +1,62 @@
+class JobStatusWithoutEnum < ActiveRecord::Migration[6.0]
+  def up
+    add_column :delayed_job_statuses, :status_new, :integer
+
+    map = <<-CASE
+       WHEN 'in_queue' THEN 0
+       WHEN 'in_process' THEN 1
+       WHEN 'error' THEN 2
+       WHEN 'success' THEN 3
+       WHEN 'failure' THEN 4
+    CASE
+
+    update_new_column(map)
+
+    remove_column :delayed_job_statuses, :status
+    rename_column :delayed_job_statuses, :status_new, :status
+    change_column :delayed_job_statuses, :status, :integer, default: 0
+
+    execute <<-SQL
+      DROP TYPE delayed_job_status;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      CREATE TYPE delayed_job_status AS ENUM ('in_queue', 'error', 'in_process', 'success', 'failure');
+    SQL
+
+    add_column :delayed_job_statuses, :status_new, :delayed_job_status
+
+    map = <<-CASE
+      WHEN 0 THEN 'in_queue'::delayed_job_status
+      WHEN 1 THEN 'in_process'::delayed_job_status
+      WHEN 2 THEN 'error'::delayed_job_status
+      WHEN 3 THEN 'success'::delayed_job_status
+      WHEN 4 THEN 'failure'::delayed_job_status
+    CASE
+
+    update_new_column(map)
+
+    remove_column :delayed_job_statuses, :status
+    rename_column :delayed_job_statuses, :status_new, :status
+    change_column :delayed_job_statuses, :status, :delayed_job_status, default: 'in_queue'
+  end
+
+  def update_new_column(map)
+    ActiveRecord::Base.connection.exec_query(
+      <<-SQL
+        UPDATE
+          delayed_job_statuses s_sink
+        SET
+          status_new = CASE s_source.status
+                       #{map}
+                       END
+        FROM
+          delayed_job_statuses s_source
+        WHERE
+          s_sink.id = s_source.id
+      SQL
+    )
+  end
+end


### PR DESCRIPTION
@machisuji, @oliverguenther this will forfeit the postgres enum in favor of an integer which will be compatible to the plain schema.rb.