### PR TITLE
[33911] Fix unnecessary scrollbars of wp graph widgets

### DIFF
--- a/frontend/src/app/modules/grids/widgets/wp-graph/wp-graph.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-graph/wp-graph.component.html
@@ -9,7 +9,7 @@
   </widget-wp-graph-menu>
 </widget-header>
 
-<wp-embedded-graph class='grid--widget-content'
+<wp-embedded-graph class='grid--widget-content -no-overflow'
                    [datasets]="datasets"
                    [chartType]="chartType">
 </wp-embedded-graph>

--- a/frontend/src/app/modules/grids/widgets/wp-overview/wp-overview.component.html
+++ b/frontend/src/app/modules/grids/widgets/wp-overview/wp-overview.component.html
@@ -9,6 +9,6 @@
 </widget-header>
 
 <wp-overview-graph
-    class='grid--widget-content'
+    class='grid--widget-content -no-overflow'
     [groupBy]="'type'">
 </wp-overview-graph>


### PR DESCRIPTION
### Problem

Depending on different browser zoom levels or screen and hamburger menu sizes horizontal (or in Safari even vertical) scrollbars appeared. 

### Solution
Because the graphs are already responsive, prevent them from overflowing so that there will be no unnecessary scrollbars shown.

See ticket: https://community.openproject.com/projects/openproject/work_packages/33911