### PR TITLE
[33073] Add notification message to board when there are no options to add

### DIFF
--- a/frontend/src/app/modules/boards/board/add-list-modal/add-list-modal.component.ts
+++ b/frontend/src/app/modules/boards/board/add-list-modal/add-list-modal.component.ts
@@ -73,6 +73,10 @@ export class AddListModalComponent extends OpModalComponent implements OnInit {
   /* Do not close on outside click (because the select option are appended to the body */
   public closeOnOutsideClick = false;
 
+  public valuesAvailable:boolean = true;
+
+  public warningText:string|undefined;
+
   public text:any = {
     title: this.I18n.t('js.boards.add_list'),
     button_add: this.I18n.t('js.button_add'),
@@ -117,6 +121,14 @@ export class AddListModalComponent extends OpModalComponent implements OnInit {
       .getAvailableValues(this.board, this.queries)
       .then(available => {
         this.availableValues = available;
+        if (this.availableValues.length === 0) {
+          this.actionService
+            .warningTextWhenNoOptionsAvailable()
+            .then((text) => {
+              this.warningText = text;
+              this.valuesAvailable = false;
+            });
+        }
       });
   }
 

--- a/frontend/src/app/modules/boards/board/add-list-modal/add-list-modal.html
+++ b/frontend/src/app/modules/boards/board/add-list-modal/add-list-modal.html
@@ -29,6 +29,14 @@
             </div>
           </div>
         </div>
+
+      <div *ngIf="!valuesAvailable && warningText"
+           class="notification-box -warning">
+        <div class="notification-box--content">
+          <p [innerHTML]="warningText"></p>
+        </div>
+      </div>
+
     </div>
     <div class="op-modal--modal-footer">
       <button class="button -highlight"

--- a/frontend/src/app/modules/boards/board/board-actions/board-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/board-action.service.ts
@@ -81,4 +81,10 @@ export interface BoardActionService {
    * @returns {the icon class or nothing}
    */
   disabledAddButtonPlaceholder(resource?:HalResource):DisabledButtonPlaceholder|undefined;
+
+  /**
+   * Determines the specific warning to be shown, when there are no options to add as a list
+   * @returns {the text or nothing}
+   */
+  warningTextWhenNoOptionsAvailable():Promise<string|undefined>;
 }

--- a/frontend/src/app/modules/boards/board/board-actions/status/status-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/status/status-action.service.ts
@@ -128,6 +128,10 @@ export class BoardStatusActionService implements BoardActionService {
     return undefined;
   }
 
+  public warningTextWhenNoOptionsAvailable() {
+    return Promise.resolve(this.I18n.t('js.boards.add_list_modal.warning.status'));
+  }
+
   private getStatuses():Promise<StatusResource[]> {
     return this.statusDm
       .list()

--- a/frontend/src/app/modules/boards/board/board-actions/version/version-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/version/version-action.service.ts
@@ -170,6 +170,10 @@ export class BoardVersionActionService implements BoardActionService {
     return value instanceof VersionResource && value.isOpen();
   }
 
+  public warningTextWhenNoOptionsAvailable() {
+    return Promise.resolve(undefined);
+  }
+
   private getVersions():Promise<VersionResource[]> {
     if (this.currentProject.id === null) {
       return Promise.resolve([]);

--- a/modules/boards/config/locales/js-en.yml
+++ b/modules/boards/config/locales/js-en.yml
@@ -49,6 +49,13 @@ en:
           version: version
         select_attribute: "Action attribute"
 
+      add_list_modal:
+        warning:
+          status: |
+            There is currently no status available. <br>
+            Either there are none or they have all already been added to the board.
+          assignee: This project currently does not have any members that can be added. <br>
+          add_members: <a href="%{link}">Add a new member to this project</a> to select users again.
       configuration_modal:
         title: 'Configure this board'
         display_settings:

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -345,10 +345,24 @@ module Pages
     end
 
     def open_and_fill_add_list_modal(name)
-      page.find('.boards-list--add-item').click
-      expect(page).to have_selector('.new-list--action-select input')
+      open_add_list_modal
       sleep(0.1)
       page.find('.op-modal--modal-container .new-list--action-select input').set(name)
+    end
+
+    def open_add_list_modal
+      page.find('.boards-list--add-item').click
+      expect(page).to have_selector('.new-list--action-select input')
+    end
+
+    def add_list_modal_shows_warning(value, with_link: false)
+      within page.find('.op-modal--modal-container') do
+        warning = '.notification-box.-warning'
+        link = '.notification-box--content a'
+
+        expect(page).to (value ? have_selector(warning) : have_no_selector(warning))
+        expect(page).to (with_link ? have_selector(link) : have_no_selector(link))
+      end
     end
   end
 end


### PR DESCRIPTION
### ToDo

- [x] Show warning when there are no options to add as a new list (e.g. no project members)
- [x] Show different texts depending on the action type of the type
- [x] The link to "Add new members" should only be visible when the user has the right to add new members to the project 
- [x] Add a test 
