### PR TITLE
[33185] Number vanishes in time logging widget

### DIFF
--- a/frontend/src/app/modules/fields/edit/field-types/duration-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/duration-edit-field.component.ts
@@ -63,7 +63,18 @@ export class DurationEditFieldComponent extends EditFieldComponent {
   }
 
   protected parseValue(val:moment.Moment | null) {
-    return val === null ? null : val.toISOString();
+    if (val === null) {
+      return val
+    }
+
+    let parsedValue;
+    if (val.isValid()) {
+      parsedValue = val.toISOString();
+    } else {
+      parsedValue = this.resource[this.name];
+    }
+
+    return parsedValue;
   }
 }
 


### PR DESCRIPTION
When having a German Chrome, entering "6." into a duration fields returns a `null` value and thus an invalid date. This leads to the input being cleared. In FF the value is "6" which parses correctly. 

To avoid this issue, I added a check on whether the date is invalid. In this case, the value should simply stay as it is. 
I do not know whether this breaks some of the localisation functionality we have for this field. 🤷‍♀️  

https://community.openproject.com/projects/openproject/work_packages/33185/activity