### PR TITLE
ensure path prefix on assignee board

### DIFF
--- a/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-action.service.ts
@@ -15,6 +15,7 @@ import {HalResourceService} from 'core-app/modules/hal/services/hal-resource.ser
 import {AssigneeBoardHeaderComponent} from "core-app/modules/boards/board/board-actions/assignee/assignee-board-header.component";
 import {input} from "reactivestates";
 import {take} from "rxjs/operators";
+import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 
 @Injectable()
 export class BoardAssigneeActionService implements BoardActionService {
@@ -24,6 +25,7 @@ export class BoardAssigneeActionService implements BoardActionService {
   constructor(protected boardListsService:BoardListsService,
               protected I18n:I18nService,
               protected halResourceService:HalResourceService,
+              protected pathHelper:PathHelperService,
               protected currentProject:CurrentProjectService
   ) {
   }
@@ -129,7 +131,7 @@ export class BoardAssigneeActionService implements BoardActionService {
     const projectIdentifier = this.currentProject.identifier!;
     this.assignees.putFromPromiseIfPristine(() =>
       this.halResourceService
-        .get('/api/v3/projects/' + projectIdentifier + '/available_assignees')
+        .get(this.pathHelper.api.v3.projects.id(projectIdentifier).available_assignees)
         .toPromise()
         .then((collection:CollectionResource<UserResource>) => collection.elements)
     );

--- a/frontend/src/app/modules/common/path-helper/apiv3/projects/apiv3-project-paths.ts
+++ b/frontend/src/app/modules/common/path-helper/apiv3/projects/apiv3-project-paths.ts
@@ -40,6 +40,9 @@ export class Apiv3ProjectPaths extends SimpleResource {
     super(projectPath, projectId);
   }
 
+  // /api/v3/projects/:project_id/available_assignees
+  public readonly available_assignees = this.path + '/available_assignees';
+
   public readonly queries = new Apiv3QueriesPaths(this.path);
 
   public readonly types = new Apiv3TypesPaths(this.path);


### PR DESCRIPTION
Ensure the subpath is taken into account when querying for the available_assignees to get the available values for columns in an assignee board.

https://community.openproject.com/wp/33202