### PR TITLE
[31617] Re-enable group sums rendering

### DIFF
--- a/frontend/src/app/components/wp-fast-table/builders/modes/grouped/group-sums-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/modes/grouped/group-sums-builder.ts
@@ -6,6 +6,7 @@ import {SchemaResource} from "core-app/modules/hal/resources/schema-resource";
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {SchemaCacheService} from "core-components/schemas/schema-cache.service";
 import {DisplayFieldService} from "core-app/modules/fields/display/display-field.service";
+import {groupedRowClassName} from "core-components/wp-fast-table/builders/modes/grouped/grouped-rows-helpers";
 
 export class GroupSumsBuilder extends SingleRowBuilder {
 
@@ -19,7 +20,7 @@ export class GroupSumsBuilder extends SingleRowBuilder {
 
   public buildSumsRow(group:GroupObject) {
     const tr:HTMLTableRowElement = document.createElement('tr');
-    tr.classList.add('wp-table--sums-row', 'wp-table--row');
+    tr.classList.add('wp-table--sums-row', 'wp-table--row', groupedRowClassName(group.index));
 
     this.renderColumns(group.sums, tr);
 

--- a/frontend/src/app/components/wp-fast-table/builders/modes/grouped/group-sums-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/modes/grouped/group-sums-builder.ts
@@ -1,0 +1,80 @@
+import {GroupObject} from 'core-app/modules/hal/resources/wp-collection-resource';
+import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
+import {SingleRowBuilder} from "core-components/wp-fast-table/builders/rows/single-row-builder";
+import {IFieldSchema} from "core-app/modules/fields/field.base";
+import {SchemaResource} from "core-app/modules/hal/resources/schema-resource";
+import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
+import {SchemaCacheService} from "core-components/schemas/schema-cache.service";
+import {DisplayFieldService} from "core-app/modules/fields/display/display-field.service";
+
+export class GroupSumsBuilder extends SingleRowBuilder {
+
+  @InjectField() readonly querySpace:IsolatedQuerySpace;
+  @InjectField() readonly schemaCache:SchemaCacheService;
+  @InjectField() readonly displayFieldService:DisplayFieldService;
+
+  private text = {
+    sum: this.I18n.t('js.label_sum')
+  };
+
+  public buildSumsRow(group:GroupObject) {
+    const tr:HTMLTableRowElement = document.createElement('tr');
+    tr.classList.add('wp-table--sums-row', 'wp-table--row');
+
+    this.renderColumns(group.sums, tr);
+
+    return tr;
+  }
+
+  public renderColumns(sums:{[key:string]:any}, tr:HTMLTableRowElement) {
+    this.augmentedColumns.forEach((column, i:number) => {
+      const td = document.createElement('td');
+      const div = this.renderContent(sums, column.id, this.sumsSchema[column.id]);
+
+      if (i === 0) {
+        this.appendFirstLabel(div);
+      }
+
+      td.appendChild(div);
+      tr.append(td);
+    });
+  }
+
+  private appendFirstLabel(div:HTMLElement) {
+    const span = document.createElement('span');
+    span.textContent = `${this.text.sum}`;
+    div.prepend(span);
+  }
+
+  private get sumsSchema():SchemaResource {
+    // The schema is ensured to be loaded by wpViewAdditionalElementsService
+    const results = this.querySpace.results.value!;
+    const href = results.sumsSchema!.$href!;
+
+    return this.schemaCache.state(href).value!;
+  }
+
+  private renderContent(sums:any, name:string, fieldSchema:IFieldSchema) {
+    const div = document.createElement('div');
+    div.classList.add('wp-table--sum-container', name);
+
+    // The field schema for this element may be undefined
+    // because it is not summable.
+    if (!fieldSchema) {
+      return div;
+    }
+
+    const field = this.displayFieldService.getField(
+      sums,
+      name,
+      fieldSchema,
+      { injector: this.injector, container: 'table', options: {} }
+    );
+
+    if (!field.isEmpty()) {
+      field.render(div, field.valueString);
+    }
+
+    return div;
+  }
+}

--- a/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
@@ -114,7 +114,7 @@ export class WorkPackageStatesInitializationService {
 
     this.wpTableRelationColumns.initialize(query, results);
 
-    this.wpTableAdditionalElements.initialize(results.elements);
+    this.wpTableAdditionalElements.initialize(query, results);
 
     this.wpTableOrder.initialize(query, results);
 

--- a/frontend/src/app/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/components/wp-table/wp-table.directive.html
@@ -61,7 +61,9 @@
       >
       </tbody>
       <tfoot>
-      <tr wpTableSumsRow></tr>
+      <tr class="wp-table--sums-row wp-table--row"
+          wpTableSumsRow
+          [wpTableSumsRow-table]="workPackageTable"></tr>
       </tfoot>
     </table>
   </div>

--- a/frontend/src/app/modules/hal/resources/wp-collection-resource.ts
+++ b/frontend/src/app/modules/hal/resources/wp-collection-resource.ts
@@ -59,6 +59,7 @@ export interface GroupObject {
   collapsed?:boolean;
   index:number;
   identifier:string;
+  sums:{[attribute:string]:number|null};
   href:{ href:string }[];
   _links:{
     valueLink:{ href:string }[];

--- a/frontend/src/app/modules/router/openproject.routes.ts
+++ b/frontend/src/app/modules/router/openproject.routes.ts
@@ -162,8 +162,8 @@ export function initializeUiRouterListeners(injector:Injector) {
   let wpBase = document.querySelector(appBaseSelector);
 
   // Uncomment to trace route changes
-  const uiRouter = injector.get(UIRouter);
-  uiRouter.trace.enable();
+  // const uiRouter = injector.get(UIRouter);
+  // uiRouter.trace.enable();
 
   // Apply classes from bodyClasses in each state definition
   // This was defined as onEnter, onExit functions in each state before

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -126,15 +126,7 @@ table.generic-table
   tfoot
     tr
       background: #f6f7f8
-      border:
-        top:    0
-        bottom: 0
-      height:   0
     td
-      height:   0
-      padding:
-        top:    0
-        bottom: 0
       font-weight: bold
 
   tbody

--- a/frontend/src/global_styles/content/work_packages/_table_content.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_content.sass
@@ -55,6 +55,14 @@
     .wp-table--cell-td
       display: none !important
 
+// Sums row background
+.wp-table--sums-row
+  background: #f6f7f8
+
+.wp-table--sum-container
+  font-weight: bold
+  padding: 3px 6px
+
 .work-package-table--container table.generic-table tbody td
   padding-left: 0
   padding-top: 0
@@ -74,7 +82,6 @@
   &:hover .inline-edit--active-field.-error:hover
     border-color: var(--content-form-danger-zone-bg-color)
 
-//
 .wp-table--faulty-query-icon
   color: var(--content-form-danger-zone-bg-color)
 

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -101,11 +101,10 @@
       @include wp-table--placeholder-time-values
 
 // Sums in wp table
-.wp-table--sum-container
-  .split-time-field
-    .-actual-value
-      @include wp-table--time-values
-      @include wp-table--actual-time-values
+.wp-table--sum-container.split-time-field
+  .-actual-value
+    @include wp-table--time-values
+    @include wp-table--actual-time-values
 
 
 // Editable fields cursor

--- a/spec/features/work_packages/index_sums_spec.rb
+++ b/spec/features/work_packages/index_sums_spec.rb
@@ -63,6 +63,7 @@ RSpec.feature 'Work package index sums', js: true do
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
   let(:columns) { ::Components::WorkPackages::Columns.new }
   let(:modal) { ::Components::WorkPackages::TableConfigurationModal.new }
+  let(:group_by) { ::Components::WorkPackages::GroupBy.new }
 
   before do
     login_as(admin)
@@ -90,6 +91,9 @@ RSpec.feature 'Work package index sums', js: true do
 
     wp_table.expect_work_package_listed work_package_1, work_package_2
 
+    # Expect the total sums row
+    expect(page).to have_selector('.wp-table--sums-row', count: 1)
+
     expect(page).to have_selector('.wp-table--sum-container', text: 'Sum')
     expect(page).to have_selector('.wp-table--sum-container', text: '25')
     expect(page).to have_selector('.wp-table--sum-container', text: '12')
@@ -103,5 +107,26 @@ RSpec.feature 'Work package index sums', js: true do
     expect(page).to have_selector('.wp-table--sum-container', text: '35')
     expect(page).to have_selector('.wp-table--sum-container', text: '12')
     expect(page).to have_selector('.wp-table--sum-container', text: '13.2')
+
+    # Enable groups
+    group_by.enable_via_menu 'Status'
+
+    # Expect to have three sums rows no
+    expect(page).to have_selector('.wp-table--sums-row', count: 3)
+
+    # First status row
+    expect(page).to have_selector('.wp-table--sum-container', text: '20 h')
+    expect(page).to have_selector(".wp-table--sum-container.customField#{int_cf.id}", text: '5')
+    expect(page).to have_selector(".wp-table--sum-container.customField#{float_cf.id}", text: '5.5')
+
+    # Second status row
+    expect(page).to have_selector('.wp-table--sum-container', text: '15 h')
+    expect(page).to have_selector(".wp-table--sum-container.customField#{int_cf.id}", text: '7')
+    expect(page).to have_selector(".wp-table--sum-container.customField#{float_cf.id}", text: '7.7')
+
+    # Total sums row is unchanged
+    expect(page).to have_selector('tfoot .wp-table--sum-container', text: '35')
+    expect(page).to have_selector("tfoot .wp-table--sum-container.customField#{int_cf.id}", text: '12')
+    expect(page).to have_selector("tfoot .wp-table--sum-container.customField#{float_cf.id}", text: '13.2')
   end
 end

--- a/spec/features/work_packages/index_sums_spec.rb
+++ b/spec/features/work_packages/index_sums_spec.rb
@@ -128,5 +128,14 @@ RSpec.feature 'Work package index sums', js: true do
     expect(page).to have_selector('tfoot .wp-table--sum-container', text: '35')
     expect(page).to have_selector("tfoot .wp-table--sum-container.customField#{int_cf.id}", text: '12')
     expect(page).to have_selector("tfoot .wp-table--sum-container.customField#{float_cf.id}", text: '13.2')
+
+    # Collapsing groups will also hide the sums row
+    page.find('.expander.icon-minus2', match: :first).click
+    sleep 1
+    page.find('.expander.icon-minus2', match: :first).click
+
+    # Expect to have only the final sums
+    expect(page).to have_selector('tbody .wp-table--sums-row', count: 0)
+    expect(page).to have_selector('tfoot .wp-table--sums-row', count: 1)
   end
 end

--- a/spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb
@@ -132,7 +132,7 @@ describe 'Work Package table hierarchy parent below', js: true do
       expect(page).to have_selector('.pagination--item.-current', text: '3')
 
       # Expect count to be correct (one additional parent shown)
-      expect(page).to have_selector('.wp-table--row', count: 4)
+      expect(page).to have_selector('.wp--row', count: 4)
 
       # Double order result from regression
       wp_table.expect_work_package_order(grandparent.id, parent.id, child.id, child2.id)

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -97,7 +97,7 @@ module Pages
 
     def expect_work_package_order(*ids)
       retry_block do
-        rows = page.all '.wp-table--row'
+        rows = page.all '.work-package-table .wp--row'
         expected = ids.map { |el| el.is_a?(WorkPackage) ? el.id.to_s : el.to_s }
         found = rows.map { |el| el['data-work-package-id'] }
 


### PR DESCRIPTION
The grouped rows builder excluded rendering of per-groups sums,
however the API returned these results anyway.

It's easy to just render a sums row as we did before. To that end,
I have removed that functionality from the sums row directive and into
a generic renderer that can be used with and without angular.

https://community.openproject.com/wp/31617