### PR TITLE
fix touching the customizable on removing custom_values

### DIFF
--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -90,42 +90,15 @@ module Redmine
           return unless values.is_a?(Hash) && values.any?
 
           values.with_indifferent_access.each do |custom_field_id, val|
-            existing_custom_values = custom_values_for_custom_field id: custom_field_id
-            new_values = Array(val)
+            existing_cv_by_value = custom_values_for_custom_field(id: custom_field_id)
+                                     .group_by(&:value)
+                                     .transform_values(&:first)
+            new_values = Array(val).map { |v| v.respond_to?(:id) ? v.id.to_s : v.to_s }
 
-            unless existing_custom_values.empty?
-              assign_new_values! custom_field_id, existing_custom_values, new_values
-              delete_obsolete_custom_values! existing_custom_values, new_values
-            end
-          end
-        end
-
-        def assign_new_values!(custom_field_id, existing_custom_values, new_values)
-          new_values.flatten.zip(existing_custom_values).each do |new_value, custom_value|
-            if custom_value.nil?
-              new_custom_value = custom_values.build(
-                customized: self, custom_field_id: custom_field_id, value: new_value
-              )
-
-              custom_field_values.push(new_custom_value)
-            else
-              custom_value.value = new_value
-            end
-          end
-        end
-
-        def delete_obsolete_custom_values!(existing_custom_values, new_values)
-          existing_custom_values.zip(new_values).each_with_index do |(custom_value, new_value), i|
-            if new_value.nil?
-              if i.zero?
-                # leave the first value but set it to nil as that's the behaviour expected
-                # by the original acts_as_customizable
-                custom_value.value = nil
-              else
-                custom_value.destroy
-                custom_field_values.delete custom_value
-                custom_values.delete custom_value
-              end
+            if existing_cv_by_value.any?
+              assign_new_values custom_field_id, existing_cv_by_value, new_values
+              delete_obsolete_custom_values existing_cv_by_value, new_values
+              handle_minimum_custom_value custom_field_id, existing_cv_by_value, new_values
             end
           end
         end
@@ -198,12 +171,19 @@ module Redmine
           self.custom_values = custom_field_values
         end
 
+        def reload(*args)
+          reset_custom_values_change_tracker
+
+          super
+        end
+
         def reset_custom_values_change_tracker
           @custom_field_values = nil
+          self.custom_value_destroyed = false
         end
 
         def reset_custom_values!
-          @custom_field_values = nil
+          reset_custom_values_change_tracker
           custom_values.each { |cv| cv.destroy unless custom_field_values.include?(cv) }
         end
 
@@ -271,6 +251,10 @@ module Redmine
           end
         end
 
+        protected
+
+        attr_accessor :custom_value_destroyed
+
         private
 
         def for_custom_field_accessor(method_symbol)
@@ -314,8 +298,54 @@ module Redmine
           end
         end
 
+        # Explicitly touch the customizable if
+        # there where only changes to custom_values (added or removed).
+        # Particularly important for caching.
         def touch_customizable
-          touch if !saved_changes? && custom_values.loaded? && custom_values.any?(&:saved_changes?)
+          touch if !saved_changes? && custom_values.loaded? && (custom_values.any?(&:saved_changes?) || custom_value_destroyed)
+        end
+
+        def assign_new_values(custom_field_id, existing_cv_by_value, new_values)
+          (new_values - existing_cv_by_value.keys).each do |new_value|
+            add_custom_value(custom_field_id, new_value)
+          end
+        end
+
+        def delete_obsolete_custom_values(existing_cv_by_value, new_values)
+          (existing_cv_by_value.keys - new_values).each do |obsolete_value|
+            next if obsolete_value.nil?
+
+            custom_value = existing_cv_by_value[obsolete_value]
+
+            remove_custom_value(custom_value)
+          end
+        end
+
+        # The original acts_as_customizable ensured to always have a custom value
+        # for every custom field. If no value was set, the custom value would have the value of nil
+        def handle_minimum_custom_value(custom_field_id, existing_cv_by_value, new_values)
+          nil_value = existing_cv_by_value[nil]
+
+          if new_values.any?
+            remove_custom_value(nil_value)
+          elsif nil_value.nil?
+            add_custom_value(custom_field_id, nil)
+          end
+        end
+
+        def add_custom_value(custom_field_id, value)
+          new_custom_value = custom_values.build(custom_field_id: custom_field_id,
+                                                 value: value)
+
+          custom_field_values.push(new_custom_value)
+        end
+
+        def remove_custom_value(custom_value)
+          return unless custom_value
+
+          custom_value.mark_for_destruction
+          custom_field_values.delete custom_value
+          self.custom_value_destroyed = true
         end
 
         module ClassMethods

--- a/spec/features/custom_fields/multi_value_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_value_custom_field_spec.rb
@@ -141,6 +141,8 @@ describe "multi select custom values", clear_cache: true, js: true do
 
         wp1_field.submit_by_dashboard
 
+        wp_page.expect_and_dismiss_notification message: 'Successful update'
+
         # Expect changed groups
         expect(page).to have_selector('.group--value .count', count: 1)
         expect(page).to have_selector('.group--value', text: 'ham (2)')
@@ -152,6 +154,8 @@ describe "multi select custom values", clear_cache: true, js: true do
         field.activate!
         field.unset_value "ham", true
         field.submit_by_dashboard
+
+        wp_page.expect_and_dismiss_notification message: 'Successful update'
 
         # Expect none selected in split and table
         field.expect_state_text '-'

--- a/spec/models/work_package/work_package_multi_value_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_multi_value_custom_fields_spec.rb
@@ -44,9 +44,11 @@ describe WorkPackage, type: :model do
   end
 
   let(:custom_values) do
-    ["ham", "onions", "pineapple"].map do |str|
-      custom_field.custom_options.find { |co| co.value == str }.try(:id)
-    end
+    custom_field
+      .custom_options
+      .where(value: ["ham", "onions", "pineapple"])
+      .pluck(:id)
+      .map(&:to_s)
   end
 
   let(:work_package) do
@@ -63,7 +65,7 @@ describe WorkPackage, type: :model do
   let(:typed_values) { work_package.typed_custom_value_for(custom_field.id) }
 
   it 'returns the properly typed values' do
-    expect(values.map { |cv| cv.value.to_i }).to eq(custom_values)
+    expect(values.map { |cv| cv.value }).to eq(custom_values)
     expect(typed_values).to eq(%w(ham onions pineapple))
   end
 
@@ -73,6 +75,65 @@ describe WorkPackage, type: :model do
     it 'returns nil properly' do
       expect(values).to eq(nil)
       expect(typed_values).to eq(nil)
+    end
+  end
+
+  describe 'setting and reading values' do
+    shared_examples_for 'custom field values updates' do
+      before do
+        # Reload to reset i.e. the saved_changes filter on custom_values
+        work_package.reload
+      end
+
+      it 'touches the work_package' do
+        expect do
+          work_package.custom_field_values = { custom_field.id => ids }
+          work_package.save
+        end
+          .to(change { work_package.lock_version })
+      end
+
+      it 'sets the values' do
+        work_package.custom_field_values = { custom_field.id => ids }
+        work_package.save
+
+        expect(work_package.send("custom_field_#{custom_field.id}"))
+          .to eql values
+      end
+    end
+
+    context 'when removing some custom values' do
+      it_behaves_like 'custom field values updates' do
+        let(:ids) { [custom_values.first.to_s] }
+        let(:values) { ['ham'] }
+      end
+    end
+
+    context 'when removing all custom values' do
+      it_behaves_like 'custom field values updates' do
+        let(:ids) { [] }
+        let(:values) { [nil] }
+      end
+    end
+
+    context 'when adding values' do
+      it_behaves_like 'custom field values updates' do
+        let(:ids) do
+          CustomOption.where(value: ["ham", "onions", "pineapple", "mushrooms"]).pluck(:id).map(&:to_s)
+        end
+        let(:values) { ["ham", "onions", "pineapple", "mushrooms"] }
+      end
+    end
+
+    context 'when first having no values and then adding some' do
+      let(:custom_values) { [] }
+
+      it_behaves_like 'custom field values updates' do
+        let(:ids) do
+          CustomOption.where(value: ["ham", "mushrooms"]).pluck(:id).map(&:to_s)
+        end
+        let(:values) { ["ham", "mushrooms"] }
+      end
     end
   end
 end


### PR DESCRIPTION
Before the commit, the existing custom_values where attempted to be
reused but there was no deterministic behaviour with which reusing them
was attempted. Additionally, the existing values where always changed
(or they would receive the current value again) whenever values where
provided, regardless of whether those values actually changes. There
was no explicit flag that a value was removed.

This poses a couple of problems:
* Even if no new values where provided the order of the custom values as
  stored in the db might change leading to journal entries that where
  not actually caused by the user.
* If values where only removed, due to the missing
  explicit removal flag, it became luck whether an existing custom
  value was actually changed. Only then would the customized object be
  touched leading to an update of cached fragments, i.e. representers.
* Because the values where updated all the time, the performance would
  suffer.
* Removed custom values where removed right away and not only after
  save.

This commit introduces an explicit flag for removal and does not alter
existing custom values. This might have the drawback of creating a
custom value even when a value, chosen to be removed by the user, could
be reused but this should be negligible.

It also has the drawback of introducing a flag to be maintained.

This fixes the notoriously flickering 

`rspec ./spec/features/custom_fields/multi_value_custom_field_spec.rb:119`

on my machine which, as it turns out, was failing correctly after all.