### PR TITLE
[34167] Add new project custom fields to enabled columns

### DIFF
--- a/app/contracts/concerns/requires_admin_guard.rb
+++ b/app/contracts/concerns/requires_admin_guard.rb
@@ -1,0 +1,43 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module RequiresAdminGuard
+  extend ActiveSupport::Concern
+
+  included do
+    validate :validate_admin_only
+
+    def validate_admin_only
+      unless user.admin?
+        errors.add :base, :error_unauthorized
+      end
+    end
+  end
+end

--- a/app/contracts/custom_fields/base_contract.rb
+++ b/app/contracts/custom_fields/base_contract.rb
@@ -1,0 +1,53 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module CustomFields
+  class BaseContract < ::ModelContract
+    include RequiresAdminGuard
+
+    attribute :editable
+    attribute :type
+    attribute :field_format
+    attribute :is_filter
+    attribute :is_for_all
+    attribute :is_required
+    attribute :max_length
+    attribute :min_length
+    attribute :name
+    attribute :possible_values
+    attribute :regexp
+    attribute :searchable
+    attribute :visible
+    attribute :default_value
+    attribute :possible_values
+    attribute :multi_value
+    attribute :content_right_to_left
+  end
+end

--- a/app/contracts/custom_fields/create_contract.rb
+++ b/app/contracts/custom_fields/create_contract.rb
@@ -1,0 +1,34 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module CustomFields
+  class CreateContract < BaseContract
+  end
+end

--- a/app/contracts/custom_fields/update_contract.rb
+++ b/app/contracts/custom_fields/update_contract.rb
@@ -1,0 +1,34 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module CustomFields
+  class UpdateContract < BaseContract
+  end
+end

--- a/app/services/custom_fields/create_service.rb
+++ b/app/services/custom_fields/create_service.rb
@@ -53,6 +53,16 @@ module CustomFields
       cf
     end
 
+    def after_perform(call)
+      cf = call.result
+
+      if cf.is_a?(ProjectCustomField)
+        add_cf_to_visible_columns(cf.id)
+      end
+
+      call
+    end
+
     private
 
     def add_cf_to_visible_columns(id)

--- a/app/services/custom_fields/create_service.rb
+++ b/app/services/custom_fields/create_service.rb
@@ -1,0 +1,62 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module CustomFields
+  class CreateService < ::BaseServices::Create
+    def self.careful_new_custom_field(type)
+      if type.to_s =~ /.+CustomField\z/
+        klass = type.to_s.constantize
+        klass.new if klass.ancestors.include? CustomField
+      end
+    rescue NameError => e
+      Rails.logger.error "#{e.message}:\n#{e.backtrace.join("\n")}"
+      nil
+    end
+
+    def perform(params)
+      super
+    rescue StandardError => e
+      ServiceResult.new(success: false, message: e.message)
+    end
+
+    def instance(params)
+      cf = self.class.careful_new_custom_field(params[:type])
+      raise ArgumentError.new("Invalid CF type") unless cf
+
+      cf
+    end
+
+    private
+
+    def add_cf_to_visible_columns(id)
+      Setting.enabled_projects_columns = (Setting.enabled_projects_columns + ["cf_#{id}"]).uniq
+    end
+  end
+end

--- a/app/services/custom_fields/set_attributes_service.rb
+++ b/app/services/custom_fields/set_attributes_service.rb
@@ -1,0 +1,34 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module CustomFields
+  class SetAttributesService < ::BaseServices::SetAttributes
+  end
+end

--- a/app/services/custom_fields/update_service.rb
+++ b/app/services/custom_fields/update_service.rb
@@ -1,0 +1,34 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module CustomFields
+  class UpdateService < ::BaseServices::Update
+  end
+end

--- a/db/migrate/20200903064009_enable_current_project_custom_fields_columns.rb
+++ b/db/migrate/20200903064009_enable_current_project_custom_fields_columns.rb
@@ -1,0 +1,12 @@
+class EnableCurrentProjectCustomFieldsColumns < ActiveRecord::Migration[6.0]
+  def up
+    columns = Setting.enabled_projects_columns
+    cf_columns = ProjectCustomField.pluck(:id).map { |id| "cf_#{id}" }
+
+    Setting.enabled_projects_columns = (columns + cf_columns).uniq
+  end
+
+  def down
+    # Nothing to do as setting is not used
+  end
+end

--- a/spec/contracts/custom_fields/create_contract_spec.rb
+++ b/spec/contracts/custom_fields/create_contract_spec.rb
@@ -1,0 +1,56 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomFields::CreateContract do
+  let(:cf) { FactoryBot.build :project_custom_field }
+  let(:contract) do
+    described_class.new(cf, current_user, options: { changed_by_system: [] })
+  end
+
+  describe 'as admin' do
+    let(:current_user) { FactoryBot.build_stubbed :admin }
+
+    it 'validates the contract' do
+      expect(contract.validate).to eq(true)
+    end
+  end
+
+  describe 'as regular user' do
+    let(:current_user) { FactoryBot.build_stubbed :user }
+
+    it 'invalidates the contract' do
+      expect(contract.validate).to eq(false)
+      expect(contract.errors.symbols_for(:base))
+        .to match_array [:error_unauthorized]
+    end
+  end
+end

--- a/spec/contracts/custom_fields/update_contract_spec.rb
+++ b/spec/contracts/custom_fields/update_contract_spec.rb
@@ -1,0 +1,56 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomFields::UpdateContract do
+  let(:cf) { FactoryBot.build :project_custom_field }
+  let(:contract) do
+    described_class.new(cf, current_user, options: { changed_by_system: [] })
+  end
+
+  describe 'as admin' do
+    let(:current_user) { FactoryBot.build_stubbed :admin }
+
+    it 'validates the contract' do
+      expect(contract.validate).to eq(true)
+    end
+  end
+
+  describe 'as regular user' do
+    let(:current_user) { FactoryBot.build_stubbed :user }
+
+    it 'invalidates the contract' do
+      expect(contract.validate).to eq(false)
+      expect(contract.errors.symbols_for(:base))
+        .to match_array [:error_unauthorized]
+    end
+  end
+end

--- a/spec/controllers/custom_fields_controller_spec.rb
+++ b/spec/controllers/custom_fields_controller_spec.rb
@@ -29,12 +29,12 @@
 require 'spec_helper'
 
 describe CustomFieldsController, type: :controller do
+  using_shared_fixtures :admin
+
   let(:custom_field) { FactoryBot.build_stubbed(:custom_field) }
 
   before do
-    allow(@controller).to receive(:authorize)
-    allow(@controller).to receive(:check_if_login_required)
-    allow(@controller).to receive(:require_admin)
+    login_as admin
   end
 
   describe 'POST edit' do
@@ -99,8 +99,8 @@ describe CustomFieldsController, type: :controller do
       end
 
       it 'responds ok' do
-        expect(response.status).to eq(302)
-        expect(assigns(:custom_field).name).to eq('field')
+        expect(response).to be_redirect
+        expect(CustomField.last.name).to eq 'field'
       end
     end
   end

--- a/spec/services/custom_fields/create_service_spec.rb
+++ b/spec/services/custom_fields/create_service_spec.rb
@@ -1,0 +1,155 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomFields::CreateService, type: :model do
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:contract_class) do
+    double('contract_class', '<=': true)
+  end
+  let(:cf_valid) { true }
+  let(:instance) do
+    described_class.new(user: user, contract_class: contract_class)
+  end
+  let(:call_attributes) { { type: 'ProjectCustomField', name: 'Some name', field_format: 'string' } }
+  let(:set_attributes_success) do
+    true
+  end
+  let(:set_attributes_errors) do
+    double('set_attributes_errors')
+  end
+  let(:set_attributes_result) do
+    ServiceResult.new result: created_cf,
+                      success: set_attributes_success,
+                      errors: set_attributes_errors
+  end
+  let!(:created_cf) do
+    cf = FactoryBot.build_stubbed(:project_custom_field)
+
+    allow(ProjectCustomField)
+      .to receive(:new)
+      .and_return(cf)
+
+    allow(cf)
+      .to receive(:save)
+      .and_return(cf_valid)
+
+    cf
+  end
+
+  let!(:set_attributes_service) do
+    service = double('set_attributes_service_instance')
+
+    allow(CustomFields::SetAttributesService)
+      .to receive(:new)
+      .with(user: user,
+            model: created_cf,
+            contract_class: contract_class,
+            contract_options: {})
+      .and_return(service)
+
+    allow(service)
+      .to receive(:call)
+      .and_return(set_attributes_result)
+  end
+  let(:new_project_role) { FactoryBot.build_stubbed(:role) }
+
+  describe 'call' do
+    subject { instance.call(call_attributes) }
+
+    it 'is successful' do
+      expect(subject.success?).to be_truthy
+    end
+
+    it 'returns the result of the SetAttributesService' do
+      expect(subject)
+        .to eql set_attributes_result
+    end
+
+    it 'persists the custom_field' do
+      expect(created_cf)
+        .to receive(:save)
+        .and_return(cf_valid)
+
+      subject
+    end
+
+    it 'modifies the settings' do
+      subject
+      expect(Setting.enabled_projects_columns).to include "cf_#{created_cf.id}"
+    end
+
+    it 'creates the custom field' do
+      expect(subject.result).to eql created_cf
+      expect(subject.result).to be_kind_of(ProjectCustomField)
+    end
+
+    context 'if the SetAttributeService is unsuccessful' do
+      let(:set_attributes_success) { false }
+
+      it 'is unsuccessful' do
+        expect(subject.success?).to be_falsey
+      end
+
+      it 'returns the result of the SetAttributesService' do
+        expect(subject)
+          .to eql set_attributes_result
+      end
+
+      it 'does not persist the changes' do
+        expect(created_cf)
+          .to_not receive(:save)
+
+        subject
+      end
+
+      it "exposes the contract's errors" do
+        subject
+
+        expect(subject.errors).to eql set_attributes_errors
+      end
+    end
+
+    context 'when the cf is invalid' do
+      let(:cf_valid) { false }
+
+      it 'is unsuccessful' do
+        expect(subject.success?).to be_falsey
+      end
+
+      it "exposes the message's errors" do
+        subject
+
+        expect(subject.errors).to eql created_cf.errors
+      end
+    end
+  end
+end

--- a/spec/services/custom_fields/set_attributes_service_spec.rb
+++ b/spec/services/custom_fields/set_attributes_service_spec.rb
@@ -1,0 +1,126 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomFields::SetAttributesService, type: :model do
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:contract_instance) do
+    contract = double('contract_instance')
+    allow(contract)
+      .to receive(:validate)
+      .and_return(contract_valid)
+    allow(contract)
+      .to receive(:errors)
+      .and_return(contract_errors)
+    contract
+  end
+
+  let(:contract_errors) { double('contract_errors') }
+  let(:contract_valid) { true }
+  let(:cf_valid) { true }
+
+  let(:instance) do
+    described_class.new(user: user,
+                        model: cf_instance,
+                        contract_class: contract_class,
+                        contract_options: {})
+  end
+  let(:cf_instance) { ProjectCustomField.new }
+  let(:contract_class) do
+    allow(CustomFields::CreateContract)
+      .to receive(:new)
+      .with(cf_instance, user, options: { changed_by_system: [] })
+    .and_return(contract_instance)
+
+    CustomFields::CreateContract
+  end
+
+  let(:params) { {} }
+
+  before do
+    allow(cf_instance)
+      .to receive(:valid?)
+      .and_return(cf_valid)
+  end
+
+  subject { instance.call(params) }
+
+  it 'returns the cf instance as the result' do
+    expect(subject.result)
+      .to eql cf_instance
+  end
+
+  it 'is a success' do
+    is_expected
+      .to be_success
+  end
+
+  context 'with params' do
+    let(:params) do
+      {
+        name: 'Foobar'
+      }
+    end
+
+    let(:expected) do
+      {
+        name: 'Foobar'
+      }.with_indifferent_access
+    end
+
+    it 'assigns the params' do
+      subject
+
+      attributes_of_interest = cf_instance
+                                 .attributes
+                                 .slice(*expected.keys)
+
+      expect(attributes_of_interest)
+        .to eql(expected)
+    end
+  end
+
+  context 'with an invalid contract' do
+    let(:contract_valid) { false }
+    let(:expect_time_instance_save) do
+      expect(cf_instance)
+        .not_to receive(:save)
+    end
+
+    it 'returns failure' do
+      is_expected
+        .not_to be_success
+    end
+
+    it "returns the contract's errors" do
+      expect(subject.errors)
+        .to eql(contract_errors)
+    end
+  end
+end

--- a/spec/services/custom_fields/update_service_spec.rb
+++ b/spec/services/custom_fields/update_service_spec.rb
@@ -1,0 +1,152 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomFields::UpdateService, type: :model do
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:contract_class) do
+    double('contract_class', "<=": true)
+  end
+  let(:cf_valid) { true }
+  let(:instance) do
+    described_class.new(user: user,
+                        model: cf,
+                        contract_class: contract_class,
+                        contract_options: {})
+  end
+  let(:call_attributes) { {} }
+  let(:set_attributes_success) do
+    true
+  end
+  let(:set_attributes_errors) do
+    double('set_attributes_errors')
+  end
+  let(:set_attributes_result) do
+    ServiceResult.new result: cf,
+                      success: set_attributes_success,
+                      errors: set_attributes_errors
+  end
+  let!(:cf) do
+    cf = FactoryBot.build_stubbed(:project_custom_field)
+
+    allow(cf)
+      .to receive(:save)
+      .and_return(cf_valid)
+
+    cf
+  end
+  let!(:set_attributes_service) do
+    service = double('set_attributes_service_instance')
+
+    allow(CustomFields::SetAttributesService)
+      .to receive(:new)
+      .with(user: user,
+            model: cf,
+            contract_class: contract_class,
+            contract_options: {})
+      .and_return(service)
+
+    allow(service)
+      .to receive(:call)
+            .and_return(set_attributes_result)
+
+    service
+  end
+
+  describe 'call' do
+    shared_examples_for 'service call' do
+      subject { instance.call(call_attributes) }
+
+      it 'is successful' do
+        expect(subject.success?).to be_truthy
+      end
+
+      it 'returns the result of the SetAttributesService' do
+        expect(subject)
+          .to eql set_attributes_result
+      end
+
+      it 'persists the custom field' do
+        expect(cf)
+          .to receive(:save)
+                .and_return(cf_valid)
+
+        subject
+      end
+
+      context 'when the SetAttributeService is unsuccessful' do
+        let(:set_attributes_success) { false }
+
+        it 'is unsuccessful' do
+          expect(subject.success?).to be_falsey
+        end
+
+        it 'returns the result of the SetAttributesService' do
+          expect(subject)
+            .to eql set_attributes_result
+        end
+
+        it 'does not persist the changes' do
+          expect(cf)
+            .to_not receive(:save)
+
+          subject
+        end
+
+        it "exposes the contract's errors" do
+          subject
+
+          expect(subject.errors).to eql set_attributes_errors
+        end
+      end
+
+      context 'when the custom field is invalid' do
+        let(:cf_valid) { false }
+
+        it 'is unsuccessful' do
+          expect(subject.success?).to be_falsey
+        end
+
+        it "exposes the custom field's errors" do
+          subject
+
+          expect(subject.errors).to eql cf.errors
+        end
+      end
+    end
+
+    context 'with parameters' do
+      let(:call_attributes) { { sticky: true } }
+
+      it_behaves_like 'service call'
+    end
+  end
+end


### PR DESCRIPTION
The project portfolio results in no longer adding new custom fields to the project list. This PR fixes that and:

- Refactors the custom field creation into services to easier perform this change
- Adds a migration to ensure current project custom fields are added to the project list

https://community.openproject.com/wp/34167