### PR TITLE
[33344] Multiple spaces in project name causes problems

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -155,6 +155,9 @@ class Project < ApplicationRecord
   validates :name,
             presence: true,
             length: { maximum: 255 }
+
+  before_validation :remove_white_spaces_from_project_name
+
   # TODO: we temporarily disable this validation because it leads to failed tests
   # it implicitly assumes a db:seed-created standard type to be present and currently
   # neither development nor deployment setups are prepared for this
@@ -572,5 +575,9 @@ class Project < ApplicationRecord
     Version
       .includes(:project)
       .references(:projects)
+  end
+
+  def remove_white_spaces_from_project_name
+    self.name = name.squish unless self.name.nil?
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -184,6 +184,18 @@ describe Project, type: :model do
     end
   end
 
+  describe 'name' do
+    let(:project) { FactoryBot.build_stubbed :project, name: '     Hello    World   '}
+
+    before do
+      project.valid?
+    end
+
+    it 'trims the name' do
+      expect(project.name).to eql('Hello World')
+    end
+  end
+
   describe '#types_used_by_work_packages' do
     let(:project) { FactoryBot.create(:project_with_types) }
     let(:type) { project.types.first }


### PR DESCRIPTION
Remove too much spaces from the project name before saving it. Otherwise the spaces will cause problems later, e.g when trying to delete the project.

https://community.openproject.com/projects/openproject/work_packages/33344/activity