### PR TITLE
Emitting stateLinkClicked events from cards

### DIFF
--- a/frontend/src/app/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.html
+++ b/frontend/src/app/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.html
@@ -1,5 +1,6 @@
 <div class="preview-modal--container" wp-isolated-query-space *ngIf="workPackage">
  <wp-single-card [workPackage]="workPackage"
-                 orientation="horizontal">
+                 orientation="horizontal"
+                 (stateLinkClicked)="openStateLink($event)">
  </wp-single-card>
 </div>

--- a/frontend/src/app/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.ts
+++ b/frontend/src/app/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.ts
@@ -34,6 +34,7 @@ import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {APIV3Service} from "core-app/modules/apiv3/api-v3.service";
+import {StateService} from "@uirouter/core";
 
 @Component({
   templateUrl: './wp-preview.modal.html',
@@ -52,7 +53,8 @@ export class WpPreviewModal extends OpModalComponent implements OnInit {
               readonly cdRef:ChangeDetectorRef,
               readonly i18n:I18nService,
               readonly apiV3Service:APIV3Service,
-              readonly opModalService:OpModalService) {
+              readonly opModalService:OpModalService,
+              readonly $state:StateService) {
     super(locals, cdRef, elementRef);
   }
 
@@ -82,5 +84,11 @@ export class WpPreviewModal extends OpModalComponent implements OnInit {
       of: target,
       collision: 'flipfit'
     });
+  }
+
+  public openStateLink(event:{ workPackageId:string; requestedState:string }) {
+    const params = { workPackageId: event.workPackageId };
+
+    this.$state.go(event.requestedState, params);
   }
 }

--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.html
@@ -20,7 +20,8 @@
                     [draggable]="this.canDragOutOf(wp)"
                     [orientation]="orientation"
                     [shrinkOnMobile]="shrinkOnMobile"
-                    (onRemove)="removeCard(wp)">
+                    (onRemove)="removeCard(wp)"
+                    (stateLinkClicked)="stateLinkClicked.emit($event)">
     </wp-single-card>
 
     <hr *ngIf="shrinkOnMobile"

--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.html
@@ -9,7 +9,7 @@
     <a class="wp-card--details-button -no-decoration"
        *ngIf="!workPackage.isNew && showInfoButton"
        [title]="text.detailsView"
-       (accessibleClick)="openSplitScreen(workPackage)">
+       (accessibleClick)="emitStateLinkClicked(workPackage, true)">
       <op-icon icon-classes="icon icon-info2"></op-icon>
     </a>
     <a class="wp-card--inline-cancel-button -no-decoration"
@@ -45,10 +45,9 @@
           class="wp-card--type"
           [ngClass]="typeHighlightingClass(workPackage)">
     </span>
-    <a uiSref="work-packages.show" 
-       [uiParams]="{workPackageId: workPackage.id}"
-       class="wp-card--id"
-       [ngClass]="uiStateLinkClass">
+    <a class="wp-card--id"
+       [ngClass]="uiStateLinkClass"
+       (accessibleClick)="emitStateLinkClicked(workPackage)">
       #{{workPackage.id}}
     </a>
     <span [textContent]="wpSubject(workPackage)" 

--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.ts
@@ -37,7 +37,8 @@ export class WorkPackageSingleCardComponent extends UntilDestroyedMixin implemen
   @Input() public orientation:CardViewOrientation = 'vertical';
   @Input() public shrinkOnMobile:boolean = false;
 
-  @Output() public onRemove = new EventEmitter<WorkPackageResource>();
+  @Output() onRemove = new EventEmitter<WorkPackageResource>();
+  @Output() stateLinkClicked = new EventEmitter<{ workPackageId:string, requestedState:string }>();
 
   public uiStateLinkClass:string = uiStateLinkClass;
 
@@ -71,14 +72,13 @@ export class WorkPackageSingleCardComponent extends UntilDestroyedMixin implemen
     return this.cardView.classIdentifier(wp);
   }
 
-  public openSplitScreen(wp:WorkPackageResource) {
-    let classIdentifier = this.classIdentifier(wp);
+  public emitStateLinkClicked(wp:WorkPackageResource, detail?:boolean) {
+    const classIdentifier = this.classIdentifier(wp);
+    const stateToEmit = detail ? splitViewRoute(this.$state) : 'work-packages.show';
+
     this.wpTableSelection.setSelection(wp.id!, this.cardView.findRenderedCard(classIdentifier));
     this.wpTableFocus.updateFocus(wp.id!);
-    this.$state.go(
-      splitViewRoute(this.$state),
-      { workPackageId: wp.id! }
-    );
+    this.stateLinkClicked.emit({ workPackageId:wp.id!, requestedState: stateToEmit });
   }
 
   public cardClasses() {

--- a/frontend/src/app/modules/bim/ifc_models/bcf/list-container/bcf-list-container.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/bcf/list-container/bcf-list-container.component.ts
@@ -88,19 +88,12 @@ export class BcfListContainerComponent extends WorkPackageListViewComponent impl
     }
 
     if (event.double) {
-      this.goToWpDetailState(event.workPackageId, this.$state.params.cards);
+      this.goToWpDetailState(event.workPackageId, this.uIRouterGlobals.params.cards);
     }
   }
 
   openStateLink(event:{ workPackageId:string; requestedState:string }) {
-    // In case we're in a regular list without view,
-    // reuse the default list behavior
-    if (this.bimView.current === bimListViewIdentifier) {
-      super.openStateLink(event);
-      return;
-    }
-
-    this.goToWpDetailState(event.workPackageId, this.$state.params.cards, true);
+    this.goToWpDetailState(event.workPackageId, this.uIRouterGlobals.params.cards, true);
   }
 
   goToWpDetailState(workPackageId:string, cards:boolean, focus?:boolean) {

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.html
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.html
@@ -56,7 +56,8 @@
                     [showInfoButton]="true"
                     [highlightingMode]="board.highlightingMode"
                     [showStatusButton]="showCardStatusButton()"
-                    (itemClicked)="openFullViewOnDoubleClick($event)" >
+                    (itemClicked)="openFullViewOnDoubleClick($event)"
+                    (stateLinkClicked)="openStateLink($event)">
 
       </wp-card-view>
     </div>

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -148,7 +148,8 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
               readonly schemaCache:SchemaCacheService,
               readonly boardService:BoardService,
               readonly boardActionRegistry:BoardActionsRegistryService,
-              readonly causedUpdates:CausedUpdatesService) {
+              readonly causedUpdates:CausedUpdatesService,
+              readonly $state:StateService) {
     super(I18n, injector);
   }
 
@@ -476,6 +477,13 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
       );
     }
   }
+
+  openStateLink(event:{ workPackageId:string; requestedState:string }) {
+    const params = { workPackageId: event.workPackageId };
+
+    this.$state.go(event.requestedState, params);
+  }
+
   private schema(workPackage:WorkPackageResource) {
     return this.schemaCache.of(workPackage);
   }


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/33969/activity?query_id=2563

- [x] Refactor WorkPackageCardViewComponent and WorkPackageSingleCardComponent to emit the stateLinkClicked event instead of handling it themselves. This allows more flexibility in its use. The card also emits the default state that would be loaded (split view when clicking in the info icon, full view when clicking on the 'id'). 
- [x]  On Revit / plugin environment, show the wp detail page always in full view (because there is no viewer).
