### PR TITLE
[33478] Users without editing permission can move widgets on overview page (frontend only)

### DIFF
--- a/frontend/src/app/modules/grids/grid/grid.component.html
+++ b/frontend/src/app/modules/grids/grid/grid.component.html
@@ -20,7 +20,7 @@
          cdkDrag
          (cdkDragStarted)="drag.start(area)"
          (cdkDragDropped)="drag.drop()"
-         [cdkDragDisabled]="isMobileDevice">
+         [cdkDragDisabled]="isMobileDevice || !drag.isDraggable">
 
       <span *ngIf="drag.isDraggable"
             class="grid--area-drag-handle


### PR DESCRIPTION
Change disable condition of cdkDrag that the user without permission can't move the widgets.

https://community.openproject.com/projects/openproject/work_packages/33478/activity