### PR TITLE
[24025] Allow description and long text custom fields as columns on work package lists

### DIFF
--- a/app/models/queries/work_packages/columns/custom_field_column.rb
+++ b/app/models/queries/work_packages/columns/custom_field_column.rb
@@ -100,7 +100,6 @@ class Queries::WorkPackages::Columns::CustomFieldColumn < Queries::WorkPackages:
     else
       WorkPackageCustomField.all
     end
-      .reject { |cf| cf.field_format == 'text' }
       .map { |cf| new(cf) }
   end
 end

--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -48,6 +48,9 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
     subject: {
       sortable: "#{WorkPackage.table_name}.subject"
     },
+    description: {
+      sortable: "#{WorkPackage.table_name}.description"
+    },
     type: {
       association: 'type',
       sortable: "position",

--- a/spec/models/queries/work_packages/columns/custom_field_column_spec.rb
+++ b/spec/models/queries/work_packages/columns/custom_field_column_spec.rb
@@ -55,14 +55,6 @@ describe Queries::WorkPackages::Columns::CustomFieldColumn, type: :model do
           .and_return([text_custom_field,
                        list_custom_field])
       end
-
-      it 'contains only non text cf columns' do
-        expect(described_class.instances(project).length)
-          .to eq 1
-
-        expect(described_class.instances(project)[0].custom_field)
-          .to eq list_custom_field
-      end
     end
 
     context 'global' do
@@ -71,14 +63,6 @@ describe Queries::WorkPackages::Columns::CustomFieldColumn, type: :model do
           .to receive(:all)
           .and_return([text_custom_field,
                        list_custom_field])
-      end
-
-      it 'contains only non text cf columns' do
-        expect(described_class.instances.length)
-          .to eq 1
-
-        expect(described_class.instances[0].custom_field)
-          .to eq list_custom_field
       end
     end
   end


### PR DESCRIPTION
Enable WP grid to have description and long text custom field columns.

https://community.openproject.com/projects/openproject/work_packages/24025/activity