### PR TITLE
Feature/default dates for children

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -62,15 +62,30 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
   def set_default_attributes(*)
     return unless work_package.new_record?
 
-    work_package.priority ||= IssuePriority.active.default
-    work_package.author ||= user
-    work_package.status ||= Status.default
-
-    work_package.start_date ||= Date.today if Setting.work_package_startdate_is_adddate?
+    set_default_priority
+    set_default_author
+    set_default_status
+    set_default_dates
   end
 
   def non_or_default_description?
     work_package.description.blank? || false
+  end
+
+  def set_default_author
+    work_package.author ||= user
+  end
+
+  def set_default_status
+    work_package.status ||= Status.default
+  end
+
+  def set_default_priority
+    work_package.priority ||= IssuePriority.active.default
+  end
+
+  def set_default_dates
+    work_package.start_date ||= Date.today if Setting.work_package_startdate_is_adddate?
   end
 
   def set_templated_description

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -59,13 +59,14 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
     work_package.attributes = assignable_attributes
   end
 
-  def set_default_attributes(*)
+  def set_default_attributes(attributes)
     return unless work_package.new_record?
 
     set_default_priority
     set_default_author
     set_default_status
-    set_default_dates
+    set_default_start_date(attributes)
+    set_default_due_date(attributes)
   end
 
   def non_or_default_description?
@@ -84,8 +85,22 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
     work_package.priority ||= IssuePriority.active.default
   end
 
-  def set_default_dates
-    work_package.start_date ||= Date.today if Setting.work_package_startdate_is_adddate?
+  def set_default_start_date(attributes)
+    work_package.start_date ||= if attributes.has_key?(:start_date)
+                                  nil
+                                elsif parent_start_earlier_than_due?
+                                  work_package.parent.start_date
+                                elsif Setting.work_package_startdate_is_adddate?
+                                  Date.today
+                                end
+  end
+
+  def set_default_due_date(attributes)
+    work_package.due_date ||= if attributes.has_key?(:due_date)
+                                nil
+                              elsif parent_due_later_than_start?
+                                work_package.parent.due_date
+                              end
   end
 
   def set_templated_description
@@ -263,5 +278,13 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
 
   def max_child_date
     (work_package.children.map(&:start_date) + work_package.children.map(&:due_date)).compact.max
+  end
+
+  def parent_start_earlier_than_due?
+    work_package.parent&.start_date && work_package.parent.start_date < (work_package.due_date || work_package.parent.due_date)
+  end
+
+  def parent_due_later_than_start?
+    work_package.parent&.due_date && work_package.parent.due_date > (work_package.start_date || work_package.parent.start_date)
   end
 end

--- a/frontend/src/app/components/wp-edit-form/work-package-filter-values.spec.ts
+++ b/frontend/src/app/components/wp-edit-form/work-package-filter-values.spec.ts
@@ -120,7 +120,7 @@ describe('WorkPackageFilterValues', () => {
       }
     ];
 
-    subject = new WorkPackageFilterValues(injector, changeset, filters);
+    subject = new WorkPackageFilterValues(injector, filters);
   }
 
   describe('when a filter value already exists in values', () => {
@@ -141,7 +141,7 @@ describe('WorkPackageFilterValues', () => {
       });
 
       it('it should not apply the first value (Regression #30817)', (() => {
-        subject.applyDefaultsFromFilters();
+        subject.applyDefaultsFromFilters(changeset);
 
         expect(changeset.changedAttributes.length).toEqual(0);
         expect(changeset.value('type').href).toEqual('/api/v3/types/1');
@@ -164,7 +164,7 @@ describe('WorkPackageFilterValues', () => {
       });
 
       it('it should not apply the first value (Regression #30817)', (() => {
-        subject.applyDefaultsFromFilters();
+        subject.applyDefaultsFromFilters(changeset);
 
         expect(changeset.changedAttributes.length).toEqual(0);
         expect(changeset.value('type').href).toEqual('/api/v3/types/2');

--- a/frontend/src/app/components/wp-new/wp-create.component.ts
+++ b/frontend/src/app/components/wp-new/wp-create.component.ts
@@ -45,6 +45,8 @@ import * as URI from 'urijs';
 import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 import {splitViewRoute} from "core-app/modules/work_packages/routing/split-view-routes.helper";
 import {APIV3Service} from "core-app/modules/apiv3/api-v3.service";
+import {HalSource, HalSourceLinks} from "core-app/modules/hal/resources/hal-resource";
+import {HalLinkSource} from "core-app/modules/hal/hal-link/hal-link";
 
 @Directive()
 export class WorkPackageCreateComponent extends UntilDestroyedMixin implements OnInit {
@@ -169,10 +171,22 @@ export class WorkPackageCreateComponent extends UntilDestroyedMixin implements O
   }
 
   protected createdWorkPackage() {
+    let defaults:HalSource = {
+      _links: {}
+    };
+
     const type = this.stateParams.type ? parseInt(this.stateParams.type) : undefined;
+    const parent = this.stateParams.parent_id ? parseInt(this.stateParams.parent_id) : undefined;
     const project = this.stateParams.projectPath;
 
-    return this.wpCreate.createOrContinueWorkPackage(project, type);
+    if (type) {
+      defaults._links['type'] = { href: this.apiV3Service.types.id(type).path };
+    }
+    if (parent) {
+      defaults._links['parent'] = { href: this.apiV3Service.work_packages.id(parent).path };
+    }
+
+    return this.wpCreate.createOrContinueWorkPackage(project, type, defaults);
   }
 
   private closeEditFormWhenNewWorkPackageSaved() {

--- a/frontend/src/app/modules/apiv3/endpoints/work_packages/api-v3-work-package-cached-subresource.ts
+++ b/frontend/src/app/modules/apiv3/endpoints/work_packages/api-v3-work-package-cached-subresource.ts
@@ -26,15 +26,10 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {APIv3GettableResource, APIv3ResourcePath} from "core-app/modules/apiv3/paths/apiv3-resource";
-import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
-import {Apiv3RelationsPaths} from "core-app/modules/apiv3/endpoints/relations/apiv3-relations-paths";
+import {APIv3GettableResource} from "core-app/modules/apiv3/paths/apiv3-resource";
 import {WorkPackageCollectionResource} from "core-app/modules/hal/resources/wp-collection-resource";
 import {Observable} from "rxjs";
-import {ApiV3FilterBuilder} from "core-components/api/api-v3/api-v3-filter-builder";
-import {CachableAPIV3Resource} from "core-app/modules/apiv3/cache/cachable-apiv3-resource";
 import {APIV3WorkPackagesPaths} from "core-app/modules/apiv3/endpoints/work_packages/api-v3-work-packages-paths";
-import {StateCacheService} from "core-app/modules/apiv3/cache/state-cache.service";
 import {take, tap} from "rxjs/operators";
 import {WorkPackageCache} from "core-app/modules/apiv3/endpoints/work_packages/work-package.cache";
 

--- a/frontend/src/app/modules/apiv3/endpoints/work_packages/apiv3-work-package-form.ts
+++ b/frontend/src/app/modules/apiv3/endpoints/work_packages/apiv3-work-package-form.ts
@@ -1,21 +1,30 @@
 import {APIv3FormResource} from "core-app/modules/apiv3/forms/apiv3-form-resource";
 import {FormResource} from "core-app/modules/hal/resources/form-resource";
 import {Observable} from "rxjs";
+import {HalSource} from "core-app/modules/hal/resources/hal-resource";
 
 export class APIv3WorkPackageForm extends APIv3FormResource {
   /**
-   * Returns a promise to post `/api/v3/work_packages/form` where the
-   * type has already been set to the one provided.
+   * Returns a promise to post `/api/v3/work_packages/form` with only the type part of the
+   * provided payload being sent to the backend.
    *
-   * @param typeId: The id of the type to initialize the form with
-   * @returns An empty work package form resource.
+   * @param payload: The payload to be sent to the backend
+   * @returns A work package form resource prefilled with the provided payload.
    */
-  public forType(typeId:number):Observable<FormResource> {
+  public forTypePayload(payload:HalSource):Observable<FormResource> {
+    let typePayload = payload._links['type'] ? { _links: { type: payload['_links']['type'] } } : { _links: {} } ;
 
-    const typeUrl = this.apiRoot.types.id(typeId).path;
-    const request = { _links: { type: { href: typeUrl } } };
-
-    return this.post(request);
+    return this.post(payload);
+  }
+  /**
+   * Returns a promise to post `/api/v3/work_packages/form` where the
+   * payload sent to the backend has been provided.
+   *
+   * @param payload: The payload to be sent to the backend
+   * @returns A work package form resource prefilled with the provided payload.
+   */
+  public forPayload(payload:HalSource):Observable<FormResource> {
+    return this.post(payload);
   }
 }
 

--- a/frontend/src/app/modules/boards/board/board-actions/board-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/board-action.service.ts
@@ -230,8 +230,8 @@ export abstract class BoardActionService {
       );
     }
 
-    const filter = new WorkPackageFilterValues(this.injector, changeset, query.filters);
-    filter.applyDefaultsFromFilters();
+    new WorkPackageFilterValues(this.injector, query.filters)
+        .applyDefaultsFromFilters(changeset);
   }
 
   /**

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -31,8 +31,6 @@ import {WorkPackageStatesInitializationService} from "core-components/wp-list/wp
 import {ApiV3Filter} from "core-components/api/api-v3/api-v3-filter-builder";
 import {BoardService} from "app/modules/boards/board/board.service";
 import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
-import {WorkPackageFilterValues} from "core-components/wp-edit-form/work-package-filter-values";
-
 import {HalResourceEditingService} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
 import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
 import {BoardActionsRegistryService} from "core-app/modules/boards/board/board-actions/board-actions-registry.service";

--- a/frontend/src/app/modules/common/path-helper/path-helper.service.ts
+++ b/frontend/src/app/modules/common/path-helper/path-helper.service.ts
@@ -81,7 +81,6 @@ class Apiv3Paths {
       '/principals?' +
       filters.toParams({ sortBy: '[["name","asc"]]', offset: '1', pageSize: '10' });
   }
-
 }
 
 @Injectable({ providedIn: 'root' })

--- a/frontend/src/app/modules/fields/edit/field-types/combined-date-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/combined-date-edit-field.component.ts
@@ -97,4 +97,13 @@ export class CombinedDateEditFieldComponent extends DateEditFieldComponent imple
         this.handler.handleUserSubmit();
       });
   }
+
+  // Overwrite super in order to set the inital dates.
+  protected initialize() {
+    super.initialize();
+
+    // this breaks the preceived abstraction of the edit fields. But the date picker
+    // is already highly specific to start and due Date.
+    this.dates = `${this.resource['startDate']} - ${this.resource['dueDate']}`;
+  }
 }

--- a/frontend/src/app/modules/hal/resources/hal-resource.ts
+++ b/frontend/src/app/modules/hal/resources/hal-resource.ts
@@ -41,6 +41,17 @@ export interface HalResourceClass<T extends HalResource = HalResource> {
       $halType:string):T;
 }
 
+export type HalSourceLink = { href:string|null };
+
+export type HalSourceLinks = {
+  [key:string]:HalSourceLink
+};
+
+export type HalSource = {
+  [key:string]:string|number|null|HalSourceLinks,
+  _links:HalSourceLinks
+};
+
 export class HalResource {
   // TODO this is the source of many issues in the frontend
   // because it no longer properly type checks stuff

--- a/frontend/src/app/modules/hal/schemas/hal-payload.helper.ts
+++ b/frontend/src/app/modules/hal/schemas/hal-payload.helper.ts
@@ -85,7 +85,7 @@ export class HalPayloadHelper {
     _.each(nonLinkProperties, property => {
       if (resource.hasOwnProperty(property) || resource[property]) {
         if (Array.isArray(resource[property])) {
-          payload[property] = _.map(resource[property], (element:any) => {
+          payload[property] = _.map(resource[property], (element:any) => {
             if (element instanceof HalResource) {
               return this.extractPayloadFromSchema(element, element.currentSchema || element.schema);
             } else {
@@ -93,7 +93,7 @@ export class HalPayloadHelper {
             }
           });
         } else {
-          payload[property] = resource[property];
+          payload[property] = resource[property];
         }
       }
     });

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -294,33 +294,228 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
     end
 
-    context 'start_date with default setting', with_settings: { work_package_startdate_is_adddate: true } do
-      context 'no value set before for a new work package' do
-        let(:call_attributes) { {} }
+    context 'start_date & due_date' do
+      let(:parent) do
+        FactoryBot.build_stubbed(:stubbed_work_package,
+                                 start_date: parent_start_date,
+                                 due_date: parent_due_date)
+      end
+      let(:parent_start_date) { Date.today - 5.days }
+      let(:parent_due_date) { Date.today + 10.days }
+
+      context 'with a parent' do
         let(:attributes) { {} }
         let(:work_package) { new_work_package }
 
-        it_behaves_like 'service call' do
-          it "sets the default priority" do
-            subject
+        context 'with the parent having dates and not providing own dates' do
+          let(:call_attributes) { { parent: parent } }
 
-            expect(work_package.start_date)
-              .to eql Date.today
+          it_behaves_like 'service call' do
+            it "sets the start_date to the parent`s start_date" do
+              subject
+
+              expect(work_package.start_date)
+                .to eql parent_start_date
+            end
+
+            it "sets the due_date to the parent`s due_date" do
+              subject
+
+              expect(work_package.due_date)
+                .to eql parent_due_date
+            end
+          end
+        end
+
+        context 'with the parent having dates but providing own dates' do
+          let(:call_attributes) { { parent: parent, start_date: Date.today, due_date: Date.today + 1.day } }
+
+          it_behaves_like 'service call' do
+            it "sets the start_date to the provided date" do
+              subject
+
+              expect(work_package.start_date)
+                .to eql Date.today
+            end
+
+            it "sets the due_date to the provided date" do
+              subject
+
+              expect(work_package.due_date)
+                .to eql Date.today + 1.day
+            end
+          end
+        end
+
+        context 'with the parent having dates but providing own start_date' do
+          let(:call_attributes) { { parent: parent, start_date: Date.today } }
+
+          it_behaves_like 'service call' do
+            it "sets the start_date to the provided date" do
+              subject
+
+              expect(work_package.start_date)
+                .to eql Date.today
+            end
+
+            it "sets the due_date to the parent's due_date" do
+              subject
+
+              expect(work_package.due_date)
+                .to eql parent_due_date
+            end
+          end
+        end
+
+        context 'with the parent having dates but providing own due_date' do
+          let(:call_attributes) { { parent: parent, due_date: Date.today + 4.days } }
+
+          it_behaves_like 'service call' do
+            it "sets the start_date to the parent's start date" do
+              subject
+
+              expect(work_package.start_date)
+                .to eql parent_start_date
+            end
+
+            it "sets the due_date to the provided date" do
+              subject
+
+              expect(work_package.due_date)
+                .to eql Date.today + 4.days
+            end
+          end
+        end
+
+        context 'with the parent having dates but providing own empty start_date' do
+          let(:call_attributes) { { parent: parent, start_date: nil } }
+
+          it_behaves_like 'service call' do
+            it "sets the start_date to nil" do
+              subject
+
+              expect(work_package.start_date)
+                .to be_nil
+            end
+
+            it "sets the due_date to the parent's due_date" do
+              subject
+
+              expect(work_package.due_date)
+                .to eql parent_due_date
+            end
+          end
+        end
+
+        context 'with the parent having dates but providing own empty due_date' do
+          let(:call_attributes) { { parent: parent, due_date: nil } }
+
+          it_behaves_like 'service call' do
+            it "sets the start_date to the parent's start date" do
+              subject
+
+              expect(work_package.start_date)
+                .to eql parent_start_date
+            end
+
+            it "sets the due_date to nil" do
+              subject
+
+              expect(work_package.due_date)
+                .to be_nil
+            end
+          end
+        end
+
+        context 'with the parent having dates but providing a start date that is before parent`s due date`' do
+          let(:call_attributes) { { parent: parent, start_date: parent_due_date - 4.days } }
+
+          it_behaves_like 'service call' do
+            it "sets the start_date to the provided date" do
+              subject
+
+              expect(work_package.start_date)
+                .to eql parent_due_date - 4.days
+            end
+
+            it "sets the due_date to the parent's due_date" do
+              subject
+
+              expect(work_package.due_date)
+                .to eql parent_due_date
+            end
+          end
+        end
+
+        context 'with the parent having dates but providing a start date that is after the parent`s due date`' do
+          let(:call_attributes) { { parent: parent, start_date: parent_due_date + 1.day } }
+
+          it_behaves_like 'service call' do
+            it "sets the start_date to the provided date" do
+              subject
+
+              expect(work_package.start_date)
+                .to eql parent_due_date + 1.day
+            end
+
+            it "leaves the due date empty" do
+              subject
+
+              expect(work_package.due_date)
+                .to be_nil
+            end
+          end
+        end
+
+        context 'with the parent having dates but providing a due date that is before the parent`s start date`' do
+          let(:call_attributes) { { parent: parent, due_date: parent_start_date - 3.day } }
+
+          it_behaves_like 'service call' do
+            it "leaves the start date empty" do
+              subject
+
+              expect(work_package.start_date)
+                .to be_nil
+            end
+
+            it "set the due date to the provided date" do
+              subject
+
+              expect(work_package.due_date)
+                .to eql parent_start_date - 3.day
+            end
           end
         end
       end
 
-      context 'value set on new work package' do
-        let(:call_attributes) { { start_date: Date.today + 1.day } }
-        let(:attributes) { {} }
-        let(:work_package) { new_work_package }
+      context 'with default setting', with_settings: { work_package_startdate_is_adddate: true } do
+        context 'no value set before for a new work package' do
+          let(:call_attributes) { {} }
+          let(:attributes) { {} }
+          let(:work_package) { new_work_package }
 
-        it_behaves_like 'service call' do
-          it 'stays that value' do
-            subject
+          it_behaves_like 'service call' do
+            it "sets the default priority" do
+              subject
 
-            expect(work_package.start_date)
-              .to eq(Date.today + 1.day)
+              expect(work_package.start_date)
+                .to eql Date.today
+            end
+          end
+        end
+
+        context 'value set on new work package' do
+          let(:call_attributes) { { start_date: Date.today + 1.day } }
+          let(:attributes) { {} }
+          let(:work_package) { new_work_package }
+
+          it_behaves_like 'service call' do
+            it 'stays that value' do
+              subject
+
+              expect(work_package.start_date)
+                .to eq(Date.today + 1.day)
+            end
           end
         end
       end

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -294,6 +294,38 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
     end
 
+    context 'start_date with default setting', with_settings: { work_package_startdate_is_adddate: true } do
+      context 'no value set before for a new work package' do
+        let(:call_attributes) { {} }
+        let(:attributes) { {} }
+        let(:work_package) { new_work_package }
+
+        it_behaves_like 'service call' do
+          it "sets the default priority" do
+            subject
+
+            expect(work_package.start_date)
+              .to eql Date.today
+          end
+        end
+      end
+
+      context 'value set on new work package' do
+        let(:call_attributes) { { start_date: Date.today + 1.day } }
+        let(:attributes) { {} }
+        let(:work_package) { new_work_package }
+
+        it_behaves_like 'service call' do
+          it 'stays that value' do
+            subject
+
+            expect(work_package.start_date)
+              .to eq(Date.today + 1.day)
+          end
+        end
+      end
+    end
+
     context 'priority' do
       let(:default_priority) { FactoryBot.build_stubbed(:priority) }
       let(:other_priority) { FactoryBot.build_stubbed(:priority) }
@@ -319,42 +351,6 @@ describe WorkPackages::SetAttributesService, type: :model do
 
             expect(work_package.priority)
               .to eql default_priority
-          end
-        end
-      end
-
-      context 'start_date with default setting', with_settings: { work_package_startdate_is_adddate: true } do
-        context 'no value set before for a new work package' do
-          let(:call_attributes) { {} }
-          let(:attributes) { {} }
-          let(:work_package) { new_work_package }
-
-          before do
-            work_package.priority = nil
-          end
-
-          it_behaves_like 'service call' do
-            it "sets the default priority" do
-              subject
-
-              expect(work_package.priority)
-                .to eql default_priority
-            end
-          end
-        end
-
-        context 'value set on new work package' do
-          let(:call_attributes) { { start_date: Date.today + 1.day } }
-          let(:attributes) { {} }
-          let(:work_package) { new_work_package }
-
-          it_behaves_like 'service call' do
-            it 'stays that value' do
-              subject
-
-              expect(work_package.start_date)
-                .to eq(Date.today + 1.day)
-            end
           end
         end
       end

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -66,7 +66,13 @@ class DateEditField < EditField
   end
 
   def input_element
-    modal_element.find(input_selector)
+    # The date picker might not be opened but the input might still be visible,
+    # e.g. when the work package form is opened completely like on create
+    if active?
+      modal_element.find(input_selector)
+    else
+      page.find(".#{property_name} input")
+    end
   end
 
   def active?
@@ -109,8 +115,7 @@ class DateEditField < EditField
   end
 
   def expect_value(value)
-    expect
-    expect(input_element.text).to eq(value)
+    expect(input_element.value).to eq(value)
   end
 
   def select_value(value)

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -193,7 +193,7 @@ module Pages
       when /customField(\d+)$/
         work_package_custom_field(key, $1)
       when :date, :startDate, :dueDate, :combinedDate
-        DateEditField.new container, key, is_milestone: work_package.milestone?
+        DateEditField.new container, key, is_milestone: work_package&.milestone?
       when :description
         TextEditorField.new container, key
       when :status


### PR DESCRIPTION
Whenever a child work package is created, it should have the parent's dates as default values. That way, if the default is chosen, the parent's dates are not altered.

In order to get the dates, the parent has to be provided on the initial form request. Doing that will set the parent in the work package payload and the backend will set the start/due dates accordingly. 

There exist currently two ways of setting the parent in the front end:
 * Via the "Add child" entry of the context menu in the work package table.
 * Via the "Children" table in the relations tab of a work package.

The first works by providing the parent id in the url query. That way, it also works on hard reload. The second way works by having filters for the parent defined in the embedded table. So while the first is set explicitly, the later is merged in along with the other potential filter values (e.g. status). The parent cannot be set afterwards if the default values of the backend are to be used correctly. Because a default value for e.g. the start date will already be provided based on the current date. That value would then be send along with every following request rendering the backend useless. To avoid this scenario, we have to first get the default values correctly from the backend before we create the work package resource. In case the child is created via the relations tab, this unfortunately requires us to make an additional form request just to place the payload parts correctly (i.e. within the links section). The additional request will also be made whenever the work package is created inline in any other table. 

https://community.openproject.com/work_packages/33925