### PR TITLE
Fix/34126 Gantt chart styles conflict between last active work package and hovered work package

### DIFF
--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -18,9 +18,6 @@
   &.-new
     padding-right: 25px
 
-  &.-checked
-    background-color: var(--table-row-highlighting-color)
-
   &.-horizontal
     height: 100%
     
@@ -33,6 +30,10 @@
   // Style shadow element while dragging
   wp-single-card:host.gu-transit &
     @include modifying--placeholder
+
+::ng-deep .work-packages-partitioned-query-space--container.-split
+  .wp-card.-checked
+    background-color: var(--table-row-highlighting-color)
 
 .wp-card--content:not(.-new)
   display: grid

--- a/frontend/src/app/components/wp-table/wp-table-hover-sync.ts
+++ b/frontend/src/app/components/wp-table/wp-table-hover-sync.ts
@@ -27,6 +27,7 @@
 // ++
 
 const cssClassRowHovered = 'row-hovered';
+const cssClassChecked = '-checked';
 
 export class WpTableHoverSync {
 
@@ -49,7 +50,7 @@ export class WpTableHoverSync {
 
   deactivate() {
     window.removeEventListener('mousemove', this.eventListener);
-    this.removeAllHoverClasses();
+    this.removeCSSClasses([cssClassRowHovered]);
   }
 
   private locateHoveredTableRow(child:JQuery):Element | null {
@@ -75,7 +76,7 @@ export class WpTableHoverSync {
 
     // remove all hover classes if cursor does not hover a row
     if (parentTableRow === null && parentTimelineRow === null) {
-      this.removeAllHoverClasses();
+      this.removeCSSClasses([cssClassRowHovered]);
       return;
     }
 
@@ -96,15 +97,17 @@ export class WpTableHoverSync {
                                 this.tableAndTimeline.find('div.wp-ancestor-row-' + wpId).first();
 
     requestAnimationFrame(() => {
-      this.removeAllHoverClasses();
+      this.removeCSSClasses([cssClassRowHovered, cssClassChecked]);
       timelineRow.addClass(cssClassRowHovered);
       tableRow.addClass(cssClassRowHovered);
     });
   }
 
-  private removeAllHoverClasses() {
-    this.tableAndTimeline
-      .find(`.${cssClassRowHovered}`)
-      .removeClass(cssClassRowHovered);
+  private removeCSSClasses(cssClasses:string[]) {
+    cssClasses.forEach(cssClass => {
+      this.tableAndTimeline
+        .find(`.${cssClass}`)
+        .removeClass(cssClass);
+    });
   }
 }

--- a/frontend/src/app/components/wp-table/wp-table-hover-sync.ts
+++ b/frontend/src/app/components/wp-table/wp-table-hover-sync.ts
@@ -27,7 +27,6 @@
 // ++
 
 const cssClassRowHovered = 'row-hovered';
-const cssClassChecked = '-checked';
 
 export class WpTableHoverSync {
 
@@ -50,7 +49,7 @@ export class WpTableHoverSync {
 
   deactivate() {
     window.removeEventListener('mousemove', this.eventListener);
-    this.removeCSSClasses([cssClassRowHovered]);
+    this.removeAllHoverClasses();
   }
 
   private locateHoveredTableRow(child:JQuery):Element | null {
@@ -76,7 +75,7 @@ export class WpTableHoverSync {
 
     // remove all hover classes if cursor does not hover a row
     if (parentTableRow === null && parentTimelineRow === null) {
-      this.removeCSSClasses([cssClassRowHovered]);
+      this.removeAllHoverClasses();
       return;
     }
 
@@ -97,17 +96,15 @@ export class WpTableHoverSync {
                                 this.tableAndTimeline.find('div.wp-ancestor-row-' + wpId).first();
 
     requestAnimationFrame(() => {
-      this.removeCSSClasses([cssClassRowHovered, cssClassChecked]);
+      this.removeAllHoverClasses();
       timelineRow.addClass(cssClassRowHovered);
       tableRow.addClass(cssClassRowHovered);
     });
   }
 
-  private removeCSSClasses(cssClasses:string[]) {
-    cssClasses.forEach(cssClass => {
-      this.tableAndTimeline
-        .find(`.${cssClass}`)
-        .removeClass(cssClass);
-    });
+  private removeAllHoverClasses() {
+    this.tableAndTimeline
+      .find(`.${cssClassRowHovered}`)
+      .removeClass(cssClassRowHovered);
   }
 }

--- a/frontend/src/global_styles/content/_tables.sass
+++ b/frontend/src/global_styles/content/_tables.sass
@@ -153,7 +153,6 @@ th.hidden
 
 tr.context-menu-selection,
 tr.-checked
-  background-color: var(--table-row-highlighting-color) !important
   &[class*=__hl_background]
     outline: var(--table-row-highlighting-outline-color) solid 2px
 
@@ -163,6 +162,10 @@ tr.-checked
     color: var(--body-font-color) !important
     a
       color: var(--body-font-color) !important
+
+.work-packages-partitioned-query-space--container.-split
+  tr.-checked
+    background-color: var(--table-row-highlighting-color) !important
 
 #custom-options-table
   .custom-option-value

--- a/frontend/src/global_styles/content/_work_packages.sass
+++ b/frontend/src/global_styles/content/_work_packages.sass
@@ -26,6 +26,9 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
+// Cards styles
+@import work_packages/cards
+
 // Table editing styles
 @import work_packages/table_content
 @import work_packages/table_hierarchy

--- a/frontend/src/global_styles/content/work_packages/_cards.sass
+++ b/frontend/src/global_styles/content/work_packages/_cards.sass
@@ -1,0 +1,3 @@
+.work-packages-partitioned-query-space--container.-split
+  .wp-card.-checked
+    background-color: var(--table-row-highlighting-color)


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34126

This pull request:

- [x] Highlights open work package row only on "split view".  
- [x] Highlights open work package card only on "split view".

* These changes assume that the highlighting is meant to only show clearly that the work package detail opened on the right side belongs to the work package highlighted on the left side. Is this right? Does it have any other purpose?

![image](https://user-images.githubusercontent.com/25689432/91996691-952e9c00-ed39-11ea-814a-9feba26d8057.png)
![image](https://user-images.githubusercontent.com/25689432/91996703-995ab980-ed39-11ea-80ff-e042ae9ba226.png)