### PR TITLE
Add header component style to all action boards

### DIFF
--- a/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-board-header.component.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-board-header.component.ts
@@ -27,6 +27,8 @@
 //++
 import {Component, Input} from "@angular/core";
 import {UserResource} from "core-app/modules/hal/resources/user-resource";
+import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
+import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 
 
 @Component({
@@ -36,4 +38,12 @@ import {UserResource} from "core-app/modules/hal/resources/user-resource";
 })
 export class AssigneeBoardHeaderComponent {
   @Input('resource') public user:UserResource;
+
+  text = {
+    assignee: this.I18n.t('js.work_packages.properties.assignee')
+  };
+
+  constructor(readonly pathHelper:PathHelperService,
+              readonly I18n:I18nService) {
+  }
 }

--- a/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-board-header.html
+++ b/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-board-header.html
@@ -1,6 +1,11 @@
 <div class="assignee-board-header" *ngIf="user">
   <user-avatar *ngIf="user.id" [user]="user" data-class-list="avatar-mini"></user-avatar>
-  <h2 [textContent]="user.name"
-      class="editable-toolbar-title--fixed">
+  <h2 class="editable-toolbar-title--fixed">
+    <small [textContent]="text.assignee"></small>
+    <br/>
+    <a [href]="pathHelper.userPath(user.id)"
+       [textContent]="user.name"
+       target="_blank">
+    </a>
   </h2>
 </div>

--- a/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-board-header.sass
+++ b/frontend/src/app/modules/boards/board/board-actions/assignee/assignee-board-header.sass
@@ -4,3 +4,6 @@
   user-avatar
     align-self: center
     padding-right: 5px
+
+.editable-toolbar-title--fixed
+  line-height: 1 !important

--- a/frontend/src/app/modules/boards/board/board-actions/status/status-action.service.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/status/status-action.service.ts
@@ -3,6 +3,7 @@ import {Board} from "core-app/modules/boards/board/board";
 import {StatusResource} from "core-app/modules/hal/resources/status-resource";
 import {BoardActionService} from "core-app/modules/boards/board/board-actions/board-action.service";
 import {CachedBoardActionService} from "core-app/modules/boards/board/board-actions/cached-board-action.service";
+import {StatusBoardHeaderComponent} from "core-app/modules/boards/board/board-actions/status/status-board-header.component";
 
 @Injectable()
 export class BoardStatusActionService extends CachedBoardActionService {
@@ -20,6 +21,10 @@ export class BoardStatusActionService extends CachedBoardActionService {
 
   public get localizedName() {
     return this.I18n.t('js.work_packages.properties.status');
+  }
+
+  headerComponent() {
+    return StatusBoardHeaderComponent;
   }
 
   public addInitialColumnsForAction(board:Board):Promise<Board> {

--- a/frontend/src/app/modules/boards/board/board-actions/status/status-board-header.component.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/status/status-board-header.component.ts
@@ -1,0 +1,47 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2020 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+//++
+import {Component, Input} from "@angular/core";
+import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {StatusResource} from "core-app/modules/hal/resources/status-resource";
+
+
+@Component({
+  templateUrl: './status-board-header.html',
+  styleUrls: ['./status-board-header.sass'],
+  host: { 'class': 'title-container -small' }
+})
+export class StatusBoardHeaderComponent {
+  @Input('resource') public status:StatusResource;
+
+  text = {
+    status: this.I18n.t('js.work_packages.properties.status')
+  };
+
+  constructor(readonly I18n:I18nService) {
+  }
+}

--- a/frontend/src/app/modules/boards/board/board-actions/status/status-board-header.html
+++ b/frontend/src/app/modules/boards/board/board-actions/status/status-board-header.html
@@ -1,0 +1,7 @@
+<div class="status-board-header" *ngIf="status">
+  <h2 class="editable-toolbar-title--fixed">
+    <small [textContent]="text.status"></small>
+    <br/>
+    {{ status.name }}
+  </h2>
+</div>

--- a/frontend/src/app/modules/boards/board/board-actions/status/status-board-header.sass
+++ b/frontend/src/app/modules/boards/board/board-actions/status/status-board-header.sass
@@ -1,0 +1,2 @@
+.editable-toolbar-title--fixed
+  line-height: 1 !important

--- a/frontend/src/app/modules/boards/board/board-actions/version/version-board-header.component.ts
+++ b/frontend/src/app/modules/boards/board/board-actions/version/version-board-header.component.ts
@@ -28,6 +28,7 @@
 import {Component, Input} from "@angular/core";
 import {VersionResource} from "core-app/modules/hal/resources/version-resource";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 
 
 @Component({
@@ -38,11 +39,13 @@ import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 export class VersionBoardHeaderComponent {
   @Input('resource') public version:VersionResource;
 
-  constructor(private I18n:I18nService) {
+  constructor(readonly I18n:I18nService,
+              readonly pathHelper:PathHelperService) {
   }
 
   public text = {
     isLocked: this.I18n.t('js.boards.version.is_locked'),
-    isClosed: this.I18n.t('js.boards.version.is_closed')
+    isClosed: this.I18n.t('js.boards.version.is_closed'),
+    version: this.I18n.t('js.work_packages.properties.version')
   };
 }

--- a/frontend/src/app/modules/boards/board/board-actions/version/version-board-header.html
+++ b/frontend/src/app/modules/boards/board/board-actions/version/version-board-header.html
@@ -1,8 +1,14 @@
 <div class="version-board-header"
      [ngClass]="{ '-closed': version.isClosed(), '-locked': version.isLocked() }"
      *ngIf="version">
-  <h2 [textContent]="version.name"
-      class="editable-toolbar-title--fixed">
+  <h2 class="editable-toolbar-title--fixed">
+    <small [textContent]="text.version"></small>
+    <br/>
+    <a [href]="pathHelper.versionShowPath(version.id)"
+       [textContent]="version.name"
+       target="_blank">
+    </a>
   </h2>
+
   <span class="version-board-header--info-row -italic -small-font"> {{version.endDate}}  </span>
 </div>

--- a/frontend/src/app/modules/boards/board/board-actions/version/version-board-header.sass
+++ b/frontend/src/app/modules/boards/board/board-actions/version/version-board-header.sass
@@ -1,3 +1,6 @@
 .version-board-header
   display: flex
   flex-direction: column
+
+.editable-toolbar-title--fixed
+  line-height: 1 !important

--- a/frontend/src/app/modules/boards/openproject-boards.module.ts
+++ b/frontend/src/app/modules/boards/openproject-boards.module.ts
@@ -54,6 +54,7 @@ import {AssigneeBoardHeaderComponent} from "core-app/modules/boards/board/board-
 import { TileViewComponent } from './tile-view/tile-view.component';
 import {SubprojectBoardHeaderComponent} from "core-app/modules/boards/board/board-actions/subproject/subproject-board-header.component";
 import {SubtasksBoardHeaderComponent} from "core-app/modules/boards/board/board-actions/subtasks/subtasks-board-header.component";
+import {StatusBoardHeaderComponent} from "core-app/modules/boards/board/board-actions/status/status-board-header.component";
 
 @NgModule({
   imports: [
@@ -91,6 +92,7 @@ import {SubtasksBoardHeaderComponent} from "core-app/modules/boards/board/board-
     AssigneeBoardHeaderComponent,
     SubprojectBoardHeaderComponent,
     SubtasksBoardHeaderComponent,
+    StatusBoardHeaderComponent,
     TileViewComponent,
   ]
 })


### PR DESCRIPTION
Adds the small text indicator to let the user know what kind of action board the board is that we added to subprojects/subtasks to the other boards