### PR TITLE
[33685]Number of watchers not shown when opening work package in full screen (through double-click)

### DIFF
--- a/frontend/src/app/components/work-packages/wp-relations-count/wp-watchers-count.component.ts
+++ b/frontend/src/app/components/work-packages/wp-relations-count/wp-watchers-count.component.ts
@@ -23,7 +23,7 @@ export class WorkPackageWatchersCountComponent extends UntilDestroyedMixin imple
       ).subscribe((workPackage) => {
         this.wpWatcherService.require(workPackage)
         .then((watchers:HalResource[]) => {
-          this.count = watchers.length;
+          this.count = watchers?.length;
         });
     });
   }

--- a/frontend/src/app/components/work-packages/wp-relations-count/wp-watchers-count.component.ts
+++ b/frontend/src/app/components/work-packages/wp-relations-count/wp-watchers-count.component.ts
@@ -1,6 +1,8 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {WorkPackageCacheService} from '../../work-packages/work-package-cache.service';
 import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import { WorkPackageWatchersService } from 'core-app/components/wp-single-view-tabs/watchers-tab/wp-watchers.service';
+import { HalResource } from 'core-app/modules/hal/resources/hal-resource';
 
 @Component({
   templateUrl: './wp-relations-count.html',
@@ -10,7 +12,7 @@ export class WorkPackageWatchersCountComponent extends UntilDestroyedMixin imple
   @Input('wpId') wpId:string;
   public count:number = 0;
 
-  constructor(protected wpCacheService:WorkPackageCacheService) {
+  constructor(protected wpCacheService:WorkPackageCacheService, protected wpWatcherService:WorkPackageWatchersService) {
     super();
   }
 
@@ -19,7 +21,10 @@ export class WorkPackageWatchersCountComponent extends UntilDestroyedMixin imple
       .pipe(
         this.untilDestroyed()
       ).subscribe((workPackage) => {
-      this.count = _.size(workPackage.watchers.elements);
+        this.wpWatcherService.require(workPackage)
+        .then((watchers:HalResource[]) => {
+          this.count = watchers.length;
+        });
     });
   }
 }

--- a/frontend/src/app/components/work-packages/wp-relations-count/wp-watchers-count.component.ts
+++ b/frontend/src/app/components/work-packages/wp-relations-count/wp-watchers-count.component.ts
@@ -12,7 +12,8 @@ export class WorkPackageWatchersCountComponent extends UntilDestroyedMixin imple
   @Input('wpId') wpId:string;
   public count:number = 0;
 
-  constructor(protected wpCacheService:WorkPackageCacheService, protected wpWatcherService:WorkPackageWatchersService) {
+  constructor(protected wpCacheService:WorkPackageCacheService,
+              protected wpWatcherService:WorkPackageWatchersService) {
     super();
   }
 

--- a/frontend/src/app/components/work-packages/wp-relations-count/wp-watchers-count.component.ts
+++ b/frontend/src/app/components/work-packages/wp-relations-count/wp-watchers-count.component.ts
@@ -24,7 +24,7 @@ export class WorkPackageWatchersCountComponent extends UntilDestroyedMixin imple
       ).subscribe((workPackage) => {
         this.wpWatcherService.require(workPackage)
         .then((watchers:HalResource[]) => {
-          this.count = watchers?.length;
+          this.count = watchers.length;
         });
     });
   }

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -6,7 +6,6 @@ describe 'Watcher tab', js: true, selenium: true do
   let(:project) { FactoryBot.create(:project) }
   let(:work_package) { FactoryBot.create(:work_package, project: project) }
   let(:tabs) { ::Components::WorkPackages::Tabs.new(work_package) }
-
   let(:user) { FactoryBot.create(:user, member_in_project: project, member_through_role: role) }
   let(:role) { FactoryBot.create(:role, permissions: permissions) }
   let(:permissions) {
@@ -119,5 +118,22 @@ describe 'Watcher tab', js: true, selenium: true do
   context 'full screen' do
     let(:wp_page) { Pages::FullWorkPackage.new(work_package) }
     it_behaves_like 'watchers tab'
+  end
+  
+  context 'when the work package has a watcher' do
+    let(:watchers) { FactoryBot.create(:watcher, watchable: work_package, user: user) }
+    let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+
+    before do
+      watchers
+      login_as(user)
+      wp_table.visit!
+      wp_table.expect_work_package_listed work_package
+    end 
+    
+    it 'should show the number of watchers [#33685]' do
+      wp_table.open_full_screen_by_doubleclick(work_package)
+      expect(page).to have_selector('.wp-tabs-count',  text: 1)
+    end
   end
 end


### PR DESCRIPTION
watchers number should be displayed in wp full view.

https://community.openproject.com/projects/openproject/work_packages/33685/activity