### PR TITLE
[33124]Missing space below user rate history

### DIFF
--- a/app/assets/stylesheets/content/_user.sass
+++ b/app/assets/stylesheets/content/_user.sass
@@ -77,3 +77,6 @@ tr user-avatar
 .-spaced
   &.avatar-medium, &.avatar-mini
     margin-right: 5px
+
+.user-history-rates-no-result
+  margin-bottom: 25px

--- a/app/assets/stylesheets/content/_user.sass
+++ b/app/assets/stylesheets/content/_user.sass
@@ -78,5 +78,5 @@ tr user-avatar
   &.avatar-medium, &.avatar-mini
     margin-right: 5px
 
-.user-history-rates-no-result
+.user-rate-history-list
   margin-bottom: 25px

--- a/modules/costs/app/views/hourly_rates/_list_default.html.erb
+++ b/modules/costs/app/views/hourly_rates/_list_default.html.erb
@@ -32,7 +32,9 @@ See docs/COPYRIGHT.rdoc for more details.
 </div>
 <h3><%= User.human_attribute_name(:default_rates) %></h3>
 <% if @rates_default.blank? %>
+<div class="user-history-rates-no-result">
   <%= no_results_box %>
+</div>
 <% else %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">

--- a/modules/costs/app/views/hourly_rates/_list_default.html.erb
+++ b/modules/costs/app/views/hourly_rates/_list_default.html.erb
@@ -26,15 +26,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
-
+<div class="user-rate-history-list">
 <div class="contextual">
   <%= link_to t(:button_update), edit_hourly_rate_path(@user), :class => 'icon icon-edit', :accesskey => accesskey(:edit) %>
 </div>
 <h3><%= User.human_attribute_name(:default_rates) %></h3>
 <% if @rates_default.blank? %>
-<div class="user-history-rates-no-result">
   <%= no_results_box %>
-</div>
 <% else %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
@@ -90,3 +88,4 @@ See docs/COPYRIGHT.rdoc for more details.
     </div>
   </div>
 <% end %>
+</div>

--- a/modules/costs/app/views/hourly_rates/_list_project.html.erb
+++ b/modules/costs/app/views/hourly_rates/_list_project.html.erb
@@ -45,7 +45,9 @@ See docs/COPYRIGHT.rdoc for more details.
 </div>
 <h3><%=h project.name %><%= (" - " + number_to_currency(current_rate.rate)) if current_rate %></h3>
 <% if rates.empty? %>
+<div class="user-history-rates-no-result">
   <%= no_results_box %>
+</div>
 <% else %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">

--- a/modules/costs/app/views/hourly_rates/_list_project.html.erb
+++ b/modules/costs/app/views/hourly_rates/_list_project.html.erb
@@ -37,7 +37,7 @@ See docs/COPYRIGHT.rdoc for more details.
                    current_rate = @user.current_rate(project)
                  end
 %>
-
+<div class="user-rate-history-list">
 <div class="contextual">
   <% if project && User.current.allowed_to?({:controller => '/hourly_rates', :action => 'edit'}, project) %>
     <%= link_to t(:button_update), {:controller => '/hourly_rates', :action => 'edit', :project_id => project, :id => @user}, :class => 'icon icon-edit', :accesskey => accesskey(:edit) %>
@@ -45,9 +45,7 @@ See docs/COPYRIGHT.rdoc for more details.
 </div>
 <h3><%=h project.name %><%= (" - " + number_to_currency(current_rate.rate)) if current_rate %></h3>
 <% if rates.empty? %>
-<div class="user-history-rates-no-result">
   <%= no_results_box %>
-</div>
 <% else %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
@@ -102,3 +100,4 @@ See docs/COPYRIGHT.rdoc for more details.
     </div>
   </div>
 <% end %>
+</div>


### PR DESCRIPTION
When there is nothing to display, the distance between the block and the next headline should be increased.

https://community.openproject.com/projects/openproject/work_packages/33124/activity