### PR TITLE
[34001] Ensure filters always receive the query context

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -77,22 +77,15 @@ class Query < ApplicationRecord
     end
   end
 
-  after_initialize :set_context
-  # For some reasons the filters loose their context
-  # between the after_save and the after_commit callback.
-  after_commit :set_context
-
-  def set_context
-    # We need to set the project for each filter if a project
-    # is present because the information is not available when
-    # deserializing the filters from the db.
-
-    # Allow to use AR's select(...) without
-    # the filters attribute
-    return unless respond_to?(:filters)
-
-    filters.each do |filter|
-      filter.context = self
+  ##
+  # Ensure the filters receive
+  # the query context as this appears to be lost
+  # whenever the field is reloaded from the serialized value
+  def filters
+    super.tap do |filters|
+      filters.each do |filter|
+        filter.context = self
+      end
     end
   end
 

--- a/app/services/queries/copy_service.rb
+++ b/app/services/queries/copy_service.rb
@@ -43,7 +43,6 @@ module Queries
       new_query = ::Query.new source.attributes.dup.except(*skipped_attributes)
       new_query.sort_criteria = source.sort_criteria if source.sort_criteria
       new_query.project = state.project || source.project
-      new_query.set_context
 
       ServiceResult.new(success: new_query.save, result: new_query)
     end

--- a/app/workers/work_packages/exports/export_job.rb
+++ b/app/workers/work_packages/exports/export_job.rb
@@ -50,7 +50,6 @@ module WorkPackages
         query.tap do |q|
           q.attributes = query_attributes
           q.filters = filters
-          q.set_context
         end
       end
 

--- a/lib/api/v3/work_packages/schema/form_configurations/query_representer.rb
+++ b/lib/api/v3/work_packages/schema/form_configurations/query_representer.rb
@@ -50,9 +50,6 @@ module API
                                 getter: ->(*) do
                                   next unless embed_links
 
-                                  # For some reason, the context (query) of the filters
-                                  # are lost. We therefore set it anew:
-                                  query.set_context
                                   ::API::V3::Queries::QueryRepresenter.new(query, current_user: current_user)
                                 end
 


### PR DESCRIPTION
In the mentioned project, the query copy service fails to execute because a filter has lost its context right after `query.save`.

There is a hook for `after_commit` which is not relevant here since we're in a transaction, but the context is lost regardless.

Instead, we could ensure whenever accessing the filters, the context is set correctly.

https://community.openproject.com/wp/34001 