### PR TITLE
Bim: Fixing several issues with the BCF XML import

### DIFF
--- a/modules/bim/app/models/bim/bcf/issue.rb
+++ b/modules/bim/app/models/bim/bcf/issue.rb
@@ -15,6 +15,7 @@ module Bim::Bcf
     after_update :invalidate_markup_cache
 
     validates :work_package, presence: true
+    validates_uniqueness_of :uuid, message: :uuid_already_taken
 
     # The virtual attributes are defined so that an API client can attempt to set them.
     # However, currently such information is not persisted. But adding them fits better into the code

--- a/modules/bim/app/views/bim/bcf/issues/configure_invalid_people.html.erb
+++ b/modules/bim/app/views/bim/bcf/issues/configure_invalid_people.html.erb
@@ -1,7 +1,7 @@
 <%= stylesheet_link_tag 'bim/bcf.css' %>
 <%= toolbar title: t('bcf.bcf_xml.import_title') %>
 
-<%= styled_form_tag({ action: :perform_import }, multipart: true, method: :post) do %>
+<%= styled_form_tag({ action: :configure_import }, multipart: true, method: :post) do %>
   <%= render partial: 'import_errors', locals: { error_message: t('bcf.bcf_xml.import.invalid_emails_found'),
                                                  error_objects:  @importer.aggregations.invalid_people,
                                                  error_default_text: t('bcf.bcf_xml.import.unknown_property')} %>

--- a/modules/bim/app/views/bim/bcf/issues/configure_non_members.html.erb
+++ b/modules/bim/app/views/bim/bcf/issues/configure_non_members.html.erb
@@ -1,7 +1,7 @@
 <%= stylesheet_link_tag 'bim/bcf.css' %>
 <%= toolbar title: t('bcf.bcf_xml.import_title') %>
 
-<%= styled_form_tag({ action: :perform_import }, multipart: true, method: :post) do %>
+<%= styled_form_tag({ action: :configure_import }, multipart: true, method: :post) do %>
   <%= render partial: 'import_errors', locals: { error_message: t('bcf.bcf_xml.import.non_members_found'),
                                                  error_objects: @importer.aggregations.non_members,
                                                  error_default_text: t('bcf.bcf_xml.import.unknown_property')} %>

--- a/modules/bim/app/views/bim/bcf/issues/configure_unknown_mails.html.erb
+++ b/modules/bim/app/views/bim/bcf/issues/configure_unknown_mails.html.erb
@@ -1,7 +1,7 @@
 <%= stylesheet_link_tag 'bim/bcf.css' %>
 <%= toolbar title: t('bcf.bcf_xml.import_title') %>
 
-<%= styled_form_tag({ action: :perform_import }, multipart: true, method: :post) do %>
+<%= styled_form_tag({ action: :configure_import }, multipart: true, method: :post) do %>
   <%= render partial: 'import_errors', locals: { error_message: t('bcf.bcf_xml.import.unknown_emails_found'),
                                                  error_objects: @importer.aggregations.unknown_mails,
                                                  error_default_text: t('bcf.bcf_xml.import.unknown_property')} %>

--- a/modules/bim/app/views/bim/bcf/issues/configure_unknown_priorities.html.erb
+++ b/modules/bim/app/views/bim/bcf/issues/configure_unknown_priorities.html.erb
@@ -1,7 +1,7 @@
 <%= stylesheet_link_tag 'bim/bcf.css' %>
 <%= toolbar title: t('bcf.bcf_xml.import_title') %>
 
-<%= styled_form_tag({ action: :perform_import }, multipart: true, method: :post, class: '-vertical') do %>
+<%= styled_form_tag({ action: :configure_import }, multipart: true, method: :post, class: '-vertical') do %>
   <%= render partial: 'import_errors', locals: { error_message: t('bcf.bcf_xml.import.invalid_priorities_found'),
                                                 error_objects: @importer.aggregations.unknown_priorities,
                                                 error_default_text: t('bcf.bcf_xml.import.no_priority_provided')} %>

--- a/modules/bim/app/views/bim/bcf/issues/configure_unknown_statuses.html.erb
+++ b/modules/bim/app/views/bim/bcf/issues/configure_unknown_statuses.html.erb
@@ -1,7 +1,7 @@
 <%= stylesheet_link_tag 'bim/bcf.css' %>
 <%= toolbar title: t('bcf.bcf_xml.import_title') %>
 
-<%= styled_form_tag({ action: :perform_import }, multipart: true, method: :post, class: '-vertical') do %>
+<%= styled_form_tag({ action: :configure_import }, multipart: true, method: :post, class: '-vertical') do %>
   <%= render partial: 'import_errors', locals: { error_message: t('bcf.bcf_xml.import.invalid_statuses_found'),
                                                  error_objects: @importer.aggregations.unknown_statuses,
                                                  error_default_text: t('bcf.bcf_xml.import.no_status_provided')} %>

--- a/modules/bim/app/views/bim/bcf/issues/configure_unknown_types.html.erb
+++ b/modules/bim/app/views/bim/bcf/issues/configure_unknown_types.html.erb
@@ -1,7 +1,7 @@
 <%= stylesheet_link_tag 'bim/bcf.css' %>
 <%= toolbar title: t('bcf.bcf_xml.import_title') %>
 
-<%= styled_form_tag({ action: :perform_import }, multipart: true, method: :post, class: '-vertical') do %>
+<%= styled_form_tag({ action: :configure_import }, multipart: true, method: :post, class: '-vertical') do %>
   <%= render partial: 'import_errors', locals: { error_message: t('bcf.bcf_xml.import.invalid_types_found'),
                                                  error_objects: @importer.aggregations.unknown_types,
                                                  error_default_text: t('bcf.bcf_xml.import.no_type_provided')} %>

--- a/modules/bim/config/locales/en.yml
+++ b/modules/bim/config/locales/en.yml
@@ -107,6 +107,8 @@ en:
           snapshot_type_unsupported: "snapshot_type needs to be either 'png' or 'jpg'."
           snapshot_data_blank: "snapshot_data needs to be provided."
           unsupported_key: "An unsupported json property is included."
+        bim/bcf/issue:
+          uuid_already_taken: "Can't import this BCF issue as there already is another with the same GUID. Could it be that this BCF issue had already been imported into a different project?"
   ifc_models:
     label_ifc_models: 'IFC models'
     label_new_ifc_model: 'New IFC model'

--- a/modules/bim/config/routes.rb
+++ b/modules/bim/config/routes.rb
@@ -34,6 +34,7 @@ OpenProject::Application.routes.draw do
       resources :issues, controller: 'bim/bcf/issues' do
         get :upload, action: :upload, on: :collection
         post :prepare_import, action: :prepare_import, on: :collection
+        post :configure_import, action: :configure_import, on: :collection
         post :import, action: :perform_import, on: :collection
       end
 

--- a/modules/bim/db/migrate/20200610083854_add_uniqueness_contrain_to_bcf_topic_on_uuid.rb
+++ b/modules/bim/db/migrate/20200610083854_add_uniqueness_contrain_to_bcf_topic_on_uuid.rb
@@ -1,0 +1,13 @@
+class AddUniquenessContrainToBcfTopicOnUuid < ActiveRecord::Migration[6.0]
+  def up
+    # Create unique index on an issue's uuid. A BCF issue should only exist once on an instance. If you need a copy,
+    # then it is not the same anymore and thus should have a different uuid.
+    remove_index :bcf_issues, :uuid
+    add_index :bcf_issues, %i[uuid], unique: true
+  end
+
+  def down
+    remove_index :bcf_issues, :uuid
+    add_index :bcf_issues, %i[uuid]
+  end
+end

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -57,7 +57,7 @@ module OpenProject::Bim
                    { 'bim/bcf/issues': %i[index] },
                    dependencies: %i[view_work_packages]
         permission :manage_bcf,
-                   { 'bim/bcf/issues': %i[index upload prepare_import perform_import] },
+                   { 'bim/bcf/issues': %i[index upload prepare_import configure_import perform_import] },
                    dependencies: %i[view_linked_issues
                                     view_work_packages
                                     add_work_packages

--- a/modules/bim/spec/controllers/issues_controller_spec.rb
+++ b/modules/bim/spec/controllers/issues_controller_spec.rb
@@ -125,6 +125,35 @@ describe ::Bim::Bcf::IssuesController, type: :controller do
     end
   end
 
+  describe '#configure_import' do
+    let(:action) do
+      post :configure_import, params: { project_id: project.identifier.to_s }
+    end
+
+    context 'with valid BCF file' do
+      let(:filename) { 'MaximumInformation.bcf' }
+      let(:file) do
+        Rack::Test::UploadedFile.new(
+            File.join(Rails.root, "modules/bim/spec/fixtures/files/#{filename}"),
+            'application/octet-stream'
+        )
+      end
+
+      before do
+        allow_any_instance_of(Attachment).to receive(:diskfile).and_return(file)
+        allow(Attachment).to receive(:find_by).and_return(Attachment.new)
+      end
+
+      it 'should be successful' do
+        expect { action }.to change { Attachment.count }.by(0)
+        expect(response).to be_successful
+      end
+
+      it_behaves_like "check permissions"
+    end
+  end
+
+
   describe '#perform_import' do
     let(:action) do
       post :perform_import, params: { project_id: project.identifier.to_s }


### PR DESCRIPTION
- Enforce uniqueness of BCF GUIDs throughout an OP instance.
- Regression: The configuration dialogue can now have multiple
  steps again.
- Regression: The importer gets propperly configured with default
  options when no configuration steps get triggerd.