### PR TITLE
remove operators not applicable to only subprojects filter

### DIFF
--- a/app/models/queries/work_packages/filter/only_subproject_filter.rb
+++ b/app/models/queries/work_packages/filter/only_subproject_filter.rb
@@ -30,6 +30,9 @@
 
 class Queries::WorkPackages::Filter::OnlySubprojectFilter <
   Queries::WorkPackages::Filter::SubprojectFilter
+  def type
+    :list
+  end
 
   def human_name
     I18n.t('query_fields.only_subproject_id')

--- a/app/models/queries/work_packages/filter/subproject_filter.rb
+++ b/app/models/queries/work_packages/filter/subproject_filter.rb
@@ -36,10 +36,8 @@ class Queries::WorkPackages::Filter::SubprojectFilter <
     end
   end
 
-  def available_operators
-    all_and_none = [::Queries::Operators::All, ::Queries::Operators::None]
-
-    all_and_none + (super - all_and_none)
+  def default_operator
+    ::Queries::Operators::All
   end
 
   def available?

--- a/spec/models/queries/work_packages/filter/subproject_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/subproject_filter_spec.rb
@@ -126,11 +126,10 @@ describe Queries::WorkPackages::Filter::SubprojectFilter, type: :model do
       end
     end
 
-    describe '#available_operators' do
-      it 'is the same as for every list_optional but the `all` operator comes first' do
-        expect(instance.available_operators)
-          .to eql([::Queries::Operators::All, ::Queries::Operators::None,
-                   ::Queries::Operators::Equals, ::Queries::Operators::NotEquals])
+    describe '#default_operator' do
+      it 'is the `all` operator' do
+        expect(instance.default_operator)
+          .to eql(::Queries::Operators::All)
       end
     end
 


### PR DESCRIPTION
The none operator does not make sense as it means that no work package will be returned. Selecting it will lead to an SQL error. And the all operator will be the same as not having the filter at all.

There is a minor change in the UI in this change in that the order of the opertors of the subproject filter is altered. But this should not be a problem for the user and leads to a simpler implementation.