### PR TITLE
[34238] Map filters from api and queries in one filter mapper object

### DIFF
--- a/app/services/base_services/copy.rb
+++ b/app/services/base_services/copy.rb
@@ -87,9 +87,7 @@ module BaseServices
     #
     # Note that for dependent copy services to be called
     # this will already be present.
-    def prepare(params)
-      params[:copy_state] ||= {}
-    end
+    def prepare(_params); end
 
     ##
     # dependent services to copy associations

--- a/app/services/grids/copy/widgets_dependent_service.rb
+++ b/app/services/grids/copy/widgets_dependent_service.rb
@@ -89,7 +89,8 @@ module Grids::Copy
 
     def reference_mappers
       {
-        /query_?id/i => method(:map_query_id)
+        /query_?id/i => method(:map_query_id),
+        filters: method(:map_query_filters)
       }
     end
 
@@ -101,6 +102,14 @@ module Grids::Copy
       else
         duplicate_query(query_id, params).map(&:id)
       end
+    end
+
+    def map_query_filters(filters, _params)
+      ::Queries::Copy::FiltersMapper
+        .new(state, filters)
+        .map_filters!
+
+      ServiceResult.new success: true, result: filters
     end
 
     def duplicate_query(query_id, params)

--- a/app/services/queries/copy/filters_mapper.rb
+++ b/app/services/queries/copy/filters_mapper.rb
@@ -1,0 +1,97 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Queries::Copy
+  class FiltersMapper
+    attr_reader :state, :filters, :mappers
+
+    def initialize(state, filters)
+      @state = state
+      @filters = filters
+      @mappers = build_filter_mappers
+    end
+
+    ##
+    # Returns the mapped filter array for either
+    # hash-based APIv3 filters or filter clasess
+    def map_filters!
+      filters.each do |filter|
+        if filter.is_a?(Hash)
+          map_api_filter_hash(filter)
+        else
+          map_filter_class(filter)
+        end
+      end
+
+      filters
+    end
+
+    protected
+
+    ##
+    # Maps an API v3 filter hash
+    # e.g.,
+    # { parent: { operator: '=', values: [1234] } }
+    def map_api_filter_hash(filter)
+      name = filter.keys.first
+      subhash = filter[name]
+      ar_name = ::API::Utilities::QueryFiltersNameConverter.to_ar_name(name, refer_to_ids: true)
+
+      subhash['values'] = mapped_values(ar_name, subhash['values'])
+    end
+
+    def map_filter_class(filter)
+      filter.values = mapped_values(filter.name, filter.values)
+    end
+
+    def mapped_values(ar_name, values)
+      mapper = mappers[ar_name.to_sym]
+
+      mapper&.call(values) || values
+    end
+
+    def build_filter_mappers
+      {
+        version_id: state_mapper(:version_id_lookup),
+        category_id: state_mapper(:category_id_lookup),
+        parent: state_mapper(:work_package_id_lookup)
+      }
+    end
+
+    def state_mapper(lookup_key)
+      ->(values) do
+        lookup = state.send(lookup_key)
+        next unless lookup.is_a?(Hash)
+
+        values.map { |id| (lookup[id.to_i] || id).to_s }
+      end
+    end
+  end
+end

--- a/app/services/queries/copy_service.rb
+++ b/app/services/queries/copy_service.rb
@@ -44,38 +44,11 @@ module Queries
       new_query.sort_criteria = source.sort_criteria if source.sort_criteria
       new_query.project = state.project || source.project
 
-      map_filters new_query
+      ::Queries::Copy::FiltersMapper
+        .new(state, new_query.filters)
+        .map_filters!
 
       ServiceResult.new(success: new_query.save, result: new_query)
-    end
-
-    def map_filters(query)
-      mappers = filter_mappers
-
-      query.filters.each do |filter|
-        mapper = mappers[filter.name.to_sym]
-
-        mapper&.call filter
-      end
-    end
-
-    def filter_mappers
-      {
-        version_id: method(:map_version_filter),
-        category_id: method(:map_category_filter)
-      }
-    end
-
-    def map_version_filter(filter)
-      return unless state.version_id_lookup
-
-      filter.values = filter.values.map { |id| state.version_id_lookup[id.to_i] || id }
-    end
-
-    def map_category_filter(filter)
-      return unless state.category_id_lookup
-
-      filter.values = filter.values.map { |id| state.category_id_lookup[id.to_i] || id }
     end
 
     def skipped_attributes

--- a/spec/services/queries/filter_mappper_spec.rb
+++ b/spec/services/queries/filter_mappper_spec.rb
@@ -1,0 +1,103 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Queries::Copy::FiltersMapper do
+  let(:state) { ::Shared::ServiceState.new }
+  let(:instance) { described_class.new(state, filters) }
+  subject { instance.map_filters! }
+
+  describe 'with a query filters array' do
+    let(:query) do
+      query = FactoryBot.build(:query)
+      query.add_filter 'parent', '=', ['1']
+      query.add_filter 'category_id', '=', ['2']
+      query.add_filter 'version_id', '=', ['3']
+
+      query
+    end
+    let(:filters) { query.filters }
+
+    context 'when mapping state exists' do
+      before do
+        state.work_package_id_lookup = { 1 => 11 }
+        state.category_id_lookup = { 2 => 22 }
+        state.version_id_lookup = { 3 => 33 }
+      end
+
+      it 'maps the filters' do
+        expect(subject[1].values).to eq(['11'])
+        expect(subject[2].values).to eq(['22'])
+        expect(subject[3].values).to eq(['33'])
+      end
+    end
+
+    context 'when mapping state does not exist' do
+      it 'does not map the filters' do
+        expect(subject[1].values).to eq(['1'])
+        expect(subject[2].values).to eq(['2'])
+        expect(subject[3].values).to eq(['3'])
+      end
+    end
+  end
+
+  describe 'with a filter hash array' do
+    let(:filters) do
+      [
+        { 'parent' => { 'operator' => '=', 'values' => ['1'] } },
+        { 'category_id' => { 'operator' => '=', 'values' => ['2'] } },
+        { 'version_id' => { 'operator' => '=', 'values' => ['3'] } }
+      ]
+    end
+
+    context 'when mapping state exists' do
+      before do
+        state.work_package_id_lookup = { 1 => 11 }
+        state.category_id_lookup = { 2 => 22 }
+        state.version_id_lookup = { 3 => 33 }
+      end
+
+      it 'maps the filters' do
+        expect(subject[0]['parent']['values']).to eq(['11'])
+        expect(subject[1]['category_id']['values']).to eq(['22'])
+        expect(subject[2]['version_id']['values']).to eq(['33'])
+      end
+    end
+
+    context 'when mapping state does not exist' do
+      it 'does not map the filters' do
+        expect(subject[0]['parent']['values']).to eq(['1'])
+        expect(subject[1]['category_id']['values']).to eq(['2'])
+        expect(subject[2]['version_id']['values']).to eq(['3'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows mapping the parent filter and other foreign key references that should be updated during copy.

https://community.openproject.com/wp/34238