### PR TITLE
Build docker image using Github Action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,24 @@
+name: Docker
+on:
+  # Scheduled workflows run on the latest commit on the default or base branch
+  schedule:
+    - cron: '20 2 * * *' # Daily at 02:20
+
+  push:
+    tags:
+      - v*
+jobs:
+  publish:
+    # restrict this job to base repo for now
+    if: github.repository == 'opf/openproject'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Publish to registry
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: openproject/community-test
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tag_semver: true
+          cache: ${{ github.event_name != 'schedule' }}


### PR DESCRIPTION
This new workflow allows to build and publish our official Docker images directly from a GitHub Action.

It is triggered whenever a tag beginning with `v*` is created, and will publish 3 docker image tags according to the semver behaviour.

For instance, if you push `v10.6.0`, it will create the following docker tags:
* `10.6.0`
* `10.6`
* `10`

Then if you push `v10.6.1`, it will publish the `10.6.1` tag, and update the `10.6` and `10` tag to point to the same ref as `10.6.1`.

I have created a new Docker hub repository (`community-test`) where images will be pushed for the time being, because I think we want to test the behaviour for at least two tags before enabling for the main repo.

The workflow will also trigger every night to build and tag the latest docker image from the `dev` branch. 

Examples tags I created from my fork: https://hub.docker.com/repository/docker/openproject/community-test/tags?page=1

I'll remove them once we merge this.