### PR TITLE
[33683, 33684] Extend Date picker to show two months next to each other and a "Today" link

### DIFF
--- a/app/assets/stylesheets/content/_forms_mobile.sass
+++ b/app/assets/stylesheets/content/_forms_mobile.sass
@@ -50,7 +50,7 @@
       max-width: 100%
 
   #tab-content-info form,
-  .op-modal--modal-body,
+  .op-modal--modal-body form:not(.-vertical),
   form.-wide-labels .op-modal--modal-body
     .form--label,
     .form--field-container

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -435,7 +435,7 @@ en:
     label_sum_for: "Sum for"
     label_subject: "Subject"
     label_this_week: "this week"
-    label_today: "today"
+    label_today: "Today"
     label_time_entry_plural: "Spent time"
     label_up: "Up"
     label_user_plural: "Users"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -941,7 +941,6 @@ en:
       label_delete_page: "Delete current page"
       button_apply: "Apply"
       button_save: "Save"
-      button_clear_all: "Clear all"
       button_submit: "Submit"
       button_cancel: "Cancel"
       form_submit:

--- a/frontend/src/app/components/datepicker/datepicker.helper.ts
+++ b/frontend/src/app/components/datepicker/datepicker.helper.ts
@@ -74,11 +74,13 @@ export class DatepickerHelper {
 
   public setDatepickerRestrictions(dates:{ [key in DateKeys]:string }, datePicker:DatePicker) {
     if (this.isStateOfCurrentActivatedField('start')) {
-      datePicker.datepickerInstance.set('minDate', null);
-      datePicker.datepickerInstance.set('maxDate', dates.end);
+      datePicker.datepickerInstance.set('disable', [(date:Date) => {
+        return date > new Date(dates.end).setHours(0,0,0,0);
+      }]);
     } else {
-      datePicker.datepickerInstance.set('minDate', dates.start);
-      datePicker.datepickerInstance.set('maxDate', null);
+      datePicker.datepickerInstance.set('disable', [(date:Date) => {
+        return date < new Date(dates.start).setHours(0,0,0,0);
+      }]);
     }
   }
 

--- a/frontend/src/app/components/datepicker/datepicker.helper.ts
+++ b/frontend/src/app/components/datepicker/datepicker.helper.ts
@@ -29,6 +29,7 @@
 import {Injectable} from '@angular/core';
 import {DateKeys} from "core-components/datepicker/datepicker.modal";
 import {DatePicker} from "core-app/modules/common/op-date-picker/datepicker";
+import {DateOption} from "flatpickr/dist/types/options";
 
 @Injectable({ providedIn: 'root' })
 export class DatepickerHelper {
@@ -70,6 +71,14 @@ export class DatepickerHelper {
 
   public isStateOfCurrentActivatedField(val:DateKeys):boolean {
     return this.currentlyActivatedDateField === val;
+  }
+
+  public setDates(dates:DateOption|DateOption[], datePicker:DatePicker) {
+    let currentMonth = datePicker.datepickerInstance.currentMonth;
+    datePicker.setDates(dates);
+
+    // Keep currently active month and avoid jump because of two-month layout
+    datePicker.datepickerInstance.currentMonth = currentMonth;
   }
 
   public setDatepickerRestrictions(dates:{ [key in DateKeys]:string }, datePicker:DatePicker) {

--- a/frontend/src/app/components/datepicker/datepicker.helper.ts
+++ b/frontend/src/app/components/datepicker/datepicker.helper.ts
@@ -111,7 +111,7 @@ export class DatepickerHelper {
           this.selectRangeFromUntil(firstDay, selectedElements[0]);
         }
       } else if (this.datepickerIsInDateRange(monthContainer[i], dates)) {
-        jQuery('.dayContainer .flatpickr-day').addClass('inRange');
+        jQuery(monthContainer[i]).find('.flatpickr-day').addClass('inRange');
       }
     }
   }

--- a/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
@@ -32,7 +32,7 @@ import {DatePicker} from "core-app/modules/common/op-date-picker/datepicker";
 import {DateOption} from "flatpickr/dist/types/options";
 
 @Injectable({ providedIn: 'root' })
-export class DatepickerHelper {
+export class DatePickerModalHelper {
   public currentlyActivatedDateField:DateKeys;
 
   /**

--- a/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
@@ -46,11 +46,11 @@ export class DatePickerModalHelper {
 
   public parseDate(date:Date|string):Date|'' {
     if (date instanceof Date) {
-      return date;
+      return new Date(date.setHours(0,0,0,0));
     } else if (date === '') {
       return '';
     } else {
-      return new Date(date);
+      return new Date(new Date(date).setHours(0,0,0,0));
     }
   }
 

--- a/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
@@ -82,13 +82,20 @@ export class DatePickerModalHelper {
   }
 
   public setDatepickerRestrictions(dates:{ [key in DateKeys]:string }, datePicker:DatePicker) {
+    if (!dates.start && !dates.end) {
+      return false;
+    }
+
     if (this.isStateOfCurrentActivatedField('start')) {
+      // In case, that the end date is not set yet, the start date is the limit
+      let limit = dates.end ? dates.end : dates.start;
       datePicker.datepickerInstance.set('disable', [(date:Date) => {
-        return date.getTime() > new Date(dates.end).setHours(0,0,0,0);
+        return date.getTime() > new Date(limit).setHours(0,0,0,0);
       }]);
     } else {
+      let limit = dates.start ? dates.start : dates.end;
       datePicker.datepickerInstance.set('disable', [(date:Date) => {
-        return date.getTime() < new Date(dates.start).setHours(0,0,0,0);
+        return date.getTime() < new Date(limit).setHours(0,0,0,0);
       }]);
     }
   }

--- a/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
@@ -73,12 +73,20 @@ export class DatePickerModalHelper {
     return this.currentlyActivatedDateField === val;
   }
 
-  public setDates(dates:DateOption|DateOption[], datePicker:DatePicker) {
+  public setDates(dates:DateOption|DateOption[], datePicker:DatePicker, enforceDate?:Date) {
     let currentMonth = datePicker.datepickerInstance.currentMonth;
+    let currentYear = datePicker.datepickerInstance.currentYear;
     datePicker.setDates(dates);
 
-    // Keep currently active month and avoid jump because of two-month layout
-    datePicker.datepickerInstance.currentMonth = currentMonth;
+    if (enforceDate) {
+      datePicker.datepickerInstance.currentMonth = enforceDate.getMonth();
+      datePicker.datepickerInstance.currentYear = enforceDate.getFullYear();
+    } else {
+      // Keep currently active month and avoid jump because of two-month layout
+      datePicker.datepickerInstance.currentMonth = currentMonth;
+      datePicker.datepickerInstance.currentYear = currentYear;
+    }
+
     datePicker.datepickerInstance.redraw();
   }
 

--- a/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
@@ -46,11 +46,11 @@ export class DatePickerModalHelper {
 
   public parseDate(date:Date|string):Date|'' {
     if (date instanceof Date) {
-      return date;
+      return date.setHours(0,0,0,0);
     } else if (date === '') {
       return '';
     } else {
-      return new Date(date);
+      return new Date(date).setHours(0,0,0,0);
     }
   }
 
@@ -79,6 +79,7 @@ export class DatePickerModalHelper {
 
     // Keep currently active month and avoid jump because of two-month layout
     datePicker.datepickerInstance.currentMonth = currentMonth;
+    datePicker.datepickerInstance.redraw();
   }
 
   public setDatepickerRestrictions(dates:{ [key in DateKeys]:string }, datePicker:DatePicker) {

--- a/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
@@ -83,7 +83,7 @@ export class DatePickerModalHelper {
 
   public setDatepickerRestrictions(dates:{ [key in DateKeys]:string }, datePicker:DatePicker) {
     if (!dates.start && !dates.end) {
-      return false;
+      return;
     }
 
     if (this.isStateOfCurrentActivatedField('start')) {

--- a/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
@@ -46,11 +46,11 @@ export class DatePickerModalHelper {
 
   public parseDate(date:Date|string):Date|'' {
     if (date instanceof Date) {
-      return date.setHours(0,0,0,0);
+      return date;
     } else if (date === '') {
       return '';
     } else {
-      return new Date(date).setHours(0,0,0,0);
+      return new Date(date);
     }
   }
 
@@ -141,10 +141,8 @@ export class DatePickerModalHelper {
     var firstDayOfMonthElement = jQuery(container).find('.flatpickr-day:not(.hidden)')[0];
     var firstDayOfMonth = new Date(firstDayOfMonthElement.getAttribute('aria-label')!);
 
-    return firstDayOfMonth.getFullYear() <= new Date(dates.end).getFullYear() &&
-           firstDayOfMonth.getMonth() < new Date(dates.end).getMonth() &&
-           firstDayOfMonth.getFullYear() >= new Date(dates.start).getFullYear() &&
-           firstDayOfMonth.getMonth() > new Date(dates.start).getMonth();
+    return firstDayOfMonth <= new Date(dates.end) &&
+           firstDayOfMonth >= new Date(dates.start);
   }
 
   private selectRangeFromUntil(from:Element, until:string|Element) {

--- a/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.helper.ts
@@ -94,7 +94,7 @@ export class DatePickerModalHelper {
   }
 
   public setRangeClasses(dates:{ [key in DateKeys]:string }) {
-    if (!dates.start || !dates.end) {
+    if (!dates.start || !dates.end || (dates.start === dates.end)) {
       return;
     }
 

--- a/frontend/src/app/components/datepicker/datepicker.modal.html
+++ b/frontend/src/app/components/datepicker/datepicker.modal.html
@@ -5,7 +5,7 @@
        tabindex="0">
     <div class="op-modal--modal-body">
       <form class="form -vertical">
-        <div class="grid-block">
+        <div class="datepicker-modal--dates-container">
           <ng-container *ngIf="singleDate">
             <div class="form--field">
               <label class="form--label"
@@ -21,6 +21,11 @@
                          (ngModelChange)="updateDate('date', $event)"
                          (click)="datepickerHelper.setCurrentActivatedField('date')">
                 </div>
+                <a class="form--field-inline-action"
+                   [title]="text.clear"
+                   (click)="clear('date')">
+                  <span class="icon2 icon-small icon-cancel"></span>
+                </a>
               </div>
             </div>
           </ng-container>
@@ -40,6 +45,11 @@
                          (ngModelChange)="updateDate('start', $event)"
                          (click)="datepickerHelper.setCurrentActivatedField('start')">
                 </div>
+                <a class="form--field-inline-action"
+                   [title]="text.clear"
+                   (click)="clear('start')">
+                  <span class="icon2 icon-small  icon-cancel"></span>
+                </a>
               </div>
             </div>
             <div class="form--field">
@@ -56,26 +66,28 @@
                          (ngModelChange)="updateDate('end', $event)"
                          (click)="datepickerHelper.setCurrentActivatedField('end')">
                 </div>
+                <a class="form--field-inline-action"
+                   [title]="text.clear"
+                   (click)="clear('end')">
+                  <span class="icon2 icon-small icon-cancel"></span>
+                </a>
               </div>
             </div>
           </ng-container>
-
-          <a (click)="clear()"
-             class="datepicker-modal--action"
-             [textContent]="text.clear">
-          </a>
-        </div>
-        <div class="form--field">
-          <label class="form--label-with-check-box">
-            <div class="form--check-box-container">
-              <input type="checkbox"
-                     name="scheduling"
-                     class="form--check-box datepicker-modal--scheduling-action"
-                     [ngModel]="scheduleManually"
-                     (ngModelChange)="changeSchedulingMode()">
+          <div class="form--field datepicker-modal--scheduling-action-container">
+            <div class="form--field-container">
+              <label class="form--label-with-check-box">
+                <div class="form--check-box-container">
+                  <input type="checkbox"
+                         name="scheduling"
+                         class="form--check-box datepicker-modal--scheduling-action"
+                         [ngModel]="scheduleManually"
+                         (ngModelChange)="changeSchedulingMode()">
+                </div>
+                {{ text.manualScheduling }}
+              </label>
             </div>
-            {{ text.manualScheduling }}
-          </label>
+          </div>
         </div>
       </form>
 

--- a/frontend/src/app/components/datepicker/datepicker.modal.html
+++ b/frontend/src/app/components/datepicker/datepicker.modal.html
@@ -27,6 +27,11 @@
                   <span class="icon2 icon-small icon-cancel"></span>
                 </a>
               </div>
+              <div class="form--field-extra-actions">
+                <a (click)="setToday('date')"
+                   [textContent]="text.today">
+                </a>
+              </div>
             </div>
           </ng-container>
 
@@ -51,6 +56,12 @@
                   <span class="icon2 icon-small  icon-cancel"></span>
                 </a>
               </div>
+              <div class="form--field-extra-actions">
+                <a *ngIf="datepickerHelper.isStateOfCurrentActivatedField('start')"
+                   (click)="setToday('start')"
+                   [textContent]="text.today">
+                </a>
+              </div>
             </div>
             <div class="form--field">
               <label class="form--label"
@@ -70,6 +81,12 @@
                    [title]="text.clear"
                    (click)="clear('end')">
                   <span class="icon2 icon-small icon-cancel"></span>
+                </a>
+              </div>
+              <div class="form--field-extra-actions">
+                <a *ngIf="datepickerHelper.isStateOfCurrentActivatedField('end')"
+                   (click)="setToday('end')"
+                   [textContent]="text.today">
                 </a>
               </div>
             </div>

--- a/frontend/src/app/components/datepicker/datepicker.modal.html
+++ b/frontend/src/app/components/datepicker/datepicker.modal.html
@@ -43,7 +43,7 @@
                          [ngClass]="{'-current' : datepickerHelper.isStateOfCurrentActivatedField('start')}"
                          [ngModel]="dates.start"
                          (ngModelChange)="updateDate('start', $event)"
-                         (click)="datepickerHelper.setCurrentActivatedField('start')">
+                         (click)="setCurrentActivatedField('start')">
                 </div>
                 <a class="form--field-inline-action"
                    [title]="text.clear"
@@ -64,7 +64,7 @@
                          [ngClass]="{'-current' : datepickerHelper.isStateOfCurrentActivatedField('end')}"
                          [ngModel]="dates.end"
                          (ngModelChange)="updateDate('end', $event)"
-                         (click)="datepickerHelper.setCurrentActivatedField('end')">
+                         (click)="setCurrentActivatedField('end')">
                 </div>
                 <a class="form--field-inline-action"
                    [title]="text.clear"

--- a/frontend/src/app/components/datepicker/datepicker.modal.html
+++ b/frontend/src/app/components/datepicker/datepicker.modal.html
@@ -57,7 +57,7 @@
                 </a>
               </div>
               <div class="form--field-extra-actions">
-                <a *ngIf="datepickerHelper.isStateOfCurrentActivatedField('start')"
+                <a *ngIf="showTodayLink('start')"
                    (click)="setToday('start')"
                    [textContent]="text.today">
                 </a>
@@ -84,7 +84,7 @@
                 </a>
               </div>
               <div class="form--field-extra-actions">
-                <a *ngIf="datepickerHelper.isStateOfCurrentActivatedField('end')"
+                <a *ngIf="showTodayLink('end')"
                    (click)="setToday('end')"
                    [textContent]="text.today">
                 </a>

--- a/frontend/src/app/components/datepicker/datepicker.modal.sass
+++ b/frontend/src/app/components/datepicker/datepicker.modal.sass
@@ -11,6 +11,16 @@
   .grid-block
     align-items: center
 
+.datepicker-modal--dates-container
+  display: grid
+  grid-template-columns: 170px 1fr auto
+
+  .datepicker-modal--scheduling-action-container
+    margin-top: 28px
+
+    .form--label-with-check-box
+      padding: 0
+
 .datepicker-modal--actions-container
   display: grid
   grid-template-columns: auto auto
@@ -24,3 +34,9 @@
   &.-current,
   &.-current:hover
     outline: 2px solid var(--primary-color)
+
+.form--field-inline-action
+  .icon-small:before
+    vertical-align: text-bottom
+  &:hover, &:focus
+    text-decoration: none

--- a/frontend/src/app/components/datepicker/datepicker.modal.sass
+++ b/frontend/src/app/components/datepicker/datepicker.modal.sass
@@ -11,9 +11,17 @@
   .grid-block
     align-items: center
 
+
 .datepicker-modal--dates-container
   display: grid
   grid-template-columns: 170px 1fr auto
+
+  .form--date-field
+    margin: 2px !important
+
+    &.-current,
+    &.-current:hover
+      outline: 2px solid var(--primary-color)
 
   .datepicker-modal--scheduling-action-container
     margin-top: 28px
@@ -21,22 +29,16 @@
     .form--label-with-check-box
       padding: 0
 
+  .form--field-inline-action
+    .icon-small:before
+      vertical-align: text-bottom
+    &:hover, &:focus
+      text-decoration: none
+
+
 .datepicker-modal--actions-container
   display: grid
   grid-template-columns: auto auto
   grid-column-gap: 30px
   margin-top: 20px
   justify-content: end
-
-.form--date-field
-  margin: 2px !important
-
-  &.-current,
-  &.-current:hover
-    outline: 2px solid var(--primary-color)
-
-.form--field-inline-action
-  .icon-small:before
-    vertical-align: text-bottom
-  &:hover, &:focus
-    text-decoration: none

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -147,9 +147,12 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
   }
 
   updateDate(key:DateKeys, val:string) {
-    this.dates[key] = val;
-    if (this.datepickerHelper.validDate(val) && this.datePickerInstance) {
-      this.setDatesToDatepicker();
+    // Epxected minimal format YYYY-M-D => 8 characters
+    if (val.length >= 8) {
+      this.dates[key] = val;
+      if (this.datepickerHelper.validDate(val) && this.datePickerInstance) {
+        this.setDatesToDatepicker(false);
+      }
     }
   }
 
@@ -157,7 +160,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
     let today = this.datepickerHelper.parseDate(new Date());
     this.dates[key] = this.timezoneService.formattedISODate(today);
 
-    (today instanceof Date) ? this.setDatesToDatepicker(today) : this.setDatesToDatepicker();
+    (today instanceof Date) ? this.setDatesToDatepicker(true, today) : this.setDatesToDatepicker();
   }
 
   reposition(element:JQuery<HTMLElement>, target:JQuery<HTMLElement>) {
@@ -206,7 +209,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
     );
   }
 
-  private setDatesToDatepicker(enforceDate?:Date) {
+  private setDatesToDatepicker(toggleField:boolean = true, enforceDate?:Date) {
     if (this.singleDate) {
       let date = this.datepickerHelper.parseDate(this.dates.date);
       this.datepickerHelper.setDates(date, this.datePickerInstance, enforceDate);
@@ -214,8 +217,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
       let dates = [this.datepickerHelper.parseDate(this.dates.start), this.datepickerHelper.parseDate(this.dates.end)];
       this.datepickerHelper.setDates(dates, this.datePickerInstance, enforceDate);
 
-      this.datepickerHelper.toggleCurrentActivatedField(this.dates, this.datePickerInstance);
-      this.datepickerHelper.setRangeClasses(this.dates);
+      this.updateDatePickerAppearance(toggleField);
     }
   }
 
@@ -257,8 +259,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
           let index = this.datepickerHelper.isStateOfCurrentActivatedField('start') ? 0 : 1;
           this.dates[this.datepickerHelper.currentlyActivatedDateField] = this.timezoneService.formattedISODate(dates[index]);
 
-          this.datepickerHelper.toggleCurrentActivatedField(this.dates, this.datePickerInstance);
-          this.datepickerHelper.setRangeClasses(this.dates);
+          this.updateDatePickerAppearance();
         }
 
         break;
@@ -291,5 +292,12 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
 
   private initialActivatedField():DateKeys {
     return this.locals.fieldName === 'dueDate' || (this.dates.start && !this.dates.end) ? 'end' : 'start';
+  }
+
+  private updateDatePickerAppearance(toggleField:boolean = true) {
+    if (toggleField) {
+      this.datepickerHelper.toggleCurrentActivatedField(this.dates, this.datePickerInstance);
+    }
+    this.datepickerHelper.setRangeClasses(this.dates);
   }
 }

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -189,10 +189,10 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
   private setDatesToDatepicker() {
     if (this.singleDate) {
       let date = this.datepickerHelper.parseDate(this.dates.date);
-      this.datePickerInstance.setDates(date);
+      this.datepickerHelper.setDates(date, this.datePickerInstance);
     } else {
       let dates = [this.datepickerHelper.parseDate(this.dates.start), this.datepickerHelper.parseDate(this.dates.end)];
-      this.datePickerInstance.setDates(dates);
+      this.datepickerHelper.setDates(dates, this.datePickerInstance);
     }
   }
 
@@ -220,7 +220,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
         if ((!this.dates.end && this.datepickerHelper.isStateOfCurrentActivatedField('start')) ||
             (!this.dates.start && this.datepickerHelper.isStateOfCurrentActivatedField('end'))) {
           // If we change a start date when no end date is set, we keep only the newly clicked value and not both
-          this.datePickerInstance.setDates([dates[1]]);
+          this.datepickerHelper.setDates([dates[1]], this.datePickerInstance);
           this.onDatePickerChange([dates[1]]);
         } else {
           // Sort dates so that the start date is always first
@@ -228,7 +228,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
             dates.sort(function(a:Date, b:Date) {
               return a.getTime() - b.getTime();
             });
-            this.datePickerInstance.setDates([dates[0], dates[1]]);
+            this.datepickerHelper.setDates([dates[0], dates[1]], this.datePickerInstance);
           }
 
           let index = this.datepickerHelper.isStateOfCurrentActivatedField('start') ? 0 : 1;
@@ -243,10 +243,10 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
       default: {
         // Reset the date picker with the two new values
         if (this.datepickerHelper.isStateOfCurrentActivatedField('start')) {
-          this.datePickerInstance.setDates([dates[2], dates[1]]);
+          this.datepickerHelper.setDates([dates[2], dates[1]], this.datePickerInstance);
           this.onDatePickerChange([dates[2], dates[1]]);
         } else {
-          this.datePickerInstance.setDates([dates[0], dates[2]]);
+          this.datepickerHelper.setDates([dates[0], dates[2]], this.datePickerInstance);
           this.onDatePickerChange([dates[0], dates[2]]);
         }
 

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -65,7 +65,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
   text = {
     save: this.I18n.t('js.button_save'),
     cancel: this.I18n.t('js.button_cancel'),
-    clear: this.I18n.t('js.button_clear'),
+    clear: this.I18n.t('js.work_packages.button_clear'),
     manualScheduling: this.I18n.t('js.scheduling.manual'),
     date: this.I18n.t('js.work_packages.properties.date'),
     startDate: this.I18n.t('js.work_packages.properties.startDate'),
@@ -107,7 +107,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
     } else {
       this.dates.start = this.changeset.value('startDate');
       this.dates.end = this.changeset.value('dueDate');
-      this.datepickerHelper.setCurrentActivatedField(this.locals.fieldName === 'dueDate' ? 'end' : 'start');
+      this.datepickerHelper.setCurrentActivatedField(this.initialActivatedField());
     }
   }
 
@@ -266,5 +266,9 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
 
     let output = this.singleDate ? date : start + ' - ' + end;
     this.onDataUpdated.emit(output);
+  }
+
+  private initialActivatedField():DateKeys {
+    return this.locals.fieldName === 'dueDate' || (this.dates.start && !this.dates.end) ? 'end' : 'start';
   }
 }

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -154,7 +154,6 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
   }
 
   setToday(key:DateKeys) {
-    this.datepickerHelper.toggleCurrentActivatedField(this.dates, this.datePickerInstance);
     this.updateDate(key, this.timezoneService.formattedISODate(Date.now()));
   }
 
@@ -179,9 +178,9 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
     }
 
     if (key === 'start') {
-      return this.datepickerHelper.parseDate(Date.now()) <= this.datepickerHelper.parseDate(this.dates['end']);
+      return new Date().setHours(0,0,0,0) <= new Date(this.dates['end']).setHours(0,0,0,0);
     } else {
-      return this.datepickerHelper.parseDate(Date.now()) >= this.datepickerHelper.parseDate(this.dates['start']);
+      return new Date().setHours(0,0,0,0) >= new Date(this.dates['start']).setHours(0,0,0,0);
     }
   }
 
@@ -211,8 +210,10 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
     } else {
       let dates = [this.datepickerHelper.parseDate(this.dates.start), this.datepickerHelper.parseDate(this.dates.end)];
       this.datepickerHelper.setDates(dates, this.datePickerInstance);
+
+      this.datepickerHelper.toggleCurrentActivatedField(this.dates, this.datePickerInstance);
+      this.datepickerHelper.setRangeClasses(this.dates);
     }
-    this.datepickerHelper.setRangeClasses(this.dates);
   }
 
   private onDatePickerChange(dates:Date[]) {

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -114,7 +114,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
   ngAfterViewInit():void {
     this.initializeDatepicker();
     this.datepickerHelper.setDatepickerRestrictions(this.dates, this.datePickerInstance);
-    this.datepickerHelper.setRangeClasses(this.dates, this.datePickerInstance);
+    this.datepickerHelper.setRangeClasses(this.dates);
 
     this.onDataChange();
   }
@@ -174,8 +174,8 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
 
           this.onDataChange();
         },
-        onMonthChange: () => { this.datepickerHelper.setRangeClasses(this.dates, this.datePickerInstance); },
-        onYearChange: () => { this.datepickerHelper.setRangeClasses(this.dates, this.datePickerInstance); },
+        onMonthChange: () => { this.datepickerHelper.setRangeClasses(this.dates); },
+        onYearChange: () => { this.datepickerHelper.setRangeClasses(this.dates); },
       }
     );
   }
@@ -229,7 +229,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
           this.dates[this.datepickerHelper.currentlyActivatedDateField] = this.timezoneService.formattedISODate(dates[index]);
 
           this.datepickerHelper.toggleCurrentActivatedField(this.dates, this.datePickerInstance);
-          this.datepickerHelper.setRangeClasses(this.dates, this.datePickerInstance);
+          this.datepickerHelper.setRangeClasses(this.dates);
         }
 
         break;

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -161,6 +161,12 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
     });
   }
 
+  setCurrentActivatedField(key:DateKeys) {
+    this.datepickerHelper.setCurrentActivatedField(key);
+    this.datepickerHelper.setDatepickerRestrictions(this.dates, this.datePickerInstance);
+    this.datepickerHelper.setRangeClasses(this.dates);
+  }
+
   private initializeDatepicker() {
     this.datePickerInstance = new DatePicker(
       '#flatpickr-input',

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -147,8 +147,8 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
   }
 
   updateDate(key:DateKeys, val:string) {
-    // Epxected minimal format YYYY-M-D => 8 characters
-    if (val.length >= 8) {
+    // Expected minimal format YYYY-M-D => 8 characters OR empty
+    if (val.length >= 8 || val.length === 0) {
       this.dates[key] = val;
       if (this.datepickerHelper.validDate(val) && this.datePickerInstance) {
         this.enforceManualChangesToDatepicker(false);

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -46,7 +46,7 @@ import {TimezoneService} from "core-components/datetime/timezone.service";
 import {DatePicker} from "core-app/modules/common/op-date-picker/datepicker";
 import {HalResourceEditingService} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
 import {ResourceChangeset} from "core-app/modules/fields/changeset/resource-changeset";
-import {DatepickerHelper} from "core-components/datepicker/datepicker.helper";
+import {DatePickerModalHelper} from "core-components/datepicker/datepicker.modal.helper";
 
 export type DateKeys = 'date'|'start'|'end';
 
@@ -60,7 +60,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
   @InjectField() I18n:I18nService;
   @InjectField() timezoneService:TimezoneService;
   @InjectField() halEditing:HalResourceEditingService;
-  @InjectField() datepickerHelper:DatepickerHelper;
+  @InjectField() datepickerHelper:DatePickerModalHelper;
 
   text = {
     save: this.I18n.t('js.button_save'),

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -154,7 +154,10 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
   }
 
   setToday(key:DateKeys) {
-    this.updateDate(key, this.timezoneService.formattedISODate(Date.now()));
+    let today = this.datepickerHelper.parseDate(new Date());
+    this.dates[key] = this.timezoneService.formattedISODate(today);
+
+    (today instanceof Date) ? this.setDatesToDatepicker(today) : this.setDatesToDatepicker();
   }
 
   reposition(element:JQuery<HTMLElement>, target:JQuery<HTMLElement>) {
@@ -203,13 +206,13 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
     );
   }
 
-  private setDatesToDatepicker() {
+  private setDatesToDatepicker(enforceDate?:Date) {
     if (this.singleDate) {
       let date = this.datepickerHelper.parseDate(this.dates.date);
-      this.datepickerHelper.setDates(date, this.datePickerInstance);
+      this.datepickerHelper.setDates(date, this.datePickerInstance, enforceDate);
     } else {
       let dates = [this.datepickerHelper.parseDate(this.dates.start), this.datepickerHelper.parseDate(this.dates.end)];
-      this.datepickerHelper.setDates(dates, this.datePickerInstance);
+      this.datepickerHelper.setDates(dates, this.datePickerInstance, enforceDate);
 
       this.datepickerHelper.toggleCurrentActivatedField(this.dates, this.datePickerInstance);
       this.datepickerHelper.setRangeClasses(this.dates);

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -173,6 +173,18 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
     this.datepickerHelper.setRangeClasses(this.dates);
   }
 
+  showTodayLink(key:DateKeys):boolean {
+    if (!this.datepickerHelper.isStateOfCurrentActivatedField(key)) {
+      return false;
+    }
+
+    if (key === 'start') {
+      return this.datepickerHelper.parseDate(Date.now()) <= this.datepickerHelper.parseDate(this.dates['end']);
+    } else {
+      return this.datepickerHelper.parseDate(Date.now()) >= this.datepickerHelper.parseDate(this.dates['start']);
+    }
+  }
+
   private initializeDatepicker() {
     this.datePickerInstance = new DatePicker(
       '#flatpickr-input',

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -65,7 +65,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
   text = {
     save: this.I18n.t('js.button_save'),
     cancel: this.I18n.t('js.button_cancel'),
-    clear: this.I18n.t('js.modals.button_clear_all'),
+    clear: this.I18n.t('js.button_clear'),
     manualScheduling: this.I18n.t('js.scheduling.manual'),
     date: this.I18n.t('js.work_packages.properties.date'),
     startDate: this.I18n.t('js.work_packages.properties.startDate'),
@@ -140,14 +140,9 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
     this.closeMe();
   }
 
-  clear():void {
-    this.dates = {
-      date: '',
-      start: '',
-      end: ''
-    };
-
-    this.datePickerInstance.clear();
+  clear(key:DateKeys):void {
+    this.dates[key] = '';
+    this.setDatesToDatepicker();
   }
 
   updateDate(key:DateKeys, val:string) {
@@ -172,6 +167,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
       this.singleDate ? this.dates.date : [this.dates.start, this.dates.end],
       {
         mode: this.singleDate ? 'single' : 'multiple',
+        showMonths: 2,
         inline: true,
         onChange: (dates:Date[]) => {
           this.onDatePickerChange(dates);

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -178,9 +178,9 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
     }
 
     if (key === 'start') {
-      return new Date().setHours(0,0,0,0) <= new Date(this.dates['end']).setHours(0,0,0,0);
+      return this.datepickerHelper.parseDate(new Date()) <= this.datepickerHelper.parseDate(this.dates.end);
     } else {
-      return new Date().setHours(0,0,0,0) >= new Date(this.dates['start']).setHours(0,0,0,0);
+      return this.datepickerHelper.parseDate(new Date()) >= this.datepickerHelper.parseDate(this.dates.start);
     }
   }
 

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -148,6 +148,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
   updateDate(key:DateKeys, val:string) {
     this.dates[key] = val;
     if (this.datepickerHelper.validDate(val) && this.datePickerInstance) {
+      this.datepickerHelper.toggleCurrentActivatedField(this.dates, this.datePickerInstance);
       this.setDatesToDatepicker();
     }
   }
@@ -194,6 +195,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
       let dates = [this.datepickerHelper.parseDate(this.dates.start), this.datepickerHelper.parseDate(this.dates.end)];
       this.datepickerHelper.setDates(dates, this.datePickerInstance);
     }
+    this.datepickerHelper.setRangeClasses(this.dates);
   }
 
   private onDatePickerChange(dates:Date[]) {

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -70,7 +70,8 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
     date: this.I18n.t('js.work_packages.properties.date'),
     startDate: this.I18n.t('js.work_packages.properties.startDate'),
     endDate: this.I18n.t('js.work_packages.properties.dueDate'),
-    placeholder: this.I18n.t('js.placeholders.default')
+    placeholder: this.I18n.t('js.placeholders.default'),
+    today: this.I18n.t('js.label_today')
   };
   public onDataUpdated = new EventEmitter<string>();
 
@@ -148,9 +149,13 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
   updateDate(key:DateKeys, val:string) {
     this.dates[key] = val;
     if (this.datepickerHelper.validDate(val) && this.datePickerInstance) {
-      this.datepickerHelper.toggleCurrentActivatedField(this.dates, this.datePickerInstance);
       this.setDatesToDatepicker();
     }
+  }
+
+  setToday(key:DateKeys) {
+    this.datepickerHelper.toggleCurrentActivatedField(this.dates, this.datePickerInstance);
+    this.updateDate(key, this.timezoneService.formattedISODate(Date.now()));
   }
 
   reposition(element:JQuery<HTMLElement>, target:JQuery<HTMLElement>) {

--- a/frontend/src/app/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/components/datepicker/datepicker.modal.ts
@@ -47,12 +47,13 @@ import {DatePicker} from "core-app/modules/common/op-date-picker/datepicker";
 import {HalResourceEditingService} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
 import {ResourceChangeset} from "core-app/modules/fields/changeset/resource-changeset";
 import {DatePickerModalHelper} from "core-components/datepicker/datepicker.modal.helper";
+import {BrowserDetector} from "core-app/modules/common/browser/browser-detector.service";
 
 export type DateKeys = 'date'|'start'|'end';
 
 @Component({
   templateUrl: './datepicker.modal.html',
-  styleUrls: ['./datepicker.modal.sass'],
+  styleUrls: ['./datepicker.modal.sass', './datepicker_mobile.modal.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None
 })
@@ -61,6 +62,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
   @InjectField() timezoneService:TimezoneService;
   @InjectField() halEditing:HalResourceEditingService;
   @InjectField() datepickerHelper:DatePickerModalHelper;
+  @InjectField() browserDetector:BrowserDetector;
 
   text = {
     save: this.I18n.t('js.button_save'),
@@ -196,7 +198,7 @@ export class DatePickerModal extends OpModalComponent implements AfterViewInit {
       this.singleDate ? this.dates.date : [this.dates.start, this.dates.end],
       {
         mode: this.singleDate ? 'single' : 'multiple',
-        showMonths: 2,
+        showMonths: this.browserDetector.isMobile ? 1 : 2,
         inline: true,
         onChange: (dates:Date[]) => {
           this.handleDatePickerChange(dates);

--- a/frontend/src/app/components/datepicker/datepicker_mobile.modal.sass
+++ b/frontend/src/app/components/datepicker/datepicker_mobile.modal.sass
@@ -1,0 +1,7 @@
+@media screen and (max-width: 679px)
+  .datepicker-modal--dates-container
+    grid-template-columns: 1fr 1fr
+    grid-template-rows: 75px 40px
+
+    .datepicker-modal--scheduling-action-container
+      margin: 10px 0

--- a/frontend/src/app/modules/common/op-date-picker/datepicker.ts
+++ b/frontend/src/app/modules/common/op-date-picker/datepicker.ts
@@ -134,7 +134,7 @@ export class DatePicker {
       return document.elementFromPoint(input.offset()!.left, input.offset()!.top) === input[0] &&
         document.activeElement === input[0];
     } catch (e) {
-      console.error("Failed to test visibleAndActive " + e)
+      console.error("Failed to test visibleAndActive " + e);
       return false;
     }
   };

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -51,17 +51,17 @@ describe 'date inplace editor',
     work_packages_page.ensure_page_loaded
   end
 
-  it 'uses the start date as a placeholder for the end date' do
+  it 'can directly set the due date when only a start date is set' do
     start_date.activate!
     start_date.expect_active!
 
     start_date.datepicker.expect_year '2016'
-    start_date.datepicker.expect_month 'January'
+    start_date.datepicker.expect_month 'January', true
     start_date.datepicker.select_day '25'
 
     start_date.save!
     start_date.expect_inactive!
-    start_date.expect_state_text '2016-01-25'
+    start_date.expect_state_text '2016-01-01 - 2016-01-25'
   end
 
   it 'saves the date when clearing and then confirming' do

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -79,6 +79,21 @@ describe 'date inplace editor',
     start_date.expect_state_text '2016-01-01 - ' + Date.today.strftime('%Y-%m-%d')
   end
 
+  it 'can set start and due date to the same day' do
+    start_date.activate!
+    start_date.expect_active!
+
+    # Set the due date
+    start_date.datepicker.set_date Date.today, true
+    # As the to be selected date is automatically toggled,
+    # we can directly set the start date afterwards to the same day
+    start_date.datepicker.set_date Date.today, true
+
+    start_date.save!
+    start_date.expect_inactive!
+    start_date.expect_state_text Date.today.strftime('%Y-%m-%d') + ' - ' + Date.today.strftime('%Y-%m-%d')
+  end
+
   it 'saves the date when clearing and then confirming' do
     start_date.activate!
 

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -64,6 +64,21 @@ describe 'date inplace editor',
     start_date.expect_state_text '2016-01-01 - 2016-01-25'
   end
 
+  it 'can set "today" as a date via the provided link' do
+    start_date.activate!
+    start_date.expect_active!
+
+    start_date.click_today
+
+    start_date.datepicker.expect_year Date.today.year
+    start_date.datepicker.expect_month Date.today.strftime("%B"), true
+    start_date.datepicker.expect_day Date.today.day
+
+    start_date.save!
+    start_date.expect_inactive!
+    start_date.expect_state_text '2016-01-01 - ' + Date.today.strftime('%Y-%m-%d')
+  end
+
   it 'saves the date when clearing and then confirming' do
     start_date.activate!
 

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -16,16 +16,33 @@ module Components
     # Select year from input
     def select_year(value)
       container
-        .find('.numInput.cur-year')
+        .first('.numInput.cur-year')
         .set value
     end
 
     ##
-    # Select month from select
-    def select_month(value)
-      container
-        .find('.flatpickr-monthDropdown-months option', text: value, visible: :all)
-        .select_option
+    # Select month from datepicker
+    def select_month(month, multiple_month_shown = false)
+      if multiple_month_shown
+        month = Date::MONTHNAMES.index(month) if month.is_a?(String)
+        current_month = Date::MONTHNAMES.index(container.first('.cur-month').text)
+
+        if current_month < month
+          while (current_month < month) do
+            container.find('.flatpickr-next-month').click
+            current_month = Date::MONTHNAMES.index(container.first('.cur-month').text)
+          end
+        elsif current_month > month
+          while (current_month > month) do
+            container.find('.flatpickr-prev-month').click
+            current_month = Date::MONTHNAMES.index(container.first('.cur-month').text)
+          end
+        end
+      else
+        container
+          .first('.flatpickr-monthDropdown-months option', text: month, visible: :all)
+          .select_option
+      end
     end
 
     ##
@@ -36,7 +53,7 @@ module Components
       end
 
       container
-        .find('.flatpickr-days .flatpickr-day:not(.nextMonthDay):not(.prevMonthDay)',
+        .first('.flatpickr-days .flatpickr-day:not(.nextMonthDay):not(.prevMonthDay)',
               text: value,
               exact_text: true)
         .click
@@ -44,22 +61,28 @@ module Components
 
     ##
     # Set a ISO8601 date through the datepicker
-    def set_date(date)
+    def set_date(date, multiple_month_shown = false)
       date = Date.parse(date) unless date.is_a?(Date)
 
       select_year date.year
-      select_month date.strftime('%B')
+      select_month multiple_month_shown ? date.month : date.strftime('%B'), multiple_month_shown
       select_day date.day
     end
 
     ##
     # Expect the selected month
-    def expect_month(month)
-      month = Date::MONTHNAMES.index(month) if month.is_a?(String)
+    def expect_month(month, multiple_month_shown = false)
+      if multiple_month_shown
+        field = container.first('.cur-month')
+        expect(field.text).to eq(month)
+      else
+        month = Date::MONTHNAMES.index(month) if month.is_a?(String)
 
-      # Month is 0-index in select
-      field = container.find('.flatpickr-monthDropdown-months')
-      expect(field.value.to_i).to eq(month - 1)
+        # Month is 0-index in select
+        field = container.find('.flatpickr-monthDropdown-months')
+        expect(field.value.to_i).to eq(month - 1)
+
+      end
     end
 
     ##
@@ -71,18 +94,18 @@ module Components
     ##
     # Expect the selected year
     def expect_year(value)
-      field = container.find('.cur-year')
+      field = container.first('.cur-year')
       expect(field.value.to_i).to eq(value.to_i)
     end
 
     ##
     # Expect the current selection to match the
     # given ISO601 date
-    def expect_current_date(date)
+    def expect_current_date(date, multiple_month_shown = false)
       date = Date.parse(date) unless date.is_a?(Date)
 
       expect_year(date.year)
-      expect_month(date.month)
+      expect_month(date.month, multiple_month_shown)
       expect_day(date.day)
     end
   end

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -95,7 +95,7 @@ class DateEditField < EditField
   end
 
   def select_value(value)
-    datepicker.set_date value
+    datepicker.set_date value, true
   end
 
   def save!
@@ -108,10 +108,6 @@ class DateEditField < EditField
 
   def cancel_by_click
     scroll_to_and_click action_button('Cancel')
-  end
-
-  def clear_changes
-    scroll_to_and_click action_button('Clear all')
   end
 
   def action_button(text)

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -89,6 +89,12 @@ class DateEditField < EditField
     end
   end
 
+  def click_today
+    within_modal do
+      find('.form--field-extra-actions a', text: 'Today').click
+    end
+  end
+
   def expect_value(value)
     expect
     expect(input_element.text).to eq(value)


### PR DESCRIPTION
### Todo

- [x] In the WP date field modal, show two months next to each other.
  - [x] Show range correctly over the two months
  - [x] Prevent that the date picker jumps in 1-month steps (e.g when focusing the due date which is in the next month and thus already visible)
- [x] In the WP date field modal, below the input fields, there should be a link "Today" which sets the current date
  - [x] The link should only be shown when the field is currently active and Today is possible as a date 
  - [x] When the link is pressed, the datepicker should jump to that date 
- [x] Make the date input fields clearable individually 
- [x] Handle case that the user clicks on an already selected date (which will remove the date by default, but we want to keep it)
- [x] Add a test case
 