### PR TITLE
employ the default datepicker for backlogs sprints

### DIFF
--- a/frontend/src/app/modules/augmenting/dynamic-scripts/backlogs/editable_inplace.js
+++ b/frontend/src/app/modules/augmenting/dynamic-scripts/backlogs/editable_inplace.js
@@ -36,10 +36,12 @@ RB.EditableInplace = (function ($) {
 
     getEditor: function () {
       // Create the model editor container if it does not yet exist
-      var editor = this.$.children(".editors").first().html('');
+      var editor = this.$.children(".editors");
 
       if (editor.length === 0) {
         editor = $("<div class='editors'></div>").appendTo(this.$);
+      } else if (!editor.hasClass('permanent')) {
+        editor.first().html('');
       }
       return editor;
     },

--- a/frontend/src/app/modules/backlogs/backlogs-page/styles/master_backlog.sass
+++ b/frontend/src/app/modules/backlogs/backlogs-page/styles/master_backlog.sass
@@ -293,17 +293,19 @@
       .velocity, .add_new_story
         display: none
   .backlog .sprint.editing
-    .name.editor
-      line-height: 1.5rem
-      margin: 0
-      min-width: 15em
-      width: 57%
-    .start_date.editor, .effective_date.editor
+    .editor
       font-size: 0.9rem
       line-height: 1.5rem
+      height: 30px
       margin: 0
       padding: 0
-      width: 75px
+
+      &.name
+        min-width: 15em
+        width: calc(100% - 2 * 85px - 10px)
+      &.start_date, &.effective_date
+        width: 85px
+
   .stories .story.editing
     >
       *, .editors label

--- a/modules/backlogs/app/views/rb_sprints/_sprint.html.erb
+++ b/modules/backlogs/app/views/rb_sprints/_sprint.html.erb
@@ -34,13 +34,30 @@ See docs/COPYRIGHT.rdoc for more details.
   </div>
 
   <% User.current.allowed_to?(:update_sprints, @project) ? editable = "editable" :  editable = "" %>
-  <div class="effective_date date <%= editable %>" fieldname="effective_date" field_id=<%= sprint.id %>>
-    <%= sprint.effective_date %>
+
+  <div class="show">
+    <div class="effective_date date <%= editable %>" fieldname="effective_date" field_id=<%= sprint.id %>>
+      <%= sprint.effective_date %>
+    </div>
+    <div class="start_date <%= editable %> date" fieldname="start_date" field_id=<%= sprint.id %>>
+      <%= sprint.start_date %>
+    </div>
+    <div class="name <%= editable %>" fieldname="name" field_id="<%= sprint.id %>"><%= sprint.name %></div>
   </div>
-  <div class="start_date <%= editable %> date" fieldname="start_date" field_id=<%= sprint.id %>>
-    <%= sprint.start_date %>
+
+  <div class="editors permanent">
+    <%= text_field_tag :effective_date,
+                       sprint.effective_date,
+                       id: "effective_date_#{sprint.id}",
+                       class: '-augmented-datepicker effective_date editor' %>
+    <%= text_field_tag :start_date,
+                       sprint.start_date,
+                       id: "start_date_#{sprint.id}",
+                       class: '-augmented-datepicker effective_date editor' %>
+    <%= text_field_tag :name,
+                       sprint.name,
+                       class: 'name editor' %>
   </div>
-  <div class="name <%= editable %>" fieldname="name" field_id=<%= sprint.id %>><%= sprint.name %></div>
 
   <div class="meta">
     <%= render :partial => "shared/model_errors", :object => sprint.errors %>


### PR DESCRIPTION
Because the datepickers are powered by angular, we cannot recreate
the date fields via ja every time the user clicks. Instead, the fields
are prerendered but hidden to the user. When the user clicks,
the fields are simply displayed.

https://community.openproject.com/wp/34436