### PR TITLE
[33931] Increase modal width

### DIFF
--- a/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.sass
+++ b/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.sass
@@ -1,3 +1,10 @@
+.job-status--modal
+  min-height: 350px
+  min-width: 450px
+
+  @media screen and (max-width: 679px)
+    min-width: 200px
+
 .loading-indicator--location
   height: 220px
 
@@ -6,4 +13,3 @@
   height: 100%
   align-items: center
   justify-content: center
-

--- a/frontend/src/global_styles/content/_modal.sass
+++ b/frontend/src/global_styles/content/_modal.sass
@@ -57,7 +57,7 @@ $ng-modal-image-height: 135px
   background: var(--body-background)
   position: relative
   padding: 5px $ng-modal-padding / 2
-  min-width: 200px
+  min-width: 450px
   max-width: 60vw
   overflow-y: auto
 
@@ -205,4 +205,5 @@ ul.export-options
   .wp-table--configuration-modal,
   .op-modal--modal-container
     width: 90vw
+    min-width: 200px
     max-width: unset

--- a/frontend/src/global_styles/content/_modal.sass
+++ b/frontend/src/global_styles/content/_modal.sass
@@ -57,7 +57,7 @@ $ng-modal-image-height: 135px
   background: var(--body-background)
   position: relative
   padding: 5px $ng-modal-padding / 2
-  min-width: 450px
+  min-width: 200px
   max-width: 60vw
   overflow-y: auto
 
@@ -205,5 +205,4 @@ ul.export-options
   .wp-table--configuration-modal,
   .op-modal--modal-container
     width: 90vw
-    min-width: 200px
     max-width: unset


### PR DESCRIPTION
### Problem

The modal width currently depends on its content size with a minimum width of 200px. This causes in some cases a 'flickering' effect when successively shown loading modals differ in width.

### Changes in this PR

Increase the job statuses modal minimum width and height a bit, so that smaller modals have the same size.


See ticket: https://community.openproject.com/projects/openproject/work_packages/33931