### PR TITLE
[33446] Closing icon overlaps modal header when the content is small

### DIFF
--- a/app/assets/stylesheets/content/_modal.lsg
+++ b/app/assets/stylesheets/content/_modal.lsg
@@ -3,18 +3,14 @@
 ## Modals: Standard style
 
 ```
-<div class="modal-container">
+<div class="op-modal--modal-container">
   <div class="op-modal--modal-header">
+    <h3>Export</h3>
     <a class="op-modal--modal-close-button">
       <i class="icon-close" title="Close popup"></i>
     </a>
   </div>
-  <div class="modal-content">
-    <h3>Modal Headline</h3>
-    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper
-  </div>
-</div><br /><br />
-<h3>Export</h3>
+  <div class="op-modal--modal-body">
     <ul class="export-options">
       <li>
         <a>
@@ -24,13 +20,13 @@
       </li>
        <li>
         <a>
-          <i class="icon-export-vnd-ms-excel icon-big"></i>
+          <i class="icon-export-xls icon-big"></i>
           <span class="export-label">XLS</span>
         </a>
       </li>
        <li>
         <a>
-          <i class="icon-export-vnd-ms-excel-descr icon-big"></i>
+          <i class="icon-export-export-xls-with-descriptions icon-big"></i>
           <span class="export-label">XLS with description</span>
         </a>
       </li>
@@ -53,6 +49,9 @@
         </a>
       </li>
     </ul>
+  </div>
+</div>
+
 ```
 
 ## Modals: Highlighted and with footer

--- a/app/assets/stylesheets/content/_modal.sass
+++ b/app/assets/stylesheets/content/_modal.sass
@@ -58,7 +58,7 @@ $modal-footer-height: $modal-header-height
   transition: opacity 0.25s ease
   background: $ng-modal-background
   position: relative
-  padding: $ng-modal-padding / 2
+  padding: 5px $ng-modal-padding / 2
   min-width: 200px
   max-width: 60vw
   overflow-y: auto
@@ -74,7 +74,21 @@ $modal-footer-height: $modal-header-height
     min-height: 20vh
 
 .op-modal--modal-header
-  padding: 0
+  display: flex
+  align-items: center
+  height: $modal-header-height
+  padding: 0 45px 0 0
+  margin-bottom: 15px
+  border-bottom: 1px solid $light-gray
+
+  *
+    height: $modal-header-height
+    line-height: $modal-header-height
+
+  h2, h3
+    border: none
+    @include text-shortener
+    margin: 0
 
 .op-modal--modal-body
   margin: 1em 0
@@ -95,8 +109,8 @@ $modal-footer-height: $modal-header-height
 
 .op-modal--modal-close-button
   position: absolute
-  top: 0.75rem
-  right: 0.75rem
+  right: 25px
+  top: 4px
   cursor: pointer
   @include varprop(color, body-font-color)
   &:hover
@@ -109,32 +123,19 @@ $modal-footer-height: $modal-header-height
 
   // Overridden header styles
   .op-modal--modal-header
-    display: flex
-    align-items: center
-    height: $modal-header-height
-    padding: 0 45px 0 1.5rem
-    border-bottom-style: solid
+    padding-left: 1.5rem
     @include varprop(background-color, header-bg-color)
     @include varprop(border-bottom-width, header-border-bottom-width)
     @include varprop(border-bottom-color, header-border-bottom-color)
 
     *
       @include varprop(color, header-item-font-color)
-      height: $modal-header-height
-      line-height: $modal-header-height
-
-    h2, h3
-      @include text-shortener
-      margin: 0
-      border: none
 
   .op-modal--modal-footer
     margin: 1em 0
 
   .op-modal--modal-close-button
-    right: 10px
     top: 0
-    @include varprop(line-height, modal-header-height)
     @include varprop(color, header-item-font-color)
 
   .avatar

--- a/app/views/wiki/_wiki_export_modal.html.erb
+++ b/app/views/wiki/_wiki_export_modal.html.erb
@@ -29,14 +29,14 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <div class="modal-wrapper--content">
   <div class="onboarding--top-menu op-modal--modal-header">
+    <h3><%= I18n.t('js.label_export') %></h3>
+
     <a class="op-modal--modal-close-button dynamic-content-modal--close-button"
        title="<%= t('js.close_popup_title') %>"
        aria-label="<%= t('js.close_popup_title') %>">
       <%= op_icon('icon-close') %>
     </a>
   </div>
-
-  <h3><%= I18n.t('js.label_export') %></h3>
 
   <div class="op-modal--modal-body">
     <ul class="export-options">

--- a/frontend/src/app/components/modals/export-modal/wp-table-export.modal.html
+++ b/frontend/src/app/components/modals/export-modal/wp-table-export.modal.html
@@ -2,6 +2,8 @@
   <div class="op-modal--modal-container wp-table--configuration-modal"
        tabindex="0">
     <div class="op-modal--modal-header">
+      <h3 [textContent]="text.title"></h3>
+
       <a class="op-modal--modal-close-button">
         <i
             class="icon-close"
@@ -10,8 +12,6 @@
         </i>
       </a>
     </div>
-
-    <h3 [textContent]="text.title"></h3>
 
     <ul *ngIf="exportOptions" class="export-options" [ngClass]="{'-hidden': isLoading}">
       <li *ngFor="let option of exportOptions">

--- a/frontend/src/app/components/modals/save-modal/save-query.modal.html
+++ b/frontend/src/app/components/modals/save-modal/save-query.modal.html
@@ -3,6 +3,8 @@
        data-indicator-name="modal"
        tabindex="0">
     <div class="op-modal--modal-header">
+      <h3 [textContent]="text.save_as"></h3>
+
       <a class="op-modal--modal-close-button">
         <i
             class="icon-close"
@@ -11,8 +13,6 @@
         </i>
       </a>
     </div>
-
-    <h3 [textContent]="text.save_as"></h3>
 
     <form name="modalSaveForm" class="form">
       <div class="form--field -required">

--- a/frontend/src/app/components/modals/share-modal/query-sharing.modal.html
+++ b/frontend/src/app/components/modals/share-modal/query-sharing.modal.html
@@ -3,6 +3,8 @@
        data-indicator-name="modal"
        tabindex="0">
     <div class="op-modal--modal-header">
+      <h3 [textContent]="text.label_visibility_settings"></h3>
+
       <a class="op-modal--modal-close-button">
         <i
             class="icon-close"
@@ -11,8 +13,6 @@
         </i>
       </a>
     </div>
-
-    <h3 [textContent]="text.label_visibility_settings"></h3>
 
     <query-sharing-form
         [isSave]="false"

--- a/frontend/src/app/components/wp-table/configuration-modal/wp-table-configuration.modal.html
+++ b/frontend/src/app/components/wp-table/configuration-modal/wp-table-configuration.modal.html
@@ -3,6 +3,8 @@
        data-indicator-name="modal"
        tabindex="0">
     <div class="op-modal--modal-header">
+      <h3 [textContent]="text.title"></h3>
+
       <a class="op-modal--modal-close-button">
         <i
             class="icon-close"
@@ -11,8 +13,6 @@
         </i>
       </a>
     </div>
-
-    <h3 [textContent]="text.title"></h3>
 
     <ng-container *ngIf="!!prependModalComponent">
       <ng-container *ngComponentOutlet="prependModalComponent; injector: injector"></ng-container>

--- a/frontend/src/app/modules/boards/board/board-video-teaser-modal/board-video-teaser-modal.component.ts
+++ b/frontend/src/app/modules/boards/board/board-video-teaser-modal/board-video-teaser-modal.component.ts
@@ -14,6 +14,8 @@ import {DomSanitizer} from "@angular/platform-browser";
            data-indicator-name="modal"
            tabindex="0">
         <div class="op-modal--modal-header">
+          <h3 [textContent]="text.title"></h3>
+          
           <a class="op-modal--modal-close-button">
             <i
               class="icon-close"
@@ -22,8 +24,6 @@ import {DomSanitizer} from "@angular/platform-browser";
             </i>
           </a>
         </div>
-
-        <h3 [textContent]="text.title"></h3>
 
         <iframe [src]="teaserVideoUrl"
                 width="800"

--- a/frontend/src/app/modules/boards/board/configuration-modal/board-configuration.modal.html
+++ b/frontend/src/app/modules/boards/board/configuration-modal/board-configuration.modal.html
@@ -3,6 +3,8 @@
        data-indicator-name="modal"
        tabindex="0">
     <div class="op-modal--modal-header">
+      <h3 [textContent]="text.title"></h3>
+
       <a class="op-modal--modal-close-button">
         <i
             class="icon-close"
@@ -11,8 +13,6 @@
         </i>
       </a>
     </div>
-
-    <h3 [textContent]="text.title"></h3>
 
     <div *ngIf="!!tabPortalHost"
          class="content--tabs scrollable-tabs">

--- a/frontend/src/app/modules/common/help-texts/help-text.modal.html
+++ b/frontend/src/app/modules/common/help-texts/help-text.modal.html
@@ -2,6 +2,11 @@
      data-indicator-name="modal">
   <div class="op-modal--modal-container attribute-help-text--modal" tabindex="0">
     <div class="op-modal--modal-header">
+      <h3>
+        <span class="icon-context icon-help1"></span>
+        <span class="ellipsis" [textContent]="helpText.attributeCaption"></span>
+      </h3>
+
       <a class="op-modal--modal-close-button">
         <i
           class="icon-close"
@@ -10,11 +15,6 @@
         </i>
       </a>
     </div>
-
-    <h3>
-      <span class="icon-context icon-help1"></span>
-      <span class="ellipsis" [textContent]="helpText.attributeCaption"></span>
-    </h3>
 
     <div class="op-modal--modal-body -formattable"
          tabindex="0"


### PR DESCRIPTION
Previously the closing icon overlapped the header of modals when the modal was rather small. However, all `-highlighted` modals already solved this issue, as they had a different way of aligning the header elements. 

So to reduce doubled implementations, the solution of the highlighted modals was applied generally. Leaving the `-highlighted` class to change only colours and some paddings (which is a win-win, as it matches more the BEM structure).
 
Because of these changes, the HTML structure of all modals needed be unified like to match how it is defined now in the LSG.

https://community.openproject.com/projects/openproject/work_packages/33446/activity