### PR TITLE
[34509] Output html of custom field long text value on projects

### DIFF
--- a/app/cells/projects/row_cell.rb
+++ b/app/cells/projects/row_cell.rb
@@ -31,7 +31,7 @@ module Projects
       custom_value = project.custom_value_for(cf).formatted_value
 
       if cf.field_format == 'text'
-        shorten_text(custom_value, 20)
+        custom_value.html_safe
       else
         custom_value
       end


### PR DESCRIPTION
The long text custom field texts were shortened, but that won't work. They need to be output as html.
https://community.openproject.com/wp/34509