### PR TITLE
Fix/34710 allow schedule manual parent wp on gantt chart

### DIFF
--- a/frontend/src/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
+++ b/frontend/src/app/components/wp-table/timeline/cells/wp-timeline-cell-mouse-handler.ts
@@ -149,7 +149,9 @@ export function registerWorkPackageMouseHandler(this:void,
       return;
     }
 
-    if (!(wp.isLeaf && renderer.canMoveDates(wp))) {
+    const isEditable = (wp.isLeaf || wp.scheduleManually) && renderer.canMoveDates(wp);
+
+    if (!isEditable) {
       cell.style.cursor = 'not-allowed';
       return;
     }


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34710

This pull request:

- [x] Allows parent work packages that are on 'Manual Scheduling' mode to be scheduled right from the Gantt chart as the independent work packages are.