### PR TITLE
[33579] OpenProject registration screen not localized

### DIFF
--- a/app/services/set_localization_service.rb
+++ b/app/services/set_localization_service.rb
@@ -12,11 +12,11 @@ class SetLocalizationService
   # The locale is determined with the following priority:
   #
   #   1. The language as configured by the user.
-  #   2. The first language defined in the Accept-Language header sent by the browser.
-  #   3. OpenProject's default language defined in the settings.
+  #   2. OpenProject's default language defined in the settings.
+  #   3. The first language defined in the Accept-Language header sent by the browser.
 
   def call
-    lang = user_language || header_language || default_language
+    lang = user_language || default_language || header_language
 
     set_language_if_valid(lang)
   end

--- a/app/views/users/users_settings.html.erb
+++ b/app/views/users/users_settings.html.erb
@@ -36,7 +36,7 @@ See docs/COPYRIGHT.rdoc for more details.
     <legend class="form--fieldset-legend"><%= t(:'settings.user.default_preferences')%></legend>
 
     <div class="form--field" id="setting_default_language">
-      <%= setting_select :default_language, all_lang_options_for_select(false), container_class: '-slim' %>
+      <%= setting_select :default_language, lang_options_for_select(false), container_class: '-slim' %>
     </div>
 
     <%=


### PR DESCRIPTION
1. Give system default language a higher priority than the browser language.
2. Limit the available default languages to those that are enabled in the system.

https://community.openproject.com/projects/openproject/work_packages/33579/activity