### PR TITLE
Fix/34538 default gantt chart query wrong name

### DIFF
--- a/frontend/src/app/components/wp-query-select/wp-static-queries.service.ts
+++ b/frontend/src/app/components/wp-query-select/wp-static-queries.service.ts
@@ -77,7 +77,7 @@ export class WorkPackageStaticQueriesService {
       {
         identifier: 'gantt',
         label: this.text.gantt,
-        query_props: `{"c":["id","type","subject","status","startDate","dueDate"],"tv":true,"tzl":"auto","tll":"{\\"left\\":\\"startDate\\",\\"right\\":\\"dueDate\\",\\"farRight\\":null}","hi":true,"g":"","t":"id:asc","t":"startDate:asc","f":[{"n":"status","o":"o","v":[]}]}`
+        query_props: `{"c":["id","type","subject","status","startDate","dueDate"],"tv":true,"tzl":"auto","tll":"{\\"left\\":\\"startDate\\",\\"right\\":\\"dueDate\\",\\"farRight\\":null}","hi":true,"g":"","t":"startDate:asc","f":[{"n":"status","o":"o","v":[]}]}`
       },
       {
         identifier: 'recently_created',
@@ -118,9 +118,10 @@ export class WorkPackageStaticQueriesService {
       let queryProps = JSON.parse(this.$state.params.query_props);
       delete queryProps.pp;
       delete queryProps.pa;
+      let queryPropsString = JSON.stringify(queryProps);
 
       const matched = _.find(this.all, item =>
-        item.query_props && item.query_props === JSON.stringify(queryProps)
+        item.query_props && item.query_props === queryPropsString
       );
 
       if (matched) {


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34538

This pull request:

- [x] Removes the duplicated 't' params on the static Gantt query so it matches the URL query params.

NOTE:
I don't know what does this 't' stands for, if it can be duplicated and, mainly, I don't know if it was working before this way. If it was working in the past then this change could lead to other errors.