### PR TITLE
Code Snippits need more space

### DIFF
--- a/app/assets/stylesheets/openproject/_settings.scss
+++ b/app/assets/stylesheets/openproject/_settings.scss
@@ -187,13 +187,12 @@ $breakpoint-classes: (tiny small medium large xlarge xxlarge xxxlarge);
 // $code-color: grayscale($primary-color);
 // $code-font-family: Consolas, 'Liberation Mono', Courier, monospace;
 // $code-font-weight: $font-weight-normal;
-// $code-font-size: 0.95em;
 // $code-background-color: scale-color($secondary-color, $lightness: 70%);
 // $code-border-size: 1px;
 // $code-border-style: solid;
 // $code-border-color: scale-color($code-background-color, $lightness: -10%);
 // $code-padding: rem-calc(2) rem-calc(5) rem-calc(1);
-// $code-line-height: 1.7em;
+// $code-line-height: 1.75em;
 
 // We use these to style anchors
 // $anchor-text-decoration: none;

--- a/app/assets/stylesheets/openproject/_settings.scss
+++ b/app/assets/stylesheets/openproject/_settings.scss
@@ -187,11 +187,13 @@ $breakpoint-classes: (tiny small medium large xlarge xxlarge xxxlarge);
 // $code-color: grayscale($primary-color);
 // $code-font-family: Consolas, 'Liberation Mono', Courier, monospace;
 // $code-font-weight: $font-weight-normal;
+// $code-font-size: 0.95em;
 // $code-background-color: scale-color($secondary-color, $lightness: 70%);
 // $code-border-size: 1px;
 // $code-border-style: solid;
 // $code-border-color: scale-color($code-background-color, $lightness: -10%);
 // $code-padding: rem-calc(2) rem-calc(5) rem-calc(1);
+// $code-line-height: 1.7em;
 
 // We use these to style anchors
 // $anchor-text-decoration: none;

--- a/app/assets/stylesheets/vendor/foundation-apps/scss/_settings.scss
+++ b/app/assets/stylesheets/vendor/foundation-apps/scss/_settings.scss
@@ -187,13 +187,12 @@
 // $code-color: grayscale($primary-color);
 // $code-font-family: Consolas, 'Liberation Mono', Courier, monospace;
 // $code-font-weight: $font-weight-normal;
-// $code-font-size: 0.9em;
 // $code-background-color: scale-color($secondary-color, $lightness: 70%);
 // $code-border-size: 1px;
 // $code-border-style: solid;
 // $code-border-color: scale-color($code-background-color, $lightness: -10%);
 // $code-padding: rem-calc(2) rem-calc(5) rem-calc(1);
-// $code-line-height: 1.7em;
+// $code-line-height: 1.75em;
 
 // We use these to style anchors
 // $anchor-text-decoration: none;

--- a/app/assets/stylesheets/vendor/foundation-apps/scss/_settings.scss
+++ b/app/assets/stylesheets/vendor/foundation-apps/scss/_settings.scss
@@ -187,11 +187,13 @@
 // $code-color: grayscale($primary-color);
 // $code-font-family: Consolas, 'Liberation Mono', Courier, monospace;
 // $code-font-weight: $font-weight-normal;
+// $code-font-size: 0.9em;
 // $code-background-color: scale-color($secondary-color, $lightness: 70%);
 // $code-border-size: 1px;
 // $code-border-style: solid;
 // $code-border-color: scale-color($code-background-color, $lightness: -10%);
 // $code-padding: rem-calc(2) rem-calc(5) rem-calc(1);
+// $code-line-height: 1.7em;
 
 // We use these to style anchors
 // $anchor-text-decoration: none;

--- a/app/assets/stylesheets/vendor/foundation-apps/scss/components/_typography.scss
+++ b/app/assets/stylesheets/vendor/foundation-apps/scss/components/_typography.scss
@@ -68,11 +68,13 @@ $paragraph-text-rendering: optimizeLegibility !default;
 $code-color: grayscale($primary-color) !default;
 $code-font-family: Consolas, 'Liberation Mono', Courier, monospace !default;
 $code-font-weight: $font-weight-normal !default;
+$code-font-size: 0.95em !default;
 $code-background-color: scale-color($secondary-color, $lightness: 70%) !default;
 $code-border-size: 1px !default;
 $code-border-style: solid !default;
 $code-border-color: scale-color($code-background-color, $lightness: -10%) !default;
 $code-padding: rem-calc(2) rem-calc(5) rem-calc(1) !default;
+$code-line-height: 1.7em !default;
 
 // We use these to style anchors
 $anchor-text-decoration: none !default;

--- a/app/assets/stylesheets/vendor/foundation-apps/scss/components/_typography.scss
+++ b/app/assets/stylesheets/vendor/foundation-apps/scss/components/_typography.scss
@@ -253,6 +253,7 @@ $acronym-underline: 1px dotted #ddd !default;
     border-style: $code-border-style;
     border-color: $code-border-color;
     padding: $code-padding;
+    line-height: $code-line-height;
   }
 
   /* Lists */

--- a/app/assets/stylesheets/vendor/foundation-apps/scss/components/_typography.scss
+++ b/app/assets/stylesheets/vendor/foundation-apps/scss/components/_typography.scss
@@ -68,13 +68,12 @@ $paragraph-text-rendering: optimizeLegibility !default;
 $code-color: grayscale($primary-color) !default;
 $code-font-family: Consolas, 'Liberation Mono', Courier, monospace !default;
 $code-font-weight: $font-weight-normal !default;
-$code-font-size: 0.95em !default;
 $code-background-color: scale-color($secondary-color, $lightness: 70%) !default;
 $code-border-size: 1px !default;
 $code-border-style: solid !default;
 $code-border-color: scale-color($code-background-color, $lightness: -10%) !default;
 $code-padding: rem-calc(2) rem-calc(5) rem-calc(1) !default;
-$code-line-height: 1.7em !default;
+$code-line-height: 1.75em !default;
 
 // We use these to style anchors
 $anchor-text-decoration: none !default;


### PR DESCRIPTION
Hey, so I noticed that code snippets don't seem to get the space they deserve. I found that out when I recently have many code snippits in a table and the readability suffered substantually.

To improve readability I updated the styling to give code snippits a bigger line-height and slighty decreased the font-size to make a bit more room.

Before:
![hallow welt](https://user-images.githubusercontent.com/18314920/83621418-ef7b5d80-a58e-11ea-9ab3-3adcbc3136fe.png)

After my changes:
![grafik](https://user-images.githubusercontent.com/18314920/83621466-fc984c80-a58e-11ea-8358-8f2178741e7a.png)

As you can see the `line-height: 1.7em;` improved the situation already by a big amount. As this still is quite packed I could imagine going to 1.8em or even above.

I tested the changes in Firefox 76.0.1 and Chrome 80.0.3987.132
