### PR TITLE
Fix/34126 gantt chart row styles conflict between active and hovered

### DIFF
--- a/frontend/src/app/modules/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/modules/global_search/input/global-search-input.component.html
@@ -63,8 +63,10 @@
                   #{{item.id}}
                   </a>
                   <span [textContent]="item.status"
+                    [ngClass]="statusHighlighting(item.statusId)"
                     class="global-search--wp-status">
                   </span>
+
                 </div>
               </div>
             </a>

--- a/frontend/src/app/modules/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/modules/global_search/input/global-search-input.component.html
@@ -62,11 +62,9 @@
                     [ngClass]="uiStateLinkClass">
                   #{{item.id}}
                   </a>
-                  <span [textContent]="item.status" 
-                    [ngClass]="statusHighlighting(item.statusId)"
+                  <span [textContent]="item.status"
                     class="global-search--wp-status">
                   </span>
-                  
                 </div>
               </div>
             </a>

--- a/frontend/src/global_styles/layout/work_packages/_table.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table.sass
@@ -62,7 +62,7 @@
   div.row-hovered
     // Use important to override the background styles from __hl classes
     // That also have to be important (cf. 30863)
-    background: #d1ebfb85 !important
+    background: var(--gray-lighter) !important
 
 // Left part of the split view
 // == flex container for (table|timeline)


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34126

This pull request:

- [x] Changes the hovered row's background color from blue to grey to avoid styles conflict with the selected row (blue).

NOTE:
The changes on global-search-input.component.html are just 'auto-format' replacements made by Rubymine.