### PR TITLE
Fix/budget visibility on work package

### DIFF
--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -284,7 +284,7 @@ module API
                                            }
                                          },
                                          show_if: ->(*) {
-                                           represented.project&.module_enabled?(:budgets)
+                                           current_user_allowed_to(:view_budgets, context: represented.project)
                                          }
 
           def attribute_groups

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -160,7 +160,10 @@ module API
           schema :spent_time,
                  type: 'Duration',
                  required: false,
-                 show_if: ->(*) { represented.project&.module_enabled?('costs') }
+                 show_if: ->(*) {
+                   current_user_allowed_to(:view_time_entries, context: represented.project) ||
+                     current_user_allowed_to(:view_own_time_entries, context: represented.project)
+                 }
 
           schema :percentage_done,
                  type: 'Integer',

--- a/modules/budgets/lib/api/v3/budgets/budgets_api.rb
+++ b/modules/budgets/lib/api/v3/budgets/budgets_api.rb
@@ -37,7 +37,7 @@ module API
             after_validation do
               @budget = Budget.find(params[:id])
 
-              authorize_any(%i[view_work_packages view_budgets], projects: @budget.project)
+              authorize(:view_budgets, context: @budget.project)
             end
 
             get do

--- a/modules/budgets/lib/api/v3/budgets/budgets_by_project_api.rb
+++ b/modules/budgets/lib/api/v3/budgets/budgets_by_project_api.rb
@@ -34,7 +34,7 @@ module API
       class BudgetsByProjectAPI < ::API::OpenProjectAPI
         resources :budgets do
           after_validation do
-            authorize_any(%i[view_work_packages view_budgets], projects: @project)
+            authorize(:view_budgets, context: @project)
             @budgets = @project.budgets
           end
 

--- a/modules/budgets/spec/requests/api/v3/budgets/budget_resource_spec.rb
+++ b/modules/budgets/spec/requests/api/v3/budgets/budget_resource_spec.rb
@@ -37,7 +37,7 @@ describe 'API v3 Budget resource' do
   let(:current_user) do
     FactoryBot.create(:user,
                       member_in_project: project,
-                      member_with_permissions: [:view_work_packages])
+                      member_with_permissions: [:view_budgets])
   end
   subject(:response) { last_response }
 

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -548,12 +548,8 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     describe 'spentTime' do
-      context 'with \'costs\' enabled' do
-        before do
-          allow(project)
-            .to receive(:module_enabled?)
-            .and_return(true)
-        end
+      context 'with the view_time_entries permission' do
+        let(:permissions) { %i[edit_work_packages view_time_entries] }
 
         it_behaves_like 'has basic schema properties' do
           let(:path) { 'spentTime' }
@@ -564,15 +560,20 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         end
       end
 
-      context 'with \'costs\' disabled' do
-        before do
-          allow(project)
-            .to receive(:module_enabled?) do |name|
-            name != 'costs'
-          end
-        end
+      context 'with the view_own_time_entries permission' do
+        let(:permissions) { %i[edit_work_packages view_own_time_entries] }
 
-        it 'has no date attribute' do
+        it_behaves_like 'has basic schema properties' do
+          let(:path) { 'spentTime' }
+          let(:type) { 'Duration' }
+          let(:name) { I18n.t('activerecord.attributes.work_package.spent_time') }
+          let(:required) { false }
+          let(:writable) { false }
+        end
+      end
+
+      context 'without any view time_entries permission' do
+        it 'has no spentTime attribute' do
           is_expected.to_not have_json_path('spentTime')
         end
       end

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -916,28 +916,25 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     describe 'budget' do
-      it_behaves_like 'has basic schema properties' do
-        let(:path) { 'budget' }
-        let(:type) { 'Budget' }
-        let(:name) { I18n.t('attributes.budget') }
-        let(:required) { false }
-        let(:writable) { true }
-      end
+      context 'user allowed to view_budgets' do
+        let(:permissions) { %i[edit_work_packages view_budgets] }
 
-      it_behaves_like 'has a collection of allowed values' do
-        let(:json_path) { 'budget' }
-        let(:href_path) { 'budgets' }
-        let(:factory) { :budget }
-      end
-
-      context 'budgets disabled' do
-        before do
-          allow(schema.project)
-            .to receive(:module_enabled?)
-            .with(:budgets)
-            .and_return(false)
+        it_behaves_like 'has basic schema properties' do
+          let(:path) { 'budget' }
+          let(:type) { 'Budget' }
+          let(:name) { I18n.t('attributes.budget') }
+          let(:required) { false }
+          let(:writable) { true }
         end
 
+        it_behaves_like 'has a collection of allowed values' do
+          let(:json_path) { 'budget' }
+          let(:href_path) { 'budgets' }
+          let(:factory) { :budget }
+        end
+      end
+
+      context 'user not allowed to view_budgets' do
         it 'has no schema for budget' do
           is_expected.not_to have_json_path('budget')
         end


### PR DESCRIPTION
Before the fix, :view_work_packages also gave the user the permission to view budgets. Now, the specific permission :view bugdets is imployed. In effect, a user without the view_budgets permission but with the :view_work_packages permission will see the work package without the budget property displayed.

The PR also addresses the spentTime property which suffered from a similar problem. The code would only check whether the `costs` module was activated. However, there was not information leak here, as the permission checks on aggregating the spent_time took the permissions into account properly. 

https://community.openproject.com/wp/33981