### PR TITLE
Fix/child scheduling restrictions

### DIFF
--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -31,6 +31,10 @@
 class Relation < ApplicationRecord
   include VirtualAttribute
 
+  include ::Scopes::Scoped
+
+  scope_classes Relations::Scopes::FollowsNonManualAncestors
+
   scope :of_work_package,
         ->(work_package) { where('from_id = ? OR to_id = ?', work_package, work_package) }
 

--- a/app/models/relations/scopes/follows_non_manual_ancestors.rb
+++ b/app/models/relations/scopes/follows_non_manual_ancestors.rb
@@ -1,0 +1,57 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+# Returns all follows relationships of work package ancestors or work package unless
+# the ancestor or a work package between the ancestor and self is manually scheduled.
+module Relations::Scopes
+  class FollowsNonManualAncestors
+    class << self
+      def fetch(work_package)
+        ancestor_relations_non_manual = Relation
+                                          .hierarchy_or_reflexive
+                                          .where(to_id: work_package.id)
+                                          .where.not(from_id: from_manual_ancestors(work_package).select(:from_id))
+        Relation
+          .where(from_id: ancestor_relations_non_manual.select(:from_id))
+          .follows
+      end
+
+      private
+
+      def from_manual_ancestors(work_package)
+        manually_schedule_ancestors = work_package.ancestors.where(schedule_manually: true)
+
+        Relation
+          .hierarchy_or_reflexive
+          .where(to_id: manually_schedule_ancestors.select(:id))
+      end
+    end
+  end
+end

--- a/app/models/work_package/scheduling_rules.rb
+++ b/app/models/work_package/scheduling_rules.rb
@@ -55,8 +55,10 @@ module WorkPackage::SchedulingRules
   #   B is 2017/07/25
   #   A is 2017/07/25
   def soonest_start
+    # eager load `to` to avoid n+1 on successor_soonest_start
     @soonest_start ||=
       ancestors_follows_relations
+        .includes(:to)
         .map(&:successor_soonest_start)
         .compact
         .max


### PR DESCRIPTION
If a parent has a follows relations with another work package, that relationship also limits children of the work package. But if the work package is scheduled manually, this creates a scheduling barrier. Children of a manually scheduled work package are not hampered by the follows relationships of the parent or other ancestors.

This change then leads to no longer having an error message displayed when moving a child work package to a date before the parent's successor due_date.

https://community.openproject.com/projects/openproject/work_packages/34076