### PR TITLE
[33307] Move "log time" icon outside of the hover highlighting

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_display_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_display_fields.sass
@@ -86,6 +86,9 @@
       font-style: italic
       font-weight: bold
 
+  &.spentTime .time-logging--value
+    padding: 0 2px
+
 .wp-table--cell-container
   &.estimatedTime
     width: 100%
@@ -118,11 +121,14 @@
       white-space: inherit
 
 // Mark focused, non-editable read-values
-.inline-edit--display-field:not(.id).-read-only
+// Special handling for spent time field, as the logTime link should not be highlighted
+.inline-edit--display-field:not(.id):not(.spentTime).-read-only,
+.inline-edit--display-field.spentTime.-read-only .time-logging--value
+  cursor: not-allowed
+
   &:focus, &:hover
     color: $inplace-edit--color--disabled
     background: $inplace-edit--bg-color--disabled
-  cursor: not-allowed
 
 editable-attribute-field
   width: 100%

--- a/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -52,6 +52,7 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
     const link = document.createElement('a');
     link.textContent = displayText;
     link.setAttribute('title', this.text.linkTitle);
+    link.setAttribute('class', 'time-logging--value');
 
     if (this.resource.project) {
       const wpID = this.resource.id.toString();


### PR DESCRIPTION
Exclude the logTime link from the highlighting of the field. 
Unfortunately, within the the `render` method of the `WorkPackageSpentTimeDisplayField` we do not have access to the later parent node yet. Thus, I could not easily move the node itself out of the `inline-edit--display-field` class container (which is responsible for the highlighting). That is why I decided to go via the CSS

https://community.openproject.com/projects/openproject/work_packages/33307/activity