### PR TITLE
[33144] Wiki CKEditor5 toolbar no longer sticky

### DIFF
--- a/app/assets/stylesheets/content/_wiki.sass
+++ b/app/assets/stylesheets/content/_wiki.sass
@@ -155,10 +155,9 @@ h1:hover, h2:hover, h3:hover
   @include styled-scroll-bar
 
 .wiki--content--attribute
-  .form--field-container
-    max-width: 100%
+  .form--field-container,
   .form--text-area-container
-    overflow: hidden
+    max-width: 100%
 
 #wiki_page_parent_id
   overflow: auto


### PR DESCRIPTION
Enable sticky toolbar in wiki again. At the same time, ensure that very wide tables in the wiki are also still scrollable.

https://community.openproject.com/projects/openproject/work_packages/33144/activity

