### PR TITLE
Flexible widget title input field width

### DIFF
--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
@@ -10,6 +10,7 @@
     <span aria-hidden="true" class="icon icon-save"></span>
   </a>
   <input #editableTitleInput
+         size="1"
          type="text"
          aria-required="true"
          [attr.name]="selectableTitleIdentifier"
@@ -24,6 +25,7 @@
          [disabled]="inFlight"
          [ngClass]="{ '-error': isEmpty, '-changed': showSave }"
          class="editable-toolbar-title--input -border-on-hover-only toolbar--editable-toolbar ellipsis"/>
+  <div class="editable-toolbar-title--input-shim">{{ selectedTitle || text.input_placeholder }}</div>
 </div>
 <h2 *ngIf="!editable"
     [attr.title]="selectedTitle"

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
@@ -25,8 +25,10 @@
          [disabled]="inFlight"
          [ngClass]="{ '-error': isEmpty, '-changed': showSave }"
          class="editable-toolbar-title--input -border-on-hover-only toolbar--editable-toolbar ellipsis"/>
-  <!-- This is not an angular component, rather it is a custom element so the specificity of the css stays low -->
-  <input-shim class="editable-toolbar-title--input editable-toolbar-title--input-shim toolbar--editable-toolbar">{{ selectedTitle || text.input_placeholder }}</input-shim>
+  <!-- This is not an angular component, rather it is a custom element so the specificity of the css stays low.
+       The &nbsp;&nbsp; is for making sure that the shim is always a bit larger than the input. Sometimes the ellipsis
+       would kick in to early otherwise. -->
+  <input-shim class="editable-toolbar-title--input editable-toolbar-title--input-shim toolbar--editable-toolbar">{{ selectedTitle || text.input_placeholder }}{{ selectedTitle ? '&nbsp;&nbsp;' : ''}}</input-shim>
 </div>
 <h2 *ngIf="!editable"
     [attr.title]="selectedTitle"

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.html
@@ -25,7 +25,8 @@
          [disabled]="inFlight"
          [ngClass]="{ '-error': isEmpty, '-changed': showSave }"
          class="editable-toolbar-title--input -border-on-hover-only toolbar--editable-toolbar ellipsis"/>
-  <div class="editable-toolbar-title--input-shim">{{ selectedTitle || text.input_placeholder }}</div>
+  <!-- This is not an angular component, rather it is a custom element so the specificity of the css stays low -->
+  <input-shim class="editable-toolbar-title--input editable-toolbar-title--input-shim toolbar--editable-toolbar">{{ selectedTitle || text.input_placeholder }}</input-shim>
 </div>
 <h2 *ngIf="!editable"
     [attr.title]="selectedTitle"

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.sass
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.sass
@@ -1,6 +1,6 @@
 .editable-toolbar-title--container
   display: grid
-  align-items: stretch
+  align-items: center
   grid-template-columns: auto auto 1fr
 
   &::before
@@ -37,7 +37,7 @@
   &.-changed
     font-style: italic
 
-.editable-toolbar-title--input,
+.editable-toolbar-title--input
   display: block
   grid-area: 1/2
   padding-left: 5px
@@ -46,5 +46,12 @@
 
 .editable-toolbar-title--input-shim
   visibility: hidden
-  height: 100%
-  white-space: pre;
+  white-space: pre
+
+// Here we make sure the shim layouts like the normal input
+// This is an element selector so the specificity stays lower than other selectors that might write here.
+// The rules are taken from input[type="text"]
+input-shim 
+  border: 1px solid transparent
+  padding: 0.375rem
+  margin: 0

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.sass
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.sass
@@ -1,12 +1,26 @@
 .editable-toolbar-title--container
-  display: flex
-  align-items: center
+  display: grid
+  align-items: stretch
+  grid-template-columns: auto auto 1fr
+
+  &::before
+  &::after
+    display: block
+    content: ''
+
+  &::before
+    grid-area: 1/1
+
+  &::after
+    grid-area: 1/3
 
 .editable-toolbar-title--fixed
   padding: 0
   cursor: default
 
 .editable-toolbar-title--save
+  grid-area: 1/1
+
   span:before
     color: #5F5F5F
 
@@ -14,8 +28,27 @@
     color: darken(#5F5F5F, 20%)
 
 .editable-toolbar-title--input
-  padding-left: 5px
   color: #5F5F5F
 
   &.-changed
     font-style: italic
+
+.editable-toolbar-title--input,
+.editable-toolbar-title--input-shim
+  display: block
+  grid-area: 1/2
+  padding-left: 5px
+  width: auto
+  min-width: 1em
+
+.editable-toolbar-title--input-shim
+  visibility: hidden
+  height: 100%
+  // Make sure it layouts like the normal input
+  border: 1px solid transparent
+  padding: 0.375rem
+  margin: 0 0 1rem 0
+  font: inherit
+  text-transform: uppercase
+  font-size: 16px
+  letter-spacing: 1px

--- a/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.sass
+++ b/frontend/src/app/modules/common/editable-toolbar-title/editable-toolbar-title.sass
@@ -30,11 +30,14 @@
 .editable-toolbar-title--input
   color: #5F5F5F
 
+  &:focus
+    border-color: #999
+    box-shadow: 0 0 0 1px #999
+
   &.-changed
     font-style: italic
 
 .editable-toolbar-title--input,
-.editable-toolbar-title--input-shim
   display: block
   grid-area: 1/2
   padding-left: 5px
@@ -44,11 +47,4 @@
 .editable-toolbar-title--input-shim
   visibility: hidden
   height: 100%
-  // Make sure it layouts like the normal input
-  border: 1px solid transparent
-  padding: 0.375rem
-  margin: 0 0 1rem 0
-  font: inherit
-  text-transform: uppercase
-  font-size: 16px
-  letter-spacing: 1px
+  white-space: pre;

--- a/frontend/src/global_styles/content/_editable_toolbar.sass
+++ b/frontend/src/global_styles/content/_editable_toolbar.sass
@@ -18,7 +18,7 @@
     font-size: 1.2rem
     line-height: 32px
 
-input[type="text"].toolbar--editable-toolbar
+.toolbar--editable-toolbar
   color: var(--toolbar-title-color)
   font-size: 20px
   font-weight: bold

--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -124,7 +124,7 @@ $widget-box--enumeration-width: 20px
 
   // Ensure style for read-only widget headers
   .editable-toolbar-title--fixed,
-  input[type="text"].toolbar--editable-toolbar
+  .toolbar--editable-toolbar
     color: #5F5F5F
     font-size: 16px
     letter-spacing: 1px

--- a/frontend/src/global_styles/layout/_toolbar.sass
+++ b/frontend/src/global_styles/layout/_toolbar.sass
@@ -204,7 +204,6 @@ $nm-color-success-background: #d8fdd1
 // Allow title container to grow
 .title-container
   flex: 1 1
-  overflow: hidden
   white-space: nowrap
   margin-bottom: 10px
   // margin-bottom of toolbar buttons

--- a/frontend/src/global_styles/layout/_toolbar.sass
+++ b/frontend/src/global_styles/layout/_toolbar.sass
@@ -206,6 +206,7 @@ $nm-color-success-background: #d8fdd1
   flex: 1 1
   white-space: nowrap
   margin-bottom: 10px
+  max-width: 100%
   // margin-bottom of toolbar buttons
 
   &.-no-grow

--- a/frontend/src/global_styles/layout/work_packages/_table.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table.sass
@@ -54,7 +54,7 @@
   > .toolbar-container
     margin-top: 5px
 
-  input[type="text"].toolbar--editable-toolbar
+  .toolbar--editable-toolbar
     font-size: 24px
 
   // Match both rows and timeline specifically


### PR DESCRIPTION
When entering a text, the input field now autoresizes with the input text. This gracefully handles overflowing, but
requires browsers to support CSS grid, which all of the browsers in browserslistrc do.

This solution is a bit hacky on the CSS side, but requires almost no javascript to function, and utilizes the browser layouting engine to do width calculations. This is both faster and more accurate, since it accounts for the specific widths of the font being rendered, as well as sub-pixel sizes.

I'm not sure about the coding style, since I was only able to find Ruby standard for that. Feel free to correct that when reviewing.

Closes https://community.openproject.com/projects/openproject/work_packages/32176/activity