### PR TITLE
Avoid requesting the form more than once per changeset instance

### DIFF
--- a/frontend/src/app/components/time-entries/time-entry-changeset.ts
+++ b/frontend/src/app/components/time-entries/time-entry-changeset.ts
@@ -7,10 +7,8 @@ export class TimeEntryChangeset extends ResourceChangeset<TimeEntryResource> {
     super.setValue(key, val);
 
     // Update the form for fields that may alter the form itself
-    // when the time entry is new. Otherwise, the save request afterwards
-    // will update the form automatically.
-    if (this.pristineResource.isNew && (key === 'workPackage')) {
-      this.updateForm().then(() => this.push());
+    if (key === 'workPackage') {
+      this.updateForm();
     }
   }
 

--- a/frontend/src/app/components/wp-edit/work-package-changeset.ts
+++ b/frontend/src/app/components/wp-edit/work-package-changeset.ts
@@ -10,7 +10,7 @@ export class WorkPackageChangeset extends ResourceChangeset<WorkPackageResource>
     // when the work package is new. Otherwise, the save request afterwards
     // will update the form automatically.
     if (this.pristineResource.isNew && (key === 'project' || key === 'type')) {
-      this.updateForm();
+      this.form$.clear(`${key} changed in a new work package`);
     }
   }
 

--- a/frontend/src/app/components/wp-edit/work-package-changeset.ts
+++ b/frontend/src/app/components/wp-edit/work-package-changeset.ts
@@ -6,11 +6,9 @@ export class WorkPackageChangeset extends ResourceChangeset<WorkPackageResource>
   public setValue(key:string, val:any) {
     super.setValue(key, val);
 
-    // Update the form for fields that may alter the form itself
-    // when the work package is new. Otherwise, the save request afterwards
-    // will update the form automatically.
-    if (this.pristineResource.isNew && (key === 'project' || key === 'type')) {
+    if (key === 'project' || key === 'type') {
       this.form$.clear(`${key} changed in a new work package`);
+      this.getForm();
     }
   }
 

--- a/frontend/src/app/components/wp-edit/work-package-changeset.ts
+++ b/frontend/src/app/components/wp-edit/work-package-changeset.ts
@@ -7,8 +7,7 @@ export class WorkPackageChangeset extends ResourceChangeset<WorkPackageResource>
     super.setValue(key, val);
 
     if (key === 'project' || key === 'type') {
-      this.form$.clear(`${key} changed in a new work package`);
-      this.getForm();
+      this.updateForm();
     }
   }
 

--- a/frontend/src/app/modules/fields/edit/edit-form/edit-form.ts
+++ b/frontend/src/app/modules/fields/edit/edit-form/edit-form.ts
@@ -89,7 +89,7 @@ export abstract class EditForm<T extends HalResource = HalResource> {
    */
   protected onSaved(isInitial:boolean, saved:HalResource):void {
     const eventType = isInitial ? 'created' : 'updated';
-    this.halEvents.push(saved, {eventType});
+    this.halEvents.push(saved, { eventType });
   }
 
   protected abstract focusOnFirstError():void;
@@ -168,6 +168,9 @@ export abstract class EditForm<T extends HalResource = HalResource> {
       return Promise.resolve(this.resource);
     }
 
+    // Mark changeset as in flight
+    this.change.inFlight = true;
+
     // Reset old error notifcations
     this.errorsPerAttribute = {};
 
@@ -188,6 +191,7 @@ export abstract class EditForm<T extends HalResource = HalResource> {
           this.halNotification.showSave(result.resource, result.wasNew);
           this.editMode = false;
           this.onSaved(result.wasNew, result.resource);
+          this.change.inFlight = false;
         })
         .catch((error:ErrorResource|Object) => {
           this.halNotification.handleRawError(error, this.resource);
@@ -196,6 +200,8 @@ export abstract class EditForm<T extends HalResource = HalResource> {
             this.handleSubmissionErrors(error);
             reject();
           }
+
+          this.change.inFlight = false;
         });
     });
   }

--- a/frontend/src/app/modules/fields/edit/services/hal-resource-editing.service.ts
+++ b/frontend/src/app/modules/fields/edit/services/hal-resource-editing.service.ts
@@ -103,25 +103,14 @@ export class HalResourceEditingService extends StateCacheService<ResourceChanges
   }
 
   public async save<V extends HalResource, T extends ResourceChangeset<V>>(change:T):Promise<ResourceChangesetCommit<V>> {
-    change.inFlight = true;
-
     // Form the payload we're going to save
-    const [form, payload] = await change.buildRequestPayload();
-    // Reject errors when occurring in form validation
-    const errors = form.getErrors();
-    if (errors !== null) {
-      change.inFlight = false;
-      throw(errors);
-    }
-
+    const payload = await change.buildRequestPayload();
     const savedResource = await change.pristineResource.$links.updateImmediately(payload);
 
     // Initialize any potentially new HAL values
     savedResource.retainFrom(change.pristineResource);
 
     this.onSaved(savedResource);
-
-    change.inFlight = false;
 
     // Complete the change
     return this.complete(change, savedResource);

--- a/frontend/src/app/modules/work_packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-full-view/wp-full-view.component.ts
@@ -32,12 +32,17 @@ import {Component, Injector, OnInit} from '@angular/core';
 import {WorkPackageViewSelectionService} from 'core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-selection.service';
 import {WorkPackageSingleViewBase} from "core-app/modules/work_packages/routing/wp-view-base/work-package-single-view.base";
 import {of} from "rxjs";
+import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
+import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
 
 @Component({
   templateUrl: './wp-full-view.html',
   selector: 'wp-full-view-entry',
   // Required class to support inner scrolling on page
-  host: { 'class': 'work-packages-page--ui-view' }
+  host: { 'class': 'work-packages-page--ui-view' },
+  providers: [
+    { provide: HalResourceNotificationService, useExisting: WorkPackageNotificationService }
+  ]
 })
 export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase implements OnInit {
   // Watcher properties

--- a/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
+++ b/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
@@ -183,8 +183,10 @@ describe 'custom field inplace editor', js: true do
         field.set_value ''
         field.expect_invalid
 
-        expect(WorkPackages::UpdateService).not_to receive(:new)
         field.save!
+
+        work_package.reload
+        expect(work_package.send("custom_field_#{custom_field.id}")).to eq 123
       end
     end
   end

--- a/spec/features/work_packages/table/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table/edit_work_packages_spec.rb
@@ -110,8 +110,8 @@ describe 'Inline editing work packages', js: true do
       subject_field.set_value('')
       subject_field.expect_invalid
 
-      expect(WorkPackages::UpdateService).not_to receive(:new)
       subject_field.save!
+      expect(work_package.reload.subject).to eq 'Foobar'
     end
   end
 


### PR DESCRIPTION
We don't need to call `updateForm()` unless the project or type changed in a new work package.