### PR TITLE
Prevent double 409 conflict form errors after saving the work package

### DIFF
--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.component.ts
@@ -156,7 +156,7 @@ export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implemen
     this.$element = jQuery(this.elementRef.nativeElement);
 
     const change = this.halEditing.changeFor<WorkPackageResource, WorkPackageChangeset>(this.workPackage);
-    this.resourceContextChange.next(this.contextFrom(change));
+    this.resourceContextChange.next(this.contextFrom(change.projectedResource));
     this.refresh(change);
 
     // Whenever the resource context changes in any way,
@@ -172,13 +172,13 @@ export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implemen
     // Update the resource context on every update to the temporary resource.
     // This allows detecting a changed type value in a new work package.
     this.halEditing
-      .typedState<WorkPackageResource, WorkPackageChangeset>(this.workPackage)
+      .temporaryEditResource(this.workPackage)
       .values$()
       .pipe(
         this.untilDestroyed()
       )
-      .subscribe((change:WorkPackageChangeset) => {
-        this.resourceContextChange.next(this.contextFrom(change));
+      .subscribe(resource => {
+        this.resourceContextChange.next(this.contextFrom(resource));
       });
   }
 
@@ -368,12 +368,11 @@ export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implemen
    * Used to identify changes in the schema or project that may result in visual changes
    * to the single view.
    *
-   * @param {WorkPackageChangeset} change
+   * @param {WorkPackage} workPackage
    * @returns {SchemaContext}
    */
-  private contextFrom(change:WorkPackageChangeset):ResourceContextChange {
-    let schema = change.schema;
-    let workPackage = change.projectedResource;
+  private contextFrom(workPackage:WorkPackageResource):ResourceContextChange {
+    let schema = workPackage.schema;
 
     let schemaHref:string|null = null;
     let projectHref:string|null = workPackage.project && workPackage.project.href;

--- a/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.html
+++ b/frontend/src/app/components/wp-buttons/wp-status-button/wp-status-button.html
@@ -4,7 +4,7 @@
      *ngIf="status">
   <button class="button"
           [ngClass]="statusHighlightClass"
-          [disabled]="isDisabled"
+          [disabled]="!allowed"
           [attr.aria-label]="text.explanation"
           wpStatusDropdown
           [wpStatusDropdown-workPackage]="workPackage">

--- a/frontend/src/app/components/wp-edit-form/table-edit-form.ts
+++ b/frontend/src/app/components/wp-edit-form/table-edit-form.ts
@@ -70,7 +70,6 @@ export class TableEditForm extends EditForm<WorkPackageResource> {
 
   destroy() {
     this.resourceSubscription.unsubscribe();
-    super.destroy();
   }
 
   public findContainer(fieldName:string):JQuery {

--- a/frontend/src/app/components/wp-new/wp-create.component.ts
+++ b/frontend/src/app/components/wp-new/wp-create.component.ts
@@ -92,7 +92,6 @@ export class WorkPackageCreateComponent extends UntilDestroyedMixin implements O
 
   public ngOnDestroy() {
     super.ngOnDestroy();
-    this.editForm.destroy();
   }
 
   public switchToFullscreen() {
@@ -102,7 +101,7 @@ export class WorkPackageCreateComponent extends UntilDestroyedMixin implements O
   public onSaved(params:{ savedResource:WorkPackageResource, isInitial:boolean }) {
     let { savedResource, isInitial } = params;
 
-    this.editForm?.stop();
+    this.editForm?.cancel(false);
 
     if (this.successState) {
       this.$state.go(this.successState, { workPackageId: savedResource.id })

--- a/frontend/src/app/modules/common/edit-actions-bar/wp-edit-actions-bar.component.ts
+++ b/frontend/src/app/modules/common/edit-actions-bar/wp-edit-actions-bar.component.ts
@@ -66,7 +66,7 @@ export class WorkPackageEditActionsBarComponent {
 
     this.saving = true;
     this.editForm
-      .save()
+      .submit()
       .then(() => {
         this.saving = false;
         this.onSave.emit();
@@ -77,7 +77,7 @@ export class WorkPackageEditActionsBarComponent {
   }
 
   public cancel():void {
-    this.editForm.stop();
+    this.editForm.cancel();
     this.onCancel.emit();
   }
 }

--- a/frontend/src/app/modules/fields/edit/edit-form/edit-form.component.ts
+++ b/frontend/src/app/modules/fields/edit/edit-form/edit-form.component.ts
@@ -43,6 +43,7 @@ import {IFieldSchema} from "core-app/modules/fields/field.base";
 import {EditFieldHandler} from "core-app/modules/fields/edit/editing-portal/edit-field-handler";
 import {EditingPortalService} from "core-app/modules/fields/edit/editing-portal/editing-portal-service";
 import {EditFormRoutingService} from "core-app/modules/fields/edit/edit-form/edit-form-routing.service";
+import {ResourceChangesetCommit} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
 
 @Component({
   selector: 'edit-form,[edit-form]',
@@ -84,7 +85,7 @@ export class EditFormComponent extends EditForm<HalResource> implements OnInit, 
           return false;
         }
 
-        this.stop();
+        this.cancel(false);
       }
 
       return true;
@@ -92,7 +93,7 @@ export class EditFormComponent extends EditForm<HalResource> implements OnInit, 
   }
 
   ngOnDestroy() {
-    this.destroy();
+    this.unregisterListener();
   }
 
   ngOnInit() {
@@ -101,11 +102,6 @@ export class EditFormComponent extends EditForm<HalResource> implements OnInit, 
     if (this.initializeEditMode) {
       this.start();
     }
-  }
-
-  destroy() {
-    this.unregisterListener();
-    super.destroy();
   }
 
   public async activateField(form:EditForm, schema:IFieldSchema, fieldName:string, errors:string[]):Promise<EditFieldHandler> {
@@ -129,9 +125,18 @@ export class EditFormComponent extends EditForm<HalResource> implements OnInit, 
     ctrl.deactivate(focus);
   }
 
-  public onSaved(isInitial:boolean, saved:HalResource) {
-    super.onSaved(isInitial, saved);
-    this.stopEditingAndLeave(saved, isInitial);
+  public onSaved(commit:ResourceChangesetCommit) {
+    this.cancel(false);
+    this.onSavedEmitter.emit({savedResource: commit.resource, isInitial: commit.wasNew });
+  }
+
+  public cancel(reset:boolean = false) {
+    this.editMode = false;
+    this.closeEditFields('all', reset);
+
+    if (reset) {
+      this.halEditing.reset(this.change)
+    }
   }
 
   public requireVisible(fieldName:string):Promise<void> {
@@ -176,27 +181,6 @@ export class EditFormComponent extends EditForm<HalResource> implements OnInit, 
 
   public start() {
     _.each(this.fields, ctrl => this.activate(ctrl.fieldName));
-  }
-
-  public stop() {
-    this.editMode = false;
-    this.closeEditFields();
-    this.halEditing.stopEditing(this.resource);
-    this.destroy();
-  }
-
-  public save() {
-    const isInitial = this.resource.isNew;
-    return this
-      .submit()
-      .then((savedResource:HalResource) => {
-        this.stopEditingAndLeave(savedResource, isInitial);
-      });
-  }
-
-  public stopEditingAndLeave(savedResource:HalResource, isInitial:boolean) {
-    this.stop();
-    this.onSavedEmitter.emit({savedResource, isInitial});
   }
 
   protected focusOnFirstError():void {

--- a/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
@@ -114,7 +114,7 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
 
   public get ckEditorContext():ICKEditorContext {
     return {
-      resource: this.resource,
+      resource: this.change.pristineResource,
       macros: 'none' as 'none',
       previewContext: this.previewContext,
       options: { rtl: this.schema.options && this.schema.options.rtl }

--- a/frontend/src/app/modules/fields/edit/services/hal-resource-editing.service.ts
+++ b/frontend/src/app/modules/fields/edit/services/hal-resource-editing.service.ts
@@ -204,7 +204,7 @@ export class HalResourceEditingService extends StateCacheService<ResourceChanges
       return this.edit<V, T>(resource);
     }
 
-    changeset.pristineResource = resource;
+    changeset.updatePristineResource(resource);
     return changeset;
   }
 
@@ -229,7 +229,7 @@ export class HalResourceEditingService extends StateCacheService<ResourceChanges
           filter(([resource, _]) => !!resource),
           map(([resource, change]) => {
             if (change) {
-              change.pristineResource = resource as V;
+              change.updatePristineResource(resource as V);
               return change.projectedResource;
             }
 

--- a/frontend/src/app/modules/hal/resources/hal-resource.ts
+++ b/frontend/src/app/modules/hal/resources/hal-resource.ts
@@ -235,10 +235,12 @@ export class HalResource {
   /**
    * Update the state
    */
-  public push(newValue:this):void {
+  public push(newValue:this):Promise<unknown> {
     if (this.state) {
       this.state.putValue(newValue);
     }
+
+    return Promise.resolve();
   }
 
   public previewPath():string|undefined {

--- a/frontend/src/app/modules/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/modules/hal/resources/work-package-resource.ts
@@ -338,7 +338,7 @@ export class WorkPackageBaseResource extends HalResource {
   /**
    * Update the state
    */
-  public push(newValue:this):void {
+  public push(newValue:this):Promise<unknown> {
     this.wpActivity.clear(newValue.id!);
 
     // If there is a parent, its view has to be updated as well
@@ -346,7 +346,7 @@ export class WorkPackageBaseResource extends HalResource {
       this.wpCacheService.require(newValue.parent.id!, true);
     }
 
-    this.wpCacheService.updateWorkPackage(newValue as any);
+    return this.wpCacheService.updateWorkPackage(newValue as any);
   }
 
   public get hasOverriddenSchema():boolean {

--- a/frontend/src/app/modules/time_entries/form/form.component.ts
+++ b/frontend/src/app/modules/time_entries/form/form.component.ts
@@ -75,7 +75,7 @@ export class TimeEntryFormComponent extends UntilDestroyedMixin implements OnIni
   }
 
   public save() {
-    return this.editForm.save();
+    return this.editForm.submit();
   }
 
   public get inEditMode() {

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -147,6 +147,7 @@ describe 'Switching types in work package table', js: true do
 
       # Now switch back to a type without the required CF
       type_field.activate!
+      type_field.openSelectField
       type_field.set_value type_task.name
 
       wp_table.expect_notification(


### PR DESCRIPTION
Due to the way the changesets are used and cleared, we were causing
double posting to the form with an old work package lockVersion:

1. Lock version in changeset correct, editing work package, saving it

2. The EditForm destroys the changeset on submit prior to the work
package being updated in state

3. The WPStatusButtonComponent got a call after the changeset was
destroyed, resulting in an immediate new changeset being created.

4. The new changeset resulted in the changeset set being fired, which
triggered the select edit fields

5. They requested the form post with an older lock version

Without 3.), we don't always have a changeset present for the resource, so we need to rely on the `temporaryEditResource` to get either the projected or the pristine work package in other places (such as the single-view). Otherwise, switching types will not properly reload the form