### PR TITLE
Fix/plugin settings breadcrumb label

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -474,11 +474,10 @@ class ApplicationController < ActionController::Base
   end
 
   def default_breadcrumb
-    name = l('label_' + self.class.name.gsub('Controller', '').underscore.singularize + '_plural')
-    if name =~ /translation missing/i
-      name = l('label_' + self.class.name.gsub('Controller', '').underscore.singularize)
-    end
-    name
+    label = "label_#{self.class.name.gsub('Controller', '').underscore.singularize}"
+
+    I18n.t(label + '_plural',
+           default: label.to_sym)
   end
   helper_method :default_breadcrumb
 

--- a/app/views/admin/plugins.html.erb
+++ b/app/views/admin/plugins.html.erb
@@ -26,8 +26,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<% html_title l(:label_administration), l(:label_plugins) %>
-<%= toolbar title: l(:label_modules_and_plugins) %>
+<% html_title t(:label_administration), t(:label_plugins) %>
+<%= toolbar title: t(:label_modules_and_plugins) %>
 <% if @plugins.any? %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -28,7 +28,6 @@ See docs/COPYRIGHT.rdoc for more details.
 ++#%>
 
 <%
-  parent_node = admin_first_level_menu_entry
   if local_assigns[:additional_breadcrumb].nil?
     breadcrumb_paths(ActionController::Base.helpers.link_to(t(:label_administration), admin_index_path),
                      default_breadcrumb)

--- a/app/views/my/settings.html.erb
+++ b/app/views/my/settings.html.erb
@@ -27,10 +27,10 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<% html_title(l(:label_my_account), l(:label_settings)) %>
+<% html_title(l(:label_my_account), l(:label_setting_plural)) %>
 
-<% breadcrumb_paths(l(:label_my_account), l(:label_settings)) %>
-<%= toolbar title: l(:label_settings) %>
+<% breadcrumb_paths(l(:label_my_account), l(:label_setting_plural)) %>
+<%= toolbar title: l(:label_setting_plural) %>
 
 <%= error_messages_for 'user' %>
 <%= labelled_tabular_form_for @user, as: :user, url: { action: 'update_settings' },

--- a/app/views/repositories/_repository_header.html.erb
+++ b/app/views/repositories/_repository_header.html.erb
@@ -74,7 +74,7 @@ See docs/COPYRIGHT.rdoc for more details.
   <% if User.current.allowed_to?(:manage_repository, @project) %>
     <li class="toolbar-item -icon-only">
       <%= link_to settings_repository_project_path(@project),
-          class: 'button', title: l(:label_settings) do %>
+          class: 'button', title: l(:label_setting_plural) do %>
         <%= op_icon('button--icon icon-settings') %>
       <% end %>
     </li>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -98,7 +98,7 @@ Redmine::MenuManager.map :my_menu do |menu|
   menu_push
   menu.push :settings,
             { controller: '/my', action: 'settings' },
-            caption: :label_settings,
+            caption: :label_setting_plural,
             icon: 'icon2 icon-settings2'
   menu.push :password,
             { controller: '/my', action: 'password' },
@@ -136,7 +136,7 @@ Redmine::MenuManager.map :admin_menu do |menu|
 
   menu.push :user_settings,
             { controller: '/users_settings' },
-            caption: :label_settings,
+            caption: :label_setting_plural,
             parent: :users_and_permissions
 
   menu.push :users,
@@ -166,7 +166,7 @@ Redmine::MenuManager.map :admin_menu do |menu|
 
   menu.push :work_packages_setting,
             { controller: '/work_packages/settings' },
-            caption: :label_settings,
+            caption: :label_setting_plural,
             parent: :admin_work_packages
 
   menu.push :types,
@@ -242,7 +242,7 @@ Redmine::MenuManager.map :admin_menu do |menu|
 
   menu.push :authentication_settings,
             { controller: '/authentication', action: 'authentication_settings' },
-            caption: :label_settings,
+            caption: :label_setting_plural,
             parent: :authentication
 
   menu.push :ldap_authentication,
@@ -297,7 +297,7 @@ Redmine::MenuManager.map :admin_menu do |menu|
 
   menu.push :costs_setting,
             { controller: '/settings', action: 'plugin', id: :costs },
-            caption: :label_settings,
+            caption: :label_setting_plural,
             parent: :admin_costs
 
   menu.push :admin_backlogs,
@@ -307,7 +307,7 @@ Redmine::MenuManager.map :admin_menu do |menu|
 
   menu.push :backlogs_settings,
             { controller: '/settings', action: 'plugin', id: :openproject_backlogs },
-            caption: :label_settings,
+            caption: :label_setting_plural,
             parent: :admin_backlogs
 end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1648,7 +1648,7 @@ en:
   label_search: "Search"
   label_send_information: "Send account information to the user"
   label_send_test_email: "Send a test email"
-  label_settings: "Settings"
+  label_setting_plural: "Settings"
   label_system_settings: "System settings"
   label_show_completed_versions: "Show completed versions"
   label_sort: "Sort"

--- a/modules/recaptcha/app/views/recaptcha/admin/show.html.erb
+++ b/modules/recaptcha/app/views/recaptcha/admin/show.html.erb
@@ -7,7 +7,7 @@
                       method: :post,
                       id: 'update-recaptcha-settings-form') do %>
     <fieldset class="form--fieldset">
-      <legend class="form--fieldset-legend"><%= t(:label_settings) %></legend>
+      <legend class="form--fieldset-legend"><%= t(:label_setting_plural) %></legend>
       <div class="form--field">
         <label class="form--label" for='recaptcha_type'><%= t('recaptcha.settings.type') %></label>
         <div class="form--field-container">

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/settings.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/settings.html.erb
@@ -47,7 +47,7 @@
       </div>
     </fieldset>
     <fieldset class="form--fieldset">
-      <legend class="form--fieldset-legend"><%= t(:label_settings) %></legend>
+      <legend class="form--fieldset-legend"><%= t(:label_setting_plural) %></legend>
       <div class="form--field">
         <label class="form--label" for='settings[enforced]'><%= t('two_factor_authentication.settings.label_enforced') %></label>
         <div class="form--field-container ">


### PR DESCRIPTION
Changes the i18n key for 'Settings' to adhere to the standard as defined in the breadcrumb. Also simplifies the breadcrumb code. 

https://community.openproject.com/projects/openproject/work_packages/34188