### PR TITLE
move backlogs errors on work_packages to activerecord namespace

### DIFF
--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -45,19 +45,12 @@ en:
               can_only_contain_work_packages_of_current_sprint: "can only contain IDs of work packages in the current sprint."
               must_block_at_least_one_work_package: "must contain the ID of at least one ticket."
             parent_id:
+              parent_child_relationship_across_projects: "is invalid because the work package '%{work_package_name}' is a backlog task and therefore cannot have a parent outside of the current project."
               type_must_be_one_of_the_following: "Type must be one of the following: %{type_names}."
-        sprint:
-          cannot_end_before_it_starts: "Sprint cannot end before it starts."
-
-  activemodel:
-    errors:
-      models:
-        work_package:
-          attributes:
             version_id:
               task_version_must_be_the_same_as_story_version: "must be the same as the parent story's version."
-            parent_id:
-              parent_child_relationship_across_projects: "is invalid because the work package '%{work_package_name}' is a backlog task and therefore cannot have a parent outside of the current project."
+        sprint:
+          cannot_end_before_it_starts: "Sprint cannot end before it starts."
 
   backlogs:
     add_new_story: "New Story"


### PR DESCRIPTION
All errors for models reside in activerecord. The contracts where specifically amended to use that namespace.

Fixes the error details part of: https://community.openproject.com/wp/34298