### PR TITLE
set the default value for newly build custom values

### DIFF
--- a/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -112,9 +112,9 @@ module Redmine
             existing_cvs = custom_values.select { |v| v.custom_field_id == custom_field.id }
 
             if existing_cvs.empty?
-              new_value = custom_values.build(
-                customized: self, custom_field: custom_field, value: nil
-              )
+              new_value = custom_values.build(customized: self,
+                                              custom_field: custom_field,
+                                              value: custom_field.default_value)
               existing_cvs.push new_value
             end
 
@@ -187,6 +187,11 @@ module Redmine
           custom_values.each { |cv| cv.destroy unless custom_field_values.include?(cv) }
         end
 
+        # Builds custom values for all custom fields for which no custom value already exists.
+        # The value of that newly build value is set to the default value which can also be nil.
+        # Calling this should only be necessary if additional custom fields are made available
+        # after custom_field_values has already been called as that method will also build custom values
+        # (with their default values set) for all custom values for which no prior value existed.
         def set_default_values!
           new_values = {}
 

--- a/spec/models/work_package/work_package_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_custom_fields_spec.rb
@@ -47,12 +47,12 @@ describe WorkPackage, type: :model do
 
     let(:cf_required) { true }
 
-    shared_context 'project with custom field' do
+    shared_context 'project with custom field' do |save = true|
       before do
         project.work_package_custom_fields << custom_field
         type.custom_fields << custom_field
 
-        work_package.save
+        work_package.save if save
       end
     end
 
@@ -343,6 +343,34 @@ describe WorkPackage, type: :model do
         end
 
         it { is_expected.to eq(value) }
+      end
+    end
+
+    describe 'default values' do
+      include_context 'project with custom field', false
+
+      context 'for a custom field with default value' do
+        before do
+          custom_field.custom_options[1].update_attribute(:default_value, true)
+        end
+
+        it 'sets the default values for custom_field_values' do
+          expect(work_package.custom_field_values.length)
+            .to eql 1
+
+          expect(work_package.custom_field_values[0].value)
+            .to eql custom_field.custom_options[1].id.to_s
+        end
+      end
+
+      context 'for a custom field without default value' do
+        it 'sets the default values for custom_field_values' do
+          expect(work_package.custom_field_values.length)
+            .to eql 1
+
+          expect(work_package.custom_field_values[0].value)
+            .to be_nil
+        end
       end
     end
 

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -120,7 +120,7 @@ describe Projects::SetAttributesService, type: :model do
             it 'sets a default identifier' do
               allow(Project)
                 .to receive(:next_identifier)
-                      .and_return('ipsum')
+                .and_return('ipsum')
 
               expect(subject.result.identifier)
                 .to eql 'ipsum'
@@ -146,7 +146,7 @@ describe Projects::SetAttributesService, type: :model do
             it 'stays nil' do
               allow(Project)
                 .to receive(:next_identifier)
-                      .and_return('ipsum')
+                .and_return('ipsum')
 
               expect(subject.result.identifier)
                 .to be_nil
@@ -155,7 +155,7 @@ describe Projects::SetAttributesService, type: :model do
         end
       end
 
-      context 'public default value', with_settings: {default_projects_public: true} do
+      context 'public default value', with_settings: { default_projects_public: true } do
         context 'with a value for is_public provided' do
           let(:call_attributes) do
             {
@@ -177,7 +177,7 @@ describe Projects::SetAttributesService, type: :model do
         end
       end
 
-      context 'enabled_module_names default value', with_settings: {default_projects_modules: ['lorem', 'ipsum']} do
+      context 'enabled_module_names default value', with_settings: { default_projects_modules: ['lorem', 'ipsum'] } do
         context 'with a value for enabled_module_names provided' do
           let(:call_attributes) do
             {


### PR DESCRIPTION
Most of the time, the getter #custom_field_values is used with unbeknown to the caller will build custom values for not covered custom values. This method
always assigned nil to the value of the newly build custom value when it should have used the default value. Once that is fixed, all models including acts_as_customizable
will again have set the default values for custom fields correctly. This is true regardless of wether the custom value is added before or after the creation of the model.

Only for work_packages is the additional method #set_default_values! required as the availble_custom_field might change during a request upon a switch in project and/or type.

https://community.openproject.com/wp/34420