### PR TITLE
[34432] Save the tablesorter sort options in session

### DIFF
--- a/frontend/src/app/modules/reporting/reporting-page/functionality/tablesorter.ts
+++ b/frontend/src/app/modules/reporting/reporting-page/functionality/tablesorter.ts
@@ -26,6 +26,10 @@ function initTableSorter() {
     .not('.tablesorter')
     .tablesorter({
       sortList: [[0, 0]],
+      widgets: ['saveSort'],
+      widgetOptions: {
+        storage_storageType: 's'
+      },
       textExtraction: function (node:HTMLElement, table:any, cellIndex:any) {
         return node.getAttribute('raw-data');
       }


### PR DESCRIPTION
The reporting table sorting works only in the frontend with tablesorter. It does not retain the sort order when reloading, but will always apply a default order. We might want to persist the sort in a session variable, which is specific for this one table instance only.

https://community.openproject.com/wp/34432