### PR TITLE
[33119]The onboarding tour does not start when closing the language modal via Escape

### DIFF
--- a/app/assets/javascripts/onboarding/onboarding_tour.js
+++ b/app/assets/javascripts/onboarding/onboarding_tour.js
@@ -45,6 +45,13 @@
                 $('.op-modal--modal-close-button').click(function () {
                     homescreenTour();
                 });
+
+                //Start automatically when the escape button is pressed
+                $(document).on('keydown', function(event) {
+                    if (event.key == "Escape") {
+                        homescreenTour();
+                    }
+                });
             }
 
             // ------------------------------- Tutorial Homescreen page -------------------------------


### PR DESCRIPTION
When closing the modal via Escape, the tour directly starts.

https://community.openproject.com/projects/openproject/work_packages/33119/activity