### PR TITLE
[33496] Don't try to lookup custom value by value in Reporting

### DIFF
--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -80,7 +80,7 @@ module WorkPackagesHelper
 
     parts[:link] << "##{h(package.id)}" if options[:id]
 
-    parts[:link] << "#{h(package.status)}" if options[:id] && options[:status] && package.status
+    parts[:link] << "#{h(package.status)}" if options[:id] && options[:status] && package.status_id
 
     # Hidden link part
 

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -100,6 +100,9 @@ class CustomValue < ApplicationRecord
   end
 
   def strategy
-    @strategy ||= OpenProject::CustomFieldFormat.find_by_name(custom_field.field_format).formatter.new(self)
+    @strategy ||= begin
+      format = custom_field&.field_format || 'empty'
+      OpenProject::CustomFieldFormat.find_by_name(format).formatter.new(self)
+    end
   end
 end

--- a/app/models/custom_value/empty_strategy.rb
+++ b/app/models/custom_value/empty_strategy.rb
@@ -1,5 +1,4 @@
 #-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH
@@ -28,30 +27,14 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CustomValue::ListStrategy < CustomValue::ARObjectStrategy
-  def validate_type_of_value
-    unless custom_field.custom_options.pluck(:id).include?(value.to_i)
-      :inclusion
-    end
-  end
-
+class CustomValue::EmptyStrategy < CustomValue::FormatStrategy
   def typed_value
-    super_value = super
-    super_value && super_value.to_s || nil
+    "#{value} #{I18n.t(:label_not_found)}"
   end
 
-  private
-
-  def ar_class
-    CustomOption
+  def formatted_value
+    typed_value
   end
 
-  def ar_object(value)
-    option = CustomOption.find_by(id: value.to_s)
-    if option.nil?
-      "#{value} #{I18n.t(:label_not_found)}"
-    else
-      option.value
-    end
-  end
+  def validate_type_of_value; end
 end

--- a/config/initializers/custom_field_format.rb
+++ b/config/initializers/custom_field_format.rb
@@ -56,6 +56,10 @@ OpenProject::CustomFieldFormat.map do |fields|
                                                      label: :label_boolean,
                                                      order: 7,
                                                      formatter: 'CustomValue::BoolStrategy')
+  fields.register OpenProject::CustomFieldFormat.new('empty',
+                                                     label: :label_empty,
+                                                     order: 7,
+                                                     formatter: 'CustomValue::EmptyStrategy')
   fields.register OpenProject::CustomFieldFormat.new('user',
                                                      label: Proc.new { User.model_name.human },
                                                      only: %w(WorkPackage TimeEntry

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1543,6 +1543,7 @@ en:
   label_no_parent_page: "No parent page"
   label_nothing_display: "Nothing to display"
   label_nobody: "nobody"
+  label_not_found: 'not found'
   label_none: "none"
   label_none_parentheses: "(none)"
   label_not_contains: "doesn't contain"

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -34,6 +34,7 @@ module API
       class CustomFieldInjector
         TYPE_MAP = {
           'string' => 'String',
+          'empty' => 'String',
           'text' => 'Formattable',
           'int' => 'Integer',
           'float' => 'Float',

--- a/modules/reporting/app/helpers/reporting_helper.rb
+++ b/modules/reporting/app/helpers/reporting_helper.rb
@@ -99,7 +99,7 @@ module ReportingHelper
   end
 
   def field_representation_map(key, value)
-    return I18n.t(:label_none) if value.blank?
+    return I18n.t(:'placeholders.default') if value.blank?
 
     case key.to_sym
     when :activity_id                           then mapped value, Enumeration, "<i>#{l(:caption_material_costs)}</i>"
@@ -110,18 +110,28 @@ module ReportingHelper
     when :tmonth                                then month_name(value.to_i)
     when :category_id                           then h(Category.find(value.to_i).name)
     when :cost_type_id                          then mapped value, CostType, l(:caption_labor)
-    when :budget_id                        then budget_link value
+    when :budget_id                             then budget_link value
     when :work_package_id                       then link_to_work_package(WorkPackage.find(value.to_i))
     when :spent_on                              then format_date(value.to_date)
     when :type_id                               then h(Type.find(value.to_i).name)
     when :week                                  then "#{l(:label_week)} #%s" % value.to_i.modulo(100)
     when :priority_id                           then h(IssuePriority.find(value.to_i).name)
-    when :version_id                      then h(Version.find(value.to_i).name)
+    when :version_id                            then h(Version.find(value.to_i).name)
     when :singleton_value                       then ''
     when :status_id                             then h(Status.find(value.to_i).name)
-    when /custom_field\d+/                      then CustomOption.find_by(id: value)&.value || value.to_s
+    when /custom_field\d+/                      then custom_value(key, value)
     else h(value.to_s)
     end
+  end
+
+  def custom_value(cf_identifier, value)
+    cf_id = cf_identifier.gsub('custom_field', '').to_i
+
+    # Reuses rails cache to locate the custom field
+    # and then properly cast the value
+    CustomValue
+      .new(custom_field_id: cf_id, value: value)
+      .typed_value
   end
 
   def field_sort_map(key, value)

--- a/modules/reporting/spec/helpers/reporting_helper_spec.rb
+++ b/modules/reporting/spec/helpers/reporting_helper_spec.rb
@@ -32,29 +32,46 @@ describe ReportingHelper, type: :helper do
   describe '#field_representation_map' do
     context 'for a custom field' do
       context 'for which a custom option exists (e.g. a list field)' do
+        let(:custom_field) do
+          FactoryBot.create(
+            :list_wp_custom_field,
+            name: "Ingredients",
+            possible_values: ["ham"]
+          )
+        end
+
         it 'returns the option value' do
-          option = FactoryBot.build(:custom_option)
+          option = custom_field.possible_values.first
 
-          allow(CustomOption)
-            .to receive(:find_by)
-            .with(id: "345")
-            .and_return(option)
+          expect(field_representation_map("custom_field#{custom_field.id}", option.id))
+            .to eql 'ham'
+        end
 
-          expect(field_representation_map("custom_field22", "345"))
-            .to eql option.value
+        it 'returns not found for an outdated value value' do
+          expect(field_representation_map("custom_field#{custom_field.id}", "1234123"))
+            .to eql '1234123 not found'
+        end
+      end
+
+      context 'for which no custom option exists (e.g. a float field)' do
+        let(:custom_field) do
+          FactoryBot.create(
+            :float_wp_custom_field,
+            name: "Estimate"
+          )
+        end
+
+        it 'returns the option value' do
+          expect(field_representation_map("custom_field#{custom_field.id}", 3.0))
+            .to eql 3.0
         end
       end
     end
 
     context 'for which no custom option exists' do
-      it 'returns the option value' do
-        allow(CustomOption)
-          .to receive(:find_by)
-          .with(id: "345")
-          .and_return(nil)
-
-        expect(field_representation_map("custom_field22", "345"))
-          .to eql "345"
+      it 'returns the not found value' do
+        expect(field_representation_map("custom_field12345", "345"))
+          .to eql "345 not found"
       end
     end
   end

--- a/spec/models/custom_value_spec.rb
+++ b/spec/models/custom_value_spec.rb
@@ -96,6 +96,17 @@ describe CustomValue do
     end
   end
 
+  describe 'trying to use a custom field that does not exist' do
+    subject { FactoryBot.build(:custom_value, custom_field_id: 123412341, value: 'my value') }
+
+    it 'returns an empty placeholder' do
+      expect(subject.custom_field).to be_nil
+      expect(subject.send(:strategy)).to be_kind_of CustomValue::EmptyStrategy
+      expect(subject.typed_value).to eq 'my value not found'
+      expect(subject.formatted_value).to eq 'my value not found'
+    end
+  end
+
   describe 'value/value=' do
     let(:custom_value) { FactoryBot.build_stubbed(:custom_value) }
     let(:strategy_double) { double('strategy_double') }


### PR DESCRIPTION
Custom fields for reporting was incorrectly treating values as IDs all the time, even though for plain text custom fields, these values would incorrectly match other custom field's values.

Only for list types, the value will be an integer to look up by id, but instead use `CustomValue.new(...).typed_value` to use the formatter classes to correctly look up the value.

Since it can happen that values are shown for custom fields that do not know that value, we introduce a safety "Empty" strategy that outputs the string back with "not found" similar to how invalid custom field list values are output.

https://community.openproject.com/wp/33496