### PR TITLE
[33233] Display errors in the heading of project widgets with missing edit rights

### DIFF
--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
@@ -28,5 +28,5 @@
 <h2 *ngIf="!editable"
     [attr.title]="selectedTitle"
     [ngClass]="{ '-disabled': disabled, '-small': smallHeader }"
-    class="editable-toolbar-title--fixed"> {{ selectedTitle | slice:0:50 }}
+    class="editable-toolbar-title--fixed"> {{ selectedTitle }}
 </h2>


### PR DESCRIPTION
When it is in non-editable mode, widget title should be shown in complete form.

https://community.openproject.com/projects/openproject/work_packages/33233/activity