### PR TITLE
[34253] Fix positioning of datepicker

### DIFF
--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -30,7 +30,7 @@ $datepicker--border-radius: 2px
 $datepicker--line-height:   28px
 $datepicker--hover-color:   #DDDDDD
 
-.flatpickr-calendar
+.flatpickr-calendar.inline
   width: initial !important
   top: 0 !important
   margin: 0 1.5rem


### PR DESCRIPTION
https://github.com/opf/openproject/pull/8579 styled the datepicker for the inline work package datepickers that are inline (rendered beneath the field). There, some styles were set such as margin and top that do not make sense in the default global datepicker

https://community.openproject.com/wp/34253