### PR TITLE
allow me id in principal filter

### DIFF
--- a/app/models/queries/members/filters/principal_filter.rb
+++ b/app/models/queries/members/filters/principal_filter.rb
@@ -35,7 +35,7 @@ class Queries::Members::Filters::PrincipalFilter < Queries::Members::Filters::Me
     @allowed_values ||= begin
       values = Principal
                .active_or_registered
-               .in_visible_project
+               .in_visible_project_or_me
                .map { |s| [s.name, s.id.to_s] }
                .sort
 

--- a/spec/models/queries/members/filters/principal_filter_spec.rb
+++ b/spec/models/queries/members/filters/principal_filter_spec.rb
@@ -45,7 +45,7 @@ describe Queries::Members::Filters::PrincipalFilter, type: :model do
       .and_return(principal_scope)
 
     allow(principal_scope)
-      .to receive(:in_visible_project)
+      .to receive(:in_visible_project_or_me)
       .and_return([user, group, current_user])
   end
 


### PR DESCRIPTION
The magic me value has been allowed the whole time but the equivalent id of the current user was not.

https://community.openproject.com/projects/openproject/work_packages/34108