### PR TITLE
sort project cf columns by cf position

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -54,7 +54,6 @@ class ProjectsController < ApplicationController
     end
 
     @projects = load_projects query
-    @custom_fields = ProjectCustomField.visible(User.current)
 
     render layout: 'no_menu'
   end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -65,6 +65,14 @@ module ProjectsHelper
     end
   end
 
+  def project_custom_fields_for_index
+    @project_custom_fields_for_index ||= if EnterpriseToken.allows_to?(:custom_fields_in_projects_list)
+                                           ProjectCustomField.visible(User.current).order(:position)
+                                         else
+                                           ProjectCustomField.none
+                                         end
+  end
+
   def project_more_menu_items(project)
     [project_more_menu_subproject_item(project),
      project_more_menu_settings_item(project),

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -67,10 +67,8 @@ See docs/COPYRIGHT.rdoc for more details.
             <%= projects_sort_header_tag('name', caption: Project.human_attribute_name(:name), param: :json) %>
             <%= projects_sort_header_tag('project_status', caption: Project.human_attribute_name(:status), param: :json) %>
             <%= projects_sort_header_tag('public', caption: Project.human_attribute_name(:public), param: :json) %>
-            <% if EnterpriseToken.allows_to?(:custom_fields_in_projects_list) %>
-              <% @custom_fields.each do |custom_field| %>
-                <%= sort_header_tag("cf_#{custom_field.id}", caption: custom_field.name, param: :json) %>
-              <% end %>
+            <% project_custom_fields_for_index.each do |custom_field| %>
+              <%= sort_header_tag("cf_#{custom_field.id}", caption: custom_field.name, param: :json) %>
             <% end %>
             <% if User.current.admin? %>
               <%= projects_sort_header_tag('required_disk_space', caption: I18n.t(:label_required_disk_storage), param: :json) %>
@@ -108,18 +106,16 @@ See docs/COPYRIGHT.rdoc for more details.
                 <% end %>
               </td>
               <td><%= checked_image project.public? %></td>
-              <% if EnterpriseToken.allows_to?(:custom_fields_in_projects_list) %>
-                <% @custom_fields.each do |custom_field| %>
-                  <td class="format-<%= custom_field.field_format %>">
-                    <% custom_value = project.custom_value_for(custom_field).formatted_value %>
+              <% project_custom_fields_for_index.each do |custom_field| %>
+                <td class="format-<%= custom_field.field_format %>">
+                  <% custom_value = project.custom_value_for(custom_field).formatted_value %>
 
-                    <% if custom_field.field_format == 'text' %>
-                      <%= shorten_text(custom_value, 20) %>
-                    <% else %>
-                      <%= custom_value %>
-                    <% end %>
-                  </td>
-                <% end %>
+                  <% if custom_field.field_format == 'text' %>
+                    <%= shorten_text(custom_value, 20) %>
+                  <% else %>
+                    <%= custom_value %>
+                  <% end %>
+                </td>
               <% end %>
               <% if User.current.admin? %>
                 <td><%= number_to_human_size(project.required_disk_space, precision: 2) if project.required_disk_space.to_i > 0 %></td>
@@ -151,7 +147,7 @@ See docs/COPYRIGHT.rdoc for more details.
             <% unless project.description.blank? %>
               <tr class="project-description <%= project_css_classes(project) %> <%= level > 0 ? "idnt idnt-#{level}" : nil %> <%= params[:expand] == 'all' ? '-expanded' : '' %>">
                 <td></td>
-                <td colspan="<%= @custom_fields.size + (User.current.admin? ? 7 : 4) %>" class="project--hierarchy">
+                <td colspan="<%= project_custom_fields_for_index.length + (User.current.admin? ? 7 : 4) %>" class="project--hierarchy">
                   <div class="description-container">
                     <span class="wiki"><%= format_text(short_project_description(project), project: project) %></span>
                   </div>


### PR DESCRIPTION
Let the project cf columns on project index adhere to the position the project custom fields are ordered by.

https://community.openproject.com/wp/33580