### PR TITLE
[33650]ATOM feed link for all activities is not created as intended

### DIFF
--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -84,7 +84,8 @@ See docs/COPYRIGHT.rdoc for more details.
 <% end %>
 
 <% content_for :header_tags do %>
-  <%= auto_discovery_link_tag(:atom, params.merge(format: 'atom', from: nil, key: User.current.rss_key)) %>
+  <%= auto_discovery_link_tag(:atom,
+                              { format: 'atom', from: nil, key: User.current.rss_key }) %>
 <% end %>
 
 <% content_for :sidebar do %>


### PR DESCRIPTION
fix the format of atom link in header of activities form.

https://community.openproject.com/projects/openproject/work_packages/33650/activity