### PR TITLE
fix/no mails when seeding

### DIFF
--- a/app/models/journal/notification_configuration.rb
+++ b/app/models/journal/notification_configuration.rb
@@ -30,12 +30,6 @@
 
 class Journal::NotificationConfiguration
   class << self
-    attr_reader :active
-
-    def reset
-      self.active = true
-    end
-
     def with(send_notifications, &block)
       old_value = active
 
@@ -46,15 +40,13 @@ class Journal::NotificationConfiguration
       self.active = old_value
     end
 
-    def with_reset(&block)
-      block.call
-    ensure
-      reset
+    def active?
+      active
     end
 
     protected
 
-    attr_writer :active
+    attr_accessor :active
   end
 
   self.active = true

--- a/app/models/journal/notification_configuration.rb
+++ b/app/models/journal/notification_configuration.rb
@@ -30,14 +30,18 @@
 
 class Journal::NotificationConfiguration
   class << self
+    # Allows controlling whether notifications are sent out for created journals.
+    # After the block is executed, the setting is returned to its original state which is true by default.
+    # In case the method is called multiple times within itself, the first setting prevails.
+    # This allows to control the setting globally without having to pass the setting down the call stack in
+    # order to ensure all subsequent code follows the provided setting.
     def with(send_notifications, &block)
-      old_value = active
-
-      self.active = send_notifications
-
-      block.call
-    ensure
-      self.active = old_value
+      if already_set
+        log_warning(send_notifications)
+        yield
+      else
+        with_first(send_notifications, &block)
+      end
     end
 
     def active?
@@ -46,8 +50,31 @@ class Journal::NotificationConfiguration
 
     protected
 
-    attr_accessor :active
+    def with_first(send_notifications)
+      old_value = active
+      self.already_set = true
+
+      self.active = send_notifications
+
+      yield
+    ensure
+      self.active = old_value
+      self.already_set = false
+    end
+
+    def log_warning(send_notifications)
+      return if active == send_notifications
+
+      message = <<~MSG
+        Ignoring setting journal notifications to '#{send_notifications}' as a parent block already send it to #{active}"
+      MSG
+      Rails.logger.debug message
+    end
+
+    attr_accessor :active,
+                  :already_set
   end
 
   self.active = true
+  self.already_set = false
 end

--- a/app/models/journal/notification_configuration.rb
+++ b/app/models/journal/notification_configuration.rb
@@ -66,7 +66,7 @@ class Journal::NotificationConfiguration
       return if active == send_notifications
 
       message = <<~MSG
-        Ignoring setting journal notifications to '#{send_notifications}' as a parent block already send it to #{active}"
+        Ignoring setting journal notifications to '#{send_notifications}' as a parent block already set it to #{active}"
       MSG
       Rails.logger.debug message
     end

--- a/app/models/journal/notification_configuration.rb
+++ b/app/models/journal/notification_configuration.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH
@@ -27,30 +28,34 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-##
-# Create journal for the given user and note.
-# Does not change the work package itself.
+class Journal::NotificationConfiguration
+  class << self
+    attr_reader :active
 
-class AddWorkPackageNoteService
-  include Contracted
-  attr_accessor :user, :work_package
-
-  def initialize(user:, work_package:)
-    self.user = user
-    self.work_package = work_package
-    self.contract_class = WorkPackages::CreateNoteContract
-  end
-
-  def call(notes, send_notifications: true)
-    Journal::NotificationConfiguration.with send_notifications do
-      work_package.add_journal(user, notes)
-
-      success, errors = validate_and_yield(work_package, user) do
-        work_package.save_journals
-      end
-
-      journal = work_package.journals.last if success
-      ServiceResult.new(success: success, result: journal, errors: errors)
+    def reset
+      self.active = true
     end
+
+    def with(send_notifications, &block)
+      old_value = active
+
+      self.active = send_notifications
+
+      block.call
+    ensure
+      self.active = old_value
+    end
+
+    def with_reset(&block)
+      block.call
+    ensure
+      reset
+    end
+
+    protected
+
+    attr_writer :active
   end
+
+  self.active = true
 end

--- a/app/models/journal_manager.rb
+++ b/app/models/journal_manager.rb
@@ -29,8 +29,6 @@
 
 class JournalManager
   class << self
-    attr_accessor :send_notification
-
     def changes_on_association(current, predecessor, association, key, value)
       merged_journals = merge_reference_journals_by_id(current, predecessor, key.to_s, value.to_s)
 
@@ -39,10 +37,6 @@ class JournalManager
         .merge(changed_references(merged_journals))
 
       to_changes_format(changes, association.to_s)
-    end
-
-    def reset_notification
-      @send_notification = true
     end
 
     private
@@ -151,8 +145,6 @@ class JournalManager
       end
     end
   end
-
-  self.send_notification = true
 
   def self.journalized?(obj)
     not obj.nil? and obj.respond_to? :journals
@@ -348,17 +340,5 @@ class JournalManager
     data.each_with_object({}) do |e, h|
       h[e[0]] = (e[1].is_a?(String) ? e[1].gsub(/\r\n/, "\n") : e[1])
     end
-  end
-
-  def self.with_send_notifications(send_notifications, &block)
-    old_value = send_notification
-
-    self.send_notification = send_notifications
-
-    result = block.call
-  ensure
-    self.send_notification = old_value
-
-    result
   end
 end

--- a/app/seeders/demo_data/version_builder.rb
+++ b/app/seeders/demo_data/version_builder.rb
@@ -71,7 +71,9 @@ module DemoData
       page = WikiPage.create! wiki: version.project.wiki, title: version.wiki_page_title
 
       content = with_references config[:content], project
-      WikiContent.create! page: page, author: User.admin.first, text: content
+      Journal::NotificationConfiguration.with false do
+        WikiContent.create! page: page, author: User.admin.first, text: content
+      end
 
       version.save!
     end

--- a/app/seeders/demo_data/work_package_board_seeder.rb
+++ b/app/seeders/demo_data/work_package_board_seeder.rb
@@ -161,7 +161,6 @@ module DemoData
           query.save!
         end
       end
-
     end
 
     def scrum_query_work_packages

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH
@@ -117,7 +118,7 @@ module DemoData
 
     def find_principal(name)
       if name
-        group_assignee =  Group.find_by(lastname: name)
+        group_assignee = Group.find_by(lastname: name)
         return group_assignee unless group_assignee.nil?
       end
 
@@ -175,7 +176,7 @@ module DemoData
     end
 
     def set_workpackage_relations
-      work_packages_data =  project_data_for(key, 'work_packages')
+      work_packages_data = project_data_for(key, 'work_packages')
 
       work_packages_data.each do |attributes|
         create_relations attributes

--- a/app/seeders/demo_data_seeder.rb
+++ b/app/seeders/demo_data_seeder.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/seeder.rb
+++ b/app/seeders/seeder.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH
@@ -30,7 +31,9 @@
 class Seeder
   def seed!
     if applicable?
-      seed_data!
+      without_notifications do
+        seed_data!
+      end
     else
       puts "   *** #{not_applicable_message}"
     end
@@ -75,5 +78,9 @@ class Seeder
 
   def project_has_data_for?(project, key)
     I18n.exists?("seeders.#{OpenProject::Configuration['edition']}.demo_data.projects.#{project}.#{key}")
+  end
+
+  def without_notifications(&block)
+    Journal::NotificationConfiguration.with(false, &block)
   end
 end

--- a/app/services/shared/service_context.rb
+++ b/app/services/shared/service_context.rb
@@ -51,7 +51,7 @@ module Shared
 
       ActiveRecord::Base.transaction do
         User.execute_as user do
-          JournalManager.with_send_notifications(send_notifications) do
+          Journal::NotificationConfiguration.with(send_notifications) do
             result = yield
 
             if result.failure?

--- a/app/services/work_packages/copy_service.rb
+++ b/app/services/work_packages/copy_service.rb
@@ -43,7 +43,7 @@ class WorkPackages::CopyService
   end
 
   def call(send_notifications: true, **attributes)
-    in_context(work_package) do
+    in_context(work_package, send_notifications) do
       copy(attributes, send_notifications)
     end
   end

--- a/app/services/work_packages/update_ancestors_service.rb
+++ b/app/services/work_packages/update_ancestors_service.rb
@@ -44,7 +44,7 @@ class WorkPackages::UpdateAncestorsService
     set_journal_note(modified)
 
     # Do not send notification for parent updates
-    success = JournalManager.with_send_notifications(false) do
+    success = Journal::NotificationConfiguration.with(false) do
       modified.all? { |wp| wp.save(validate: false) }
     end
 

--- a/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/save_hooks.rb
+++ b/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/save_hooks.rb
@@ -69,7 +69,7 @@ module Redmine::Acts::Journalized
     end
 
     def save_journals
-      with_journal_attributes_and_notification_reset do
+      with_ensured_journal_attributes do
         add_journal = journals.empty? || JournalManager.changed?(self) || !@journal_notes.empty?
 
         if add_journal
@@ -77,7 +77,7 @@ module Redmine::Acts::Journalized
 
           OpenProject::Notifications.send('journal_created',
                                           journal: journal,
-                                          send_notification: Journal::NotificationConfiguration.active)
+                                          send_notification: Journal::NotificationConfiguration.active?)
 
         end
       end
@@ -89,15 +89,6 @@ module Redmine::Acts::Journalized
     end
 
     private
-
-    def with_journal_attributes_and_notification_reset
-      with_ensured_journal_attributes do
-        # Need to clear the notification setting after each usage otherwise it might be cached
-        Journal::NotificationConfiguration.with_reset do
-          yield
-        end
-      end
-    end
 
     def with_ensured_journal_attributes
       @journal_user ||= User.current

--- a/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/save_hooks.rb
+++ b/lib/plugins/acts_as_journalized/lib/redmine/acts/journalized/save_hooks.rb
@@ -79,6 +79,7 @@ module Redmine::Acts::Journalized
                                           journal: journal,
                                           send_notification: Journal::NotificationConfiguration.active?)
 
+          true
         end
       end
     end

--- a/modules/bim/lib/open_project/bim/patches/work_package_seeder_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/work_package_seeder_patch.rb
@@ -10,7 +10,7 @@ module OpenProject::Bim::Patches::WorkPackageSeederPatch
 
         start_date = calculate_start_date(attributes[:start])
         due_date = calculate_due_date(start_date, attributes[:duration])
-        
+
         work_package = find_bcf_issue(uuid)
 
         work_package.update_columns(created_at: Time.now,
@@ -26,13 +26,13 @@ module OpenProject::Bim::Patches::WorkPackageSeederPatch
     end
 
     def update_parent(work_package, attributes)
-      if attributes[:parent]
-        parent = WorkPackage.find_by(subject: attributes[:parent])
-        if parent.present?
-          work_package.parent = parent
-          work_package.save!
-        end
-      end
+      return unless attributes[:parent]
+
+      parent = WorkPackage.find_by(subject: attributes[:parent])
+      return if parent.nil?
+
+      work_package.parent = parent
+      work_package.save!
     end
 
     def find_bcf_issue(uuid)

--- a/modules/bim/spec/seeders/demo_data_seeder_spec.rb
+++ b/modules/bim/spec/seeders/demo_data_seeder_spec.rb
@@ -30,44 +30,29 @@
 
 require 'spec_helper'
 
-def translate_with_base_url(string)
-  I18n.t(string, deep_interpolation: true, base_url: OpenProject::Configuration.rails_relative_url_root)
-end
-
 describe 'seeds' do
-  before do
-    allow(OpenProject::Configuration).to receive(:[]).and_call_original
-    allow(OpenProject::Configuration).to receive(:[]).with('edition').and_return(edition)
-  end
-
-  context 'BIM edition' do
-    let(:edition) { 'bim' }
-
+  context 'BIM edition', with_config: { edition: 'bim' } do
     it 'create the demo data' do
-      perform_deliveries = ActionMailer::Base.perform_deliveries
-      ActionMailer::Base.perform_deliveries = false
+      expect { ::Bim::BasicDataSeeder.new.seed! }.not_to raise_error
+      expect { AdminUserSeeder.new.seed! }.not_to raise_error
+      expect { DemoDataSeeder.new.seed! }.not_to raise_error
 
-      begin
-        # Avoid asynchronous DeliverWorkPackageCreatedJob
-        Delayed::Worker.delay_jobs = false
-        expect { ::Bim::BasicDataSeeder.new.seed! }.not_to raise_error
-        expect { AdminUserSeeder.new.seed! }.not_to raise_error
-        expect { DemoDataSeeder.new.seed! }.not_to raise_error
+      expect(User.where(admin: true).count).to eq 1
+      expect(Project.count).to eq 4
+      expect(WorkPackage.count).to eq 76
+      expect(Wiki.count).to eq 3
+      expect(Query.count).to eq 25
+      expect(Group.count).to eq 8
+      expect(Type.count).to eq 7
+      expect(Status.count).to eq 4
+      expect(IssuePriority.count).to eq 4
+      expect(Projects::Status.count).to eq 4
+      expect(Bim::IfcModels::IfcModel.count).to eq 3
 
-        expect(User.where(admin: true).count).to eq 1
-        expect(Project.count).to eq 4
-        expect(WorkPackage.count).to eq 76
-        expect(Wiki.count).to eq 3
-        expect(Query.count).to eq 25
-        expect(Group.count).to eq 8
-        expect(Type.count).to eq 7
-        expect(Status.count).to eq 4
-        expect(IssuePriority.count).to eq 4
-        expect(Projects::Status.count).to eq 4
-        expect(Bim::IfcModels::IfcModel.count).to eq 3
-      ensure
-        ActionMailer::Base.perform_deliveries = perform_deliveries
-      end
+      perform_enqueued_jobs
+
+      expect(ActionMailer::Base.deliveries)
+        .to be_empty
     end
   end
 end

--- a/spec/models/journal/notification_configuration_spec.rb
+++ b/spec/models/journal/notification_configuration_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe Journal::NotificationConfiguration, type: :model do
   describe '.with' do
-    let!(:send_notification_before) { described_class.active }
+    let!(:send_notification_before) { described_class.active? }
     let(:proc_called_counter) { OpenStruct.new called: false, send_notifications: !send_notification_before }
     let(:proc) { Proc.new { proc_called_counter.called = true } }
 
@@ -51,7 +51,7 @@ describe Journal::NotificationConfiguration, type: :model do
     it 'resets the send_notifications to the value before' do
       described_class.with !send_notification_before, &proc
 
-      expect(described_class.active)
+      expect(described_class.active?)
         .to eql send_notification_before
     end
 
@@ -60,7 +60,7 @@ describe Journal::NotificationConfiguration, type: :model do
         expect { described_class.with(!send_notification_before) { raise ArgumentError } }
           .to raise_error ArgumentError
 
-        expect(described_class.active)
+        expect(described_class.active?)
           .to eql send_notification_before
       end
     end

--- a/spec/models/journal/notification_configuration_spec.rb
+++ b/spec/models/journal/notification_configuration_spec.rb
@@ -1,0 +1,68 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Journal::NotificationConfiguration, type: :model do
+  describe '.with' do
+    let!(:send_notification_before) { described_class.active }
+    let(:proc_called_counter) { OpenStruct.new called: false, send_notifications: !send_notification_before }
+    let(:proc) { Proc.new { proc_called_counter.called = true } }
+
+    it 'executes the block' do
+      described_class.with !send_notification_before, &proc
+
+      expect(proc_called_counter.called)
+        .to be_truthy
+    end
+
+    it 'uses the provided send_notifications value within the proc' do
+      described_class.with !send_notification_before, &proc
+
+      expect(proc_called_counter.send_notifications)
+        .to eql !send_notification_before
+    end
+
+    it 'resets the send_notifications to the value before' do
+      described_class.with !send_notification_before, &proc
+
+      expect(described_class.active)
+        .to eql send_notification_before
+    end
+
+    context 'with an exception being raised within the block' do
+      it 'raises the exception but always resets the notification value' do
+        expect { described_class.with(!send_notification_before) { raise ArgumentError } }
+          .to raise_error ArgumentError
+
+        expect(described_class.active)
+          .to eql send_notification_before
+      end
+    end
+  end
+end

--- a/spec/models/journal_manager_spec.rb
+++ b/spec/models/journal_manager_spec.rb
@@ -160,41 +160,4 @@ describe JournalManager, type: :model do
       end
     end
   end
-
-  describe '.with_send_notifications' do
-    let!(:send_notification_before) { described_class.send_notification }
-    let(:proc_called_counter) { OpenStruct.new called: false, send_notifications: !send_notification_before }
-    let(:proc) { Proc.new { proc_called_counter.called = true } }
-
-    it 'executes the block' do
-      described_class.with_send_notifications !send_notification_before, &proc
-
-      expect(proc_called_counter.called)
-        .to be_truthy
-    end
-
-    it 'uses the provided send_notifications value within the proc' do
-      described_class.with_send_notifications !send_notification_before, &proc
-
-      expect(proc_called_counter.send_notifications)
-        .to eql !send_notification_before
-    end
-
-    it 'resets the send_notifications to the value before' do
-      described_class.with_send_notifications !send_notification_before, &proc
-
-      expect(described_class.send_notification)
-        .to eql send_notification_before
-    end
-
-    context 'with an exception being raised within the block' do
-      it 'raises the exception but always resets the notification value' do
-        expect { described_class.with_send_notifications(!send_notification_before) { raise ArgumentError } }
-          .to raise_error ArgumentError
-
-        expect(described_class.send_notification)
-          .to eql send_notification_before
-      end
-    end
-  end
 end

--- a/spec/models/work_package/work_package_action_mailer_spec.rb
+++ b/spec/models/work_package/work_package_action_mailer_spec.rb
@@ -47,7 +47,7 @@ describe WorkPackage, type: :model do
       allow(work_package).to receive(:recipients).and_return([user_1])
       allow(work_package).to receive(:watcher_recipients).and_return([user_2])
 
-      JournalManager.with_send_notifications true do
+      Journal::NotificationConfiguration.with true do
         work_package.save
       end
     end
@@ -79,7 +79,7 @@ describe WorkPackage, type: :model do
       before do
         ActionMailer::Base.deliveries.clear # clear mails sent due to prior WP creation
 
-        JournalManager.with_send_notifications false do
+        Journal::NotificationConfiguration.with false do
           work_package.save!
         end
       end

--- a/spec/seeders/demo_data_seeder_spec.rb
+++ b/spec/seeders/demo_data_seeder_spec.rb
@@ -30,41 +30,25 @@
 
 require 'spec_helper'
 
-def translate_with_base_url(string)
-  I18n.t(string, deep_interpolation: true, base_url: OpenProject::Configuration.rails_relative_url_root)
-end
-
 describe 'seeds' do
-  before do
-    allow(OpenProject::Configuration).to receive(:[]).and_call_original
-    allow(OpenProject::Configuration).to receive(:[]).with('edition').and_return(edition)
-  end
-
-  context 'standard edition' do
-    let(:edition) { 'standard' }
-
+  context 'standard edition', with_config: { edition: 'standard' } do
     it 'create the demo data' do
-      perform_deliveries = ActionMailer::Base.perform_deliveries
-      ActionMailer::Base.perform_deliveries = false
+      expect { StandardSeeder::BasicDataSeeder.new.seed! }.not_to raise_error
+      expect { AdminUserSeeder.new.seed! }.not_to raise_error
+      expect { DemoDataSeeder.new.seed! }.not_to raise_error
 
-      begin
-        # Avoid asynchronous DeliverWorkPackageCreatedJob
-        Delayed::Worker.delay_jobs = false
+      expect(User.where(admin: true).count).to eq 1
+      expect(Project.count).to eq 2
+      expect(WorkPackage.count).to eq 41
+      expect(Wiki.count).to eq 2
+      expect(Query.where.not(hidden: true).count).to eq 8
+      expect(Query.count).to eq 24
+      expect(Projects::Status.count).to eq 2
 
-        expect { StandardSeeder::BasicDataSeeder.new.seed! }.not_to raise_error
-        expect { AdminUserSeeder.new.seed! }.not_to raise_error
-        expect { DemoDataSeeder.new.seed! }.not_to raise_error
+      perform_enqueued_jobs
 
-        expect(User.where(admin: true).count).to eq 1
-        expect(Project.count).to eq 2
-        expect(WorkPackage.count).to eq 41
-        expect(Wiki.count).to eq 2
-        expect(Query.where.not(hidden: true).count).to eq 8
-        expect(Query.count).to eq 24
-        expect(Projects::Status.count).to eq 2
-      ensure
-        ActionMailer::Base.perform_deliveries = perform_deliveries
-      end
+      expect(ActionMailer::Base.deliveries)
+        .to be_empty
     end
   end
 end

--- a/spec/services/add_work_package_note_service_spec.rb
+++ b/spec/services/add_work_package_note_service_spec.rb
@@ -56,8 +56,8 @@ describe AddWorkPackageNoteService, type: :model do
     let(:send_notifications) { false }
 
     before do
-      expect(JournalManager)
-        .to receive(:with_send_notifications)
+      expect(Journal::NotificationConfiguration)
+        .to receive(:with)
         .with(send_notifications)
         .and_yield
 

--- a/spec/services/work_packages/update_service_spec.rb
+++ b/spec/services/work_packages/update_service_spec.rb
@@ -87,8 +87,8 @@ describe WorkPackages::UpdateService, type: :model do
     let(:send_notifications) { true }
 
     before do
-      expect(JournalManager)
-        .to receive(:with_send_notifications)
+      expect(Journal::NotificationConfiguration)
+        .to receive(:with)
         .with(send_notifications)
         .and_yield
 


### PR DESCRIPTION
Ensures not sending emails on seeding. Although that should not have happened in the first place as 
```
ActionMailer::Base.perform_deliveries = false
```
is set.

Emails where still attempted to be sent which lead to errors if the mail configuration was not yet correctly configured.

This PR contains a change to the way notification settings for journals are controlled generally. Only when executed within a block, can a caller disable email sending. That way, we can ensure resetting the notification setting at the correct place, i.e. after the block is completed. Before, the first saved journal would reset the setting which might not be intended if e.g. saving two work packages within the block.

Only the first call to the `Journal::NotificationConfiguration.with` block is actually able to alter the settings. Later calls are passed through without reacting to the setting (with a message if in debug mode). This is done so that the setting from a higher level can prevail.

https://community.openproject.com/wp/33245  