### PR TITLE
remove unnecessary redefinition of order_by_name scope

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -256,7 +256,7 @@ class Attachment < ApplicationRecord
   end
 
   def self.create_pending_direct_upload(file_name:, author:, container: nil, content_type: nil, file_size: 0)
-    a = new(
+    a = create(
       container: container,
       author: author,
       content_type: content_type.presence || "application/octet-stream",

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -58,7 +58,7 @@ class Version < ApplicationRecord
 
   scope :systemwide, -> { where(sharing: 'system') }
 
-  scope :order_by_name, -> { order(Arel.sql("LOWER(#{Version.table_name}.name)")) }
+  scope :order_by_name, -> { order(Arel.sql("LOWER(#{Version.table_name}.name) ASC")) }
 
   def self.with_status_open
     where(status: 'open')

--- a/modules/backlogs/app/models/sprint.rb
+++ b/modules/backlogs/app/models/sprint.rb
@@ -38,9 +38,6 @@ class Sprint < Version
   scope :order_by_date, -> {
     reorder(Arel.sql("start_date ASC NULLS LAST, effective_date ASC NULLS LAST"))
   }
-  scope :order_by_name, -> {
-    order Arel.sql("#{Version.table_name}.name ASC")
-  }
 
   scope :apply_to, lambda { |project|
     where("#{Version.table_name}.project_id = #{project.id}" +


### PR DESCRIPTION
Seeing

```
W, [2020-07-06T09:29:04.298457 #22316]  WARN -- : hook registered
W, [2020-07-06T09:29:07.534498 #22316]  WARN -- : Creating scope :order_by_name. Overwriting existing method Sprint.order_by_name.
W, [2020-08-11T09:34:29.240530 #68326]  WARN -- : Creating scope :order_by_name. Overwriting existing method Sprint.order_by_name.
```

in the logs for OpenProject everytime a process starts bothers me. So I went ahead and removed the first warning right away, and created this PR to see if I can remove the seemingly redundant `order_by_name` scope in `sprint.rb` too.