### PR TITLE
Fix/cleanup journal data

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -54,17 +54,6 @@ class Journal < ApplicationRecord
   # logs like the history on issue#show
   scope :changing, -> { where(['version > 1']) }
 
-  # TODO: check if this can be removed
-  # Overrides the +user=+ method created by the polymorphic +belongs_to+ user association.
-  # Based on the class of the object given, either the +user+ association columns or the
-  # +user_name+ string column is populated.
-  def user=(value)
-    case value
-    when ActiveRecord::Base then super(value)
-    else self.user = User.find_by_login(value)
-    end
-  end
-
   # In conjunction with the included Comparable module, allows comparison of journal records
   # based on their corresponding version numbers, creation timestamps and IDs.
   def <=>(other)
@@ -132,9 +121,5 @@ class Journal < ApplicationRecord
                      .where("#{self.class.table_name}.version < ?", version)
                      .order("#{self.class.table_name}.version DESC")
                      .first
-  end
-
-  def journalized_object_type
-    "#{journaled_type.gsub('Journal', '')}".constantize
   end
 end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -48,6 +48,8 @@ class Journal < ApplicationRecord
   has_many :attachable_journals, class_name: 'Journal::AttachableJournal', dependent: :destroy
   has_many :customizable_journals, class_name: 'Journal::CustomizableJournal', dependent: :destroy
 
+  before_destroy :destroy_data
+
   # Scopes to all journals excluding the initial journal - useful for change
   # logs like the history on issue#show
   scope :changing, -> { where(['version > 1']) }
@@ -119,6 +121,10 @@ class Journal < ApplicationRecord
   end
 
   private
+
+  def destroy_data
+    data.destroy
+  end
 
   def predecessor
     @predecessor ||= self.class

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -385,7 +385,7 @@ module Journals
     end
 
     def journable_data_sql_addition
-      journable.class.vestal_journals_options[:data_sql]&.call(journable) || ''
+      journable.class.aaj_options[:data_sql]&.call(journable) || ''
     end
 
     def text_column_names

--- a/db/migrate/20200924085508_cleanup_orphaned_journal_data.rb
+++ b/db/migrate/20200924085508_cleanup_orphaned_journal_data.rb
@@ -1,0 +1,37 @@
+class CleanupOrphanedJournalData < ActiveRecord::Migration[6.0]
+  def up
+    cleanup_orphaned_journals('attachable_journals')
+    cleanup_orphaned_journals('customizable_journals')
+    cleanup_orphaned_journals('attachment_journals')
+    cleanup_orphaned_journals('changeset_journals')
+    cleanup_orphaned_journals('message_journals')
+    cleanup_orphaned_journals('news_journals')
+    cleanup_orphaned_journals('wiki_content_journals')
+    cleanup_orphaned_journals('work_package_journals')
+  end
+
+  # No down needed as this only cleans up data that should have been deleted anyway.
+
+  private
+
+  def cleanup_orphaned_journals(table)
+    execute <<~SQL
+      DELETE
+      FROM
+        #{table}
+      WHERE
+        #{table}.id IN (
+          SELECT
+            #{table}.id
+          FROM
+            #{table}
+          LEFT OUTER JOIN
+            journals
+          ON
+            journals.id = #{table}.journal_id
+          WHERE
+            journals.id IS NULL
+        )
+    SQL
+  end
+end

--- a/lib/plugins/acts_as_journalized/lib/acts/journalized/creation.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts/journalized/creation.rb
@@ -79,29 +79,6 @@ module Acts::Journalized
       end
     end
 
-    # Class methods added to ActiveRecord::Base to facilitate the creation of new journals.
-    module ClassMethods
-      # Overrides the basal +prepare_journaled_options+ method defined in VestalVersions::Options
-      # to extract the <tt>:calculate</tt> option into +vestal_journals_options+.
-      def prepare_journaled_options(options)
-        result = super(options)
-
-        assign_vestal = lambda do |key, array|
-          return unless result[key]
-
-          vestal_journals_options[key] = if array
-                                           Array(result.delete(key)).map(&:to_s).uniq
-                                         else
-                                           result.delete(key)
-                                         end
-        end
-
-        assign_vestal.call(:data_sql, false)
-
-        result
-      end
-    end
-
     module InstanceMethods
       # Returns an array of column names that are journaled.
       def journaled_columns_names

--- a/lib/plugins/acts_as_journalized/lib/acts/journalized/options.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts/journalized/options.rb
@@ -109,7 +109,7 @@ module Acts::Journalized
         result_options = journal_options.symbolize_keys
         result_options.reverse_merge!(
           class_name: Journal.name,
-          dependent: :delete_all,
+          dependent: :destroy,
           foreign_key: :journable_id,
           as: :journable
         )

--- a/lib/plugins/acts_as_journalized/lib/acts_as_journalized.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts_as_journalized.rb
@@ -73,11 +73,11 @@ module Acts
 
         include_aaj_modules
 
-        journal_hash = prepare_journaled_options(options)
+        prepare_journaled_options(options)
 
         has_many :journals, -> {
           order("#{Journal.table_name}.version ASC")
-        }, **journal_hash
+        }, **has_many_journals_options
       end
 
       private

--- a/spec/features/work_packages/tabs/activity_revisions_spec.rb
+++ b/spec/features/work_packages/tabs/activity_revisions_spec.rb
@@ -8,7 +8,7 @@ describe 'Activity tab', js: true, selenium: true do
     work_package.update(attributes.merge(updated_at: at))
 
     note_journal = work_package.journals.last
-    note_journal.update(created_at: at, user: attributes[:user])
+    note_journal.update(created_at: at, user: user)
   end
 
   let(:project) { FactoryBot.create :project_with_types, public: true }

--- a/spec/features/work_packages/tabs/activity_tab_spec.rb
+++ b/spec/features/work_packages/tabs/activity_tab_spec.rb
@@ -8,7 +8,7 @@ describe 'Activity tab', js: true, selenium: true do
     work_package.update(attributes.merge(updated_at: at))
 
     note_journal = work_package.journals.last
-    note_journal.update(created_at: at, user: attributes[:user])
+    note_journal.update(created_at: at, user: user)
   end
 
   let(:project) { FactoryBot.create :project_with_types, public: true }


### PR DESCRIPTION
Ensure all journal data (Journal, AttachableJournal, CustomizableJournal and the data entry e.g. Journal::WorkPackageJournal) are removed upon destruction of an aaj record. 

Before, at least in parts, they would reside in the DB, cluttering it.

https://community.openproject.com/wp/22048

### TODO

* [x] Write migration to clean up journal data for aaj entries already removed. E.g on community, we have about 60k orphaned CustomizableJournal, 70k orphaned AttachableJournal and 90 k orphaned Journal::WorkPackageJournal entries