### PR TITLE
Datepicker shown on first click with no side effects

### DIFF
--- a/frontend/src/app/modules/augmenting/dynamic-scripts/backlogs/model.js
+++ b/frontend/src/app/modules/augmenting/dynamic-scripts/backlogs/model.js
@@ -312,7 +312,10 @@ RB.Model = (function ($) {
 
       if (!j.hasClass('editing') && !j.hasClass('dragging') && !j.hasClass('prevent_edit') && !$(e.target).hasClass('prevent_edit')) {
         editor = model.edit();
-        editor.find('.' + $(e.currentTarget).attr('fieldname') + '.editor').focus();
+        var input = editor.find('.' + $(e.currentTarget).attr('fieldname') + '.editor');
+
+        input.focus();
+        input.click();
       }
     },
 

--- a/frontend/src/app/modules/augmenting/dynamic-scripts/backlogs/story.js
+++ b/frontend/src/app/modules/augmenting/dynamic-scripts/backlogs/story.js
@@ -37,7 +37,7 @@ RB.Story = (function ($) {
 
       // Associate this object with the element for later retrieval
       this.$.data('this', this);
-      this.$.on('mouseup', '.editable', this.handleClick);
+      this.$.on('click', '.editable', this.handleClick);
     },
 
     /**

--- a/modules/backlogs/app/views/rb_sprints/_sprint.html.erb
+++ b/modules/backlogs/app/views/rb_sprints/_sprint.html.erb
@@ -54,7 +54,7 @@ See docs/COPYRIGHT.rdoc for more details.
       <%= text_field_tag :start_date,
                          sprint.start_date,
                          id: "start_date_#{sprint.id}",
-                         class: '-augmented-datepicker effective_date editor' %>
+                         class: '-augmented-datepicker start_date editor' %>
       <%= text_field_tag :name,
                          sprint.name,
                          class: 'name editor' %>


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34436

This pull request:

- [x] Changes the stories edit trigger from 'mouseup' to 'click' to avoid editing a story when a mouse event that has been generated over another element (ie: datepicker) is 'mouseup' over a story.
- [x] Triggers a  'click' event whenever a story date input is focused so the global click handler creates a date pickers on it.
- [x] Fixes a CSS class that was wrong applied causing the date picker not to be shown on start dates. 