### PR TITLE
Improve wording of titles and buttons on BCF module.

### DIFF
--- a/frontend/src/app/modules/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
@@ -39,7 +39,7 @@ import {ViewerBridgeService} from "core-app/modules/bim/bcf/bcf-viewer-bridge/vi
 export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent {
 
   text = {
-    title: this.I18n.t('js.ifc_models.models.default'),
+    title: this.I18n.t('js.bcf.management'),
     delete: this.I18n.t('js.button_delete'),
     edit: this.I18n.t('js.button_edit'),
     areYouSure: this.I18n.t('js.text_are_you_sure')
@@ -134,10 +134,8 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent {
   updateTitle(query?:QueryResource) {
     if (this.bimView.current === bimListViewIdentifier) {
       super.updateTitle(query);
-    } else if (this.ifcData.isSingleModel()) {
-      this.selectedTitle = this.ifcData.models[0].name;
     } else {
-      this.selectedTitle = this.I18n.t('js.ifc_models.models.default');
+      this.selectedTitle = this.I18n.t('js.bcf.management');
     }
 
     // For now, disable any editing

--- a/frontend/src/app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component.ts
@@ -40,7 +40,7 @@ import {OpModalService} from "core-components/op-modals/op-modal.service";
 
 @Component({
   template: `
-    <a [title]="text.export"
+    <a [title]="text.export_hover"
        class="button export-bcf-button"
        [attr.href]="exportLink"
        (click)="showDelayedExport($event)">
@@ -52,7 +52,8 @@ import {OpModalService} from "core-components/op-modals/op-modal.service";
 })
 export class BcfExportButtonComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
   public text = {
-    export: this.I18n.t('js.bcf.export')
+    export: this.I18n.t('js.bcf.export'),
+    export_hover: this.I18n.t('js.bcf.export_bcf_xml_file')
   };
   public query:QueryResource;
   public exportLink:string;

--- a/frontend/src/app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component.ts
@@ -33,7 +33,9 @@ import {BcfPathHelperService} from "core-app/modules/bim/bcf/helper/bcf-path-hel
 
 @Component({
   template: `
-    <a [title]="text.import" class="button import-bcf-button" (click)="handleClick()">
+    <a [title]="text.import_hover"
+      (click)="handleClick()"
+      class="button import-bcf-button">
       <op-icon icon-classes="button--icon icon-import"></op-icon>
       <span class="button--text"> {{text.import}} </span>
     </a>
@@ -42,7 +44,8 @@ import {BcfPathHelperService} from "core-app/modules/bim/bcf/helper/bcf-path-hel
 })
 export class BcfImportButtonComponent {
   public text = {
-    import: this.I18n.t('js.bcf.import')
+    import: this.I18n.t('js.bcf.import'),
+    import_hover: this.I18n.t('js.bcf.import_bcf_xml_file')
   };
 
   constructor(readonly I18n:I18nService,

--- a/frontend/src/app/modules/bim/ifc_models/toolbar/manage-ifc-models-button/bim-manage-ifc-models-button.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/toolbar/manage-ifc-models-button/bim-manage-ifc-models-button.component.ts
@@ -49,7 +49,7 @@ import {IfcModelsDataService} from "core-app/modules/bim/ifc_models/pages/viewer
 export class BimManageIfcModelsButtonComponent {
 
   text = {
-    manage: this.I18n.t('js.ifc_models.models.manage'),
+    manage: this.I18n.t('js.ifc_models.models.ifc_models'),
   };
 
   manageAllowed = this.ifcData.allowed('manage_ifc_models');

--- a/modules/bim/config/locales/js-en.yml
+++ b/modules/bim/config/locales/js-en.yml
@@ -4,18 +4,20 @@ en:
     bcf:
       label_bcf: 'BCF'
       import: 'Import'
+      import_bcf_xml_file: 'Import BCF XML file (BCF version 2.1)'
       export: 'Export'
+      export_bcf_xml_file: 'Export BCF XML file (BCF version 2.1)'
       viewpoint: 'Viewpoint'
       add_viewpoint: 'Add viewpoint'
       show_viewpoint: 'Show viewpoint'
       delete_viewpoint: 'Delete viewpoint'
+      management: 'BCF management'
     ifc_models:
       empty_warning: "This project does not yet have any IFC models."
       use_this_link_to_manage: "Use this link to upload and manage your IFC models"
       keyboard_input_disabled: "Viewer does not have keyboard controls. Click on the viewer to give keyboard control to the viewer."
       models:
-        default: 'Default IFC models'
-        manage: 'Manage models'
+        ifc_models: 'IFC models'
       views:
         viewer: 'Viewer'
         split: 'Viewer and table'

--- a/modules/bim/spec/support/pages/ifc_models/show_default.rb
+++ b/modules/bim/spec/support/pages/ifc_models/show_default.rb
@@ -96,7 +96,7 @@ module Pages
       private
 
       def toolbar_items
-        ['Manage models']
+        ['IFC models']
       end
 
       def create_page_class_instance(type)


### PR DESCRIPTION
Renaming
- Button with gear box icon "Manage models" to "IFC models"
- Title "Default models" to "BCF management" as most users don't think about default or not. And it confuses the meaning of the "Import" and "Export" buttons, as they seem to refer to IFC models. But they refer to BCFs.
- Also remove the feature to set the title when a specific model is opened (via URL). The feature was broken and did not add a real value. So I decided to remove it.