### PR TITLE
[33249] Bim error on console when creating a global Work Package

### DIFF
--- a/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-new-wp-attribute-group.component.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-new-wp-attribute-group.component.ts
@@ -11,11 +11,13 @@ import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-r
 export class BcfNewWpAttributeGroupComponent extends BcfWpAttributeGroupComponent {
 
   ngAfterViewInit():void {
-    super.ngAfterViewInit();
+    if (this.viewerVisible) {
+      super.ngAfterViewInit();
 
-    // Save any leftover viewpoints when saving the work package
-    if (this.workPackage.isNew) {
-      this.observeCreation();
+      // Save any leftover viewpoints when saving the work package
+      if (this.workPackage.isNew) {
+        this.observeCreation();
+      }
     }
   }
 


### PR DESCRIPTION
When opening the create form for Work Packages, there is a change listener registered in the `BcfWpAttributeGroupComponent`. This listener expects a project, which is not available in the global create form, resulting in the error.
This PR takes care that observers ("create" and "change") are only registered when the viewer is shown. Otherwise the BCF group is not visible in the create form anyway.

https://community.openproject.com/projects/openproject/work_packages/33249/activity