### PR TITLE
allow omni-auth user to switch to password on reinvitation

### DIFF
--- a/app/controllers/concerns/user_invitation.rb
+++ b/app/controllers/concerns/user_invitation.rb
@@ -88,15 +88,23 @@ module UserInvitation
   # @param user_id [Integer] ID of the user to be re-invited.
   # @return [Token] The new token used for the invitation.
   def reinvite_user(user_id)
-    clear_tokens user_id
+    User.transaction do
+      clear_tokens user_id
+      reset_login user_id
 
-    Token::Invitation.create!(user_id: user_id).tap do |token|
-      OpenProject::Notifications.send Events.user_reinvited, token
+      Token::Invitation.create!(user_id: user_id).tap do |token|
+        OpenProject::Notifications.send Events.user_reinvited, token
+      end
     end
   end
 
   def clear_tokens(user_id)
     Token::Invitation.where(user_id: user_id).delete_all
+  end
+
+  def reset_login(user_id)
+    User.where(id: user_id).update_all identity_url: nil
+    UserPassword.where(user_id: user_id).destroy_all
   end
 
   ##


### PR DESCRIPTION
Also make sure to delete passwords on reinvitation so users switching to omni-auth can't still login using the old password while we're at it.