### PR TITLE
Fix/duplicate work packages across pages

### DIFF
--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -203,7 +203,7 @@ class WorkPackagesController < ApplicationController
     @results = @query.results
     @work_packages = if @query.valid?
                        @results
-                         .sorted_work_packages
+                         .work_packages
                          .page(page_param)
                          .per_page(per_page_param)
                      else

--- a/app/models/queries/base_query.rb
+++ b/app/models/queries/base_query.rb
@@ -53,21 +53,11 @@ class Queries::BaseQuery
   end
 
   def results
-    scope = default_scope
-
     if valid?
-      filters.each do |filter|
-        scope = scope.merge(filter.scope)
-      end
-
-      orders.each do |order|
-        scope = scope.merge(order.scope)
-      end
+      apply_orders(apply_filters(default_scope))
     else
-      scope = empty_scope
+      empty_scope
     end
-
-    scope
   end
 
   def where(attribute, operator, values)
@@ -140,5 +130,33 @@ class Queries::BaseQuery
 
   def context
     nil
+  end
+
+  def apply_filters(scope)
+    filters.each do |filter|
+      scope = scope.merge(filter.scope)
+    end
+
+    scope
+  end
+
+  def apply_orders(scope)
+    orders.each do |order|
+      scope = scope.merge(order.scope)
+    end
+
+    # To get deterministic results, especially when paginating (limit + offset)
+    # an order needs to be prepended that is ensured to be
+    # different between all elements.
+    # Without such a criteria, results can occur on multiple pages.
+    already_ordered_by_id?(scope) ? scope : scope.order(id: :desc)
+  end
+
+  def already_ordered_by_id?(scope)
+    scope.order_values.any? do |order|
+      order.respond_to?(:value) && order.value.respond_to?(:relation) &&
+        order.value.relation.name == self.class.model.table_name &&
+        order.value.name == 'id'
+    end
   end
 end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -180,28 +180,6 @@ class Query < ApplicationRecord
     filters << filter
   end
 
-  def add_short_filter(field, expression)
-    return unless expression
-
-    parms = expression.scan(/\A(o|c|!\*|!|\*)?(.*)\z/).first
-    add_filter field, (parms[0] || '='), [parms[1] || '']
-  end
-
-  # Add multiple filters using +add_filter+
-  def add_filters(fields, operators, values)
-    values ||= {}
-
-    if fields.is_a?(Array) && operators.respond_to?(:[]) && values.respond_to?(:[])
-      fields.each do |field|
-        add_filter(field, operators[field], values[field])
-      end
-    end
-  end
-
-  def has_filter?(field)
-    filters.present? && filters.any? { |f| f.field.to_s == field.to_s }
-  end
-
   def filter_for(field)
     filter = (filters || []).detect { |f| f.field.to_s == field.to_s } || super(field)
 

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -51,27 +51,15 @@ class ::Query::Results
     raise ::Query::StatementInvalid.new(e.message)
   end
 
-  # This method is deprecated use sorted_work_packages instead
-  # noinspection Rails3Deprecated
+  # Returns the work packages adhering to the filters and ordered by the provided criteria (grouping and sorting)
   def work_packages
-    OpenProject::Deprecation.replaced :work_packages, :sorted_work_packages, caller
-
     work_package_scope
       .where(query.statement)
       .includes(all_includes)
       .joins(all_joins)
       .order(order_option)
       .references(:projects)
-  end
-
-  # Same as :work_packages, but returns a result sorted by the sort_criteria defined in the query.
-  # Note: It escapes me, why this is not the default behaviour.
-  # If there is a reason: This is a somewhat DRY way of using the sort criteria.
-  # If there is no reason: The :work_package method can die over time and be replaced by this one.
-  #
-  # TODO: Once the #work_packages method is removed, rename this to work_packages
-  def sorted_work_packages
-    work_packages.order(sort_criteria_array)
+      .order(sort_criteria_array)
   end
 
   def versions

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -51,7 +51,11 @@ class ::Query::Results
     raise ::Query::StatementInvalid.new(e.message)
   end
 
+  # This method is deprecated use sorted_work_packages instead
+  # noinspection Rails3Deprecated
   def work_packages
+    OpenProject::Deprecation.replaced :work_packages, :sorted_work_packages, caller
+
     work_package_scope
       .where(query.statement)
       .includes(all_includes)
@@ -64,6 +68,8 @@ class ::Query::Results
   # Note: It escapes me, why this is not the default behaviour.
   # If there is a reason: This is a somewhat DRY way of using the sort criteria.
   # If there is no reason: The :work_package method can die over time and be replaced by this one.
+  #
+  # TODO: Once the #work_packages method is removed, rename this to work_packages
   def sorted_work_packages
     work_packages.order(sort_criteria_array)
   end

--- a/app/models/query/sort_criteria.rb
+++ b/app/models/query/sort_criteria.rb
@@ -42,7 +42,7 @@ class ::Query::SortCriteria < ::SortHelper::SortCriteria
   # Building the query sort criteria needs to respect
   # specific options of the column
   def to_a
-    @criteria
+    criteria_with_default_order
       .map { |attribute, order| [find_column(attribute), @available_criteria[attribute], order] }
       .reject { |column, criterion, _| column.nil? || criterion.nil? }
       .map { |column, criterion, order| [column, execute_criterion(criterion), order] }
@@ -64,7 +64,7 @@ class ::Query::SortCriteria < ::SortHelper::SortCriteria
   def append_order(column, criterion, asc = true)
     ordered_criterion = append_direction(criterion, asc)
 
-    ordered_criterion.map { |statement| "#{statement} #{column.null_handling(asc)}" }
+    ordered_criterion.map { |statement| "#{statement} #{column.null_handling(asc)}".strip }
   end
 
   def execute_criterion(criteria)
@@ -74,6 +74,14 @@ class ::Query::SortCriteria < ::SortHelper::SortCriteria
       else
         criterion
       end
+    end
+  end
+
+  def criteria_with_default_order
+    if @criteria.none? { |attribute, _| attribute == 'id' }
+      @criteria + [['id', false]]
+    else
+      @criteria
     end
   end
 end

--- a/app/models/work_package/exporter/base.rb
+++ b/app/models/work_package/exporter/base.rb
@@ -73,7 +73,7 @@ class WorkPackage::Exporter::Base
   def work_packages
     @work_packages ||= query
                        .results
-                       .sorted_work_packages
+                       .work_packages
                        .page(page)
                        .per_page(Setting.work_packages_export_limit.to_i)
   end

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -55,7 +55,7 @@ module API
       private
 
       def results_to_representer(params)
-        results_scope = query.results.sorted_work_packages
+        results_scope = query.results.work_packages
 
         if scope
           results_scope = results_scope.where(id: scope.select(:id))

--- a/lib/deprecated_alias.rb
+++ b/lib/deprecated_alias.rb
@@ -29,7 +29,7 @@
 module DeprecatedAlias
   def deprecated_alias(old_method, new_method)
     define_method(old_method) do |*args, &block|
-      ActiveSupport::Deprecation.warn "#{old_method} is deprecated and will be removed in a future OpenProject version. Please use #{new_method} instead.", caller
+      OpenProject::Deprecation.replaced(old_method, new_method, caller)
       send(new_method, *args, &block)
     end
   end

--- a/lib/open_project/deprecation.rb
+++ b/lib/open_project/deprecation.rb
@@ -37,5 +37,9 @@ module OpenProject::Deprecation
     def deprecate_method(mod, method)
       deprecator.deprecate_methods(mod, method)
     end
+
+    def replaced(old_method, new_method, called_from)
+      ActiveSupport::Deprecation.warn "#{old_method} is deprecated and will be removed in a future OpenProject version. Please use #{new_method} instead.", called_from
+    end
   end
 end

--- a/modules/costs/spec/models/queries/time_entries/time_entry_query_spec.rb
+++ b/modules/costs/spec/models/queries/time_entries/time_entry_query_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe Queries::TimeEntries::TimeEntryQuery, type: :model do
   let(:user) { FactoryBot.build_stubbed(:user) }
-  let(:base_scope) { TimeEntry.visible(user) }
+  let(:base_scope) { TimeEntry.visible(user).order(id: :desc) }
   let(:instance) { described_class.new }
 
   before do
@@ -158,6 +158,15 @@ describe Queries::TimeEntries::TimeEntryQuery, type: :model do
       it 'is invalid if the filter is invalid' do
         instance.where('work_package_id', '=', [''])
         expect(instance).to be_invalid
+      end
+    end
+  end
+
+  context 'with an order by id asc' do
+    describe '#results' do
+      it 'returns all visible time entries ordered by id asc' do
+        expect(instance.order(id: :asc).results.to_sql)
+          .to eql base_scope.except(:order).order(id: :asc).to_sql
       end
     end
   end

--- a/modules/documents/spec/models/queries/documents/document_query_spec.rb
+++ b/modules/documents/spec/models/queries/documents/document_query_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe Queries::Documents::DocumentQuery, type: :model do
   let(:user) { FactoryBot.build_stubbed(:user) }
-  let(:base_scope) { Document.visible(user) }
+  let(:base_scope) { Document.visible(user).order(id: :desc) }
   let(:instance) { described_class.new }
 
   before do

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -218,7 +218,7 @@ describe WorkPackagesController, type: :controller do
             # Note: Stubs for methods used to build up the json query results.
             # TODO RS:  Clearly this isn't testing anything, but it all needs to be moved to an API controller anyway.
             allow(query).to receive(:results).and_return(results)
-            allow(results).to receive_message_chain(:sorted_work_packages, :page, :per_page).and_return(work_packages)
+            allow(results).to receive_message_chain(:work_packages, :page, :per_page).and_return(work_packages)
 
             expect(controller).to receive(:render_feed).with(work_packages, anything) do |*_args|
               # We need to render something because otherwise

--- a/spec/features/work_packages/table/hierarchy/hierarchy_spec.rb
+++ b/spec/features/work_packages/table/hierarchy/hierarchy_spec.rb
@@ -117,6 +117,7 @@ describe 'Work Package table hierarchy', js: true do
       query.column_names = ['subject', 'category']
       query.filters.clear
       query.show_hierarchies = false
+      query.sort_criteria = [['id', 'asc']]
 
       query.save!
       query

--- a/spec/models/queries/news/news_query_spec.rb
+++ b/spec/models/queries/news/news_query_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe Queries::News::NewsQuery, type: :model do
   let(:user) { FactoryBot.build_stubbed(:user) }
-  let(:base_scope) { News.visible(user) }
+  let(:base_scope) { News.visible(user).order(id: :desc) }
   let(:instance) { described_class.new }
 
   before do
@@ -71,6 +71,15 @@ describe Queries::News::NewsQuery, type: :model do
       it 'is invalid if the filter is invalid' do
         instance.where('project_id', '=', [''])
         expect(instance).to be_invalid
+      end
+    end
+  end
+
+  context 'with an order by id asc' do
+    describe '#results' do
+      it 'returns all visible news ordered by id asc' do
+        expect(instance.order(id: :asc).results.to_sql)
+          .to eql base_scope.except(:order).order(id: :asc).to_sql
       end
     end
   end

--- a/spec/models/queries/projects/project_query_spec.rb
+++ b/spec/models/queries/projects/project_query_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe Queries::Projects::ProjectQuery, type: :model do
   let(:instance) { described_class.new }
-  let(:base_scope) { Project.all }
+  let(:base_scope) { Project.all.order(id: :desc) }
   let(:current_user) { FactoryBot.build_stubbed(:admin) }
 
   before do
@@ -128,6 +128,15 @@ describe Queries::Projects::ProjectQuery, type: :model do
 
           expect(instance.results.to_sql).to eql expected.to_sql
         end
+      end
+    end
+  end
+
+  context 'with an order by id asc' do
+    describe '#results' do
+      it 'returns all visible projects ordered by id asc' do
+        expect(instance.order(id: :asc).results.to_sql)
+          .to eql base_scope.except(:order).order(id: :asc).to_sql
       end
     end
   end

--- a/spec/models/queries/queries/query_query_spec.rb
+++ b/spec/models/queries/queries/query_query_spec.rb
@@ -31,7 +31,7 @@ require 'spec_helper'
 describe Queries::Queries::QueryQuery, type: :model do
   let(:user) { FactoryBot.build_stubbed(:user) }
   let(:instance) { described_class.new(user: user) }
-  let(:base_scope) { Query.visible(to: user) }
+  let(:base_scope) { Query.visible(to: user).order(id: :desc) }
 
   context 'without a filter' do
     describe '#results' do

--- a/spec/models/queries/relations/relation_query_spec.rb
+++ b/spec/models/queries/relations/relation_query_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe Queries::Relations::RelationQuery, type: :model do
   let(:instance) { described_class.new }
-  let(:base_scope) { Relation.direct }
+  let(:base_scope) { Relation.direct.order(id: :desc) }
 
   context 'without a filter' do
     describe '#results' do
@@ -91,6 +91,15 @@ describe Queries::Relations::RelationQuery, type: :model do
                           .where("from_id IN ('1') AND to_id IN (#{visible_sql})"))
 
         expect(instance.results.to_sql).to eql expected.to_sql
+      end
+    end
+  end
+
+  context 'with an order by id asc' do
+    describe '#results' do
+      it 'returns all visible relations ordered by id asc' do
+        expect(instance.order(id: :asc).results.to_sql)
+          .to eql base_scope.visible.except(:order).order(id: :asc).to_sql
       end
     end
   end

--- a/spec/models/queries/users/user_query_spec.rb
+++ b/spec/models/queries/users/user_query_spec.rb
@@ -33,7 +33,7 @@ require 'system_user'
 
 describe Queries::Users::UserQuery, type: :model do
   let(:instance) { described_class.new }
-  let(:base_scope) { User.not_builtin }
+  let(:base_scope) { User.not_builtin.order(id: :desc) }
 
   context 'without a filter' do
     describe '#results' do
@@ -161,12 +161,12 @@ describe Queries::Users::UserQuery, type: :model do
 
   context 'with an id sortation' do
     before do
-      instance.order(id: :desc)
+      instance.order(id: :asc)
     end
 
     describe '#results' do
       it 'is the same as handwriting the query' do
-        expected = base_scope.merge(User.order(id: :desc))
+        expected = User.not_builtin.merge(User.order(id: :asc))
 
         expect(instance.results.to_sql).to eql expected.to_sql
       end
@@ -180,7 +180,7 @@ describe Queries::Users::UserQuery, type: :model do
 
     describe '#results' do
       it 'is the same as handwriting the query' do
-        expected = base_scope.merge(User.order_by_name.reverse_order)
+        expected = User.not_builtin.merge(User.order_by_name.reverse_order).order(id: :desc)
 
         expect(instance.results.to_sql).to eql expected.to_sql
       end
@@ -194,7 +194,7 @@ describe Queries::Users::UserQuery, type: :model do
 
     describe '#results' do
       it 'is the same as handwriting the query' do
-        expected = base_scope.merge(User.joins(:groups).order("groups_users.lastname DESC"))
+        expected = User.not_builtin.merge(User.joins(:groups).order("groups_users.lastname DESC")).order(id: :desc)
 
         expect(instance.results.to_sql).to eql expected.to_sql
       end

--- a/spec/models/queries/work_packages/manual_sorting_spec.rb
+++ b/spec/models/queries/work_packages/manual_sorting_spec.rb
@@ -83,8 +83,8 @@ describe Query, "manual sorting ", type: :model do
       query.sort_criteria = [[:manual_sorting, 'asc']]
       query2.sort_criteria = [[:manual_sorting, 'asc']]
 
-      expect(query.results.sorted_work_packages.pluck(:id)).to eq [wp_1.id, wp_2.id]
-      expect(query2.results.sorted_work_packages.pluck(:id)).to eq [wp_2.id, wp_1.id]
+      expect(query.results.work_packages.pluck(:id)).to eq [wp_1.id, wp_2.id]
+      expect(query2.results.work_packages.pluck(:id)).to eq [wp_2.id, wp_1.id]
     end
   end
 end

--- a/spec/models/query/results_cf_sorting_integration_spec.rb
+++ b/spec/models/query/results_cf_sorting_integration_spec.rb
@@ -83,7 +83,7 @@ describe ::Query::Results, 'Sorting of custom field floats', type: :model, with_
     let(:sort_criteria) { [["cf_#{custom_field.id}", 'asc']] }
 
     it 'returns the correctly sorted result' do
-      expect(query_results.sorted_work_packages.pluck(:id))
+      expect(query_results.work_packages.pluck(:id))
         .to match [work_package_without_float, work_package_with_float].map(&:id)
     end
   end
@@ -92,7 +92,7 @@ describe ::Query::Results, 'Sorting of custom field floats', type: :model, with_
     let(:sort_criteria) { [["cf_#{custom_field.id}", 'desc']] }
 
     it 'returns the correctly sorted result' do
-      expect(query_results.sorted_work_packages.pluck(:id))
+      expect(query_results.work_packages.pluck(:id))
         .to match [work_package_with_float, work_package_without_float].map(&:id)
     end
   end

--- a/spec/models/query/results_spec.rb
+++ b/spec/models/query/results_spec.rb
@@ -467,7 +467,7 @@ describe ::Query::Results, type: :model, with_mail: false do
     end
   end
 
-  describe '#sorted_work_packages' do
+  describe '#work_packages' do
     let(:work_package1) { FactoryBot.create(:work_package, project: project_1, id: 1) }
     let(:work_package2) { FactoryBot.create(:work_package, project: project_1, id: 2) }
     let(:work_package3) { FactoryBot.create(:work_package, project: project_1, id: 3) }
@@ -523,7 +523,7 @@ describe ::Query::Results, type: :model, with_mail: false do
         #   work_package 3
         # user_z
         #   work_package 2
-        expect(query_results.sorted_work_packages)
+        expect(query_results.work_packages)
           .to match [work_package1, work_package3, work_package2]
       end
     end
@@ -559,7 +559,7 @@ describe ::Query::Results, type: :model, with_mail: false do
         #   work_package 1
         # user_z
         #   work_package 2
-        expect(query_results.sorted_work_packages)
+        expect(query_results.work_packages)
           .to match [work_package3, work_package1, work_package2]
 
         query.sort_criteria = [['author', 'desc']]
@@ -571,7 +571,7 @@ describe ::Query::Results, type: :model, with_mail: false do
         #   work_package 3
         # user_z
         #   work_package 2
-        expect(query_results.sorted_work_packages)
+        expect(query_results.work_packages)
           .to match [work_package1, work_package3, work_package2]
       end
     end
@@ -594,12 +594,12 @@ describe ::Query::Results, type: :model, with_mail: false do
       it 'respects the sorting (Regression #29689)' do
         query.sort_criteria = [['priority', 'asc']]
 
-        expect(query_results.sorted_work_packages)
+        expect(query_results.work_packages)
           .to match [work_package1, work_package2]
 
         query.sort_criteria = [['priority', 'desc']]
 
-        expect(query_results.sorted_work_packages)
+        expect(query_results.work_packages)
           .to match [work_package2, work_package1]
       end
     end
@@ -622,12 +622,12 @@ describe ::Query::Results, type: :model, with_mail: false do
       it 'properly selects project_id (Regression #31667)' do
         query.sort_criteria = [['priority', 'asc']]
 
-        expect(query_results.sorted_work_packages)
+        expect(query_results.work_packages)
           .to match [work_package1, work_package2]
 
         query.sort_criteria = [['priority', 'desc']]
 
-        expect(query_results.sorted_work_packages)
+        expect(query_results.work_packages)
           .to match [work_package2, work_package1]
 
         group_count = query_results.work_package_count_by_group
@@ -670,7 +670,7 @@ describe ::Query::Results, type: :model, with_mail: false do
         #   work_package 1
         # user_z
         #   work_package 2
-        expect(query_results.sorted_work_packages)
+        expect(query_results.work_packages)
           .to match [work_package3, work_package1, work_package2]
 
         query.sort_criteria = [['author', 'desc'], ['responsible', 'asc']]
@@ -682,7 +682,7 @@ describe ::Query::Results, type: :model, with_mail: false do
         #   work_package 3
         # user_z
         #   work_package 2
-        expect(query_results.sorted_work_packages)
+        expect(query_results.work_packages)
           .to match [work_package1, work_package3, work_package2]
       end
     end

--- a/spec/models/query/results_version_integration_spec.rb
+++ b/spec/models/query/results_version_integration_spec.rb
@@ -119,7 +119,7 @@ describe ::Query::Results, 'Grouping and sorting for version', type: :model, wit
       expect(query_results.work_package_count_by_group)
         .to eql(old_version => 1, no_date_version => 1, new_version => 1, nil => 1)
 
-      expect(query_results.sorted_work_packages.pluck(:id))
+      expect(query_results.work_packages.pluck(:id))
         .to match work_packages_asc.map(&:id)
     end
   end
@@ -128,7 +128,7 @@ describe ::Query::Results, 'Grouping and sorting for version', type: :model, wit
     let(:sort_criteria) { [['version', 'asc']] }
 
     it 'returns the correctly sorted result' do
-      expect(query_results.sorted_work_packages.pluck(:id))
+      expect(query_results.work_packages.pluck(:id))
         .to match work_packages_asc.map(&:id)
     end
   end
@@ -140,7 +140,7 @@ describe ::Query::Results, 'Grouping and sorting for version', type: :model, wit
       # null values are still sorted last
       work_packages_order = [newest_version_wp, no_date_version_wp, oldest_version_wp, no_version_wp]
 
-      expect(query_results.sorted_work_packages.pluck(:id))
+      expect(query_results.work_packages.pluck(:id))
         .to match work_packages_order.map(&:id)
     end
   end

--- a/spec/models/query/sort_criteria_spec.rb
+++ b/spec/models/query/sort_criteria_spec.rb
@@ -45,47 +45,72 @@ describe ::Query::SortCriteria, type: :model do
   end
 
   describe 'ordered handling' do
+    context 'with an empty sort_criteria' do
+      let(:sort_criteria) { [] }
+
+      it 'returns the default order by id' do
+        expect(subject)
+          .to eq [['work_packages.id DESC']]
+      end
+    end
+
+    context 'with a sort_criteria for id' do
+      let(:sort_criteria) { [['id']] }
+
+      it 'returns the default order by id only once' do
+        expect(subject)
+          .to eq [['work_packages.id']]
+      end
+    end
+
+    context 'with a sort_criteria for id ASC' do
+      let(:sort_criteria) { [%w[id asc]] }
+
+      it 'returns the custom order by id asc' do
+        expect(subject)
+          .to eq [['work_packages.id']]
+      end
+    end
+
     context 'with sort_criteria with order handling and no order statement' do
       let(:sort_criteria) { [['start_date']] }
 
-      it 'adds the order handling' do
-        expect(subject.length).to eq 1
-        expect(subject.first).to eq ['work_packages.start_date NULLS LAST']
+      it 'adds the order handling (and the default order by id)' do
+        expect(subject)
+          .to eq [['work_packages.start_date NULLS LAST'], ['work_packages.id DESC']]
       end
     end
 
     context 'with sort_criteria with order handling and ASC order statement' do
-      let(:sort_criteria) { [['start_date', 'asc']] }
+      let(:sort_criteria) { [%w[start_date asc]] }
 
-      it 'adds the order handling' do
-        expect(subject.length).to eq 1
-        expect(subject.first).to eq ['work_packages.start_date NULLS LAST']
+      it 'adds the order handling (and the default order by id)' do
+        expect(subject)
+          .to eq [['work_packages.start_date NULLS LAST'], ['work_packages.id DESC']]
       end
     end
 
     context 'with sort_criteria with order handling and DESC order statement' do
-      let(:sort_criteria) { [['start_date', 'desc']] }
+      let(:sort_criteria) { [%w[start_date desc]] }
 
-      it 'adds the order handling' do
-        expect(subject.length).to eq 1
-        expect(subject.first).to eq ['work_packages.start_date DESC NULLS LAST']
+      it 'adds the order handling (and the default order by id)' do
+        expect(subject)
+          .to eq [['work_packages.start_date DESC NULLS LAST'], ['work_packages.id DESC']]
       end
     end
 
     context 'with multiple sort_criteria with order handling and misc order statement' do
-      let(:sort_criteria) { [['version', 'desc'], ['start_date', 'asc']] }
+      let(:sort_criteria) { [%w[version desc], %w[start_date asc]] }
 
-      it 'adds the order handling' do
-        expect(subject.length)
-          .to eq 2
-
+      it 'adds the order handling (and the default order by id)' do
         sort_sql = <<~SQL
           array_remove(regexp_split_to_array(regexp_replace(substring(versions.name from '^[^a-zA-Z]+'), '\\D+', ' ', 'g'), ' '), '')::int[]
         SQL
 
-        expect(subject.first)
-          .to eq ["#{sort_sql} DESC NULLS LAST", 'name DESC NULLS LAST']
-        expect(subject.last).to eq ['work_packages.start_date NULLS LAST']
+        expect(subject)
+          .to eq [["#{sort_sql} DESC NULLS LAST", 'name DESC NULLS LAST'],
+                  ['work_packages.start_date NULLS LAST'],
+                  ['work_packages.id DESC']]
       end
     end
   end

--- a/spec/requests/api/v3/user/user_resource_spec.rb
+++ b/spec/requests/api/v3/user/user_resource_spec.rb
@@ -44,7 +44,7 @@ describe 'API v3 User resource',
   subject(:response) { last_response }
 
   before do
-    allow(User).to receive(:current).and_return current_user
+    login_as(current_user)
   end
 
   describe '#index' do
@@ -87,7 +87,7 @@ describe 'API v3 User resource',
 
         it 'contains the current user in the response' do
           expect(subject.body)
-            .to be_json_eql(user.name.to_json)
+            .to be_json_eql(current_user.name.to_json)
             .at_path('_embedded/elements/0/name')
         end
       end

--- a/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
+++ b/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
@@ -45,7 +45,7 @@ describe ::API::V3::WorkPackageCollectionFromQueryService,
     results = double('results')
 
     allow(results)
-      .to receive(:sorted_work_packages)
+      .to receive(:work_packages)
       .and_return([work_package])
 
     allow(results)


### PR DESCRIPTION
Ensure a deterministic order for all queries (the generic `BaseQuery` used by e.g. `TimeEntry` and `News` as well as the specific `Query` used by `WorkPackages`) by appending an order by the id values. If there already exists an ordering by id, no additional order is added.

This is necessary to avoid duplicate entries being returned when paginating. In that case, a combination of `LIMIT` and `OFFSET` is executed in the database. But if rows are not ordered deterministically, either because they are not ordered at all or ordered by properties, that are shared between filter results (e.g. start_date or the position of a status), the DBMS determines the order of the rows. Even within the exact same running DBMS, the order can be different between different values for `LIMIT` and `OFFSET` so that rows might be returned on multiple result sets.

Fixes:
https://community.openproject.com/wp/33679   
https://community.openproject.com/wp/33328