### PR TITLE
Show modal when logging time via the context menu of a WP view 

### DIFF
--- a/frontend/src/app/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
+++ b/frontend/src/app/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
@@ -13,12 +13,16 @@ import {PERMITTED_CONTEXT_MENU_ACTIONS} from 'core-components/op-context-menu/wp
 import {OpModalService} from 'core-components/op-modals/op-modal.service';
 import {WorkPackageAuthorization} from 'core-components/work-packages/work-package-authorization.service';
 import {WorkPackageAction} from 'core-components/wp-table/context-menu-helper/wp-context-menu-helper.service';
+import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
+import {TimeEntryCreateService} from "core-app/modules/time_entries/create/create.service";
 
 @Directive({
   selector: '[wpSingleContextMenu]'
 })
 export class WorkPackageSingleContextMenuDirective extends OpContextMenuTrigger {
   @Input('wpSingleContextMenu-workPackage') public workPackage:WorkPackageResource;
+
+  @InjectField() public timeEntryCreateService:TimeEntryCreateService;
 
   constructor(readonly HookService:HookService,
               readonly $state:StateService,
@@ -52,6 +56,13 @@ export class WorkPackageSingleContextMenuDirective extends OpContextMenuTrigger 
         break;
       case 'delete':
         this.opModalService.show(WpDestroyModal, this.injector, { workPackages: [this.workPackage] });
+        break;
+      case 'log_time':
+        this.timeEntryCreateService
+          .create(moment(new Date()), this.workPackage, false)
+          .catch(() => {
+            // do nothing, the user closed without changes
+          });
         break;
 
       default:

--- a/frontend/src/app/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive.ts
+++ b/frontend/src/app/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive.ts
@@ -15,6 +15,7 @@ import {OpModalService} from "core-components/op-modals/op-modal.service";
 import {WpDestroyModal} from "core-components/modals/wp-destroy-modal/wp-destroy.modal";
 import {StateService} from "@uirouter/core";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
+import {TimeEntryCreateService} from "core-app/modules/time_entries/create/create.service";
 
 export class WorkPackageViewContextMenu extends OpContextMenuHandler {
 
@@ -24,6 +25,7 @@ export class WorkPackageViewContextMenu extends OpContextMenuHandler {
   @InjectField() protected $state:StateService;
   @InjectField() protected wpTableSelection:WorkPackageViewSelectionService;
   @InjectField() protected WorkPackageContextMenuHelper:WorkPackageContextMenuHelperService;
+  @InjectField() protected timeEntryCreateService:TimeEntryCreateService;
 
   protected workPackage = this.states.workPackages.get(this.workPackageId).value!;
   protected selectedWorkPackages = this.getSelectedWorkPackages();
@@ -77,6 +79,10 @@ export class WorkPackageViewContextMenu extends OpContextMenuHandler {
         this.wpRelationsHierarchyService.addNewChildWp(this.baseRoute, this.workPackage);
         break;
 
+      case 'log_time':
+        this.logTimeForSelectedWorkPackage();
+        break;
+
       default:
         window.location.href = link!;
         break;
@@ -110,6 +116,14 @@ export class WorkPackageViewContextMenu extends OpContextMenuHandler {
     };
 
     this.$state.go(this.baseRoute + '.copy', params);
+  }
+
+  private logTimeForSelectedWorkPackage() {
+    this.timeEntryCreateService
+      .create(moment(new Date()), this.workPackage)
+      .catch(() => {
+        // do nothing, the user closed without changes
+      });
   }
 
   private getSelectedWorkPackages() {

--- a/spec/features/work_packages/table/context_menu_spec.rb
+++ b/spec/features/work_packages/table/context_menu_spec.rb
@@ -8,6 +8,7 @@ describe 'Work package table context menu', js: true do
   let(:wp_timeline) { Pages::WorkPackagesTimeline.new(work_package.project) }
   let(:menu) { Components::WorkPackages::ContextMenu.new }
   let(:destroy_modal) { Components::WorkPackages::DestroyModal.new }
+  let(:time_logging_modal) { Components::TimeLoggingModal.new }
   let(:display_representation) { ::Components::WorkPackages::DisplayRepresentation.new }
 
   def goto_context_menu list_view = true
@@ -43,7 +44,9 @@ describe 'Work package table context menu', js: true do
         # Open log time
         goto_context_menu list_view
         menu.choose('Log time')
-        expect(page).to have_selector('h2', text: I18n.t(:label_spent_time))
+        time_logging_modal.is_visible true
+        time_logging_modal.work_package_is_missing false
+        time_logging_modal.perform_action 'Cancel'
 
         # Open Move
         goto_context_menu list_view


### PR DESCRIPTION
In #8306 the timelogging modal is first introduced within the WP view (within the spentTimeDisaplyField). The same functionality is now added to the "log time"-triggers within the context menus of the different WP views: full view, split view and table context menu.