### PR TITLE
Fix/add members users before groups

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -47,11 +47,11 @@ class MembersController < ApplicationController
 
   def create
     if params[:member]
-      members = new_members_from_params
+      members = new_members_from_params(params[:member])
       @project.members << members
     end
 
-    if members.present? && members.all?(&:valid?)
+    if no_create_errors?(members)
       flash[:notice] = members_added_notice members
 
       redirect_to project_members_path(project_id: @project, status: 'all')
@@ -169,12 +169,6 @@ class MembersController < ApplicationController
     /\A\S+@\S+\.\S+\z/
   end
 
-  def self.tab_scripts
-    scripts = %w(hideOnLoad init_members_cb)
-
-    scripts.join('(); ') + '();'
-  end
-
   def set_index_data!
     set_roles_and_principles!
 
@@ -199,12 +193,16 @@ class MembersController < ApplicationController
                .includes(:roles, :principal, :member_roles)
   end
 
-  def new_members_from_params
-    roles = Role.where(id: possibly_seperated_ids_for_entity(params[:member], :role))
+  def new_members_from_params(member_params)
+    roles = roles_for_new_members(member_params)
 
     if roles.present?
-      user_ids = invite_new_users possibly_seperated_ids_for_entity(params[:member], :user)
+      user_ids = user_ids_for_new_members(member_params)
       members = user_ids.map { |user_id| new_member user_id }
+      # In edge cases, the user might choose a group together with a member which is also part of a group added
+      # at the same time. If the group is added before the user, a :taken error is produced. To avoid this, we
+      # get the user to be added first.
+      members = sort_by_groups_last(members)
 
       # most likely wrong user input, use a dummy member for error handling
       if !members.present? && roles.present?
@@ -225,6 +223,14 @@ class MembersController < ApplicationController
     Member.new(permitted_params.member).tap do |member|
       member.user_id = user_id if user_id
     end
+  end
+
+  def user_ids_for_new_members(member_params)
+    invite_new_users possibly_seperated_ids_for_entity(member_params, :user)
+  end
+
+  def roles_for_new_members(member_params)
+    Role.where(id: possibly_seperated_ids_for_entity(member_params, :role))
   end
 
   def invite_new_users(user_ids)
@@ -295,5 +301,15 @@ class MembersController < ApplicationController
     else
       I18n.t(:notice_members_added, number: members.size)
     end
+  end
+
+  def no_create_errors?(members)
+    members.present? && members.map(&:errors).select(&:any?).empty?
+  end
+
+  def sort_by_groups_last(members)
+    group_ids = Group.where(id: members.map(&:user_id)).pluck(:id)
+
+    members.sort_by { |m| group_ids.include?(m.user_id) ? 1 : -1 }
   end
 end

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -372,6 +372,7 @@ Redmine::MenuManager.map :project_menu do |menu|
             { controller: '/members', action: 'index' },
             param: :project_id,
             caption: :label_member_plural,
+            before: :settings,
             icon: 'icon2 icon-group'
 
   menu.push :settings,

--- a/modules/documents/lib/open_project/documents/engine.rb
+++ b/modules/documents/lib/open_project/documents/engine.rb
@@ -36,11 +36,13 @@ module OpenProject::Documents
              author_url: "http://www.openproject.com",
              bundled: true do
 
-      menu :project_menu, :documents,
-                          { controller: '/documents', action: 'index' },
-                          param: :project_id,
-                          caption: :label_document_plural,
-                          icon: 'icon2 icon-notes'
+      menu :project_menu,
+           :documents,
+           { controller: '/documents', action: 'index' },
+           param: :project_id,
+           caption: :label_document_plural,
+           before: :members,
+           icon: 'icon2 icon-notes'
 
       project_module :documents do |_map|
         permission :view_documents, documents: [:index, :show, :download]

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -55,10 +55,12 @@ module OpenProject::Meeting
         search.register :meetings
       end
 
-      menu :project_menu, :meetings, { controller: '/meetings', action: 'index' },
+      menu :project_menu,
+           :meetings, { controller: '/meetings', action: 'index' },
            caption: :project_module_meetings,
            param: :project_id,
            after: :wiki,
+           before: :members,
            icon: 'icon2 icon-meetings'
 
       ActiveSupport::Inflector.inflections do |inflect|


### PR DESCRIPTION
As a user cannot be member of a project twice, an error is produced if the group will add the user as a member and then the user is added in its own right. On the other hand, a user may first be added as member and then a group containing the user may also be added. By simply sorting by group vs. user we can ensure that users are always added first.

Additionally, the PR places the members menu item right before the project settings.

https://community.openproject.com/wp/34428