### PR TITLE
Fix/cost table time entries

### DIFF
--- a/frontend/src/app/modules/time_entries/edit/trigger-actions-entry.component.ts
+++ b/frontend/src/app/modules/time_entries/edit/trigger-actions-entry.component.ts
@@ -3,7 +3,6 @@ import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 import {TimeEntryEditService} from "core-app/modules/time_entries/edit/edit.service";
 import {TimeEntryCacheService} from "core-components/time-entries/time-entry-cache.service";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
-import {TimeEntryResource} from "core-app/modules/hal/resources/time-entry-resource";
 import {TimeEntryDmService} from "core-app/modules/hal/dm-services/time-entry-dm.service";
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
 
@@ -12,12 +11,12 @@ export const triggerActionsEntryComponentSelector = 'time-entry--trigger-actions
 @Component({
   selector: triggerActionsEntryComponentSelector,
   template: `
-    <a (click)="editTimeEntry(entry)"
+    <a (click)="editTimeEntry()"
        [title]="text.edit"
        class="no-decoration-on-hover">
       <op-icon icon-classes="icon-context icon-edit"></op-icon>
     </a>
-    <a (click)="deleteTimeEntry(entry)"
+    <a (click)="deleteTimeEntry()"
        [title]="text.delete"
        class="no-decoration-on-hover">
       <op-icon icon-classes="icon-context icon-delete"></op-icon>
@@ -34,8 +33,6 @@ export class TriggerActionsEntryComponent {
   @InjectField() readonly i18n:I18nService;
   @InjectField() readonly cdRef:ChangeDetectorRef;
 
-  public entry:TimeEntryResource;
-
   public text = {
     edit: this.i18n.t('js.button_edit'),
     delete: this.i18n.t('js.button_delete'),
@@ -46,8 +43,7 @@ export class TriggerActionsEntryComponent {
   constructor(readonly injector:Injector) {
   }
 
-
-  editTimeEntry(entry:TimeEntryResource) {
+  editTimeEntry() {
     this.loadEntry()
       .then(entry => {
         this.timeEntryEditService
@@ -61,7 +57,7 @@ export class TriggerActionsEntryComponent {
       });
   }
 
-  deleteTimeEntry(entry:TimeEntryResource) {
+  deleteTimeEntry() {
     if (!window.confirm(this.text.areYouSure)) {
       return;
     }

--- a/frontend/src/app/modules/time_entries/edit/trigger-actions-entry.component.ts
+++ b/frontend/src/app/modules/time_entries/edit/trigger-actions-entry.component.ts
@@ -12,14 +12,12 @@ export const triggerActionsEntryComponentSelector = 'time-entry--trigger-actions
 @Component({
   selector: triggerActionsEntryComponentSelector,
   template: `
-    <a *ngIf="entry"
-       (click)="editTimeEntry(entry)"
+    <a (click)="editTimeEntry(entry)"
        [title]="text.edit"
        class="no-decoration-on-hover">
       <op-icon icon-classes="icon-context icon-edit"></op-icon>
     </a>
-    <a *ngIf="entry"
-       (click)="deleteTimeEntry(entry)"
+    <a (click)="deleteTimeEntry(entry)"
        [title]="text.delete"
        class="no-decoration-on-hover">
       <op-icon icon-classes="icon-context icon-delete"></op-icon>
@@ -27,7 +25,7 @@ export const triggerActionsEntryComponentSelector = 'time-entry--trigger-actions
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TriggerActionsEntryComponent implements OnInit {
+export class TriggerActionsEntryComponent {
   @InjectField() readonly timeEntryEditService:TimeEntryEditService;
   @InjectField() readonly timeEntryCache:TimeEntryCacheService;
   @InjectField() readonly timeEntryDmService:TimeEntryDmService;
@@ -46,27 +44,20 @@ export class TriggerActionsEntryComponent implements OnInit {
   };
 
   constructor(readonly injector:Injector) {
-
   }
 
-  ngOnInit() {
-    let timeEntryId = this.elementRef.nativeElement.dataset['entry'];
-    this.timeEntryCache
-      .require(timeEntryId)
-      .then((loadedEntry) => {
-        this.entry = loadedEntry;
-        this.cdRef.detectChanges();
-      });
-  }
 
   editTimeEntry(entry:TimeEntryResource) {
-    this.timeEntryEditService
-      .edit(entry)
-      .then(() => {
-        window.location.reload();
-      })
-      .catch(() => {
-        // User canceled the modal
+    this.loadEntry()
+      .then(entry => {
+        this.timeEntryEditService
+          .edit(entry)
+          .then(() => {
+            window.location.reload();
+          })
+          .catch(() => {
+            // User canceled the modal
+          });
       });
   }
 
@@ -75,13 +66,23 @@ export class TriggerActionsEntryComponent implements OnInit {
       return;
     }
 
-    this.timeEntryDmService
-      .delete(entry)
-      .then(() => {
-        window.location.reload();
-      })
-      .catch((error) => {
-        this.notificationsService.addError(error || this.text.error);
+    this.loadEntry()
+      .then(entry => {
+        this.timeEntryDmService
+          .delete(entry)
+          .then(() => {
+            window.location.reload();
+          })
+          .catch((error) => {
+            this.notificationsService.addError(error || this.text.error);
+          });
       });
+  }
+
+  protected loadEntry() {
+    let timeEntryId = this.elementRef.nativeElement.dataset['entry'];
+
+    return this.timeEntryCache
+      .require(timeEntryId);
   }
 }


### PR DESCRIPTION
Avoids querying the time entries api for every result displayed in an ungrouped cost report table.

It comes at the cost of a small delay once the user clicks on the edit/delete button as the time entry will then have to be fetched. 

The delay would be fairly easy to circumvent when deleting as we only need the ID to perform the delete request but I decided against doing this for as the current solution might be good enough.

https://community.openproject.com/work_packages/33522