### PR TITLE
Fix/backlogs error messages

### DIFF
--- a/frontend/src/app/modules/backlogs/backlogs-page/styles/master_backlog.sass
+++ b/frontend/src/app/modules/backlogs/backlogs-page/styles/master_backlog.sass
@@ -63,8 +63,19 @@
  *any elements
  */
 
-.controller-rb_master_backlogs.action-index #content
-  padding-bottom: 180px
+.controller-rb_master_backlogs
+  .action-index #content
+    padding-bottom: 180px
+
+  .ui-dialog
+    background: #FFFFFF
+    border: 1px solid #E4E4E4
+
+/* Hide the close button since we do no longer include the necessary image for the close icon
+.controller-rb_master_backlogs,
+.controller-rb_taskboards
+  .ui-dialog-titlebar-close
+    display: none
 
 #rb
   #backlogs_container .backlog .header

--- a/modules/backlogs/app/controllers/rb_impediments_controller.rb
+++ b/modules/backlogs/app/controllers/rb_impediments_controller.rb
@@ -54,7 +54,7 @@ class RbImpedimentsController < RbApplicationController
     @include_meta = true
 
     respond_to do |format|
-      format.html { render partial: 'impediment', object: @impediment, status: status }
+      format.html { render partial: 'impediment', object: @impediment, status: status, locals: { errors: call.errors } }
     end
   end
 

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -68,7 +68,7 @@ class RbStoriesController < RbApplicationController
     story = call.result
 
     respond_to do |format|
-      format.html { render partial: 'story', object: story, status: status }
+      format.html { render partial: 'story', object: story, status: status, locals: { errors: call.errors } }
     end
   end
 

--- a/modules/backlogs/app/controllers/rb_tasks_controller.rb
+++ b/modules/backlogs/app/controllers/rb_tasks_controller.rb
@@ -60,7 +60,7 @@ class RbTasksController < RbApplicationController
     @include_meta = true
 
     respond_to do |format|
-      format.html { render partial: 'task', object: @task, status: status }
+      format.html { render partial: 'task', object: @task, status: status, locals: { errors: call.errors } }
     end
   end
 

--- a/modules/backlogs/app/views/rb_impediments/_impediment.html.erb
+++ b/modules/backlogs/app/views/rb_impediments/_impediment.html.erb
@@ -44,6 +44,6 @@ See docs/COPYRIGHT.rdoc for more details.
   <div class="meta">
     <div class="story_id"><%= impediment.parent_id %></div>
     <div class="status_id"><%= impediment.status_id %></div>
-    <%= render :partial => "shared/model_errors", :object => impediment.errors %>
+    <%= render(:partial => "shared/model_errors", :object => errors) if defined?(errors) && errors.size > 0 %>
   </div>
 </div>

--- a/modules/backlogs/app/views/rb_stories/_story.html.erb
+++ b/modules/backlogs/app/views/rb_stories/_story.html.erb
@@ -45,6 +45,6 @@ See docs/COPYRIGHT.rdoc for more details.
   <div class="version_id"><%= story.version_id %></div>
   <div class="higher_item_id"><%= !defined?(higher_item) || higher_item.nil? ? '' : higher_item.id %></div>
   <div class="meta">
-    <%= render(:partial => "shared/model_errors", :object => story.errors) if story.errors.size > 0 %>
+    <%= render(:partial => "shared/model_errors", :object => errors) if defined?(errors) && errors.size > 0 %>
   </div>
 </li>

--- a/modules/backlogs/app/views/rb_tasks/_task.html.erb
+++ b/modules/backlogs/app/views/rb_tasks/_task.html.erb
@@ -43,6 +43,6 @@ See docs/COPYRIGHT.rdoc for more details.
   <div class="meta">
     <div class="story_id"><%= task.parent_id %></div>
     <div class="status_id"><%= task.status_id %></div>
-    <%= render :partial => "shared/model_errors", :object => task.errors %>
+    <%= render(:partial => "shared/model_errors", :object => errors) if defined?(errors) && errors.size > 0 %>
   </div>
 </div>


### PR DESCRIPTION
Uses the contract's error messages instead of the model's. That way, errors set in the contract are displayed.

Also duct tapes the backlogs modals (jquery ui modal) so that it looks bearable again without investing a lot.

https://community.openproject.com/wp/34345