### PR TITLE
Fix-Regression: BCF-XML import adding existing users

### DIFF
--- a/modules/bim/app/controllers/bim/bcf/issues_controller.rb
+++ b/modules/bim/app/controllers/bim/bcf/issues_controller.rb
@@ -102,12 +102,12 @@ module Bim
           unknown_priorities_action: params.dig(:import_options, :unknown_priorities_action).presence || "use_default",
           invalid_people_action: params.dig(:import_options, :invalid_people_action).presence || "anonymize",
           unknown_mails_action: params.dig(:import_options, :unknown_mails_action).presence || 'invite',
-          non_members_action: params.dig(:import_options, :non_members_action).presence || 'add',
+          non_members_action: params.dig(:import_options, :non_members_action).presence || 'chose',
           unknown_types_chose_ids: params.dig(:import_options, :unknown_types_chose_ids) || [],
           unknown_statuses_chose_ids: params.dig(:import_options, :unknown_statuses_chose_ids) || [],
           unknown_priorities_chose_ids: params.dig(:import_options, :unknown_priorities_chose_ids) || [],
           unknown_mails_invite_role_ids: params.dig(:import_options, :unknown_mails_invite_role_ids) || [],
-          non_members_add_role_ids: params.dig(:import_options, :non_members_add_role_ids) || []
+          non_members_chose_role_ids: params.dig(:import_options, :non_members_chose_role_ids) || []
         }
       end
 

--- a/modules/bim/app/views/bim/bcf/issues/_import_options_hidden_fields.html.erb
+++ b/modules/bim/app/views/bim/bcf/issues/_import_options_hidden_fields.html.erb
@@ -24,8 +24,8 @@
     <%= hidden_field :import_options, 'unknown_mails_invite_role_ids[]', :name => 'import_options[unknown_mails_invite_role_ids][]', :value => id %>
   <% end %>
 <% end %>
-<% if params.dig(:import_options, :non_members_add_role_ids)&.any? %>
-  <% params.dig(:import_options, :non_members_add_role_ids).each do |id| %>
-    <%= hidden_field :import_options, 'non_members_add_role_ids[]', :name => 'import_options[non_members_add_role_ids][]', :value => id %>
+<% if params.dig(:import_options, :non_members_chose_role_ids)&.any? %>
+  <% params.dig(:import_options, :non_members_chose_role_ids).each do |id| %>
+    <%= hidden_field :import_options, 'non_members_chose_role_ids[]', :name => 'import_options[non_members_chose_role_ids][]', :value => id %>
   <% end %>
 <% end %>

--- a/modules/bim/app/views/bim/bcf/issues/configure_non_members.html.erb
+++ b/modules/bim/app/views/bim/bcf/issues/configure_non_members.html.erb
@@ -8,7 +8,7 @@
   <% if @roles.any? %>
     <% if User.current.allowed_to?(:manage_members, @project) %>
 
-      <%= render partial: 'import_solution', locals: { solution_select_id: 'non_members_add_role_ids',
+      <%= render partial: 'import_solution', locals: { solution_select_id: 'non_members_chose_role_ids',
                                                        hidden_field_identifier: 'non_members_action',
                                                        solution_text: t('bcf.bcf_xml.import.add_as_members_with_role', project: @project.name),
                                                        solution_options: @roles.collect { |obj| [obj.name, obj.id] }} %>

--- a/modules/bim/lib/open_project/bim/bcf_xml/importer.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/importer.rb
@@ -13,12 +13,12 @@ module OpenProject::Bim::BcfXml
       unknown_priorities_action: "use_default",
       invalid_people_action: "anonymize",
       unknown_mails_action: 'invite',
-      non_members_action: 'add',
+      non_members_action: 'chose',
       unknown_types_chose_ids: [],
       unknown_statuses_chose_ids: [],
       unknown_priorities_chose_ids: [],
       unknown_mails_invite_role_ids: [],
-      non_members_add_role_ids: []
+      non_members_chose_role_ids: []
     }.freeze
 
     def initialize(file, project, current_user:)
@@ -135,7 +135,7 @@ module OpenProject::Bim::BcfXml
       membership_service = ::Members::EditMembershipService.new(member,
                                                                 save: true,
                                                                 current_user: User.current)
-      membership_service.call(attributes: { role_ids: options[:non_members_add_role_ids] })
+      membership_service.call(attributes: { role_ids: options[:non_members_chose_role_ids] })
     end
 
     def treat_unknown_mails?(options)
@@ -146,8 +146,8 @@ module OpenProject::Bim::BcfXml
 
     def treat_non_members?(options)
       aggregations.non_members.any? &&
-        options[:non_members_action] == 'add' &&
-        options[:non_members_add_role_ids].any?
+        options[:non_members_action] == 'chose' &&
+        options[:non_members_chose_role_ids].any?
     end
 
     def to_listing(extractor)


### PR DESCRIPTION
Apparently some refactoring a couple of months back broke adding non members to projects during BCF-XML import.

https://community.openproject.com/projects/bim/work_packages/33540