### PR TITLE
Correct width calculation on cells with user picture

### DIFF
--- a/frontend/src/global_styles/content/modules/_avatars.sass
+++ b/frontend/src/global_styles/content/modules/_avatars.sass
@@ -23,6 +23,9 @@
 .avatar-default
   margin-right: 5px
 
+.avatar--fallback
+  max-width: none
+
 .user-avatar--multi-line
   display: block
   margin-bottom: 2px


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34431

This pull request:

- [x] Removes an inherited max-width from the avatars with a user picture so their width is correctly calculated and the final column width is right (the ellipsis is not shown if not needed).