### PR TITLE
Scrolling previous row working

### DIFF
--- a/frontend/src/app/modules/work_packages/routing/wp-list-view/wp-list-view.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-list-view/wp-list-view.component.ts
@@ -129,11 +129,17 @@ export class WorkPackageListViewComponent extends UntilDestroyedMixin implements
     // detection on the entire app
     this.ngZone.runOutsideAngular(() => {
       setTimeout(() => {
-        const selectedElement = this.elementRef.nativeElement.querySelector('.wp-table--row.-checked') ||
-                                this.elementRef.nativeElement.querySelector('.wp-card.-checked');
+        const selectedRow = this.elementRef.nativeElement.querySelector('.wp-table--row.-checked');
+        const selectedCard = this.elementRef.nativeElement.querySelector('.wp-card.-checked');
 
-        if (selectedElement) {
-          selectedElement.scrollIntoView({block: "start"});
+        // The header of the table hides the scrolledIntoView element
+        // so we scrollIntoView the previous element, if any
+        if (selectedRow && selectedRow.previousSibling) {
+          selectedRow.previousSibling.scrollIntoView({block: "start"});
+        }
+
+        if (selectedCard) {
+          selectedCard.scrollIntoView({block: "start"});
         }
       }, 0);
     });


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/33966/activity?query_id=2563

In some cases, when scrolling back from a wp detail page, the header of the workpackages table hides the scrolled into view element (the last opened wp (-checked)). Scrolling the previous element instead (if any) avoids this issue.