### PR TITLE
fixed typo wit to with

### DIFF
--- a/docs/installation-and-operations/installation/manual/README.md
+++ b/docs/installation-and-operations/installation/manual/README.md
@@ -4,7 +4,7 @@ sidebar_navigation: false
 
 # Manual installation guide
 
-**IMPORTANT: We strongly recommend to use one of the officially supported [installation methods](../../installation). This guide is simply provided as a reference, and is most likely NOT up to date wit relation to the latest OpenProject releases.**
+**IMPORTANT: We strongly recommend to use one of the officially supported [installation methods](../../installation). This guide is simply provided as a reference, and is most likely NOT up to date with relation to the latest OpenProject releases.**
 
 Please be aware that:
 


### PR DESCRIPTION
In the [manual installation guide](https://docs.openproject.org/installation-and-operations/installation/manual/#docs-feedback), there was a typo in the **IMPORTANT** notice.