### PR TITLE
Revert "[34712] Menu too small/completely hidden on Roadmap"

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -148,17 +148,17 @@ See docs/COPYRIGHT.rdoc for more details.
       <div id="main-menu" class="main-menu">
         <h1 class="hidden-for-sighted"><%= t(:label_main_menu) %></h1>
         <main-menu-resizer></main-menu-resizer>
-          <div id="menu-sidebar"> 
-            <div class="main-menu-wrapper">
-              <%= main_menu %>
-              <%= content_for :main_menu %>
-              <%= call_hook :view_layouts_base_main_menu %>
-              <!-- Sidebar -->
-              <div id="sidebar">
-                <%= content_for :sidebar %>
-                <%= call_hook :view_layouts_base_sidebar %>
-              </div>
+        <div id="menu-sidebar">
+          <div class="main-menu-wrapper">
+            <%= main_menu %>
+            <%= content_for :main_menu %>
+            <%= call_hook :view_layouts_base_main_menu %>
+            <!-- Sidebar -->
+            <div id="sidebar">
+              <%= content_for :sidebar %>
+              <%= call_hook :view_layouts_base_sidebar %>
             </div>
+          </div>
         </div>
       </div>
     <% end %>

--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -69,10 +69,9 @@ $menu-item-line-height: 30px
       @include styled-scroll-bar
     
     .main-menu-wrapper
-      .menu_root.closed:nth-last-child(3)
-        display: flex
-        flex-direction: column
-        height: 100%
+      display: flex
+      flex-direction: column
+      height: 100%
 
   a:focus
     color: var(--main-menu-font-color)


### PR DESCRIPTION
Reverts opf/openproject#8743 as it brakes the BCF module (and we have a deployment on BIM shards tomorrow morning). In the BCF module the tab contents for **Models**, **Objects**, **Classes**, and **Storeys** look empty although they are not.
![image](https://user-images.githubusercontent.com/327272/94856565-74d52880-0430-11eb-9a13-79c84cd6fea4.png)
