### PR TITLE
Fix/n+1 query for bcf issues

### DIFF
--- a/lib/api/v3/work_packages/eager_loading/checksum.rb
+++ b/lib/api/v3/work_packages/eager_loading/checksum.rb
@@ -70,7 +70,7 @@ module API
             end
 
             def checksum_associations
-              %i[status author responsible assigned_to version priority category type bcf_issue]
+              %i[status author responsible assigned_to version priority category type]
             end
 
             def md5_checksum_table_name(association_name)

--- a/lib/api/v3/work_packages/eager_loading/checksum.rb
+++ b/lib/api/v3/work_packages/eager_loading/checksum.rb
@@ -49,7 +49,7 @@ module API
             def fetch_checksums_for(work_packages)
               WorkPackage
                 .where(id: work_packages.map(&:id).uniq)
-                .left_joins(:status, :author, :responsible, :assigned_to, :version, :priority, :category, :type)
+                .left_joins(*checksum_associations)
                 .pluck('work_packages.id', Arel.sql(md5_concat.squish))
                 .to_h
             end
@@ -57,24 +57,39 @@ module API
             protected
 
             def md5_concat
+              md5_parts = checksum_associations.map do |association_name|
+                table_name = md5_checksum_table_name(association_name)
+                timestamp_column_name = md5_checksum_timestamp_column(association_name)
+
+                %W[#{table_name}.id #{table_name}.#{timestamp_column_name}]
+              end.flatten
+
               <<-SQL
-                MD5(CONCAT(statuses.id,
-                           statuses.updated_at,
-                           users.id,
-                           users.updated_on,
-                           responsibles_work_packages.id,
-                           responsibles_work_packages.updated_on,
-                           assigned_tos_work_packages.id,
-                           assigned_tos_work_packages.updated_on,
-                           versions.id,
-                           versions.updated_on,
-                           types.id,
-                           types.updated_at,
-                           enumerations.id,
-                           enumerations.updated_at,
-                           categories.id,
-                           categories.updated_at))
+                MD5(CONCAT(#{md5_parts.join(', ')}))
               SQL
+            end
+
+            def checksum_associations
+              %i[status author responsible assigned_to version priority category type bcf_issue]
+            end
+
+            def md5_checksum_table_name(association_name)
+              case association_name
+              when :responsible
+                'responsibles_work_packages'
+              when :assigned_to
+                'assigned_tos_work_packages'
+              else
+                association_class(association_name).table_name
+              end
+            end
+
+            def md5_checksum_timestamp_column(association_name)
+              (association_class(association_name).all_timestamp_attributes_in_model & %w[updated_at updated_on]).first
+            end
+
+            def association_class(association_name)
+              WorkPackage.reflect_on_association(association_name).class_name.constantize
             end
           end
 

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -50,14 +50,14 @@ module OpenProject::Bim
                      'bim/ifc_models/ifc_viewer': %i[show]
                    }
         permission :manage_ifc_models,
-                   {'bim/ifc_models/ifc_models': %i[index show destroy edit update create new]},
+                   { 'bim/ifc_models/ifc_models': %i[index show destroy edit update create new] },
                    dependencies: %i[view_ifc_models]
 
         permission :view_linked_issues,
-                   {'bim/bcf/issues': %i[index]},
+                   { 'bim/bcf/issues': %i[index] },
                    dependencies: %i[view_work_packages]
         permission :manage_bcf,
-                   {'bim/bcf/issues': %i[index upload prepare_import perform_import]},
+                   { 'bim/bcf/issues': %i[index upload prepare_import perform_import] },
                    dependencies: %i[view_linked_issues
                                     view_work_packages
                                     add_work_packages
@@ -101,9 +101,6 @@ module OpenProject::Bim
     patch_with_namespace :DemoData, :WorkPackageBoardSeeder
 
     extend_api_response(:v3, :work_packages, :work_package) do
-      # extend cached_representer for bcf issue
-      cached_representer key_parts: %i(bcf_issue)
-
       include API::Bim::Utilities::PathHelper
 
       link :bcfTopic,

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -94,6 +94,7 @@ module OpenProject::Bim
     patch_with_namespace :API, :V3, :Activities, :ActivityRepresenter
     patch_with_namespace :Journal, :AggregatedJournal
     patch_with_namespace :API, :V3, :Activities, :ActivitiesSharedHelpers
+    patch_with_namespace :API, :V3, :WorkPackages, :EagerLoading, :Checksum
 
     patch_with_namespace :DemoData, :QueryBuilder
     patch_with_namespace :DemoData, :ProjectSeeder

--- a/modules/bim/lib/open_project/bim/patches/api/v3/work_packages/eager_loading/checksum_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/api/v3/work_packages/eager_loading/checksum_patch.rb
@@ -1,0 +1,43 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module OpenProject::Bim::Patches::API::V3::WorkPackages::EagerLoading::ChecksumPatch
+  def self.included(base)
+    class << base
+      prepend ClassMethods
+    end
+  end
+
+  module ClassMethods
+    protected
+
+    def checksum_associations
+      super + %i[bcf_issue]
+    end
+  end
+end

--- a/modules/bim/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
+++ b/modules/bim/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
@@ -1,0 +1,74 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++require 'rspec'
+
+require 'spec_helper'
+require Rails.root + 'spec/lib/api/v3/work_packages/eager_loading/eager_loading_mock_wrapper'
+
+describe ::API::V3::WorkPackages::EagerLoading::Checksum do
+  let!(:bcf_issue) do
+    FactoryBot.create(:bcf_issue,
+                      work_package: work_package)
+  end
+  let!(:work_package) do
+    FactoryBot.create(:work_package)
+  end
+
+  describe '.apply' do
+    let!(:orig_checksum) do
+      EagerLoadingMockWrapper
+        .wrap(described_class, [work_package])
+        .first
+        .cache_checksum
+    end
+
+    let(:new_checksum) do
+      EagerLoadingMockWrapper
+        .wrap(described_class, [work_package])
+        .first
+        .cache_checksum
+    end
+
+    it 'produces a different checksum on changes to the bcf issue id' do
+      bcf_issue.delete
+      FactoryBot.create(:bcf_issue,
+                        work_package: work_package)
+
+      expect(new_checksum)
+        .not_to eql orig_checksum
+    end
+
+    it 'produces a different checksum on changes to the bcf issue' do
+      bcf_issue.update_column(:updated_at, Time.now + 10.seconds)
+
+      expect(new_checksum)
+        .not_to eql orig_checksum
+    end
+  end
+end


### PR DESCRIPTION
Refactors the checksum building mapper for work package eager loading to improve extensibility. Then, it patches that class to add the bcf_issue to the checksum calculation. The inclusion of the bcf_issue into the cached_representer configuration is no longer necessary any more as the issue is now part of the checksum.

https://community.openproject.com/wp/33234