### PR TITLE
Fix: Api vs API (API settings not found on saas)

### DIFF
--- a/app/controllers/settings/api_controller.rb
+++ b/app/controllers/settings/api_controller.rb
@@ -27,7 +27,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Settings::ApiController < SettingsController
+class Settings::APIController < SettingsController
   include AdminSettingsUpdater
 
   menu_item :settings_api

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -57,7 +57,8 @@ OpenProject::Inflector.inflection(
   'pop3' => 'POP3',
   'cors' => 'CORS',
   'openid_connect' => 'OpenIDConnect',
-  'pdf_export' => 'PDFExport'
+  'pdf_export' => 'PDFExport',
+  'api_controller' => 'APIController'
 )
 
 Rails.autoloaders.each do |autoloader|


### PR DESCRIPTION
WP [#34294](https://community.openproject.com/projects/gmbh/work_packages/34294/activity)

Requirement for https://github.com/opf/saas-openproject/pull/81