### PR TITLE
[32126] Use time logging widget on project overview page

### DIFF
--- a/frontend/src/app/modules/common/path-helper/path-helper.service.ts
+++ b/frontend/src/app/modules/common/path-helper/path-helper.service.ts
@@ -171,14 +171,6 @@ export class PathHelperService {
     }
   }
 
-  public timeEntryPath(timeEntryIdentifier:string) {
-    return this.staticBase + '/time_entries/' + timeEntryIdentifier;
-  }
-
-  public timeEntryEditPath(timeEntryIdentifier:string) {
-    return this.timeEntryPath(timeEntryIdentifier) + '/edit';
-  }
-
   public usersPath() {
     return this.staticBase + '/users';
   }

--- a/frontend/src/app/modules/grids/openproject-grids.module.ts
+++ b/frontend/src/app/modules/grids/openproject-grids.module.ts
@@ -63,6 +63,7 @@ import {WidgetSubprojectsComponent} from "core-app/modules/grids/widgets/subproj
 import {OpenprojectAttachmentsModule} from "core-app/modules/attachments/openproject-attachments.module";
 import {WidgetMembersComponent} from "core-app/modules/grids/widgets/members/members.component";
 import {WidgetProjectStatusComponent} from "core-app/modules/grids/widgets/project-status/project-status.component";
+import {OpenprojectTimeEntriesModule} from "core-app/modules/time_entries/openproject-time-entries.module";
 
 @NgModule({
   imports: [
@@ -74,6 +75,7 @@ import {WidgetProjectStatusComponent} from "core-app/modules/grids/widgets/proje
     OpenprojectWorkPackagesModule,
     OpenprojectWorkPackageGraphsModule,
     OpenprojectCalendarModule,
+    OpenprojectTimeEntriesModule,
 
     OpenprojectAttachmentsModule,
 

--- a/frontend/src/app/modules/grids/widgets/time-entries/list/time-entries-list.component.html
+++ b/frontend/src/app/modules/grids/widgets/time-entries/list/time-entries-list.component.html
@@ -89,13 +89,12 @@
             <em [textContent]="item.sum"></em>
           </td>
           <td class="buttons">
-            <a [href]="editPath(item.entry)"
-               *ngIf="item.entry && item.entry.updateImmediately"
+            <a *ngIf="item.entry && item.entry.updateImmediately"
+               (click)="editTimeEntry(item.entry)"
                [title]="text.edit">
               <op-icon icon-classes="icon-context icon-edit"></op-icon>
             </a>
-            <a [href]="deletePath(item.entry)"
-               *ngIf="item.entry && item.entry.delete"
+            <a *ngIf="item.entry && item.entry.delete"
                (click)="deleteIfConfirmed($event, item.entry)"
                [title]="text.delete" >
               <op-icon icon-classes="icon-context icon-delete"></op-icon>

--- a/frontend/src/app/modules/grids/widgets/time-entries/list/time-entries-list.component.ts
+++ b/frontend/src/app/modules/grids/widgets/time-entries/list/time-entries-list.component.ts
@@ -1,4 +1,4 @@
-import {OnInit, ChangeDetectorRef, Injector} from "@angular/core";
+import {ChangeDetectorRef, Injector, OnInit} from "@angular/core";
 import {AbstractWidgetComponent} from "core-app/modules/grids/widgets/abstract-widget.component";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {TimeEntryDmService} from "core-app/modules/hal/dm-services/time-entry-dm.service";
@@ -7,6 +7,9 @@ import {TimezoneService} from "core-components/datetime/timezone.service";
 import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 import {ConfirmDialogService} from "core-components/modals/confirm-dialog/confirm-dialog.service";
 import {FilterOperator} from "core-components/api/api-v3/api-v3-filter-builder";
+import {TimeEntryEditService} from "core-app/modules/time_entries/edit/edit.service";
+import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
+import {TimeEntryCacheService} from "core-components/time-entries/time-entry-cache.service";
 
 export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetComponent implements OnInit {
   public text = {
@@ -26,8 +29,11 @@ export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetCompo
   private entriesLoaded = false;
   public rows:{ date:string, sum?:string, entry?:TimeEntryResource}[] = [];
 
+  @InjectField() public readonly timeEntryEditService:TimeEntryEditService;
+  @InjectField() public readonly timeEntryCache:TimeEntryCacheService;
+
   constructor(readonly timeEntryDm:TimeEntryDmService,
-              protected readonly injector:Injector,
+              readonly injector:Injector,
               readonly timezone:TimezoneService,
               readonly i18n:I18nService,
               readonly pathHelper:PathHelperService,
@@ -82,20 +88,27 @@ export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetCompo
     return this.formatNumber(this.timezone.toHours(entry.hours));
   }
 
-  public editPath(entry:TimeEntryResource) {
-    return this.pathHelper.timeEntryEditPath(entry.id!);
-  }
-
-  public deletePath(entry:TimeEntryResource) {
-    return this.pathHelper.timeEntryPath(entry.id!);
-  }
-
   public workPackagePath(entry:TimeEntryResource) {
     return this.pathHelper.workPackagePath(entry.workPackage.idFromLink);
   }
 
   public get isEditable() {
     return false;
+  }
+
+  public editTimeEntry(entry:TimeEntryResource) {
+    this.timeEntryCache.require(entry.id!).then((loadedEntry) => {
+      this.timeEntryEditService
+        .edit(loadedEntry)
+        .then((changedEntry) => {
+          let newEntries = Object.assign(this.entries, [changedEntry.entry]);
+
+          this.buildEntries(newEntries);
+        })
+        .catch(() => {
+          // User canceled the modal
+        });
+    });
   }
 
   public deleteIfConfirmed(event:Event, entry:TimeEntryResource) {

--- a/frontend/src/app/modules/grids/widgets/time-entries/project/time-entries-project.component.ts
+++ b/frontend/src/app/modules/grids/widgets/time-entries/project/time-entries-project.component.ts
@@ -13,7 +13,7 @@ import {CurrentProjectService} from "core-components/projects/current-project.se
 })
 export class WidgetTimeEntriesProjectComponent extends WidgetTimeEntriesListComponent implements OnInit {
   constructor(readonly timeEntryDm:TimeEntryDmService,
-              protected readonly injector:Injector,
+              readonly injector:Injector,
               readonly timezone:TimezoneService,
               readonly i18n:I18nService,
               readonly pathHelper:PathHelperService,

--- a/frontend/src/app/modules/time_entries/openproject-time-entries.module.ts
+++ b/frontend/src/app/modules/time_entries/openproject-time-entries.module.ts
@@ -32,6 +32,8 @@ import {OpenprojectFieldsModule} from "core-app/modules/fields/openproject-field
 import {TimeEntryCreateModal} from "core-app/modules/time_entries/create/create.modal";
 import {TimeEntryEditModal} from "core-app/modules/time_entries/edit/edit.modal";
 import {TimeEntryFormComponent} from "core-app/modules/time_entries/form/form.component";
+import {HalResourceEditingService} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
+import {TimeEntryEditService} from "core-app/modules/time_entries/edit/edit.service";
 
 @NgModule({
   imports: [
@@ -42,6 +44,8 @@ import {TimeEntryFormComponent} from "core-app/modules/time_entries/form/form.co
     OpenprojectFieldsModule,
   ],
   providers: [
+    TimeEntryEditService,
+    HalResourceEditingService
   ],
   declarations: [
     TimeEntryEditModal,


### PR DESCRIPTION
Use the existing time logging widget within the "Spent time" widget on the project overview page for editing. The pathHelpers are nor needed any more and could thus already be removed.

Part of:
https://community.openproject.com/projects/openproject/work_packages/32126/activity