### PR TITLE
[33247] Cannot drag & drop work package outside of currently displayed browser window

### DIFF
--- a/frontend/src/app/modules/common/drag-and-drop/dom-autoscroll.service.ts
+++ b/frontend/src/app/modules/common/drag-and-drop/dom-autoscroll.service.ts
@@ -45,8 +45,15 @@ export class DomAutoscrollService {
     this.cleanAnimation();
   }
 
-  public add(el:Element) {
-    this.elements.push(el);
+  public add(el:Element|Element[]) {
+    if (Array.isArray(el)) {
+      this.elements = this.elements.concat(el);
+
+      // Remove duplicates
+      this.elements = Array.from(new Set(this.elements));
+    } else {
+      this.elements.push(el);
+    }
   }
 
   public onUp() {

--- a/frontend/src/app/modules/common/drag-and-drop/drag-and-drop.service.ts
+++ b/frontend/src/app/modules/common/drag-and-drop/drag-and-drop.service.ts
@@ -71,14 +71,15 @@ export class DragAndDropService implements OnDestroy {
 
   public register(member:DragMember) {
     this.members.push(member);
-    const dragContainer = member.dragContainer;
+    const scrollContainers = member.scrollContainers;
 
     if (this.autoscroll) {
-      this.autoscroll.add(dragContainer);
+      this.autoscroll.add(scrollContainers);
     } else {
-      this.setupAutoscroll([dragContainer]);
+      this.setupAutoscroll(scrollContainers);
     }
 
+    const dragContainer = member.dragContainer;
     if (this.drake === null) {
       this.initializeDrake([dragContainer]);
     } else {


### PR DESCRIPTION
Enable autoscrolling while dragging in the WP table again. It was broken, because the wrong container was passed to the DomAutoScrollService.


https://community.openproject.com/projects/openproject/work_packages/33247/activity