### PR TITLE
Restrict table width by break-all words

### DIFF
--- a/app/assets/stylesheets/content/editor/_ckeditor.sass
+++ b/app/assets/stylesheets/content/editor/_ckeditor.sass
@@ -32,6 +32,15 @@ ckeditor-augmented-textarea .op-ckeditor--wrapper
   figure.image
     margin: 1em 0
 
+  figure.table
+    // Ensure we break apart words in table cells that
+    // are restricted in width (OP#33524)
+    td[style*=";width:"],
+    td[style^="width:"],
+    th[style*=";width:"],
+    th[style^="width:"]
+      word-break: break-all
+
 .ck .ck-widget.op-ckeditor--code-block
   // Display content as pre
   white-space: pre-wrap

--- a/app/assets/stylesheets/content/editor/_markdown.sass
+++ b/app/assets/stylesheets/content/editor/_markdown.sass
@@ -55,3 +55,11 @@ div.ck-editor__preview
     > table
       height: 100%
       width: 100%
+
+    // Ensure we break apart words in table cells that
+    // are restricted in width (OP#33524)
+    td[style*=";width:"],
+    td[style^="width:"],
+    th[style*=";width:"],
+    th[style^="width:"]
+      word-break: break-all


### PR DESCRIPTION
This ensures that if you forced a cell width, it breaks apart all words to ensure the width does not increase.

https://community.openproject.com/wp/33524