### PR TITLE
Fixed: added margin bottom to the Gantt chart

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_table.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table.sass
@@ -131,6 +131,9 @@
   will-change: transform
   // Hinter browser that the content of the flex is contained except for size
   contain: strict
+  // Added on split view to compensate the 'wpTableSumsRow' that the left table has.
+  // If not, when scrolling down the last rows are misaligned
+  padding-bottom: calc(var(--table-timeline--row-height) - 1px)
 
 .work-package--attachments--files
   margin-bottom: 1rem


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34127

This pull request:

- [x] Adds a margin-bottom to the Gantt chart so it has the same height than the table (which now has an extra invisible row for showing sums).