### PR TITLE
Reduce max-age header for snapshot request to S3 maximum

### DIFF
--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/viewpoints/api.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/viewpoints/api.rb
@@ -81,7 +81,9 @@ module Bim::Bcf::API::V2_1
             get do
               viewpoint = @issue.viewpoints.find_by!(uuid: params[:viewpoint_uuid])
               if snapshot = viewpoint.snapshot
-                respond_with_attachment snapshot, cache_seconds: 1.year.to_i
+                # Cache that value at max 604799 seconds, which is the max
+                # allowed expiry time for AWS generated links
+                respond_with_attachment snapshot, cache_seconds: 604799
               else
                 raise ActiveRecord::RecordNotFound
               end

--- a/modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb
@@ -204,13 +204,13 @@ describe 'BCF 2.1 viewpoints resource', type: :request, content_type: :json, wit
         expect(subject.status).to eq 200
         expect(subject.headers['Content-Type']).to eq 'image/jpeg'
 
-        expect(subject.headers["Cache-Control"]).to eq "public, max-age=#{1.year.to_i}"
+        expect(subject.headers["Cache-Control"]).to eq "public, max-age=604799"
         expect(subject.headers["Expires"]).to be_present
 
         expires_time = Time.parse response.headers["Expires"]
 
-        expect(expires_time < Time.now.utc + 1.year.to_i).to be_truthy
-        expect(expires_time > Time.now.utc + 1.year.to_i - 60).to be_truthy
+        expect(expires_time < Time.now.utc + 604799).to be_truthy
+        expect(expires_time > Time.now.utc + 604799 - 60).to be_truthy
       end
     end
 


### PR DESCRIPTION
Another place where we have to reduce the maximum caching of attachments to one week instead of one year. Apparently we forgot the snapshots 

https://community.openproject.com/wp/32825