### PR TITLE
 [33690] wiki after navigate on item in sidebar, the sidebar reset to top and lose the view of focus item

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -148,13 +148,15 @@ See docs/COPYRIGHT.rdoc for more details.
         <h1 class="hidden-for-sighted"><%= t(:label_main_menu) %></h1>
         <main-menu-resizer></main-menu-resizer>
         <div id="menu-sidebar">
-          <%= main_menu %>
-          <%= content_for :main_menu %>
-          <%= call_hook :view_layouts_base_main_menu %>
-          <!-- Sidebar -->
-          <div id="sidebar">
-            <%= content_for :sidebar %>
-            <%= call_hook :view_layouts_base_sidebar %>
+          <div class="main-menu-wrapper">
+            <%= main_menu %>
+            <%= content_for :main_menu %>
+            <%= call_hook :view_layouts_base_main_menu %>
+            <!-- Sidebar -->
+            <div id="sidebar">
+              <%= content_for :sidebar %>
+              <%= call_hook :view_layouts_base_sidebar %>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -67,6 +67,11 @@ $menu-item-line-height: 30px
       height: calc(100% - (var(--main-menu-item-height) + 10px)) // 10px spacing
       overflow: auto
       @include styled-scroll-bar
+    
+    .main-menu-wrapper
+      display: flex
+      flex-direction: column
+      height: 100%
 
   a:focus
     color: var(--main-menu-font-color)
@@ -74,6 +79,7 @@ $menu-item-line-height: 30px
   ul
     margin: 0
     padding: 0
+    overflow-y: auto
 
     // -------------------- ALL menu items ---------------------------
     li


### PR DESCRIPTION
Making the sidebar menu scrollable when there is a teaser. There was a gap in the sidebar menu, we had to change some styles in saas-openproject and make other changes in core.

https://community.openproject.com/projects/openproject/work_packages/34284/activity