### PR TITLE
fix grid rows calculation

### DIFF
--- a/frontend/src/app/modules/grids/grid/area.service.ts
+++ b/frontend/src/app/modules/grids/grid/area.service.ts
@@ -95,7 +95,7 @@ export class GridAreaService {
   }
 
   public persist() {
-    this.resource.rowCount = this.numRows = (this.widgetAreas.map(area => area.endRow).sort().pop() || 2) - 1;
+    this.resource.rowCount = this.numRows = (this.widgetAreas.map(area => area.endRow).sort((a, b) => a - b).pop() || 2) - 1;
     this.resource.columnCount = this.numColumns;
 
     this.writeAreaChangesToWidgets();


### PR DESCRIPTION
JS will sort lexicographically if not otherwise instructed. Thus, the maximum after sorting was only 9 which led to widgets being outside of the grid.

Given the error messages and the behaviour described in the bug reports, I assume this fixes:

https://community.openproject.com/wp/34381
https://community.openproject.com/wp/34442