### PR TITLE
Dont call #delete on status params

### DIFF
--- a/app/services/projects/set_attributes_service.rb
+++ b/app/services/projects/set_attributes_service.rb
@@ -32,7 +32,8 @@ module Projects
   class SetAttributesService < ::BaseServices::SetAttributes
     private
 
-    def set_attributes(attributes)
+    def set_attributes(params)
+      attributes = params.dup
       status_attributes = attributes.delete(:status) || {}
 
       ret = super(attributes)


### PR DESCRIPTION
This removes it from params on subsequent calls after the SetAttributesService.

Extends the test to ensure the assigning of status over a template is working.

https://community.openproject.com/wp/33513