### PR TITLE
remove usage of deprecated doorkeeper config

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -114,14 +114,6 @@ Doorkeeper.configure do
   #
   # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
 
-  # Change the native redirect uri for client apps
-  # When clients register with the following redirect uri, they won't be redirected to any server and
-  # the authorizationcode will be displayed within the provider
-  # The value can be any string. Use nil to disable this feature. When disabled, clients must provide a valid URL
-  # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
-  #
-  native_redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
-
   # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
   # by default in non-development environments). OAuth2 delegates security in
   # communication to the HTTPS protocol so it is wise to keep this enabled.


### PR DESCRIPTION
The default value for `native_redirect_uri` is the same value we provide.

https://github.com/doorkeeper-gem/doorkeeper/blob/v5.3-stable/lib/doorkeeper/config.rb#L267

https://community.openproject.com/wp/33197