### PR TITLE
[33617] Allow SSO providers to define logout flows

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -63,9 +63,11 @@ class AccountController < ApplicationController
     # Keep attributes from the session
     # to identify the user
     previous_session = session.to_h.with_indifferent_access
+    previous_user = current_user
+
     logout_user
 
-    perform_post_logout previous_session
+    perform_post_logout previous_session, previous_user
   end
 
   # Enable user to choose a new password

--- a/app/controllers/concerns/accounts/current_user.rb
+++ b/app/controllers/concerns/accounts/current_user.rb
@@ -104,15 +104,21 @@ module Accounts::CurrentUser
 
   # Redirect the user according to the logout scheme
   def perform_post_logout(prev_session, prev_user)
+    # First, check if there is an SLO callback for a given
+    # omniauth provider of the user
+    provider = ::OpenProject::Plugins::AuthPlugin.login_provider_for(prev_user)
+    if provider && (callback = provider[:single_sign_out_callback])
+      instance_exec prev_session, prev_user, &callback
+      return if performed?
+    end
+
+    # Otherwise, if there is an omniauth direct login
+    # and we're not logging out globablly, ensure the
+    # user does not get re-logged in
     if Setting.login_required? && omniauth_direct_login?
       flash.now[:notice] = I18n.t :notice_logged_out
       render :exit, locals: { instructions: :after_logout }
       return
-    end
-
-    provider = ::OpenProject::Plugins::AuthPlugin.login_provider_for(prev_user)
-    if provider && (callback = provider[:single_sign_out_callback])
-      instance_exec prev_session, prev_user, &callback
     end
 
     redirect_to(home_url) unless performed?

--- a/app/controllers/concerns/accounts/current_user.rb
+++ b/app/controllers/concerns/accounts/current_user.rb
@@ -110,7 +110,7 @@ module Accounts::CurrentUser
       return
     end
 
-    provider = login_provider_for(prev_user)
+    provider = ::OpenProject::Plugins::AuthPlugin.login_provider_for(prev_user)
     if provider && (callback = provider[:single_sign_out_callback])
       instance_exec prev_session, prev_user, &callback
     end

--- a/app/controllers/concerns/accounts/omniauth_login.rb
+++ b/app/controllers/concerns/accounts/omniauth_login.rb
@@ -110,6 +110,13 @@ module Accounts::OmniauthLogin
     omniauth_start_url(direct_login_provider, params)
   end
 
+  def login_provider_for(user)
+    return unless user.identity_url
+
+    provider_name = user.identity_url.split(':').first
+    ::OpenProject::Plugins::AuthPlugin.find_provider_by_name(provider_name)
+  end
+
   private
 
   def authorization_successful(user, auth_hash)

--- a/app/controllers/concerns/accounts/omniauth_login.rb
+++ b/app/controllers/concerns/accounts/omniauth_login.rb
@@ -110,13 +110,6 @@ module Accounts::OmniauthLogin
     omniauth_start_url(direct_login_provider, params)
   end
 
-  def login_provider_for(user)
-    return unless user.identity_url
-
-    provider_name = user.identity_url.split(':').first
-    ::OpenProject::Plugins::AuthPlugin.find_provider_by_name(provider_name)
-  end
-
   private
 
   def authorization_successful(user, auth_hash)

--- a/app/controllers/concerns/auth_source_sso.rb
+++ b/app/controllers/concerns/auth_source_sso.rb
@@ -150,7 +150,7 @@ module AuthSourceSSO
     user.activate!
   end
 
-  def perform_post_logout(prev_session)
+  def perform_post_logout(prev_session, previous_user)
     if prev_session[:user_from_auth_header] && header_slo_url.present?
       redirect_to header_slo_url
     else

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -44,13 +44,13 @@ module Users
 
       ::Sessions::InitializeSessionService.call(user, controller.session)
 
-      controller.session.merge! retained_values
+      controller.session.merge!(retained_values) if retained_values
 
       ServiceResult.new(result: user)
     end
 
     def retain_sso_session_values!(user)
-      provider = controller.login_provider_for(user)
+      provider = ::OpenProject::Plugins::AuthPlugin.login_provider_for(user)
       return unless provider && provider[:retain_from_session]
 
       controller.session.to_h.slice(*provider[:retain_from_session])

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -36,13 +36,24 @@ module Users
     end
 
     def call(user)
+      retained_values = retain_sso_session_values!(user)
+
       controller.reset_session
 
       User.current = user
 
       ::Sessions::InitializeSessionService.call(user, controller.session)
 
+      controller.session.merge! retained_values
+
       ServiceResult.new(result: user)
+    end
+
+    def retain_sso_session_values!(user)
+      provider = controller.login_provider_for(user)
+      return unless provider && provider[:retain_from_session]
+
+      controller.session.to_h.slice(*provider[:retain_from_session])
     end
   end
 end

--- a/modules/auth_plugins/lib/open_project/plugins/auth_plugin.rb
+++ b/modules/auth_plugins/lib/open_project/plugins/auth_plugin.rb
@@ -47,7 +47,12 @@ module OpenProject::Plugins
     end
 
     def self.providers_for(strategy)
-      filtered_strategies strategies[strategy_key(strategy)].map(&:call).flatten.map(&:to_hash)
+      matching = Array(strategies[strategy_key(strategy)])
+      filtered_strategies matching.map(&:call).flatten.map(&:to_hash)
+    end
+
+    def self.find_provider_by_name(provider_name)
+      providers.detect { |hash| hash[:name].to_s == provider_name.to_s }
     end
 
     def self.providers
@@ -69,6 +74,7 @@ module OpenProject::Plugins
 
     def self.strategy_key(strategy)
       return strategy if strategy.is_a? Symbol
+      return strategy.to_sym if strategy.is_a? String
 
       name = strategy.name.demodulize
       camelization = OmniAuth.config.camelizations.select do |_k, v|

--- a/modules/auth_plugins/lib/open_project/plugins/auth_plugin.rb
+++ b/modules/auth_plugins/lib/open_project/plugins/auth_plugin.rb
@@ -51,6 +51,13 @@ module OpenProject::Plugins
       filtered_strategies matching.map(&:call).flatten.map(&:to_hash)
     end
 
+    def self.login_provider_for(user)
+      return unless user.identity_url
+
+      provider_name = user.identity_url.split(':').first
+      find_provider_by_name(provider_name)
+    end
+
     def self.find_provider_by_name(provider_name)
       providers.detect { |hash| hash[:name].to_s == provider_name.to_s }
     end

--- a/modules/auth_saml/lib/open_project/auth_saml/engine.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/engine.rb
@@ -74,6 +74,19 @@ module OpenProject
       register_auth_providers do
         strategy :saml do
           OpenProject::AuthSaml.configuration.values.map do |h|
+            # Remember saml session values when logging in user
+            h[:retain_from_session] = %w[saml_uid saml_session_index]
+
+            h[:single_sign_out_callback] = Proc.new do |prev_session, _prev_user|
+              next unless h[:idp_slo_target_url]
+              next unless prev_session[:saml_uid] && prev_session[:saml_session_index]
+
+              # Set the uid and index for the logout in this session again
+              session.merge! prev_session.slice(*h[:retain_from_session])
+
+              redirect_to omniauth_start_path(h[:name]) + "/spslo"
+            end
+
             h[:openproject_attribute_map] = Proc.new do |auth|
               {}.tap do |additional|
                 additional[:login] = auth.info[:login] if auth.info.key? :login

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -298,7 +298,7 @@ describe AccountController, type: :controller do
         end
 
         before do
-          allow(controller)
+          allow(::OpenProject::Plugins::AuthPlugin)
             .to(receive(:login_provider_for))
             .and_return(sso_provider)
           login_as user

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -320,6 +320,22 @@ describe AccountController, type: :controller do
             end
           end
 
+          context 'with direct login and redirecting callback',
+                  with_settings: { login_required?: true },
+                  with_config: { omniauth_direct_login_provider: 'foo' } do
+
+            it 'will still call the callback' do
+              # Set the previous session
+              session[:foo] = 'bar'
+
+              get :logout
+              expect(response).to redirect_to '/login'
+
+              # Expect session to be cleared
+              expect(session[:foo]).to eq nil
+            end
+          end
+
           it 'will call the callback' do
             # Set the previous session
             session[:foo] = 'bar'

--- a/spec/services/users/login_service_spec.rb
+++ b/spec/services/users/login_service_spec.rb
@@ -71,6 +71,7 @@ describe ::Users::LoginService, type: :model do
           subject
 
           expect(session[:foo]).to be_present
+          expect(session[:what]).to eq nil
           expect(session[:user_id]).to eq input_user.id
         end
       end

--- a/spec/services/users/login_service_spec.rb
+++ b/spec/services/users/login_service_spec.rb
@@ -47,7 +47,7 @@ describe ::Users::LoginService, type: :model do
       end
 
       before do
-        allow(controller)
+        allow(::OpenProject::Plugins::AuthPlugin)
           .to(receive(:login_provider_for))
           .and_return sso_provider
 

--- a/spec/services/users/login_service_spec.rb
+++ b/spec/services/users/login_service_spec.rb
@@ -1,0 +1,79 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::Users::LoginService, type: :model do
+  let(:input_user) { FactoryBot.build_stubbed(:user) }
+  let(:controller) { double('ApplicationController') }
+  let(:session) { {} }
+
+  let(:instance) { described_class.new(controller: controller) }
+
+  subject { instance.call(input_user) }
+
+  describe 'session' do
+    context 'with an SSO provider' do
+      let(:sso_provider) do
+        {
+          name: 'saml',
+          retain_from_session: %i[foo bar]
+        }
+      end
+
+      before do
+        allow(controller)
+          .to(receive(:login_provider_for))
+          .and_return sso_provider
+
+        allow(controller)
+          .to(receive(:session))
+          .and_return session
+
+        allow(controller)
+          .to(receive(:reset_session)) do
+          session.clear
+        end
+      end
+
+      context 'if provider retains session values' do
+        let(:retained_values) { %i[foo bar] }
+
+        it 'retains present session values' do
+          session[:foo] = 'foo value'
+          session[:what] = 'should be cleared'
+
+          subject
+
+          expect(session[:foo]).to be_present
+          expect(session[:user_id]).to eq input_user.id
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR provides the following changes:

- Session values when logging in can be retained by properties in the omniauth/SSO provider configuration. This ensures that custom session values such as `saml_uid` and `saml_session_index` are being retained for single log out purposes.
- Providers are called with a signing out callback just after `AccountController#logout` was performed. They get the previous session to ensure they can restore some of these custom values such as `saml_uid` for redirecting back to the idP.

https://community.openproject.com/wp/33617