### PR TITLE
[33317] Deleted issue still in split view after deleting it in WP-Fullscreen mode 

### DIFF
--- a/frontend/src/app/components/wp-single-view-tabs/keep-tab/keep-tab.service.ts
+++ b/frontend/src/app/components/wp-single-view-tabs/keep-tab/keep-tab.service.ts
@@ -68,8 +68,12 @@ export class KeepTabService {
     return 'work-packages.partitioned.list.details.' + this.currentDetailsTab;
   }
 
+  public get currentDetailsSubState():string {
+    return '.details.' + this.currentDetailsTab;
+  }
+
   public isDetailsState(stateName:string) {
-    return stateName === 'work-packages.partitioned.list.details';
+    return !!stateName && stateName.includes('.details');
   }
 
   public get currentShowTab():string {

--- a/frontend/src/app/modules/bim/ifc_models/openproject-ifc-models.routes.ts
+++ b/frontend/src/app/modules/bim/ifc_models/openproject-ifc-models.routes.ts
@@ -72,6 +72,7 @@ export const IFC_ROUTES:Ng2StateDeclaration[] = [
     name: 'bim.partitioned.split',
     url: '/split',
     data: {
+      baseRoute: 'bim.partitioned.split',
       partition: '-split',
       newRoute: 'bim.partitioned.split.new',
       bodyClasses: 'router--work-packages-partitioned-split-view'

--- a/frontend/src/app/modules/common/back-routing/back-routing.service.ts
+++ b/frontend/src/app/modules/common/back-routing/back-routing.service.ts
@@ -35,6 +35,7 @@ interface BackRouteOptions {
   name:string;
   params:{};
   parent:string;
+  baseRoute:string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -50,7 +51,7 @@ export class BackRoutingService {
   public goBack(preferListOverSplit:boolean = false) {
     // Default: back to list
     // When coming from a deep link or a create form
-    const baseRoute = this.$state.current.data.baseRoute || 'work-packages.partitioned.list';
+    const baseRoute = this.backRoute?.baseRoute || this.$state.current.data.baseRoute || 'work-packages.partitioned.list';
 
     if (!this.backRoute || this.backRoute.name.includes('new')) {
       this.$state.go(baseRoute, this.$state.params);
@@ -59,7 +60,7 @@ export class BackRoutingService {
         if (preferListOverSplit) {
           this.$state.go(baseRoute, this.$state.params);
         } else {
-          this.$state.go(this.keepTab.currentDetailsState, this.$state.params);
+          this.$state.go(baseRoute + this.keepTab.currentDetailsSubState, this.$state.params);
         }
       } else {
         this.$state.go(this.backRoute.name, this.backRoute.params);
@@ -82,7 +83,10 @@ export class BackRoutingService {
       toState.data &&
       fromState.data.parent !== toState.data.parent) {
       const paramsFromCopy = { ...transition.params('from') };
-      this.backRoute = { name: fromState.name, params: paramsFromCopy, parent: fromState.data.parent };
+      this.backRoute = { name: fromState.name,
+                         params: paramsFromCopy,
+                         parent: fromState.data.parent,
+                         baseRoute: fromState.data.baseRoute };
     }
   }
 

--- a/frontend/src/app/modules/work_packages/routing/split-view-routes.template.ts
+++ b/frontend/src/app/modules/work_packages/routing/split-view-routes.template.ts
@@ -83,6 +83,7 @@ export function makeSplitViewRoutes(baseRoute:string,
       url: '/overview',
       component: WorkPackageOverviewTabComponent,
       data: {
+        baseRoute: baseRoute,
         menuItem: menuItemClass,
         parent: baseRoute + '.details'
       }
@@ -92,6 +93,7 @@ export function makeSplitViewRoutes(baseRoute:string,
       url: '/activity',
       component: WorkPackageActivityTabComponent,
       data: {
+        baseRoute: baseRoute,
         menuItem: menuItemClass,
         parent: baseRoute + '.details'
       }
@@ -101,6 +103,7 @@ export function makeSplitViewRoutes(baseRoute:string,
       url: '/relations',
       component: WorkPackageRelationsTabComponent,
       data: {
+        baseRoute: baseRoute,
         menuItem: menuItemClass,
         parent: baseRoute + '.details'
       }
@@ -110,6 +113,7 @@ export function makeSplitViewRoutes(baseRoute:string,
       url: '/watchers',
       component: WorkPackageWatchersTabComponent,
       data: {
+        baseRoute: baseRoute,
         menuItem: menuItemClass,
         parent: baseRoute + '.details'
       }


### PR DESCRIPTION
Allow the `keepTabService` to check on basis of other pages (e.g 'bim') instead of 'work-packages' only. Therefore pass the baseRoute as a parameter. This is needed to navigate back to the correct view after deleting a WP coming from the BIM page


https://community.openproject.com/projects/openproject/work_packages/33317/activity