### PR TITLE
always use list cf subquery on list custom field filtering

### DIFF
--- a/modules/reporting/spec/features/custom_fields_spec.rb
+++ b/modules/reporting/spec/features/custom_fields_spec.rb
@@ -34,27 +34,28 @@ describe 'Custom fields reporting', type: :feature, js: true do
 
   let(:user) { FactoryBot.create :admin }
 
-  let(:work_package) {
+  let(:work_package) do
     FactoryBot.create :work_package,
-                       project: project,
-                       custom_values: initial_custom_values
-  }
+                      project: project,
+                      type: type,
+                      custom_values: initial_custom_values
+  end
 
-  let!(:time_entry1) {
+  let!(:time_entry1) do
     FactoryBot.create :time_entry,
-                       user: user,
-                       work_package: work_package,
-                       project: project,
-                       hours: 10
-  }
+                      user: user,
+                      work_package: work_package,
+                      project: project,
+                      hours: 10
+  end
 
-  let!(:time_entry2) {
+  let!(:time_entry2) do
     FactoryBot.create :time_entry,
-                       user: user,
-                       work_package: work_package,
-                       project: project,
-                       hours: 2.50
-  }
+                      user: user,
+                      work_package: work_package,
+                      project: project,
+                      hours: 2.50
+  end
 
 
   def custom_value_for(cf, str)
@@ -63,18 +64,24 @@ describe 'Custom fields reporting', type: :feature, js: true do
 
   context 'with multi value cf' do
     let!(:custom_field) do
-      FactoryBot.create(
-          :list_wp_custom_field,
-          name: "List CF",
-          multi_value: true,
-          types: [type],
-          projects: [project],
-          possible_values: ['First option', 'Second option']
-      )
+      FactoryBot.create(:list_wp_custom_field,
+                        name: "List CF",
+                        multi_value: true,
+                        types: [type],
+                        projects: [project],
+                        possible_values: ['First option', 'Second option'])
     end
 
     let(:initial_custom_values) { { custom_field.id => custom_value_for(custom_field, 'First option') } }
     let(:cf_id) { "custom_field#{custom_field.id}" }
+
+    # Have a second work package in the test that will have no values
+    # as this caused problems with casting the nil value of the custom value to 0.
+    let!(:work_package2) do
+      FactoryBot.create :work_package,
+                        project: project,
+                        type: type
+    end
 
     before do
       login_as(user)
@@ -85,24 +92,14 @@ describe 'Custom fields reporting', type: :feature, js: true do
       expect(page).to have_selector('#add_filter_select option', text: 'List CF')
       select 'List CF', from: 'add_filter_select'
 
-      # Adds filter to page
+      # Adds filter to page, filtering out the time entries on the work package
       expect(page).to have_selector("label##{cf_id}")
       custom_field_selector = "##{cf_id}_arg_1_val"
       select = find(custom_field_selector)
       expect(select).to have_selector('option', text: 'First option')
       expect(select).to have_selector('option', text: 'Second option')
-      select.find('option', text: 'First option').select_option
-
-      find('#query-icon-apply-button').click
-
-      # Expect row of work package
-      within('#result-table') do
-        expect(page).to have_selector('.top.result', text: '12.50 hours')
-      end
-
-      # Update filter to other value
-      select = find(custom_field_selector)
       select.find('option', text: 'Second option').select_option
+
       find('#query-icon-apply-button').click
 
       # Expect empty result table
@@ -110,6 +107,16 @@ describe 'Custom fields reporting', type: :feature, js: true do
         expect(page).to have_no_selector('.top.result', text: '12.50 hours')
       end
       expect(page).to have_selector('.generic-table--no-results-title')
+
+      # Update filter to value the work package has
+      select = find(custom_field_selector)
+      select.find('option', text: 'First option').select_option
+      find('#query-icon-apply-button').click
+
+      # Expect row of work package
+      within('#result-table') do
+        expect(page).to have_selector('.top.result', text: '12.50 hours')
+      end
     end
 
     it 'groups by the multi CF (Regression #26050)' do
@@ -141,29 +148,27 @@ describe 'Custom fields reporting', type: :feature, js: true do
 
     context 'with additional WP with invalid value' do
       let!(:custom_field_2) do
-        FactoryBot.create(
-            :list_wp_custom_field,
-            name: "Invalid List CF",
-            multi_value: true,
-            types: [type],
-            projects: [project],
-            possible_values: ['A', 'B']
-        )
+        FactoryBot.create(:list_wp_custom_field,
+                          name: "Invalid List CF",
+                          multi_value: true,
+                          types: [type],
+                          projects: [project],
+                          possible_values: %w[A B])
       end
 
-      let!(:work_package2) {
+      let!(:work_package2) do
         FactoryBot.create :work_package,
-                           project: project,
-                           custom_values: { custom_field_2.id => custom_value_for(custom_field_2, 'A')}
-      }
+                          project: project,
+                          custom_values: { custom_field_2.id => custom_value_for(custom_field_2, 'A')}
+      end
 
-      let!(:time_entry1) {
+      let!(:time_entry1) do
         FactoryBot.create :time_entry,
-                           user: user,
-                           work_package: work_package2,
-                           project: project,
-                           hours: 10
-      }
+                          user: user,
+                          work_package: work_package2,
+                          project: project,
+                          hours: 10
+      end
 
       before do
         CustomValue.find_by(customized_id: work_package2.id).update_columns(value: 'invalid')
@@ -196,12 +201,10 @@ describe 'Custom fields reporting', type: :feature, js: true do
 
   context 'with text CF' do
     let(:custom_field) do
-      FactoryBot.create(
-          :text_wp_custom_field,
-          name: 'Text CF',
-          types: [type],
-          projects: [project]
-      )
+      FactoryBot.create(:text_wp_custom_field,
+                        name: 'Text CF',
+                        types: [type],
+                        projects: [project])
     end
     let(:initial_custom_values) { { custom_field.id => 'foo' } }
 


### PR DESCRIPTION
The check in place before would check if any custom value, when casted to int would not be greater than zero. This also applies to nil -> 0. This then lead to the non list cf subquery being used when filtering. As a lot of custom values have nil for their value attribute, filtering for list custom fields was only possible in very rare cases.

https://community.openproject.com/wp/34530