### PR TITLE
allow `filter` for firlters params

### DIFF
--- a/app/services/api/v3/parse_query_params_service.rb
+++ b/app/services/api/v3/parse_query_params_service.rb
@@ -113,9 +113,9 @@ module API
       #   { /* more filters if needed */}
       # ]
       def filters_from_params(params)
-        return unless params[:filters]
+        filters = params[:filters] || params[:filter]
+        return unless filters
 
-        filters = params[:filters]
         filters = JSON.parse filters if filters.is_a? String
 
         filters.map do |filter|


### PR DESCRIPTION
Users sometimes get stuck by typing filter instead of filters for the query params filters property. We can be lenient here.