### PR TITLE
Add support for Ubuntu 20.04 on packager.io

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -17,6 +17,8 @@ targets:
     <<: *debian9
   ubuntu-18.04:
     <<: *debian9
+  ubuntu-20.04:
+    <<: *debian9
   centos-8:
    dependencies:
       - epel-release


### PR DESCRIPTION
This adds support for the latest Ubuntu 20.04 on Packager.io.