### PR TITLE
[33143] (Work packages) Custom fields for long text

### DIFF
--- a/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
+++ b/app/assets/stylesheets/content/work_packages/single_view/_single_view.sass
@@ -151,16 +151,6 @@ i
     .-columns-2
       @include two-column-layout
 
-      @supports (column-span: all)
-        // Let some elements still span both columns
-        .attributes-key-value.-span-all-columns
-          column-span: all
-          .attributes-key-value--key
-            flex-basis: calc(22.5% - (4rem / 6))
-          .attributes-key-value--value-container
-            flex-basis: calc(77.5% + (4rem / 6))
-            max-width: calc(77.5% + (4rem / 6))
-
   @supports (column-span: all)
     // Remove the outline on focus since that breaks the column in chrome
     // Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=565116

--- a/app/assets/stylesheets/openproject/_mixins.sass
+++ b/app/assets/stylesheets/openproject/_mixins.sass
@@ -135,6 +135,16 @@ $scrollbar-size: 10px
 @mixin two-column-layout
   column-count: 2
   column-gap: 3rem
+  
+  @supports (column-span: all)
+        // Let some elements still span both columns
+        .attributes-key-value.-span-all-columns
+          column-span: all
+          .attributes-key-value--key
+            flex-basis: calc(22.5% - (4rem / 6))
+          .attributes-key-value--value-container
+            flex-basis: calc(77.5% + (4rem / 6))
+            max-width: calc(77.5% + (4rem / 6))
 
   .attributes-key-value
     -webkit-column-break-inside: avoid


### PR DESCRIPTION
When there is a long text custom field in a group attribute of WP overview, it should spans for 100% width of panel.

https://community.openproject.com/projects/openproject/work_packages/33143/activity