### PR TITLE
Fix: Remove default values for BCF timestamps.

### DIFF
--- a/db/migrate/20200914092212_set_current_timestamp_defaults_for_bcf_viewpoints_and_issues.rb
+++ b/db/migrate/20200914092212_set_current_timestamp_defaults_for_bcf_viewpoints_and_issues.rb
@@ -1,0 +1,12 @@
+class SetCurrentTimestampDefaultsForBcfViewpointsAndIssues < ActiveRecord::Migration[6.0]
+  def up
+    change_column_default(:bcf_issues, :created_at, -> { 'CURRENT_TIMESTAMP' })
+    change_column_default(:bcf_issues, :updated_at, -> { 'CURRENT_TIMESTAMP' })
+    change_column_default(:bcf_viewpoints, :created_at, -> { 'CURRENT_TIMESTAMP' })
+    change_column_default(:bcf_viewpoints, :updated_at, -> { 'CURRENT_TIMESTAMP' })
+  end
+
+  def down
+    # Nothing to do.
+  end
+end


### PR DESCRIPTION
The default values broke the ActiveRecord timestamp logic. AR did
not set the timestamp values with the real creation date time. Instead it left
the default values that were defined on DB level. The result was that all new BCF issues or viewpoints had identical timestamps.

This PR removes the default values from DB level.

Part of https://community.openproject.com/wp/34366