### PR TITLE
Show server error message when uploaded file is too big

### DIFF
--- a/frontend/src/app/components/api/op-file-upload/op-direct-file-upload.service.ts
+++ b/frontend/src/app/components/api/op-file-upload/op-direct-file-upload.service.ts
@@ -141,11 +141,6 @@ export class OpenProjectDirectFileUploadService extends OpenProjectFileUploadSer
         });
 
         return { url: res._links.addAttachment.href, form: form, response: res };
-      })
-      .catch((err) => {
-        console.log(err);
-
-        return new FormData();
       });
 
     return result;


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34016

- [x] Replace the default error message shown when the uploaded file is too big ("An internal error...") with the error message returned by the server. 