### PR TITLE
[33193] Missing translation for default assignee board name

### DIFF
--- a/frontend/src/app/modules/boards/board/board.service.ts
+++ b/frontend/src/app/modules/boards/board/board.service.ts
@@ -25,7 +25,7 @@ export class BoardService {
   private text = {
     unnamed_board: this.I18n.t('js.boards.label_unnamed_board'),
     action_board: (attr:string) => this.I18n.t('js.boards.board_type.action_by_attribute',
-      { attribute: attr }),
+      { attribute: this.I18n.t('js.boards.board_type.action_type.' + attr )}),
     unnamed_list: this.I18n.t('js.boards.label_unnamed_list'),
   };
 

--- a/frontend/src/app/modules/boards/index-page/boards-index-page.component.ts
+++ b/frontend/src/app/modules/boards/index-page/boards-index-page.component.ts
@@ -29,7 +29,7 @@ export class BoardsIndexPageComponent extends UntilDestroyedMixin implements OnI
     type: this.I18n.t('js.boards.label_board_type'),
     type_free: this.I18n.t('js.boards.board_type.free'),
     action_by_attribute: (attr:string) => this.I18n.t('js.boards.board_type.action_by_attribute',
-      { attribute: attr }),
+      { attribute: this.I18n.t('js.boards.board_type.action_type.' + attr ) }),
     createdAt: this.I18n.t('js.label_created_on'),
     delete: this.I18n.t('js.button_delete'),
     areYouSure: this.I18n.t('js.text_are_you_sure'),

--- a/modules/boards/config/locales/js-en.yml
+++ b/modules/boards/config/locales/js-en.yml
@@ -43,6 +43,10 @@ en:
         action_text: >
           Create a board with filtered lists on a single attribute. Moving work packages to other lists
           will update their attribute.
+        action_type:
+          assignee: assignee
+          status: status
+          version: version
         select_attribute: "Action attribute"
 
       configuration_modal:


### PR DESCRIPTION
Translate type of action board in the default name "Action board (_actionType_)"

https://community.openproject.com/projects/openproject/work_packages/33193/activity