### PR TITLE
fix archiving projects via api

### DIFF
--- a/app/contracts/projects/archive_contract.rb
+++ b/app/contracts/projects/archive_contract.rb
@@ -28,8 +28,10 @@
 
 module Projects
   class ArchiveContract < ModelContract
+    include Projects::Archiver
+
     def validate
-      user_allowed
+      validate_admin_only
       validate_no_foreign_wp_references
 
       super
@@ -37,31 +39,8 @@ module Projects
 
     protected
 
-    def user_allowed
-      unless authorized?
-        errors.add :base, :error_unauthorized
-      end
-    end
-
-    # Check that there is no wp of a non descendant project that is assigned
-    # to one of the project or descendant versions
-    def validate_no_foreign_wp_references
-      version_ids = model.rolled_up_versions.select(:id)
-
-      exists = WorkPackage
-               .where.not(project_id: model.self_and_descendants.select(:id))
-               .where(version_id: version_ids)
-               .exists?
-
-      errors.add :base, :foreign_wps_reference_version if exists
-    end
-
     def validate_model?
       false
-    end
-
-    def authorized?
-      user.admin?
     end
   end
 end

--- a/app/contracts/projects/archiver.rb
+++ b/app/contracts/projects/archiver.rb
@@ -27,20 +27,30 @@
 #++
 
 module Projects
-  class UnarchiveContract < ModelContract
-    include Projects::Archiver
-
-    def validate
-      validate_admin_only
-      validate_all_ancestors_active
-
-      super
+  module Archiver
+    def validate_admin_only
+      unless user.admin?
+        errors.add :base, :error_unauthorized
+      end
     end
 
-    protected
+    # Check that there is no wp of a non descendant project that is assigned
+    # to one of the project or descendant versions
+    def validate_no_foreign_wp_references
+      version_ids = model.rolled_up_versions.select(:id)
 
-    def validate_model?
-      false
+      exists = WorkPackage
+                 .where.not(project_id: model.self_and_descendants.select(:id))
+                 .where(version_id: version_ids)
+                 .exists?
+
+      errors.add :base, :foreign_wps_reference_version if exists
+    end
+
+    def validate_all_ancestors_active
+      if model.ancestors.any?(&:archived?)
+        errors.add :base, :archived_ancestor
+      end
     end
   end
 end

--- a/app/services/projects/update_service.rb
+++ b/app/services/projects/update_service.rb
@@ -50,6 +50,7 @@ module Projects
       send_update_notification
       update_wp_versions_on_parent_change
       persist_status
+      handle_archiving
 
       service_call
     end
@@ -80,6 +81,22 @@ module Projects
 
     def persist_status
       model.status.save if model.status.changed?
+    end
+
+    def handle_archiving
+      return unless model.saved_change_to_active?
+
+      if model.active?
+        # was unarchived
+        Projects::UnarchiveService
+          .new(user: user, model: model)
+          .call
+      else
+        # as archived
+        Projects::ArchiveService
+          .new(user: user, model: model)
+          .call
+      end
     end
   end
 end


### PR DESCRIPTION
When archiving, we need to assume the old `active` status to see if any modifications can be made. On top of that, whenever that status is changed the archive/unarchive service needs to be called as well so that e.g. the child projects are also archived.

https://community.openproject.com/projects/openproject/work_packages/33987