### PR TITLE
Sums and group rows color swap, but not in table footer

### DIFF
--- a/frontend/src/global_styles/content/work_packages/_table_content.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_content.sass
@@ -55,10 +55,6 @@
     .wp-table--cell-td
       display: none !important
 
-// Sums row background
-.wp-table--sums-row
-  background: #f6f7f8
-
 .wp-table--sum-container
   font-weight: bold
   padding: 3px 6px
@@ -88,8 +84,10 @@
 // Remove padding from grouping rows (exceeds allowed width of 41px)
 .wp-table--group-header
   height: var(--table-timeline--row-height)
+  background-color: var(--gray-light)
   td
     padding: 0 !important
+    background-color: transparent !important
 
   .group--value
     @include text-shortener


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34711

This pulls request:

- [x] Swaps colors between sums and group rows, but not in the table footer were it remains grey even if it has sums.