### PR TITLE
Allow template to set the default advanced settings once selected

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -37,6 +37,9 @@ class ProjectsController < ApplicationController
   before_action :authorize_global, only: %i[new create]
   before_action :require_admin, only: %i[archive unarchive destroy destroy_info]
 
+  before_action :assign_default_create_variables, only: %i[new]
+  before_action :new_project, only: %i[new]
+
   include SortHelper
   include PaginationHelper
   include CustomFieldsHelper
@@ -63,10 +66,6 @@ class ProjectsController < ApplicationController
   end
 
   def new
-    assign_default_create_variables
-
-    @project = Project.new
-
     Projects::SetAttributesService
       .new(user: current_user, model: @project, contract_class: EmptyContract)
       .call(params.permit(:parent_id))
@@ -100,9 +99,9 @@ class ProjectsController < ApplicationController
     @altered_project = Project.find(@project.id)
 
     service_call = Projects::UpdateService
-                   .new(user: current_user,
-                        model: @altered_project)
-                   .call(permitted_params.project)
+      .new(user: current_user,
+           model: @altered_project)
+      .call(permitted_params.project)
 
     @errors = service_call.errors
 
@@ -112,9 +111,9 @@ class ProjectsController < ApplicationController
 
   def update_identifier
     service_call = Projects::UpdateService
-                   .new(user: current_user,
-                        model: @project)
-                   .call(permitted_params.project)
+      .new(user: current_user,
+           model: @project)
+      .call(permitted_params.project)
 
     if service_call.success?
       flash[:notice] = I18n.t(:notice_successful_update)
@@ -167,8 +166,8 @@ class ProjectsController < ApplicationController
   # Delete @project
   def destroy
     service_call = ::Projects::ScheduleDeletionService
-                   .new(user: current_user, model: @project)
-                   .call
+      .new(user: current_user, model: @project)
+      .call
 
     if service_call.success?
       flash[:notice] = I18n.t('projects.delete.scheduled')
@@ -253,11 +252,6 @@ class ProjectsController < ApplicationController
     @query
   end
 
-  def assign_default_create_variables
-    @wp_custom_fields = WorkPackageCustomField.order("#{CustomField.table_name}.position")
-    @types = ::Type.all
-  end
-
   protected
 
   def create_from_params
@@ -308,6 +302,38 @@ class ProjectsController < ApplicationController
     # e.g. when one of the demo projects gets deleted or a archived
     if project.identifier == 'your-scrum-project' || project.identifier == 'demo-project'
       Setting.demo_projects_available = value
+    end
+  end
+
+  def assign_default_create_variables
+    @wp_custom_fields = WorkPackageCustomField.order("#{CustomField.table_name}.position")
+    @types = ::Type.all
+  end
+
+  def new_project
+    # If a template is passed, assign that as default
+    @template_project = template_project_from_param
+    @project =
+      if @template_project.nil?
+        Project.new
+      else
+        Projects::CopyService
+          .new(user: current_user, source: @template_project)
+          .call(target_project_params: {}, attributes_only: true)
+          .result
+      end
+
+    # Allow setting the name when selecting template
+    if params[:name]
+      @project.name = params[:name]
+    end
+  end
+
+  def template_project_from_param
+    if params[:template_project]
+      ::Projects::InstantiateTemplateContract
+        .visible_templates(current_user)
+        .find_by(id: params[:template_project])
     end
   end
 end

--- a/app/services/projects/copy_service.rb
+++ b/app/services/projects/copy_service.rb
@@ -69,6 +69,9 @@ module Projects
       target.types = source.types
       target.work_package_custom_fields = source.work_package_custom_fields
 
+      # Copy status object
+      target.status = source.status&.dup
+
       # Copy enabled custom fields and their values
       target.custom_field_values = source.custom_value_attributes
       target.custom_values = source.custom_values.map(&:dup)

--- a/app/views/projects/form/_select_template.html.erb
+++ b/app/views/projects/form/_select_template.html.erb
@@ -31,7 +31,7 @@ See docs/COPYRIGHT.rdoc for more details.
   <%= styled_label_tag 'from_template', t('project.template.use_template') %>
   <div class="form--field-container">
     <%= styled_select_tag :from_template,
-                          options_for_select(project_options_for_templated),
+                          options_for_select(project_options_for_templated, @template_project&.id),
                           id: 'project-select-template',
                           prompt: "(#{t(:label_none)})",
                           container_class: '-wide' %>

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -547,6 +547,7 @@ en:
       context: 'Project context'
       work_package_belongs_to: 'This work package belongs to project %{projectname}.'
       click_to_switch_context: 'Open this work package in that project.'
+      confirm_template_load: 'Switching the template will reload the page and you will lose all input to this form. Continue?'
 
       autocompleter:
         label: 'Project autocompletion'

--- a/frontend/src/app/globals/global-listeners/toggable-fieldset.ts
+++ b/frontend/src/app/globals/global-listeners/toggable-fieldset.ts
@@ -66,6 +66,8 @@ function getFieldset(el:HTMLElement) {
 
 function toggleFieldset(el:HTMLElement) {
   var fieldset = getFieldset(el);
+  // Mark the fieldset that the user has touched it at least once
+  fieldset.attr('data-touched', 'true');
   var contentArea = fieldset.find('> div').not('.form--toolbar');
 
   fieldset.toggleClass('collapsed');
@@ -90,7 +92,7 @@ export function setupToggableFieldsets() {
     .each(function() {
       var fieldset = getFieldset(this);
 
-      var contentArea = fieldset.find('> div');
+      let contentArea = fieldset.find('> div');
       if (fieldset.hasClass('collapsed')) {
         contentArea.hide();
       }

--- a/frontend/src/app/modules/augmenting/dynamic-scripts/project_form_listener.js
+++ b/frontend/src/app/modules/augmenting/dynamic-scripts/project_form_listener.js
@@ -86,33 +86,36 @@
       return identifier;
     }
 
+    function updateIdentifierFromName() {
+      if(!projectIdentifierLocked) {
+        jQuery('#project_identifier').val(generateProjectIdentifier());
+      }
+    }
+
     function observeProjectName() {
-      jQuery('#project_name').keyup(function() {
-        if(!projectIdentifierLocked) {
-          jQuery('#project_identifier').val(generateProjectIdentifier());
-        }
-      });
+      jQuery('#project_name').keyup(updateIdentifierFromName);
+      updateIdentifierFromName();
     }
 
     function observeProjectIdentifier() {
       jQuery('#project_identifier').keyup(function() {
-        if(this.value !== '' && this.value != generateProjectIdentifier()) {
-          projectIdentifierLocked = true;
-        } else {
-          projectIdentifierLocked = false;
-        }
+        projectIdentifierLocked = this.value !== '' && this.value != generateProjectIdentifier();
       });
     }
 
     function observeTemplateChanges() {
       jQuery('#project-select-template').on('change', function() {
-        let templateSelected = $(this).val() !== '';
-        let settings = $('#advanced-settings');
+        const name = document.getElementById('project_name');
+        const fieldset = document.getElementById('advanced-settings');
 
-        settings
-          .toggle(!templateSelected)
-          .find('input:not(#project_identifier), select, textarea')
-          .prop('disabled', templateSelected);
+        // When the advanced settings were opened once, we assume they were changed
+        // and show an alert before switching the template
+        if (!fieldset.dataset.touched || window.confirm(I18n.t('js.project.confirm_template_load'))) {
+          let params = new URLSearchParams(location.search);
+          params.set('template_project', this.value);
+          params.set('name', name.value);
+          window.location.search = params.toString();
+        }
       });
     }
 

--- a/spec/features/projects/template_spec.rb
+++ b/spec/features/projects/template_spec.rb
@@ -60,12 +60,13 @@ describe 'Project templates', type: :feature, js: true do
     let!(:template) {
       FactoryBot.create(:template_project, name: 'My template', enabled_module_names: %w[wiki work_package_tracking])
     }
+    let!(:template_status) { FactoryBot.create(:project_status, project: template, explanation: 'source') }
+    let!(:other_project) { FactoryBot.create(:project, name: 'Some other project') }
     let!(:work_package) { FactoryBot.create :work_package, project: template }
     let!(:wiki_page) { FactoryBot.create(:wiki_page_with_content, wiki: template.wiki) }
 
-    let!(:role) { FactoryBot.create(:role, permissions: %i[view_project view_work_packages copy_projects add_project]) }
-    let!(:current_user) { FactoryBot.create(:user, member_in_project: template, member_through_role: role) }
-    let!(:current_user) { FactoryBot.create(:user, member_in_project: template, member_through_role: role) }
+    let!(:role) { FactoryBot.create(:role, permissions: %i[view_project view_work_packages copy_projects add_subprojects add_project]) }
+    let!(:current_user) { FactoryBot.create(:user, member_in_projects: [template, other_project], member_through_role: role) }
     let(:status_field_selector) { 'ckeditor-augmented-textarea[textarea-selector="#project_status_explanation"]' }
     let(:status_description) { ::Components::WysiwygEditor.new status_field_selector }
 
@@ -78,13 +79,38 @@ describe 'Project templates', type: :feature, js: true do
 
       fill_in 'project[name]', with: 'Foo bar'
 
-      expect(page).to have_selector('#advanced-settings', visible: true, text: 'ADVANCED SETTINGS')
-
-      # Choosing template hides advanced settings
+      # Choosing template reloads the page and sets advanced settings
       select 'My template', from: 'project-select-template'
-      expect(page).to have_no_selector('#advanced-settings', visible: true, text: 'ADVANCED SETTINGS')
 
-      sleep 1
+      # It reloads the page without any warning dialog and keeps the name
+      expect(page).to have_field 'Name', with: 'Foo bar'
+      expect(page).to have_select 'project-select-template', selected: 'My template'
+
+      # Updates the identifier in advanced settings
+      page.find('#advanced-settings').click
+      expect(page).to have_field 'project_identifier', with: 'foo-bar'
+      expect(page).to have_select 'project_status_code', selected: 'On track'
+
+      # Changing the template now causes a dialog
+      select '(none)', from: 'project-select-template'
+      page.driver.browser.switch_to.alert.accept
+
+      # Choosing template reloads the page and sets advanced settings
+      select 'My template', from: 'project-select-template'
+
+      # It reloads the page without any warning dialog and keeps the name
+      expect(page).to have_field 'Name', with: 'Foo bar'
+      expect(page).to have_select 'project-select-template', selected: 'My template'
+
+      # Expend advanced settings
+      page.find('#advanced-settings').click
+      expect(page).to have_field 'project_identifier', with: 'foo-bar'
+      expect(page).to have_select 'project_status_code', selected: 'On track'
+
+      # Update status to off track
+      select 'Off track', from: 'project_status_code'
+      select other_project.name, from: 'project_parent_id'
+
       click_on 'Create'
 
       expect(page).to have_content I18n.t('project.template.copying')


### PR DESCRIPTION
Previously, advanced settings were simply hidden when project templates were selected. This however prohibits setting/overriding certain attributes, such as the parent project.

This commit results in:

  - Selecting a template will reload the page
  - When advanced settings were opened, confirms from the user that the
page should be reloaded
  - The template is being applied to the new project to ensure the
attributes are being used
  - The user can then override or delete whatever params she wants