### PR TITLE
Fix/conditionally disable bim column and filter

### DIFF
--- a/modules/bim/app/models/bim/queries/work_packages/columns/bcf_thumbnail_column.rb
+++ b/modules/bim/app/models/bim/queries/work_packages/columns/bcf_thumbnail_column.rb
@@ -28,28 +28,16 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module OpenProject::Bim
-  class QueryBcfThumbnailColumn < Queries::WorkPackages::Columns::WorkPackageColumn
+module ::Bim::Queries::WorkPackages::Columns
+  class BcfThumbnailColumn < Queries::WorkPackages::Columns::WorkPackageColumn
     def caption
       I18n.t('attributes.bcf_thumbnail')
     end
 
-    class_attribute :bcf_thumbnail_columns
-
-    self.bcf_thumbnail_columns = {
-      bcf_thumbnail: {
-        summable: false,
-        groupable: false,
-        sortable: false
-      }
-    }
-
     def self.instances(_context = nil)
-      # return [] if context && !context.module_enabled?(:bcf_module)
+      return [] unless OpenProject::Configuration.bim?
 
-      bcf_thumbnail_columns.map do |name, options|
-        new(name, options)
-      end
+      [new(:bcf_thumbnail, { summable: false, groupable: false, sortable: false })]
     end
   end
 end

--- a/modules/bim/app/models/bim/queries/work_packages/filter/bcf_issue_associated_filter.rb
+++ b/modules/bim/app/models/bim/queries/work_packages/filter/bcf_issue_associated_filter.rb
@@ -28,7 +28,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module ::OpenProject::Bim
+module ::Bim::Queries::WorkPackages::Filter
   class BcfIssueAssociatedFilter < ::Queries::WorkPackages::Filter::WorkPackageFilter
     attr_reader :join_table_suffix
 
@@ -63,6 +63,10 @@ module ::OpenProject::Bim
 
     def dependency_class
       '::API::V3::Queries::Schemas::BooleanFilterDependencyRepresenter'
+    end
+
+    def available?
+      OpenProject::Configuration.bim?
     end
 
     private

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -208,7 +208,7 @@ module OpenProject::Bim
         .register_for_list(:bcf, OpenProject::Bim::BcfXml::Exporter)
 
       ::Queries::Register.filter ::Query, ::Bim::Queries::WorkPackages::Filter::BcfIssueAssociatedFilter
-      ::Queries::Register.column ::Query, OpenProject::Bim::QueryBcfThumbnailColumn
+      ::Queries::Register.column ::Query, ::Bim::Queries::WorkPackages::Columns::BcfThumbnailColumn
 
       ::API::Root.class_eval do
         content_type :binary, 'application/octet-stream'

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -207,7 +207,7 @@ module OpenProject::Bim
       ::WorkPackage::Exporter
         .register_for_list(:bcf, OpenProject::Bim::BcfXml::Exporter)
 
-      ::Queries::Register.filter ::Query, OpenProject::Bim::BcfIssueAssociatedFilter
+      ::Queries::Register.filter ::Query, ::Bim::Queries::WorkPackages::Filter::BcfIssueAssociatedFilter
       ::Queries::Register.column ::Query, OpenProject::Bim::QueryBcfThumbnailColumn
 
       ::API::Root.class_eval do

--- a/modules/bim/spec/api/v3/queries/filters/query_filter_instance_representer_spec.rb
+++ b/modules/bim/spec/api/v3/queries/filters/query_filter_instance_representer_spec.rb
@@ -31,7 +31,8 @@ require 'spec_helper'
 describe ::API::V3::Queries::Filters::QueryFilterInstanceRepresenter do
   let(:operator) { '=' }
   let(:filter) do
-    ::OpenProject::Bim::BcfIssueAssociatedFilter.create!(name: "bcf_issue_associated", operator: operator, values: values)
+    ::Bim::Queries::WorkPackages::Filter::BcfIssueAssociatedFilter
+      .create!(name: "bcf_issue_associated", operator: operator, values: values)
   end
 
   let(:representer) { described_class.new(filter) }

--- a/modules/bim/spec/models/queries/work_packages/columns/bcf_thumbnail_column_spec.rb
+++ b/modules/bim/spec/models/queries/work_packages/columns/bcf_thumbnail_column_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require Rails.root + 'spec/models/queries/work_packages/columns/shared_query_column_specs'
+
+describe Bim::Queries::WorkPackages::Columns::BcfThumbnailColumn, type: :model do
+  let(:instance) { described_class.new(:query_column) }
+
+  it_behaves_like 'query column'
+
+  describe 'instances' do
+    context 'bim edition', with_config: { edition: 'bim' } do
+      it 'the bcf_thumbnail column exists' do
+        expect(described_class.instances.map(&:name))
+          .to include :bcf_thumbnail
+      end
+    end
+
+    context 'vanilla edition' do
+      it 'the bcf_thumbnail column does not exist' do
+        expect(described_class.instances.map(&:name))
+          .not_to include :bcf_thumbnail
+      end
+    end
+  end
+end

--- a/modules/bim/spec/models/queries/work_packages/filter/bcf_issue_associated_filter_spec.rb
+++ b/modules/bim/spec/models/queries/work_packages/filter/bcf_issue_associated_filter_spec.rb
@@ -1,0 +1,56 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+require 'spec_helper'
+
+describe Bim::Queries::WorkPackages::Filter::BcfIssueAssociatedFilter, type: :model do
+  include_context 'filter tests'
+  let(:values) { [OpenProject::Database::DB_VALUE_TRUE] }
+
+  it_behaves_like 'basic query filter' do
+    let(:class_key) { :bcf_issue_associated }
+    let(:type) { :list }
+
+    describe '#available?' do
+      context 'if bim is enabled', with_config: { edition: 'bim' } do
+        it 'is available' do
+          expect(instance)
+            .to be_available
+        end
+      end
+
+      context 'if bim is disabled' do
+        it 'is not available' do
+          expect(instance)
+            .not_to be_available
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hides bim specific column and filter in case the instance is not configured to support bim.

https://community.openproject.com/wp/33190

It would be an option to be even more strict and also hide both in case the bim module is not activated. That would be in line with the behaviour of the other filters/columns. However, the removed code fragment suggests, that the desired behaviour is to be more lenient here. 