### PR TITLE
Allow to map internal UID from attributes

### DIFF
--- a/app/controllers/concerns/accounts/omniauth_login.rb
+++ b/app/controllers/concerns/accounts/omniauth_login.rb
@@ -202,8 +202,14 @@ module Accounts::OmniauthLogin
     end
   end
 
+  ##
+  # Allow strategies to map a value for uid instead
+  # of always taking the global UID.
+  # For SAML, the global UID may change with every session
+  # (in case of transient nameIds)
   def identity_url_from_omniauth(auth)
-    "#{auth[:provider]}:#{auth[:uid]}"
+    identifier = auth[:info][:uid] || auth[:uid]
+    "#{auth[:provider]}:#{identifier}"
   end
 
   # if the omni auth registration happened too long ago,


### PR DESCRIPTION
SAML idP will often generate transient session IDs as `nameID` that are not persistent , but at the same time the SAML gem will always return `nameID` as the `:uid` auth hash attribute. We thus have no chance to configure what attribute the `identity_url` we use for uniquely identifying users across auth sources is made of.

This PR allows to create a mapping for `:uid` so we can read an encrypted attribute from the SAML response and use that to set the internal id.