### PR TITLE
Link viewpoint to the work package's project BCF module

### DIFF
--- a/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.ts
@@ -150,7 +150,7 @@ export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements
           this.viewerBridge.showViewpoint(data);
         } else {
           window.location.href = this.pathHelper.bimDetailsPath(
-            this.currentProject.identifier!,
+            this.workPackage.project.identifier,
             this.workPackage.id!,
             index
           );


### PR DESCRIPTION
https://community.openproject.com/projects/bim/work_packages/details/33195/overview

Link to the viewpoint project (not to the current project) when it is listed on a parent project.