### PR TITLE
download rather than build pgloader by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:2.6-stretch AS pgloader
-RUN apt-get update -qq && apt-get install -y libsqlite3-dev make curl gawk freetds-dev libzip-dev
-COPY docker/mysql-to-postgres/bin/build /tmp/build-pgloader
-RUN /tmp/build-pgloader && rm /tmp/build-pgloader
+COPY docker/mysql-to-postgres/bin/download /tmp/download-pgloader
+RUN /tmp/download-pgloader && rm /tmp/download-pgloader
 
 FROM ruby:2.6-stretch
 MAINTAINER operations@openproject.com
@@ -26,7 +25,7 @@ ENV ATTACHMENTS_STORAGE_PATH $APP_DATA_PATH/files
 # Set a default key base, ensure to provide a secure value in production environments!
 ENV SECRET_KEY_BASE OVERWRITE_ME
 
-COPY --from=pgloader /usr/local/bin/pgloader-ccl /usr/local/bin/
+COPY --from=pgloader /usr/bin/pgloader-ccl /usr/local/bin/
 
 # install node + npm
 RUN curl https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz | tar xzf - -C /usr/local --strip-components=1

--- a/docker/mysql-to-postgres/bin/build
+++ b/docker/mysql-to-postgres/bin/build
@@ -2,10 +2,12 @@
 set -e
 set -o pipefail
 
+apt-get update -qq && apt-get install -y libsqlite3-dev make curl gawk freetds-dev libzip-dev
+
 cd /opt
 
 # install Clozure CL to avoid memory issues with the standard SBCL
-curl -sL https://github.com/Clozure/ccl/releases/download/v1.11.5/ccl-1.11.5-linuxx86.tar.gz -o - | tar xzf - -C /opt/ 
+curl -sL https://github.com/Clozure/ccl/releases/download/v1.11.5/ccl-1.11.5-linuxx86.tar.gz -o - | tar xzf - -C /opt/
 ln -s /opt/ccl/scripts/ccl64 /usr/local/bin/ccl
 
 export CCL_DEFAULT_DIRECTORY=/opt/ccl

--- a/docker/mysql-to-postgres/bin/download
+++ b/docker/mysql-to-postgres/bin/download
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# In case we don't want to build it ourselves, we can just download the already
+# built binaries from packager.io.
+
+apt-get update -qq && apt-get install -y apt-transport-https ca-certificates
+
+wget -qO- https://dl.packager.io/srv/opf/pgloader-ccl/key | apt-key add -
+wget -O /etc/apt/sources.list.d/pgloader-ccl.list https://dl.packager.io/srv/opf/pgloader-ccl/master/installer/debian/9.repo
+
+apt-get update -qq && apt-get install -y pgloader-ccl


### PR DESCRIPTION
We had some trouble on our CI with the pgloader build.
So let's just download it from packager to circumvent that and save some time.

Still leaving the build script in there as it still works in principle and may be useful.