### PR TITLE
Cache webdrivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ cache:
   directories:
     - public/assets
     - frontend/src/locales
+    - ~/.webdrivers
 
 branches:
   only:

--- a/Gemfile
+++ b/Gemfile
@@ -220,7 +220,7 @@ group :test do
   gem 'capybara', '~> 3.33.0'
   gem 'capybara-screenshot', '~> 1.0.17'
   gem 'selenium-webdriver', '~> 3.14'
-  gem 'webdrivers', '~> 4.4.1', require: false
+  gem 'webdrivers', '~> 4.4.1'
 
   gem 'fuubar', '~> 2.5.0'
   gem 'timecop', '~> 0.9.0'

--- a/script/ci/cache_prepare.sh
+++ b/script/ci/cache_prepare.sh
@@ -38,10 +38,11 @@ run() {
   eval $2;
 }
 
-run "bundle exec rake db:migrate"
+run "bundle exec rake db:migrate webdrivers:chromedriver:update webdrivers:geckodriver:update"
 
 run "for i in {1..3}; do npm install && break || sleep 15; done"
 
 run "bundle exec rake assets:precompile assets:clean"
 
 run "cp -rp config/frontend_assets.manifest.json public/assets/frontend_assets.manifest.json"
+


### PR DESCRIPTION
Cache webdrivers on CI in cache_prepare step

This may prevent the github 429 requests we keep seeing.