### PR TITLE
correct attachment list to be displayed check

### DIFF
--- a/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/components/work-packages/wp-single-view/wp-single-view.html
@@ -124,8 +124,7 @@
   </div>
 </div>
 
-<div class="work-packages--attachments attributes-group"
-     *ngIf="workPackage.canAddAttachments || workPackage.hasAttachments">
+<div class="work-packages--attachments attributes-group">
   <div class="work-packages--attachments-container">
     <div class="attributes-group--header">
       <div class="attributes-group--header-container">
@@ -138,7 +137,8 @@
     </ndc-dynamic>
 
     <ndc-dynamic [ndcDynamicComponent]="attachmentUploadComponent()"
-                 [ndcDynamicInputs]="{ resource: workPackage }">
+                 [ndcDynamicInputs]="{ resource: workPackage }"
+                 *ngIf="workPackage.canAddAttachments">
     </ndc-dynamic>
   </div>
 </div>


### PR DESCRIPTION
When coming from the wp list, the attachments are not loaded yet. They are only embedded when fetching an individual work package. When coming from the list, loading attachments is triggered by the attachments list component. But that only takes place if that component is initialized.

I'd like to have this merged into 10.5 due to a customer requiring the fix. We would then need to merge the branch into 10.6 obviously.