### PR TITLE
Use present? on filter string

### DIFF
--- a/app/models/ldap_auth_source.rb
+++ b/app/models/ldap_auth_source.rb
@@ -185,7 +185,7 @@ class LdapAuthSource < AuthSource
   end
 
   def parsed_filter_string
-    Net::LDAP::Filter.from_rfc2254(filter_string) if filter_string
+    Net::LDAP::Filter.from_rfc2254(filter_string) if filter_string.present?
   end
 
   private


### PR DESCRIPTION
We want the filter string to be optional, but if an empty string is passed this results in an error.