### PR TITLE
[34511] Modify default timeline props

### DIFF
--- a/frontend/src/app/components/wp-query-select/wp-static-queries.service.ts
+++ b/frontend/src/app/components/wp-query-select/wp-static-queries.service.ts
@@ -77,7 +77,7 @@ export class WorkPackageStaticQueriesService {
       {
         identifier: 'gantt',
         label: this.text.gantt,
-        query_props: '{"c":["id","subject","startDate","dueDate"],"tv":true,"tzl":"years","hi":true,"g":"","t":"id:asc","t":"startDate:asc","f":[{"n":"status","o":"o","v":[]}]}'
+        query_props: `{"c":["id","type","subject","status","startDate","dueDate"],"tv":true,"tzl":"auto","tll":"{\\"left\\":\\"startDate\\",\\"right\\":\\"dueDate\\",\\"farRight\\":null}","hi":true,"g":"","t":"id:asc","t":"startDate:asc","f":[{"n":"status","o":"o","v":[]}]}`
       },
       {
         identifier: 'recently_created',


### PR DESCRIPTION
Update the settings used to show the default gantt query as shown in https://community.openproject.com/wp/34511