### PR TITLE
[31614] Prevent wp attribute fields from repositioning

### DIFF
--- a/frontend/src/app/components/wp-form-group/wp-attribute-group.component.ts
+++ b/frontend/src/app/components/wp-form-group/wp-attribute-group.component.ts
@@ -26,7 +26,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {Component, Injector, Input} from '@angular/core';
+import {Component, Injector, Input, AfterViewInit} from '@angular/core';
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {FieldDescriptor, GroupDescriptor} from 'core-components/work-packages/wp-single-view/wp-single-view.component';
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
@@ -36,13 +36,17 @@ import {EditFormComponent} from "core-app/modules/fields/edit/edit-form/edit-for
   selector: 'wp-attribute-group',
   templateUrl: './wp-attribute-group.template.html'
 })
-export class WorkPackageFormAttributeGroupComponent {
+export class WorkPackageFormAttributeGroupComponent implements AfterViewInit {
   @Input() public workPackage:WorkPackageResource;
   @Input() public group:GroupDescriptor;
 
   constructor(readonly I18n:I18nService,
               public wpEditForm:EditFormComponent,
               protected injector:Injector) {
+  }
+
+  ngAfterViewInit() {
+    setTimeout(() => this.fixColumns());
   }
 
   public trackByName(_index:number, elem:{ name:string }) {
@@ -64,5 +68,25 @@ export class WorkPackageFormAttributeGroupComponent {
     } else {
       return name;
     }
+  }
+
+  /**
+   * Fix the top of the columns after view has been loaded
+   * to prevent columns from repositioning (e.g. when editing multi-select fields)
+   */
+  private fixColumns() {
+    let lastOffset = 0;
+    // Find corresponding HTML of attribute fields for each group
+    let htmlAttributes = jQuery('div.attributes-group:contains(' + this.group.name + ')').find('.attributes-key-value');
+
+    htmlAttributes.each(function() {
+      let offset = jQuery(this).position().top;
+
+      if (offset < lastOffset) {
+        // Fix position of the column start
+        jQuery(this).addClass('-column-start');
+      }
+      lastOffset = offset;
+    });
   }
 }

--- a/frontend/src/app/modules/fields/edit/field/editable-attribute-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field/editable-attribute-field.component.ts
@@ -118,8 +118,6 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
         this.resource = resource;
         this.render();
       });
-
-    this.calcRows();
   }
 
   // Open the field when its closed and relay drag & drop events to it.
@@ -147,8 +145,6 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
     if (focus) {
       setTimeout(() => this.$element.find(`.${displayClassName}`).focus(), 20);
     }
-
-    this.calcRows();
   }
 
   public get isEditable() {
@@ -219,21 +215,6 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
       return this.halEditing.typedState(this.resource).value!.schema;
     } else {
       return this.schemaCache.of(this.resource) as ISchemaProxy;
-    }
-  }
-
-  /**
-   * Calculate the number of rows each edit field should span
-   * to create more of a 'masonry' layout look without large gaps
-   */
-  public calcRows() {
-    const rowHeight = 38;
-    let elem = jQuery(this.displayContainer.nativeElement);
-    let elemHeight = elem.height();
-
-    if (elemHeight !== undefined && elemHeight > rowHeight) {
-      let rowspan = Math.ceil(elemHeight / rowHeight);
-      elem.closest('.attributes-key-value').css('grid-row', 'span ' + rowspan);
     }
   }
 }

--- a/frontend/src/app/modules/fields/edit/field/editable-attribute-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field/editable-attribute-field.component.ts
@@ -118,6 +118,8 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
         this.resource = resource;
         this.render();
       });
+
+    this.calcRows();
   }
 
   // Open the field when its closed and relay drag & drop events to it.
@@ -145,6 +147,8 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
     if (focus) {
       setTimeout(() => this.$element.find(`.${displayClassName}`).focus(), 20);
     }
+
+    this.calcRows();
   }
 
   public get isEditable() {
@@ -215,6 +219,21 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
       return this.halEditing.typedState(this.resource).value!.schema;
     } else {
       return this.schemaCache.of(this.resource) as ISchemaProxy;
+    }
+  }
+
+  /**
+   * Calculate the number of rows each edit field should span
+   * to create more of a 'masonry' layout look without large gaps
+   */
+  public calcRows() {
+    const rowHeight = 38;
+    let elem = jQuery(this.displayContainer.nativeElement);
+    let elemHeight = elem.height();
+
+    if (elemHeight !== undefined && elemHeight > rowHeight) {
+      let rowspan = Math.ceil(elemHeight / rowHeight);
+      elem.closest('.attributes-key-value').css('grid-row', 'span ' + rowspan);
     }
   }
 }

--- a/frontend/src/global_styles/content/_attributes_key_value.sass
+++ b/frontend/src/global_styles/content/_attributes_key_value.sass
@@ -49,7 +49,9 @@
   flex: 1 0 65%
   max-width: 65%
   margin-bottom: 0.1875rem
+  padding: 0.375rem 0
   align-self: center
+  height: 100%
 
   p
     font-size: $form-label-fontsize

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -133,13 +133,14 @@ $scrollbar-size: 10px
     visibility: hidden
 
 @mixin two-column-layout
-  column-count: 2
-  column-gap: 3rem
+  display: grid
+  grid-template-columns: repeat(auto-fill, minmax(45%, 1fr))
+  grid-gap: 0 3rem
   
   @supports (column-span: all)
         // Let some elements still span both columns
         .attributes-key-value.-span-all-columns
-          column-span: all
+          grid-column: -1/1
           .attributes-key-value--key
             flex-basis: calc(22.5% - (4rem / 6))
           .attributes-key-value--value-container

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -133,14 +133,17 @@ $scrollbar-size: 10px
     visibility: hidden
 
 @mixin two-column-layout
-  display: grid
-  grid-template-columns: repeat(auto-fill, minmax(45%, 1fr))
-  grid-gap: 0 3rem
+  column-count: 2
+  column-gap: 3rem
+
+  .attributes-key-value.-column-start
+    column-break-before: always !important
+    break-before: column
   
   @supports (column-span: all)
         // Let some elements still span both columns
         .attributes-key-value.-span-all-columns
-          grid-column: -1/1
+          column-span: all
           .attributes-key-value--key
             flex-basis: calc(22.5% - (4rem / 6))
           .attributes-key-value--value-container


### PR DESCRIPTION
### Problem
Due to the CSS column-count calculation, fields will re-position when editing especially larger multi-select fields.

### Changes
Unfortunately, there is no thing like auto-spanning of rows in the CSS 'grid' layout yet, which could prevent larger gaps in the grid. So this PR proposes a solution, which calculates the row span and adapts the layout.

See ticket: https://community.openproject.com/projects/openproject/work_packages/31614