### PR TITLE
Refactoring viewpoint management in the Frontend

### DIFF
--- a/frontend/src/app/modules/bim/bcf/api/viewpoints/bcf-viewpoint-item.interface.ts
+++ b/frontend/src/app/modules/bim/bcf/api/viewpoints/bcf-viewpoint-item.interface.ts
@@ -1,0 +1,10 @@
+import {BcfViewpointInterface} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.interface";
+
+export interface BcfViewpointItem {
+  /** The URL of the viewpoint, if persisted */
+  href?:string|null;
+  /** URL (persisted or data) to the snapshot */
+  snapshotURL:string;
+  /** The loaded snapshot, if exists */
+  viewpoint?:BcfViewpointInterface;
+}

--- a/frontend/src/app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.interface.ts
+++ b/frontend/src/app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.interface.ts
@@ -3,7 +3,9 @@ export interface BcfViewpointInterface {
   guid:string;
   components:unknown;
   bitmaps:unknown[];
+  snapshot:{ snapshot_type:string, snapshot_data:string };
   orthogonal_camera?:unknown;
   perspective_camera?:unknown;
-  snapshot:{ snapshot_type:string, snapshot_data:string };
+  clipping_planes?:unknown[];
+  lines?:unknown[];  
 }

--- a/frontend/src/app/modules/bim/bcf/bcf-viewer-bridge/revit-bridge.service.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-viewer-bridge/revit-bridge.service.ts
@@ -5,6 +5,9 @@ import {BcfViewpointInterface} from "core-app/modules/bim/bcf/api/viewpoints/bcf
 import {ViewerBridgeService} from "core-app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service";
 import {input} from "reactivestates";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
+import {ViewpointsService} from "core-app/modules/bim/bcf/helper/viewpoints.service";
+import {map} from "rxjs/operators";
+import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 
 
 declare global {
@@ -19,10 +22,12 @@ export class RevitBridgeService extends ViewerBridgeService {
   private _trackingIdNumber = 0;
   private _ready$ = input<boolean>(false);
 
+  @InjectField() viewpointsService:ViewpointsService;
+
   revitMessageReceived$ = this.revitMessageReceivedSource.asObservable();
 
   constructor(readonly injector:Injector) {
-    super();
+    super(injector);
 
     if (window.RevitBridge) {
       console.log("window.RevitBridge is already there, so let's hook up the Revit Listener");
@@ -40,7 +45,7 @@ export class RevitBridgeService extends ViewerBridgeService {
     return this._ready$.getValueOr(false);
   }
 
-  public getViewpoint():Promise<any> {
+  public getViewpoint$():Observable<BcfViewpointInterface> {
     const trackingId = this.newTrackingId();
 
     this.sendMessageToRevit('ViewpointGenerationRequest', trackingId, '');
@@ -51,24 +56,23 @@ export class RevitBridgeService extends ViewerBridgeService {
         filter(message => message.messageType === 'ViewpointData' && message.trackingId === trackingId),
         first()
       )
-      .toPromise()
-      .then((message) => {
-        let viewpointJson = JSON.parse(message.messagePayload);
+      .pipe(
+        map((message) => {
+          let viewpointJson = JSON.parse(message.messagePayload);
 
-        viewpointJson.snapshot = {
-          snapshot_type: 'png',
-          snapshot_data: viewpointJson.snapshot
-        };
-
-        return viewpointJson;
-      });
+          viewpointJson.snapshot = {
+            snapshot_type: 'png',
+            snapshot_data: viewpointJson.snapshot
+          };
+          return viewpointJson;
+        })
+      )
   }
 
   public showViewpoint(workPackage:WorkPackageResource, index:number) {
-    /* const viewPointResource = this.getViewPointResource(workPackage:WorkPackageResource, index:number);
-
-    this.getViewPointData$(viewpointHref)
-          .subscribe(viewpoint => this.sendMessageToRevit('ShowViewpoint', this.newTrackingId(), JSON.stringify(viewpoint))); */    
+     this.viewpointsService
+              .getViewPoint$(workPackage, index)
+              .subscribe((viewpoint: BcfViewpointInterface) =>  this.sendMessageToRevit('ShowViewpoint', this.newTrackingId(), JSON.stringify(viewpoint)));
   }
 
   sendMessageToRevit(messageType:string, trackingId:string, messagePayload?:any) {

--- a/frontend/src/app/modules/bim/bcf/bcf-viewer-bridge/revit-bridge.service.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-viewer-bridge/revit-bridge.service.ts
@@ -1,9 +1,11 @@
-import {Injectable} from '@angular/core';
+import {Injectable, Injector} from '@angular/core';
 import {Observable, Subject} from "rxjs";
 import {distinctUntilChanged, filter, first, mapTo} from "rxjs/operators";
 import {BcfViewpointInterface} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.interface";
 import {ViewerBridgeService} from "core-app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service";
 import {input} from "reactivestates";
+import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
+
 
 declare global {
   interface Window {
@@ -19,7 +21,7 @@ export class RevitBridgeService extends ViewerBridgeService {
 
   revitMessageReceived$ = this.revitMessageReceivedSource.asObservable();
 
-  constructor() {
+  constructor(readonly injector:Injector) {
     super();
 
     if (window.RevitBridge) {
@@ -34,11 +36,11 @@ export class RevitBridgeService extends ViewerBridgeService {
     }
   }
 
-  viewerVisible() {
+  public viewerVisible() {
     return this._ready$.getValueOr(false);
   }
 
-  getViewpoint():Promise<any> {
+  public getViewpoint():Promise<any> {
     const trackingId = this.newTrackingId();
 
     this.sendMessageToRevit('ViewpointGenerationRequest', trackingId, '');
@@ -62,8 +64,11 @@ export class RevitBridgeService extends ViewerBridgeService {
       });
   }
 
-  showViewpoint(data:BcfViewpointInterface) {
-    this.sendMessageToRevit('ShowViewpoint', this.newTrackingId(), JSON.stringify(data));
+  public showViewpoint(workPackage:WorkPackageResource, index:number) {
+    /* const viewPointResource = this.getViewPointResource(workPackage:WorkPackageResource, index:number);
+
+    this.getViewPointData$(viewpointHref)
+          .subscribe(viewpoint => this.sendMessageToRevit('ShowViewpoint', this.newTrackingId(), JSON.stringify(viewpoint))); */    
   }
 
   sendMessageToRevit(messageType:string, trackingId:string, messagePayload?:any) {

--- a/frontend/src/app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service.ts
@@ -3,12 +3,21 @@ import {BcfViewpointInterface} from "core-app/modules/bim/bcf/api/viewpoints/bcf
 import {Observable} from "rxjs";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
+import {StateService} from "@uirouter/core";
 
 
 @Injectable()
 export abstract class ViewerBridgeService {
-  constructor(readonly injector:Injector) {}
+  @InjectField() state:StateService;
+  /**
+   * Check if we are on a router state where there is a place
+   * where the viewer could be shown
+   */
+  get routeWithViewer():boolean {
+    return this.state.includes('bim.partitioned.split');
+  }
 
+  constructor(readonly injector:Injector) {}
   /**
    * Get a viewpoint from the viewer
    */

--- a/frontend/src/app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service.ts
@@ -1,17 +1,24 @@
+import {Injector, Injectable} from '@angular/core';
 import {BcfViewpointInterface} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.interface";
 import {Observable} from "rxjs";
+import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
+import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 
+
+@Injectable()
 export abstract class ViewerBridgeService {
+  constructor(readonly injector:Injector) {}
+
   /**
    * Get a viewpoint from the viewer
    */
-  abstract getViewpoint():Promise<BcfViewpointInterface>;
+  abstract getViewpoint$():Observable<BcfViewpointInterface>;
 
   /**
    * Show the given viewpoint JSON in the viewer
    * @param viewpoint
    */
-  abstract showViewpoint(viewpoint:BcfViewpointInterface):void;
+  abstract showViewpoint(workPackage:WorkPackageResource, index:number):void;
 
   /**
    * Determine whether a viewer is present to ensure we can show viewpoints

--- a/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-new-wp-attribute-group.component.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-new-wp-attribute-group.component.ts
@@ -1,14 +1,19 @@
 import {ChangeDetectionStrategy, Component} from "@angular/core";
 import {BcfWpAttributeGroupComponent} from "core-app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component";
-import {take} from "rxjs/operators";
+import {take, switchMap} from "rxjs/operators";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
+import {forkJoin} from "rxjs";
+import {BcfViewpointInterface} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.interface";
+import {BcfViewpointItem} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint-item.interface";
+
 
 @Component({
   templateUrl: './bcf-wp-attribute-group.component.html',
   styleUrls: ['./bcf-wp-attribute-group.component.sass'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BcfNewWpAttributeGroupComponent extends BcfWpAttributeGroupComponent {
+  galleryViewpoints:BcfViewpointItem[] = [];
 
   ngAfterViewInit():void {
     if (this.viewerVisible) {
@@ -21,58 +26,69 @@ export class BcfNewWpAttributeGroupComponent extends BcfWpAttributeGroupComponen
     }
   }
 
+  // Because this is a new WorkPackage, in order to save the
+  // viewpoints on it we need to:
+  // - Wait until the WorkPackage is created
+  // - Create the BCFTopic on it to save the viewpoints
+  private observeCreation() {
+    this.wpCreate
+          .onNewWorkPackage()
+          .pipe(
+            this.untilDestroyed(),
+            take(1),
+            switchMap((wp:WorkPackageResource) => this.viewpointsService.setBcfTopic$(wp), (wp) => wp),
+            switchMap((wp:WorkPackageResource) => {
+              this.workPackage = wp;
+              const observables = this.galleryViewpoints
+                                        .filter(viewPointItem => !viewPointItem.href && viewPointItem.viewpoint)
+                                        .map(viewPointItem => this.viewpointsService.saveViewpoint$(this.workPackage, viewPointItem.viewpoint));             
+
+              return forkJoin(observables);
+            })
+          )
+          .subscribe((viewpoints: BcfViewpointInterface[]) => {
+            this.showIndex = this.galleryViewpoints.length - 1;
+          });
+  }
+
   // Disable show viewpoint functionality
   showViewpoint(workPackage:WorkPackageResource, index:number) {
     return;
   }
 
   deleteViewpoint(workPackage:WorkPackageResource, index:number) {
-    this.setViewpoints(
-      this.viewpoints.filter((_, i) => i !== index)
-    );
+    this.galleryViewpoints = this.galleryViewpoints.filter((_, i) => i !== index);
+
+    this.setViewpointsOnGallery(this.galleryViewpoints);
+    
     return;
   }
 
-  async saveCurrentAsViewpoint() {
-    const viewpoint = await this.viewerBridge!.getViewpoint();
+  saveViewpoint() {
+    this.viewerBridge
+          .getViewpoint$() 
+          .subscribe(viewpoint => {            
+            const newViewpoint = {
+                snapshotURL: viewpoint.snapshot.snapshot_data,
+                viewpoint: viewpoint
+            };
 
-    this.setViewpoints([
-      ...this.viewpoints,
-      {
-        snapshotURL: viewpoint.snapshot.snapshot_data,
-        viewpoint: viewpoint
-      }
-    ]);
+            this.galleryViewpoints = [
+              ...this.galleryViewpoints,
+              newViewpoint
+            ];
 
-    // Select the last created viewpoint and show it
-    this.showIndex = this.viewpoints.length - 1;
-    this.selectViewpointInGallery();
+            this.setViewpointsOnGallery(this.galleryViewpoints);
+
+            // Select the last created viewpoint and show it
+            this.showIndex = this.galleryViewpoints.length - 1;
+            this.selectViewpointInGallery();
+          });
   }
 
   shouldShowGroup() {
     return this.createAllowed && this.viewerVisible;
   }
-
-  private observeCreation() {
-    this.wpCreate
-      .onNewWorkPackage()
-      .pipe(
-        this.untilDestroyed(),
-        take(1)
-      )
-      .subscribe(async (wp:WorkPackageResource) => {
-        this.workPackage = wp;
-        for (let el of this.viewpoints) {
-          if (!el.href && el.viewpoint) {
-            await this.persistViewpoint(el.viewpoint!);
-          }
-        }
-
-        this.showIndex = this.viewpoints.length - 1;
-        this.wpCache.require(this.workPackage.id!, true);
-      });
-  }
-
   protected actions() {
     // Show only delete button
     return super

--- a/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-new-wp-attribute-group.component.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-new-wp-attribute-group.component.ts
@@ -22,11 +22,11 @@ export class BcfNewWpAttributeGroupComponent extends BcfWpAttributeGroupComponen
   }
 
   // Disable show viewpoint functionality
-  showViewpoint(index:number) {
+  showViewpoint(workPackage:WorkPackageResource, index:number) {
     return;
   }
 
-  deleteViewpoint(index:number) {
+  deleteViewpoint(workPackage:WorkPackageResource, index:number) {
     this.setViewpoints(
       this.viewpoints.filter((_, i) => i !== index)
     );

--- a/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.html
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.html
@@ -20,7 +20,7 @@
     <a *ngIf="viewerVisible && createAllowed"
        [title]="text.add_viewpoint"
        class="button"
-       (click)="saveCurrentAsViewpoint()">
+       (click)="saveCurrentAsViewpoint(workPackage)">
       <op-icon icon-classes="button--icon icon-add"></op-icon>
       <span class="button--text"> {{text.viewpoint}} </span>
     </a>

--- a/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.html
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.html
@@ -20,7 +20,7 @@
     <a *ngIf="viewerVisible && createAllowed"
        [title]="text.add_viewpoint"
        class="button"
-       (click)="saveCurrentAsViewpoint(workPackage)">
+       (click)="saveViewpoint(workPackage)">
       <op-icon icon-classes="button--icon icon-add"></op-icon>
       <span class="button--text"> {{text.viewpoint}} </span>
     </a>

--- a/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.ts
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.ts
@@ -10,35 +10,24 @@ import {
 import {StateService} from "@uirouter/core";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {NgxGalleryComponent, NgxGalleryOptions} from '@kolkov/ngx-gallery';
-import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 import {HalLink} from "core-app/modules/hal/hal-link/hal-link";
-import {BcfApiService} from "core-app/modules/bim/bcf/api/bcf-api.service";
-import {BcfViewpointPaths} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.paths";
-import {CurrentProjectService} from "core-components/projects/current-project.service";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {ViewerBridgeService} from "core-app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service";
 import {WorkPackageCacheService} from "core-components/work-packages/work-package-cache.service";
 import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
-import {BcfViewpointInterface} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.interface";
 import {WorkPackageCreateService} from "core-components/wp-new/wp-create.service";
 import {BcfAuthorizationService} from "core-app/modules/bim/bcf/api/bcf-authorization.service";
 import {ViewpointsService} from "core-app/modules/bim/bcf/helper/viewpoints.service";
+import {BcfViewpointItem} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint-item.interface";
 
 
-export interface ViewpointItem {
-  /** The URL of the viewpoint, if persisted */
-  href?:string;
-  /** URL (persisted or data) to the snapshot */
-  snapshotURL:string;
-  /** The loaded snapshot, if exists */
-  viewpoint?:BcfViewpointInterface;
-}
 
 @Component({
   templateUrl: './bcf-wp-attribute-group.component.html',
   styleUrls: ['./bcf-wp-attribute-group.component.sass'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [ViewpointsService]
 })
 export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements AfterViewInit, OnDestroy {
   @Input() workPackage:WorkPackageResource;
@@ -109,25 +98,19 @@ export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements
     }
   ];
 
-  viewpoints:ViewpointItem[] = [];
+  viewpoints:BcfViewpointItem[] = [];
 
   galleryImages:any[] = [];
-
-  // Remember the topic UUID, which we might just create
-  topicUUID:string|undefined;
 
   // Store whether viewing is allowed
   viewAllowed:boolean = false;
   // Store whether viewpoint creation is allowed
   createAllowed:boolean = false;
-
   // Currently, this is static. Need observable if this changes over time
   viewerVisible = this.viewerBridge.viewerVisible();
+  projectId: string;
 
   constructor(readonly state:StateService,
-              readonly pathHelper:PathHelperService,
-              readonly currentProject:CurrentProjectService,
-              readonly bcfApi:BcfApiService,
               readonly bcfAuthorization:BcfAuthorizationService,
               readonly viewerBridge:ViewerBridgeService,
               readonly wpCache:WorkPackageCacheService,
@@ -146,52 +129,38 @@ export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements
 
   protected observeChanges() {
     this.wpCache
-      .observe(this.workPackage.id!)
-      .pipe(
-        this.untilDestroyed()
-      )
-      .subscribe(async wp => {
-        this.workPackage = wp;
-        //this.setTopicUUIDFromWorkPackage();
+          .observe(this.workPackage.id!)
+          .pipe(this.untilDestroyed())
+          .subscribe(async wp => {
+            this.workPackage = wp;
 
-        const projectId = this.workPackage.project.idFromLink;
-        this.viewAllowed = await this.bcfAuthorization.isAllowedTo(projectId, 'project_actions', 'viewTopic');
-        this.createAllowed = await this.bcfAuthorization.isAllowedTo(projectId, 'topic_actions', 'createViewpoint');
+            if (!this.projectId) {
+              await this.initialize(this.workPackage);
+            }
 
-        if (wp.bcfViewpoints) {
-          this.viewpoints = wp.bcfViewpoints.map((el:HalLink) => {
-            return { href: el.href, snapshotURL: `${el.href}/snapshot` };
+            if (wp.bcfViewpoints) {
+              this.refreshViewpoints(wp.bcfViewpoints);
+            }
           });
-          this.setViewpointsOnGallery(this.viewpoints);
-          this.loadViewpointFromRoute(this.workPackage);
-        }
+  }
 
-        this.cdRef.detectChanges();
-      });
+  async initialize(workPackage:WorkPackageResource) {
+    this.projectId = workPackage.project.idFromLink;
+    this.viewAllowed = await this.bcfAuthorization.isAllowedTo(this.projectId, 'project_actions', 'viewTopic');
+    this.createAllowed = await this.bcfAuthorization.isAllowedTo(this.projectId, 'topic_actions', 'createViewpoint'); 
+
+    this.loadViewpointFromRoute(workPackage);
+    this.cdRef.detectChanges();
+  }
+
+  refreshViewpoints(viewpoints:HalLink[]) {
+    this.viewpoints = viewpoints.map((el:HalLink) => ({ href: el.href, snapshotURL: `${el.href}/snapshot` }));
+
+    this.setViewpointsOnGallery(this.viewpoints);
   }
 
   protected showViewpoint(workPackage:WorkPackageResource, index:number) {
     this.viewerBridge.showViewpoint(workPackage, index);
-
-    /* this
-      .viewpointFromIndex(index)
-      .get()
-      .subscribe(data => {
-        if (this.viewerVisible) {
-          this.viewerBridge.showViewpoint(data);
-        } else {
-          // Send a message to Revit, waiting for response
-          // TODO: Show feedback to the user (Trying to communicate with Revit...)
-          // TODO: Check if there is a 'model-loaded' event
-
-          // SKIP this on PLUGINS SCENARIO
-          window.location.href = this.pathHelper.bimDetailsPath(
-            this.workPackage.project.idFromLink,
-            this.workPackage.id!,
-            index
-          );
-        }
-      }); */
   }
 
   protected deleteViewpoint(workPackage:WorkPackageResource, index:number) {
@@ -202,42 +171,18 @@ export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements
     this.viewpointsService
           .deleteViewPoint$(workPackage, index) 
           .subscribe(data => {
-            // Update the work package to reload the viewpoint
             this.notifications.addSuccess(this.text.notice_successful_delete);
-            this.wpCache.require(this.workPackage.id!, true);
             this.gallery.preview.close();
           });
-
-    /* this
-      .viewpointFromIndex(index)
-      .delete()
-      .subscribe(data => {
-        // Update the work package to reload the viewpoint
-        this.notifications.addSuccess(this.text.notice_successful_delete);
-        this.wpCache.require(this.workPackage.id!, true);
-        this.gallery.preview.close();
-      }); */
   }
 
-  public saveCurrentAsViewpoint(workPackage:WorkPackageResource) {
+  public saveViewpoint(workPackage:WorkPackageResource) {
     this.viewpointsService
-          .saveCurrentAsViewpoint$(workPackage) 
-          .subscribe(response => {
-            console.log('Type this response', response);
-            // Update the work package to reload the viewpoint
+          .saveViewpoint$(workPackage) 
+          .subscribe(viewpoint => {
             this.notifications.addSuccess(this.text.notice_successful_create);
             this.showIndex = this.viewpoints.length;
-            this.wpCache.require(this.workPackage.id!, true);
           });
-
-    /* const viewpoint = await this.viewerBridge!.getViewpoint();
-
-    await this.persistViewpoint(viewpoint);
-
-    // Update the work package to reload the viewpoint
-    this.notifications.addSuccess(this.text.notice_successful_create);
-    this.showIndex = this.viewpoints.length;
-    this.wpCache.require(this.workPackage.id!, true); */
   }
 
   protected loadViewpointFromRoute(workPackage:WorkPackageResource) {
@@ -255,43 +200,6 @@ export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements
       (this.viewpoints.length > 0 ||
         (this.createAllowed && this.viewerVisible));
   }
-
-  /* protected async persistViewpoint(viewpoint:BcfViewpointInterface) {
-    this.topicUUID = this.topicUUID || await this.createBcfTopic();
-
-    return this.bcfApi
-      .projects.id(this.wpProjectId)
-      .topics.id(this.topicUUID)
-      .viewpoints
-      .post(viewpoint)
-      .toPromise();
-  } */
-
-  /* protected setTopicUUIDFromWorkPackage() {
-    const topicHref:string|undefined = this.workPackage.bcfTopic?.href;
-
-    if (topicHref) {
-      this.topicUUID = this.bcfApi.parse<BcfViewpointPaths>(topicHref)!.id as string;
-    }
-  } */
-
-/*   protected async createBcfTopic():Promise<string> {
-    return this.bcfApi
-      .projects.id(this.wpProjectId)
-      .topics
-      .post(this.workPackage.convertBCF.payload)
-      .toPromise()
-      .then(resource => resource.guid);
-  } */
-
-  /* protected viewpointFromIndex(index:number):BcfViewpointPaths {
-    let viewpointHref = this.workPackage.bcfViewpoints[index].href;
-    return this.bcfApi.parse<BcfViewpointPaths>(viewpointHref);
-  } */
-
-  /*   protected get wpProjectId() {
-    return this.workPackage.project.idFromLink;
-  } */
 
   // Gallery functionality
   protected actions() {
@@ -335,7 +243,7 @@ export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements
     return this.galleryOptions[0].startIndex!;
   }
 
-  protected setViewpointsOnGallery(viewpoints:ViewpointItem[]) {
+  protected setViewpointsOnGallery(viewpoints:BcfViewpointItem[]) {
     const length = viewpoints.length;
 
     this.setThumbnailProperties(length);

--- a/frontend/src/app/modules/bim/bcf/helper/viewpoints.service.ts
+++ b/frontend/src/app/modules/bim/bcf/helper/viewpoints.service.ts
@@ -70,7 +70,7 @@ export class ViewpointsService {
             );
   }
 
-  setBcfTopic$(workPackage:WorkPackageResource) {
+  public setBcfTopic$(workPackage:WorkPackageResource) {
     if (this.topicUUID) {
       return of(this.topicUUID);
     } else {
@@ -83,7 +83,7 @@ export class ViewpointsService {
     }
   }
 
-  public createBcfTopic$(workPackage:WorkPackageResource):Observable<string> {
+  private createBcfTopic$(workPackage:WorkPackageResource):Observable<string> {
     const wpProjectId = workPackage.project.idFromLink;
     const wpPayload = workPackage.convertBCF.payload;
 

--- a/frontend/src/app/modules/bim/bcf/helper/viewpoints.service.ts
+++ b/frontend/src/app/modules/bim/bcf/helper/viewpoints.service.ts
@@ -1,0 +1,86 @@
+import {Injectable, Injector} from '@angular/core';
+import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
+import {BcfApiService} from "core-app/modules/bim/bcf/api/bcf-api.service";
+import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
+import {BcfViewpointPaths} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.paths";
+import {ViewerBridgeService} from "core-app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service";
+import {switchMap, map} from 'rxjs/operators';
+import {of, forkJoin, Observable} from 'rxjs';
+import {BcfViewpointInterface} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.interface";
+
+
+@Injectable()
+export class ViewpointsService {
+  @InjectField() bcfApi:BcfApiService;
+  @InjectField() viewerBridge:ViewerBridgeService;
+
+  constructor(readonly injector:Injector) {
+    console.log('this.bcfApi: ', this.bcfApi);
+  }
+
+  public getViewPointResource(workPackage:WorkPackageResource, index:number):BcfViewpointPaths {
+    const viewpointHref = workPackage.bcfViewpoints[index].href;
+    
+    return this.bcfApi.parse<BcfViewpointPaths>(viewpointHref);
+  }
+
+  public getViewPoint$(workPackage:WorkPackageResource, index:number):Observable<BcfViewpointInterface> {
+    const viewpointResource = this.getViewPointResource(workPackage, index);
+    
+    return viewpointResource.get();
+  }
+
+  public deleteViewPoint$(workPackage:WorkPackageResource, index:number):Observable<BcfViewpointInterface> {
+    const viewpointResource = this.getViewPointResource(workPackage, index);
+    
+    return viewpointResource.delete();
+  }
+
+  public saveCurrentAsViewpoint$(workPackage:WorkPackageResource): Observable<BcfViewpointInterface> {
+    const wpProjectId = workPackage.project.idFromLink;
+    const topicHref = workPackage.bcfTopic?.href;
+    const topicUUID$ = topicHref ?
+                        of(this.bcfApi.parse<BcfViewpointPaths>(topicHref)!.id) :
+                        this.createBcfTopic$(workPackage);
+    
+    return forkJoin({
+              topicUUID: topicUUID$,
+              viewpoint: this.viewerBridge!.getViewpoint$(),
+            })
+            .pipe(
+              switchMap(results => this.bcfApi
+                                          .projects.id(wpProjectId)
+                                          .topics.id(results.topicUUID as (string | number))
+                                          .viewpoints
+                                          .post(results.viewpoint))
+            );
+
+    /* const viewpoint = await this.viewerBridge!.getViewpoint();     
+    const topicUUID = workPackage.bcfTopic?.href ?
+                        this.bcfApi.parse<BcfViewpointPaths>(topicHref)!.id :
+                        this.createBcfTopic();
+    const wpProjectId = workPackage.project.idFromLink;
+
+    return this.bcfApi
+                .projects.id(wpProjectId)
+                .topics.id(topicUUID)
+                .viewpoints
+                .post(viewpoint); */
+  }
+
+  protected createBcfTopic$(workPackage:WorkPackageResource):Observable<string> {
+    const wpProjectId = workPackage.project.idFromLink;
+    const wpPayload = workPackage.convertBCF.payload
+
+    return this.bcfApi
+                  .projects.id(wpProjectId)
+                  .topics
+                  .post(wpPayload)
+                  .pipe(
+                    map((resource: BcfViewpointInterface) => {
+                      console.log('Type this: ', resource);
+                      return resource.guid;
+                    })
+                  );
+  }
+}

--- a/frontend/src/app/modules/bim/bcf/openproject-bcf.module.ts
+++ b/frontend/src/app/modules/bim/bcf/openproject-bcf.module.ts
@@ -35,6 +35,7 @@ import {HTTP_INTERCEPTORS} from "@angular/common/http";
 import {OpenProjectHeaderInterceptor} from "core-app/modules/hal/http/openproject-header-interceptor";
 import {BcfDetectorService} from "core-app/modules/bim/bcf/helper/bcf-detector.service";
 import {BcfPathHelperService} from "core-app/modules/bim/bcf/helper/bcf-path-helper.service";
+import {ViewpointsService} from "core-app/modules/bim/bcf/helper/viewpoints.service";
 import {BcfImportButtonComponent} from "core-app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component";
 import {BcfExportButtonComponent} from "core-app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component";
 import {RevitBridgeService} from "core-app/modules/bim/bcf/bcf-viewer-bridge/revit-bridge.service";
@@ -53,9 +54,9 @@ import {BcfNewWpAttributeGroupComponent} from "core-app/modules/bim/bcf/bcf-wp-a
  */
 export const viewerBridgeServiceFactory = (injector:Injector) => {
   if (window.navigator.userAgent.search('Revit') > -1) {
-    return new RevitBridgeService();
+    return new RevitBridgeService(injector);
   } else {
-    return injector.get(IFCViewerService, new IFCViewerService());
+    return injector.get(IFCViewerService, new IFCViewerService(injector));
   }
 };
 
@@ -72,7 +73,8 @@ export const viewerBridgeServiceFactory = (injector:Injector) => {
       deps: [Injector]
     },
     BcfDetectorService,
-    BcfPathHelperService
+    BcfPathHelperService,
+    ViewpointsService,
   ],
   declarations: [
     BcfWpAttributeGroupComponent,

--- a/frontend/src/app/modules/bim/ifc_models/ifc-base-view/event-handler/bcf-click-handler.ts
+++ b/frontend/src/app/modules/bim/ifc_models/ifc-base-view/event-handler/bcf-click-handler.ts
@@ -16,13 +16,7 @@ export class BcfClickHandler extends CardClickHandler {
 
     // Open the viewpoint if any
     if (this.viewer.viewerVisible() && wp.bcfViewpoints) {
-      const first = wp.bcfViewpoints[0].href;
-      const resource = this.bcfApi.parse(first) as BcfViewpointPaths;
-      resource
-        .get()
-        .subscribe((viewpoint) => {
-          this.viewer.showViewpoint(viewpoint);
-        });
+      this.viewer.showViewpoint(wp, 0);
     }
   }
 }

--- a/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
+++ b/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
@@ -46,7 +46,6 @@ export class IFCViewerService extends ViewerBridgeService {
 
   constructor(readonly injector:Injector){
     super(injector);
-    console.log('IFCViewerService constructor called', this.pathHelper, this.bcfApi);
   }
 
   public newViewer(elements:XeokitElements, projects:any[]) {
@@ -99,18 +98,16 @@ export class IFCViewerService extends ViewerBridgeService {
   }
 
   public showViewpoint(workPackage:WorkPackageResource, index:number) {
-    console.log('showViewpoint  1:', workPackage, workPackage.project.identifier, index, this.viewer, this.pathHelper, this.bcfApi, this.pathHelper.bimDetailsPath(
-        workPackage.project.idFromLink,
-        workPackage.id!,
-        index
-      ));
-    
-    if (this.viewer) {
-      this.viewpointsService
-            .getViewPoint$(workPackage, index)
-            .subscribe(viewpoint => this.viewer.loadBCFViewpoint(viewpoint, {}));
+    // Avoid reload the app when 
+    if (this.routeWithViewer) {
+      if (this.viewer) {
+        this.viewpointsService
+              .getViewPoint$(workPackage, index)
+              .subscribe(viewpoint => this.viewer.loadBCFViewpoint(viewpoint, {}));
+      }
     } else {
       // Reload the whole app to get the correct menus and GON data
+      // and redirect to a route with a place for the viewer
       window.location.href = this.pathHelper.bimDetailsPath(
         workPackage.project.idFromLink,
         workPackage.id!,

--- a/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
+++ b/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
@@ -1,8 +1,15 @@
-import {Injectable} from '@angular/core';
+import {Injectable, Inject, Injector} from '@angular/core';
 import {XeokitServer} from "core-app/modules/bim/ifc_models/xeokit/xeokit-server";
 import {BcfViewpointInterface} from "core-app/modules/bim/bcf/api/viewpoints/bcf-viewpoint.interface";
 import {ViewerBridgeService} from "core-app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service";
 import {Observable, Subject} from "rxjs";
+import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
+import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
+import {BcfApiService} from "core-app/modules/bim/bcf/api/bcf-api.service";
+import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
+import {ViewpointsService} from "core-app/modules/bim/bcf/helper/viewpoints.service";
+import {of} from 'rxjs';
+
 
 export interface XeokitElements {
   canvasElement:HTMLElement;
@@ -26,9 +33,21 @@ export interface BCFLoadOptions {
 
 @Injectable()
 export class IFCViewerService extends ViewerBridgeService {
+  @InjectField() pathHelper:PathHelperService;
+  @InjectField() bcfApi:BcfApiService;
+  @InjectField() viewpointsService:ViewpointsService;  
+
   private _viewer:any;
 
+  // private _loaded:BehaviorSubject<boolean> = new BehaviorSubject(false);
+  // readonly loaded$:Observable<boolean> = this._loaded.asObservable().pipe(shareReplay({refCount: true, bufferSize: 1}));
+
   private $loaded = new Subject<void>();
+
+  constructor(readonly injector:Injector){
+    super(injector);
+    console.log('IFCViewerService constructor called', this.pathHelper, this.bcfApi);
+  }
 
   public newViewer(elements:XeokitElements, projects:any[]) {
     import('@xeokit/xeokit-bim-viewer/dist/main').then((XeokitViewerModule:any) => {
@@ -70,23 +89,41 @@ export class IFCViewerService extends ViewerBridgeService {
     this.viewer.setKeyboardEnabled(val);
   }
 
-  public getViewpoint():Promise<BcfViewpointInterface> {
+  public getViewpoint$():Observable<BcfViewpointInterface> {
     const viewpoint = this.viewer.saveBCFViewpoint({ spacesVisible: true });
 
     // The backend rejects viewpoints with bitmaps
     delete viewpoint.bitmaps;
 
-    return Promise.resolve(viewpoint);
+    return of(viewpoint);
   }
 
-  public showViewpoint(viewpoint:BcfViewpointInterface) {
-    this.viewer.loadBCFViewpoint(viewpoint, {});
+  public showViewpoint(workPackage:WorkPackageResource, index:number) {
+    console.log('showViewpoint  1:', workPackage, workPackage.project.identifier, index, this.viewer, this.pathHelper, this.bcfApi, this.pathHelper.bimDetailsPath(
+        workPackage.project.idFromLink,
+        workPackage.id!,
+        index
+      ));
+    
+    if (this.viewer) {
+      this.viewpointsService
+            .getViewPoint$(workPackage, index)
+            .subscribe(viewpoint => this.viewer.loadBCFViewpoint(viewpoint, {}));
+    } else {
+      // Reload the whole app to get the correct menus and GON data
+      window.location.href = this.pathHelper.bimDetailsPath(
+        workPackage.project.idFromLink,
+        workPackage.id!,
+        index
+      );
+    }
   }
 
   public viewerVisible():boolean {
     return !!this.viewer;
   }
 
+  // TODO: Remove this?
   public onLoad$():Observable<void> {
     return this.$loaded;
   }

--- a/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
+++ b/frontend/src/app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
@@ -98,7 +98,8 @@ export class IFCViewerService extends ViewerBridgeService {
   }
 
   public showViewpoint(workPackage:WorkPackageResource, index:number) {
-    // Avoid reload the app when 
+    // Avoid reload the app when there is a place to show the viewer
+    // ('bim.partitioned.split')
     if (this.routeWithViewer) {
       if (this.viewer) {
         this.viewpointsService
@@ -107,7 +108,8 @@ export class IFCViewerService extends ViewerBridgeService {
       }
     } else {
       // Reload the whole app to get the correct menus and GON data
-      // and redirect to a route with a place for the viewer
+      // and redirect to a route with a place to show viewer
+      // ('bim.partitioned.split')
       window.location.href = this.pathHelper.bimDetailsPath(
         workPackage.project.idFromLink,
         workPackage.id!,


### PR DESCRIPTION
This refactor main goals are:
- [x] Speed up the following developments based on this functionality (plugins), which is a prerequisite for working on https://community.openproject.com/wp/31374

This PR does:
- [x] Remove the business logic from the components so they only handle functionality related to the view. This will also make them more testable.
- [x] Abstract viewpoint management logic into its own service, hiding its implementation details, in order to simplify its use, increase its reusability, and make them more testable.
- [x] Default to observables to stick to reactive patterns.

