### PR TITLE
Hiding 'Manage models' button on plugins (Revit)

### DIFF
--- a/frontend/src/app/modules/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
@@ -22,6 +22,7 @@ import {BehaviorSubject} from "rxjs";
 import {BcfImportButtonComponent} from "core-app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component";
 import {BcfExportButtonComponent} from "core-app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component";
 import {componentDestroyed} from "@w11k/ngx-componentdestroyed";
+import {ViewerBridgeService} from "core-app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service";
 
 @Component({
   templateUrl: '/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.html',
@@ -79,7 +80,11 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent {
     },
     {
       component: BimManageIfcModelsButtonComponent,
-      show: () => this.ifcData.allowed('manage_ifc_models')
+      show: () => {
+        // Hide 'Manage models' on plugin environment (ie: Revit)
+        return this.viewerBridgeService.shouldShowViewer &&
+               this.ifcData.allowed('manage_ifc_models');
+      }
     }
   ];
 
@@ -88,7 +93,8 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent {
               readonly bimView:BimViewService,
               readonly transition:TransitionService,
               readonly gon:GonService,
-              readonly injector:Injector) {
+              readonly injector:Injector,
+              readonly viewerBridgeService:ViewerBridgeService) {
     super(injector);
   }
 

--- a/frontend/src/app/modules/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
@@ -81,7 +81,7 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent {
     {
       component: BimManageIfcModelsButtonComponent,
       show: () => {
-        // Hide 'Manage models' on plugin environment (ie: Revit)
+        // Hide 'Manage models' toolbar button on plugin environment (ie: Revit)
         return this.viewerBridgeService.shouldShowViewer &&
                this.ifcData.allowed('manage_ifc_models');
       }

--- a/modules/bim/spec/features/bim_revit_add_in_navigation_spec.rb
+++ b/modules/bim/spec/features/bim_revit_add_in_navigation_spec.rb
@@ -61,7 +61,7 @@ describe 'BIM Revit Add-in navigation spec',
     end
 
     it 'shows a toolbar' do
-      model_page.page_shows_a_toolbar true
+      model_page.page_has_a_toolbar
     end
 
     it 'shows no viewer' do

--- a/modules/bim/spec/support/pages/ifc_models/show_default.rb
+++ b/modules/bim/spec/support/pages/ifc_models/show_default.rb
@@ -72,6 +72,10 @@ module Pages
         end
       end
 
+      def page_has_a_toolbar
+        expect(page).to have_selector('.toolbar-container')
+      end
+
       def page_shows_a_filter_button(visible)
         expect(page).to have_conditional_selector(visible, '.toolbar-item', text: 'Filter')
       end


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/33939

There is no need of managing IFC models on the Revit add-in so the "Manage models" button is hidden on plugins environment.