### PR TITLE
deepClone payload source object to avoid side effects

### DIFF
--- a/frontend/src/app/modules/fields/changeset/resource-changeset.ts
+++ b/frontend/src/app/modules/fields/changeset/resource-changeset.ts
@@ -297,10 +297,11 @@ export class ResourceChangeset<T extends HalResource|{ [key:string]:unknown; } =
     if (this.pristineResource.isNew) {
       // If the resource is new, we need to pass the entire form payload
       // to let all default values be transmitted (type, status, etc.)
+      // We clone the object to avoid later manipulations to affect the original resource.
       if (this.form$.value) {
-        payload = this.form$.value.payload.$source;
+        payload = _.cloneDeep(this.form$.value.payload.$source);
       } else {
-        payload = this.pristineResource.$source;
+        payload = _.cloneDeep(this.pristineResource.$source);
       }
 
       // Add attachments to be assigned.

--- a/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
+++ b/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
@@ -86,7 +86,7 @@ describe 'My page time entries current user widget spec', type: :feature, js: tr
                       hours: 4
   end
   let!(:custom_field) do
-    FactoryBot.create :time_entry_custom_field, field_format: 'string'
+    FactoryBot.create :time_entry_custom_field, field_format: 'text'
   end
   let(:other_user) do
     FactoryBot.create(:user)
@@ -99,7 +99,7 @@ describe 'My page time entries current user widget spec', type: :feature, js: tr
   let(:my_page) do
     Pages::My::Page.new
   end
-  let(:cf_field) { ::EditField.new(page, "customField#{custom_field.id}") }
+  let(:cf_field) { ::TextEditorField.new(page, "customField#{custom_field.id}") }
   let(:time_logging_modal) { ::Components::TimeLoggingModal.new }
 
   before do


### PR DESCRIPTION
Every change to the source would otherwise alter the source of the form/resource when the intend of the method is to build a payload. In the case of time entries, the [project is removed](https://github.com/opf/openproject/blob/dev/frontend/src/app/components/time-entries/time-entry-changeset.ts#L19) as it will later be deduced by the work package. But if the project reference in the source is removed, later code will fail when trying to instantiate the project (which is done lazily).

https://community.openproject.com/wp/33310