### PR TITLE
[34000] Ensure user custom fields can be copied 

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -277,7 +277,7 @@ class CustomField < ApplicationRecord
 
   def possible_user_values_options(obj)
     mapped_with_deduced_project(obj) do |project|
-      if project
+      if project&.persisted?
         project.users
       else
         Principal

--- a/app/services/copy/dependency.rb
+++ b/app/services/copy/dependency.rb
@@ -80,7 +80,7 @@ module Copy
       rescue StandardError => e
         Rails.logger.error { "Failed to copy dependency #{self.class.identifier}: #{e.message}" }
         result.success = false
-        result.errors.add(:base, :could_not_be_copied, dependency: self.class.name)
+        result.errors.add(:base, :could_not_be_copied, dependency: self.class.human_name)
       end
 
       result

--- a/app/services/projects/copy_service.rb
+++ b/app/services/projects/copy_service.rb
@@ -73,11 +73,8 @@ module Projects
       # Copy status object
       target.status = source.status&.dup
 
-      # Copy enabled custom fields and their values
+      # Take over the CF values for attributes
       target.custom_field_values = source.custom_value_attributes
-      target.custom_values = source.custom_values.map(&:dup)
-
-      target.status = source.status.dup
 
       # Additional input target params
       target_project_params = params[:target_project_params].with_indifferent_access

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -553,7 +553,7 @@ describe Projects::CopyService, 'integration', type: :model do
         end
       end
 
-      describe 'user custom field' do
+      describe 'work package user custom field' do
         let(:custom_field) do
           FactoryBot.create(:user_wp_custom_field).tap do |cf|
             source.work_package_custom_fields << cf
@@ -588,6 +588,32 @@ describe Projects::CopyService, 'integration', type: :model do
             expect(wp.send(:"custom_field_#{custom_field.id}"))
               .to be_nil
           end
+        end
+      end
+    end
+
+    describe 'project custom fields' do
+      context 'with user project CF' do
+        let(:user_custom_field) { FactoryBot.create(:user_project_custom_field) }
+        let(:user_value) do
+          FactoryBot.create(:user,
+                            member_in_project: source,
+                            member_through_role: role)
+        end
+
+        before do
+          source.custom_values << CustomValue.new(custom_field: user_custom_field, value: user_value.id.to_s)
+        end
+
+        let(:only_args) { %w[wiki] }
+
+        it 'copies the custom_field' do
+          expect(subject).to be_success
+
+          cv = project_copy.custom_values.reload.find_by(custom_field: user_custom_field)
+          expect(cv).to be_present
+          expect(cv.value).to eq user_value.id.to_s
+          expect(cv.typed_value).to eq user_value
         end
       end
     end


### PR DESCRIPTION
User CFs were not copiable because they depend on project members being copied.

They need to be overridable in the copy form however, so we need to be able to set this before and after members are copied. The only option is to allow visible members to be selected when the project is not yet saved.

This is identical to the behavior for versions: https://github.com/opf/openproject/blob/15a8257314e83b8178bf52571420c9f96dd99fc1/app/models/custom_field.rb#L270


https://community.openproject.com/wp/34000