### PR TITLE
Fix redirect loop when loading viewpoint

### DIFF
--- a/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
+++ b/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
@@ -80,7 +80,9 @@ export class IFCViewerService extends ViewerBridgeService {
   }
 
   public showViewpoint(viewpoint:BcfViewpointInterface) {
-    this.viewer.loadBCFViewpoint(viewpoint, {});
+    if (this.viewerVisible()) {
+      this.viewer.loadBCFViewpoint(viewpoint, {});
+    }
   }
 
   public viewerVisible():boolean {


### PR DESCRIPTION
Also prevent loading the viewpoint when we do a hard redirect anyways.

Further, run the initialization of the WpBcfAttributeGroup only once
and not for all updates/changes on the workpackage, which can be
plenty, as the WP's activity gets also loaded.

https://community.openproject.com/wp/33387