### PR TITLE
Fix: 'Create wp row' created but not shown because of permissions

### DIFF
--- a/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
@@ -50,9 +50,8 @@ import {
 } from './inline-create-row-builder';
 import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/isolated-query-space";
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
-import {FocusHelperService} from 'core-app/modules/common/focus/focus-helper';
 import {WorkPackageInlineCreateService} from "core-components/wp-inline-create/wp-inline-create.service";
-import {BehaviorSubject, Subscription} from 'rxjs';
+import {Subscription} from 'rxjs';
 import {WorkPackageViewColumnsService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-columns.service";
 import {WorkPackageChangeset} from "core-components/wp-edit/work-package-changeset";
 import {EditForm} from "core-app/modules/fields/edit/edit-form/edit-form";

--- a/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
@@ -52,7 +52,7 @@ import {IsolatedQuerySpace} from "core-app/modules/work_packages/query-space/iso
 import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
 import {FocusHelperService} from 'core-app/modules/common/focus/focus-helper';
 import {WorkPackageInlineCreateService} from "core-components/wp-inline-create/wp-inline-create.service";
-import {Subscription} from 'rxjs';
+import {BehaviorSubject, Subscription} from 'rxjs';
 import {WorkPackageViewColumnsService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-columns.service";
 import {WorkPackageChangeset} from "core-components/wp-edit/work-package-changeset";
 import {EditForm} from "core-app/modules/fields/edit/edit-form/edit-form";
@@ -88,6 +88,10 @@ export class WorkPackageInlineCreateComponent extends UntilDestroyedMixin implem
 
   private $element:JQuery;
 
+  get isActive():boolean {
+    return this.mode !== 'inactive';
+  }
+
   constructor(public readonly injector:Injector,
               protected readonly elementRef:ElementRef,
               protected readonly schemaCache:SchemaCacheService,
@@ -104,24 +108,23 @@ export class WorkPackageInlineCreateComponent extends UntilDestroyedMixin implem
 
   ngOnInit() {
     this.$element = jQuery(this.elementRef.nativeElement);
+  }
 
+  ngAfterViewInit() {
     this.authorisationService
       .observeUntil(componentDestroyed(this))
       .subscribe(() => {
         this.canReference = this.hasReferenceClass && this.wpInlineCreate.canReference;
         this.canAdd = this.wpInlineCreate.canAdd;
         this.cdRef.detectChanges();
+
+        if (this.canAdd || this.canReference) {
+          // Add this row's height as a padding to the timeline
+          // so the table and the timeline keep aligned
+          const container = jQuery(this.table.timelineBody);
+          container.addClass('-inline-create-mirror');
+        }
       });
-  }
-
-  get isActive():boolean {
-    return this.mode !== 'inactive';
-  }
-
-  ngAfterViewInit() {
-    // Mirror the row height in timeline
-    const container = jQuery(this.table.timelineBody);
-    container.addClass('-inline-create-mirror');
 
     // Register callback on newly created work packages
     this.registerCreationCallback();


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34127

This pull request:

- [x] Covers the corner case when the 'Create WP' row is added to the table but its button is not shown because the user doesn't have permissions. Without button the row has no height, but it was keepint adding the paddint-bottom to the timeline to keep it aligned. Now it only adds it if the user has permissions.