### PR TITLE
allow adding members to invalid groups

### DIFF
--- a/app/contracts/groups/add_users_contract.rb
+++ b/app/contracts/groups/add_users_contract.rb
@@ -1,0 +1,39 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Groups
+  class AddUsersContract < Groups::BaseContract
+    protected
+
+    # No need to validate the whole of the group when we only want to ensure that the user is an admin.
+    # In case more conditions are added to the BaseContract, we might need an extra AdminOnlyContract
+    def validate_model?
+      false
+    end
+  end
+end

--- a/app/services/groups/add_users_service.rb
+++ b/app/services/groups/add_users_service.rb
@@ -35,7 +35,7 @@ module Groups
       @group = group
 
       super user: current_user,
-            contract_class: BaseContract
+            contract_class: Groups::AddUsersContract
     end
 
     def after_validate(user_ids, _call)


### PR DESCRIPTION
If a group is invalid (e.g. because it has a required custom field) it should still be possible to add members to that group. Therefore, the contract no longer checks the model itself but only the user performing the operation.

https://community.openproject.com/wp/34446