### PR TITLE
Push images to official docker repository

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Publish to registry
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
-          name: openproject/community-test
+          name: openproject/community
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tag_semver: true


### PR DESCRIPTION
Now that the functionality has been tested on the test repo, enable it on the main repo and disable our jenkins job.