### PR TITLE
[34290] Fix autoscroller on type groups

### DIFF
--- a/frontend/src/app/modules/admin/types/type-form-configuration.component.ts
+++ b/frontend/src/app/modules/admin/types/type-form-configuration.component.ts
@@ -4,7 +4,7 @@ import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {NotificationsService} from 'core-app/modules/common/notifications/notifications.service';
 import {ExternalRelationQueryConfigurationService} from 'core-components/wp-table/external-configuration/external-relation-query-configuration.service';
 import {DomAutoscrollService} from 'core-app/modules/common/drag-and-drop/dom-autoscroll.service';
-import {DragulaService} from 'ng2-dragula';
+import {DragulaService, DrakeWithModels} from 'ng2-dragula';
 import {ConfirmDialogService} from 'core-components/modals/confirm-dialog/confirm-dialog.service';
 import {Drake} from 'dragula';
 import {GonService} from "core-app/modules/common/gon/gon.service";
@@ -60,8 +60,8 @@ export class TypeFormConfigurationComponent extends UntilDestroyedMixin implemen
   public groups:TypeGroup[] = [];
   public inactives:TypeFormAttribute[] = [];
 
-  private attributeDrake:Drake;
-  private groupsDrake:Drake;
+  private attributeDrake:DrakeWithModels;
+  private groupsDrake:DrakeWithModels;
 
   private no_filter_query:string;
 
@@ -108,22 +108,20 @@ export class TypeFormConfigurationComponent extends UntilDestroyedMixin implemen
     });
 
     // Setup groups
-    this.dragula.createGroup('groups', {
-      moves: (el, source, handle:HTMLElement) => handle.classList.contains('group-handle')
-    });
+    this.groupsDrake = this
+      .dragula
+      .createGroup('groups', {
+        moves: (el, source, handle:HTMLElement) => handle.classList.contains('group-handle')
+      })
+      .drake;
 
     // Setup attributes
-    this.dragula.createGroup('attributes', {
-      moves: (el, source, handle:HTMLElement) => handle.classList.contains('attribute-handle')
-    });
-
-    this.dragula.dropModel("attributes")
-      .pipe(
-        this.untilDestroyed()
-      )
-      .subscribe((event) => {
-        console.log(event);
-      });
+    this.attributeDrake = this
+      .dragula
+      .createGroup('attributes', {
+        moves: (el, source, handle:HTMLElement) => handle.classList.contains('attribute-handle')
+      })
+      .drake;
 
     // Get attribute id
     this.groups = JSON
@@ -144,7 +142,8 @@ export class TypeFormConfigurationComponent extends UntilDestroyedMixin implemen
         autoScroll: function (this:any) {
           const groups = that.groupsDrake && that.groupsDrake.dragging;
           const attributes = that.attributeDrake && that.attributeDrake.dragging;
-          return this.down && (groups || attributes);
+
+          return groups || attributes;
         }
       });
   }

--- a/frontend/src/app/modules/common/drag-and-drop/dom-autoscroll.service.ts
+++ b/frontend/src/app/modules/common/drag-and-drop/dom-autoscroll.service.ts
@@ -31,9 +31,12 @@ export class DomAutoscrollService {
 
   public init() {
     jQuery(window).on('mousemove.domautoscroll touchmove.domautoscroll', (evt:any) => {
-      this.pointCB(evt);
-      this.onMove(evt);
+      if (this.down) {
+        this.pointCB(evt);
+        this.onMove(evt);
+      }
     });
+    jQuery(window).on('mousedown.domautoscroll touchstart.domautoscroll', () => this.down = true);
     jQuery(window).on('mouseup.domautoscroll touchend.domautoscroll', () => this.onUp());
     jQuery(window).on('scroll.domautoscroll', (evt:any) => this.setScroll(evt));
   }
@@ -57,6 +60,7 @@ export class DomAutoscrollService {
   }
 
   public onUp() {
+    this.down = false;
     cancelAnimationFrame(this.animationFrame);
     cancelAnimationFrame(this.windowAnimationFrame);
   }


### PR DESCRIPTION
The `DomAutoScroller` no longer sets the `down` property when `touchstart` or `mousedown` events are fired, also the acessing of dragula groups were broken. This prevented the autoscroller to work.

https://community.openproject.com/wp/34290