### PR TITLE
journalize changes to the scheduling mode

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -37,6 +37,7 @@ class Journal < ApplicationRecord
   register_journal_formatter :diff, OpenProject::JournalFormatter::Diff
   register_journal_formatter :attachment, OpenProject::JournalFormatter::Attachment
   register_journal_formatter :custom_field, OpenProject::JournalFormatter::CustomField
+  register_journal_formatter :schedule_manually, OpenProject::JournalFormatter::ScheduleManually
 
   # Make sure each journaled model instance only has unique version ids
   validates_uniqueness_of :version, scope: [:journable_id, :journable_type]

--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -93,6 +93,7 @@ module WorkPackage::Journalized
     register_on_journal_formatter(:fraction, 'derived_estimated_hours')
     register_on_journal_formatter(:decimal, 'done_ratio')
     register_on_journal_formatter(:diff, 'description')
+    register_on_journal_formatter(:schedule_manually, 'schedule_manually')
     register_on_journal_formatter(:attachment, /attachments_?\d+/)
     register_on_journal_formatter(:custom_field, /custom_fields_\d+/)
 
@@ -101,7 +102,6 @@ module WorkPackage::Journalized
                                   :status_id, :type_id,
                                   :assigned_to_id, :priority_id,
                                   :category_id, :version_id,
-                                  :planning_element_status_id,
                                   :author_id, :responsible_id
     register_on_journal_formatter :datetime, :start_date, :due_date
     register_on_journal_formatter :plaintext, :subject

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -543,7 +543,7 @@ en:
         parent_work_package: "Parent"
         priority: "Priority"
         progress: "Progress (%)"
-        schedule_manually: "Schedule manually"
+        schedule_manually: "Manual scheduling"
         spent_hours: "Spent time"
         spent_time: "Spent time"
         subproject: "Subproject"
@@ -2165,6 +2165,10 @@ en:
     warnings:
       cannot_annotate: "This file cannot be annotated."
 
+  scheduling:
+    activated: 'activated'
+    deactivated: 'deactivated'
+
   search_input_placeholder: "Search ..."
 
   setting_email_delivery_method: "Email delivery method"
@@ -2377,6 +2381,7 @@ en:
   text_journal_deleted_with_diff: "%{label} deleted (%{link})"
   text_journal_set_to: "%{label} set to %{value}"
   text_journal_set_with_diff: "%{label} set (%{link})"
+  text_journal_label_value: "%{label} %{value}"
   text_latest_note: "The latest comment is: %{note}"
   text_length_between: "Length between %{min} and %{max} characters."
   text_line_separated: "Multiple values allowed (one line for each value)."

--- a/db/migrate/20200803081038_journalize_scheduling_mode.rb
+++ b/db/migrate/20200803081038_journalize_scheduling_mode.rb
@@ -1,0 +1,5 @@
+class JournalizeSchedulingMode < ActiveRecord::Migration[6.0]
+  def change
+    add_column :work_package_journals, :schedule_manually, :boolean, default: false
+  end
+end

--- a/lib/open_project/journal_formatter/diff.rb
+++ b/lib/open_project/journal_formatter/diff.rb
@@ -55,12 +55,10 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
 
     if value.blank?
       l(:text_journal_deleted_with_diff, label: label, link: link)
+    elsif old_value.present?
+      l(:text_journal_changed_with_diff, label: label, link: link)
     else
-      if old_value.present?
-        l(:text_journal_changed_with_diff, label: label, link: link)
-      else
-        l(:text_journal_set_with_diff, label: label, link: link)
-      end
+      l(:text_journal_set_with_diff, label: label, link: link)
     end
   end
 

--- a/lib/open_project/journal_formatter/schedule_manually.rb
+++ b/lib/open_project/journal_formatter/schedule_manually.rb
@@ -22,23 +22,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module JournalFormatter
-  class Attribute < Base
-    private
+class OpenProject::JournalFormatter::ScheduleManually < JournalFormatter::Base
+  def render(key, values, options = { no_html: false })
+    label_text = options[:no_html] ? label(key) : content_tag('strong', label(key))
+    activated_text = values.last ? I18n.t('scheduling.activated') : I18n.t('scheduling.deactivated')
 
-    def format_details(key, values)
-      label = label(key)
-
-      old_value, value = *format_values(values)
-
-      [label, old_value, value]
-    end
-
-    def format_values(values)
-      values.map { |v| v.try(:to_s) }
-    end
+    I18n.t(:text_journal_label_value, label: label_text, value: activated_text)
   end
 end

--- a/spec/features/work_packages/scheduling/scheduling_mode_spec.rb
+++ b/spec/features/work_packages/scheduling/scheduling_mode_spec.rb
@@ -113,6 +113,9 @@ describe 'scheduling mode',
 
     work_packages_page.expect_and_dismiss_notification message: 'Successful update.'
 
+    # Changing the scheduling mode is journalized
+    work_packages_page.expect_activity_message("Manual scheduling activated")
+
     expect_dates(wp, '2016-01-05', '2016-01-10')
     expect(wp.schedule_manually).to be_truthy
 

--- a/spec/lib/journal_formatter/schedule_manually_spec.rb
+++ b/spec/lib/journal_formatter/schedule_manually_spec.rb
@@ -22,23 +22,40 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module JournalFormatter
-  class Attribute < Base
-    private
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper.rb')
 
-    def format_details(key, values)
-      label = label(key)
+describe OpenProject::JournalFormatter::ScheduleManually do
+  let(:klass) { described_class }
+  let(:id) { 1 }
+  let(:journal) do
+    OpenStruct.new(id: id, journable: WorkPackage.new)
+  end
+  let(:instance) { klass.new(journal) }
+  let(:key) { 'schedule_manually' }
 
-      old_value, value = *format_values(values)
+  describe '#render' do
+    describe 'with the first value being true, and the second false' do
+      let(:expected) do
+        I18n.t(:text_journal_label_value,
+               label: "<strong>Manual scheduling</strong>",
+               value: 'deactivated')
+      end
 
-      [label, old_value, value]
+      it { expect(instance.render(key, [true, false])).to eq(expected) }
     end
 
-    def format_values(values)
-      values.map { |v| v.try(:to_s) }
+    describe 'with the first value being false, and the second true' do
+      let(:expected) do
+        I18n.t(:text_journal_label_value,
+               label: "<strong>Manual scheduling</strong>",
+               value: 'activated')
+      end
+
+      it { expect(instance.render(key, [false, true])).to eq(expected) }
     end
   end
 end

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -69,9 +69,14 @@ describe WorkPackage, type: :model do
           .to match_array [nil, work_package.project_id]
       end
 
-      it 'notes the description to project' do
+      it 'notes the description' do
         expect(Journal.first.details[:description])
           .to match_array [nil, work_package.description]
+      end
+
+      it 'notes the scheduling mode' do
+        expect(Journal.first.details[:schedule_manually])
+          .to match_array [nil, false]
       end
 
       it 'has the timestamp of the work package update time for created_at' do
@@ -173,6 +178,7 @@ describe WorkPackage, type: :model do
         work_package.assigned_to = User.current
         work_package.responsible = User.current
         work_package.parent = parent_work_package
+        work_package.schedule_manually = true
 
         work_package.save!
       end
@@ -183,7 +189,7 @@ describe WorkPackage, type: :model do
         it 'contains all changes' do
           %i(subject description type_id status_id priority_id
              start_date due_date estimated_hours assigned_to_id
-             responsible_id parent_id).each do |a|
+             responsible_id parent_id schedule_manually).each do |a|
             expect(subject).to have_key(a.to_s), "Missing change for #{a}"
           end
         end
@@ -213,6 +219,22 @@ describe WorkPackage, type: :model do
 
           context 'new value' do
             let(:expected_value) { 'changed' }
+
+            it_behaves_like 'new value'
+          end
+        end
+
+        context 'schedule_manually' do
+          let(:property) { 'schedule_manually' }
+
+          context 'old_value' do
+            let(:expected_value) { false }
+
+            it_behaves_like 'old value'
+          end
+
+          context 'new value' do
+            let(:expected_value) { true }
 
             it_behaves_like 'new value'
           end


### PR DESCRIPTION
Adds the `schedule_manually` column to the work_package_journals table which enables journalizing the changes to the scheduling mode.

Also adds a specific journal formatter to render the changes in an easily understandable manner:

![image](https://user-images.githubusercontent.com/617519/89189408-3b06b380-d5a0-11ea-8015-98dbd1feb4d7.png)

https://community.openproject.com/work_packages/33649