### PR TITLE
[32649] Increase visibility of toggle buttons in the right wp split screen

### DIFF
--- a/app/assets/stylesheets/content/_attributes_group.lsg
+++ b/app/assets/stylesheets/content/_attributes_group.lsg
@@ -137,7 +137,7 @@
       <h3 class="attributes-group--header-text">Related To</h3>
     </div>
     <div class="attributes-group--header-toggle">
-      <a href="#" class="button -small -with-icon icon-group-by icon-small">Group by work package type</a>
+      <a href="#" class="button -small -transparent -with-icon icon-group-by icon-small">Group by work package type</a>
     </div>
   </div>
   <div class="content">

--- a/app/assets/stylesheets/content/_attributes_group.lsg
+++ b/app/assets/stylesheets/content/_attributes_group.lsg
@@ -137,7 +137,7 @@
       <h3 class="attributes-group--header-text">Related To</h3>
     </div>
     <div class="attributes-group--header-toggle">
-      <a href="#" class="button -small -transparent">Group by work package type</a>
+      <a href="#" class="button -small -with-icon icon-group-by icon-small">Group by work package type</a>
     </div>
   </div>
   <div class="content">

--- a/app/assets/stylesheets/content/_attributes_group.sass
+++ b/app/assets/stylesheets/content/_attributes_group.sass
@@ -59,7 +59,7 @@
   overflow-y: hidden
 
   .button
-    margin: 0 0 0.4rem 0
+    margin: 0 0 8px 0
 
 // HACK. TODO: Remove H3 element rules in various places.
 .attributes-group--header-text,

--- a/app/assets/stylesheets/content/_attributes_group.sass
+++ b/app/assets/stylesheets/content/_attributes_group.sass
@@ -59,7 +59,7 @@
   overflow-y: hidden
 
   .button
-    margin: 0 0 5px 0
+    margin: 0 0 0.4rem 0
 
 // HACK. TODO: Remove H3 element rules in various places.
 .attributes-group--header-text,

--- a/app/assets/stylesheets/content/_buttons.sass
+++ b/app/assets/stylesheets/content/_buttons.sass
@@ -87,23 +87,18 @@ a.button
 
 
   &.-transparent
-    @include button-style($background: $button--font-color, $style: hollow)
-    border-color: transparent
+    background: transparent
 
-    &:hover, &:focus
-      @include varprop(border-color, button--border-color)
-
-    &.-active
-      background: $button--active-background-color
-
-      &:hover, &:focus
-        border-color: $button--active-border-color
+    &:hover, &:focus, &.-active
+      background: $button--background-hover-color
 
   &.-tiny
     @include button-size(tiny)
 
   &.-small
     @include button-size(small)
+    &.-with-icon:before
+      vertical-align: initial
 
   &.-large
     @include button-size(large)

--- a/app/assets/stylesheets/content/work_packages/tabs/_activities.sass
+++ b/app/assets/stylesheets/content/work_packages/tabs/_activities.sass
@@ -77,7 +77,7 @@ h4.comment
 
 .work-package-details-activities-list
   list-style-type: none
-  margin: 0
+  margin: 35px 0 0 0
 
 // Position first date with comment toggler
 .activity-date.-with-toggler

--- a/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
+++ b/app/assets/stylesheets/content/work_packages/tabs/_relations.sass
@@ -130,9 +130,3 @@
   .wp-relations-input-section
     margin-right: 10px
     flex: 1
-
-.detail-panel--relations
-  .panel-toggler .icon-small
-    height: 18px
-    display: inline-block
-    vertical-align: middle

--- a/frontend/src/app/components/wp-relations/wp-relations-group/wp-relations-group.template.html
+++ b/frontend/src/app/components/wp-relations/wp-relations-group/wp-relations-group.template.html
@@ -9,8 +9,7 @@
          *ngIf="firstGroup">
       <accessible-by-keyboard #wpRelationGroupByToggler
                               (execute)="toggleButton()"
-                              linkClass="panel-toggler ng-scope ng-isolate-scope hide-when-print
-                                         button -small -with-icon icon-group-by icon-small"
+                              linkClass="button -small -with-icon icon-group-by icon-small hide-when-print"
                               [linkAriaLabel]="togglerText">
         <span [textContent]="togglerText"></span>
       </accessible-by-keyboard>

--- a/frontend/src/app/components/wp-relations/wp-relations-group/wp-relations-group.template.html
+++ b/frontend/src/app/components/wp-relations/wp-relations-group/wp-relations-group.template.html
@@ -7,15 +7,13 @@
     </div>
     <div class="attributes-group--header-toggle"
          *ngIf="firstGroup">
-      <div id="wp-relation-group-by-toggle"
-           #wpRelationGroupByToggler
-           class="panel-toggler ng-scope ng-isolate-scope hide-when-print">
-        <accessible-by-keyboard linkClass="button -transparent"
-                                (execute)="toggleButton()">
-          <op-icon icon-classes="icon-small icon-group-by icon4"></op-icon>
-          <span [textContent]="togglerText"></span>
-        </accessible-by-keyboard>
-      </div>
+      <accessible-by-keyboard #wpRelationGroupByToggler
+                              (execute)="toggleButton()"
+                              linkClass="panel-toggler ng-scope ng-isolate-scope hide-when-print
+                                         button -small -with-icon icon-group-by icon-small"
+                              [linkAriaLabel]="togglerText">
+        <span [textContent]="togglerText"></span>
+      </accessible-by-keyboard>
     </div>
   </div>
 

--- a/frontend/src/app/components/wp-relations/wp-relations-group/wp-relations-group.template.html
+++ b/frontend/src/app/components/wp-relations/wp-relations-group/wp-relations-group.template.html
@@ -7,9 +7,10 @@
     </div>
     <div class="attributes-group--header-toggle"
          *ngIf="firstGroup">
-      <accessible-by-keyboard #wpRelationGroupByToggler
+      <accessible-by-keyboard id="wp-relation-group-by-toggle"
+                              #wpRelationGroupByToggler
                               (execute)="toggleButton()"
-                              linkClass="button -small -with-icon icon-group-by icon-small hide-when-print"
+                              linkClass="button -small -transparent -with-icon icon-group-by icon-small hide-when-print"
                               [linkAriaLabel]="togglerText">
         <span [textContent]="togglerText"></span>
       </accessible-by-keyboard>

--- a/frontend/src/app/components/wp-single-view-tabs/activity-panel/activity-tab.html
+++ b/frontend/src/app/components/wp-single-view-tabs/activity-panel/activity-tab.html
@@ -10,7 +10,7 @@
             <span class="activity-date--label" [textContent]="inf.date"></span>
             <accessible-by-keyboard (execute)="toggleComments()"
                                     *ngIf="first && showToggler"
-                                    linkClass="activity-comments--toggler button -small -with-icon icon-filter icon-small hide-when-print"
+                                    linkClass="activity-comments--toggler button -small -transparent -with-icon icon-filter icon-small hide-when-print"
                                     [linkAriaLabel]="togglerText">
               <span [textContent]="togglerText"></span>
             </accessible-by-keyboard>

--- a/frontend/src/app/components/wp-single-view-tabs/activity-panel/activity-tab.html
+++ b/frontend/src/app/components/wp-single-view-tabs/activity-panel/activity-tab.html
@@ -10,7 +10,7 @@
             <span class="activity-date--label" [textContent]="inf.date"></span>
             <accessible-by-keyboard (execute)="toggleComments()"
                                     *ngIf="first && showToggler"
-                                    linkClass="activity-comments--toggler button -small -transparent"
+                                    linkClass="activity-comments--toggler button -small -with-icon icon-filter icon-small"
                                     [linkAriaLabel]="togglerText">
               <span [textContent]="togglerText"></span>
             </accessible-by-keyboard>

--- a/frontend/src/app/components/wp-single-view-tabs/activity-panel/activity-tab.html
+++ b/frontend/src/app/components/wp-single-view-tabs/activity-panel/activity-tab.html
@@ -10,7 +10,7 @@
             <span class="activity-date--label" [textContent]="inf.date"></span>
             <accessible-by-keyboard (execute)="toggleComments()"
                                     *ngIf="first && showToggler"
-                                    linkClass="activity-comments--toggler button -small -with-icon icon-filter icon-small"
+                                    linkClass="activity-comments--toggler button -small -with-icon icon-filter icon-small hide-when-print"
                                     [linkAriaLabel]="togglerText">
               <span [textContent]="togglerText"></span>
             </accessible-by-keyboard>


### PR DESCRIPTION
### Changes in this PR
- increase recognizability of activity-toggle-button by giving it a bordered button look and an icon (such as the button in the relations tab)
- adapt structure and look of buttons in this area to each other (adapt group-by-button)

See ticket: https://community.openproject.com/projects/openproject/work_packages/32649