### PR TITLE
[33400] Increase size of placeholder for editable empty wp fields

### DIFF
--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_display_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_display_fields.sass
@@ -47,6 +47,8 @@
 
   &.-placeholder
     font-style: italic
+    display: inline-block
+    min-width: 100px
 
   // Always render custom options as inline
   // when only one line
@@ -90,12 +92,13 @@
     padding: 0 2px
 
 .wp-table--cell-container
+  .inline-edit--display-field.-placeholder,
   &.estimatedTime
     width: 100%
 
     .-placeholder
       @include wp-table--placeholder-time-values
-      
+
 // Sums in wp table
 .wp-table--sum-container
   .split-time-field

--- a/app/assets/stylesheets/content/work_packages/inplace_editing/_display_fields.sass
+++ b/app/assets/stylesheets/content/work_packages/inplace_editing/_display_fields.sass
@@ -49,6 +49,7 @@
     font-style: italic
     display: inline-block
     min-width: 100px
+    vertical-align: middle
 
   // Always render custom options as inline
   // when only one line


### PR DESCRIPTION
### Changes
- empty fields in the wp table will span the whole column width
- empty fields in a wp full view will be at least 100px

See ticket: https://community.openproject.com/projects/openproject/work_packages/33400