### PR TITLE
extend session TTL for logged-in users when using cache store for sessions

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -29,6 +29,44 @@
 
 # Be sure to restart your server when you modify this file.
 
+module OpenProject
+  ##
+  # `expire_store_after` option specifically for the cache store.
+  #
+  # Prepend to ActionDispatch::Session::CacheStore to override `write_session`.
+  #
+  # We hook into there to override the `expire_after` option so that we can
+  # customize it on the storage level. I.e. we want sessions to remain longer
+  # in storage without affecting the session ID cookie's expiration which is
+  # set one level higher up in the call chain in the rack session middleware.
+  module ExpireStoreAfterOption
+    def write_session(env, sid, session, options)
+      if update_entry_ttl? session, options
+        opts = options.to_hash
+
+        return super env, sid, session, opts.merge(expire_after: new_expire_after(session, opts))
+      end
+
+      super
+    end
+
+    def new_expire_after(session, options)
+      options[:expire_store_after].call session, options[:expire_after]
+    rescue StandardError => e
+      Rails.logger.error(
+        "Failed to determine new `after_expire` value. " +
+        "Falling back to original value. (#{e.message} at #{caller.first})"
+      )
+
+      options[:expire_after]
+    end
+
+    def update_entry_ttl?(session, options)
+      session && options[:expire_store_after] && options[:expire_store_after].respond_to?(:call)
+    end
+  end
+end
+
 config = OpenProject::Configuration
 
 # Enforce session storage for testing
@@ -45,6 +83,33 @@ session_options = {
   secure: Setting.https?,
   path:   relative_url_root
 }
+
+if session_store == :cache_store
+  # env OPENPROJECT_CACHE__STORE__SESSION__USER__TTL__DAYS
+  session_ttl = config['cache_store_session_user_ttl_days']&.to_i&.days || 3.days
+
+  # Extend session cache entry TTL so that they can stay logged in when their
+  # session ID cookie's TTL is 'session' where usually the session entry in the
+  # cache would expire before the session in the browser by default.
+  session_options[:expire_store_after] = lambda do |session, expire_after|
+    if session.include? "user_id" # logged-in user
+      [session_ttl, expire_after].compact.max
+    else
+      expire_after # anonymous user
+    end
+  end
+
+  method = ActionDispatch::Session::CacheStore.instance_method(:write_session)
+  unless method.to_s.include?("write_session(env, sid, session, options)")
+    raise(
+      "The signature for `ActionDispatch::Session::CacheStore.write_session` " +
+      "seems to have changed. Please update the " +
+      "`ExpireStoreAfterOption` module (and this check) in #{__FILE__}"
+    )
+  end
+
+  ActionDispatch::Session::CacheStore.prepend OpenProject::ExpireStoreAfterOption
+end
 
 OpenProject::Application.config.session_store session_store, **session_options
 


### PR DESCRIPTION
WP [#33575](https://community.openproject.com/projects/openproject/work_packages/33575/activity)

This is so that users don't get logged-out when they leave their tab open due to the session entry in the cache expiring.

If you want to test it you could start memcached using docker like this:

```
docker run -p 11211:11211 --name memcached -d memcached
```

Then run the OpenProject server with the following env variables set:

```
export CACHE_MEMCACHE_SERVER=localhost:11211
export CACHE_NAMESPACE=openproject_core
export RAILS_CACHE_STORE=memcache
```

I have confirmed the extended TTL inside memcached as well.

```
telnet localhost 11211
> stats items
```

Lists the so called slabs in the cache. I then went through them until I found the session:

```
stats cachedump 7 0
ITEM openproject_core:_session_id:2::875c3400c83cdd7690e06b84e6a43e2b690213cef1096e5191c7d821dc8f4869 [193 b; 1600425312 s]
```

So number at the end followed by `s` is the unix timestamp of the entry's expiry.
The default for all entries (i.e. settings, representers etc.) is 0 as seen here:

```
stats cachedump 20 0
ITEM openproject_core:/openproject/settings/all/1599036440 [6969 b; 0 s]
```

For the user session (with this PR), rather than 0, it is `1600425312` which is today in 3 days in that case.

We'll have to see how this works in practice. I.e. whether memcached evicts items with 0s earlier than items with a later expiry which I would expect it to do, though.