### PR TITLE
[30918] Boards: Cards do not update on change in split screen

### DIFF
--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -128,7 +128,7 @@ export class WorkPackageCardViewComponent extends UntilDestroyedMixin implements
     this.halEvents
       .aggregated$('WorkPackage')
       .pipe(
-        map(events => events.filter(event => event.eventType === 'update')),
+        map(events => events.filter(event => event.eventType === 'updated')),
         filter(events => {
           const wpIds:string[] = this.workPackages.map(el => el.id!.toString());
           return !!events.find(event => wpIds.indexOf(event.id) !== -1);

--- a/modules/boards/spec/features/board_update_spec.rb
+++ b/modules/boards/spec/features/board_update_spec.rb
@@ -1,0 +1,69 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+
+require 'spec_helper'
+require_relative './support/board_index_page'
+require_relative './support/board_page'
+
+describe 'Work Package boards updating spec', type: :feature, js: true do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  let(:project) { FactoryBot.create(:project, enabled_module_names: %i[work_package_tracking board_view]) }
+  let!(:priority) { FactoryBot.create :default_priority }
+  let!(:status) { FactoryBot.create :default_status }
+
+  let(:board_index) { Pages::BoardIndex.new(project) }
+  let!(:board_view) { FactoryBot.create :board_grid_with_query, name: 'My board', project: project }
+
+  before do
+    with_enterprise_token :board_view
+    project
+    login_as(admin)
+    board_index.visit!
+  end
+
+  it 'Changing the title in the split screen, updates the card automatically' do
+    board_page = board_index.open_board board_view
+    board_page.expect_query 'List 1', editable: true
+    board_page.add_card 'List 1', 'Foo Bar'
+    board_page.expect_notification message: I18n.t(:notice_successful_create)
+
+    work_package = WorkPackage.last
+    expect(work_package.subject).to eq 'Foo Bar'
+
+    # Open in split view
+    card = board_page.card_for(work_package)
+    split_view = card.open_details_view
+    split_view.expect_subject
+    split_view.edit_field(:subject).update('My super cool new title')
+
+    split_view.expect_and_dismiss_notification message: 'Successful update.'
+    card.expect_subject 'My super cool new title'
+  end
+end


### PR DESCRIPTION
Fix typo which prevented any update event to pass the map. Thus the cards did not update.

https://community.openproject.com/projects/openproject/work_packages/30918/activity