### PR TITLE
[33930] Fix broken documents layout 

### DIFF
--- a/frontend/src/global_styles/content/modules/_index.sass
+++ b/frontend/src/global_styles/content/modules/_index.sass
@@ -4,5 +4,6 @@
 @import 'avatars'
 @import 'bim'
 @import 'costs'
+@import 'documents'
 @import '2fa'
 @import 'webhooks'

--- a/frontend/src/global_styles/openproject/_variables.scss
+++ b/frontend/src/global_styles/openproject/_variables.scss
@@ -53,7 +53,7 @@
   --h2-font-color: var(--body-font-color);
   --h3-font-size: 1.125rem;
   --h3-font-color: var(--body-font-color);
-  --h4-font-size: calc(var(--h3-font-size) * 0.75);
+  --h4-font-size: 1rem;
   --h4-font-color: var(--body-font-color);
   --list-side-margin: 40px;
   --list-nested-margin: 30px;


### PR DESCRIPTION
### Problem

The broken layout was mainly caused by the missing import of the .sass file.
Also the h4 font seemed to be a lot smaller than before (and also smaller than the normal font size), which looked a bit confusing.

See ticket: https://community.openproject.com/projects/openproject/work_packages/33930