### PR TITLE
[33592] Allow type configuration to be empty

### DIFF
--- a/frontend/src/app/modules/admin/types/type-form-configuration.component.ts
+++ b/frontend/src/app/modules/admin/types/type-form-configuration.component.ts
@@ -30,6 +30,7 @@ export interface TypeGroup {
 }
 
 export const adminTypeFormConfigurationSelector = 'admin-type-form-configuration';
+export const emptyTypeGroup = '__empty';
 
 @Component({
   selector: adminTypeFormConfigurationSelector,
@@ -125,7 +126,9 @@ export class TypeFormConfigurationComponent extends UntilDestroyedMixin implemen
       });
 
     // Get attribute id
-    this.groups = JSON.parse(this.element.dataset.activeGroups!);
+    this.groups = JSON
+      .parse(this.element.dataset.activeGroups!)
+      .filter((group:TypeGroup) => group?.key !== emptyTypeGroup);
     this.inactives = JSON.parse(this.element.dataset.inactiveAttributes!);
 
     // Setup autoscroll
@@ -222,9 +225,23 @@ export class TypeFormConfigurationComponent extends UntilDestroyedMixin implemen
     this.inactives = [...newValue].sort((a, b) => a.translation.localeCompare(b.translation));
   }
 
+  // We maintain an empty group
+  // that gets hidden in the frontend in case the user
+  // decides to remove all groups
+  // This was necessary since the "default" is actually an empty array of groups
+  private get emptyGroup():TypeGroup {
+    return { type: 'attribute', key: emptyTypeGroup, name: 'empty', attributes: [] };
+  }
+
   private updateHiddenFields() {
     const hiddenField = this.form.find('.admin-type-form--hidden-field');
-    hiddenField.val(JSON.stringify(this.groups));
+    if (this.groups.length === 0) {
+      // Ensure we're adding an empty group if deliberately removing
+      // all values.
+      hiddenField.val(JSON.stringify([this.emptyGroup]));
+    } else {
+      hiddenField.val(JSON.stringify(this.groups));
+    }
   }
 }
 

--- a/spec/support/components/admin/type_configuration_form.rb
+++ b/spec/support/components/admin/type_configuration_form.rb
@@ -58,6 +58,10 @@ module Components
         page.find '#type-form-conf-inactive-group .attributes'
       end
 
+      def expect_empty
+        expect(page).to have_no_selector('#draggable-groups .group-head')
+      end
+
       def find_group(name)
         head = page.find('.group-head', text: name.upcase)
 
@@ -192,6 +196,14 @@ module Components
         input.send_keys(:return)
 
         expect(page).to have_selector('.group-edit-handler', text: to.upcase)
+      end
+
+      def remove_group(name)
+        container = find('.group-head', text: name.upcase)
+
+        container.find('.delete-group').click
+
+        expect(page).to have_no_selector('.group-head', text: name.upcase)
       end
 
       def expect_no_attribute(attribute, group)


### PR DESCRIPTION
We currently signal resetting of attribute groups with an empty array. If you wanted to remove all optional attributes and just be left with subject and description, you couldn't do that at the moment.

This changes the reset signal to simple a single empty group, which ensures the two things are handled differently. 

https://community.openproject.com/wp/33592