### PR TITLE
Adding spinner to buttons with running actions

### DIFF
--- a/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.html
+++ b/frontend/src/app/modules/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.html
@@ -17,12 +17,15 @@
       </ngx-gallery>
     </div>
 
-    <a *ngIf="viewerVisible && createAllowed"
+    <button *ngIf="viewerVisible && createAllowed"
        [title]="text.add_viewpoint"
        class="button"
+       [class.-running]="saveViewpointRunning$ | async"
+       [disabled]="saveViewpointRunning$ | async"
        (click)="saveViewpoint(workPackage)">
       <op-icon icon-classes="button--icon icon-add"></op-icon>
       <span class="button--text"> {{text.viewpoint}} </span>
-    </a>
+      <op-icon icon-classes="button-icon icon-loading1" class="-running-indicator"></op-icon>
+    </button>
   </div>
 </ng-container>

--- a/frontend/src/global_styles/content/_buttons.lsg
+++ b/frontend/src/global_styles/content/_buttons.lsg
@@ -80,6 +80,20 @@
 <input type="submit" class="button ***-active***" value="Do not connect" disabled />
 ```
 
+## Running (spinning/loading) buttons
+
+Sometimes we want to add extra emphasis that an action takes a longer time. Then it might be useful to provide some
+visual cue. This adds a spinner icon to the button.
+
+Careful, this will make the button wider and thus might cause issues with your layout.
+
+```
+<button class="button ***-running***" ***disabled=true***>
+  <span class="button--text">Save</span>
+  <i class="button--icon ***icon-loading1 -running-indicator***"></i>
+</button>
+```
+
 ## Transparent buttons
 
 ```

--- a/frontend/src/global_styles/content/_buttons.sass
+++ b/frontend/src/global_styles/content/_buttons.sass
@@ -71,7 +71,6 @@ a.button
     @include button-style(#fff, #f2f2f2, var(--content-link-color), var(--button-style))
     border-color: var(--content-link-color)
 
-
   &.-alt-highlight
     @include button-style(var(--button--alt-highlight-background-color), var(--button--alt-highlight-background-hover-color), var(--button--alt-highlight-font-color), var(--button-style))
     @include button-style(var(--button--alt-highlight-background-color), var(--button--alt-highlight-background-hover-color), var(--button--alt-highlight-font-color), var(--button-style))
@@ -85,6 +84,26 @@ a.button
     border-color: var(--button--active-border-color)
     box-shadow: 0 0 3px var(--button--active-border-color) inset
 
+  &.-running
+    .-running-indicator
+      display: inline-block
+      animation-name: loading1-spin
+      animation-duration: 200ms
+      animation-iteration-count: infinite
+      animation-timing-function: linear
+
+  // The glyph for icon loading1 is not vertically centered.
+  // When spinning it 360 degrees you'd see that the circles
+  // center is not the center of the spinning. As a hack, we
+  // just animate for one tick (30 degrees).
+  @keyframes loading1-spin
+    from
+      transform: rotate(0deg)
+    to
+      transform: rotate(29deg)
+
+  .-running-indicator
+    display: none
 
   &.-transparent
     background: transparent


### PR DESCRIPTION
This given an extra visual cue that the operation
might take longer.

- Added a new modifier "-running" for buttons.
- Documented in living style guide.
- Applied at the "+ Viewpoint" button which can
  take very long in the Revit Add-in.
- Added a timeout that unblocks the UI in case
  the viewpoint service does not respond.

https://community.openproject.com/wp/34485