### PR TITLE
Fix/query sums for string

### DIFF
--- a/app/models/queries/work_packages/columns/custom_field_column.rb
+++ b/app/models/queries/work_packages/columns/custom_field_column.rb
@@ -79,7 +79,7 @@ class Queries::WorkPackages::Columns::CustomFieldColumn < Queries::WorkPackages:
 
   def sum_of(work_packages)
     if work_packages.respond_to?(:joins)
-      cast = @cf.field_format == 'int' ? 'INTEGER' : 'FLOAT'
+      cast = @cf.field_format == 'int' ? 'BIGINT' : 'FLOAT'
 
       CustomValue
         .where(customized: work_packages, custom_field: @cf)

--- a/app/models/queries/work_packages/columns/custom_field_column.rb
+++ b/app/models/queries/work_packages/columns/custom_field_column.rb
@@ -90,7 +90,7 @@ class Queries::WorkPackages::Columns::CustomFieldColumn < Queries::WorkPackages:
     else
       # TODO: eliminate calls of this method with an Array and drop the :compact call below
       ActiveSupport::Deprecation.warn('Passing an array of work packages is deprecated. Pass an AR-relation instead.')
-      work_packages.map { |wp| value(wp) }.compact.reduce(:+)
+      work_packages.map { |wp| wp.typed_custom_value_for(@cf) }.compact.reduce(:+)
     end
   end
 

--- a/app/models/query/sums.rb
+++ b/app/models/query/sums.rb
@@ -99,7 +99,7 @@ module ::Query::Sums
   end
 
   def crunch(num)
-    return num if num.nil? or num.integer?
+    return num if num.nil? || !num.respond_to?(:integer?) || num.integer?
 
     Float(format('%.2f', num.to_f))
   end


### PR DESCRIPTION
Fixes two error cases that might occur if activating both grouping and sums on queries:
* The sum can become so large that it overflows the INTEGER value (custom fields only)
* The formatted (read string) value for integer and float values where taken when calculating the groups sums leading to e.g. '5206' for the values 5, 20 and 6

Meant as a hotfix on 10.5 (as we might need to deploy this) until we rewrite this in 10.7 (https://community.openproject.com/wp/31617) 