### PR TITLE
[33830] Extend attribute help text for projects and allow images

### DIFF
--- a/app/contracts/attribute_help_texts/base_contract.rb
+++ b/app/contracts/attribute_help_texts/base_contract.rb
@@ -28,46 +28,26 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module HelpTexts
-      class HelpTextRepresenter < ::API::Decorators::Single
-        include API::Decorators::LinkedResource
-        include API::Caching::CachedRepresenter
-        include ::API::V3::Attachments::AttachableRepresenterMixin
+module AttributeHelpTexts
+  class BaseContract < ::ModelContract
+    include Attachments::ValidateReplacements
 
-        self_link path: :help_text,
-                  id_attribute: :id,
-                  title_getter: ->(*) { nil }
+    def validate
+      validate_user_allowed_to_manage
 
-        link :editText do
-          if current_user.admin? && represented.persisted?
-            {
-              href: edit_attribute_help_text_path(represented.id),
-              type: 'text/html'
-            }
-          end
-        end
+      super
+    end
 
-        property :id
-        property :attribute_name,
-                 as: :attribute,
-                 getter: ->(*) {
-                   ::API::Utilities::PropertyNameConverter.from_ar_name(attribute_name)
-                 }
-        property :attribute_caption
-        property :attribute_scope,
-                 as: :scope
-        property :help_text,
-                 exec_context: :decorator,
-                 getter: ->(*) {
-                   ::API::Decorators::Formattable.new(represented.help_text)
-                 }
+    def self.model
+      AttributeHelpText
+    end
 
-        def _type
-          'HelpText'
-        end
-      end
+    attribute :type
+    attribute :attribute_name
+    attribute :help_text
+
+    def validate_user_allowed_to_manage
+      errors.add :base, :error_unauthorized unless user.admin?
     end
   end
 end

--- a/app/contracts/attribute_help_texts/create_contract.rb
+++ b/app/contracts/attribute_help_texts/create_contract.rb
@@ -28,46 +28,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module HelpTexts
-      class HelpTextRepresenter < ::API::Decorators::Single
-        include API::Decorators::LinkedResource
-        include API::Caching::CachedRepresenter
-        include ::API::V3::Attachments::AttachableRepresenterMixin
-
-        self_link path: :help_text,
-                  id_attribute: :id,
-                  title_getter: ->(*) { nil }
-
-        link :editText do
-          if current_user.admin? && represented.persisted?
-            {
-              href: edit_attribute_help_text_path(represented.id),
-              type: 'text/html'
-            }
-          end
-        end
-
-        property :id
-        property :attribute_name,
-                 as: :attribute,
-                 getter: ->(*) {
-                   ::API::Utilities::PropertyNameConverter.from_ar_name(attribute_name)
-                 }
-        property :attribute_caption
-        property :attribute_scope,
-                 as: :scope
-        property :help_text,
-                 exec_context: :decorator,
-                 getter: ->(*) {
-                   ::API::Decorators::Formattable.new(represented.help_text)
-                 }
-
-        def _type
-          'HelpText'
-        end
-      end
-    end
+module AttributeHelpTexts
+  class CreateContract < BaseContract
   end
 end

--- a/app/contracts/attribute_help_texts/update_contract.rb
+++ b/app/contracts/attribute_help_texts/update_contract.rb
@@ -28,46 +28,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module HelpTexts
-      class HelpTextRepresenter < ::API::Decorators::Single
-        include API::Decorators::LinkedResource
-        include API::Caching::CachedRepresenter
-        include ::API::V3::Attachments::AttachableRepresenterMixin
-
-        self_link path: :help_text,
-                  id_attribute: :id,
-                  title_getter: ->(*) { nil }
-
-        link :editText do
-          if current_user.admin? && represented.persisted?
-            {
-              href: edit_attribute_help_text_path(represented.id),
-              type: 'text/html'
-            }
-          end
-        end
-
-        property :id
-        property :attribute_name,
-                 as: :attribute,
-                 getter: ->(*) {
-                   ::API::Utilities::PropertyNameConverter.from_ar_name(attribute_name)
-                 }
-        property :attribute_caption
-        property :attribute_scope,
-                 as: :scope
-        property :help_text,
-                 exec_context: :decorator,
-                 getter: ->(*) {
-                   ::API::Decorators::Formattable.new(represented.help_text)
-                 }
-
-        def _type
-          'HelpText'
-        end
-      end
-    end
+module AttributeHelpTexts
+  class UpdateContract < BaseContract
   end
 end

--- a/app/models/attribute_help_text/work_package.rb
+++ b/app/models/attribute_help_text/work_package.rb
@@ -43,10 +43,6 @@ class AttributeHelpText::WorkPackage < AttributeHelpText
 
   validates_inclusion_of :attribute_name, in: ->(*) { available_attributes.keys }
 
-  def attribute_scope
-    'WorkPackage'
-  end
-
   def type_caption
     I18n.t(:label_work_package)
   end
@@ -57,7 +53,8 @@ class AttributeHelpText::WorkPackage < AttributeHelpText
                        .pluck(:id)
                        .map { |id| "custom_field_#{id}" }
 
-    where(attribute_name: visible_cf_names)
-      .or(where.not("attribute_name LIKE 'custom_field_%'"))
+    ::AttributeHelpText
+      .where(attribute_name: visible_cf_names)
+      .or(::AttributeHelpText.where.not("attribute_name LIKE 'custom_field_%'"))
   end
 end

--- a/app/services/attribute_help_texts/create_service.rb
+++ b/app/services/attribute_help_texts/create_service.rb
@@ -28,46 +28,12 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module HelpTexts
-      class HelpTextRepresenter < ::API::Decorators::Single
-        include API::Decorators::LinkedResource
-        include API::Caching::CachedRepresenter
-        include ::API::V3::Attachments::AttachableRepresenterMixin
+module AttributeHelpTexts
+  class CreateService < ::BaseServices::Create
+    include Attachments::ReplaceAttachments
 
-        self_link path: :help_text,
-                  id_attribute: :id,
-                  title_getter: ->(*) { nil }
-
-        link :editText do
-          if current_user.admin? && represented.persisted?
-            {
-              href: edit_attribute_help_text_path(represented.id),
-              type: 'text/html'
-            }
-          end
-        end
-
-        property :id
-        property :attribute_name,
-                 as: :attribute,
-                 getter: ->(*) {
-                   ::API::Utilities::PropertyNameConverter.from_ar_name(attribute_name)
-                 }
-        property :attribute_caption
-        property :attribute_scope,
-                 as: :scope
-        property :help_text,
-                 exec_context: :decorator,
-                 getter: ->(*) {
-                   ::API::Decorators::Formattable.new(represented.help_text)
-                 }
-
-        def _type
-          'HelpText'
-        end
-      end
+    def instance(params)
+      instance_class.new type: params[:type]
     end
   end
 end

--- a/app/services/attribute_help_texts/set_attributes_service.rb
+++ b/app/services/attribute_help_texts/set_attributes_service.rb
@@ -28,46 +28,8 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module HelpTexts
-      class HelpTextRepresenter < ::API::Decorators::Single
-        include API::Decorators::LinkedResource
-        include API::Caching::CachedRepresenter
-        include ::API::V3::Attachments::AttachableRepresenterMixin
-
-        self_link path: :help_text,
-                  id_attribute: :id,
-                  title_getter: ->(*) { nil }
-
-        link :editText do
-          if current_user.admin? && represented.persisted?
-            {
-              href: edit_attribute_help_text_path(represented.id),
-              type: 'text/html'
-            }
-          end
-        end
-
-        property :id
-        property :attribute_name,
-                 as: :attribute,
-                 getter: ->(*) {
-                   ::API::Utilities::PropertyNameConverter.from_ar_name(attribute_name)
-                 }
-        property :attribute_caption
-        property :attribute_scope,
-                 as: :scope
-        property :help_text,
-                 exec_context: :decorator,
-                 getter: ->(*) {
-                   ::API::Decorators::Formattable.new(represented.help_text)
-                 }
-
-        def _type
-          'HelpText'
-        end
-      end
-    end
+module AttributeHelpTexts
+  class SetAttributesService < ::BaseServices::SetAttributes
+    include Attachments::SetReplacements
   end
 end

--- a/app/services/attribute_help_texts/update_service.rb
+++ b/app/services/attribute_help_texts/update_service.rb
@@ -28,46 +28,8 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module HelpTexts
-      class HelpTextRepresenter < ::API::Decorators::Single
-        include API::Decorators::LinkedResource
-        include API::Caching::CachedRepresenter
-        include ::API::V3::Attachments::AttachableRepresenterMixin
-
-        self_link path: :help_text,
-                  id_attribute: :id,
-                  title_getter: ->(*) { nil }
-
-        link :editText do
-          if current_user.admin? && represented.persisted?
-            {
-              href: edit_attribute_help_text_path(represented.id),
-              type: 'text/html'
-            }
-          end
-        end
-
-        property :id
-        property :attribute_name,
-                 as: :attribute,
-                 getter: ->(*) {
-                   ::API::Utilities::PropertyNameConverter.from_ar_name(attribute_name)
-                 }
-        property :attribute_caption
-        property :attribute_scope,
-                 as: :scope
-        property :help_text,
-                 exec_context: :decorator,
-                 getter: ->(*) {
-                   ::API::Decorators::Formattable.new(represented.help_text)
-                 }
-
-        def _type
-          'HelpText'
-        end
-      end
-    end
+module AttributeHelpTexts
+  class UpdateService < ::BaseServices::Update
+    include Attachments::ReplaceAttachments
   end
 end

--- a/app/views/attribute_help_texts/_form.html.erb
+++ b/app/views/attribute_help_texts/_form.html.erb
@@ -40,7 +40,23 @@ See docs/COPYRIGHT.rdoc for more details.
       <%= f.select :attribute_name, selectable_attributes(@attribute_help_text), container_class: '-middle' %>
     <% end %>
   </div>
+
+  <% resource = ::API::V3::HelpTexts::HelpTextRepresenter.new(@attribute_help_text,
+                                                              current_user: current_user,
+                                                              embed_links: true) %>
+
   <div class="form--field -required -visible-overflow">
-    <%= f.text_area :help_text, cols: 100, rows: 20, class: 'wiki-edit', with_text_formatting: true %>
+    <%= f.text_area :help_text,
+                    cols: 100,
+                    rows: 20,
+                    class: 'wiki-edit',
+                    with_text_formatting: true,
+                    resource: resource %>
+    <div class="form--field-instructions">
+      <p>
+        <strong><%= t(:note) %>:</strong>
+        <%= t('attribute_help_texts.note_public') %>
+      </p>
+    </div>
   </div>
 </section>

--- a/app/views/attribute_help_texts/_tab.html.erb
+++ b/app/views/attribute_help_texts/_tab.html.erb
@@ -1,0 +1,78 @@
+<% entries = @texts_by_type[tab[:name]] || [] %>
+<% if entries.any? %>
+  <div class="generic-table--container">
+    <div class="generic-table--results-container">
+      <table class="generic-table">
+        <colgroup>
+          <col highlight-col>
+          <col highlight-col>
+          <col highlight-col>
+          <col>
+        </colgroup>
+        <thead>
+        <tr>
+          <th>
+            <div class="generic-table--sort-header-outer">
+              <div class="generic-table--sort-header">
+                  <span>
+                    <%= AttributeHelpText.human_attribute_name(:attribute_name) %>
+                  </span>
+              </div>
+            </div>
+          </th>
+          <th>
+            <div class="generic-table--sort-header-outer">
+              <div class="generic-table--sort-header">
+                  <span>
+                    <%= AttributeHelpText.human_attribute_name(:help_text) %>
+                  </span>
+              </div>
+            </div>
+          </th>
+          <th>
+            <div class="generic-table--empty-header"></div>
+          </th>
+        </tr>
+        </thead>
+        <tbody>
+        <% entries.each do |attribute_help_text| -%>
+          <tr class="attribute-help-text--entry">
+            <td>
+              <%= link_to h(attribute_help_text.attribute_caption),
+                          edit_attribute_help_text_path(attribute_help_text) %>
+            </td>
+            <td>
+              <attribute-help-text
+                data-help-text-id="<%= attribute_help_text.id %>"
+                data-attribute="<%= attribute_help_text.attribute_name %>"
+                data-attribute-scope="'<%= attribute_help_text.attribute_scope %>'"
+                data-additional-label="<%= t(:'attribute_help_texts.show_preview') %>">
+              </attribute-help-text>
+            </td>
+            <td class="buttons">
+              <%= link_to(
+                    op_icon('icon icon-delete'),
+                    (attribute_help_text_path(attribute_help_text)),
+                    method: :delete,
+                    data: { confirm: I18n.t(:text_are_you_sure) },
+                    title: t(:button_delete)) %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% else %>
+  <%= no_results_box %>
+<% end %>
+
+<div class="generic-table--action-buttons">
+  <%= link_to new_attribute_help_text_path(name: tab[:name]),
+              { class: 'attribute-help-texts--create-button button -alt-highlight',
+                aria: {label: t(:'attribute_help_texts.add_new')},
+                title: t(:'attribute_help_texts.add_new')} do %>
+    <%= op_icon('button--icon icon-add') %>
+    <span class="button--text"><%= t('activerecord.models.attribute_help_text') %></span>
+  <% end %>
+</div>

--- a/app/views/attribute_help_texts/index.html.erb
+++ b/app/views/attribute_help_texts/index.html.erb
@@ -26,93 +26,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<% name = 'WorkPackage' %>
-
-<%= toolbar title: t(:'attribute_help_texts.label_plural') do %>
-  <li class="toolbar-item">
-    <%= link_to new_attribute_help_text_path(name: name),
-                { class: 'attribute-help-texts--create-button button -alt-highlight',
-                  aria: {label: t(:'attribute_help_texts.add_new')},
-                  title: t(:'attribute_help_texts.add_new')} do %>
-      <%= op_icon('button--icon icon-add') %>
-      <span class="button--text"><%= t('activerecord.models.attribute_help_text') %></span>
-    <% end %>
-  </li>
-<% end %>
-
-<div class="notification-box -info">
-  <div class="notification-box--content">
-    <p><%= t('attribute_help_texts.text_overview') %></p>
-  </div>
-</div>
-
-<% html_title(t(:label_administration), t(:'attribute_help_texts.label_plural')) -%>
-
-<% entries = @texts_by_type[name] || [] %>
-<% if entries.any? %>
-  <div class="generic-table--container">
-    <div class="generic-table--results-container">
-      <table class="generic-table">
-        <colgroup>
-          <col highlight-col>
-          <col highlight-col>
-          <col highlight-col>
-          <col>
-        </colgroup>
-        <thead>
-        <tr>
-          <th>
-            <div class="generic-table--sort-header-outer">
-              <div class="generic-table--sort-header">
-                  <span>
-                    <%= AttributeHelpText.human_attribute_name(:attribute_name) %>
-                  </span>
-              </div>
-            </div>
-          </th>
-          <th>
-            <div class="generic-table--sort-header-outer">
-              <div class="generic-table--sort-header">
-                  <span>
-                    <%= AttributeHelpText.human_attribute_name(:help_text) %>
-                  </span>
-              </div>
-            </div>
-          </th>
-          <th>
-            <div class="generic-table--empty-header"></div>
-          </th>
-        </tr>
-        </thead>
-        <tbody>
-        <% entries.each do |attribute_help_text| -%>
-          <tr class="attribute-help-text--entry">
-            <td>
-              <%= link_to h(attribute_help_text.attribute_caption),
-                          edit_attribute_help_text_path(attribute_help_text) %>
-            </td>
-            <td>
-              <attribute-help-text
-                data-help-text-id="<%= attribute_help_text.id %>"
-                data-attribute="<%= attribute_help_text.attribute_name %>"
-                data-attribute-scope="'<%= attribute_help_text.attribute_scope %>'"
-                data-additional-label="<%= t(:'attribute_help_texts.show_preview') %>">
-              </attribute-help-text>
-            </td>
-            <td class="buttons">
-              <%= link_to(
-                    op_icon('icon icon-delete'),
-                    (attribute_help_text_path(attribute_help_text)),
-                    method: :delete,
-                    data: { confirm: I18n.t(:text_are_you_sure) },
-                    title: t(:button_delete)) %>
-            </td>
-          </tr>
-        <% end %>
-        </tbody>
-      </table>
-    </div>
-  </div>
-<% else %>
-  <%= no_results_box %>
-<% end %>
+<%= render_tabs [
+                  {
+                    name: 'WorkPackage',
+                    partial: 'attribute_help_texts/tab',
+                    path: attribute_help_texts_path(tab: 'WorkPackage'),
+                    label: :label_work_package
+                  },
+                  {
+                    name: 'Project',
+                    partial: 'attribute_help_texts/tab',
+                    path: attribute_help_texts_path(tab: 'Project'),
+                    label: Project.model_name.human
+                  }
+                ]
+%>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -207,7 +207,7 @@ Redmine::MenuManager.map :admin_menu do |menu|
   menu.push :attribute_help_texts,
             { controller: '/attribute_help_texts' },
             caption: :'attribute_help_texts.label_plural',
-            parent: :admin_work_packages,
+            icon: 'icon2 icon-help2',
             if: Proc.new {
               EnterpriseToken.allows_to?(:attribute_help_texts)
             }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,7 @@ en:
     is_inactive: currently not displayed
 
   attribute_help_texts:
+    note_public: 'Any text and images you add to this field is publically visible to all logged in users!'
     text_overview: 'In this view, you can create custom help texts for attributes view. When defined, these texts can be shown by clicking the help icon next to its belonging attribute.'
     label_plural: 'Attribute help texts'
     show_preview: 'Preview text'

--- a/frontend/src/app/modules/common/help-texts/attribute-help-text.modal.ts
+++ b/frontend/src/app/modules/common/help-texts/attribute-help-text.modal.ts
@@ -26,7 +26,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {ChangeDetectorRef, Component, ElementRef, Inject} from '@angular/core';
+import {ChangeDetectorRef, Component, ElementRef, Inject, OnInit} from '@angular/core';
 import {OpModalComponent} from 'core-components/op-modals/op-modal.component';
 import {OpModalLocalsMap} from 'core-components/op-modals/op-modal.types';
 import {HelpTextResource} from 'core-app/modules/hal/resources/help-text-resource';
@@ -36,7 +36,7 @@ import {OpModalLocalsToken} from "core-components/op-modals/op-modal.service";
 @Component({
   templateUrl: './help-text.modal.html'
 })
-export class AttributeHelpTextModal extends OpModalComponent {
+export class AttributeHelpTextModal extends OpModalComponent implements OnInit {
 
   /* Close on escape? */
   public closeOnEscape = true;
@@ -56,6 +56,17 @@ export class AttributeHelpTextModal extends OpModalComponent {
               readonly cdRef:ChangeDetectorRef,
               readonly elementRef:ElementRef) {
     super(locals, cdRef, elementRef);
+  }
+
+  ngOnInit() {
+    super.ngOnInit();
+
+    // Load the attachments
+    this
+      .helpText
+      .attachments
+      .$load()
+      .then(() => this.cdRef.detectChanges());
   }
 
   public get helpTextLink() {

--- a/frontend/src/app/modules/common/help-texts/attribute-help-text.modal.ts
+++ b/frontend/src/app/modules/common/help-texts/attribute-help-text.modal.ts
@@ -26,7 +26,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {ChangeDetectorRef, Component, ElementRef, Inject, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject, OnInit} from '@angular/core';
 import {OpModalComponent} from 'core-components/op-modals/op-modal.component';
 import {OpModalLocalsMap} from 'core-components/op-modals/op-modal.types';
 import {HelpTextResource} from 'core-app/modules/hal/resources/help-text-resource';
@@ -34,7 +34,8 @@ import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {OpModalLocalsToken} from "core-components/op-modals/op-modal.service";
 
 @Component({
-  templateUrl: './help-text.modal.html'
+  templateUrl: './help-text.modal.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AttributeHelpTextModal extends OpModalComponent implements OnInit {
 

--- a/frontend/src/app/modules/common/help-texts/help-text.modal.html
+++ b/frontend/src/app/modules/common/help-texts/help-text.modal.html
@@ -21,6 +21,10 @@
          [innerHtml]="helpText.helpText.html">
     </div>
 
+    <attachments [resource]="helpText"
+                 data-allow-uploading="false">
+    </attachments>
+
     <div class="modal--form-actions">
       <a class="help-text--edit-button button"
          *ngIf="helpText.editText"

--- a/frontend/src/app/modules/common/openproject-common.module.ts
+++ b/frontend/src/app/modules/common/openproject-common.module.ts
@@ -31,8 +31,6 @@ import {Injector, NgModule} from "@angular/core";
 
 import {AuthoringComponent} from 'core-app/modules/common/authoring/authoring.component';
 import {OpDateTimeComponent} from 'core-app/modules/common/date/op-date-time.component';
-import {AttributeHelpTextComponent} from 'core-app/modules/common/help-texts/attribute-help-text.component';
-import {AttributeHelpTextModal} from 'core-app/modules/common/help-texts/attribute-help-text.modal';
 import {OpIcon} from 'core-app/modules/common/icon/op-icon';
 import {NotificationComponent} from 'core-app/modules/common/notifications/notification.component';
 import {NotificationsContainerComponent} from 'core-app/modules/common/notifications/notifications-container.component';
@@ -152,8 +150,6 @@ export function bootstrapModule(injector:Injector) {
     OpIcon,
     AutofocusDirective,
 
-    AttributeHelpTextComponent,
-    AttributeHelpTextModal,
     FocusWithinDirective,
     FocusDirective,
     AuthoringComponent,
@@ -163,9 +159,6 @@ export function bootstrapModule(injector:Injector) {
     NotificationComponent,
     UploadProgressComponent,
     OpDateTimeComponent,
-
-    // Entries for ng1 downgraded components
-    AttributeHelpTextComponent,
 
     // Table highlight
     HighlightColDirective,
@@ -206,8 +199,6 @@ export function bootstrapModule(injector:Injector) {
     OpIcon,
     AutofocusDirective,
 
-    AttributeHelpTextComponent,
-    AttributeHelpTextModal,
     FocusWithinDirective,
     FocusDirective,
     AuthoringComponent,
@@ -220,9 +211,6 @@ export function bootstrapModule(injector:Injector) {
 
     OPContextMenuComponent,
     IconTriggeredContextMenuComponent,
-
-    // Entries for ng1 downgraded components
-    AttributeHelpTextComponent,
 
     // Table highlight
     HighlightColDirective,

--- a/frontend/src/app/modules/common/tabs/content-tabs/content-tabs.component.ts
+++ b/frontend/src/app/modules/common/tabs/content-tabs/content-tabs.component.ts
@@ -71,7 +71,7 @@ export class ContentTabsComponent extends ScrollableTabsComponent {
     this.tabs = this.gonTabs.map((tab:GonTab) => {
       return {
         id: tab.name,
-        name: this.I18n.t('js.' + tab.label),
+        name: this.I18n.t('js.' + tab.label, { defaultValue: tab.label }),
         path: tab.path
       };
     });

--- a/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.html
+++ b/frontend/src/app/modules/grids/widgets/custom-text/custom-text.component.html
@@ -3,6 +3,7 @@
     (onRenamed)="renameWidget($event)">
 
   <widget-menu
+      slot="menu"
       [resource]="resource">
   </widget-menu>
 </widget-header>

--- a/frontend/src/app/modules/grids/widgets/documents/documents.component.html
+++ b/frontend/src/app/modules/grids/widgets/documents/documents.component.html
@@ -3,6 +3,7 @@
     [editable]="isEditable">
 
   <widget-menu
+      slot="menu"
       [resource]="resource">
   </widget-menu>
 </widget-header>

--- a/frontend/src/app/modules/grids/widgets/header/header.component.html
+++ b/frontend/src/app/modules/grids/widgets/header/header.component.html
@@ -1,11 +1,13 @@
 <h3 class="widget-box--header"
     [ngClass]="{ '-editable': isRenameable }">
 
+  <ng-content select="[slot=prepend]"></ng-content>
+
   <editable-toolbar-title [title]="name"
                           (onSave)="renamed($event)"
                           [editable]="isRenameable"
                           class="widget-box--header-title">
   </editable-toolbar-title>
 
-  <ng-content></ng-content>
+  <ng-content select="[slot=menu]"></ng-content>
 </h3>

--- a/frontend/src/app/modules/grids/widgets/members/members.component.html
+++ b/frontend/src/app/modules/grids/widgets/members/members.component.html
@@ -3,6 +3,7 @@
     [editable]="isEditable">
 
   <widget-menu
+      slot="menu"
       [resource]="resource">
   </widget-menu>
 </widget-header>

--- a/frontend/src/app/modules/grids/widgets/news/news.component.html
+++ b/frontend/src/app/modules/grids/widgets/news/news.component.html
@@ -1,7 +1,9 @@
 <widget-header [name]="widgetName"
                [editable]="isEditable">
 
-  <widget-menu [resource]="resource">
+  <widget-menu
+    slot="menu"
+    [resource]="resource">
   </widget-menu>
 
 </widget-header>

--- a/frontend/src/app/modules/grids/widgets/project-description/project-description.component.html
+++ b/frontend/src/app/modules/grids/widgets/project-description/project-description.component.html
@@ -2,7 +2,12 @@
   [name]="widgetName"
   [editable]="isEditable">
 
+  <attribute-help-text slot="prepend"
+                       attribute="description"
+                       [attributeScope]="'Project'"></attribute-help-text>
+
   <widget-menu
+      slot="menu"
       [resource]="resource">
   </widget-menu>
 </widget-header>
@@ -11,7 +16,7 @@
   <edit-form *ngIf="(project$ | async) as project"
              [resource]="project">
     <editable-attribute-field [resource]="project"
-                              [fieldName]="'description'">
+                              fieldName="description">
     </editable-attribute-field>
   </edit-form>
 </div>

--- a/frontend/src/app/modules/grids/widgets/project-details/project-details.component.html
+++ b/frontend/src/app/modules/grids/widgets/project-details/project-details.component.html
@@ -3,6 +3,7 @@
     [editable]="isEditable">
 
   <widget-menu
+      slot="menu"
       [resource]="resource">
   </widget-menu>
 </widget-header>
@@ -14,6 +15,8 @@
       <ng-container *ngFor="let cf of customFields">
         <div class="attributes-map--key">
           {{ cf.label }}
+          <attribute-help-text [attribute]="cf.key"
+                               [attributeScope]="'Project'"></attribute-help-text>
         </div>
         <div class="attributes-map--value">
           <editable-attribute-field [resource]="project"

--- a/frontend/src/app/modules/grids/widgets/project-status/project-status.component.html
+++ b/frontend/src/app/modules/grids/widgets/project-status/project-status.component.html
@@ -2,7 +2,12 @@
   [name]="widgetName"
   [editable]="isEditable">
 
+  <attribute-help-text slot="prepend"
+                       attribute="status"
+                       [attributeScope]="'Project'"></attribute-help-text>
+
   <widget-menu
+    slot="menu"
     [resource]="resource">
   </widget-menu>
 </widget-header>

--- a/frontend/src/app/modules/grids/widgets/subprojects/subprojects.component.html
+++ b/frontend/src/app/modules/grids/widgets/subprojects/subprojects.component.html
@@ -3,6 +3,7 @@
     [editable]="isEditable">
 
   <widget-menu
+      slot="menu"
       [resource]="resource">
   </widget-menu>
 </widget-header>

--- a/frontend/src/app/modules/grids/widgets/time-entries/current-user/time-entries-current-user.component.html
+++ b/frontend/src/app/modules/grids/widgets/time-entries/current-user/time-entries-current-user.component.html
@@ -3,6 +3,7 @@
   [editable]="isEditable">
 
   <widget-time-entries-current-user-menu
+    slot="menu"
     [resource]="resource"
     (onConfigured)="updateConfiguration($event)">
   </widget-time-entries-current-user-menu>

--- a/frontend/src/app/modules/grids/widgets/time-entries/list/time-entries-list.component.html
+++ b/frontend/src/app/modules/grids/widgets/time-entries/list/time-entries-list.component.html
@@ -3,6 +3,7 @@
     [editable]="isEditable">
 
   <widget-menu
+      slot="menu"
       [resource]="resource">
   </widget-menu>
 </widget-header>

--- a/frontend/src/app/modules/grids/widgets/wp-calendar/wp-calendar.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-calendar/wp-calendar.component.html
@@ -3,6 +3,7 @@
     (onRenamed)="renameWidget($event)">
 
   <widget-menu
+      slot="menu"
       [resource]="resource">
   </widget-menu>
 </widget-header>

--- a/frontend/src/app/modules/grids/widgets/wp-graph/wp-graph.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-graph/wp-graph.component.html
@@ -3,6 +3,7 @@
     (onRenamed)="renameWidget($event)">
 
   <widget-wp-graph-menu
+      slot="menu"
       [resource]="resource"
       (onConfigured)="updateGraph($event)">
   </widget-wp-graph-menu>

--- a/frontend/src/app/modules/grids/widgets/wp-overview/wp-overview.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-overview/wp-overview.component.html
@@ -3,7 +3,8 @@
     (onRenamed)="renameWidget($event)">
 
   <widget-menu
-      [resource]="resource">
+    slot="menu"
+    [resource]="resource">
   </widget-menu>
 </widget-header>
 

--- a/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-table/wp-table.component.html
@@ -2,6 +2,7 @@
   [name]="widgetName"
   (onRenamed)="renameWidget($event)">
   <widget-wp-table-menu
+    slot="menu"
     [resource]="resource">
   </widget-wp-table-menu>
 </widget-header>

--- a/frontend/src/app/modules/hal/resources/help-text-resource.ts
+++ b/frontend/src/app/modules/hal/resources/help-text-resource.ts
@@ -28,8 +28,9 @@
 
 import {HalResource} from 'core-app/modules/hal/resources/hal-resource';
 import {CallableHalLink} from 'core-app/modules/hal/hal-link/hal-link';
+import {Attachable} from "core-app/modules/hal/resources/mixins/attachable-mixin";
 
-export class HelpTextResource extends HalResource {
+export class HelpTextBaseResource extends HalResource {
 
   public id:string;
   public attribute:string;
@@ -38,6 +39,8 @@ export class HelpTextResource extends HalResource {
   public helpText:api.v3.Formattable;
 }
 
-export interface HelpTextResource {
+export const HelpTextResource = Attachable(HelpTextBaseResource);
+
+export interface HelpTextResource extends HelpTextBaseResource {
   editText?:CallableHalLink;
 }

--- a/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
@@ -130,7 +130,6 @@ import {WorkPackageCacheService} from 'core-components/work-packages/work-packag
 import {SchemaCacheService} from 'core-components/schemas/schema-cache.service';
 import {WorkPackageWatchersService} from 'core-components/wp-single-view-tabs/watchers-tab/wp-watchers.service';
 import {WorkPackagesActivityService} from 'core-components/wp-single-view-tabs/activity-panel/wp-activity.service';
-import {KeepTabService} from 'core-components/wp-single-view-tabs/keep-tab/keep-tab.service';
 import {QueryFormDmService} from 'core-app/modules/hal/dm-services/query-form-dm.service';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {WorkPackageChildrenQueryComponent} from "core-components/wp-relations/embedded/children/wp-children-query.component";
@@ -169,6 +168,8 @@ import {WorkPackageViewPageComponent} from "core-app/modules/work_packages/routi
 import {WorkPackageSettingsButtonComponent} from "core-components/wp-buttons/wp-settings-button/wp-settings-button.component";
 import {BackButtonComponent} from "core-app/modules/common/back-routing/back-button.component";
 import {DatePickerModal} from "core-components/datepicker/datepicker.modal";
+import {AttributeHelpTextComponent} from "core-app/modules/common/help-texts/attribute-help-text.component";
+import {AttributeHelpTextModal} from "core-app/modules/common/help-texts/attribute-help-text.modal";
 
 @NgModule({
   imports: [
@@ -379,6 +380,10 @@ import {DatePickerModal} from "core-components/datepicker/datepicker.modal";
     WorkPackageCardViewComponent,
     WorkPackageSingleCardComponent,
     WorkPackageViewToggleButton,
+
+    // Help texts
+    AttributeHelpTextComponent,
+    AttributeHelpTextModal,
   ],
   exports: [
     WorkPackagesTableController,
@@ -412,7 +417,11 @@ import {DatePickerModal} from "core-components/datepicker/datepicker.modal";
     WorkPackageEditActionsBarComponent,
     WorkPackageSingleViewComponent,
     WorkPackageSplitViewComponent,
-    BackButtonComponent
+    BackButtonComponent,
+
+    // Help texts
+    AttributeHelpTextComponent,
+    AttributeHelpTextModal,
   ]
 })
 export class OpenprojectWorkPackagesModule {

--- a/lib/api/decorators/schema_representer.rb
+++ b/lib/api/decorators/schema_representer.rb
@@ -242,6 +242,15 @@ module API
             form_embedded: form_embedded)
       end
 
+      def self.representable_definitions
+        representable_config = self.representable_attrs
+
+        # For reasons beyond me, Representable::Config contains the definitions
+        #  * nested in [:definitions] in some envs, e.g. development
+        #  * directly in other envs, e.g. test
+        representable_config.try(:definitions) || representable_config
+      end
+
       def initialize(represented,
                      self_link = nil,
                      current_user:,

--- a/lib/api/v3/attachments/attachments_by_help_text_api.rb
+++ b/lib/api/v3/attachments/attachments_by_help_text_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH
@@ -30,42 +28,23 @@
 
 module API
   module V3
-    module HelpTexts
-      class HelpTextRepresenter < ::API::Decorators::Single
-        include API::Decorators::LinkedResource
-        include API::Caching::CachedRepresenter
-        include ::API::V3::Attachments::AttachableRepresenterMixin
+    module Attachments
+      class AttachmentsByHelpTextAPI < ::API::OpenProjectAPI
+        resources :attachments do
+          helpers API::V3::Attachments::AttachmentsByContainerAPI::Helpers
 
-        self_link path: :help_text,
-                  id_attribute: :id,
-                  title_getter: ->(*) { nil }
+          helpers do
+            def container
+              @help_text
+            end
 
-        link :editText do
-          if current_user.admin? && represented.persisted?
-            {
-              href: edit_attribute_help_text_path(represented.id),
-              type: 'text/html'
-            }
+            def get_attachment_self_path
+              api_v3_paths.attachments_by_help_text(container.id)
+            end
           end
-        end
 
-        property :id
-        property :attribute_name,
-                 as: :attribute,
-                 getter: ->(*) {
-                   ::API::Utilities::PropertyNameConverter.from_ar_name(attribute_name)
-                 }
-        property :attribute_caption
-        property :attribute_scope,
-                 as: :scope
-        property :help_text,
-                 exec_context: :decorator,
-                 getter: ->(*) {
-                   ::API::Decorators::Formattable.new(represented.help_text)
-                 }
-
-        def _type
-          'HelpText'
+          get &API::V3::Attachments::AttachmentsByContainerAPI.read
+          post &API::V3::Attachments::AttachmentsByContainerAPI.create
         end
       end
     end

--- a/lib/api/v3/help_texts/help_texts_api.rb
+++ b/lib/api/v3/help_texts/help_texts_api.rb
@@ -47,6 +47,8 @@ module API
             get do
               HelpTextRepresenter.new(@help_text, current_user: current_user)
             end
+
+            mount ::API::V3::Attachments::AttachmentsByHelpTextAPI
           end
         end
       end

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -115,6 +115,10 @@ module API
             "#{work_package(id)}/attachments"
           end
 
+          def self.attachments_by_help_text(id)
+            "#{help_text(id)}/attachments"
+          end
+
           def self.attachments_by_wiki_page(id)
             "#{wiki_page(id)}/attachments"
           end

--- a/lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb
+++ b/lib/plugins/acts_as_attachable/lib/acts_as_attachable.rb
@@ -66,6 +66,7 @@ module Redmine
             add_on_new_permission: add_on_new_permission(options),
             add_on_persisted_permission: add_on_persisted_permission(options),
             only_user_allowed: only_user_allowed(options),
+            viewable_by_all_users: viewable_by_all_users(options),
             modification_blocked: options[:modification_blocked],
             extract_tsv: attachable_extract_tsv_option(options)
           }
@@ -80,6 +81,7 @@ module Redmine
                           :add_on_persisted_permission,
                           :add_permission,
                           :only_user_allowed,
+                          :viewable_by_all_users,
                           :modification_blocked,
                           :extract_tsv)
         end
@@ -98,6 +100,10 @@ module Redmine
 
         def add_on_persisted_permission(options)
           options[:add_on_persisted_permission] || options[:add_permission] || edit_permission_default
+        end
+
+        def viewable_by_all_users(options)
+          options.fetch(:viewable_by_all_users, false)
         end
 
         def only_user_allowed(options)
@@ -149,6 +155,8 @@ module Redmine
           end
 
           def attachments_visible?(user = User.current)
+            return true if user.logged? && self.class.attachable_options[:viewable_by_all_users]
+
             allowed_to_on_attachment?(user, self.class.attachable_options[:view_permission])
           end
 

--- a/spec/contracts/attribute_help_texts/base_contract_spec.rb
+++ b/spec/contracts/attribute_help_texts/base_contract_spec.rb
@@ -1,0 +1,53 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe AttributeHelpTexts::BaseContract do
+  let(:model) { FactoryBot.build_stubbed :work_package_help_text }
+  let(:contract) { described_class.new(model, current_user) }
+  subject { contract.validate }
+
+  context 'as admin' do
+    let(:current_user) { FactoryBot.build_stubbed :admin }
+
+    it 'validates the contract' do
+      expect(subject).to eq true
+    end
+  end
+
+  context 'as regular user' do
+    let(:current_user) { FactoryBot.build_stubbed :user }
+
+    it 'returns an error on validation' do
+      expect(subject).to eq false
+      expect(contract.errors.symbols_for(:base))
+        .to match_array [:error_unauthorized]
+    end
+  end
+end

--- a/spec/controllers/attribute_help_texts_controller_spec.rb
+++ b/spec/controllers/attribute_help_texts_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe AttributeHelpTextsController, type: :controller do
+  let(:user) { FactoryBot.build_stubbed :admin }
   let(:model) { FactoryBot.build :work_package_help_text }
   let(:relation_columns_allowed) { true }
 
@@ -13,8 +14,7 @@ describe AttributeHelpTextsController, type: :controller do
 
   before do
     with_enterprise_token(relation_columns_allowed ? :attribute_help_texts : nil)
-
-    expect(controller).to receive(:require_admin)
+    login_as user
   end
 
   describe '#index' do

--- a/spec/factories/attribute_help_text_factory.rb
+++ b/spec/factories/attribute_help_text_factory.rb
@@ -4,4 +4,10 @@ FactoryBot.define do
     help_text { 'Attribute help text' }
     attribute_name { 'status' }
   end
+
+  factory :project_help_text, class: AttributeHelpText::Project do
+    type { 'AttributeHelpText::Project' }
+    help_text { 'Attribute help text' }
+    attribute_name { 'status' }
+  end
 end

--- a/spec/features/admin/attribute_help_texts_spec.rb
+++ b/spec/features/admin/attribute_help_texts_spec.rb
@@ -77,6 +77,11 @@ describe 'Attribute help texts' do
         expect(modal.modal_container).to have_text 'My attribute help text'
         expect(modal.modal_container).to have_selector('img')
         modal.expect_edit(admin: true)
+
+        # Expect files section to be present
+        expect(modal.modal_container).to have_selector('.form--fieldset-legend', text: 'FILES')
+        expect(modal.modal_container).to have_selector('.work-package--attachments--filename')
+
         modal.close!
 
         # -> edit

--- a/spec/features/admin/attribute_help_texts_spec.rb
+++ b/spec/features/admin/attribute_help_texts_spec.rb
@@ -34,6 +34,7 @@ describe 'Attribute help texts' do
   let(:instance) { AttributeHelpText.last }
   let(:modal) { Components::AttributeHelpTextModal.new(instance) }
   let(:editor) { Components::WysiwygEditor.new }
+  let(:image_fixture) { Rails.root.join('spec/fixtures/files/image.png') }
 
   let(:relation_columns_allowed) { true }
 
@@ -57,13 +58,26 @@ describe 'Attribute help texts' do
         # -> create
         select 'Status', from: 'attribute_help_text_attribute_name'
         editor.set_markdown('My attribute help text')
+
+        # Add an image
+        # adding an image
+        editor.drag_attachment image_fixture, 'Image uploaded on creation'
+        expect(page).to have_selector('attachment-list-item', text: 'image.png')
         click_button 'Save'
 
         # Should now show on index for editing
         expect(page).to have_selector('.attribute-help-text--entry td', text: 'Status')
         expect(instance.attribute_scope).to eq 'WorkPackage'
         expect(instance.attribute_name).to eq 'status'
-        expect(instance.help_text).to eq 'My attribute help text'
+        expect(instance.help_text).to include 'My attribute help text'
+        expect(instance.help_text).to match /\/api\/v3\/attachments\/\d+\/content/
+
+        # Open help text modal
+        modal.open!
+        expect(modal.modal_container).to have_text 'My attribute help text'
+        expect(modal.modal_container).to have_selector('img')
+        modal.expect_edit(admin: true)
+        modal.close!
 
         # -> edit
         page.find('.attribute-help-text--entry td a', text: 'Status').click

--- a/spec/features/projects/attribute_help_texts_spec.rb
+++ b/spec/features/projects/attribute_help_texts_spec.rb
@@ -1,0 +1,96 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Project attribute help texts', type: :feature, js: true do
+  let(:project) { FactoryBot.create :project }
+
+  let(:instance) do
+    FactoryBot.create :project_help_text,
+                      attribute_name: :status,
+                      help_text: 'Some **help text** for status.'
+  end
+
+  let(:grid) do
+    grid = FactoryBot.create :grid
+    grid.widgets << FactoryBot.create(:grid_widget,
+                                      identifier: 'project_status',
+                                      options: { 'name' => 'Project status' },
+                                      start_row: 1,
+                                      end_row: 2,
+                                      start_column: 1,
+                                      end_column: 1)
+  end
+
+  let(:modal) { Components::AttributeHelpTextModal.new(instance) }
+  let(:wp_page) { Pages::FullWorkPackage.new work_package }
+
+  before do
+    login_as user
+    project
+    instance
+  end
+
+  shared_examples 'allows to view help texts' do
+    it 'shows an indicator for whatever help text exists' do
+      visit project_path(project)
+
+      within '#menu-sidebar' do
+        click_link "Overview"
+      end
+
+      expect(page).to have_selector('.widget-box--header .help-text--entry', wait: 10)
+
+      # Open help text modal
+      modal.open!
+      expect(modal.modal_container).to have_selector('strong', text: 'help text')
+      modal.expect_edit(admin: user.admin?)
+
+      modal.close!
+    end
+  end
+
+  describe 'as admin' do
+    let(:user) { FactoryBot.create :admin }
+    it_behaves_like 'allows to view help texts'
+  end
+
+  describe 'as regular user' do
+    let(:view_role) do
+      FactoryBot.create :role, permissions: [:view_project]
+    end
+    let(:user) do
+      FactoryBot.create :user,
+                        member_in_project: project,
+                        member_through_role: view_role
+    end
+
+    it_behaves_like 'allows to view help texts'
+  end
+end

--- a/spec/lib/api/v3/help_texts/help_text_representer_spec.rb
+++ b/spec/lib/api/v3/help_texts/help_text_representer_spec.rb
@@ -51,6 +51,13 @@ describe ::API::V3::HelpTexts::HelpTextRepresenter do
         "editText" => {
           "href" => edit_attribute_help_text_path(help_text.id),
           "type" => "text/html"
+        },
+        "attachments" => {
+          "href" => api_v3_paths.attachments_by_help_text(help_text.id)
+        },
+        "addAttachment" => {
+          "href" => api_v3_paths.attachments_by_help_text(help_text.id),
+          "method" => "post"
         }
       },
       "id" => help_text.id,

--- a/spec/models/attribute_help_text/work_package_spec.rb
+++ b/spec/models/attribute_help_text/work_package_spec.rb
@@ -29,6 +29,11 @@
 require 'spec_helper'
 
 describe AttributeHelpText::WorkPackage, type: :model do
+  it_behaves_like 'acts_as_attachable included' do
+    let(:model_instance) { FactoryBot.create(:work_package_help_text) }
+    let(:project) { FactoryBot.create(:project) }
+  end
+
   describe '.available_attributes' do
     subject { described_class.available_attributes }
     it 'returns an array of potential attributes' do

--- a/spec/support/shared/acts_as_attachable.rb
+++ b/spec/support/shared/acts_as_attachable.rb
@@ -153,4 +153,18 @@ shared_examples_for 'acts_as_attachable included' do
       end
     end
   end
+
+  describe '#attachments_visible' do
+    let!(:attachment1) { FactoryBot.create(:attachment, container: model_instance, author: current_user) }
+
+    it 'allows access to a logged user when viewable_by_all_users is set' do
+      if model_instance.class.attachable_options[:viewable_by_all_users]
+        expect(model_instance.attachments_visible?(other_user)).to eq true
+        expect(attachment1.visible?(no_permission_user)).to eq true
+      else
+        expect(model_instance.attachments_visible?(other_user)).to eq false
+        expect(attachment1.visible?(other_user)).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Attribute help text so far could only be added to work packages. This commit adds support for projects and adds the help texts to
widget headers for status and description modals in the overview  tab as well as extending the attachable mixin to allow uploading images.

Uploaded attachments are to be expected to be visible regardless of permissions, thus this also adds an option to make attachments visible to all

https://community.openproject.com/wp/33830
https://community.openproject.com/wp/32610