### PR TITLE
Avoid disabled hidden inputs that generates the not focusable error

### DIFF
--- a/modules/costs/app/views/cost_types/_rate.html.erb
+++ b/modules/costs/app/views/cost_types/_rate.html.erb
@@ -53,7 +53,7 @@ See docs/COPYRIGHT.rdoc for more details.
       <%= rate_form.text_field :valid_from,
                                class: 'date costs-date-picker -augmented-datepicker',
                                index: id_or_index,
-                               required: true %>
+                               required: templated ? false : true %>
     </td>
     <td class="currency">
       <span class="inline-label">
@@ -62,7 +62,7 @@ See docs/COPYRIGHT.rdoc for more details.
                                  size: 7,
                                  index: id_or_index,
                                  value: rate.rate ? rate.rate.round(2) : "",
-                                 required: true %>
+                                 required: templated ? false : true %>
         <span class="form-label">
           <%= Setting.plugin_costs['costs_currency'] %>
         </span>


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/details/34144

This pull request:

- [x] Removes the required attribute from hidden inputs to avoid the 'not focusable input error' that prevents the cost type form to be submitted. 
