### PR TITLE
[33677] Let boolean CF filters be kind of BooleanFilter

### DIFF
--- a/app/models/queries/filters/shared/custom_fields/bool.rb
+++ b/app/models/queries/filters/shared/custom_fields/bool.rb
@@ -33,22 +33,7 @@ require_relative 'base'
 module Queries::Filters::Shared
   module CustomFields
     class Bool < Base
-      def allowed_values
-        [
-          [I18n.t(:general_text_yes), OpenProject::Database::DB_VALUE_TRUE],
-          [I18n.t(:general_text_no), OpenProject::Database::DB_VALUE_FALSE]
-        ]
-      end
-
-      def type
-        :list
-      end
-
-      protected
-
-      def type_strategy_class
-        ::Queries::Filters::Strategies::BooleanList
-      end
+      include Queries::Filters::Shared::BooleanFilter
     end
   end
 end


### PR DESCRIPTION
We detect boolean filters based on that mixin class as there is no generic way to find out what is a boolean filter.

The CF boolean filters duplicated the behavior of  `::Queries::Filters::Strategies::BooleanList` but did not include it.

https://community.openproject.com/wp/33677