### PR TITLE
[34550] Output board widget errors even if successful copy

### DIFF
--- a/app/services/copy/dependency.rb
+++ b/app/services/copy/dependency.rb
@@ -62,8 +62,8 @@ module Copy
 
     ##
     # Merge some other model's errors with the result errors
-    def add_error!(model, errors)
-      result.errors.add(:base, "#{human_model_name(model)}: #{error_messages(errors)}")
+    def add_error!(model, errors, model_name: human_model_name(model))
+      result.errors.add(:base, "#{model_name}: #{error_messages(errors)}")
     end
 
     def human_model_name(model)

--- a/app/services/grids/copy/widgets_dependent_service.rb
+++ b/app/services/grids/copy/widgets_dependent_service.rb
@@ -41,7 +41,7 @@ module Grids::Copy
         new_widget = duplicate_widget widget, new_grid, params
 
         if new_widget && !new_widget.save
-          add_error! new_widget, new_widget.errors
+          add_error! new_widget, new_widget.errors, model_name: widget_model_name(widget)
         end
       end
     end
@@ -56,11 +56,16 @@ module Grids::Copy
             new_widget.options[option] = value
           end
         else
-          add_error! widget, result.errors
+          add_error! widget, result.errors, model_name: widget_model_name(widget)
         end
       end
 
       new_widget if references.all?(&:success?)
+    end
+
+    # Provide a human readable name for the widget
+    def widget_model_name(widget)
+      I18n.t('grids.label_widget_in_grid', grid_name: widget.grid.to_s)
     end
 
     def map_references(widget, params)

--- a/app/services/projects/copy/boards_dependent_service.rb
+++ b/app/services/projects/copy/boards_dependent_service.rb
@@ -49,7 +49,7 @@ module Projects::Copy
         .new(source: board, user: user)
         .with_state(state)
         .call(params.merge)
-        .on_failure { |result| add_error! board, result.errors }
+        .tap { |call| result.merge!(call, without_success: true) }
     end
   end
 end

--- a/app/services/projects/copy/overview_dependent_service.rb
+++ b/app/services/projects/copy/overview_dependent_service.rb
@@ -44,7 +44,7 @@ module Projects::Copy
         .new(source: overview, user: user)
         .with_state(state)
         .call(params.merge)
-        .on_failure { |result| add_error! overview, result.errors }
+        .tap { |call| result.merge!(call, without_success: true) }
     end
   end
 end

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -134,13 +134,13 @@ class ServiceResult
     self.dependent_results += inner_results
   end
 
-  def on_success
-    tap if success?
+  def on_success(&block)
+    tap(&block) if success?
     self
   end
 
-  def on_failure
-    tap if failure?
+  def on_failure(&block)
+    tap(&block) if failure?
     self
   end
 

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -135,12 +135,17 @@ class ServiceResult
   end
 
   def on_success
-    yield(self) if success?
+    tap if success?
     self
   end
 
   def on_failure
-    yield(self) if failure?
+    tap if failure?
+    self
+  end
+
+  def tap
+    yield(self)
     self
   end
 

--- a/modules/boards/spec/services/copy_service_integration_spec.rb
+++ b/modules/boards/spec/services/copy_service_integration_spec.rb
@@ -36,20 +36,9 @@ describe Projects::CopyService, 'integration', type: :model do
                       member_in_project: source,
                       member_through_role: role)
   end
-  let(:role) { FactoryBot.create :role, permissions: %i[copy_projects] }
-
-  let(:source) { FactoryBot.create :project, enabled_module_names: %w[boards work_package_tracking] }
-  let!(:wp_1) { FactoryBot.create(:work_package, project: source, subject: 'Second') }
-  let!(:wp_2) { FactoryBot.create(:work_package, project: source, subject: 'First') }
-
-  let!(:board_view) { FactoryBot.create :board_grid_with_query, project: source, name: 'My Board' }
+  let!(:source) { FactoryBot.create :project, enabled_module_names: %w[boards work_package_tracking] }
   let(:query) { board_view.contained_queries.first }
-
-  before do
-    ::OrderedWorkPackage.create(query: query, work_package: wp_1, position: 1234)
-    ::OrderedWorkPackage.create(query: query, work_package: wp_2, position: -1000)
-  end
-
+  let(:role) { FactoryBot.create :role, permissions: %i[copy_projects] }
   let(:instance) do
     described_class.new(source: source, user: current_user)
   end
@@ -60,51 +49,102 @@ describe Projects::CopyService, 'integration', type: :model do
   let(:params) do
     { target_project_params: target_project_params, only: only_args }
   end
+  subject { instance.call(params) }
+  let(:project_copy) { subject.result }
+  let(:board_copies) { Boards::Grid.where(project: project_copy) }
+  let(:board_copy) { board_copies.first }
 
-  describe 'call' do
-    subject { instance.call(params) }
-    let(:project_copy) { subject.result }
-    let(:board_copies) { Boards::Grid.where(project: project_copy) }
-    let(:board_copy) { board_copies.first }
+  describe 'for a subproject board' do
+    let(:current_user) do
+      FactoryBot.create(:user,
+                        member_in_projects: [source, child_project],
+                        member_through_role: role)
+    end
+    let!(:child_project) { FactoryBot.create :project, parent: source }
+    let!(:board_view) do
+      FactoryBot.create :board_grid_with_query,
+                        project: source,
+                        name: 'Subproject board',
+                        options: { "type" => "action", "attribute" => "subproject" }
+    end
 
-    it 'will copy the boards with the order correct' do
+    before do
+      login_as current_user
+
+      # Modify the actual saved query to contain the subproject filter
+      query = board_view.contained_queries.first
+      query.add_filter('only_subproject_id', '=', child_project.id)
+      query.save!
+    end
+
+    let(:expected_error) do
+      "Widget contained in Grid Board 'Subproject board': Only subproject Values is not set to one of the allowed values."
+    end
+
+    it 'will succeed to copy, but add an error for the missing subproject column (Regression #34550)' do
+      # Expect to have created to board, but with error
       expect(subject).to be_success
-
+      expect(subject.errors.full_messages).to eq([expected_error])
       expect(board_copies.count).to eq 1
 
       # Expect board name to match
-      expect(board_copy.name).to eq 'My Board'
+      expect(board_copy.name).to eq 'Subproject board'
 
-      # Expect query to differ
-      query_id = board_copy.widgets.first.options['queryId']
-      expect(query_id.to_i).not_to eq(query.id)
+      # Expect the widget to be lost during save
+      expect(board_copy.widgets).to be_empty
+    end
+  end
 
-      # Expect query to be in correct project
-      query = Query.find(query_id)
-      expect(query.project).to eq project_copy
+  describe 'for ordered work packages' do
+    let!(:board_view) { FactoryBot.create :board_grid_with_query, project: source, name: 'My Board' }
+    let!(:wp_1) { FactoryBot.create(:work_package, project: source, subject: 'Second') }
+    let!(:wp_2) { FactoryBot.create(:work_package, project: source, subject: 'First') }
 
-      # Expect widgets have been copied (including updated query references)
-      widget = board_view.widgets.first
-      widget_copy = board_copy.widgets.first
+    before do
+      ::OrderedWorkPackage.create(query: query, work_package: wp_1, position: 1234)
+      ::OrderedWorkPackage.create(query: query, work_package: wp_2, position: -1000)
+    end
 
-      different_attr = %w(id grid_id options)
-      expect(widget.attributes.except(*different_attr)).to eq widget_copy.attributes.except(*different_attr)
+    describe 'call' do
+      it 'will copy the boards with the order correct' do
+        expect(subject).to be_success
 
-      expect(widget_copy.grid_id).to eq board_copy.id
-      expect(widget_copy.options["queryId"]).to eq query.id
-      expect(widget_copy.options["filters"]).to eq widget.options["filters"]
+        expect(board_copies.count).to eq 1
 
-      # Expect work packages have been copied in the correct order
-      wps = query.ordered_work_packages
-      expect(wps.count).to eq 2
+        # Expect board name to match
+        expect(board_copy.name).to eq 'My Board'
 
-      expect(wps[0].work_package.subject).to eq 'First'
-      expect(wps[0].position).to eq -1000
-      expect(wps[0].work_package.id).not_to eq wp_2.id
+        # Expect query to differ
+        query_id = board_copy.widgets.first.options['queryId']
+        expect(query_id.to_i).not_to eq(query.id)
 
-      expect(wps[1].work_package.subject).to eq 'Second'
-      expect(wps[1].position).to eq 1234
-      expect(wps[1].work_package.id).not_to eq wp_1.id
+        # Expect query to be in correct project
+        query = Query.find(query_id)
+        expect(query.project).to eq project_copy
+
+        # Expect widgets have been copied (including updated query references)
+        widget = board_view.widgets.first
+        widget_copy = board_copy.widgets.first
+
+        different_attr = %w(id grid_id options)
+        expect(widget.attributes.except(*different_attr)).to eq widget_copy.attributes.except(*different_attr)
+
+        expect(widget_copy.grid_id).to eq board_copy.id
+        expect(widget_copy.options["queryId"]).to eq query.id
+        expect(widget_copy.options["filters"]).to eq widget.options["filters"]
+
+        # Expect work packages have been copied in the correct order
+        wps = query.ordered_work_packages
+        expect(wps.count).to eq 2
+
+        expect(wps[0].work_package.subject).to eq 'First'
+        expect(wps[0].position).to eq -1000
+        expect(wps[0].work_package.id).not_to eq wp_2.id
+
+        expect(wps[1].work_package.subject).to eq 'Second'
+        expect(wps[1].position).to eq 1234
+        expect(wps[1].work_package.id).not_to eq wp_1.id
+      end
     end
   end
 end

--- a/modules/grids/app/models/grids/grid.rb
+++ b/modules/grids/app/models/grids/grid.rb
@@ -43,6 +43,10 @@ module Grids
       false
     end
 
+    def to_s
+      name.presence || self.class.to_s.demodulize
+    end
+
     acts_as_attachable
   end
 end

--- a/modules/grids/config/locales/en.yml
+++ b/modules/grids/config/locales/en.yml
@@ -1,4 +1,6 @@
 en:
+  grids:
+    label_widget_in_grid: "Widget contained in Grid %{grid_name}"
   activerecord:
     attributes:
       grids/grid:


### PR DESCRIPTION
If you try to copy a subproject board to a new project, the subproject will not be copied and the board column will no longer be valid. This error was not output, was the overall board copy succeeded and we allow errors to happen during the dependencies, but not fail the entire copy.

We just need to output the errors on successful copy as well, which is what this PR does. It also extends the copy depdency to allow customized names for grid widgets, which don't really have a humanly identifiable name other than their grid connection

https://community.openproject.com/wp/34550