### PR TITLE
Allow jobs to define a title for the job status modal

### DIFF
--- a/app/workers/copy_project_job.rb
+++ b/app/workers/copy_project_job.rb
@@ -82,6 +82,12 @@ class CopyProjectJob < ApplicationJob
     true
   end
 
+  protected
+
+  def title
+    I18n.t(:label_copy_project)
+  end
+
   private
 
   def successful_status_update

--- a/app/workers/work_packages/exports/export_job.rb
+++ b/app/workers/work_packages/exports/export_job.rb
@@ -18,6 +18,12 @@ module WorkPackages
         true
       end
 
+      protected
+
+      def title
+        I18n.t('export.your_work_packages_export')
+      end
+
       private
 
       def export_work_packages(export, mime_type, query, options)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1160,6 +1160,7 @@ en:
     work_package_note: 'Work Package note added'
 
   export:
+    your_work_packages_export: "Your work packages export"
     succeeded: "The export has completed successfully."
     format:
       atom: "Atom"

--- a/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.html
+++ b/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.html
@@ -2,6 +2,7 @@
   <div class="op-modal--modal-container job-status--modal"
        tabindex="0">
     <div class="op-modal--modal-header">
+      <h3 [textContent]="title"></h3>
       <a class="op-modal--modal-close-button">
         <i
           class="icon-close"
@@ -10,8 +11,6 @@
         </i>
       </a>
     </div>
-
-    <h3 [textContent]="text.title"></h3>
 
     <div>
       <div class="loading-indicator--location"

--- a/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.ts
+++ b/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.ts
@@ -50,6 +50,9 @@ export class JobStatusModal extends OpModalComponent implements OnInit {
   /** Public message to show */
   public message:string;
 
+  /** Title to show */
+  public title:string = this.text.title;
+
   /** A link in case the job results in a download */
   public downloadHref:string|null = null;
 
@@ -123,6 +126,7 @@ export class JobStatusModal extends OpModalComponent implements OnInit {
       this.I18n.t(`js.job_status.generic_messages.${status}`, { defaultValue: status });
 
     if (body.payload) {
+      this.title = body.payload.title || this.text.title;
       this.handleRedirect(body.payload?.redirect);
       this.handleDownload(body.payload?.download);
     }

--- a/frontend/src/app/modules/job-status/job-status.interface.ts
+++ b/frontend/src/app/modules/job-status/job-status.interface.ts
@@ -20,6 +20,7 @@ export interface JobStatusInterface {
    * Additional payload object
    */
   payload?:{
+    title?:string;
     download?:string;
     redirect?:string;
   };

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -73,6 +73,9 @@ describe 'work package export', type: :feature do
     expect(page).to have_content I18n.t('js.job_status.generic_messages.in_queue'),
                                  wait: 10
 
+    # Expect title
+    expect(page).to have_selector 'h3', text: I18n.t('export.your_work_packages_export')
+
     begin
       perform_enqueued_jobs
     rescue

--- a/spec/workers/copy_project_job_spec.rb
+++ b/spec/workers/copy_project_job_spec.rb
@@ -181,7 +181,7 @@ describe CopyProjectJob, type: :model do
       expect(copy_job.job_status).to be_present
       expect(copy_job.job_status[:status]).to eq 'failure'
       expect(copy_job.job_status[:message]).to include "Cannot copy project #{source_project.name}"
-      expect(copy_job.job_status[:payload]).to be_nil
+      expect(copy_job.job_status[:payload]).to eq('title' => 'Copy project')
     end
   end
 
@@ -199,7 +199,7 @@ describe CopyProjectJob, type: :model do
   describe 'perform' do
     before do
       login_as(user)
-      expect(User).to receive(:current=).with(user)
+      expect(User).to receive(:current=).with(user).at_least(:once)
     end
 
     describe 'subproject' do


### PR DESCRIPTION
Adds an optional title attribute to the payload of the job status to display that value in the modal