### PR TITLE
[33678] Priority needs to be a require field

### DIFF
--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -111,10 +111,18 @@ module Type::Attributes
       #  * directly in other envs, e.g. test
       definitions = representable_config.key?(:definitions) ? representable_config[:definitions] : representable_config
 
-      skip = %w[_type _dependencies attribute_groups links parent_id parent description schedule_manually]
       definitions.keys
-                 .reject { |key| skip.include?(key) || definitions[key][:required] }
+                 .reject { |key| skipped_attribute?(key, definitions[key]) }
                  .map { |key| [key, JSON::parse(definitions[key].to_json)] }.to_h
+    end
+
+    def skipped_attribute?(key, definition)
+      # We always want to include the priority even if its required
+      return false if key == 'priority'
+
+
+      skip = %w[_type _dependencies attribute_groups links parent_id parent description schedule_manually]
+      skip.include?(key) || definition[:required]
     end
 
     def merge_date_for_form_attributes(attributes)

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -253,7 +253,7 @@ module API
                                              title: priority.name
                                            }
                                          },
-                                         required: false,
+                                         required: true,
                                          has_default: true
 
           def attribute_groups

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -745,7 +745,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:path) { 'priority' }
         let(:type) { 'Priority' }
         let(:name) { I18n.t('activerecord.attributes.work_package.priority') }
-        let(:required) { false }
+        let(:required) { true }
         let(:writable) { true }
         let(:has_default) { true }
       end
@@ -765,7 +765,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:path) { 'priority' }
           let(:type) { 'Priority' }
           let(:name) { I18n.t('activerecord.attributes.work_package.priority') }
-          let(:required) { false }
+          let(:required) { true }
           let(:writable) { false }
           let(:has_default) { true }
         end


### PR DESCRIPTION
Priority was marked non-required for it to turn up in the attribute form configuration.

But priority _is actually required_. This results in the frontend adding an optional placeholder `-` value, which makes the resource unsavable.

This commit adds priority to the form, but keeps it required as it should be.

https://community.openproject.com/wp/33678