### PR TITLE
[24343] Allow PDFs to be served inline

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -100,7 +100,7 @@ class Attachment < ApplicationRecord
 
   # images are sent inline
   def inlineable?
-    is_plain_text? || is_image?
+    is_plain_text? || is_image? || is_pdf?
   end
 
   def is_plain_text?


### PR DESCRIPTION
It still depends on the browser whether inline PDFs are allowed. In Firefox, you can configure this manually what should happen. In
Chrome, I'm not sure if there is such an option.

https://community.openproject.com/wp/24343