### PR TITLE
Don't try to load invited mail avatars

### DIFF
--- a/frontend/src/app/modules/common/autocomplete/user-autocompleter.component.html
+++ b/frontend/src/app/modules/common/autocomplete/user-autocompleter.component.html
@@ -11,7 +11,7 @@
            [appendTo]="appendTo"
            [multiple]="multiple" >
   <ng-template ng-option-tmp let-item="item" let-index="index">
-    <user-avatar *ngIf="item && item.id"
+    <user-avatar *ngIf="item && item.href"
                  [user]="item"
                  data-class-list="avatar-mini">
     </user-avatar>

--- a/frontend/src/app/modules/members/members-autocompleter.component.ts
+++ b/frontend/src/app/modules/members/members-autocompleter.component.ts
@@ -5,6 +5,7 @@ import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 import {HttpClient, HttpParams} from "@angular/common/http";
 import {Component} from "@angular/core";
 import {URLParamsEncoder} from "core-app/modules/hal/services/url-params-encoder";
+import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 
 export const membersAutocompleterSelector = 'members-autocompleter';
 
@@ -14,6 +15,7 @@ export const membersAutocompleterSelector = 'members-autocompleter';
 })
 export class MembersAutocompleterComponent extends UserAutocompleterComponent {
   @InjectField() http:HttpClient;
+  @InjectField() pathHelper:PathHelperService;
 
   protected getAvailableUsers(url:string, searchTerm:any):Observable<{ [key:string]:string|null }[]> {
     return this.http
@@ -27,7 +29,8 @@ export class MembersAutocompleterComponent extends UserAutocompleterComponent {
       .pipe(
         map((res:any) => {
           return res.results.items.map((el:any) => {
-            return { name: el.name, id: el.id, href: el.id };
+            const href = /^\d+$/.test(el.id.toString()) ? this.pathHelper.userPath(el.id) : null;
+            return { name: el.name, id: el.id, href: href };
           });
         })
       );


### PR DESCRIPTION
When inviting a user, the autocompleter tries to load the avatar as the ID is set to the users' mail. This results in a 404 as the API only accepts integer ids.

We can test whether the user ID is numeric before passing it to the autocompleter template.

https://travis-ci.com/github/opf/openproject/jobs/377352564