### PR TITLE
[33136] Filter attributes change order

### DIFF
--- a/app/models/queries/work_packages/filter/category_filter.rb
+++ b/app/models/queries/work_packages/filter/category_filter.rb
@@ -48,9 +48,11 @@ class Queries::WorkPackages::Filter::CategoryFilter <
   end
 
   def value_objects
-    int_values = values.map(&:to_i)
+    available_categories = all_project_categories.index_by(&:id)
 
-    all_project_categories.select { |c| int_values.include?(c.id) }
+    values
+      .map { |category_id| available_categories[category_id.to_i] }
+      .compact
   end
 
   def ar_object_filter?

--- a/app/models/queries/work_packages/filter/group_filter.rb
+++ b/app/models/queries/work_packages/filter/group_filter.rb
@@ -53,9 +53,11 @@ class Queries::WorkPackages::Filter::GroupFilter < Queries::WorkPackages::Filter
   end
 
   def value_objects
-    value_ints = values.map(&:to_i)
+    available_groups = all_groups.index_by(&:id)
 
-    all_groups.select { |g| value_ints.include?(g.id) }
+    values
+      .map { |group_id| available_groups[group_id.to_i] }
+      .compact
   end
 
   def where

--- a/app/models/queries/work_packages/filter/priority_filter.rb
+++ b/app/models/queries/work_packages/filter/priority_filter.rb
@@ -50,9 +50,11 @@ class Queries::WorkPackages::Filter::PriorityFilter <
   end
 
   def value_objects
-    value_ints = values.map(&:to_i)
+    available_priorities = priorities.index_by(&:id)
 
-    priorities.select { |p| value_ints.include? p.id }
+    values
+      .map { |priority_id| available_priorities[priority_id.to_i] }
+      .compact
   end
 
   private

--- a/app/models/queries/work_packages/filter/project_filter.rb
+++ b/app/models/queries/work_packages/filter/project_filter.rb
@@ -58,9 +58,11 @@ class Queries::WorkPackages::Filter::ProjectFilter < Queries::WorkPackages::Filt
   end
 
   def value_objects
-    value_ints = values.map(&:to_i)
+    available_projects = visible_projects.index_by(&:id)
 
-    visible_projects.select { |p| value_ints.include?(p.id) }
+    values
+      .map { |project_id| available_projects[project_id.to_i] }
+      .compact
   end
 
   private

--- a/app/models/queries/work_packages/filter/role_filter.rb
+++ b/app/models/queries/work_packages/filter/role_filter.rb
@@ -55,9 +55,11 @@ class Queries::WorkPackages::Filter::RoleFilter < Queries::WorkPackages::Filter:
   end
 
   def value_objects
-    value_ints = values.map(&:to_i)
+    available_roles = roles.index_by(&:id)
 
-    roles.select { |r| value_ints.include?(r.id) }
+    values
+      .map { |role_id| available_roles[role_id.to_i] }
+      .compact
   end
 
   def where

--- a/app/models/queries/work_packages/filter/status_filter.rb
+++ b/app/models/queries/work_packages/filter/status_filter.rb
@@ -30,7 +30,7 @@
 
 class Queries::WorkPackages::Filter::StatusFilter < Queries::WorkPackages::Filter::WorkPackageFilter
   def allowed_values
-    all_statuses.map { |s| [s.name, s.id.to_s] }
+    all_statuses.values.map { |s| [s.name, s.id.to_s] }
   end
 
   def available_operators
@@ -54,13 +54,13 @@ class Queries::WorkPackages::Filter::StatusFilter < Queries::WorkPackages::Filte
   end
 
   def value_objects
-    values_ids = values.map(&:to_i)
-
-    all_statuses.select { |status| values_ids.include?(status.id) }
+    values
+      .map { |status_id| all_statuses[status_id.to_i] }
+      .compact
   end
 
   def allowed_objects
-    all_statuses
+    all_statuses.values
   end
 
   def ar_object_filter?
@@ -73,7 +73,7 @@ class Queries::WorkPackages::Filter::StatusFilter < Queries::WorkPackages::Filte
     key = 'Queries::WorkPackages::Filter::StatusFilter/all_statuses'
 
     RequestStore.fetch(key) do
-      Status.all.to_a
+      Status.all.to_a.index_by(&:id)
     end
   end
 

--- a/app/models/queries/work_packages/filter/subproject_filter.rb
+++ b/app/models/queries/work_packages/filter/subproject_filter.rb
@@ -65,9 +65,11 @@ class Queries::WorkPackages::Filter::SubprojectFilter <
   end
 
   def value_objects
-    value_ints = values.map(&:to_i)
+    available_subprojects = visible_subprojects.index_by(&:id)
 
-    visible_subprojects.where(id: value_ints)
+    values
+      .map { |subproject_id| available_subprojects[subproject_id.to_i] }
+      .compact
   end
 
   def where

--- a/app/models/queries/work_packages/filter/type_filter.rb
+++ b/app/models/queries/work_packages/filter/type_filter.rb
@@ -53,9 +53,11 @@ class Queries::WorkPackages::Filter::TypeFilter <
   end
 
   def value_objects
-    value_ints = values.map(&:to_i)
+    available_types = types.index_by(&:id)
 
-    types.select { |t| value_ints.include?(t.id) }
+    values
+      .map { |type_id| available_types[type_id.to_i] }
+      .compact
   end
 
   private

--- a/app/models/queries/work_packages/filter/version_filter.rb
+++ b/app/models/queries/work_packages/filter/version_filter.rb
@@ -54,9 +54,11 @@ class Queries::WorkPackages::Filter::VersionFilter <
   end
 
   def value_objects
-    value_ints = values.map(&:to_i)
+    available_versions = versions.index_by(&:id)
 
-    versions.select { |v| value_ints.include?(v.id) }
+    values
+      .map { |version_id| available_versions[version_id.to_i] }
+      .compact
   end
 
   private

--- a/modules/backlogs/lib/open_project/backlogs/work_package_filter.rb
+++ b/modules/backlogs/lib/open_project/backlogs/work_package_filter.rb
@@ -72,8 +72,11 @@ module OpenProject::Backlogs
     end
 
     def value_objects
-      allowed_values
-        .select { |av| values.include?(av.last) }
+      available_backlog_types = allowed_values.index_by(&:last)
+
+      values
+        .map { |backlog_type_id| available_backlog_types[backlog_type_id] }
+        .compact
         .map { |value| BacklogsType.new(*value) }
     end
 

--- a/modules/costs/lib/open_project/costs/work_package_filter.rb
+++ b/modules/costs/lib/open_project/costs/work_package_filter.rb
@@ -59,7 +59,11 @@ module OpenProject::Costs
     end
 
     def value_objects
-      cost_objects.where(id: values)
+      available_cost_objects = cost_objects.index_by(&:id)
+
+      values
+        .map { |cost_object_id| available_cost_objects[cost_object_id.to_i] }
+        .compact
     end
 
     def human_name

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -488,4 +488,26 @@ describe 'filter work packages', js: true do
       end
     end
   end
+
+  describe 'keep the filter attribute order (Regression #33136)' do
+    let(:version1) { FactoryBot.create :version, project: project, name: 'Version 1', id: 1 }
+    let(:version2) { FactoryBot.create :version, project: project, name: 'Version 2', id: 2 }
+
+    it do
+      wp_table.visit!
+      loading_indicator_saveguard
+
+      filters.open
+      filters.add_filter_by 'Version', 'is', [version2.name, version1.name]
+      loading_indicator_saveguard
+
+      sleep(3)
+
+      filters.expect_filter_by 'Version', 'is', [version1.name]
+      filters.expect_filter_by 'Version', 'is', [version2.name]
+
+      # Order should stay unchanged
+      filters.expect_filter_order('Version', [version2.name, version1.name])
+    end
+  end
 end

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -123,6 +123,12 @@ module Components
         end
       end
 
+      def expect_filter_order(name, values, selector = nil)
+        id = selector || name.downcase
+
+        expect(page.all("#values-#{id} .ng-value-label").map(&:text)).to eq(values)
+      end
+
       def remove_filter(field)
         find("#filter_#{field} .advanced-filters--remove-filter-icon").click
       end


### PR DESCRIPTION
Prevent that the backend changes the order of filter attributes (sorted by id). Instead the order of the given values is kept, thus there is no change in the frontend.

https://community.openproject.com/projects/openproject/work_packages/33136/activity