### PR TITLE
Fix "how to run tests" link

### DIFF
--- a/docs/development/development-environment-ubuntu/README.md
+++ b/docs/development/development-environment-ubuntu/README.md
@@ -269,7 +269,7 @@ You can then access the application either through `localhost:3000` (Rails serve
 ## Start Coding
 
 Please have a look at [our development guidelines](https://www.openproject.org/open-source/code-contributions/) for tips and guides on how to start coding. We have advice on how to get your changes back into the OpenProject core as smooth as possible.
-Also, take a look at the `doc` directory in our sources, especially the [how to run tests](https://github.com/opf/openproject/blob/dev/docs/development/running-tests.md) documentation (we like to have automated tests for every new developed feature).
+Also, take a look at the `doc` directory in our sources, especially the [how to run tests](https://github.com/opf/openproject/blob/dev/docs/development/running-tests/README.md) documentation (we like to have automated tests for every new developed feature).
 
 ## Troubleshooting
 


### PR DESCRIPTION
Seems to be a typo in the link. `development/running-tests` is a folder containing a README.md.