### PR TITLE
Fix/missing start date on scheduling

### DIFF
--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -116,12 +116,7 @@ class WorkPackages::SetScheduleService
   #    ancestors limits moving it. Then it is moved to the earliest date possible. This limitation is propagated transtitively
   #    to all following work packages.
   def reschedule_by_follows(scheduled, dependency)
-    delta = if dependency.follows_moved.first
-              date_rescheduling_delta(dependency.follows_moved.first.to)
-            else
-              0
-            end
-
+    delta = follows_delta(dependency)
     min_start_date = dependency.max_date_of_followed
 
     if delta.zero? && min_start_date
@@ -162,5 +157,13 @@ class WorkPackages::SetScheduleService
   def schedule_on_missing_dates(scheduled, min_start_date)
     scheduled.start_date = min_start_date
     scheduled.due_date = scheduled.start_date + 1 if scheduled.due_date && scheduled.due_date < scheduled.start_date
+  end
+
+  def follows_delta(dependency)
+    if dependency.follows_moved.first
+      date_rescheduling_delta(dependency.follows_moved.first.to)
+    else
+      0
+    end
   end
 end

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -233,6 +233,16 @@ describe WorkPackages::SetScheduleService do
           end
         end
       end
+
+      context 'when the follower has no start date (which should not happen)' do
+        let(:follower1_start_date) { nil }
+
+        it_behaves_like 'reschedules' do
+          let(:expected) do
+            { following_work_package1 => [Date.today + 6.days, Date.today + 7.day] }
+          end
+        end
+      end
     end
 
     context 'moving forward with the follower having some space left' do
@@ -365,6 +375,20 @@ describe WorkPackages::SetScheduleService do
         end
         let(:unchanged) do
           [other_work_package]
+        end
+      end
+    end
+
+    context 'moving backwards with the follower having no start date (which should not happen)' do
+      let(:follower1_start_date) { nil }
+
+      before do
+        work_package.due_date = Date.today - 5.days
+      end
+
+      it_behaves_like 'reschedules' do
+        let(:expected) do
+          { following_work_package1 => [Date.today - 4.days, follower1_due_date] }
         end
       end
     end


### PR DESCRIPTION
Handles having start_date set to nil for an existing successor when scheduling. This should not happen as defining a follows relationships should set the start_date but in case it does, the scheduling algorithm now sets them again.

https://community.openproject.com/projects/gmbh/work_packages/33776