### PR TITLE
[33109]Arrow next to parent task still shown after removing subtask

### DIFF
--- a/frontend/src/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
@@ -140,7 +140,7 @@ export class WorkPackageRelationsHierarchyService {
             this.halEvents.push(wp, {
             eventType: 'association',
             relatedWorkPackage: null,
-            relationType:''
+            relationType: 'child'
             });
           });
         }

--- a/frontend/src/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
@@ -136,13 +136,14 @@ export class WorkPackageRelationsHierarchyService {
         lockVersion: childWorkPackage.lockVersion
       }).then(wp => {
         if (parentWorkPackage) {
-          this.wpCacheService.loadWorkPackage(parentWorkPackage.id!, true);
-          this.halEvents.push(parentWorkPackage, {
+          this.wpCacheService.require(parentWorkPackage.id!, true).then((wp) => {
+            this.halEvents.push(wp, {
             eventType: 'association',
             relatedWorkPackage: null,
+            relationType:''
+            });
           });
         }
-
         this.wpCacheService.updateWorkPackage(wp);
       })
         .catch((error) => {

--- a/frontend/src/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
+++ b/frontend/src/app/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
@@ -136,7 +136,11 @@ export class WorkPackageRelationsHierarchyService {
         lockVersion: childWorkPackage.lockVersion
       }).then(wp => {
         if (parentWorkPackage) {
-          this.wpCacheService.require(parentWorkPackage.id!, true);
+          this.wpCacheService.loadWorkPackage(parentWorkPackage.id!, true);
+          this.halEvents.push(parentWorkPackage, {
+            eventType: 'association',
+            relatedWorkPackage: null,
+          });
         }
 
         this.wpCacheService.updateWorkPackage(wp);

--- a/spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb
@@ -162,6 +162,7 @@ describe 'Work Package table hierarchy parent below', js: true do
       split_page.visit_tab!("relations")
       relations.remove_child(child)
       loading_indicator_saveguard
+      
       expect(page).to have_no_selector('.wp-table--hierarchy-indicator-icon')
     end
   end

--- a/spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb
@@ -142,4 +142,27 @@ describe 'Work Package table hierarchy parent below', js: true do
       hierarchy.expect_leaf_at(child, child2)
     end
   end
+
+  describe 'An arrow is beside parent name' do
+    let(:child) { FactoryBot.create(:work_package, subject: 'AA Child WP', project: project, parent: parent) }
+    let(:parent) { FactoryBot.create(:work_package, subject: 'ZZ Parent WP', project: project) }
+    let(:relations) { ::Components::WorkPackages::Relations.new(parent) }
+
+    before do
+      child
+    end
+
+    it 'and it should not be shown when children are removed "#33109"' do
+      wp_table.visit!
+      wp_table.expect_work_package_listed(child, parent)
+
+      expect(page).to have_selector('.wp-table--hierarchy-indicator-icon')
+      
+      split_page = wp_table.open_split_view(parent)
+      split_page.visit_tab!("relations")
+      relations.remove_child(child)
+      loading_indicator_saveguard
+      expect(page).to have_no_selector('.wp-table--hierarchy-indicator-icon')
+    end
+  end
 end


### PR DESCRIPTION
Arrow next to parent task should be removed after deleting its children.

https://community.openproject.com/projects/openproject/work_packages/33109/activity