### PR TITLE
Fix/34239 quick filters lost on projects system settings

### DIFF
--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/filters-tab.component.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/filters-tab.component.ts
@@ -36,6 +36,10 @@ export class WpTableConfigurationFiltersTab implements TabComponent {
     this.wpTableFilters
       .onReady()
       .then(() => this.filters = this.wpTableFilters.current);
+
+    this.wpTableFilters.changes$().subscribe(filters => {
+      this.filters = this.wpTableFilters.current;
+    });
   }
 
   public onSave() {


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34239

This pull request:

- [x] Updates WpTableConfigurationFiltersTab.filters variable whenever wpTableFilters changes so the last version is saved when the 'Save' button is clicked.

* Things to note:
- WpTableConfigurationFiltersTab.wpTableFilters.replaceIfComplete(this.filters) seems to be triggering a useless wpTableFilters update since the filters have been already updated when the action is called.
- On the  WpTableConfigurationFiltersTab template, the QueryFiltersComponent is triggering the 'filtersChanged' event duplicated, the first with the data and the second 'undefined' so seems that  WpTableConfigurationFiltersTab.filters would be always undefined.
- QueryFiltersComponent doesn't emit the 'filtersChanged' for the WorkPackageFilterByTextInputComponent (quick text) changes, so WpTableConfigurationFiltersTab.filters would never be updated with its value.

All this could mean that the WpTableConfigurationFiltersTab.onSave functionality is not needed and could be deleted.