### PR TITLE
[32111]Work package no longer included in filter "Estimated time: none" when removing value for Estimated time

### DIFF
--- a/app/models/queries/operators/none.rb
+++ b/app/models/queries/operators/none.rb
@@ -34,7 +34,7 @@ module Queries::Operators
     require_value false
 
     def self.sql_for_field(_values, db_table, db_field)
-      "#{db_table}.#{db_field} IS NULL OR #{db_table}.#{db_field}=0"
+      "#{db_table}.#{db_field} IS NULL"
     end
   end
 end

--- a/app/models/queries/operators/none.rb
+++ b/app/models/queries/operators/none.rb
@@ -34,7 +34,7 @@ module Queries::Operators
     require_value false
 
     def self.sql_for_field(_values, db_table, db_field)
-      "#{db_table}.#{db_field} IS NULL"
+      "#{db_table}.#{db_field} IS NULL OR #{db_table}.#{db_field}=0"
     end
   end
 end

--- a/app/models/queries/work_packages/filter/estimated_hours_filter.rb
+++ b/app/models/queries/work_packages/filter/estimated_hours_filter.rb
@@ -32,4 +32,12 @@ class Queries::WorkPackages::Filter::EstimatedHoursFilter <
   def type
     :integer
   end
+  
+  def where
+    if operator == Queries::Operators::None.to_sym.to_s
+      super + " OR #{WorkPackage.table_name}.estimated_hours=0"
+    else
+      super
+    end
+  end
 end

--- a/spec/models/queries/work_packages/filter/estimated_hours_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/estimated_hours_filter_spec.rb
@@ -46,5 +46,21 @@ describe Queries::WorkPackages::Filter::EstimatedHoursFilter, type: :model do
     end
 
     it_behaves_like 'non ar filter'
+
+    describe '#where' do
+      let!(:work_package_zero_hour) {FactoryBot.create(:work_package, estimated_hours: 0)}
+      let!(:work_package_no_hours) {FactoryBot.create(:work_package, estimated_hours: nil)}
+      let!(:work_package_with_hours) {FactoryBot.create(:work_package, estimated_hours: 1)}
+
+      context 'with the operator being "none"' do
+        before do
+          instance.operator = Queries::Operators::None.to_sym.to_s
+        end
+        it 'finds zero and none values' do
+          expect(WorkPackage.where(instance.where)).to match_array [work_package_zero_hour, work_package_no_hours]
+        end
+      end
+    end
   end
+  
 end


### PR DESCRIPTION
show data which is zero when we filter 'none'.

https://community.openproject.com/projects/openproject/work_packages/32111/activity