### PR TITLE
add oauth paths to application show

### DIFF
--- a/app/views/oauth/applications/show.html.erb
+++ b/app/views/oauth/applications/show.html.erb
@@ -109,6 +109,25 @@ See docs/COPYRIGHT.rdoc for more details.
         </span>
       </div>
     </div>
+    <% if !@application.client_credentials_user_id %>
+      <div class="attributes-key-value--key"><%= I18n.t(:'doorkeeper.auth_url') %></div>
+      <div class="attributes-key-value--value-container">
+        <div class="attributes-key-value--value -text">
+          <span>
+            <%= oauth_authorization_url %>
+          </span>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="attributes-key-value--key"><%= I18n.t(:'doorkeeper.access_token_url') %></div>
+    <div class="attributes-key-value--value-container">
+      <div class="attributes-key-value--value -text">
+        <span>
+          <%= oauth_token_url %>
+        </span>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2781,6 +2781,8 @@ en:
   doorkeeper:
     pre_authorization:
       status: 'Pre-authorization'
+    auth_url: 'Auth URL'
+    access_token_url: 'Access token URL'
 
     errors:
       messages:


### PR DESCRIPTION
Adds "Auth URL" and "Access token URL" to the OAuth application's show page so that users do not have to guess them.

<img width="1419" alt="oauth2-created" src="https://user-images.githubusercontent.com/617519/93927130-bc650180-fd18-11ea-8950-8a4e74939433.png">
