### PR TITLE
[33074] Add unassigned value for the assignee action board

### DIFF
--- a/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-action.service.ts
@@ -5,6 +5,10 @@ import {AssigneeBoardHeaderComponent} from "core-app/modules/boards/board/board-
 import {ProjectResource} from "core-app/modules/hal/resources/project-resource";
 import {CachedBoardActionService} from "core-app/modules/boards/board/board-actions/cached-board-action.service";
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
+import {Board} from "core-app/modules/boards/board/board";
+import {ApiV3Filter, FilterOperator} from "core-components/api/api-v3/api-v3-filter-builder";
+import {QueryResource} from "core-app/modules/hal/resources/query-resource";
+
 
 @Injectable()
 export class BoardAssigneeActionService extends CachedBoardActionService {
@@ -17,6 +21,57 @@ export class BoardAssigneeActionService extends CachedBoardActionService {
   { attribute: this.I18n.t('js.boards.board_type.action_type.assignee')});
 
   icon = 'icon-user';
+
+  readonly unassignedUser:any = {
+    id: null,
+    href: null,
+    name: this.I18n.t('js.filter.noneElement')
+  };
+
+  /**
+   * Add a single action query
+   */
+  addColumnWithActionAttribute(board:Board, value:HalResource):Promise<Board> {
+    let params:any = {
+      name: value.name,
+    };
+
+    let filter:ApiV3Filter;
+
+    if (value.id === null) {
+      filter = {
+        assignee: {
+          operator: '!*',
+          values: []
+        }
+      };
+    } else {
+      filter = {
+        assignee: {
+          operator: '=',
+          values: [value.idFromLink]
+        }
+      };
+    }
+
+    return this.boardListsService.addQuery(board, params, [filter]);
+  }
+
+  /**
+   * Returns the current filter value if any
+   * @param query
+   * @returns The loaded action reosurce
+   */
+  getLoadedActionValue(query:QueryResource):Promise<HalResource|undefined> {
+    const filter = this.getActionFilter(query);
+
+    // Return the special unassigned user
+    if (filter && filter.operator.id === '!*') {
+      return Promise.resolve(this.unassignedUser);
+    }
+
+    return super.getLoadedActionValue(query);
+  }
 
   public get localizedName() {
     return this.I18n.t('js.work_packages.properties.assignee');
@@ -56,6 +111,8 @@ export class BoardAssigneeActionService extends CachedBoardActionService {
       .available_assignees
       .get()
       .toPromise()
-      .then((collection:CollectionResource<UserResource>) => collection.elements);
+      .then(
+        (collection:CollectionResource<UserResource>) => [this.unassignedUser].concat(collection.elements)
+      );
   }
 }

--- a/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-board-header.html
+++ b/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-board-header.html
@@ -1,5 +1,5 @@
 <div class="assignee-board-header" *ngIf="user">
-  <user-avatar [user]="user" data-class-list="avatar-mini"></user-avatar>
+  <user-avatar *ngIf="user.id" [user]="user" data-class-list="avatar-mini"></user-avatar>
   <h2 [textContent]="user.name"
       class="editable-toolbar-title--fixed">
   </h2>

--- a/frontend/src/app/modules/boards/board/board-actions/board-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/board-action.service.ts
@@ -20,6 +20,7 @@ import {WorkPackageFilterValues} from "core-components/wp-edit-form/work-package
 import {APIV3Service} from "core-app/modules/apiv3/api-v3.service";
 import {SchemaCacheService} from "core-components/schemas/schema-cache.service";
 import {Observable} from "rxjs";
+import {QueryFilterInstanceResource} from "core-app/modules/hal/resources/query-filter-instance-resource";
 
 @Injectable()
 export abstract class BoardActionService {
@@ -60,12 +61,20 @@ export abstract class BoardActionService {
   text:string;
 
   /**
+   * Returns the current filter instance
+   * @param query
+   */
+  getActionFilter(query:QueryResource, getHref = false):QueryFilterInstanceResource|undefined {
+    return query.filters.find(filter => filter.id === this.filterName);
+  }
+
+  /**
    * Returns the current filter value ID if any
    * @param query
    * @returns The id of the resource
    */
   getActionValueId(query:QueryResource, getHref = false):string|undefined {
-    const filter = _.find(query.filters, filter => filter.id === this.filterName);
+    const filter = this.getActionFilter(query);
     if (!filter) {
       return;
     }
@@ -78,6 +87,7 @@ export abstract class BoardActionService {
 
     return value;
   }
+
 
   /**
    * Returns the current filter value if any

--- a/frontend/src/app/modules/boards/board/board-partitioned-page/board-list-container.component.ts
+++ b/frontend/src/app/modules/boards/board/board-partitioned-page/board-list-container.component.ts
@@ -195,7 +195,7 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
    *
    * @param board
    */
-  private getActionFiltersFromWidget(board:Board):string[] {
+  private getActionFiltersFromWidget(board:Board):(string|null)[] {
     return board.grid.widgets
       .map(widget => {
         const service = this.boardActionRegistry.get(board.actionAttribute!);
@@ -204,10 +204,10 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
         const filter = _.find(options.filters, (filter) => !!filter[filterName]);
 
         if (filter) {
-          return filter[filterName].values[0] as any;
+          return (filter[filterName].values[0] || null) as any;
         }
       })
-      .filter(value => !!value);
+      .filter(value => value !== undefined);
   }
 
 }

--- a/modules/boards/spec/features/action_boards/assignee_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/assignee_board_spec.rb
@@ -109,10 +109,8 @@ describe 'Assignee action board',
       board_page.add_list option: 'Grouped'
       board_page.expect_list 'Grouped'
 
-      # There can't be any other users added
-      board_page.open_add_list_modal
-      board_page.add_list_modal_shows_warning true, with_link: false
-      click_on 'Cancel'
+      # There is now only the none option left
+      board_page.expect_list_option '(none)'
 
       board_page.board(reload: true) do |board|
         expect(board.name).to eq 'Action board (assignee)'
@@ -197,6 +195,10 @@ describe 'Assignee action board',
 
       # Expect no assignees to be present
       board_page.expect_empty
+
+      # Add none to the list
+      board_page.add_list option: '(none)'
+      board_page.expect_list '(none)'
 
       board_page.open_add_list_modal
       board_page.add_list_modal_shows_warning true, with_link: true


### PR DESCRIPTION
Allows extension of the filter values with an empty !* type filter that is also remembered as a "null" ID column for the board list
selection.

https://community.openproject.com/wp/33074