### PR TITLE
Introduce separate permission for deleting BCF issues

### DIFF
--- a/modules/bim/app/contracts/bim/bcf/issues/delete_contract.rb
+++ b/modules/bim/app/contracts/bim/bcf/issues/delete_contract.rb
@@ -29,7 +29,7 @@
 module Bim::Bcf
   module Issues
     class DeleteContract < ::DeleteContract
-      delete_permission :manage_bcf
+      delete_permission :delete_bcf
     end
   end
 end

--- a/modules/bim/config/locales/en.yml
+++ b/modules/bim/config/locales/en.yml
@@ -72,6 +72,7 @@ en:
   project_module_bim: "BCF"
   permission_view_linked_issues: "View BCF issues"
   permission_manage_bcf: "Import and manage BCF issues"
+  permission_delete_bcf: "Delete BCF issues"
 
   oauth:
     scopes:

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -61,6 +61,13 @@ module OpenProject::Bim
                    dependencies: %i[view_linked_issues
                                     view_work_packages
                                     add_work_packages
+                                    edit_work_packages]
+        permission :delete_bcf,
+                   {},
+                   dependencies: %i[view_linked_issues
+                                    manage_bcf
+                                    view_work_packages
+                                    add_work_packages
                                     edit_work_packages
                                     delete_work_packages]
       end

--- a/modules/bim/spec/requests/api/bcf/v2_1/topics_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/topics_api_spec.rb
@@ -52,8 +52,17 @@ describe 'BCF 2.1 topics resource', type: :request, content_type: :json, with_ma
                                                   add_work_packages
                                                   view_linked_issues
                                                   view_work_packages
-                                                  edit_work_packages
-                                                  delete_work_packages])
+                                                  edit_work_packages])
+  end
+  let(:edit_and_delete_member_user) do
+    FactoryBot.create(:user,
+                      member_in_project: project,
+                      member_with_permissions: %i[delete_bcf
+                                                  delete_work_packages
+                                                  manage_bcf
+                                                  add_work_packages
+                                                  view_linked_issues
+                                                  view_work_packages])
   end
   let(:edit_work_package_member_user) do
     FactoryBot.create(:user,
@@ -61,8 +70,7 @@ describe 'BCF 2.1 topics resource', type: :request, content_type: :json, with_ma
                       member_with_permissions: %i[add_work_packages
                                                   view_linked_issues
                                                   edit_work_packages
-                                                  view_work_packages
-                                                  delete_work_packages])
+                                                  view_work_packages])
   end
   let(:non_member_user) do
     FactoryBot.create(:user)
@@ -287,7 +295,7 @@ describe 'BCF 2.1 topics resource', type: :request, content_type: :json, with_ma
 
   describe 'DELETE /api/bcf/2.1/projects/:project_id/topics/:uuid' do
     let(:path) { "/api/bcf/2.1/projects/#{project.id}/topics/#{bcf_issue.uuid}" }
-    let(:current_user) { edit_member_user }
+    let(:current_user) { edit_and_delete_member_user }
 
     before do
       login_as(current_user)
@@ -307,8 +315,8 @@ describe 'BCF 2.1 topics resource', type: :request, content_type: :json, with_ma
       expect(Bim::Bcf::Issue.where(id: bcf_issue.id)).to match_array []
     end
 
-    context 'lacking permission to manage bcf' do
-      let(:current_user) { edit_work_package_member_user }
+    context 'lacking permission to delete bcf' do
+      let(:current_user) { edit_member_user }
 
       it_behaves_like 'bcf api not allowed response'
 


### PR DESCRIPTION
Deleting BCF issues requires the permission to delete
work packages. And this is something we usually do
not want to permit too easily. As many people need
the right to manage BCF issues and less people
need the right to delete them, I think we should
separate the two.

https://community.openproject.com/wp/33438
