### PR TITLE
Fix/non integer material budget items

### DIFF
--- a/modules/budgets/app/controllers/budgets_controller.rb
+++ b/modules/budgets/app/controllers/budgets_controller.rb
@@ -121,10 +121,6 @@ class BudgetsController < ApplicationController
   end
 
   def update
-    # TODO: This was simply copied over from edit in order to have
-    # something as a starting point for separating the two
-    # Please go ahead and start removing code where necessary
-
     @budget.attributes = permitted_params.budget if params[:budget]
     if params[:budget][:existing_material_budget_item_attributes].nil?
       @budget.existing_material_budget_item_attributes = ({})

--- a/modules/budgets/app/models/budget.rb
+++ b/modules/budgets/app/models/budget.rb
@@ -174,7 +174,7 @@ class Budget < ApplicationRecord
       correct_material_attributes!(attributes)
 
       if User.current.allowed_to? :edit_budgets, material_budget_item.budget.project
-        if attributes && attributes[:units].to_i.positive?
+        if attributes && attributes[:units].to_f.positive?
           material_budget_item.attributes = attributes.merge(amount: Rate.parse_number_string(attributes[:amount]))
         else
           material_budget_items.delete(material_budget_item)

--- a/modules/budgets/app/models/budget.rb
+++ b/modules/budgets/app/models/budget.rb
@@ -90,6 +90,10 @@ class Budget < ApplicationRecord
     I18n.t(:label_budget)
   end
 
+  def edit_allowed?
+    User.current.allowed_to? :edit_budgets, project
+  end
+
   # Amount of the budget spent.  Expressed as as a percentage whole number
   def budget_ratio
     return 0.0 if budget.nil? || budget == 0.0
@@ -169,18 +173,7 @@ class Budget < ApplicationRecord
   end
 
   def existing_material_budget_item_attributes=(material_budget_item_attributes)
-    material_budget_items.reject(&:new_record?).each do |material_budget_item|
-      attributes = material_budget_item_attributes[material_budget_item.id.to_s]
-      correct_material_attributes!(attributes)
-
-      if User.current.allowed_to? :edit_budgets, material_budget_item.budget.project
-        if attributes && attributes[:units].to_f.positive?
-          material_budget_item.attributes = attributes.merge(amount: Rate.parse_number_string(attributes[:amount]))
-        else
-          material_budget_items.delete(material_budget_item)
-        end
-      end
-    end
+    update_budget_item_attributes(material_budget_item_attributes, type: 'material')
   end
 
   def save_material_budget_items
@@ -201,19 +194,10 @@ class Budget < ApplicationRecord
   end
 
   def existing_labor_budget_item_attributes=(labor_budget_item_attributes)
-    labor_budget_items.reject(&:new_record?).each do |labor_budget_item|
-      attributes = labor_budget_item_attributes[labor_budget_item.id.to_s]
-      correct_labor_attributes!(attributes)
-
-      if User.current.allowed_to? :edit_budgets, labor_budget_item.budget.project
-        if valid_labor_budget_attributes?(attributes)
-          labor_budget_item.attributes = attributes.merge(amount: Rate.parse_number_string(attributes[:amount]))
-        else
-          labor_budget_items.delete(labor_budget_item)
-        end
-      end
-    end
+    update_budget_item_attributes(labor_budget_item_attributes, type: 'labor')
   end
+
+  private
 
   def save_labor_budget_items
     labor_budget_items.each do |labor_budget_item|
@@ -233,10 +217,34 @@ class Budget < ApplicationRecord
     attributes[:units] = Rate.parse_number_string_to_number(attributes[:units])
   end
 
+  def update_budget_item_attributes(budget_item_attributes, type:)
+    return unless edit_allowed?
+
+    budget_items = send("#{type}_budget_items")
+
+    budget_items.reject(&:new_record?).each do |budget_item|
+      attributes = budget_item_attributes[budget_item.id.to_s]
+      send("correct_#{type}_attributes!", attributes)
+
+      if send("valid_#{type}_budget_attributes?", attributes)
+        budget_item.attributes = attributes.merge(amount: Rate.parse_number_string(attributes[:amount]))
+      else
+        # This is surprising as it will delete right away compared to the
+        # update of the attributes that requires a save afterwards to take effect.
+        budget_items.delete(budget_item)
+      end
+    end
+  end
+
   def valid_labor_budget_attributes?(attributes)
     attributes &&
       attributes[:hours].to_f.positive? &&
       attributes[:user_id].to_i.positive? &&
       project.possible_assignees.map(&:id).include?(attributes[:user_id].to_i)
+  end
+
+  def valid_material_budget_attributes?(attributes)
+    attributes &&
+      attributes[:units].to_f.positive?
   end
 end

--- a/modules/budgets/config/locales/en.yml
+++ b/modules/budgets/config/locales/en.yml
@@ -76,7 +76,7 @@ en:
   label_budget: "Budget"
   label_budget_new: "New budget"
   label_budget_plural: "Budgets"
-  label_cost_type_specific: "Budget #%{id}: %{name}"
+  label_budget_id: "Budget #%{id}"
   label_deliverable: "Budget"
   label_example_placeholder: 'e.g., %{decimal}'
   label_view_all_budgets: "View all budgets"

--- a/modules/budgets/config/locales/en.yml
+++ b/modules/budgets/config/locales/en.yml
@@ -37,22 +37,19 @@ en:
         budget_ratio: "Spent (ratio)"
         created_on: "Created on"
         description: "Description"
-        fixed_date: "Fixed date"
         spent: "Spent"
         status: "Status"
         subject: "Subject"
         type: "Cost type"
         updated_on: "Updated on"
-      work_package:
-        budget_subject: "Budget title"
-      budget:
         labor_budget: "Planned labor costs"
         material_budget: "Planned unit costs"
+      work_package:
+        budget_subject: "Budget title"
     models:
       budget: "Budget"
       material_budget_item: "Unit"
   attributes:
-    budget: "Planned costs"
     budget: "Budget"
 
   button_add_budget_item: "Add planned costs"

--- a/modules/budgets/spec/models/budget_spec.rb
+++ b/modules/budgets/spec/models/budget_spec.rb
@@ -83,6 +83,15 @@ describe Budget, type: :model do
             .to eql 0.5
         end
       end
+
+      context 'with no value' do
+        it 'deletes the item' do
+          budget.existing_material_budget_item_attributes = { existing_material_budget_item.id.to_s => {  } }
+
+          expect(existing_material_budget_item)
+            .to be_destroyed
+        end
+      end
     end
   end
 end

--- a/modules/budgets/spec/models/budget_spec.rb
+++ b/modules/budgets/spec/models/budget_spec.rb
@@ -59,4 +59,30 @@ describe Budget, type: :model do
     it { expect(WorkPackage.find_by_id(work_package.id)).to eq(work_package) }
     it { expect(work_package.reload.budget).to be_nil }
   end
+
+  describe '#existing_material_budget_item_attributes=' do
+    let!(:existing_material_budget_item) do
+      FactoryBot.create(:material_budget_item, budget: budget, units: 10.0)
+
+      budget.material_budget_items.reload.first
+    end
+
+    context 'allowed to edit budgets' do
+      before do
+        allow(User.current)
+          .to receive(:allowed_to?)
+          .with(:edit_budgets, project)
+          .and_return(true)
+      end
+
+      context 'with a non integer value' do
+        it 'updates the item' do
+          budget.existing_material_budget_item_attributes = { existing_material_budget_item.id.to_s => { units: "0.5" } }
+
+          expect(existing_material_budget_item.units)
+            .to eql 0.5
+        end
+      end
+    end
+  end
 end

--- a/modules/costs/app/views/cost_types/index.html.erb
+++ b/modules/costs/app/views/cost_types/index.html.erb
@@ -42,7 +42,7 @@ See docs/COPYRIGHT.rdoc for more details.
     <legend><%= t(:label_filter_plural) %></legend>
     <ul class="simple-filters--filters">
       <li class="simple-filters--filter">
-        <%= styled_label_tag :fixed_date, t(:label_fixed_date), class: 'simple-filters--filter-name' %>
+        <%= styled_label_tag :fixed_date, t(:'attributes.fixed_date'), class: 'simple-filters--filter-name' %>
         <div class='simple-filters--filter-value'>
           <%= styled_text_field_tag :fixed_date, @fixed_date, class: '-augmented-datepicker' %>
         </div>

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
     hours: "Hours"
     units: "Units"
     valid_from: "Valid from"
+    fixed_date: "Fixed date"
 
   button_add_rate: "Add rate"
   button_log_costs: "Log unit costs"
@@ -104,7 +105,6 @@ en:
   label_display_time_entries: "Display reported hours"
   label_display_types: "Display types"
   label_edit: "Edit"
-  label_fixed_date: "Fixed date"
   label_generic_user: "Generic user"
   label_greater_or_equal: ">="
   label_group_by: "Group by"

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -92,6 +92,7 @@ en:
   label_costlog: "Logged unit costs"
   label_cost_plural: "Costs"
   label_cost_type_plural: "Cost types"
+  label_cost_type_specific: "Cost type #%{id}: %{name}"
   label_costs_per_page: "Costs per page"
   label_currency: "Currency"
   label_currency_format: "Format of currency"


### PR DESCRIPTION
Allows setting a unit amount between 0 and 1 for material budget items (https://community.openproject.com/projects/openproject/work_packages/34299) and fixes i18n keys for costs/budgets (https://community.openproject.com/projects/openproject/work_packages/34300)