### PR TITLE
[33460] Standalone icon for spentTimeDisplayField

### DIFF
--- a/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -79,7 +79,7 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
       const timelogElement = document.createElement('a');
       timelogElement.setAttribute('class', 'icon icon-time');
       timelogElement.setAttribute('href', '');
-      timelogElement.textContent = this.text.logTime;
+      timelogElement.setAttribute('title', this.text.logTime);
 
       element.appendChild(timelogElement);
 


### PR DESCRIPTION
Remove text next to icon in spentTimeDisplayField to avoid ugly long texts in the table.

https://community.openproject.com/projects/openproject/work_packages/33460/activity