### PR TITLE
Restore dropped element's original styles when back-end error

### DIFF
--- a/frontend/src/app/components/wp-fast-table/handlers/state/drag-and-drop-transformer.ts
+++ b/frontend/src/app/components/wp-fast-table/handlers/state/drag-and-drop-transformer.ts
@@ -86,6 +86,8 @@ export class DragAndDropTransformer {
         } catch (e) {
           this.halNotification.handleRawError(e);
 
+          // Restore original element's styles
+          this.actionService.changeShadowElement(el, true);
           // Restore element in from container
           DragAndDropHelpers.reinsert(el, el.dataset.sourceIndex || -1, source);
         }

--- a/frontend/src/app/modules/common/drag-and-drop/drag-and-drop.helpers.ts
+++ b/frontend/src/app/modules/common/drag-and-drop/drag-and-drop.helpers.ts
@@ -12,7 +12,7 @@ export namespace DragAndDropHelpers {
     previousIndex = typeof previousIndex === 'string' ? parseInt(previousIndex, 10) : previousIndex;
 
     const children = Array.from(container.children);
-    const currentIndex = Array.from(el.parentNode.children).indexOf(el);
+    const currentIndex = Array.from(el.parentNode!.children).indexOf(el);
     const isDraggingDown = currentIndex > previousIndex;
     const pointOfInsertion = isDraggingDown ? children[previousIndex] : children[previousIndex + 1];
 

--- a/frontend/src/app/modules/common/drag-and-drop/drag-and-drop.helpers.ts
+++ b/frontend/src/app/modules/common/drag-and-drop/drag-and-drop.helpers.ts
@@ -10,11 +10,16 @@ export namespace DragAndDropHelpers {
 
   export function reinsert(el:HTMLElement, previousIndex:number|string, container:HTMLElement) {
     previousIndex = typeof previousIndex === 'string' ? parseInt(previousIndex, 10) : previousIndex;
-
+    const currentIndex = el.parentNode && Array.from(el.parentNode.children).indexOf(el) || null;
     const children = Array.from(container.children);
-    const currentIndex = Array.from(el.parentNode!.children).indexOf(el);
-    const isDraggingDown = currentIndex > previousIndex;
-    const pointOfInsertion = isDraggingDown ? children[previousIndex] : children[previousIndex + 1];
+    let pointOfInsertion;
+
+    if (currentIndex != null) {
+      const isDraggingDown = currentIndex > previousIndex;
+      pointOfInsertion = isDraggingDown ? children[previousIndex] : children[previousIndex + 1];
+    } else {
+      pointOfInsertion = children[previousIndex];
+    }
 
     if (pointOfInsertion) {
       container.insertBefore(el, pointOfInsertion);

--- a/frontend/src/app/modules/common/drag-and-drop/drag-and-drop.helpers.ts
+++ b/frontend/src/app/modules/common/drag-and-drop/drag-and-drop.helpers.ts
@@ -8,20 +8,16 @@ export namespace DragAndDropHelpers {
     return children.indexOf(el);
   }
 
-  export function reinsert(el:HTMLElement, index:number|string, container:HTMLElement) {
-    index = typeof index === 'string' ? parseInt(index, 10) : index;
+  export function reinsert(el:HTMLElement, previousIndex:number|string, container:HTMLElement) {
+    previousIndex = typeof previousIndex === 'string' ? parseInt(previousIndex, 10) : previousIndex;
 
     const children = Array.from(container.children);
+    const currentIndex = Array.from(el.parentNode.children).indexOf(el);
+    const isDraggingDown = currentIndex > previousIndex;
+    const pointOfInsertion = isDraggingDown ? children[previousIndex] : children[previousIndex + 1];
 
-    // Append to end if unknown index or no child nodes
-    if (index < 0 || index >= children.length || children.length === 0) {
-      container.appendChild(el);
-    }
-
-    // Get the element to insert before
-    const sibling = children[index];
-    if (sibling) {
-      container.insertBefore(el, sibling);
+    if (pointOfInsertion) {
+      container.insertBefore(el, pointOfInsertion);
     } else {
       container.appendChild(el);
     }


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34332

This pull request:

- [x] Restores dropped element's original styles when a back-end error takes place so it is shown again on the table.