### PR TITLE
[33707] Provide active window service and poll only when active

### DIFF
--- a/frontend/src/app/modules/boards/board/query-updated/query-updated.service.ts
+++ b/frontend/src/app/modules/boards/board/query-updated/query-updated.service.ts
@@ -2,13 +2,15 @@ import {Injectable} from "@angular/core";
 import {interval} from 'rxjs';
 import {startWith, switchMap, filter} from 'rxjs/operators';
 import {QueryDmService} from "core-app/modules/hal/dm-services/query-dm.service";
+import {ActiveWindowService} from "core-app/modules/common/active-window/active-window.service";
 
 const POLLING_INTERVAL = 2000;
 
 @Injectable()
 export class QueryUpdatedService {
 
-  constructor(readonly queryDm:QueryDmService) {}
+  constructor(readonly queryDm:QueryDmService,
+              readonly activeWindow:ActiveWindowService) {}
 
   public monitor(ids:string[]) {
     let time = new Date();
@@ -16,6 +18,7 @@ export class QueryUpdatedService {
     return interval(POLLING_INTERVAL)
            .pipe(
              startWith(0),
+             filter(() => this.activeWindow.isActive),
              switchMap(() => {
                let result = this.queryForUpdates(ids, time);
 

--- a/frontend/src/app/modules/common/active-window/active-window.service.ts
+++ b/frontend/src/app/modules/common/active-window/active-window.service.ts
@@ -1,0 +1,33 @@
+import {Inject, Injectable} from "@angular/core";
+import {DOCUMENT} from "@angular/common";
+import {BehaviorSubject, Observable, Subject} from "rxjs";
+import {debugLog} from "core-app/helpers/debug_output";
+
+@Injectable({ providedIn: 'root' })
+export class ActiveWindowService {
+
+  private activeState$ = new BehaviorSubject<boolean>(true);
+
+  constructor(@Inject(DOCUMENT) document:Document) {
+    document.addEventListener('visibilitychange', () => {
+      if (!!document.visibilityState) {
+        debugLog("Browser window has visibility state changed to " + document.visibilityState);
+        this.activeState$.next(document.visibilityState === 'visible');
+      }
+    });
+  }
+
+  /**
+   * Returns whether the browser window/tab is active
+   */
+  public get isActive():boolean {
+    return this.activeState$.value;
+  }
+
+  /**
+   * Observable for notifying when visibility changes
+   */
+  public get active$():Observable<boolean> {
+    return this.activeState$.asObservable();
+  }
+}


### PR DESCRIPTION
Adds a window service that listens to `visibilityChange` events to stop polling whenever the window/tab goes out of focus

https://community.openproject.com/wp/33707