### PR TITLE
Bim/fix/34493 revit responsive design failing on wp form

### DIFF
--- a/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
+++ b/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
@@ -15,6 +15,9 @@
     .work-packages-partitioned-page--content-right
       display: none
 
+    .work-packages-partitioned-page--content-left
+      overflow: auto
+
   &.-left-only
     wp-resizer
       display: none


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34493

This pull request:

- [x] Fixes form responsive design on the left partition (.work-packages-partitioned-query-space--container) when there is only the left side (.-left-only)(ie: Revit).