### PR TITLE
Add Enterprise trial infos and fix issues

### DIFF
--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -110,6 +110,7 @@ class EnterprisesController < ApplicationController
 
   def write_augur_to_gon
     gon.augur_url = OpenProject::Configuration.enterprise_trial_creation_host
+    gon.token_version = OpenProject::Token::VERSION
   end
 
   def default_breadcrumb

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -67,7 +67,10 @@ class EnterprisesController < ApplicationController
         @token.encoded_token = saved_encoded_token
         @current_token = @token || EnterpriseToken.new
       end
-      render action: :show
+      respond_to do |format|
+        format.html { render action: :show }
+        format.json { render json: { description: @token.errors.full_messages.join(", ") }, status: 400 }
+      end
     end
   end
 
@@ -77,8 +80,7 @@ class EnterprisesController < ApplicationController
       token.destroy
       flash[:notice] = t(:notice_successful_delete)
 
-      trial_key = Token::EnterpriseTrialKey.find_by(user_id: User.system.id)
-      trial_key&.destroy
+      delete_trial_key
 
       redirect_to action: :show
     else
@@ -88,6 +90,10 @@ class EnterprisesController < ApplicationController
 
   def save_trial_key
     Token::EnterpriseTrialKey.create(user_id: User.system.id, value: params[:trial_key])
+  end
+
+  def delete_trial_key
+    Token::EnterpriseTrialKey.where(user_id: User.system.id).delete_all
   end
 
   private

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -96,7 +96,8 @@ class EnterprisesController < ApplicationController
     @trial_key = Token::EnterpriseTrialKey.find_by(user_id: User.system.id)
     if @trial_key
       gon.ee_trial_key = {
-        value: @trial_key.value
+        value: @trial_key.value,
+        created: @trial_key.created_on
       }
     end
   end

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -187,7 +187,7 @@ en:
           confirmation: "Confirmation of email address"
           confirmation_info: >
             We sent you an email on %{date} to %{email}.
-            Please check your inbox and click the confirmation link provided to start your 14 days trial."
+            Please check your inbox and click the confirmation link provided to start your 14 days trial.
           form:
             general_consent: >
               I agree with the <a target="_blank" href="%{link_terms}">terms of service</a>

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -185,7 +185,9 @@ en:
       enterprise:
         trial:
           confirmation: "Confirmation of email address"
-          confirmation_info: "We sent you an email. Please check your emails and click the confirmation link provided to start your 14 days trial."
+          confirmation_info: >
+            We sent you an email on %{date} to %{email}.
+            Please check your inbox and click the confirmation link provided to start your 14 days trial."
           form:
             general_consent: >
               I agree with the <a target="_blank" href="%{link_terms}">terms of service</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -342,6 +342,7 @@ OpenProject::Application.routes.draw do
       resource :enterprise, only: %i[show create destroy]
       scope controller: 'enterprises' do
         post 'enterprise/save_trial_key' => 'enterprises#save_trial_key'
+        delete 'enterprise/delete_trial_key' => 'enterprises#delete_trial_key'
       end
     end
     resources :enumerations

--- a/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.html
+++ b/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.html
@@ -53,7 +53,8 @@
         <input type="text"
                id="trial-domain-name"
                class="form--text-field"
-               formControlName="domain">
+               formControlName="domain"
+               disabled>
       </div>
     </div>
     <div *ngIf="eeTrialService.domainTaken" class="form--field-instructions">{{ eeTrialService.errorMsg }}</div>

--- a/frontend/src/app/components/enterprise/enterprise-trial-waiting/ee-trial-waiting.component.html
+++ b/frontend/src/app/components/enterprise/enterprise-trial-waiting/ee-trial-waiting.component.html
@@ -1,6 +1,6 @@
 <enterprise-active-trial></enterprise-active-trial>
 
-<p>{{ text.confirmation_info }}</p>
+<p>{{ text.confirmation_info(created, email) }}</p>
 <p>
   <span>{{ text.status_label }} </span>
   <span *ngIf="!eeTrialService.confirmed; else confirmedStatus" class="status--waiting">

--- a/frontend/src/app/components/enterprise/enterprise-trial-waiting/ee-trial-waiting.component.ts
+++ b/frontend/src/app/components/enterprise/enterprise-trial-waiting/ee-trial-waiting.component.ts
@@ -32,6 +32,7 @@ import {EnterpriseTrialData, EnterpriseTrialService} from "app/components/enterp
 import {HttpClient} from "@angular/common/http";
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
 import {distinctUntilChanged} from "rxjs/operators";
+import {GonService} from "core-app/modules/common/gon/gon.service";
 
 @Component({
   selector: 'enterprise-trial-waiting',
@@ -39,9 +40,11 @@ import {distinctUntilChanged} from "rxjs/operators";
   styleUrls: ['./ee-trial-waiting.component.sass']
 })
 export class EETrialWaitingComponent implements OnInit {
+  public created:string;
+
   public text = {
     confirmation_info: this.I18n.t('js.admin.enterprise.trial.confirmation_info', {
-        date: '',
+        date: this.created,
         email: this.eeTrialService.userData$.getValueOr({})
     }),
     resend: this.I18n.t('js.admin.enterprise.trial.resend_link'),
@@ -57,11 +60,15 @@ export class EETrialWaitingComponent implements OnInit {
               readonly cdRef:ChangeDetectorRef,
               readonly I18n:I18nService,
               protected http:HttpClient,
+              readonly Gon:GonService,
               protected notificationsService:NotificationsService,
               public eeTrialService:EnterpriseTrialService) {
   }
 
   ngOnInit() {
+    let savedDateStr = (this.Gon.get('ee_trial_key') as any).created.split(' ')[0];
+    this.created = new Date(savedDateStr).toLocaleDateString();
+
     this.eeTrialService.userData$
       .values$()
       .pipe(
@@ -69,7 +76,7 @@ export class EETrialWaitingComponent implements OnInit {
       )
       .subscribe(userForm => {
         this.text.confirmation_info = this.I18n.t('js.admin.enterprise.trial.confirmation_info', {
-          date: '',
+          date: this.created,
           email: userForm.email
         });
 

--- a/frontend/src/app/components/enterprise/enterprise-trial-waiting/ee-trial-waiting.component.ts
+++ b/frontend/src/app/components/enterprise/enterprise-trial-waiting/ee-trial-waiting.component.ts
@@ -33,6 +33,7 @@ import {HttpClient} from "@angular/common/http";
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
 import {distinctUntilChanged} from "rxjs/operators";
 import {GonService} from "core-app/modules/common/gon/gon.service";
+import {CurrentUserService} from "core-components/user/current-user.service";
 
 @Component({
   selector: 'enterprise-trial-waiting',
@@ -40,13 +41,10 @@ import {GonService} from "core-app/modules/common/gon/gon.service";
   styleUrls: ['./ee-trial-waiting.component.sass']
 })
 export class EETrialWaitingComponent implements OnInit {
-  public created:string;
+  private created = new Date().toLocaleDateString(this.currentUserService.language);
 
   public text = {
-    confirmation_info: this.I18n.t('js.admin.enterprise.trial.confirmation_info', {
-        date: this.created,
-        email: this.eeTrialService.userData$.getValueOr({})
-    }),
+    confirmation_info: '',
     resend: this.I18n.t('js.admin.enterprise.trial.resend_link'),
     resend_success: this.I18n.t('js.admin.enterprise.trial.resend_success'),
     resend_warning: this.I18n.t('js.admin.enterprise.trial.resend_warning'),
@@ -60,14 +58,17 @@ export class EETrialWaitingComponent implements OnInit {
               readonly cdRef:ChangeDetectorRef,
               readonly I18n:I18nService,
               protected http:HttpClient,
-              readonly Gon:GonService,
+              readonly currentUserService:CurrentUserService,
               protected notificationsService:NotificationsService,
               public eeTrialService:EnterpriseTrialService) {
   }
 
   ngOnInit() {
-    let savedDateStr = (this.Gon.get('ee_trial_key') as any).created.split(' ')[0];
-    this.created = new Date(savedDateStr).toLocaleDateString();
+    let eeTrialKey = (window as any).gon.ee_trial_key;
+    if (eeTrialKey) {
+      let savedDateStr = eeTrialKey.created.split(' ')[0];
+      this.created = new Date(savedDateStr).toLocaleDateString(this.currentUserService.language);
+    }
 
     this.eeTrialService.userData$
       .values$()
@@ -79,7 +80,6 @@ export class EETrialWaitingComponent implements OnInit {
           date: this.created,
           email: userForm.email
         });
-
         this.cdRef.detectChanges();
       });
   }

--- a/frontend/src/app/components/enterprise/enterprise-trial.service.ts
+++ b/frontend/src/app/components/enterprise/enterprise-trial.service.ts
@@ -22,8 +22,8 @@ export class EnterpriseTrialService {
   // user data needs to be sync in ee-active-trial.component.ts
   userData$ = input<EnterpriseTrialData>();
 
-  public baseUrlAugur:string;
-
+  public readonly baseUrlAugur:string;
+  public readonly tokenVersion:string;
 
   public trialLink:string;
   public resendLink:string;
@@ -46,6 +46,7 @@ export class EnterpriseTrialService {
               protected notificationsService:NotificationsService) {
     let gon = (window as any).gon;
     this.baseUrlAugur = gon.augur_url;
+    this.tokenVersion = gon.token_version;
 
     if ((window as any).gon.ee_trial_key) {
       this.setMailSubmittedStatus();
@@ -55,7 +56,8 @@ export class EnterpriseTrialService {
   // send POST request with form object
   // receive an enterprise trial link to access a token
   public sendForm(form:FormGroup) {
-    this.http.post(this.baseUrlAugur + '/public/v1/trials', form.value)
+    const request = { ...form.value, token_version: this.tokenVersion};
+    this.http.post(this.baseUrlAugur + '/public/v1/trials', request)
       .toPromise()
       .then((enterpriseTrial:any) => {
         this.userData$.putValue(form.value);

--- a/spec/features/admin/enterprise/enterprise_trial_spec.rb
+++ b/spec/features/admin/enterprise/enterprise_trial_spec.rb
@@ -159,7 +159,6 @@ describe 'Enterprise trial management',
     fill_in 'First name', with: 'Foo'
     fill_in 'Last name', with: 'Bar'
     fill_in 'Email', with: mail
-    fill_in 'Domain', with: 'foo.example.com'
 
     find('#trial-general-consent').check
   end

--- a/spec/features/admin/enterprise/enterprise_trial_spec.rb
+++ b/spec/features/admin/enterprise/enterprise_trial_spec.rb
@@ -148,6 +148,19 @@ describe 'Enterprise trial management',
     }
   end
 
+  let(:other_error_body) do
+    {
+      _type: "error",
+      code: 409,
+      description: "Token version is invalid",
+      identifier: "token_version_too_old",
+      errors: {
+        token_version: [
+          "does not have a valid value"
+        ]
+      }
+    }
+  end
 
   before do
     login_as(admin)
@@ -165,7 +178,7 @@ describe 'Enterprise trial management',
 
   it 'blocks the request assuming the mail was used' do
     proxy.stub('https://augur.openproject-edge.com:443/public/v1/trials', method: 'post')
-      .and_return(headers: {'Access-Control-Allow-Origin' => '*'}, code: 422, body: mail_in_use_body.to_json)
+      .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 422, body: mail_in_use_body.to_json)
 
     find('.button', text: 'Start free trial').click
     fill_out_modal
@@ -178,7 +191,7 @@ describe 'Enterprise trial management',
 
   it 'blocks the request assuming the domain was used' do
     proxy.stub('https://augur.openproject-edge.com:443/public/v1/trials', method: 'post')
-      .and_return(headers: {'Access-Control-Allow-Origin' => '*'}, code: 422, body: domain_in_use_body.to_json)
+      .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 422, body: domain_in_use_body.to_json)
 
     find('.button', text: 'Start free trial').click
     fill_out_modal
@@ -189,16 +202,28 @@ describe 'Enterprise trial management',
     expect(page).to have_no_text 'email sent - waiting for confirmation'
   end
 
+  it 'shows an error in case of other errors' do
+    proxy.stub('https://augur.openproject-edge.com:443/public/v1/trials', method: 'post')
+      .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 409, body: other_error_body.to_json)
+
+    find('.button', text: 'Start free trial').click
+    fill_out_modal
+    find('.button:not(:disabled)', text: 'Submit').click
+
+    expect(page).to have_text('Token version is invalid')
+    expect(page).to have_no_text 'email sent - waiting for confirmation'
+  end
+
   context 'with a waiting request pending' do
     before do
       proxy.stub('https://augur.openproject-edge.com:443/public/v1/trials', method: 'post')
-        .and_return(headers: {'Access-Control-Allow-Origin' => '*'}, code: 200, body: created_body.to_json)
+        .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 200, body: created_body.to_json)
 
       proxy.stub("https://augur.openproject-edge.com:443/public/v1/trials/#{trial_id}")
-        .and_return(headers: {'Access-Control-Allow-Origin' => '*'}, code: 422, body: waiting_body.to_json)
+        .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 422, body: waiting_body.to_json)
 
       proxy.stub("https://augur.openproject-edge.com:443/public/v1/trials/#{trial_id}/resend", method: 'post')
-        .and_return(headers: {'Access-Control-Allow-Origin' => '*'}, code: 200, body: waiting_body.to_json)
+        .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 200, body: waiting_body.to_json)
 
       find('.button', text: 'Start free trial').click
       fill_out_modal
@@ -216,11 +241,11 @@ describe 'Enterprise trial management',
       # Stub the proxy to a successful return
       # which marks the user has confirmed the mail link
       proxy.stub("https://augur.openproject-edge.com:443/public/v1/trials/#{trial_id}")
-        .and_return(headers: {'Access-Control-Allow-Origin' => '*'}, code: 200, body: confirmed_body.to_json)
+        .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 200, body: confirmed_body.to_json)
 
       # Stub the details URL to still return 403
       proxy.stub("https://augur.openproject-edge.com:443/public/v1/trials/#{trial_id}/details")
-        .and_return(headers: {'Access-Control-Allow-Origin' => '*'}, code: 403)
+        .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 403)
 
       visit enterprise_path
 
@@ -242,7 +267,7 @@ describe 'Enterprise trial management',
       # Stub the proxy to a successful return
       # which marks the user has confirmed the mail link
       proxy.stub("https://augur.openproject-edge.com:443/public/v1/trials/#{trial_id}")
-        .and_return(headers: {'Access-Control-Allow-Origin' => '*'}, code: 200, body: confirmed_body.to_json)
+        .and_return(headers: { 'Access-Control-Allow-Origin' => '*' }, code: 200, body: confirmed_body.to_json)
 
       # Wait until the next request
       expect(page).to have_selector '.status--confirmed', text: 'confirmed', wait: 20


### PR DESCRIPTION
This PR does multiple things:

- [x] Add information of when we send the confirmation email 
- [x] Prevent an infinite loop if for some reason the mail confirmation succeeded, but saving the token did not.
- [x] Prevent that users can change the domain (because it would lead to errors)
- [x] Add the token version to the params send to augur
