### PR TITLE
Fix/backlogs burndown chart

### DIFF
--- a/frontend/src/app/modules/backlogs/openproject-backlogs.routes.ts
+++ b/frontend/src/app/modules/backlogs/openproject-backlogs.routes.ts
@@ -42,4 +42,10 @@ export const BACKLOGS_ROUTES:Ng2StateDeclaration[] = [
     url: '/sprints/{sprintId:int}/taskboard',
     component: BacklogsPageComponent
   },
+  {
+    name: 'backlogs_burndown',
+    parent: 'root',
+    url: '/sprints/{sprintId:int}/burndown_chart',
+    component: BacklogsPageComponent
+  },
 ];

--- a/modules/backlogs/app/views/rb_burndown_charts/_burndown.html.erb
+++ b/modules/backlogs/app/views/rb_burndown_charts/_burndown.html.erb
@@ -119,9 +119,21 @@ See docs/COPYRIGHT.rdoc for more details.
         $(".burndown_chart").bind("plothover", Burndown.showTooltipOnHover);
 
         Burndown.plotAccordingToChoices();
+      },
+
+      saveInit: function() {
+        // Ensure $.plot is defined before progressing.
+        // This static page might already be ready but the webpack required
+        // jquery.flot.js file might not be loaded yet.
+
+        if ($.plot) {
+          this.init();
+        } else {
+          setTimeout(() => { this.saveInit()}, 50);
+        }
       }
     };
 
-    Burndown.init();
+    Burndown.saveInit();
   });
 <% end %>

--- a/modules/backlogs/app/views/rb_burndown_charts/show.html.erb
+++ b/modules/backlogs/app/views/rb_burndown_charts/show.html.erb
@@ -38,7 +38,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <% if @burndown %>
   <%= render :partial => 'burndown', :locals => {:div => 'burndown_', :burndown => @burndown } %>
 
-  <div class="burndown_chart autoscroll" id="burndown_<%= @burndown.sprint_id %>" style="width:600px;height:300px;"><div class="loading"><%=t('backlogs.generating_chart')%></div></div>
+  <div class="burndown_chart autoscroll" id="burndown_<%= @burndown.sprint_id %>" style="width:1200px;height:600px;"><div class="loading"><%=t('backlogs.generating_chart')%></div></div>
 
   <fieldset class="burndown_control form--fieldset">
       <legend class="form--fieldset-legend"><%= t('backlogs.chart_options') %></legend>

--- a/modules/backlogs/app/views/rb_sprints/_sprint.html.erb
+++ b/modules/backlogs/app/views/rb_sprints/_sprint.html.erb
@@ -45,19 +45,21 @@ See docs/COPYRIGHT.rdoc for more details.
     <div class="name <%= editable %>" fieldname="name" field_id="<%= sprint.id %>"><%= sprint.name %></div>
   </div>
 
-  <div class="editors permanent">
-    <%= text_field_tag :effective_date,
-                       sprint.effective_date,
-                       id: "effective_date_#{sprint.id}",
-                       class: '-augmented-datepicker effective_date editor' %>
-    <%= text_field_tag :start_date,
-                       sprint.start_date,
-                       id: "start_date_#{sprint.id}",
-                       class: '-augmented-datepicker effective_date editor' %>
-    <%= text_field_tag :name,
-                       sprint.name,
-                       class: 'name editor' %>
-  </div>
+  <% if User.current.allowed_to?(:update_sprints, @project) %>
+    <div class="editors permanent">
+      <%= text_field_tag :effective_date,
+                         sprint.effective_date,
+                         id: "effective_date_#{sprint.id}",
+                         class: '-augmented-datepicker effective_date editor' %>
+      <%= text_field_tag :start_date,
+                         sprint.start_date,
+                         id: "start_date_#{sprint.id}",
+                         class: '-augmented-datepicker effective_date editor' %>
+      <%= text_field_tag :name,
+                         sprint.name,
+                         class: 'name editor' %>
+    </div>
+  <% end %>
 
   <div class="meta">
     <%= render :partial => "shared/model_errors", :object => sprint.errors %>

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -103,12 +103,6 @@ module OpenProject::Backlogs
            icon: 'icon2 icon-backlogs'
     end
 
-    assets %w(
-      backlogs/backlogs.js
-      backlogs/jquery.flot/excanvas.js
-      backlogs/burndown.js
-    )
-
     # We still override version and project settings views from the core! URH
     override_core_views!
 

--- a/modules/documents/spec/features/attachment_upload_spec.rb
+++ b/modules/documents/spec/features/attachment_upload_spec.rb
@@ -52,8 +52,10 @@ describe 'Upload attachment to documents', js: true do
     it 'can upload an image' do
       visit project_documents_path(project)
 
-      expect(page)
-        .to have_content I18n.t(:no_results_title_text)
+      # Saveguard to ensure the page is properly loaded before clicking on the "+ Document" button
+      # which sometimes seems to come to early.
+      expect(find_field(I18n.t(:'attributes.category')))
+        .to be_checked
 
       within '.toolbar-items' do
         click_on 'Document'


### PR DESCRIPTION
The $.plot function was not ensured to be defined upon calling the function as we require the js file via webpack but execute the inline script independently of that. Most of the time, the inline script ran before. Now we simply wait until it is defined.

Also appended the backlogs routes to then display the graph once it is rendered.

https://community.openproject.com/wp/34437 