### PR TITLE
[33449] Usability bug: layout bug when setting new parent

### DIFF
--- a/frontend/src/app/components/work-packages/wp-breadcrumb/wp-breadcrumb.component.ts
+++ b/frontend/src/app/components/work-packages/wp-breadcrumb/wp-breadcrumb.component.ts
@@ -55,6 +55,10 @@ export class WorkPackageBreadcrumbComponent {
   public get hierarchyLabel() {
     return (this.hierarchyCount === 1) ? this.text.parent : this.text.hierarchy;
   }
+
+  public updateActiveInput(val:boolean) {
+    this.inputActive = val;
+  }
 }
 
 

--- a/frontend/src/app/components/work-packages/wp-breadcrumb/wp-breadcrumb.html
+++ b/frontend/src/app/components/work-packages/wp-breadcrumb/wp-breadcrumb.html
@@ -20,7 +20,7 @@
     </ng-container>
     <li
         [ngClass]="{ 'active-parent-select': inputActive, 'icon4 icon-small icon-arrow-right5': !inputActive && hierarchyCount > 1 }">
-      <wp-breadcrumb-parent (onSwitch)="inputActive = !inputActive" [workPackage]="workPackage"></wp-breadcrumb-parent>
+      <wp-breadcrumb-parent (onSwitch)="updateActiveInput($event)" [workPackage]="workPackage"></wp-breadcrumb-parent>
     </li>
   </ul>
 </div>

--- a/frontend/src/app/components/work-packages/wp-breadcrumb/wp-breadcrumb.sass
+++ b/frontend/src/app/components/work-packages/wp-breadcrumb/wp-breadcrumb.sass
@@ -1,2 +1,2 @@
 .active-parent-select
-  width: 100%
+  min-width: 320px


### PR DESCRIPTION
Take care that activeInput is always correctly set and not only toggled. Otherwise the state is wrong, when I remove the parent via the icon, resulting in styling errors. Further I reduced the width of the select field, because it looked quite ugly when it spanned the whole screen.

https://community.openproject.com/projects/openproject/work_packages/33449/activity