### PR TITLE
close time entry modal on enter

### DIFF
--- a/frontend/src/app/modules/time_entries/create/create.modal.ts
+++ b/frontend/src/app/modules/time_entries/create/create.modal.ts
@@ -21,6 +21,7 @@ export class TimeEntryCreateModal extends TimeEntryBaseModal {
 
   public setModifiedEntry($event:{savedResource:HalResource, isInital:boolean}) {
     this.createdEntry = $event.savedResource as TimeEntryResource;
+    this.reloadWorkPackageAndClose();
   }
 
   public get saveText() {

--- a/frontend/src/app/modules/time_entries/edit/edit.modal.ts
+++ b/frontend/src/app/modules/time_entries/edit/edit.modal.ts
@@ -18,6 +18,7 @@ export class TimeEntryEditModal extends TimeEntryBaseModal {
 
   public setModifiedEntry($event:{savedResource:HalResource, isInital:boolean}) {
     this.modifiedEntry = $event.savedResource as TimeEntryResource;
+    this.reloadWorkPackageAndClose();
   }
 
   public get saveAllowed() {

--- a/frontend/src/app/modules/time_entries/shared/modal/base.modal.ts
+++ b/frontend/src/app/modules/time_entries/shared/modal/base.modal.ts
@@ -52,18 +52,7 @@ export abstract class TimeEntryBaseModal extends OpModalComponent {
     this.formInFlight = true;
 
     this.editForm.save()
-      .then(() => {
-        // reload workPackage
-        if (this.entry.workPackage) {
-          this
-            .apiV3Service
-            .work_packages
-            .id(this.entry.workPackage)
-            .refresh();
-        }
-        this.service.close();
-        this.formInFlight = false;
-      })
+      .then(() => this.reloadWorkPackageAndClose())
       .catch(() => this.formInFlight = false);
   }
 
@@ -77,5 +66,18 @@ export abstract class TimeEntryBaseModal extends OpModalComponent {
 
   public get deleteAllowed() {
     return true;
+  }
+
+  protected reloadWorkPackageAndClose() {
+    // reload workPackage
+    if (this.entry.workPackage) {
+      this
+        .apiV3Service
+        .work_packages
+        .id(this.entry.workPackage)
+        .refresh();
+    }
+    this.service.close();
+    this.formInFlight = false;
   }
 }

--- a/lib/api/decorators/schema_representer.rb
+++ b/lib/api/decorators/schema_representer.rb
@@ -359,7 +359,7 @@ module API
         attributes[:allowed_values_getter] = allowed_values_getter if allowed_values_getter
 
         representer = ::API::Decorators::AllowedValuesByCollectionRepresenter
-                      .new(attributes)
+                      .new(**attributes)
 
         if form_embedded
           representer.allowed_values = instance_exec(&values_callback)

--- a/lib/api/utilities/endpoints/bodied.rb
+++ b/lib/api/utilities/endpoints/bodied.rb
@@ -91,7 +91,7 @@ module API
 
           process_service
             .new(**args.compact)
-            .call(params)
+            .call(**params)
         end
 
         def render(current_user, call)

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -86,7 +86,7 @@ module API
           def initialize(schema, self_link, context)
             @base_schema_link = context.delete(:base_schema_link) || nil
             @show_lock_version = !context.delete(:hide_lock_version)
-            super(schema, self_link, context)
+            super(schema, self_link, **context)
           end
 
           link :baseSchema do

--- a/lib/open_project/journal_formatter/diff.rb
+++ b/lib/open_project/journal_formatter/diff.rb
@@ -54,11 +54,11 @@ class OpenProject::JournalFormatter::Diff < JournalFormatter::Base
     label = label(key, options[:no_html])
 
     if value.blank?
-      l(:text_journal_deleted_with_diff, label: label, link: link)
+      I18n.t(:text_journal_deleted_with_diff, label: label, link: link)
     elsif old_value.present?
-      l(:text_journal_changed_with_diff, label: label, link: link)
+      I18n.t(:text_journal_changed_with_diff, label: label, link: link)
     else
-      l(:text_journal_set_with_diff, label: label, link: link)
+      I18n.t(:text_journal_set_with_diff, label: label, link: link)
     end
   end
 

--- a/lib/plugins/acts_as_journalized/lib/journal_formatter/base.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_formatter/base.rb
@@ -87,9 +87,9 @@ module JournalFormatter
 
     def render_binary_detail_text(label, value, old_value)
       if value.blank?
-        l(:text_journal_deleted, label: label, old: old_value)
+        I18n.t(:text_journal_deleted, label: label, old: old_value)
       else
-        l(:text_journal_added, label: label, value: value)
+        I18n.t(:text_journal_added, label: label, value: value)
       end
     end
   end

--- a/lib/redmine/i18n.rb
+++ b/lib/redmine/i18n.rb
@@ -54,7 +54,7 @@ module Redmine
         ::I18n.t(*args)
       when 2
         if args.last.is_a?(Hash)
-          ::I18n.t(*args)
+          ::I18n.t(args.first, **args.last)
         elsif args.last.is_a?(String)
           ::I18n.t(args.first, value: args.last)
         else

--- a/spec/features/work_packages/table/queries/query_name_inline_edit_spec.rb
+++ b/spec/features/work_packages/table/queries/query_name_inline_edit_spec.rb
@@ -90,6 +90,10 @@ describe 'Query name inline edit', js: true do
     # Expect unchanged
     query_title.expect_not_changed
 
+    # TODO: The notification should actually not be shown at all since no update
+    # has taken place
+    wp_table.expect_and_dismiss_notification message: 'Successful update.'
+
     assignee_query.reload
     expect(assignee_query.filters.count).to eq(1)
     expect(assignee_query.filters.first.name).to eq :status_id
@@ -100,7 +104,7 @@ describe 'Query name inline edit', js: true do
 
     # Rename query
     query_title.rename 'Not my assignee query'
-    wp_table.expect_notification message: 'Successful update.'
+    wp_table.expect_and_dismiss_notification message: 'Successful update.'
 
     assignee_query.reload
     expect(assignee_query.name).to eq 'Not my assignee query'
@@ -112,7 +116,7 @@ describe 'Query name inline edit', js: true do
     page.driver.browser.switch_to.active_element.send_keys('Some other name')
     page.driver.browser.switch_to.active_element.send_keys(:return)
 
-    wp_table.expect_notification message: 'Successful update.'
+    wp_table.expect_and_dismiss_notification message: 'Successful update.'
 
     assignee_query.reload
     expect(assignee_query.name).to eq 'Some other name'


### PR DESCRIPTION
As the time entry is saved anyway once the user saves the form, e.g. by pressing enter in the hours field, we can close the whole modal along with it. The "Save" and "Cancel" buttons do not make sense then anymore

This is done instead of presenting the updated hours value as proposed in https://community.openproject.com/wp/34130. It is easier to implement and as state above, the buttons do not reflect the already saved state of the time entry anyway. 