### PR TITLE
[33383] Treat number fields as text fields to allow localized input

### DIFF
--- a/modules/budgets/app/controllers/budgets_controller.rb
+++ b/modules/budgets/app/controllers/budgets_controller.rb
@@ -178,7 +178,7 @@ class BudgetsController < ApplicationController
     user = User.where(id: params[:user_id]).first
 
     if user && params[:hours]
-      hours = params[:hours].to_s.to_hours
+      hours = Rate.parse_number_string_to_number(params[:hours])
       @costs = hours * user.rate_at(params[:fixed_date], @project).rate rescue 0.0
     else
       @costs = 0.0

--- a/modules/budgets/app/views/budgets/items/_labor_budget_item.html.erb
+++ b/modules/budgets/app/views/budgets/items/_labor_budget_item.html.erb
@@ -42,26 +42,33 @@ See docs/COPYRIGHT.rdoc for more details.
   error_messages = error_messages_for 'labor_budget_item'
 -%>
 
-<% unless error_messages.blank? %><tr><td colspan="5"><%= error_messages %></td></tr><% end %>
+<% unless error_messages.blank? %>
+  <tr>
+    <td colspan="5"><%= error_messages %></td>
+  </tr>
+<% end %>
 <%= fields_for prefix, labor_budget_item do |cost_form| %>
   <tr class="cost_entry <%= classes %>" id="<%= id_prefix %>">
     <td class="units">
       <div class="form--field-container">
         <div class="form--text-field-container -xslim">
           <label class="hidden-for-sighted" for="<%= id_prefix %>_units"><%= LaborBudgetItem.human_attribute_name(:hours) %></label>
-          <%= cost_form.number_field :hours,
-                                     index: id_or_index,
-                                     min: 0,
-                                     step: 0.01,
-                                     class: 'budget-item-value form--text-field',
-                                     data: { :'request-key' => 'hours' } %>
+          <%= cost_form.text_field :hours,
+                                   index: id_or_index,
+                                   value: unitless_currency_number(labor_budget_item.hours),
+                                   # Avoid a number field due to chrome bug (OP#32232)
+                                   # but show the appearance of a decimal field on mobile
+                                   inputmode: :decimal,
+                                   placeholder: t(:label_example_placeholder, decimal: unitless_currency_number(1000.50)),
+                                   class: 'budget-item-value form--text-field',
+                                   data: { :'request-key' => 'hours' } %>
         </div>
       </div>
     </td>
     <td class="user">
       <label class="hidden-for-sighted" for="<%= id_prefix %>_user_id"><%= t(:label_user) %></label>
       <%= cost_form.select :user_id,
-                           @project.possible_assignees.sort.map{|u| [u.name, u.id]},
+                           @project.possible_assignees.sort.map { |u| [u.name, u.id] },
                            { prompt: true },
                            {
                              index: id_or_index,
@@ -74,7 +81,7 @@ See docs/COPYRIGHT.rdoc for more details.
       <label class="hidden-for-sighted" for="<%= id_prefix %>_comments"><%= LaborBudgetItem.human_attribute_name(:comments) %></label>
       <%= cost_form.text_field :comments, index: id_or_index, size: 40 %>
     </td>
-    <% if User.current.allowed_to?(:view_cost_rates, @project)%>
+    <% if User.current.allowed_to?(:view_cost_rates, @project) %>
       <td class="currency budget-table--fields">
         <%# Keep current budget as hidden field because otherwise they will be overridden %>
         <% if templated == false && !labor_budget_item.new_record? && labor_budget_item.overridden_costs? %>

--- a/modules/budgets/app/views/budgets/items/_material_budget_item.html.erb
+++ b/modules/budgets/app/views/budgets/items/_material_budget_item.html.erb
@@ -42,64 +42,71 @@ See docs/COPYRIGHT.rdoc for more details.
   error_messages = error_messages_for 'material_budget_item'
 -%>
 
-<% unless error_messages.blank? %><tr><td colspan="5"><%= error_messages %></td></tr><% end %>
+<% unless error_messages.blank? %>
+  <tr>
+    <td colspan="5"><%= error_messages %></td>
+  </tr>
+<% end %>
 <%= fields_for prefix, material_budget_item do |cost_form| %>
-<tr class="cost_entry <%= classes %>" id="<%= id_prefix %>">
-  <td class="units">
-    <div class="form--field-container">
+  <tr class="cost_entry <%= classes %>" id="<%= id_prefix %>">
+    <td class="units">
+      <div class="form--field-container">
         <div class="form--text-field-container -xslim">
-           <label class="hidden-for-sighted" for="<%= id_prefix %>_units"><%= MaterialBudgetItem.human_attribute_name(:units) %></label>
-          <%= cost_form.number_field :units,
-                                     index: id_or_index,
-                                     min: 0,
-                                     step: 0.01,
-                                     class: 'budget-item-value form--text-field',
-                                     data: { :'request-key' => 'units' } %>
+          <label class="hidden-for-sighted" for="<%= id_prefix %>_units"><%= MaterialBudgetItem.human_attribute_name(:units) %></label>
+          <%= cost_form.text_field :units,
+                                   index: id_or_index,
+                                   value: unitless_currency_number(material_budget_item.units),
+                                   # Avoid a number field due to chrome bug (OP#32232)
+                                   # but show the appearance of a decimal field on mobile
+                                   inputmode: :decimal,
+                                   placeholder: t(:label_example_placeholder, decimal: unitless_currency_number(1000.50)),
+                                   class: 'budget-item-value form--text-field',
+                                   data: { :'request-key' => 'units' } %>
         </div>
       </div>
-  </td>
-  <td class="unit_currency budget-table--fields" id="<%= "#{id_prefix}_unit_name" %>">
-    <%=h material_budget_item.cost_type.unit_plural if material_budget_item.cost_type %>
-  </td>
-  <td class="cost_type">
-    <label class="hidden-for-sighted" for="<%= id_prefix %>_cost_type_id"><%= MaterialBudgetItem.human_attribute_name(:cost_type) %></label>
-    <%= cost_form.select :cost_type_id,
-                         cost_types_collection_for_select_options(material_budget_item.cost_type),
-                         {},
-                         {
-                           index: id_or_index,
-                           class: 'form--select budget-item-value',
-                           data: { :'request-key' => 'cost_type_id' }
-                         } %>
-  </td>
-  <td class="comment">
-    <label class="hidden-for-sighted" for="<%= id_prefix %>_comments"><%= MaterialBudgetItem.human_attribute_name(:comments) %></label>
-    <%= cost_form.text_field :comments, index: id_or_index, size: 40 %>
-  </td>
-  <% if User.current.allowed_to? :view_cost_rates, @project %>
-    <td class="currency budget-table--fields">
-      <%# Keep current budget as hidden field because otherwise they will be overridden %>
-      <% if templated == false && !material_budget_item.new_record? && material_budget_item.overridden_costs? %>
-        <%= cost_form.hidden_field :amount, value: unitless_currency_number(material_budget_item.amount) %>
-      <% end %>
-
-      <% cost_value = material_budget_item.amount || material_budget_item.calculated_costs(@budget.fixed_date) %>
-      <%= cost_form.hidden_field :currency, index: id_or_index, value: Setting.plugin_costs['costs_currency'] %>
-      <%= cost_form.hidden_field :cost_value, index: id_or_index, value: unitless_currency_number(cost_value) %>
-
-      <cost-unit-subform obj-id="<%= id_prefix %>"
-                         obj-name="<%= "#{name_prefix}[amount]" %>">
-        <a id="<%= id_prefix %>_costs" class="costs--edit-planned-costs-btn icon-context icon-edit" role="button" title="<%= t(:help_click_to_edit) %>">
-          <%= number_to_currency(cost_value) %>
-        </a>
-      </cost-unit-subform>
     </td>
-  <% end %>
-  <td class="delete budget-table--fields buttons">
-    <a class="delete-budget-item no-decoration-on-hover" title="<%= t(:button_delete) %>">
-      <%= op_icon('icon-context icon-delete') %>
-      <span class="hidden-for-sighted"><%= t(:button_delete) %></span>
-    </a>
-  </td>
-</tr>
+    <td class="unit_currency budget-table--fields" id="<%= "#{id_prefix}_unit_name" %>">
+      <%= h material_budget_item.cost_type.unit_plural if material_budget_item.cost_type %>
+    </td>
+    <td class="cost_type">
+      <label class="hidden-for-sighted" for="<%= id_prefix %>_cost_type_id"><%= MaterialBudgetItem.human_attribute_name(:cost_type) %></label>
+      <%= cost_form.select :cost_type_id,
+                           cost_types_collection_for_select_options(material_budget_item.cost_type),
+                           {},
+                           {
+                             index: id_or_index,
+                             class: 'form--select budget-item-value',
+                             data: { :'request-key' => 'cost_type_id' }
+                           } %>
+    </td>
+    <td class="comment">
+      <label class="hidden-for-sighted" for="<%= id_prefix %>_comments"><%= MaterialBudgetItem.human_attribute_name(:comments) %></label>
+      <%= cost_form.text_field :comments, index: id_or_index, size: 40 %>
+    </td>
+    <% if User.current.allowed_to? :view_cost_rates, @project %>
+      <td class="currency budget-table--fields">
+        <%# Keep current budget as hidden field because otherwise they will be overridden %>
+        <% if templated == false && !material_budget_item.new_record? && material_budget_item.overridden_costs? %>
+          <%= cost_form.hidden_field :amount, value: unitless_currency_number(material_budget_item.amount) %>
+        <% end %>
+
+        <% cost_value = material_budget_item.amount || material_budget_item.calculated_costs(@budget.fixed_date) %>
+        <%= cost_form.hidden_field :currency, index: id_or_index, value: Setting.plugin_costs['costs_currency'] %>
+        <%= cost_form.hidden_field :cost_value, index: id_or_index, value: unitless_currency_number(cost_value) %>
+
+        <cost-unit-subform obj-id="<%= id_prefix %>"
+                           obj-name="<%= "#{name_prefix}[amount]" %>">
+          <a id="<%= id_prefix %>_costs" class="costs--edit-planned-costs-btn icon-context icon-edit" role="button" title="<%= t(:help_click_to_edit) %>">
+            <%= number_to_currency(cost_value) %>
+          </a>
+        </cost-unit-subform>
+      </td>
+    <% end %>
+    <td class="delete budget-table--fields buttons">
+      <a class="delete-budget-item no-decoration-on-hover" title="<%= t(:button_delete) %>">
+        <%= op_icon('icon-context icon-delete') %>
+        <span class="hidden-for-sighted"><%= t(:button_delete) %></span>
+      </a>
+    </td>
+  </tr>
 <% end %>

--- a/modules/budgets/config/locales/en.yml
+++ b/modules/budgets/config/locales/en.yml
@@ -78,6 +78,7 @@ en:
   label_budget_plural: "Budgets"
   label_cost_type_specific: "Budget #%{id}: %{name}"
   label_deliverable: "Budget"
+  label_example_placeholder: 'e.g., %{decimal}'
   label_view_all_budgets: "View all budgets"
   label_yes: "Yes"
 

--- a/modules/budgets/spec/support/pages/budget_form.rb
+++ b/modules/budgets/spec/support/pages/budget_form.rb
@@ -138,11 +138,11 @@ module Pages
     end
 
     def unit_costs_container
-      find_container('Planned unit costs')
+      find_container(Budget.human_attribute_name(:material_budget))
     end
 
     def labor_costs_container
-      find_container('Planned labor costs')
+      find_container(Budget.human_attribute_name(:labor_budget))
     end
 
     def find_container(title)

--- a/modules/costs/app/views/cost_types/_list.html.erb
+++ b/modules/costs/app/views/cost_types/_list.html.erb
@@ -89,7 +89,14 @@ See docs/COPYRIGHT.rdoc for more details.
             <td>
               <%= form_for cost_type, :url => { :controller => '/cost_types', :action => 'set_rate', :id => cost_type }, method: :put, html: { class: 'inline-label' }  do |f| %>
                 <label class="hidden-for-sighted" for="<%= "rate_field_#{cost_type.id}" %>"><%= t(:caption_set_rate) %></label>
-                <%= content_tag :input, '', :value => "", :name => :rate, :size => 7, :id => "rate_field_#{cost_type.id}" %>
+                <%= content_tag :input,
+                                '',
+                                value: "",
+                                name: :rate,
+                                size: 7,
+                                inputmode: :decimal,
+                                placeholder: t(:label_example_placeholder, decimal: unitless_currency_number(1000.50)),
+                                id: "rate_field_#{cost_type.id}" %>
                 <span class="form-label">
                   <%= Setting.plugin_costs['costs_currency'] %>
                 </span>

--- a/modules/costs/app/views/cost_types/_rate.html.erb
+++ b/modules/costs/app/views/cost_types/_rate.html.erb
@@ -61,6 +61,8 @@ See docs/COPYRIGHT.rdoc for more details.
         <%= rate_form.text_field :rate,
                                  size: 7,
                                  index: id_or_index,
+                                 inputmode: :decimal,
+                                 placeholder: t(:label_example_placeholder, decimal: unitless_currency_number(1000.50)),
                                  value: rate.rate ? rate.rate.round(2) : "",
                                  required: templated ? false : true %>
         <span class="form-label">

--- a/modules/costs/spec/features/cost_types/create_cost_type_spec.rb
+++ b/modules/costs/spec/features/cost_types/create_cost_type_spec.rb
@@ -46,7 +46,7 @@ describe 'creating a cost type', type: :feature, js: true do
     fill_in 'cost_type_name', with: 'Test day rate'
     fill_in 'cost_type_unit', with: 'dayUnit'
     fill_in 'cost_type_unit_plural', with: 'dayUnitPlural'
-    fill_in 'cost_type_new_rate_attributes_0_rate', with: '5'
+    fill_in 'cost_type_new_rate_attributes_0_rate', with: '1,000.25'
 
     sleep 1
 
@@ -60,6 +60,43 @@ describe 'creating a cost type', type: :feature, js: true do
     expect(cost_type_row).to have_selector('td a', text: 'Test day rate')
     expect(cost_type_row).to have_selector('td', text: 'dayUnit')
     expect(cost_type_row).to have_selector('td', text: 'dayUnitPlural')
-    expect(cost_type_row).to have_selector('td.currency', text: '5')
+    expect(cost_type_row).to have_selector('td.currency', text: '1,000.25')
+
+    cost_type = CostType.last
+    expect(cost_type.name).to eq 'Test day rate'
+    cost_rate = cost_type.rates.last
+    expect(cost_rate.rate).to eq 1000.25
+  end
+
+  context 'with german locale' do
+    let(:user) { FactoryBot.create(:admin, language: :de) }
+
+    it 'creates the entry with german number separators' do
+      visit "/cost_types/new"
+
+      fill_in 'cost_type_name', with: 'Test day rate'
+      fill_in 'cost_type_unit', with: 'dayUnit'
+      fill_in 'cost_type_unit_plural', with: 'dayUnitPlural'
+      fill_in 'cost_type_new_rate_attributes_0_rate', with: '1.000,25'
+
+      sleep 1
+
+      scroll_to_and_click(find('button.-with-icon.icon-checkmark'))
+
+      expect_angular_frontend_initialized
+      expect(page).to have_selector '.generic-table', wait: 10
+
+      cost_type_row = find('tr', text: 'Test day rate')
+
+      expect(cost_type_row).to have_selector('td a', text: 'Test day rate')
+      expect(cost_type_row).to have_selector('td', text: 'dayUnit')
+      expect(cost_type_row).to have_selector('td', text: 'dayUnitPlural')
+      expect(cost_type_row).to have_selector('td.currency', text: '1.000,25')
+
+      cost_type = CostType.last
+      expect(cost_type.name).to eq 'Test day rate'
+      cost_rate = cost_type.rates.last
+      expect(cost_rate.rate).to eq 1000.25
+    end
   end
 end


### PR DESCRIPTION
The budget parsing use localized numbers to compute the budget costs for the given units.

For comma-delimited locales like German, this will break the computation for any decimal value, as the frontend number always sends dot-delimited values in Chrome due to Bug OP#32232

This PR treats the number fields like text fields with a hint on how to enter the correct value. This matches the "rate" field that does this already and should be the expected behavior, so users can use their language for numbers.

https://community.openproject.com/wp/33383