### PR TITLE
[33311] Remove wrong usage of "box" class from HTML and CSS

### DIFF
--- a/app/assets/stylesheets/content/_boxes.sass
+++ b/app/assets/stylesheets/content/_boxes.sass
@@ -32,18 +32,6 @@
   line-height: 1.5em
   border: 1px solid #e4e4e4
 
-  li
-    &.filter label
-      clear: left
-      float: left
-      width: 170px
-    &.decorated
-      margin-left: 20px
-      list-style: disc outside none
-
 .box p
   padding-top: 5px
   padding-bottom: 8px
-
-#content .box h3
-  margin-top: 3px

--- a/app/assets/stylesheets/content/_forms.sass
+++ b/app/assets/stylesheets/content/_forms.sass
@@ -587,9 +587,6 @@ input[readonly].-clickable
   line-height: normal
   padding: rem-concat-list($select-element-padding)
 
-  &.parent-select
-    height: 100%
-
   &[multiple]
     background-image: none
     padding-right: $form-padding

--- a/app/views/categories/destroy.html.erb
+++ b/app/views/categories/destroy.html.erb
@@ -27,16 +27,27 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= toolbar title: "#{Category.model_name.human} #{@category.name}" %>
-<%= form_tag({}, {method: :delete}) do %>
-  <div class="box">
-    <p><strong><%= l(:text_work_package_category_destroy_question, @issue_count) %></strong></p>
-    <p><label><%= radio_button_tag 'todo', 'nullify', true %> <%= l(:text_work_package_category_destroy_assignments) %></label>
-      <% if @categories.size > 0 %>
-        <label><%= radio_button_tag 'todo', 'reassign', false %> <%= l(:text_work_package_category_reassign_to) %></label>
-        <%= label_tag "reassign_to_id", l(:description_work_package_category_reassign), class: "hidden-for-sighted" %>
-        <%= select_tag 'reassign_to_id', options_from_collection_for_select(@categories, 'id', 'name') %></p>
-    <% end %>
+<%= form_tag({}, {method: :delete, class: 'form'}) do %>
+  <p><strong><%= l(:text_work_package_category_destroy_question, @issue_count) %></strong></p>
+
+  <div class="form--field">
+    <label class="form--label" for="todo_nullify"><%= t(:text_work_package_category_destroy_assignments) %></label>
+    <div class="form--field-container">
+      <%= styled_radio_button_tag 'todo', 'nullify', true %>
+    </div>
   </div>
+
+  <% if @categories.size > 0 %>
+    <div class="form--field">
+      <label class="form--label" for="todo_reassign"><%= t(:text_work_package_category_reassign_to) %></label>
+      <div class="form--field-container">
+        <%= styled_radio_button_tag 'todo', 'reassign', false %>
+      </div>
+      <%= label_tag "reassign_to_id", l(:description_work_package_category_reassign), class: "hidden-for-sighted" %>
+      <%= styled_select_tag 'reassign_to_id', options_from_collection_for_select(@categories, 'id', 'name'), container_class: '-middle' %>
+    </div>
+  <% end %>
+
   <%= submit_tag l(:button_apply), class: 'button -highlight' %>
   <%= link_to l(:button_cancel), { controller: '/project_settings/categories', action: 'show', id: @project },
       class: 'button' %>

--- a/app/views/wiki/_page_form.html.erb
+++ b/app/views/wiki/_page_form.html.erb
@@ -27,8 +27,7 @@
     <%= page_fields.hidden_field :parent_id %>
     <%= page_fields.select :parent_id,
                            wiki_page_options_for_select(@wiki.pages),
-                           { label: WikiPage.human_attribute_name(:parent_title), include_blank: false },
-                           { class: "parent-select form--select" } %>
+                           { label: WikiPage.human_attribute_name(:parent_title), include_blank: false, container_class: '-wide' } %>
   <% end%>
 </div>
 

--- a/app/views/wiki/destroy.html.erb
+++ b/app/views/wiki/destroy.html.erb
@@ -28,21 +28,37 @@ See docs/COPYRIGHT.rdoc for more details.
 ++#%>
 <%= toolbar title: @page.title %>
 <% html_title t(:button_delete), @page.title %>
-<%= form_tag({}, method: :delete) do %>
-  <div class="box">
-    <p><strong><%= t(:text_wiki_page_destroy_question, descendants: @descendants_count) %></strong></p>
-    <p><label><%= radio_button_tag 'todo', 'nullify', true %> <%= t(:text_wiki_page_nullify_children) %></label><br />
-      <label><%= radio_button_tag 'todo', 'destroy', false %> <%= t(:text_wiki_page_destroy_children) %></label>
-      <% if @reassignable_to.any? %>
-        <br />
-        <label><%= radio_button_tag 'todo', 'reassign', false %> <%= t(:text_wiki_page_reassign_children) %></label>
-        <%= label_tag "reassign_to_id", t(:description_wiki_subpages_reassign), class: "hidden-for-sighted" %>
-        <%= select_tag 'reassign_to_id',
-                       options_for_select(wiki_page_options_for_select(@reassignable_to)) %>
-        <% csp_onclick("jQuery('#todo_reassign').attr('checked', true)", '#reassign_to_id') %>
-      <% end %>
-    </p>
+<%= form_tag({}, method: :delete, class: 'form') do %>
+  <p><strong><%= t(:text_wiki_page_destroy_question, descendants: @descendants_count) %></strong></p>
+
+  <div class="form--field">
+    <label class="form--label" for="todo_nullify"><%= t(:text_wiki_page_nullify_children) %></label>
+    <div class="form--field-container">
+      <%= styled_radio_button_tag 'todo', 'nullify', true %>
+    </div>
   </div>
+  <div class="form--field">
+    <label class="form--label" for="todo_destroy"><%= t(:text_wiki_page_destroy_children) %></label>
+    <div class="form--field-container">
+      <%= styled_radio_button_tag 'todo', 'destroy', false %>
+    </div>
+  </div>
+
+  <% if @reassignable_to.any? %>
+    <div class="form--field">
+      <label class="form--label" for="todo_reassign"><%= t(:text_wiki_page_reassign_children) %></label>
+      <div class="form--field-container">
+        <%= styled_radio_button_tag 'todo', 'reassign', false %>
+      </div>
+
+      <%= label_tag "reassign_to_id", t(:description_wiki_subpages_reassign), class: "hidden-for-sighted" %>
+      <%= styled_select_tag 'reassign_to_id',
+                     options_for_select(wiki_page_options_for_select(@reassignable_to)),
+                     { container_class: '-wide'} %>
+      <% csp_onclick("jQuery('#todo_reassign').attr('checked', true)", '#reassign_to_id') %>
+    </div>
+  <% end %>
+
   <%= submit_tag t(:button_apply), class: 'button -highlight' %>
   <%= link_to t(:button_cancel),
       { controller: '/wiki', action: 'show', project_id: @project, id: @page },

--- a/app/views/wiki/edit_parent_page.html.erb
+++ b/app/views/wiki/edit_parent_page.html.erb
@@ -34,21 +34,18 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= error_messages_for 'page' %>
 
 <%= labelled_tabular_form_for @page, url: { id: @page, action: 'update_parent_page' } do |f| %>
-  <div class="box">
-    <p>
-      <%= f.select :parent_id,
-            wiki_page_options_for_select(@parent_pages),
-            { label: WikiPage.human_attribute_name(:parent_title), include_blank: false },
-            { class: "parent-select" } %>
-    </p>
-
-    <%= nonced_javascript_tag  do -%>
-      jQuery(function() {
-          var parent_select = jQuery('#wiki_page_parent_id');
-          parent_select.attr('size', parent_select.children().length);
-        }
-      ));
-    <% end -%>
+  <div class='form--field'>
+    <%= f.select :parent_id,
+                 wiki_page_options_for_select(@parent_pages),
+                 { label: WikiPage.human_attribute_name(:parent_title), include_blank: false, container_class: '-wide' } %>
   </div>
+
+  <%= nonced_javascript_tag  do -%>
+    jQuery(function() {
+        var parent_select = jQuery('#wiki_page_parent_id');
+        parent_select.attr('size', parent_select.children().length);
+      }
+    ));
+  <% end -%>
   <%= submit_tag t(:button_save), class: 'button -highlight' %>
 <% end %>

--- a/app/views/wiki/rename.html.erb
+++ b/app/views/wiki/rename.html.erb
@@ -33,13 +33,11 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= error_messages_for 'page' %>
 
 <%= labelled_tabular_form_for @page, url: { id: @page, action: 'rename' }, as: :page do |f| %>
-  <div class="box">
-    <div class='form--field -required'>
-      <%= f.text_field :title, required: true %>
-    </div>
-    <div class='form--field'>
-      <%= f.check_box :redirect_existing_links %>
-    </div>
+  <div class='form--field -required'>
+    <%= f.text_field :title, required: true, container_class: '-middle' %>
+  </div>
+  <div class='form--field'>
+    <%= f.check_box :redirect_existing_links %>
   </div>
   <%= submit_tag t(:button_rename), class: 'button -highlight' %>
 <% end %>

--- a/modules/costs/app/views/costlog/edit.html.erb
+++ b/modules/costs/app/views/costlog/edit.html.erb
@@ -47,91 +47,89 @@ See docs/COPYRIGHT.rdoc for more details.
     <%= back_url_hidden_field_tag %>
     <%= f.hidden_field :element_id, value: 'cost_entry', class: 'remote-field--input', data: { :'remote-field-key' =>'element_id' } %>
 
-    <div class="box">
-      <div class="form--field -required">
-        <%= f.text_field :work_package_id,
+    <div class="form--field -required">
+      <%= f.text_field :work_package_id,
+                       size: 6,
+                       required: true,
+                       autofocus: true,
+                       container_class: '-xslim' %>
+
+      <% if @cost_entry.work_package %>
+        <div class="form--field-instructions">
+          <%= h("#{@cost_entry.work_package.to_s}") %>
+        </div>
+      <% end %>
+    </div>
+    <div class="form--field -required">
+      <%= f.text_field :spent_on,
+                       size: 10,
+                       required: true,
+                       class: 'remote-field--input -augmented-datepicker',
+                       data: { :'remote-field-key' =>'fixed_date' },
+                       container_class: '-xslim' %>
+      <label for="cost_entry_spent_on" class="hidden-for-sighted"><%= l(:label_date) %> <%=l(:text_hint_date_format) %></label>
+    </div>
+    <% if User.current.allowed_to? :log_costs, @project %>
+      <div class="form--field">
+      <%# Without knowing why `prompt` is in this case responsible for no blank line in the selection options %>
+        <%= f.select :user_id,
+                     user_collection_for_select_options,
+                     required: true,
+                     prompt: true,
+                     container_class: '-middle' %>
+      </div>
+    <% else %>
+      <%= f.hidden_field :user_id, value: User.current.id %>
+    <% end %>
+    <div class="form--field -required">
+      <%# see above %>
+      <%= f.select :cost_type_id,
+                   cost_types_collection_for_select_options,
+                   { prompt: true,
+                     container_class: '-middle' },
+                   {
+                     required: true,
+                     class: 'remote-field--input',
+                     data: { :'remote-field-key' => 'cost_type_id' }
+                   } %></p>
+    </div>
+    <div class="form--field -required">
+      <% if @cost_entry.cost_type.nil? %>
+          <%= f.text_field :units, size: 6, required: true, container_class: '-slim' %>
+      <% else %>
+        <% suffix = @cost_entry.units == 1 ? @cost_entry.cost_type.unit : @cost_entry.cost_type.unit_plural %>
+        <%= f.text_field :units,
                          size: 6,
                          required: true,
-                         autofocus: true,
-                         container_class: '-xslim' %>
-
-        <% if @cost_entry.work_package %>
-          <div class="form--field-instructions">
-            <%= h("#{@cost_entry.work_package.to_s}") %>
-          </div>
-        <% end %>
-      </div>
-      <div class="form--field -required">
-        <%= f.text_field :spent_on,
-                         size: 10,
-                         required: true,
-                         class: 'remote-field--input -augmented-datepicker',
-                         data: { :'remote-field-key' =>'fixed_date' },
-                         container_class: '-xslim' %>
-        <label for="cost_entry_spent_on" class="hidden-for-sighted"><%= l(:label_date) %> <%=l(:text_hint_date_format) %></label>
-      </div>
-      <% if User.current.allowed_to? :log_costs, @project %>
-        <div class="form--field">
-        <%# Without knowing why `prompt` is in this case responsible for no blank line in the selection options %>
-          <%= f.select :user_id,
-                       user_collection_for_select_options,
-                       required: true,
-                       prompt: true,
-                       container_class: '-middle' %>
-        </div>
-      <% else %>
-        <%= f.hidden_field :user_id, value: User.current.id %>
+                         suffix: h(suffix),
+                         suffix_id: 'cost_entry_unit_name',
+                         class: 'remote-field--input',
+                         data: { :'remote-field-key' => 'units' },
+                         container_class: '-slim' %>
       <% end %>
-      <div class="form--field -required">
-        <%# see above %>
-        <%= f.select :cost_type_id,
-                     cost_types_collection_for_select_options,
-                     { prompt: true,
-                       container_class: '-middle' },
-                     {
-                       required: true,
-                       class: 'remote-field--input',
-                       data: { :'remote-field-key' => 'cost_type_id' }
-                     } %></p>
-      </div>
-      <div class="form--field -required">
-        <% if @cost_entry.cost_type.nil? %>
-            <%= f.text_field :units, size: 6, required: true, container_class: '-slim' %>
-        <% else %>
-          <% suffix = @cost_entry.units == 1 ? @cost_entry.cost_type.unit : @cost_entry.cost_type.unit_plural %>
-          <%= f.text_field :units,
-                           size: 6,
-                           required: true,
-                           suffix: h(suffix),
-                           suffix_id: 'cost_entry_unit_name',
-                           class: 'remote-field--input',
-                           data: { :'remote-field-key' => 'units' },
-                           container_class: '-slim' %>
-        <% end %>
-      </div>
+    </div>
 
-      <div class="form--field">
-        <label for="cost_entry_costs_edit" class="form--label"><%= CostEntry.human_attribute_name(:costs) %></label>
-        <span class="form--field-container">
-                <cost-unit-subform obj-id="cost_entry"
-                                   obj-name="cost_entry[overridden_costs]" %>
-            <% if User.current.allowed_to? :view_cost_rates, @cost_entry.project %>
-              <a href="#" id="cost_entry_costs" class="costs--edit-planned-costs-btn icon-context icon-edit" title="<%= t(:help_click_to_edit) %>">
-                <%= number_to_currency(@cost_entry.real_costs) %>
-              </a>
-            <% else %>
-              <span id="cost_entry_costs_editor" class="form--text-field-container">
-                <input class="currency form--text-field" value="<%= number_to_currency(@cost_entry.overridden_costs, unit: "").strip if @cost_entry.overridden_costs %>" size="7" name="cost_entry[overridden_costs]" id="cost_entry_costs_edit"/> <%= Setting.plugin_openproject_costs['costs_currency'] %>
-              </span>
-              <br /><em><%= t(:help_override_rate) %></em>
-            <% end %>
-          </cost-unit-subform>
-        </span>
-      </div>
+    <div class="form--field">
+      <label for="cost_entry_costs_edit" class="form--label"><%= CostEntry.human_attribute_name(:costs) %></label>
+      <span class="form--field-container">
+              <cost-unit-subform obj-id="cost_entry"
+                                 obj-name="cost_entry[overridden_costs]" %>
+          <% if User.current.allowed_to? :view_cost_rates, @cost_entry.project %>
+            <a href="#" id="cost_entry_costs" class="costs--edit-planned-costs-btn icon-context icon-edit" title="<%= t(:help_click_to_edit) %>">
+              <%= number_to_currency(@cost_entry.real_costs) %>
+            </a>
+          <% else %>
+            <span id="cost_entry_costs_editor" class="form--text-field-container">
+              <input class="currency form--text-field" value="<%= number_to_currency(@cost_entry.overridden_costs, unit: "").strip if @cost_entry.overridden_costs %>" size="7" name="cost_entry[overridden_costs]" id="cost_entry_costs_edit"/> <%= Setting.plugin_openproject_costs['costs_currency'] %>
+            </span>
+            <br /><em><%= t(:help_override_rate) %></em>
+          <% end %>
+        </cost-unit-subform>
+      </span>
+    </div>
 
-      <div class="form--field">
-        <%= f.text_field :comments, size: 100, container_class: '-wide' %>
-      </div>
+    <div class="form--field">
+      <%= f.text_field :comments, size: 100, container_class: '-wide' %>
     </div>
 
     <%= styled_button_tag t(:button_save), class: '-with-icon icon-checkmark' %>


### PR DESCRIPTION
Remove wrong/outdated usage of `box` class. Instead use the `form` classes and adapt HTML structure to match the LSG. The only place left where a box is now used is the meetings page.


### Before
<img width="1767" alt="Bildschirmfoto 2020-06-16 um 17 20 56" src="https://user-images.githubusercontent.com/7457313/84793733-bfec3c80-aff5-11ea-8659-6ca39bdf48bb.png">


### After
<img width="1008" alt="Bildschirmfoto 2020-06-16 um 17 20 30" src="https://user-images.githubusercontent.com/7457313/84793670-b1058a00-aff5-11ea-9d0b-5ed9bff5fc8a.png">


https://community.openproject.com/projects/openproject/work_packages/33311/activity