### PR TITLE
remove remains of rails based api - grape is used now

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -40,7 +40,6 @@ class AccountController < ApplicationController
   # prevents login action to be filtered by check_if_login_required application scope filter
   skip_before_action :check_if_login_required
 
-  before_action :disable_api
   before_action :check_auth_source_sso_failure, only: :auth_source_sso_failed
 
   layout 'no_menu'
@@ -558,13 +557,6 @@ class AccountController < ApplicationController
 
       token.user
     end
-  end
-
-  def disable_api
-    # Changing this to not use api_request? to determine whether a request is an API
-    # request can have security implications regarding CSRF. See handle_unverified_request
-    # for more information.
-    head 410 if api_request?
   end
 
   def invalid_token_and_redirect

--- a/app/controllers/colors_controller.rb
+++ b/app/controllers/colors_controller.rb
@@ -28,7 +28,7 @@
 #++
 
 class ColorsController < ApplicationController
-  before_action :require_admin_unless_readonly_api_request
+  before_action :require_admin
 
   layout 'admin'
 
@@ -112,10 +112,5 @@ class ColorsController < ApplicationController
 
   def show_local_breadcrumb
     true
-  end
-
-  def require_admin_unless_readonly_api_request
-    require_admin unless %w[index show].include? params[:action] and
-                         api_request?
   end
 end

--- a/app/controllers/concerns/accounts/current_user.rb
+++ b/app/controllers/concerns/accounts/current_user.rb
@@ -78,11 +78,6 @@ module Accounts::CurrentUser
     elsif params[:format] == 'atom' && params[:key] && accept_key_auth_actions.include?(params[:action])
       # RSS key authentication does not start a session
       User.find_by_rss_key(params[:key])
-    elsif Setting.rest_api_enabled? && api_request?
-      if (key = api_key_from_request) && accept_key_auth_actions.include?(params[:action])
-        # Use API key
-        User.find_by_api_key(key)
-      end
     end
   end
 

--- a/modules/webhooks/app/controllers/webhooks/incoming/hooks_controller.rb
+++ b/modules/webhooks/app/controllers/webhooks/incoming/hooks_controller.rb
@@ -41,15 +41,6 @@ module Webhooks
       # making it available as params[:payload]
       wrap_parameters :payload
 
-      def api_request?
-        # OpenProject only allows API requests based on an Accept request header.
-        # Webhooks (at least GitHub) don't send an Accept header as they're not interested
-        # in any part of the response except the HTTP status code.
-        # Also handling requests with a application/json Content-Type as API requests
-        # should be safe regarding CSRF as browsers don't send forms as JSON.
-        super || request.content_type == "application/json"
-      end
-
       def handle_hook
         hook = OpenProject::Webhooks.find(params.require('hook_name'))
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -119,30 +119,12 @@ describe ApplicationController, type: :controller do
     end
 
     context 'for non-API resources' do
-      before do
-        allow(@controller).to receive(:api_request?).and_return(false)
-      end
-
       it_behaves_like 'handle_unverified_request resets session'
 
       it 'should give 422' do
         expect(@controller).to receive(:render_error) do |options|
           expect(options[:status]).to eql(422)
         end
-
-        @controller.send :handle_unverified_request
-      end
-    end
-
-    context 'for API resources' do
-      before do
-        allow(@controller).to receive(:api_request?).and_return(true)
-      end
-
-      it_behaves_like 'handle_unverified_request resets session'
-
-      it 'should not render an error' do
-        expect(@controller).not_to receive(:render_error)
 
         @controller.send :handle_unverified_request
       end

--- a/spec/support/shared/permissions.rb
+++ b/spec/support/shared/permissions.rb
@@ -62,12 +62,8 @@ module PermissionSpecHelpers
         if invalid_user.logged?
           expect(response.response_code).to eq(403)
         else
-          if controller.send(:api_request?)
-            expect(response.response_code).to eq(401)
-          else
-            expect(response).to be_redirect
-            expect(response.redirect_url).to match(%r'/login')
-          end
+          expect(response).to be_redirect
+          expect(response.redirect_url).to match(%r'/login')
         end
       end
     end if test_denied

--- a/spec/views/layouts/admin.html.erb_spec.rb
+++ b/spec/views/layouts/admin.html.erb_spec.rb
@@ -40,7 +40,6 @@ describe 'layouts/admin', type: :view do
     allow(controller).to receive(:default_search_scope)
 
     parent_menu_item = Object.new
-    allow(view).to receive(:admin_first_level_menu_entry).and_return parent_menu_item
     allow(parent_menu_item).to receive(:name).and_return :root
 
     allow(User).to receive(:current).and_return admin


### PR DESCRIPTION
Those references stem from a time where API requests where handled by rails, e.g. the v2 and v1. Nowadays, all API is handled by grape.