### PR TITLE
Fix filtered() on work-packages paths to resolve to correct type

### DIFF
--- a/frontend/src/app/modules/apiv3/endpoints/work_packages/api-v3-work-package-cached-subresource.ts
+++ b/frontend/src/app/modules/apiv3/endpoints/work_packages/api-v3-work-package-cached-subresource.ts
@@ -38,12 +38,12 @@ import {StateCacheService} from "core-app/modules/apiv3/cache/state-cache.servic
 import {tap} from "rxjs/operators";
 import {WorkPackageCache} from "core-app/modules/apiv3/endpoints/work_packages/work-package.cache";
 
-export class ApiV3WorkPackageCachedSubresource extends APIv3ResourcePath<WorkPackageCollectionResource> {
+export class ApiV3WorkPackageCachedSubresource extends APIv3GettableResource<WorkPackageCollectionResource> {
 
-  public get() {
+  public get():Observable<WorkPackageCollectionResource> {
     return this
       .halResourceService
-      .get(this.path)
+      .get<WorkPackageCollectionResource>(this.path)
       .pipe(
         tap(collection => this.cache.updateWorkPackageList(collection.elements))
       );

--- a/frontend/src/app/modules/apiv3/endpoints/work_packages/api-v3-work-packages-paths.ts
+++ b/frontend/src/app/modules/apiv3/endpoints/work_packages/api-v3-work-packages-paths.ts
@@ -99,6 +99,10 @@ export class APIV3WorkPackagesPaths extends CachableAPIV3Collection<WorkPackageR
       );
   }
 
+  filtered<R = APIv3GettableResource<WorkPackageCollectionResource>>(filters:ApiV3FilterBuilder, params:{ [p:string]:string } = {}):R {
+    return super.filtered(filters, params, ApiV3WorkPackageCachedSubresource) as any;
+  }
+
   /**
    * Shortcut to filter work packages by subject or ID
    * @param term
@@ -119,7 +123,7 @@ export class APIV3WorkPackagesPaths extends CachableAPIV3Collection<WorkPackageR
       pageSize: '10'
     };
 
-    return this.filtered(filters, params, ApiV3WorkPackageCachedSubresource);
+    return this.filtered(filters, params);
   }
 
   /**
@@ -137,8 +141,7 @@ export class APIV3WorkPackagesPaths extends CachableAPIV3Collection<WorkPackageR
       pageSize: '10'
     };
 
-    return this
-      .filtered(filters, params, ApiV3WorkPackageCachedSubresource);
+    return this.filtered(filters, params);
   }
 
   /**


### PR DESCRIPTION
Expected
```
this
 .apiV3Service
 .work_packages
 .filtered(buildApiV3Filter('foo', '=', ['bar'])
 .get() // Returns Observable<WorkPackageCollectionResource>
```

Actual
```
this
 .apiV3Service
 .work_packages
 .filtered(buildApiV3Filter('foo', '=', ['bar'])
 .get() // Returns Observable<WorkPackageResource>
```