### PR TITLE
[34002] Show errors in the job modal instead of automatically redirecting

### DIFF
--- a/app/services/base_services/copy.rb
+++ b/app/services/base_services/copy.rb
@@ -60,7 +60,8 @@ module BaseServices
       copy_dependencies.each do |service_cls|
         next if skip_dependency?(params, service_cls)
 
-        call.merge! call_dependent_service(service_cls, target: copy_instance, params: params)
+        call.merge! call_dependent_service(service_cls, target: copy_instance, params: params),
+                    without_success: true
       end
 
       call

--- a/app/services/copy/dependency.rb
+++ b/app/services/copy/dependency.rb
@@ -43,6 +43,12 @@ module Copy
       name.demodulize.gsub('DependentService', '').underscore
     end
 
+    ##
+    # Localizable human name used in errors
+    def self.human_name
+      identifier.capitalize
+    end
+
     def initialize(source:, target:, user:)
       @source = source
       @target = target
@@ -64,9 +70,9 @@ module Copy
       begin
         copy_dependency(params: params)
       rescue StandardError => e
-        Rails.logger.error { "Failed to copy dependency #{self.class.name}: #{e.message}" }
+        Rails.logger.error { "Failed to copy dependency #{self.class.identifier}: #{e.message}" }
         result.success = false
-        result.errors.add(self.class.identifier, :could_not_be_copied)
+        result.errors.add(:base, :could_not_be_copied, dependency: self.class.name)
       end
 
       result

--- a/app/services/projects/copy/boards_dependent_service.rb
+++ b/app/services/projects/copy/boards_dependent_service.rb
@@ -30,6 +30,10 @@
 
 module Projects::Copy
   class BoardsDependentService < Dependency
+    def self.human_name
+      I18n.t(:'boards.label_boards')
+    end
+
     protected
 
     # Copies boards from +project+

--- a/app/services/projects/copy/categories_dependent_service.rb
+++ b/app/services/projects/copy/categories_dependent_service.rb
@@ -30,6 +30,10 @@
 
 module Projects::Copy
   class CategoriesDependentService < Dependency
+    def self.human_name
+      I18n.t(:label_work_package_category_plural)
+    end
+
     protected
 
     def copy_dependency(params:)

--- a/app/services/projects/copy/forums_dependent_service.rb
+++ b/app/services/projects/copy/forums_dependent_service.rb
@@ -30,6 +30,10 @@
 
 module Projects::Copy
   class ForumsDependentService < Dependency
+    def self.human_name
+      I18n.t(:label_forum_plural)
+    end
+
     protected
 
     def copy_dependency(params:)

--- a/app/services/projects/copy/members_dependent_service.rb
+++ b/app/services/projects/copy/members_dependent_service.rb
@@ -30,6 +30,10 @@
 
 module Projects::Copy
   class MembersDependentService < Dependency
+    def self.human_name
+      I18n.t(:label_member_plural)
+    end
+
     protected
 
     def copy_dependency(*)

--- a/app/services/projects/copy/queries_dependent_service.rb
+++ b/app/services/projects/copy/queries_dependent_service.rb
@@ -30,6 +30,10 @@
 
 module Projects::Copy
   class QueriesDependentService < Dependency
+    def self.human_name
+      I18n.t(:label_query_plural)
+    end
+
     protected
 
     # Copies queries from +project+

--- a/app/services/projects/copy/versions_dependent_service.rb
+++ b/app/services/projects/copy/versions_dependent_service.rb
@@ -30,6 +30,10 @@
 
 module Projects::Copy
   class VersionsDependentService < Dependency
+    def self.human_name
+      I18n.t(:label_version_plural)
+    end
+
     protected
 
     def copy_dependency(params:)

--- a/app/services/projects/copy/wiki_dependent_service.rb
+++ b/app/services/projects/copy/wiki_dependent_service.rb
@@ -32,6 +32,10 @@ module Projects::Copy
   class WikiDependentService < Dependency
     include ::Copy::Concerns::CopyAttachments
 
+    def self.human_name
+      I18n.t(:label_wiki_page_plural)
+    end
+
     protected
 
     def copy_dependency(params:)

--- a/app/services/projects/copy/work_packages_dependent_service.rb
+++ b/app/services/projects/copy/work_packages_dependent_service.rb
@@ -32,6 +32,10 @@ module Projects::Copy
   class WorkPackagesDependentService < Dependency
     include ::Copy::Concerns::CopyAttachments
 
+    def self.human_name
+      I18n.t(:label_work_package_plural)
+    end
+
     protected
 
     def copy_dependency(params:)

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -59,8 +59,11 @@ class ServiceResult
     !success?
   end
 
-  def merge!(other)
-    merge_success!(other)
+  ##
+  # Merge another service result into this instance
+  # allowing optionally to skip updating its service
+  def merge!(other, without_success: false)
+    merge_success!(other) unless without_success
     merge_errors!(other)
     merge_dependent!(other)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -567,7 +567,7 @@ en:
         cant_link_a_work_package_with_a_descendant: "A work package cannot be linked to one of its subtasks."
         circular_dependency: "This relation would create a circular dependency."
         confirmation: "doesn't match %{attribute}."
-        could_not_be_copied: "could not be (fully) copied."
+        could_not_be_copied: "%{dependency} could not be (fully) copied."
         does_not_exist: "does not exist."
         error_unauthorized: "may not be accessed."
         error_readonly: "was attempted to be written but is not writable."

--- a/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.html
+++ b/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.html
@@ -20,7 +20,7 @@
         </div>
       </div>
       <div>
-        <span [textContent]="message"></span>
+        <span class="job-status--modal-main-message" [textContent]="message"></span>
         <span [hidden]="!downloadHref">
           {{ text.download_starts }}
           <a #downloadLink
@@ -29,6 +29,19 @@
              [attr.href]="downloadHref">
           </a>
         </span>
+        <ng-container *ngIf="payload?.errors">
+          <h3 class="job-status--modal-additional-errors" [textContent]="text.errors"></h3>
+          <ul *ngFor="let error of payload.errors">
+            <li [textContent]="error"></li>
+          </ul>
+
+          <p *ngIf="payload?.redirect">
+            <span [textContent]="text.redirect_errors"></span>
+            <a [textContent]="text.redirect_link"
+               [attr.href]="payload.redirect">
+            </a>
+          </p>
+        </ng-container>
       </div>
     </div>
   </div>

--- a/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.sass
+++ b/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.sass
@@ -13,3 +13,11 @@
   height: 100%
   align-items: center
   justify-content: center
+
+.job-status--modal-main-message
+  font-weight: bold
+  display: flex
+  justify-content: center
+
+.job-status--modal-additional-errors
+  margin-top: 2rem

--- a/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.ts
+++ b/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.ts
@@ -32,6 +32,9 @@ export class JobStatusModal extends OpModalComponent implements OnInit {
     title: this.I18n.t('js.job_status.title'),
     closePopup: this.I18n.t('js.close_popup_title'),
     redirect: this.I18n.t('js.job_status.redirect'),
+    redirect_errors: this.I18n.t('js.job_status.redirect_errors') + ' ',
+    redirect_link: this.I18n.t('js.job_status.redirect_link'),
+    errors: this.I18n.t('js.job_status.errors'),
     download_starts: this.I18n.t('js.job_status.download_starts'),
     click_to_download: this.I18n.t('js.job_status.click_to_download'),
   };
@@ -50,6 +53,9 @@ export class JobStatusModal extends OpModalComponent implements OnInit {
 
   /** Public message to show */
   public message:string;
+
+  /** Payload object of the response */
+  public payload:any;
 
   /** Title to show */
   public title:string = this.text.title;
@@ -127,9 +133,10 @@ export class JobStatusModal extends OpModalComponent implements OnInit {
     this.message = body.message ||
       this.I18n.t(`js.job_status.generic_messages.${status}`, { defaultValue: status });
 
+    this.payload = body.payload;
     if (body.payload) {
       this.title = body.payload.title || this.text.title;
-      this.handleRedirect(body.payload?.redirect);
+      this.handleRedirect(body.payload);
       this.handleDownload(body.payload?.download);
     }
 
@@ -137,9 +144,9 @@ export class JobStatusModal extends OpModalComponent implements OnInit {
     this.cdRef.detectChanges();
   }
 
-  private handleRedirect(redirectUrl?:string) {
-    if (redirectUrl !== undefined) {
-      setTimeout(() => window.location.href = redirectUrl, 2000);
+  private handleRedirect(payload:any) {
+    if (payload?.redirect && !payload?.errors) {
+      setTimeout(() => window.location.href = payload.redirect, 2000);
       this.message += `. ${this.text.redirect}`;
     }
   }

--- a/modules/job_status/config/locales/js-en.yml
+++ b/modules/job_status/config/locales/js-en.yml
@@ -5,6 +5,9 @@ en:
       click_to_download: 'Or click here to download.'
       title: 'Background job status'
       redirect: 'You are being redirected.'
+      redirect_link: 'Please click here to continue.'
+      redirect_errors: 'Due to these errors, you will not be redirected automatically.'
+      errors: 'Some errors have occurred'
       generic_messages:
         not_found: 'This job could not be found.'
         in_queue: 'The job has been queued and will be processed shortly.'

--- a/modules/job_status/spec/factories/delayed_job_status_factory.rb
+++ b/modules/job_status/spec/factories/delayed_job_status_factory.rb
@@ -28,5 +28,7 @@
 
 FactoryBot.define do
   factory :delayed_job_status, class: ::JobStatus::Status do
+    job_id { SecureRandom.uuid }
+    user { User.current }
   end
 end

--- a/modules/job_status/spec/features/job_status_spec.rb
+++ b/modules/job_status/spec/features/job_status_spec.rb
@@ -41,4 +41,36 @@ describe 'Job status', type: :feature, js: true do
     expect(page).to have_selector('.icon-big.icon-help', wait: 10)
     expect(page).to have_content I18n.t('js.job_status.generic_messages.not_found')
   end
+
+  describe 'with a status that has an additional errors payload' do
+    let!(:status) { FactoryBot.create(:delayed_job_status, user: admin) }
+
+    before do
+      status.update! payload: { errors: ['Some error', 'Another error'] }
+    end
+
+    it 'will show a list of these errors' do
+      visit "/job_statuses/#{status.job_id}"
+
+      expect(page).to have_selector('.job-status--modal-additional-errors', text: 'Some errors have occurred', wait: 10)
+      expect(page).to have_selector('ul li', text: 'Some error')
+      expect(page).to have_selector('ul li', text: 'Another error')
+    end
+  end
+
+  describe 'with a status with error and redirect' do
+    let!(:status) { FactoryBot.create(:delayed_job_status, user: admin) }
+
+    before do
+      status.update! payload: { redirect: home_url, errors: ['Some error'] }
+    end
+
+    it 'will not automatically redirect' do
+      visit "/job_statuses/#{status.job_id}"
+
+      expect(page).to have_selector('.job-status--modal-additional-errors', text: 'Some errors have occurred', wait: 10)
+      expect(page).to have_selector('ul li', text: 'Some error')
+      expect(page).to have_selector("a[href='#{home_url}']", text: 'Please click here to continue')
+    end
+  end
 end


### PR DESCRIPTION
The project copying can succeed but with errors of some dependencies, this commit modifies the modal to show these errors instead of automatically redirecting.

https://community.openproject.com/wp/34002