### PR TITLE
Pin postgresql to 9.6 for the all-in-one docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ ENV APP_USER=app
 ENV APP_PATH=/app
 ENV APP_DATA_PATH=/var/openproject/assets
 ENV APP_DATA_PATH_LEGACY=/var/db/openproject
-ENV PGBIN="/usr/lib/postgresql/9.6/bin"
 ENV PGDATA=/var/openproject/pgdata
 ENV PGDATA_LEGACY=/var/lib/postgresql/9.6/main
 

--- a/docker/setup/postinstall.sh
+++ b/docker/setup/postinstall.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 PGBIN="$(pg_config --bindir)"
 
@@ -28,6 +29,8 @@ fi
 echo " ---> Precompiling assets. This will take a while..."
 
 (
+	set -e
+	set -o pipefail
 	pushd "${APP_PATH}/frontend"
 
 	export NG_CLI_ANALYTICS=ci # so angular cli doesn't block waiting for user input

--- a/docker/setup/postinstall.sh
+++ b/docker/setup/postinstall.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+PGBIN="$(pg_config --bindir)"
+
 display_error() {
 	echo " !--> ERROR on postinstall:"
 	tail -n 200 /tmp/dockerize.log

--- a/docker/setup/preinstall-on-prem.sh
+++ b/docker/setup/preinstall-on-prem.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -o pipefail
 
 apt-get install -y  \
 	memcached \

--- a/docker/setup/preinstall.sh
+++ b/docker/setup/preinstall.sh
@@ -10,28 +10,27 @@ display_error() {
 }
 
 echo " ---> Setting up common dependencies. This will take a while..."
-apt-get update -qq
 
 (
 	# install node + npm
 	curl -s https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz | \
 		tar xzf - -C /usr/local --strip-components=1
 
+	wget --quiet -O- https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+	echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+
+	apt-get update -qq
 	apt-get install -y \
 		apt-transport-https \
-		postgresql-client \
 		pandoc \
 		poppler-utils \
 		unrtf \
 		tesseract-ocr \
 		catdoc \
-		postgresql
+		postgresql-9.6 \
+		postgresql-client-9.6
 
-	# Set up pg defaults
-	echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.6/main/pg_hba.conf
-	echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf
-	echo "data_directory='$PGDATA'" >> /etc/postgresql/9.6/main/postgresql.conf
-	rm -rf "$PGDATA_LEGACY" && rm -rf "$PGDATA" && mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA"
+	rm -rf "$PGDATA_LEGACY"
 
 	# Specifics for BIM edition
 	wget -qO- https://packages.microsoft.com/keys/microsoft.asc | apt-key add -

--- a/docker/setup/preinstall.sh
+++ b/docker/setup/preinstall.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -o pipefail
 
 echo " ---> PREINSTALL"
 
@@ -12,6 +13,9 @@ display_error() {
 echo " ---> Setting up common dependencies. This will take a while..."
 
 (
+	set -e
+	set -o pipefail
+
 	# install node + npm
 	curl -s https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz | \
 		tar xzf - -C /usr/local --strip-components=1

--- a/docker/supervisord
+++ b/docker/supervisord
@@ -14,6 +14,8 @@ if [ "$PGDATA" == "" ]; then
 	exit 2
 fi
 
+export PGBIN="$(pg_config --bindir)"
+export PGCONF_FILE="/etc/postgresql/9.6/main/postgresql.conf"
 PGUSER=${PGUSER:=postgres}
 PGPASSWORD=${PGPASSWORD:=postgres}
 PG_STARTUP_WAIT_TIME=${PG_STARTUP_WAIT_TIME:=10}
@@ -74,34 +76,56 @@ migrate() {
 	popd >/dev/null
 }
 
+check_postgres_connection() {
+	su postgres -c "$PGBIN/psql $DATABASE_URL -c 'select 1;'"
+}
+
 wait_for_postgres() {
 	retries=${PG_STARTUP_WAIT_TIME}
 
 	echo "Trying to contact PostgreSQL server instance or waiting for it to come online."
 
-	until su postgres -c "$PGBIN/psql $DATABASE_URL -c 'select 1;' > /dev/null 2>&1" || [ $retries -eq 0 ]; do
-		echo "Waiting for postgres server, $((retries--)) remaining attempts..."
-		sleep 3
+	while ! check_postgres_connection &> /dev/null ; do
+		if [ $retries -eq 0 ]; then
+			echo "Unable to contact postgres server:"
+			check_postgres_connection
+		else
+			echo "Waiting for postgres server, $((retries--)) remaining attempts..."
+			sleep 3
+		fi
 	done
 }
 
+configure_local_postgres() {
+	mkdir -p "$PGDATA"
+	chown -R postgres:postgres "$PGDATA"
+	# remove any dangling pid
+	rm -f $PGDATA/postmaster.pid
+
+	# Set up pg defaults
+	echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.6/main/pg_hba.conf
+	echo "listen_addresses='0.0.0.0'" >> "$PGCONF_FILE"
+	echo "data_directory='$PGDATA'" >> "$PGCONF_FILE"
+}
+
 if [ "$dbhost" = "127.0.0.1" ]; then
+	configure_local_postgres
+
 	# initialize cluster if it does not exist yet
 	if [ -f "$PGDATA/PG_VERSION" ]; then
 		echo "-----> Database cluster already exists, not modifying."
-		/etc/init.d/postgresql start | indent
+		su - postgres -c "$PGBIN/pg_ctl -w -l /dev/null -o '-c config_file=$PGCONF_FILE' -D '$PGDATA' start" | indent
 		(install_plugins && migrate) | indent
-		/etc/init.d/postgresql stop | indent
+		su - postgres -c "$PGBIN/pg_ctl -D '$PGDATA' stop" | indent
 	else
 		echo "-----> Database cluster not found. Creating a new one in $PGDATA..."
-		chown -R postgres:postgres $PGDATA
 		su postgres -c "$PGBIN/initdb --pgdata=${PGDATA} --username=${PGUSER} --encoding=unicode --auth=trust --pwfile=$pwfile" | indent
 		su postgres -c "rm -f $pwfile"
-		/etc/init.d/postgresql start | indent
+		su - postgres -c "$PGBIN/pg_ctl -w -l /dev/null -o '-c config_file=$PGCONF_FILE' -D '$PGDATA' start" | indent
 		su postgres -c "$PGBIN/psql --command \"CREATE USER openproject WITH SUPERUSER PASSWORD 'openproject';\"" | indent
 		su postgres -c "$PGBIN/createdb -O openproject openproject" | indent
 		(install_plugins && migrate) | indent
-		/etc/init.d/postgresql stop | indent
+		su - postgres -c "$PGBIN/pg_ctl -D '$PGDATA' stop" | indent
 	fi
 else
 	echo "-----> You're using an external database. Not initializing a local database cluster."

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -79,7 +79,7 @@ stderr_logfile_maxbytes = 0
 [program:postgres]
 user=postgres
 priority=1
-command=/usr/lib/postgresql/9.6/bin/postgres -D %(ENV_PGDATA)s -c config_file=/etc/postgresql/9.6/main/postgresql.conf
+command=%(ENV_PGBIN)s/postgres -D %(ENV_PGDATA)s -c config_file=%(ENV_PGCONF_FILE)s
 autorestart=true
 stderr_logfile = /dev/stderr
 stdout_logfile = /dev/stdout


### PR DESCRIPTION
Since the upgrade to ruby 2.7 and the change in the source docker image, we switched to the latest debian release, which installs PostgreSQL v11 by default. For backwards-compatibility this change ensures the version stays the same as before.