### PR TITLE
bump gon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,7 +130,7 @@ gem 'browser', '~> 4.2.0'
 # Providing health checks
 gem 'okcomputer', '~> 1.18.1'
 
-gem 'gon', '~> 6.3.2'
+gem 'gon', '~> 6.4.0'
 
 # Lograge to provide sane and non-verbose logging
 gem 'lograge', '~> 0.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,7 +529,7 @@ GEM
       rchardet (~> 1.8)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    gon (6.3.2)
+    gon (6.4.0)
       actionpack (>= 3.0.20)
       i18n (>= 0.7)
       multi_json
@@ -1025,7 +1025,7 @@ DEPENDENCIES
   fog-aws
   friendly_id (~> 5.4.0)
   fuubar (~> 2.5.0)
-  gon (~> 6.3.2)
+  gon (~> 6.4.0)
   grape (~> 1.3.0)
   grids!
   html-pipeline (~> 2.14.0)


### PR DESCRIPTION
bump gon to fix 

> CVE-2020-25739: Enforce HTML entities escaping in gon output

https://github.com/gazay/gon/blob/master/CHANGELOG.md#changelog