### PR TITLE
Fix/archived projects via api

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -574,6 +574,6 @@ class Project < ApplicationRecord
   end
 
   def remove_white_spaces_from_project_name
-    self.name = name.squish unless self.name.nil?
+    self.name = name.squish unless name.nil?
   end
 end

--- a/lib/api/utilities/endpoints/bodied.rb
+++ b/lib/api/utilities/endpoints/bodied.rb
@@ -90,7 +90,7 @@ module API
                    contract_class: process_contract }
 
           process_service
-            .new(args.compact)
+            .new(**args.compact)
             .call(params)
         end
 

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -30,11 +30,20 @@ module API
   module V3
     module Projects
       class ProjectsAPI < ::API::OpenProjectAPI
+        helpers do
+          def visible_project_scope
+            if current_user.admin?
+              Project.all
+            else
+              Project.visible(current_user)
+            end
+          end
+        end
+
         resources :projects do
           get &::API::V3::Utilities::Endpoints::Index.new(model: Project,
                                                           scope: -> {
-                                                            Project
-                                                              .visible(User.current)
+                                                            visible_project_scope
                                                               .includes(ProjectRepresenter.to_eager_load)
                                                           })
                                                      .mount
@@ -52,7 +61,7 @@ module API
           end
           route_param :id do
             after_validation do
-              @project = Project.visible(current_user).find(params[:id])
+              @project = visible_project_scope.find(params[:id])
             end
 
             get &::API::V3::Utilities::Endpoints::Show.new(model: Project).mount

--- a/lib/open_project/patches/declarative_option.rb
+++ b/lib/open_project/patches/declarative_option.rb
@@ -26,8 +26,6 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-require 'representable'
-
 module OpenProject::Patches::DeclarativeOption
   extend ActiveSupport::Concern
 


### PR DESCRIPTION
The visibility check will not work in this case as no permission is active on archived projects. We therefore need to return all projects for admins at least.

I thought about modifying the `visible` scope for this but the use cases where admins are expected to actually see all projects are limited. 

https://community.openproject.com/projects/openproject/work_packages/34120