### PR TITLE
(Re)adds link to CSS styles in only_logo layout

### DIFF
--- a/app/views/layouts/only_logo.html.erb
+++ b/app/views/layouts/only_logo.html.erb
@@ -37,6 +37,8 @@ See docs/COPYRIGHT.rdoc for more details.
   <%= output_title_and_meta_tags %>
   <%= csrf_meta_tags %>
   <%= render 'common/favicons' %>
+  <%# Include CLI assets (development) or prod build assets %>
+  <%= include_frontend_assets %>
 </head>
 <body>
   <div id="wrapper">


### PR DESCRIPTION
Apparently it got lost here
https://github.com/opf/openproject/commit/2f8c303df22b92f0d0657bfaa45c031da45da389#diff-cc94c74de4ccf86a7e835af33a1100df