### PR TITLE
Allow an optional auth_source_sso flag

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -60,13 +60,12 @@ class AccountController < ApplicationController
 
   # Log out current user and redirect to welcome page
   def logout
+    # Keep attributes from the session
+    # to identify the user
+    previous_session = session.to_h.with_indifferent_access
     logout_user
-    if Setting.login_required? && omniauth_direct_login?
-      flash.now[:notice] = I18n.t :notice_logged_out
-      render :exit, locals: { instructions: :after_logout }
-    else
-      redirect_to home_url
-    end
+
+    perform_post_logout previous_session
   end
 
   # Enable user to choose a new password
@@ -358,14 +357,6 @@ class AccountController < ApplicationController
       instructions = error ? :after_error : :after_registration
 
       render :exit, locals: { instructions: instructions }
-    end
-  end
-
-  def logout_user
-    if User.current.logged?
-      cookies.delete OpenProject::Configuration['autologin_cookie_name']
-      Token::AutoLogin.where(user_id: current_user.id).delete_all
-      self.logged_user = nil
     end
   end
 

--- a/app/controllers/concerns/accounts/current_user.rb
+++ b/app/controllers/concerns/accounts/current_user.rb
@@ -1,0 +1,154 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+##
+# Intended to be used by the ApplicationController to provide login/logout helpers
+module Accounts::CurrentUser
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :current_user
+  end
+
+  protected
+
+  # The current user is a per-session kind of thing and session stuff is controller responsibility.
+  # A globally accessible User.current is a big code smell. When used incorrectly it allows getting
+  # the current user outside of a session scope, i.e. in the model layer, from mailers or
+  # in the console which doesn't make any sense. For model code that needs to be aware of the
+  # current user, i.e. when returning all visible projects for <somebody>, the controller should
+  # pass the current user to the model, instead of letting it fetch it by itself through
+  # `User.current`. This method acts as a reminder and wants to encourage you to use it.
+  # Project.visible_by actually allows the controller to pass in a user but it falls back
+  # to `User.current` and there are other places in the session-unaware codebase,
+  # that rely on `User.current`.
+  def current_user
+    User.current
+  end
+
+  def user_setup
+    # Find the current user
+    User.current = find_current_user
+  end
+
+  # check if login is globally required to access the application
+  def check_if_login_required
+    # no check needed if user is already logged in
+    return true if current_user.logged?
+
+    require_login if Setting.login_required?
+  end
+
+  # Returns the current user or nil if no user is logged in
+  # and starts a session if needed
+  def find_current_user
+    if session[:user_id]
+      # existing session
+      User.active.find_by(id: session[:user_id])
+    elsif cookies[OpenProject::Configuration['autologin_cookie_name']] && Setting.autologin?
+      # auto-login feature starts a new session
+      user = User.try_to_autologin(cookies[OpenProject::Configuration['autologin_cookie_name']])
+      session[:user_id] = user.id if user
+      user
+    elsif params[:format] == 'atom' && params[:key] && accept_key_auth_actions.include?(params[:action])
+      # RSS key authentication does not start a session
+      User.find_by_rss_key(params[:key])
+    elsif Setting.rest_api_enabled? && api_request?
+      if (key = api_key_from_request) && accept_key_auth_actions.include?(params[:action])
+        # Use API key
+        User.find_by_api_key(key)
+      end
+    end
+  end
+
+  # Sets the logged in user
+  def logged_user=(user)
+    if user&.is_a?(User)
+      login_user(user)
+    else
+      logout_user
+    end
+  end
+
+  # Logout the current user
+  def logout_user
+    ::Users::LogoutService
+      .new(controller: self)
+      .call(current_user)
+  end
+
+  # Redirect the user according to the logout scheme
+  def perform_post_logout(_prev_session)
+    if Setting.login_required? && omniauth_direct_login?
+      flash.now[:notice] = I18n.t :notice_logged_out
+      render :exit, locals: { instructions: :after_logout }
+    else
+      redirect_to home_url
+    end
+  end
+
+  # Login the current user
+  def login_user(user)
+    ::Users::LoginService
+      .new(controller: self)
+      .call(user)
+  end
+
+  def require_login
+    unless current_user.logged?
+
+      respond_to do |format|
+        format.any(:html, :atom) do
+          # Ensure we reset the session to terminate any old session objects
+          # but ONLY for html requests to avoid double-resetting sessions
+          reset_session
+
+          redirect_to main_app.signin_path(back_url: login_back_url)
+        end
+
+        auth_header = OpenProject::Authentication::WWWAuthenticate.response_header(request_headers: request.headers)
+
+        format.any(:xml, :js, :json) do
+          head :unauthorized,
+               'X-Reason' => 'login needed',
+               'WWW-Authenticate' => auth_header
+        end
+
+        format.all { head :not_acceptable }
+      end
+      return false
+    end
+    true
+  end
+
+  def require_admin
+    return unless require_login
+
+    render_403 unless current_user.admin?
+  end
+end

--- a/app/controllers/concerns/auth_source_sso.rb
+++ b/app/controllers/concerns/auth_source_sso.rb
@@ -7,20 +7,23 @@ module AuthSourceSSO
     user = super
 
     return user if user || sso_in_progress!
+    return nil unless header_name
 
+    perform_header_sso
+  end
+
+  def perform_header_sso
     if login = read_sso_login
       user = find_user_from_auth_source(login) || create_user_from_auth_source(login)
 
       handle_sso_for! user, login
+    else
+      handle_sso_failure!
     end
   end
 
   def read_sso_login
-    return nil unless header_name && secret
-
-    login, given_secret = String(request.headers[header_name]).split(":")
-
-    login if valid_credentials? login, given_secret
+    get_validated_login! String(request.headers[header_name])
   end
 
   def sso_config
@@ -35,25 +38,34 @@ module AuthSourceSSO
     sso_config && sso_config[:secret]
   end
 
-  def valid_credentials?(login, secret)
-    !invalid_credentials?(login, secret)
+  def optional?
+    sso_config && sso_config[:optional]
   end
 
-  def invalid_credentials?(login, secret)
-    if secret != self.secret.to_s
-      Rails.logger.error(
-        "Secret contained in auth source SSO header not valid. " +
-        "(#{header_name}: #{request.headers[header_name]})"
-      )
+  def get_validated_login!(value)
+    login, valid_secret = extract_from_header(value)
 
-      true
-    elsif login.nil?
-      Rails.logger.error(
-        "No login contained in auth source SSO header. " +
-        "(#{header_name}: #{request.headers[header_name]})"
-      )
+    unless valid_secret
+      Rails.logger.error("Secret contained in auth source SSO header #{header_name} is not valid.")
+      return nil
+    end
 
-      true
+    unless login.present?
+      Rails.logger.error("Secret contained in auth source SSO header #{header_name} is not valid.")
+      return nil
+    end
+
+    login
+  end
+
+  def extract_from_header(value)
+    if self.secret.present?
+      valid_secret = value.end_with?(":#{self.secret}")
+      login = value.gsub(/:#{Regexp.escape(self.secret)}\z/, '')
+
+      [login, valid_secret]
+    else
+      [value, true]
     end
   end
 
@@ -82,7 +94,7 @@ module AuthSourceSSO
       if logger && user.auth_source
         logger.info(
           "User '#{user.login}' created from external auth source: " +
-          "#{user.auth_source.type} - #{user.auth_source.name}"
+            "#{user.auth_source.type} - #{user.auth_source.name}"
         )
       end
     end
@@ -112,7 +124,7 @@ module AuthSourceSSO
 
   def handle_sso_for!(user, login)
     if sso_login_failed?(user)
-      handle_sso_failure! user, login
+      handle_sso_failure!({ user: user, login: login })
     else # valid user
       handle_sso_success user
     end
@@ -124,13 +136,13 @@ module AuthSourceSSO
     user
   end
 
-  def handle_sso_failure!(user, login)
-    session[:auth_source_sso_failure] = {
-      user: user,
-      login: login,
+  def handle_sso_failure!(session_args = {})
+    return if optional?
+
+    session[:auth_source_sso_failure] = session_args.merge(
       back_url: request.base_url + request.original_fullpath,
       ttl: 1
-    }
+    )
 
     redirect_to sso_failure_path
   end

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -1,0 +1,48 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Users
+  class LoginService
+    attr_accessor :controller
+
+    def initialize(controller:)
+      self.controller = controller
+    end
+
+    def call(user)
+      controller.reset_session
+
+      User.current = user
+
+      ::Sessions::InitializeSessionService.call(user, controller.session)
+
+      ServiceResult.new(result: user)
+    end
+  end
+end

--- a/app/services/users/logout_service.rb
+++ b/app/services/users/logout_service.rb
@@ -1,0 +1,60 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Users
+  class LogoutService
+    attr_accessor :controller
+
+    def initialize(controller:)
+      self.controller = controller
+    end
+
+    def call(user)
+      controller.reset_session
+
+      if user.logged?
+        remove_cookies! controller.send(:cookies)
+        remove_tokens! user
+      end
+
+      User.current = User.anonymous
+      ServiceResult.new(result: User.anonymous)
+    end
+
+    private
+
+    def remove_tokens!(user)
+      Token::AutoLogin.where(user_id: user.id).delete_all
+    end
+
+    def remove_cookies!(cookies)
+      cookies.delete OpenProject::Configuration.autologin_cookie_name
+    end
+  end
+end

--- a/docs/installation-and-operations/configuration/README.md
+++ b/docs/installation-and-operations/configuration/README.md
@@ -77,6 +77,8 @@ Example:
     auth_source_sso:
       header: X-Remote-User
       secret: s3cr3t
+      # Uncomment to make the header optional.
+      # optional: true
 
 Can be used to automatically login a user defined through a custom header
 sent by a load balancer or reverse proxy in front of OpenProject,

--- a/docs/system-admin-guide/authentication/kerberos/README.md
+++ b/docs/system-admin-guide/authentication/kerberos/README.md
@@ -114,6 +114,8 @@ production:
     # You can comment it out to disable if your outer server
     # fully controls this header value and you trust it.
     secret: MyPassword
+    # Uncomment to make the header optional.
+    # optional: true
 ```
 
 
@@ -141,6 +143,12 @@ As with all the rest of the OpenProject configuration settings, the Kerberos hea
 openproject config:set OPENPROJECT_AUTH__SOURCE__SSO_HEADER="X-Authenticated-User"
 openproject config:set OPENPROJECT_AUTH__SOURCE__SSO_SECRET="MyPassword"
 ```
+
+  In case you want to make the header optional, i.e. the header may or may not be present for a subset of users going through Apache, you can set the following value:
+
+  ```bash
+  openproject config:set OPENPROJECT_AUTH__SOURCE__SSO_OPTIONAL=true
+  ```
 
 Please note that every underscore (`_`) in the original configuration key has to be replaced by a duplicate underscore
 (`__`) in the environment variable as the single underscore denotes namespaces.

--- a/docs/system-admin-guide/authentication/kerberos/README.md
+++ b/docs/system-admin-guide/authentication/kerberos/README.md
@@ -110,18 +110,21 @@ production:
   auth_source_sso:
     # The header name is configured here
     header: X-Authenticated-User
+
     # The secret is configurable here
     # You can comment it out to disable if your outer server
     # fully controls this header value and you trust it.
     secret: MyPassword
+
     # Uncomment to make the header optional.
     # optional: true
+
+    # Specify a logout URL that gets redirected
+    # after the OpenProject internal logout flow
+    # logout_url: https://sso.example.com/logout
 ```
 
-
-
 Be sure to choose the correct indentation and base key. The `auth_source_sso` key should be indented two spaces (and all other keys accordingly) and the configuration should belong to the `production` group.
-
 
 
 The configuration can be provided in one of three ways:

--- a/spec/controllers/concerns/auth_source_slo_spec.rb
+++ b/spec/controllers/concerns/auth_source_slo_spec.rb
@@ -1,0 +1,80 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+##
+describe AccountController, 'Auth header logout', type: :controller do
+  render_views
+
+  let!(:auth_source) { DummyAuthSource.create name: "Dummy LDAP" }
+  let!(:user) { FactoryBot.create :user, login: login, auth_source_id: auth_source.id }
+  let(:login) { "h.wurst" }
+
+  before do
+    if sso_config
+      allow(OpenProject::Configuration)
+        .to receive(:auth_source_sso)
+        .and_return(sso_config)
+    end
+  end
+
+  describe 'logout' do
+    context 'when a logout URL is present' do
+      let(:sso_config) do
+        {
+          logout_url: 'https://example.org/foo?logout=true'
+        }
+      end
+
+      context 'and the user came from auth source' do
+        before do
+          login_as user
+          session[:user_from_auth_header] = true
+          get :logout
+        end
+
+        it 'is redirected to the logout URL' do
+          expect(response).to redirect_to 'https://example.org/foo?logout=true'
+        end
+      end
+
+      context 'and the user did not come from auth source' do
+        before do
+          login_as user
+          session[:user_from_auth_header] = nil
+          get :logout
+        end
+
+        it 'is redirected to the home URL' do
+          expect(response).to redirect_to home_url
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/auth_source_sso_spec.rb
+++ b/spec/controllers/concerns/auth_source_sso_spec.rb
@@ -58,13 +58,23 @@ describe MyController, type: :controller do
     auth_source # create auth source
     user # create user
 
-    request.headers[header] = "#{login}:#{secret}"
+    separator = secret ? ':' : ''
+    request.headers[header] = "#{login}#{separator}#{secret}"
 
     get :account
   end
 
   it "should log in given user" do
     expect(response.body.squish).to have_content("Username   h.wurst")
+  end
+
+
+  context 'when the secret being null' do
+    let(:secret) { nil }
+
+    it "should log in given user" do
+      expect(response.body.squish).to have_content("Username   h.wurst")
+    end
   end
 
   shared_examples "auth source sso failure" do
@@ -83,6 +93,20 @@ describe MyController, type: :controller do
       expect(failure[:login]).to eq login
       expect(failure[:back_url]).to eq "http://test.host/my/account"
       expect(failure[:ttl]).to eq 1
+    end
+
+    context 'when the config is marked optional' do
+      let(:sso_config) do
+        {
+          header: header,
+          secret: secret,
+          optional: true
+        }
+      end
+
+      it "should redirect to login" do
+        expect(response).to redirect_to("/login?back_url=http%3A%2F%2Ftest.host%2Fmy%2Faccount")
+      end
     end
   end
 


### PR DESCRIPTION
Allows to make secret optional and add a flag to not raise an error in case only a subset of the users shall be authenticated through auth header (e.g., only a specific network or set of IPs) 

https://community.openproject.com/wp/32979