### PR TITLE
Add install instructions for Ubuntu 20.04

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -11,8 +11,6 @@ targets:
       - catdoc
   debian-10:
     <<: *debian9
-  ubuntu-14.04:
-    <<: *debian9
   ubuntu-16.04:
     <<: *debian9
   ubuntu-18.04:

--- a/docs/installation-and-operations/installation/packaged/README.md
+++ b/docs/installation-and-operations/installation/packaged/README.md
@@ -28,6 +28,7 @@ The package is available for the following Linux distributions:
 
 | Distribution (**64 bits only**)             |
 | ------------------------------------------- |
+| [Ubuntu 20.04 Focal](#ubuntu-2004)  |
 | [Ubuntu 18.04 Bionic Beaver](#ubuntu-1804)  |
 | [Ubuntu 16.04 Xenial Xerus](#ubuntu-1604)   |
 | [Debian 10 Buster](#debian-10)              |
@@ -49,6 +50,30 @@ x86_64
 </div>
 
 ## Ubuntu Installation
+
+### Ubuntu 20.04
+
+Import the PGP key used to sign our packages:
+
+```bash
+wget -qO- https://dl.packager.io/srv/opf/openproject/key | sudo apt-key add -
+```
+
+Add the OpenProject package source:
+
+```bash
+sudo wget -O /etc/apt/sources.list.d/openproject.list \
+  https://dl.packager.io/srv/opf/openproject/stable/10/installer/ubuntu/20.04.repo
+```
+
+Download the OpenProject package:
+
+```bash
+sudo apt-get update
+sudo apt-get install openproject
+```
+
+Then finish the installation by reading the [*Initial configuration*][initial-config] section.
 
 ### Ubuntu 18.04
 

--- a/docs/installation-and-operations/system-requirements/README.md
+++ b/docs/installation-and-operations/system-requirements/README.md
@@ -23,6 +23,7 @@ The [package-based installation](../installation/packaged) requires one of the f
 
 | Distribution (**64 bits only**) |
 | ------------------------------- |
+| Ubuntu 20.04 Focal              |
 | Ubuntu 18.04 Bionic Beaver      |
 | Ubuntu 16.04 Xenial Xerus       |
 | Debian 10 Buster                |
@@ -54,20 +55,6 @@ OpenProject supports the latest versions of the major browsers.
 
 ## Frequently asked questions (FAQ)
 
-### What are the OpenProject system requirements?
-
-OpenProject can be installed in two different ways: the packaged installation of OpenProject is the recommended way to install and maintain OpenProject using DEB or RPM packages. System requirements need one of the following Linux distributions: 
-* Ubuntu 18.04 Bionic Beaver
-* Ubuntu 16.04 Xenial Xerus
-* Debian 10 Buster
-* Debian 9 Stretch
-* CentOS/RHEL 8.x
-* CentOS/RHEL 7.x
-* Suse Linux Enterprise Server 12
-
-OpenProject also provides a Docker image for the Community Edition that you can very easily install and upgrade on your servers. 
-The detailed system requirements are available [here](https://www.openproject.org/system-requirements/).
-
 ### Can I run OpenProject on Windows?
 
-At the moment this is not possible. Check above regarding the system requirements.
+At the moment this is not officially supported, although the docker image might work. Check above regarding the system requirements.


### PR DESCRIPTION
Also remove a duplicate paragraph in the FAQ, as well as the build instruction for ubuntu 14.04 (it was no longer advertised in the docs anyway).