### PR TITLE
Removed CSS that limit -checked styles to splitted views

### DIFF
--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -18,6 +18,9 @@
   &.-new
     padding-right: 25px
 
+  &.-checked
+    background-color: var(--table-row-highlighting-color)
+
   &.-horizontal
     height: 100%
     
@@ -30,10 +33,6 @@
   // Style shadow element while dragging
   wp-single-card:host.gu-transit &
     @include modifying--placeholder
-
-::ng-deep .work-packages-partitioned-query-space--container.-split
-  .wp-card.-checked
-    background-color: var(--table-row-highlighting-color)
 
 .wp-card--content:not(.-new)
   display: grid

--- a/frontend/src/global_styles/content/_tables.sass
+++ b/frontend/src/global_styles/content/_tables.sass
@@ -153,6 +153,7 @@ th.hidden
 
 tr.context-menu-selection,
 tr.-checked
+  background-color: var(--table-row-highlighting-color) !important
   &[class*=__hl_background]
     outline: var(--table-row-highlighting-outline-color) solid 2px
 
@@ -162,10 +163,6 @@ tr.-checked
     color: var(--body-font-color) !important
     a
       color: var(--body-font-color) !important
-
-.work-packages-partitioned-query-space--container.-split
-  tr.-checked
-    background-color: var(--table-row-highlighting-color) !important
 
 #custom-options-table
   .custom-option-value

--- a/frontend/src/global_styles/content/_work_packages.sass
+++ b/frontend/src/global_styles/content/_work_packages.sass
@@ -26,9 +26,6 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-// Cards styles
-@import work_packages/cards
-
 // Table editing styles
 @import work_packages/table_content
 @import work_packages/table_hierarchy

--- a/frontend/src/global_styles/content/work_packages/_cards.sass
+++ b/frontend/src/global_styles/content/work_packages/_cards.sass
@@ -1,3 +1,0 @@
-.work-packages-partitioned-query-space--container.-split
-  .wp-card.-checked
-    background-color: var(--table-row-highlighting-color)


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34282

This pull request:

- [x] Reverts the changes made by this other [pull request](fix/34126-gantt-chart-styles-conflict-between-last-active-work-package-and-hovered-work-package) in order to fix this [issue](https://community.openproject.com/projects/openproject/work_packages/34126). The new solution is pending.