### PR TITLE
Create separate service to get an active user from Omniauth

### DIFF
--- a/app/contracts/authentication/omniauth_auth_hash_contract.rb
+++ b/app/contracts/authentication/omniauth_auth_hash_contract.rb
@@ -1,0 +1,68 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Authentication
+  class OmniauthAuthHashContract
+    include ActiveModel::Validations
+
+    attr_reader :auth_hash
+
+    def initialize(auth_hash)
+      @auth_hash = auth_hash
+    end
+
+    validate :validate_auth_hash
+    validate :validate_auth_hash_not_expired
+    validate :validate_authorization_callback
+
+    private
+
+    def validate_auth_hash
+      return if auth_hash&.valid?
+
+      errors.add(:base, I18n.t(:error_omniauth_invalid_auth))
+    end
+
+    def validate_auth_hash_not_expired
+      return unless auth_hash['timestamp']
+
+      if auth_hash['timestamp'] < Time.now - 30.minutes
+        errors.add(:base, I18n.t(:error_omniauth_registration_timed_out))
+      end
+    end
+
+    def validate_authorization_callback
+      return unless auth_hash&.valid?
+
+      decision = OpenProject::OmniAuth::Authorization.authorized?(auth_hash)
+      errors.add(:base, decision.message) unless decision.approve?
+    end
+  end
+end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -420,7 +420,7 @@ class AccountController < ApplicationController
       # setting params back_url to be used by redirect_after_login
       params[:back_url] = session.delete :back_url if session.include?(:back_url)
 
-      if session[:just_registered]
+      if just_registered || session[:just_registered]
         finish_registration! user
       else
         login_user! user
@@ -463,10 +463,16 @@ class AccountController < ApplicationController
   def login_user_if_active(user, just_registered:)
     if user.active?
       successful_authentication(user, just_registered: just_registered)
-    else
-      account_inactive(user, flash_now: false)
-      redirect_to signin_path(back_url: params[:back_url])
+      return
     end
+
+    # Show an appropriate error unless
+    # the user was just registered
+    if !(just_registered && user.registered?)
+      account_inactive(user, flash_now: false)
+    end
+
+    redirect_to signin_path(back_url: params[:back_url])
   end
 
   def pending_auth_source_registration?

--- a/app/controllers/concerns/accounts/omniauth_login.rb
+++ b/app/controllers/concerns/accounts/omniauth_login.rb
@@ -85,7 +85,7 @@ module Accounts::OmniauthLogin
 
   def handle_omniauth_authentication(auth_hash, user_params: nil)
     call = ::Authentication::OmniauthService
-      .new(strategy: request.env['omniauth.strategy'], auth_hash: auth_hash, session: session)
+      .new(strategy: request.env['omniauth.strategy'], auth_hash: auth_hash, controller: self)
       .call(user_params)
 
     if call.success?

--- a/app/controllers/concerns/accounts/omniauth_login.rb
+++ b/app/controllers/concerns/accounts/omniauth_login.rb
@@ -89,6 +89,7 @@ module Accounts::OmniauthLogin
       .call(user_params)
 
     if call.success?
+      flash[:notice] = call.message.presence
       login_user_if_active(call.result)
     elsif call.includes_error?(:base, :failed_to_activate)
       redirect_omniauth_register_modal(call.result, auth_hash)

--- a/app/controllers/concerns/accounts/omniauth_login.rb
+++ b/app/controllers/concerns/accounts/omniauth_login.rb
@@ -90,7 +90,7 @@ module Accounts::OmniauthLogin
 
     if call.success?
       login_user_if_active(call.result)
-    elsif call.errors[:user].any?
+    elsif call.includes_error?(:base, :failed_to_activate)
       redirect_omniauth_register_modal(call.result, auth_hash)
     else
       error = call.message

--- a/app/controllers/concerns/accounts/omniauth_login.rb
+++ b/app/controllers/concerns/accounts/omniauth_login.rb
@@ -90,7 +90,7 @@ module Accounts::OmniauthLogin
 
     if call.success?
       flash[:notice] = call.message.presence
-      login_user_if_active(call.result, just_registered: true)
+      login_user_if_active(call.result, just_registered: call.result.just_created?)
     elsif call.includes_error?(:base, :failed_to_activate)
       redirect_omniauth_register_modal(call.result, auth_hash)
     else

--- a/app/controllers/concerns/accounts/omniauth_login.rb
+++ b/app/controllers/concerns/accounts/omniauth_login.rb
@@ -37,9 +37,9 @@ module Accounts::OmniauthLogin
     # disable CSRF protection since that should be covered by the omniauth strategy
     # the other filters are not applicable either since OmniAuth is doing authentication
     # itself
-    [
-      :verify_authenticity_token, :user_setup,
-      :check_if_login_required, :check_session_lifetime
+    %i[
+      verify_authenticity_token user_setup
+      check_if_login_required check_session_lifetime
     ]
       .each { |key| skip_before_action key, only: [:omniauth_login] }
 
@@ -47,52 +47,12 @@ module Accounts::OmniauthLogin
   end
 
   def omniauth_login
-    auth_hash = request.env['omniauth.auth']
-
-    Rails.logger.debug { "Returning from omniauth with hash #{auth_hash&.to_hash.inspect} Valid? #{auth_hash.valid?}" }
-    return render_400 unless auth_hash.valid?
-
     # Set back url to page the omniauth login link was clicked on
     params[:back_url] = request.env['omniauth.origin']
 
-    user_attributes = omniauth_hash_to_user_attributes(auth_hash)
-    user =
-      if session.include? :invitation_token
-        tok = Token::Invitation.find_by value: session[:invitation_token]
-        u = tok.user
-        u.identity_url = user_attributes[:identity_url]
-        tok.destroy
-        session.delete :invitation_token
-        u
-      else
-        find_or_initialize_user_with(user_attributes)
-      end
-
-    decision = OpenProject::OmniAuth::Authorization.authorized? auth_hash
-    if decision.approve?
-      authorization_successful user, auth_hash
-    else
-      authorization_failed user, decision.message
-    end
-  end
-
-  def find_or_initialize_user_with(user_attributes = {})
-    user = User.find_by(identity_url: user_attributes[:identity_url])
-    return user unless user.nil?
-
-    if Setting.oauth_allow_remapping_of_existing_users?
-      # Allow to map existing users with an Omniauth source if the login already exists
-      user = User.find_by(login: user_attributes[:login])
-    end
-
-    if user.nil?
-      User.new(identity_url: user_attributes[:identity_url])
-    else
-      # We might want to update all the attributes from the provider, but for
-      # backwards-compatibility only the identity_url is updated here
-      user.update_attribute :identity_url, user_attributes[:identity_url]
-      user
-    end
+    # Extract auth info and perform check / login or activate user
+    auth_hash = request.env['omniauth.auth']
+    handle_omniauth_authentication(auth_hash)
   end
 
   def omniauth_failure
@@ -106,21 +66,12 @@ module Accounts::OmniauthLogin
 
   private
 
-  def authorization_successful(user, auth_hash)
-    if user.new_record? || user.invited?
-      create_user_from_omniauth user, auth_hash
-    else
-      if user.active?
-        user.log_successful_login
-        OpenProject::OmniAuth::Authorization.after_login! user, auth_hash, self
-      end
-      login_user_if_active(user)
-    end
-  end
+  def redirect_omniauth_register_modal(user, auth_hash)
+    # Store a timestamp so we can later make sure that authentication information can
+    # only be reused for a short time.
+    session_info = auth_hash.merge(omniauth: true, timestamp: Time.new)
 
-  def authorization_failed(user, error)
-    logger.warn "Authorization for User #{user.id} failed: #{error}"
-    show_error error
+    onthefly_creation_failed(user, session_info)
   end
 
   def show_error(error)
@@ -128,100 +79,23 @@ module Accounts::OmniauthLogin
     redirect_to action: 'login'
   end
 
-  # a user may login via omniauth and (if that user does not exist
-  # in our database) will be created using this method.
-  def create_user_from_omniauth(user, auth_hash)
-    # Self-registration off
-    return self_registration_disabled unless Setting.self_registration? || user.invited?
-
-    fill_user_fields_from_omniauth user, auth_hash
-
-    opts = {
-      omni_auth_hash: auth_hash
-    }
-
-    # only enforce here so user has email filled in for the admin notification
-    # about who couldn't register/activate
-    return if enforce_activation_user_limit(user: user)
-
-    # Create on the fly
-    register_user_according_to_setting(user, opts) do
-      # Allow registration form to show provider-specific title
-      @omniauth_strategy = auth_hash[:provider]
-
-      # Store a timestamp so we can later make sure that authentication information can
-      # only be reused for a short time.
-      session_info = auth_hash.merge(omniauth: true, timestamp: Time.new)
-
-      onthefly_creation_failed(user, session_info)
-    end
+  def register_via_omniauth(session, user_attributes)
+    handle_omniauth_authentication(session[:auth_source_registration], user_params: user_attributes)
   end
 
-  def register_via_omniauth(user, session, permitted_params)
-    auth = session[:auth_source_registration]
-    return if handle_omniauth_registration_expired(auth)
+  def handle_omniauth_authentication(auth_hash, user_params: nil)
+    call = ::Authentication::OmniauthService
+      .new(strategy: request.env['omniauth.strategy'], auth_hash: auth_hash, session: session)
+      .call(user_params)
 
-    fill_user_fields_from_omniauth(user, auth)
-    user.update(permitted_params.user_register_via_omniauth)
-
-    opts = {
-      omni_auth_hash: auth
-    }
-    register_user_according_to_setting user, opts
-  end
-
-  def fill_user_fields_from_omniauth(user, auth)
-    user.assign_attributes omniauth_hash_to_user_attributes(auth)
-    user.register unless user.invited?
-    user
-  end
-
-  def omniauth_hash_to_user_attributes(auth)
-    info = auth[:info]
-
-    attribute_map = {
-      login:        info[:email],
-      mail:         info[:email],
-      firstname:    info[:first_name] || info[:name],
-      lastname:     info[:last_name],
-      identity_url: identity_url_from_omniauth(auth)
-    }
-
-    # Allow strategies to override mapping
-    strategy = request.env['omniauth.strategy']
-    if strategy.respond_to?(:omniauth_hash_to_user_attributes)
-      attribute_map.merge(strategy.omniauth_hash_to_user_attributes(auth))
+    if call.success?
+      login_user_if_active(call.result)
+    elsif call.errors[:user].any?
+      redirect_omniauth_register_modal(call.result, auth_hash)
     else
-      attribute_map
+      error = call.message
+      Rails.logger.error "Authorization request failed: #{error}"
+      show_error error
     end
-  end
-
-  ##
-  # Allow strategies to map a value for uid instead
-  # of always taking the global UID.
-  # For SAML, the global UID may change with every session
-  # (in case of transient nameIds)
-  def identity_url_from_omniauth(auth)
-    identifier = auth[:info][:uid] || auth[:uid]
-    "#{auth[:provider]}:#{identifier}"
-  end
-
-  # if the omni auth registration happened too long ago,
-  # we don't accept it anymore.
-  def handle_omniauth_registration_expired(auth)
-    if auth['timestamp'] < Time.now - 30.minutes
-      flash[:error] = I18n.t(:error_omniauth_registration_timed_out)
-      redirect_to(signin_url)
-    end
-  end
-
-  def self.url_with_params(url, params = {})
-    URI.parse(url).tap do |uri|
-      query = URI.decode_www_form(uri.query || '')
-      params.each do |key, value|
-        query << [key, value]
-      end
-      uri.query = URI.encode_www_form(query) unless query.empty?
-    end.to_s
   end
 end

--- a/app/controllers/concerns/accounts/omniauth_login.rb
+++ b/app/controllers/concerns/accounts/omniauth_login.rb
@@ -90,7 +90,7 @@ module Accounts::OmniauthLogin
 
     if call.success?
       flash[:notice] = call.message.presence
-      login_user_if_active(call.result)
+      login_user_if_active(call.result, just_registered: true)
     elsif call.includes_error?(:base, :failed_to_activate)
       redirect_omniauth_register_modal(call.result, auth_hash)
     else

--- a/app/controllers/concerns/accounts/user_limits.rb
+++ b/app/controllers/concerns/accounts/user_limits.rb
@@ -55,7 +55,7 @@ module Accounts::UserLimits
 
   def enforce_activation_user_limit(user: nil, redirect_to: signin_path)
     if user_limit_reached?
-      show_user_limit_activation_error!
+      flash[:error] = I18n.t(:error_enterprise_activation_user_limit)
       send_activation_limit_notification_about user if user
 
       redirect_back fallback_location: redirect_to

--- a/app/controllers/concerns/accounts/user_limits.rb
+++ b/app/controllers/concerns/accounts/user_limits.rb
@@ -78,10 +78,6 @@ module Accounts::UserLimits
     OpenProject::Enterprise.send_activation_limit_notification_about user
   end
 
-  def show_user_limit_activation_error!
-    flash[:error] = I18n.t(:error_enterprise_activation_user_limit)
-  end
-
   def show_user_limit_warning!(flash_now: false)
     f = flash_now ? flash.now : flash
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,6 +8,12 @@ class ApplicationRecord < ::ActiveRecord::Base
   end
 
   ##
+  # Determine whether this resource was just created ?
+  def just_created?
+    saved_change_to_attribute?(:id)
+  end
+
+  ##
   # Get the newest recently changed resource for the given record classes
   #
   # e.g., +most_recently_changed(WorkPackage, Type, Status)+

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -34,16 +34,18 @@ module Authentication
 
     attr_accessor :auth_hash,
                   :strategy,
-                  :session,
+                  :controller,
                   :contract,
                   :user_attributes,
                   :identity_url,
                   :user
 
-    def initialize(strategy:, auth_hash:, session:)
+    delegate :session, to: :controller
+
+    def initialize(strategy:, auth_hash:, controller:)
       self.strategy = strategy
       self.auth_hash = auth_hash
-      self.session = session
+      self.controller = controller
       self.contract = ::Authentication::OmniauthAuthHashContract.new(auth_hash)
     end
 

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -47,7 +47,7 @@ module Authentication
       self.contract = ::Authentication::OmniauthAuthHashContract.new(auth_hash)
     end
 
-    def call(additional_user_params)
+    def call(additional_user_params = nil)
       Rails.logger.debug { "Returning from omniauth with hash #{auth_hash&.to_hash.inspect} Valid? #{auth_hash&.valid?}" }
 
       unless contract.validate
@@ -183,7 +183,7 @@ module Authentication
         mail: info[:email],
         firstname: info[:first_name] || info[:name],
         lastname: info[:last_name],
-        identity_url: identity_url_from_omniauth(auth_hash)
+        identity_url: identity_url_from_omniauth
       }
 
       # Allow strategies to override mapping
@@ -204,9 +204,9 @@ module Authentication
     # of always taking the global UID.
     # For SAML, the global UID may change with every session
     # (in case of transient nameIds)
-    def identity_url_from_omniauth(auth)
-      identifier = auth[:info][:uid] || auth[:uid]
-      "#{auth[:provider]}:#{identifier}"
+    def identity_url_from_omniauth
+      identifier = auth_hash[:info][:uid] || auth_hash[:uid]
+      "#{auth_hash[:provider]}:#{identifier}"
     end
 
     ##

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -1,0 +1,215 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Authentication
+  class OmniauthService
+    include Contracted
+
+    attr_accessor :auth_hash,
+    :strategy,
+                  :session,
+                  :contract,
+                  :user_attributes,
+                  :identity_url,
+                  :user
+
+    def initialize(strategy:, auth_hash:, session:)
+      self.strategy = strategy
+      self.auth_hash = auth_hash
+      self.session = session
+      self.contract = ::Authentication::OmniauthAuthHashContract.new(auth_hash)
+    end
+
+    def call(additional_user_params)
+      Rails.logger.debug { "Returning from omniauth with hash #{auth_hash&.to_hash.inspect} Valid? #{auth_hash&.valid?}" }
+
+      unless contract.validate
+        result = ServiceResult.new(success: false, errors: contract.errors)
+        Rails.logger.warn { "Failed to process omniauth response for #{auth_uid}: #{result.message}" }
+
+        result
+      end
+
+      # Create or update the user from omniauth
+      update_user_from_omniauth!(additional_user_params || {})
+
+      # If we have a new or invited user, we still need to register them
+      activation_call = activate_user!
+
+      # The user should be logged in now
+      build_service_result activation_call
+    end
+
+    private
+
+    ##
+    # After login flow
+    def build_service_result(call)
+      return call unless call.success? && user.active?
+
+      user.log_successful_login
+      OpenProject::OmniAuth::Authorization.after_login! user, auth_hash, self
+      ServiceResult.new(success: true, result: user)
+    end
+
+    ##
+    # After validating the omniauth hash
+    # and the authorization is successful,
+    #
+    # login the user by locating or creating it
+    def update_user_from_omniauth!(additional_user_params)
+      # Find or create the user from the auth hash
+      self.user_attributes = build_omniauth_hash_to_user_attributes.merge(additional_user_params)
+      self.identity_url = user_attributes[:identity_url]
+      self.user = lookup_or_initialize_user
+
+      # Assign or update the user with the omniauth attributes
+      update_attributes
+    end
+
+    ##
+    # Try to find or create the user
+    # in the following order:
+    #
+    # 1. Look for an active invitation token
+    # 2. Look for an existing user for the current identity_url
+    # 3. Look for an existing user that we can remap (IF remapping is allowed)
+    # 4. Try to register a new user and activate according to settings
+    def lookup_or_initialize_user
+      find_invited_user ||
+        find_existing_user ||
+        remap_existing_user ||
+        initialize_new_user
+    end
+
+    ##
+    # Return an invited user, if there is a token
+    def find_invited_user
+      return unless session.include?(:invitation_token)
+
+      tok = Token::Invitation.find_by value: session[:invitation_token]
+      return unless tok
+
+      tok.user.tap do |user|
+        user.identity_url = user_attributes[:identity_url]
+        tok.destroy
+        session.delete :invitation_token
+      end
+    end
+
+    ##
+    # Find an existing user by the identity url
+    def find_existing_user
+      User.find_by(identity_url: identity_url)
+    end
+
+    ##
+    # Allow to map existing users with an Omniauth source if the login
+    # already exists, and no existing auth source or omniauth provider is
+    # linked
+    def remap_existing_user
+      return unless Setting.oauth_allow_remapping_of_existing_users?
+
+      User.find_by(login: user_attributes[:login])
+    end
+
+    ##
+    # Create the new user and try to activate it
+    # according to settings and system limits
+    def initialize_new_user
+      User.new(identity_url: user_attributes[:identity_url])
+    end
+
+    ##
+    # Update or assign the user attributes
+    def update_attributes
+      if user.new_record? || user.invited?
+        user.assign_attributes user_attributes
+        user.register unless user.invited?
+      else
+        # Update the user, but never change the admin flag
+        user.update user_attributes.except(:admin)
+      end
+    end
+
+    def activate_user!
+      if user.new_record? || user.invited?
+        ::Users::RegisterUserService
+          .new(user)
+          .call
+      else
+        ServiceResult.new(success: true)
+      end
+    end
+
+    ##
+    # Maps the omniauth attribute hash
+    # to our internal user attributes
+    def build_omniauth_hash_to_user_attributes
+      info = auth_hash[:info]
+
+      attribute_map = {
+        login: info[:email],
+        mail: info[:email],
+        firstname: info[:first_name] || info[:name],
+        lastname: info[:last_name],
+        identity_url: identity_url_from_omniauth(auth_hash)
+      }
+
+      # Allow strategies to override mapping
+      if strategy.respond_to?(:omniauth_hash_to_user_attributes)
+        attribute_map.merge!(strategy.omniauth_hash_to_user_attributes(auth_hash))
+      end
+
+      # Remove any nil values to avoid
+      # overriding existing attributes
+      attribute_map.compact!
+
+      Rails.logger.debug { "Mapped auth_hash user attributes #{attribute_map.inspect}" }
+      attribute_map
+    end
+
+    ##
+    # Allow strategies to map a value for uid instead
+    # of always taking the global UID.
+    # For SAML, the global UID may change with every session
+    # (in case of transient nameIds)
+    def identity_url_from_omniauth(auth)
+      identifier = auth[:info][:uid] || auth[:uid]
+      "#{auth[:provider]}:#{identifier}"
+    end
+
+    ##
+    # Try to provide some context of the auth_hash in case of errors
+    def auth_uid
+      auth_hash.try(:[], :uid) || 'unknown'
+    end
+  end
+end

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -167,7 +167,7 @@ module Authentication
           .new(user)
           .call
       else
-        ServiceResult.new(success: true)
+        ServiceResult.new(success: true, result: user)
       end
     end
 

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -66,19 +66,20 @@ module Authentication
       activation_call = activate_user!
 
       # The user should be logged in now
-      build_service_result activation_call
+      tap_service_result activation_call
     end
 
     private
 
     ##
     # After login flow
-    def build_service_result(call)
-      return call unless call.success? && user.active?
+    def tap_service_result(call)
+      if call.success? && user.active?
+        user.log_successful_login
+        OpenProject::OmniAuth::Authorization.after_login! user, auth_hash, self
+      end
 
-      user.log_successful_login
-      OpenProject::OmniAuth::Authorization.after_login! user, auth_hash, self
-      ServiceResult.new(success: true, result: user)
+      call
     end
 
     ##

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -54,7 +54,7 @@ module Authentication
         result = ServiceResult.new(success: false, errors: contract.errors)
         Rails.logger.warn { "Failed to process omniauth response for #{auth_uid}: #{result.message}" }
 
-        result
+        return result
       end
 
       # Create or update the user from omniauth

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -33,7 +33,7 @@ module Authentication
     include Contracted
 
     attr_accessor :auth_hash,
-    :strategy,
+                  :strategy,
                   :session,
                   :contract,
                   :user_attributes,
@@ -58,7 +58,9 @@ module Authentication
       end
 
       # Create or update the user from omniauth
-      update_user_from_omniauth!(additional_user_params || {})
+      # and assign non-nil parameters from the registration form - if any
+      assignable_params = (additional_user_params || {}).reject { |_, v| v.nil? }
+      update_user_from_omniauth!(assignable_params)
 
       # If we have a new or invited user, we still need to register them
       activation_call = activate_user!

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -77,7 +77,6 @@ module Authentication
     # After login flow
     def tap_service_result(call)
       if call.success? && user.active?
-        user.log_successful_login
         OpenProject::OmniAuth::Authorization.after_login! user, auth_hash, self
       end
 

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -213,7 +213,8 @@ module Authentication
     ##
     # Try to provide some context of the auth_hash in case of errors
     def auth_uid
-      auth_hash.try(:[], :uid) || 'unknown'
+      hash = (auth_hash || {})
+      hash.dig(:info, :uid) || hash.dig(:uid) || 'unknown'
     end
   end
 end

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -95,6 +95,15 @@ class ServiceResult
   end
 
   ##
+  # Test whether the returned errors respond
+  # to the search key
+  def includes_error?(attribute, error_key)
+    all_errors.any? do |error|
+      error.symbols_for(attribute).include?(error_key)
+    end
+  end
+
+  ##
   # Collect all present errors for the given result
   # and dependent results.
   #

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -52,6 +52,8 @@ module Users
 
       controller.session.merge!(retained_values) if retained_values
 
+      user.log_successful_login
+
       ServiceResult.new(result: user)
     end
 

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -36,9 +36,15 @@ module Users
     end
 
     def call(user)
+      # retain custom session values
       retained_values = retain_sso_session_values!(user)
 
+      # retain flash values
+      flash_values = controller.flash.to_h
+
       controller.reset_session
+
+      flash_values.each { |k, v| controller.flash[k] = v }
 
       User.current = user
 

--- a/app/services/users/register_user_service.rb
+++ b/app/services/users/register_user_service.rb
@@ -98,6 +98,8 @@ module Users
     def register_automatically
       return unless Setting::SelfRegistration.automatic?
 
+      user.activate
+
       with_saved_user_result do
         Rails.logger.info { "User #{user.login} was successfully activated." }
       end
@@ -132,7 +134,7 @@ module Users
       end
 
       ServiceResult.new(success: false, result: user).tap do |result|
-        result.errors.add(:user, :invalid)
+        result.errors.add(:base, :failed_to_activate)
       end
     end
   end

--- a/app/services/users/register_user_service.rb
+++ b/app/services/users/register_user_service.rb
@@ -38,6 +38,7 @@ module Users
     def call
       %i[
         register_invited_user
+        register_ldap_user
         ensure_registration_allowed!
         ensure_user_limit_not_reached!
         register_by_email_activation
@@ -78,6 +79,19 @@ module Users
     # bypassing regular restrictions
     def register_invited_user
       return unless user.invited?
+
+      user.activate
+
+      with_saved_user_result(success_message: I18n.t(:notice_account_registered_and_logged_in)) do
+        Rails.logger.info { "User #{user.login} was successfully activated after invitation." }
+      end
+    end
+
+    ##
+    # Try to register a user with an auth source connection
+    # bypassing regular restrictions
+    def register_ldap_user
+      return unless user.auth_source_id.present?
 
       user.activate
 

--- a/app/services/users/register_user_service.rb
+++ b/app/services/users/register_user_service.rb
@@ -1,0 +1,139 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Users
+  class RegisterUserService
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      %i[
+        register_invited_user
+        ensure_registration_allowed!
+        ensure_user_limit_not_reached!
+        register_by_email_activation
+        register_automatically
+        register_manually
+        fail_activation
+      ].each do |m|
+        result = send(m)
+        return result if result.is_a?(ServiceResult)
+      end
+    rescue StandardError => e
+      Rails.logger.error { "User #{user.login} failed to activate #{e}." }
+      ServiceResult.new(success: false, message: e.message)
+    end
+
+    private
+
+    ##
+    # Check whether the system allows registration
+    # for non-invited users
+    def ensure_registration_allowed!
+      if Setting::SelfRegistration.disabled?
+        raise I18n.t('account.error_self_registration_disabled')
+      end
+    end
+
+    ##
+    # Ensure the user limit is not reached
+    def ensure_user_limit_not_reached!
+      if OpenProject::Enterprise.user_limit_reached?
+        OpenProject::Enterprise.send_activation_limit_notification_about user
+        raise I18n.t(:error_enterprise_activation_user_limit)
+      end
+    end
+
+    ##
+    # Try to register an invited user
+    # bypassing regular restrictions
+    def register_invited_user
+      return unless user.invited?
+
+      register_automatically
+    end
+
+    def register_by_email_activation
+      return unless Setting::SelfRegistration.by_email?
+
+      with_saved_user_result(success_message: I18n.t(:notice_account_register_done)) do
+        token = Token::Invitation.create!(user: user)
+        UserMailer.user_signed_up(token).deliver_later
+        Rails.logger.info { "Scheduled email activation mail for #{user.login}" }
+      end
+    end
+
+    # Automatically register a user
+    #
+    # Pass a block for behavior when a user fails to save
+    def register_automatically
+      return unless Setting::SelfRegistration.automatic?
+
+      with_saved_user_result do
+        Rails.logger.info { "User #{user.login} was successfully activated." }
+      end
+    end
+
+    def register_manually
+      user.save!
+
+      # Sends an email to the administrators
+      admins = User.admin.active
+      admins.each do |admin|
+        UserMailer.account_activation_requested(admin, user).deliver_later
+      end
+
+      with_saved_user_result(success_message: I18n.t(:notice_account_pending)) do
+        Rails.logger.info { "User #{user.login} was successfully created and is pending admin activation." }
+      end
+    end
+
+    def fail_activation
+      Rails.logger.error { "User #{user.login} could not be activated, all options were exhausted." }
+      raise I18n.t(:notice_activation_failed)
+    end
+
+    ##
+    # Try to save result, return it in case of errors
+    # and add a user error to make sure we can render the account registration form
+    def with_saved_user_result(success_message: I18n.t(:notice_account_activated))
+      if user.save
+        yield if block_given?
+        return ServiceResult.new(success: true, result: user, message: success_message)
+      end
+
+      ServiceResult.new(success: false, result: user).tap do |result|
+        result.errors.add(:user, :invalid)
+      end
+    end
+  end
+end

--- a/app/services/users/register_user_service.rb
+++ b/app/services/users/register_user_service.rb
@@ -139,8 +139,10 @@ module Users
         return ServiceResult.new(success: true, result: user, message: success_message)
       end
 
-      ServiceResult.new(success: false, result: user).tap do |result|
-        result.errors.add(:base, :failed_to_activate)
+      ServiceResult.new(success: false).tap do |call|
+        # Avoid using the errors from the user
+        call.result = user
+        call.errors.add(:base, I18n.t(:notice_activation_failed), error_symbol: :failed_to_activate)
       end
     end
   end

--- a/app/services/users/register_user_service.rb
+++ b/app/services/users/register_user_service.rb
@@ -79,7 +79,11 @@ module Users
     def register_invited_user
       return unless user.invited?
 
-      register_automatically
+      user.activate
+
+      with_saved_user_result(success_message: I18n.t(:notice_account_registered_and_logged_in)) do
+        Rails.logger.info { "User #{user.login} was successfully activated after invitation." }
+      end
     end
 
     def register_by_email_activation

--- a/app/services/users/register_user_service.rb
+++ b/app/services/users/register_user_service.rb
@@ -156,7 +156,7 @@ module Users
       ServiceResult.new(success: false).tap do |call|
         # Avoid using the errors from the user
         call.result = user
-        call.errors.add(:base, I18n.t(:notice_activation_failed), error_symbol: :failed_to_activate)
+        call.errors.add(:base, I18n.t(:notice_activation_failed), error: :failed_to_activate)
       end
     end
   end

--- a/app/services/users/register_user_service.rb
+++ b/app/services/users/register_user_service.rb
@@ -37,10 +37,10 @@ module Users
 
     def call
       %i[
+        ensure_user_limit_not_reached!
         register_invited_user
         register_ldap_user
         ensure_registration_allowed!
-        ensure_user_limit_not_reached!
         register_by_email_activation
         register_automatically
         register_manually

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1141,6 +1141,7 @@ en:
   error_no_default_work_package_status: "No default work package status is defined. Please check your configuration (Go to \"Administration -> Work package statuses\")."
   error_no_type_in_project: "No type is associated to this project. Please check the Project settings."
   error_omniauth_registration_timed_out: "The registration via an external authentication provider timed out. Please try again."
+  error_omniauth_invalid_auth: "The authentication information returned from the identity provider was invalid. Please contact your adminstrator for further help."
   error_scm_command_failed: "An error occurred when trying to access the repository: %{value}"
   error_scm_not_found: "The entry or revision was not found in the repository."
   error_unable_delete_status: "The work package status cannot be deleted since it is used by at least one work package."

--- a/modules/auth_saml/lib/open_project/auth_saml/engine.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/engine.rb
@@ -75,7 +75,7 @@ module OpenProject
         strategy :saml do
           OpenProject::AuthSaml.configuration.values.map do |h|
             # Remember saml session values when logging in user
-            h[:retain_from_session] = %w[saml_uid saml_session_index]
+            h[:retain_from_session] = %w[saml_uid saml_session_index saml_transaction_id]
 
             h[:single_sign_out_callback] = Proc.new do |prev_session, _prev_user|
               next unless h[:idp_slo_target_url]

--- a/modules/auth_saml/lib/open_project/auth_saml/engine.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/engine.rb
@@ -57,20 +57,6 @@ module OpenProject
         auth_provider-saml.png
       )
 
-      config.after_initialize do
-        # Automatically update the openproject user whenever their info change in the upstream identity provider
-        OpenProject::OmniAuth::Authorization.after_login do |user, auth_hash, context|
-          # see https://github.com/opf/openproject/blob/caa07c5dd470f82e1a76d2bd72d3d55b9d2b0b83/app/controllers/concerns/omniauth_login.rb#L148
-          attributes = context.send(:omniauth_hash_to_user_attributes, auth_hash) || {}
-          attributes = attributes.with_indifferent_access
-
-          # Don't allow unsetting admin if user is already admin
-          attributes.delete(:admin) if user.admin?
-
-          user.update attributes
-        end
-      end
-
       register_auth_providers do
         strategy :saml do
           OpenProject::AuthSaml.configuration.values.map do |h|

--- a/modules/openid_connect/lib/open_project/openid_connect/engine.rb
+++ b/modules/openid_connect/lib/open_project/openid_connect/engine.rb
@@ -67,7 +67,8 @@ module OpenProject::OpenIDConnect
           access_token = auth_hash.fetch(:credentials, {})[:token]
           # put it into a cookie
           if context && access_token
-            context.send(:cookies)[:_open_project_session_access_token] = {
+            controller = context.controller
+            controller.send(:cookies)[:_open_project_session_access_token] = {
               value: access_token,
               secure: secure_cookie
             }

--- a/spec/contracts/authentication/omniauth_auth_hash_contract_spec.rb
+++ b/spec/contracts/authentication/omniauth_auth_hash_contract_spec.rb
@@ -1,0 +1,125 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Authentication::OmniauthAuthHashContract do
+  let(:auth_hash) do
+    OmniAuth::AuthHash.new(
+      provider: 'google',
+      uid: '123545',
+      info: { name: 'foo',
+              email: 'foo@bar.com',
+              first_name: 'foo',
+              last_name: 'bar'
+      }
+    )
+  end
+
+  let(:instance) { described_class.new(auth_hash) }
+
+  subject do
+    instance.validate
+    instance
+  end
+
+  shared_examples_for 'has error on' do |property, message|
+    it property do
+      expect(subject.errors[property]).to include message
+    end
+  end
+
+  shared_examples_for 'is valid' do
+    it 'is valid' do
+      expect(subject).to be_valid
+      expect(subject.errors).to be_empty
+    end
+  end
+
+  describe '#validate_auth_hash' do
+    context 'if valid' do
+      it_behaves_like 'is valid'
+    end
+
+    context 'if invalid' do
+      before do
+        allow(auth_hash).to receive(:valid?).and_return false
+      end
+
+      it_behaves_like 'has error on', :base, I18n.t(:error_omniauth_invalid_auth)
+    end
+  end
+
+  describe '#validate_auth_hash_not_expired' do
+    context 'hash contains valid timestamp' do
+      before do
+        auth_hash[:timestamp] = Time.now
+      end
+
+      it_behaves_like 'is valid'
+    end
+
+    context 'hash contains invalid timestamp' do
+      before do
+        auth_hash[:timestamp] = Time.now - 1.hour
+      end
+
+      it_behaves_like 'has error on', :base, I18n.t(:error_omniauth_registration_timed_out)
+    end
+
+    context 'hash contains no timestamp' do
+      it_behaves_like 'is valid'
+    end
+  end
+
+  describe '#validate_authorization_callback' do
+    let(:auth_double) { double('Authorization', approve?: authorized, message: message)}
+
+    before do
+      allow(OpenProject::OmniAuth::Authorization)
+        .to(receive(:authorized?))
+        .with(auth_hash)
+        .and_return(auth_double)
+    end
+
+    context 'if authorized' do
+      let(:authorized) { true }
+      let(:message) { nil }
+      it_behaves_like 'is valid'
+    end
+
+    context 'if invalid' do
+      let(:authorized) { false }
+      let(:message) { 'ERROR!' }
+
+      it_behaves_like 'has error on', :base, 'ERROR!'
+    end
+  end
+end

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -879,7 +879,7 @@ describe AccountController, type: :controller do
                    mail: 'foo@bar.com'
                  }
                }
-          expect(response).to redirect_to '/my/account'
+          expect(response).to redirect_to home_path(first_time_user: true)
 
           user = User.find_by_login('foo')
 

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -513,8 +513,9 @@ describe AccountController, type: :controller do
         post :omniauth_login, params: { provider: :google }
       end
 
-      it 'should respond with a 400' do
-        expect(response.code.to_i).to eql(400)
+      it 'should respond with an error' do
+        expect(flash[:error]).to include 'The authentication information returned from the identity provider was invalid.'
+        expect(response).to redirect_to signin_path
       end
 
       it 'should not sign in the user' do

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -243,7 +243,8 @@ describe AccountController, type: :controller do
         end
       end
 
-      context 'with self-registration disabled' do
+      context 'with self-registration disabled',
+              with_settings: { self_registration: 0 } do
         let(:omniauth_hash) do
           OmniAuth::AuthHash.new(
             provider: 'google',
@@ -257,8 +258,6 @@ describe AccountController, type: :controller do
         end
 
         before do
-          allow(Setting).to receive(:self_registration?).and_return(false)
-
           request.env['omniauth.auth'] = omniauth_hash
           request.env['omniauth.origin'] = 'https://example.net/some_back_url'
 

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -539,22 +539,4 @@ describe AccountController, type: :controller do
       end
     end
   end
-
-  describe '#identity_url_from_omniauth' do
-    let(:omniauth_hash) { { provider: 'developer', uid: 'veryuniqueid', info: {}  } }
-
-    it 'should return the correct identity_url' do
-      result = AccountController.new.send(:identity_url_from_omniauth, omniauth_hash)
-      expect(result).to eql('developer:veryuniqueid')
-    end
-
-    context 'with uid mapped from info' do
-      let(:omniauth_hash) { { provider: 'developer', uid: 'veryuniqueid', info: { uid: 'internal'} } }
-
-      it 'should return the correct identity_url' do
-        result = AccountController.new.send(:identity_url_from_omniauth, omniauth_hash)
-        expect(result).to eql('developer:internal')
-      end
-    end
-  end
 end

--- a/spec/controllers/concerns/omniauth_login_spec.rb
+++ b/spec/controllers/concerns/omniauth_login_spec.rb
@@ -34,7 +34,7 @@ describe AccountController, type: :controller do
     User.current = nil
   end
 
-  context 'GET #omniauth_login', with_settings: { self_registration: '3' } do
+  context 'GET #omniauth_login', with_settings: { self_registration: Setting::SelfRegistration.automatic} do
     describe 'with on-the-fly registration' do
       context 'providing all required fields' do
         let(:omniauth_hash) do
@@ -244,7 +244,7 @@ describe AccountController, type: :controller do
       end
 
       context 'with self-registration disabled',
-              with_settings: { self_registration: 0 } do
+              with_settings: { self_registration: Setting::SelfRegistration.disabled } do
         let(:omniauth_hash) do
           OmniAuth::AuthHash.new(
             provider: 'google',
@@ -442,7 +442,7 @@ describe AccountController, type: :controller do
       end
 
       context 'with a registered and not activated accout',
-              with_settings: { self_registration: '1' } do
+              with_settings: { self_registration: Setting::SelfRegistration.by_email } do
         before do
           user.register
           user.save!
@@ -460,7 +460,7 @@ describe AccountController, type: :controller do
       end
 
       context 'with an invited user and self registration disabled',
-              with_settings: { self_registration: '0' } do
+              with_settings: { self_registration: Setting::SelfRegistration.disabled } do
         before do
           user.invite
           user.save!

--- a/spec/features/auth/omniauth_spec.rb
+++ b/spec/features/auth/omniauth_spec.rb
@@ -63,7 +63,7 @@ describe 'Omniauth authentication', type: :feature do
   context 'sign in existing user' do
     it 'should redirect to back url' do
       visit account_lost_password_path
-      click_link("Omniauth Developer", :match => :first)
+      click_link("Omniauth Developer", match: :first, visible: :all)
       fill_in('first_name', with: user.firstname)
       fill_in('last_name', with: user.lastname)
       fill_in('email', with: user.mail)
@@ -138,6 +138,7 @@ describe 'Omniauth authentication', type: :feature do
       fill_in('email', with: user.mail)
       click_link_or_button 'Sign In'
 
+      expect(page).to have_content "Last name can't be blank"
       # on register form, we are prompted for a last name
       within('#content') do
         fill_in('user_lastname', with: user.lastname)

--- a/spec/features/auth/omniauth_spec.rb
+++ b/spec/features/auth/omniauth_spec.rb
@@ -184,11 +184,11 @@ describe 'Omniauth authentication', type: :feature do
         click_link_or_button 'Create'
       end
 
-      expect(current_url).to eql home_url(first_time_user: true)
+      expect(page).to have_current_path home_path(first_time_user: true)
     end
 
     context 'with password login disabled',
-            with_config: { disabled_password_login: 'true' } do
+            with_config: { disable_password_login: 'true' } do
 
       it_behaves_like 'omniauth user registration'
     end

--- a/spec/features/users/self_registration_spec.rb
+++ b/spec/features/users/self_registration_spec.rb
@@ -32,12 +32,8 @@ describe 'user self registration', type: :feature, js: true do
   let(:admin) { FactoryBot.create :admin, password: 'Test123Test123', password_confirmation: 'Test123Test123' }
   let(:home_page) { Pages::Home.new }
 
-  context 'with "manual account activation"' do
-    before do
-      allow(Setting)
-        .to receive(:self_registration?)
-        .and_return true
-    end
+  context 'with "manual account activation"',
+          with_settings: { self_registration: Setting::SelfRegistration.manual.to_s } do
 
     it 'allows self registration on login page (Regression #28076)' do
       visit signin_path

--- a/spec/services/authentication/omniauth_service_spec.rb
+++ b/spec/services/authentication/omniauth_service_spec.rb
@@ -1,0 +1,209 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+
+describe Authentication::OmniauthService do
+  let(:strategy) { double('Omniauth Strategy') }
+  let(:auth_hash) do
+    OmniAuth::AuthHash.new(
+      provider: 'google',
+      uid: '123545',
+      info: { name: 'foo',
+              email: 'foo@bar.com',
+              first_name: 'foo',
+              last_name: 'bar'
+      }
+    )
+  end
+  let(:session) { [] }
+
+  let(:instance) { described_class.new(strategy: strategy, auth_hash: auth_hash, session: session) }
+  let(:user_attributes) { instance.send :build_omniauth_hash_to_user_attributes }
+
+  describe '#contract' do
+    before do
+      allow(instance.contract)
+        .to(receive(:validate))
+        .and_return(valid)
+    end
+
+    context 'if valid' do
+      let(:valid) { true }
+
+      it 'it calls the registration service' do
+        expect(Users::RegisterUserService)
+          .to(receive(:new))
+          .with(kind_of(User))
+          .and_call_original
+
+        instance.call
+      end
+    end
+
+    context 'if invalid' do
+      let(:valid) { false }
+
+      it 'it does not call the registration service' do
+        expect(Users::RegisterUserService)
+          .not_to(receive(:new))
+
+        expect(instance.contract)
+          .to(receive(:errors))
+          .and_return(['foo'])
+
+        call = instance.call
+        expect(call).to be_failure
+        expect(call.errors).to eq ['foo']
+      end
+    end
+  end
+
+  describe 'activiation of users' do
+    let(:call) { instance.call }
+
+    context 'with an active found user' do
+      let(:user) { FactoryBot.build_stubbed :user }
+
+      before do
+        expect(instance).to receive(:find_existing_user).and_return(user)
+        expect(Users::RegisterUserService).not_to receive(:new)
+      end
+
+      it 'does not call register user service and logs in the user' do
+        # should update the user attributes
+        expect(user).to receive(:update).with(user_attributes)
+
+        # Logs user login and calls callback
+        expect(user).to receive(:log_successful_login)
+        expect(OpenProject::OmniAuth::Authorization)
+          .to(receive(:after_login!))
+          .with(user, auth_hash, instance)
+
+        expect(call).to be_success
+        expect(call.result).to eq user
+      end
+    end
+
+    context 'without remapping allowed',
+            with_settings: { oauth_allow_remapping_of_existing_users?: false } do
+
+      it 'does not look for the user by login' do
+        # Regular find
+        expect(User)
+          .to(receive(:find_by))
+          .with(identity_url: 'google:123545')
+          .and_return(nil)
+
+        # Remap find
+        expect(User)
+          .not_to(receive(:find_by))
+          .with(login: 'foo@bar.com')
+
+        call
+      end
+    end
+
+    context 'with an active user remapped',
+            with_settings: { oauth_allow_remapping_of_existing_users?: true } do
+      let(:user) { FactoryBot.build_stubbed :user, identity_url: 'foo' }
+
+      before do
+        # Regular find
+        expect(User)
+          .to(receive(:find_by))
+          .with(identity_url: 'google:123545')
+          .and_return(nil)
+
+        # Remap find
+        expect(User)
+          .to(receive(:find_by))
+          .with(login: 'foo@bar.com')
+          .and_return(user)
+
+        expect(Users::RegisterUserService).not_to receive(:new)
+      end
+
+      it 'does not call register user service and logs in the user' do
+        # should update the user attributes
+        expect(user).to receive(:update).with(user_attributes)
+
+        # Logs user login and calls callback
+        expect(user).to receive(:log_successful_login)
+        expect(OpenProject::OmniAuth::Authorization)
+          .to(receive(:after_login!))
+          .with(user, auth_hash, instance)
+
+        expect(call).to be_success
+        expect(call.result).to eq user
+      end
+    end
+
+    describe 'assuming registration/activation worked' do
+      let(:register_call) { ServiceResult.new(success: register_success, message: register_message) }
+      let(:register_success) { true }
+      let(:register_message) { 'It worked!' }
+
+      before do
+        expect(Users::RegisterUserService).to receive_message_chain(:new, :call).and_return(register_call)
+      end
+
+      describe 'with a new user' do
+        it 'calls the register service' do
+          expect(call).to be_success
+
+          # The user might get activated in the register service
+          expect(instance.user).not_to be_active
+          expect(instance.user).to be_new_record
+        end
+      end
+    end
+
+    describe 'assuming registration/activation failed' do
+      let(:register_success) { false }
+      let(:register_message) { 'Oh noes :(' }
+    end
+  end
+
+  describe '#identity_url_from_omniauth' do
+    let(:auth_hash) { { provider: 'developer', uid: 'veryuniqueid', info: {} } }
+    subject { instance.send(:identity_url_from_omniauth) }
+
+    it 'should return the correct identity_url' do
+      expect(subject).to eql('developer:veryuniqueid')
+    end
+
+    context 'with uid mapped from info' do
+      let(:auth_hash) { { provider: 'developer', uid: 'veryuniqueid', info: { uid: 'internal' } } }
+
+      it 'should return the correct identity_url' do
+        expect(subject).to eql('developer:internal')
+      end
+    end
+  end
+end

--- a/spec/services/authentication/omniauth_service_spec.rb
+++ b/spec/services/authentication/omniauth_service_spec.rb
@@ -41,9 +41,10 @@ describe Authentication::OmniauthService do
       }
     )
   end
-  let(:session) { [] }
+  let(:controller) { double('Controller', session: session_stub) }
+  let(:session_stub) { [] }
 
-  let(:instance) { described_class.new(strategy: strategy, auth_hash: auth_hash, session: session) }
+  let(:instance) { described_class.new(strategy: strategy, auth_hash: auth_hash, controller: controller) }
   let(:user_attributes) { instance.send :build_omniauth_hash_to_user_attributes }
 
   describe '#contract' do

--- a/spec/services/authentication/omniauth_service_spec.rb
+++ b/spec/services/authentication/omniauth_service_spec.rb
@@ -100,8 +100,6 @@ describe Authentication::OmniauthService do
         # should update the user attributes
         expect(user).to receive(:update).with(user_attributes)
 
-        # Logs user login and calls callback
-        expect(user).to receive(:log_successful_login)
         expect(OpenProject::OmniAuth::Authorization)
           .to(receive(:after_login!))
           .with(user, auth_hash, instance)
@@ -154,8 +152,6 @@ describe Authentication::OmniauthService do
         # should update the user attributes
         expect(user).to receive(:update).with(user_attributes)
 
-        # Logs user login and calls callback
-        expect(user).to receive(:log_successful_login)
         expect(OpenProject::OmniAuth::Authorization)
           .to(receive(:after_login!))
           .with(user, auth_hash, instance)

--- a/spec/services/users/login_service_spec.rb
+++ b/spec/services/users/login_service_spec.rb
@@ -65,6 +65,9 @@ describe ::Users::LoginService, type: :model do
           session.clear
           flash.clear
         end
+
+        allow(input_user)
+          .to receive(:log_successful_login)
       end
 
       context 'if provider retains session values' do

--- a/spec/services/users/login_service_spec.rb
+++ b/spec/services/users/login_service_spec.rb
@@ -32,6 +32,7 @@ describe ::Users::LoginService, type: :model do
   let(:input_user) { FactoryBot.build_stubbed(:user) }
   let(:controller) { double('ApplicationController') }
   let(:session) { {} }
+  let(:flash) { ActionDispatch::Flash::FlashHash.new() }
 
   let(:instance) { described_class.new(controller: controller) }
 
@@ -56,8 +57,13 @@ describe ::Users::LoginService, type: :model do
           .and_return session
 
         allow(controller)
+          .to(receive(:flash))
+          .and_return flash
+
+        allow(controller)
           .to(receive(:reset_session)) do
           session.clear
+          flash.clear
         end
       end
 
@@ -74,6 +80,14 @@ describe ::Users::LoginService, type: :model do
           expect(session[:what]).to eq nil
           expect(session[:user_id]).to eq input_user.id
         end
+      end
+
+      it 'retains present flash values' do
+        flash[:notice] = 'bar'
+
+        subject
+
+        expect(controller.flash[:notice]).to eq 'bar'
       end
     end
   end

--- a/spec/services/users/register_user_service_spec.rb
+++ b/spec/services/users/register_user_service_spec.rb
@@ -1,0 +1,250 @@
+#-- encoding: UTF-8
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+
+describe Users::RegisterUserService do
+  let(:user) { FactoryBot.build(:user) }
+  let(:instance) { described_class.new(user) }
+  let(:call) { instance.call }
+
+  def with_all_registration_options(except: [])
+    Setting::SelfRegistration.values.each do |name, value|
+      next if Array(except).include? name
+
+      allow(Setting).to receive(:self_registration).and_return(value)
+      yield name
+    end
+  end
+
+  describe '#register_invited_user' do
+    it 'tries to activate that user regardless of settings' do
+      with_all_registration_options do |_type|
+        user = User.new(status: Principal::STATUSES[:invited])
+        instance = described_class.new(user)
+
+        expect(user).to receive(:activate)
+        expect(user).to receive(:save).and_return true
+
+        call = instance.call
+        expect(call).to be_success
+        expect(call.result).to eq user
+        expect(call.message).to eq I18n.t(:notice_account_registered_and_logged_in)
+      end
+    end
+  end
+
+  describe '#ensure_registration_allowed!' do
+    it 'returns an error for disabled' do
+      allow(Setting).to receive(:self_registration).and_return(0)
+
+      user = User.new
+      instance = described_class.new(user)
+
+      expect(user).not_to receive(:activate)
+      expect(user).not_to receive(:save)
+
+      call = instance.call
+
+      expect(call.result).to eq user
+      expect(call.message).to eq I18n.t('account.error_self_registration_disabled')
+    end
+
+    it 'does not return an error for all cases except disabled' do
+      with_all_registration_options(except: :disabled) do |type|
+        user = User.new
+        instance = described_class.new(user)
+
+        # Assuming the next returns a result
+        expect(instance)
+          .to(receive(:ensure_user_limit_not_reached!))
+          .and_return(ServiceResult.new(success: false, result: user, message: 'test stop'))
+
+        expect(user).not_to receive(:activate)
+        expect(user).not_to receive(:save)
+
+        call = instance.call
+        expect(call.result).to eq user
+        expect(call.message).to eq 'test stop'
+      end
+    end
+  end
+
+  describe 'ensure_user_limit_not_reached!',
+           with_settings: { self_registration: 1 } do
+    before do
+      expect(OpenProject::Enterprise)
+        .to(receive(:user_limit_reached?))
+        .and_return(limit_reached)
+    end
+
+    context 'when limited' do
+      let(:limit_reached) { true }
+
+      it 'returns an error at that step' do
+        expect(call).to be_failure
+        expect(call.result).to eq user
+        expect(call.message).to eq I18n.t(:error_enterprise_activation_user_limit)
+      end
+    end
+
+    context 'when not limited' do
+      let(:limit_reached) { false }
+
+      it 'returns no error' do
+        # Assuming the next returns a result
+        expect(instance)
+          .to(receive(:register_by_email_activation))
+          .and_return(ServiceResult.new(success: false, result: user, message: 'test stop'))
+
+        call = instance.call
+        expect(call.result).to eq user
+        expect(call.message).to eq 'test stop'
+      end
+    end
+  end
+
+  describe '#register_by_email_activation' do
+    it 'activates the user with mail' do
+      allow(Setting).to receive(:self_registration).and_return(1)
+
+      user = User.new
+      instance = described_class.new(user)
+
+      expect(user).to receive(:register)
+      expect(user).to receive(:save).and_return true
+      expect(UserMailer).to receive_message_chain(:user_signed_up, :deliver_later)
+      expect(Token::Invitation).to receive(:create!).with(user: user)
+
+      call = instance.call
+
+      expect(call).to be_success
+      expect(call.result).to eq user
+      expect(call.message).to eq I18n.t(:notice_account_register_done)
+    end
+
+    it 'does not return an error for all cases except disabled' do
+      with_all_registration_options(except: %i[disabled activation_by_email]) do
+        user = User.new
+        instance = described_class.new(user)
+
+        # Assuming the next returns a result
+        expect(instance)
+          .to(receive(:register_automatically))
+          .and_return(ServiceResult.new(success: false, result: user, message: 'test stop'))
+
+        expect(user).not_to receive(:activate)
+        expect(user).not_to receive(:save)
+
+        call = instance.call
+        expect(call.result).to eq user
+        expect(call.message).to eq 'test stop'
+      end
+    end
+  end
+
+  describe '#register_automatically' do
+    it 'activates the user with mail' do
+      allow(Setting).to receive(:self_registration).and_return(3)
+
+      user = User.new
+      instance = described_class.new(user)
+
+      expect(user).to receive(:activate)
+      expect(user).to receive(:save).and_return true
+
+      call = instance.call
+
+      expect(call).to be_success
+      expect(call.result).to eq user
+      expect(call.message).to eq I18n.t(:notice_account_activated)
+    end
+
+    it 'does not return an error if manual' do
+      allow(Setting).to receive(:self_registration).and_return(2)
+
+      user = User.new
+      instance = described_class.new(user)
+
+      # Assuming the next returns a result
+      expect(instance)
+        .to(receive(:register_manually))
+        .and_return(ServiceResult.new(success: false, result: user, message: 'test stop'))
+
+      expect(user).not_to receive(:activate)
+      expect(user).not_to receive(:save)
+
+      call = instance.call
+      expect(call.result).to eq user
+      expect(call.message).to eq 'test stop'
+    end
+  end
+
+  describe '#register_manually' do
+    let(:admin_stub) { FactoryBot.build_stubbed :admin }
+
+    it 'activates the user with mail' do
+      allow(User).to receive_message_chain(:admin, :active).and_return([admin_stub])
+      allow(Setting).to receive(:self_registration).and_return(2)
+
+      user = User.new
+      instance = described_class.new(user)
+
+      expect(user).to receive(:register).and_call_original
+      expect(user).not_to receive(:activate)
+      expect(user).to receive(:save).and_return true
+
+      mail_stub = double('Mail', deliver_later: true)
+      expect(UserMailer)
+        .to(receive(:account_activation_requested))
+        .with(admin_stub, user)
+        .and_return(mail_stub)
+
+      call = instance.call
+
+      expect(call).to be_success
+      expect(call.result).to eq user
+      expect(user).to be_registered
+      expect(call.message).to eq I18n.t(:notice_account_pending)
+    end
+  end
+
+  describe 'error handling' do
+    it 'turns it into a service result' do
+      allow(instance).to receive(:ensure_registration_allowed!).and_raise 'FOO!'
+      expect(call).to be_failure
+
+      # Does not include the internal error message itself
+      expect(call.message).to eq I18n.t(:notice_activation_failed)
+    end
+  end
+
+  describe '#with_saved_user_result' do
+
+  end
+end

--- a/spec/services/users/register_user_service_spec.rb
+++ b/spec/services/users/register_user_service_spec.rb
@@ -59,6 +59,24 @@ describe Users::RegisterUserService do
     end
   end
 
+  describe '#register_ldap_user' do
+    it 'tries to activate that user regardless of settings' do
+      with_all_registration_options do |_type|
+        user = User.new(status: Principal::STATUSES[:registered])
+        instance = described_class.new(user)
+
+        allow(user).to receive(:auth_source_id).and_return 1234
+        expect(user).to receive(:activate)
+        expect(user).to receive(:save).and_return true
+
+        call = instance.call
+        expect(call).to be_success
+        expect(call.result).to eq user
+        expect(call.message).to eq I18n.t(:notice_account_registered_and_logged_in)
+      end
+    end
+  end
+
   describe '#ensure_registration_allowed!' do
     it 'returns an error for disabled' do
       allow(Setting).to receive(:self_registration).and_return(0)


### PR DESCRIPTION
Omniauth login flow is quite elaborate. It does:

- check whether the request is valid (perfect use case for contract)
- find or initialize a user from the auth hash
- try to register that user according to Setting.self_registration

This PR introduces two services to do these things

1. The omniauth request flow handler

2. A registration service to handle user activation/registration
according to setting
