### PR TITLE
Feature/34014 allow rescheduling drag on manual scheduled parents

### DIFF
--- a/frontend/src/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/timeline-cell-renderer.ts
@@ -396,7 +396,8 @@ export class TimelineCellRenderer {
     let selectionMode = renderInfo.viewParams.activeSelectionMode;
 
     // Cannot edit the work package if it has children
-    if (!wp.isLeaf && !selectionMode) {
+    // and it is not on 'Manual scheduling' mode
+    if (!wp.isLeaf && !selectionMode && !wp.scheduleManually) {
       bar.classList.add('-readonly');
     } else {
       bar.classList.remove('-readonly');

--- a/frontend/src/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -108,9 +108,10 @@ export function registerWorkPackageMouseHandler(this:void,
     workPackageTimeline.disableViewParamsCalculation = true;
     mouseDownStartDay = getCursorOffsetInDaysFromLeft(renderInfo, ev);
 
-    // If this wp is a parent element, changing it is not allowed.
+    // If this wp is a parent element, changing it is not allowed
+    // if it is not on 'Manual scheduling' mode
     // But adding a relation to it is.
-    if (!renderInfo.workPackage.isLeaf && !renderInfo.viewParams.activeSelectionMode) {
+    if (!renderInfo.workPackage.isLeaf && !renderInfo.viewParams.activeSelectionMode && !renderInfo.workPackage.scheduleManually) {
       return;
     }
 

--- a/frontend/src/app/components/wp-table/timeline/cells/wp-timeline-cell.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/wp-timeline-cell.ts
@@ -40,7 +40,6 @@ import {HalEventsService} from "core-app/modules/hal/services/hal-events.service
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 import {SchemaCacheService} from "core-components/schemas/schema-cache.service";
-import {APIV3Service} from "core-app/modules/apiv3/api-v3.service";
 
 export const classNameLeftLabel = 'labelLeft';
 export const classNameRightContainer = 'containerRight';
@@ -76,7 +75,6 @@ export class WorkPackageTimelineCell {
 
   private elementShape:string;
 
-  private timelineCell:JQuery;
   private labels:WorkPackageCellLabels;
 
   constructor(public readonly injector:Injector,

--- a/frontend/src/global_styles/content/work_packages/timelines/elements/_bar.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/elements/_bar.sass
@@ -26,7 +26,7 @@
     max-width: 20%
     height: 100%
 
-  &:hover .timeline-element--bg:not(.-clamp-style)
+  &:hover .timeline-element--bg:not(.-readonly)
     &~.leftHandle,
     &~.rightHandle
       background-color: rgba(1, 1, 1, 0.2)


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34014

Given a parent work package in manual scheduling mode displayed as a clamp in gantt view, it is possible to: 

- [x] Alter the start and finish date by dragging the end/start of the clamp
- [x] Alter the start/finish date by dragging the whole bar