### PR TITLE
fix date inheritance from parents with only one date available

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -281,10 +281,16 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
   end
 
   def parent_start_earlier_than_due?
-    work_package.parent&.start_date && work_package.parent.start_date < (work_package.due_date || work_package.parent.due_date)
+    start = work_package.parent&.start_date
+    due = work_package.due_date || work_package.parent&.due_date
+
+    (start && !due) || ((due && start) && (start < due))
   end
 
   def parent_due_later_than_start?
-    work_package.parent&.due_date && work_package.parent.due_date > (work_package.start_date || work_package.parent.start_date)
+    due = work_package.parent&.due_date
+    start = work_package.start_date || work_package.parent&.start_date
+
+    (due && !start) || ((due && start) && (due > start))
   end
 end

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -327,6 +327,48 @@ describe WorkPackages::SetAttributesService, type: :model do
           end
         end
 
+        context 'with the parent having start date (no due) and not providing own dates' do
+          let(:call_attributes) { { parent: parent } }
+          let(:parent_due_date) { nil }
+
+          it_behaves_like 'service call' do
+            it "sets the start_date to the parent`s start_date" do
+              subject
+
+              expect(work_package.start_date)
+                .to eql parent_start_date
+            end
+
+            it "sets the due_date to nil" do
+              subject
+
+              expect(work_package.due_date)
+                .to be_nil
+            end
+          end
+        end
+
+        context 'with the parent having due date (no start) and not providing own dates' do
+          let(:call_attributes) { { parent: parent } }
+          let(:parent_start_date) { nil }
+
+          it_behaves_like 'service call' do
+            it "sets the start_date to nil" do
+              subject
+
+              expect(work_package.start_date)
+                .to be_nil
+            end
+
+            it "sets the due_date to the parent`s due_date" do
+              subject
+
+              expect(work_package.due_date)
+                .to eql parent_due_date
+            end
+          end
+        end
+
         context 'with the parent having dates but providing own dates' do
           let(:call_attributes) { { parent: parent, start_date: Date.today, due_date: Date.today + 1.day } }
 


### PR DESCRIPTION
In case the dates are only set partially on the parent, e.g. only due date, a nil to Date comparison needs to be prevented.

https://community.openproject.com/wp/34797