### PR TITLE
bump puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,7 +167,7 @@ gem 'sprockets', '~> 3.7.0'
 # also, better than thin since we can control worker concurrency.
 gem 'unicorn'
 
-gem 'puma', '~> 4.3.5' # used for development and optionally for production
+gem 'puma', '~> 5.0.0' # used for development and optionally for production
 
 gem 'nokogiri', '~> 1.10.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -634,7 +634,7 @@ GEM
     net-ldap (0.16.3)
     netrc (0.11.0)
     newrelic_rpm (6.12.0.367)
-    nio4r (2.5.3)
+    nio4r (2.5.4)
     no_proxy_fix (0.1.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -716,7 +716,7 @@ GEM
       eventmachine_httpserver
       http_parser.rb (~> 0.6.0)
       multi_json
-    puma (4.3.6)
+    puma (5.0.0)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-accept (0.4.5)
@@ -1084,7 +1084,7 @@ DEPENDENCIES
   pry-rescue (~> 1.5.2)
   pry-stack_explorer (~> 0.5.1)
   puffing-billy (~> 2.4.0)
-  puma (~> 4.3.5)
+  puma (~> 5.0.0)
   rack-attack (~> 6.3.1)
   rack-cors (~> 1.1.1)
   rack-mini-profiler


### PR DESCRIPTION
Bump puma to benefit from the [5.0 release](https://github.com/puma/puma/blob/master/History.md#500)

Includes e.g an increase in the URL length:

> Increased maximum URI path length from 2048 to 8192 bytes (#2167, #2344) 