### PR TITLE
Fix/25683 warning when data will be discarded rebased

### DIFF
--- a/frontend/src/app/globals/global-listeners.ts
+++ b/frontend/src/app/globals/global-listeners.ts
@@ -97,7 +97,7 @@ import {detectOnboardingTour} from "core-app/globals/onboarding/onboarding_tour_
         // Cancel the event
         event.preventDefault();
         // Chrome requires returnValue to be set
-        event.returnValue = window.I18n.t("js.work_packages.confirm_edit_cancel");
+        event.returnValue = I18n.t("js.work_packages.confirm_edit_cancel");
       }
     });
 

--- a/frontend/src/app/globals/global-listeners.ts
+++ b/frontend/src/app/globals/global-listeners.ts
@@ -92,8 +92,7 @@ import {detectOnboardingTour} from "core-app/globals/onboarding/onboarding_tour_
     // Global beforeunload hook
     $(window).on('beforeunload', (e:JQuery.TriggeredEvent) => {
       const event = e.originalEvent as BeforeUnloadEvent;
-      if ((window.OpenProject.pageWasEdited && !window.OpenProject.pageIsSubmitted) ||
-           window.OpenProject.editFormsContainModelChanges) {
+      if (window.OpenProject.pageWasEdited && !window.OpenProject.pageIsSubmitted) {
         // Cancel the event
         event.preventDefault();
         // Chrome requires returnValue to be set

--- a/frontend/src/app/globals/global-listeners.ts
+++ b/frontend/src/app/globals/global-listeners.ts
@@ -92,11 +92,12 @@ import {detectOnboardingTour} from "core-app/globals/onboarding/onboarding_tour_
     // Global beforeunload hook
     $(window).on('beforeunload', (e:JQuery.TriggeredEvent) => {
       const event = e.originalEvent as BeforeUnloadEvent;
-      if (window.OpenProject.pageWasEdited && !window.OpenProject.pageIsSubmitted) {
+      if ((window.OpenProject.pageWasEdited && !window.OpenProject.pageIsSubmitted) ||
+           window.OpenProject.editFormsContainModelChanges) {
         // Cancel the event
         event.preventDefault();
         // Chrome requires returnValue to be set
-        event.returnValue = '';
+        event.returnValue = window.I18n.t("js.work_packages.confirm_edit_cancel");
       }
     });
 

--- a/frontend/src/app/globals/openproject.ts
+++ b/frontend/src/app/globals/openproject.ts
@@ -45,6 +45,12 @@ export class OpenProject {
   /** Globally setable variable whether the page form is submitted.
    * Necessary to avoid a data loss warning on beforeunload */
   public pageIsSubmitted:boolean = false;
+  /** Globally setable variable whether any of the EditFormComponent
+   * contain changes.
+   * Necessary to show a data loss warning on beforeunload when clicking
+   * on a link out of the Angular app (ie: main side menu)
+   * */
+  public editFormsContainModelChanges:boolean;
 
   public getPluginContext():Promise<OpenProjectPluginContext> {
     return this.pluginContext

--- a/frontend/src/app/modules/fields/edit/edit-form/edit-form.component.ts
+++ b/frontend/src/app/modules/fields/edit/edit-form/edit-form.component.ts
@@ -45,7 +45,6 @@ import {EditingPortalService} from "core-app/modules/fields/edit/editing-portal/
 import {EditFormRoutingService} from "core-app/modules/fields/edit/edit-form/edit-form-routing.service";
 import {ResourceChangesetCommit} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
 import {GlobalEditFormChangesTrackerService} from "core-app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service";
-import {FormattableEditFieldComponent} from "core-app/modules/fields/edit/field-types/formattable-edit-field.component";
 
 @Component({
   selector: 'edit-form,[edit-form]',
@@ -59,7 +58,6 @@ export class EditFormComponent extends EditForm<HalResource> implements OnInit, 
   @Output('onSaved') onSavedEmitter = new EventEmitter<{ savedResource:HalResource, isInitial:boolean }>();
 
   public fields:{ [attribute:string]:EditableAttributeFieldComponent } = {};
-  private fieldsWithModelChanges = new Map();
   private registeredFields = input<string[]>();
   private unregisterListener:Function;
 
@@ -96,16 +94,18 @@ export class EditFormComponent extends EditForm<HalResource> implements OnInit, 
     });
   }
 
-  ngOnDestroy() {
-    this.unregisterListener();
-  }
-
   ngOnInit() {
     this.editMode = this.initializeEditMode;
+    this.globalEditFormChangesTrackerService.addToActiveForms(this);
 
     if (this.initializeEditMode) {
       this.start();
     }
+  }
+
+  ngOnDestroy() {
+    this.unregisterListener();
+    this.globalEditFormChangesTrackerService.removeFromActiveForms(this);
   }
 
   public async activateField(form:EditForm, schema:IFieldSchema, fieldName:string, errors:string[]):Promise<EditFieldHandler> {
@@ -210,22 +210,5 @@ export class EditFormComponent extends EditForm<HalResource> implements OnInit, 
     const changed = this.change.changes[fieldName];
 
     return hasDefault && !changed;
-  }
-
-  public get hasModelChanges() {
-    return this.fieldsWithModelChanges.size !== 0;
-  }
-
-  public addToFieldsWithModelChanges(field:FormattableEditFieldComponent, value:any) {
-    this.fieldsWithModelChanges.set(field, value);
-    this.globalEditFormChangesTrackerService.addToFormsWithModelChanges(this);
-  }
-
-  public removeFromFieldsWithModelChanges(field:FormattableEditFieldComponent) {
-    this.fieldsWithModelChanges.delete(field);
-
-    if (!this.hasModelChanges) {
-      this.globalEditFormChangesTrackerService.removeFromFormsWithModelChanges(this);
-    }
   }
 }

--- a/frontend/src/app/modules/fields/edit/edit-form/edit-form.component.ts
+++ b/frontend/src/app/modules/fields/edit/edit-form/edit-form.component.ts
@@ -45,6 +45,7 @@ import {EditingPortalService} from "core-app/modules/fields/edit/editing-portal/
 import {EditFormRoutingService} from "core-app/modules/fields/edit/edit-form/edit-form-routing.service";
 import {ResourceChangesetCommit} from "core-app/modules/fields/edit/services/hal-resource-editing.service";
 import {GlobalEditFormChangesTrackerService} from "core-app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service";
+import {FormattableEditFieldComponent} from "core-app/modules/fields/edit/field-types/formattable-edit-field.component";
 
 @Component({
   selector: 'edit-form,[edit-form]',
@@ -215,12 +216,12 @@ export class EditFormComponent extends EditForm<HalResource> implements OnInit, 
     return this.fieldsWithModelChanges.size !== 0;
   }
 
-  public addToFieldsWithModelChanges(field:any, value:any) {
+  public addToFieldsWithModelChanges(field:FormattableEditFieldComponent, value:any) {
     this.fieldsWithModelChanges.set(field, value);
     this.globalEditFormChangesTrackerService.addToFormsWithModelChanges(this);
   }
 
-  public removeFromFieldsWithModelChanges(field:any) {
+  public removeFromFieldsWithModelChanges(field:FormattableEditFieldComponent) {
     this.fieldsWithModelChanges.delete(field);
 
     if (!this.hasModelChanges) {

--- a/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
@@ -32,7 +32,7 @@ import {
   ChangeDetectionStrategy,
   ElementRef,
   Inject,
-  ChangeDetectorRef, Injector, Optional, OnDestroy
+  ChangeDetectorRef, Injector, OnDestroy
 } from "@angular/core";
 import {
   EditFieldComponent,
@@ -46,7 +46,6 @@ import {ResourceChangeset} from "core-app/modules/fields/changeset/resource-chan
 import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 import {IFieldSchema} from "core-app/modules/fields/field.base";
 import {EditFieldHandler} from "core-app/modules/fields/edit/editing-portal/edit-field-handler";
-import {EditFormComponent} from "core-app/modules/fields/edit/edit-form/edit-form.component";
 
 export const formattableFieldTemplate = `
     <div class="textarea-wrapper">
@@ -94,9 +93,7 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
               @Inject(OpEditingPortalSchemaToken) public schema:IFieldSchema,
               @Inject(OpEditingPortalHandlerToken) readonly handler:EditFieldHandler,
               readonly cdRef:ChangeDetectorRef,
-              readonly injector:Injector,
-              // Get parent field group from injector if we're in a form
-              @Optional() protected editForm:EditFormComponent) {
+              readonly injector:Injector) {
     super(I18n, elementRef, change, schema, handler, cdRef, injector);
   }
 
@@ -113,8 +110,6 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
 
   ngOnDestroy() {
     super.ngOnDestroy();
-
-    this.editForm.removeFromFieldsWithModelChanges(this);
   }
 
   public onCkeditorSetup(editor:ICKEditorInstance) {
@@ -136,7 +131,6 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
     // in the changeset when no actual change has taken place.
     if (this.rawValue !== value) {
       this.rawValue = value;
-      this.editForm.addToFieldsWithModelChanges(this, this.rawValue);
     }
   }
 
@@ -144,15 +138,12 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
     this.getCurrentValue()
       .then(() => {
         this.handler.handleUserSubmit();
-        this.editForm.removeFromFieldsWithModelChanges(this);
       });
 
     return false;
   }
 
   public handleUserCancel() {
-    this.editForm.removeFromFieldsWithModelChanges(this);
-
     this.handler.handleUserCancel();
   }
 
@@ -174,8 +165,6 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
       this.editor.content = this.rawValue;
 
       this.cdRef.markForCheck();
-
-      this.editForm.removeFromFieldsWithModelChanges(this);
     }
   }
 

--- a/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
@@ -25,15 +25,8 @@
 // See docs/COPYRIGHT.rdoc for more details.
 // ++
 
-import {
-  Component,
-  OnInit,
-  ViewChild,
-  ChangeDetectionStrategy,
-} from "@angular/core";
-import {
-  EditFieldComponent,
-} from "core-app/modules/fields/edit/edit-field.component";
+import {Component, OnInit, ViewChild, ChangeDetectionStrategy} from "@angular/core";
+import {EditFieldComponent} from "core-app/modules/fields/edit/edit-field.component";
 import {OpCkeditorComponent} from "core-app/modules/common/ckeditor/op-ckeditor.component";
 import {ICKEditorContext, ICKEditorInstance} from "core-app/modules/common/ckeditor/ckeditor-setup.service";
 

--- a/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/formattable-edit-field.component.ts
@@ -30,22 +30,12 @@ import {
   OnInit,
   ViewChild,
   ChangeDetectionStrategy,
-  ElementRef,
-  Inject,
-  ChangeDetectorRef, Injector, OnDestroy
 } from "@angular/core";
 import {
   EditFieldComponent,
-  OpEditingPortalChangesetToken, OpEditingPortalHandlerToken,
-  OpEditingPortalSchemaToken
 } from "core-app/modules/fields/edit/edit-field.component";
 import {OpCkeditorComponent} from "core-app/modules/common/ckeditor/op-ckeditor.component";
 import {ICKEditorContext, ICKEditorInstance} from "core-app/modules/common/ckeditor/ckeditor-setup.service";
-import {I18nService} from "core-app/modules/common/i18n/i18n.service";
-import {ResourceChangeset} from "core-app/modules/fields/changeset/resource-changeset";
-import {HalResource} from "core-app/modules/hal/resources/hal-resource";
-import {IFieldSchema} from "core-app/modules/fields/field.base";
-import {EditFieldHandler} from "core-app/modules/fields/edit/editing-portal/edit-field-handler";
 
 export const formattableFieldTemplate = `
     <div class="textarea-wrapper">
@@ -61,7 +51,7 @@ export const formattableFieldTemplate = `
       <edit-field-controls *ngIf="!(handler.inEditMode || initializationError)"
                            [fieldController]="field"
                            (onSave)="handleUserSubmit()"
-                           (onCancel)="handleUserCancel()"
+                           (onCancel)="handler.handleUserCancel()"
                            [saveTitle]="text.save"
                            [cancelTitle]="text.cancel">
       </edit-field-controls>
@@ -72,7 +62,7 @@ export const formattableFieldTemplate = `
   template: formattableFieldTemplate,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class FormattableEditFieldComponent extends EditFieldComponent implements OnInit, OnDestroy {
+export class FormattableEditFieldComponent extends EditFieldComponent implements OnInit {
   public readonly field = this;
 
   // Detect when inner component could not be initalized
@@ -87,16 +77,6 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
 
   public editorType = this.resource.getEditorTypeFor(this.field.name);
 
-  constructor(readonly I18n:I18nService,
-              readonly elementRef:ElementRef,
-              @Inject(OpEditingPortalChangesetToken) protected change:ResourceChangeset<HalResource>,
-              @Inject(OpEditingPortalSchemaToken) public schema:IFieldSchema,
-              @Inject(OpEditingPortalHandlerToken) readonly handler:EditFieldHandler,
-              readonly cdRef:ChangeDetectorRef,
-              readonly injector:Injector) {
-    super(I18n, elementRef, change, schema, handler, cdRef, injector);
-  }
-
   ngOnInit() {
     super.ngOnInit();
 
@@ -106,10 +86,6 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
       save: this.I18n.t('js.inplace.button_save', {attribute: this.schema.name}),
       cancel: this.I18n.t('js.inplace.button_cancel', {attribute: this.schema.name})
     };
-  }
-
-  ngOnDestroy() {
-    super.ngOnDestroy();
   }
 
   public onCkeditorSetup(editor:ICKEditorInstance) {
@@ -141,10 +117,6 @@ export class FormattableEditFieldComponent extends EditFieldComponent implements
       });
 
     return false;
-  }
-
-  public handleUserCancel() {
-    this.handler.handleUserCancel();
   }
 
   public get ckEditorContext():ICKEditorContext {

--- a/frontend/src/app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.spec.ts
+++ b/frontend/src/app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { GlobalEditFormChangesTrackerService } from './global-edit-form-changes-tracker.service';
+import {FormattableEditFieldComponent} from "core-app/modules/fields/edit/field-types/formattable-edit-field.component";
 
 describe('GlobalEditFormChangesTrackerService', () => {
   let service:GlobalEditFormChangesTrackerService;
@@ -18,7 +19,7 @@ describe('GlobalEditFormChangesTrackerService', () => {
   });
 
   it('should have model changes when one form is added', () => {
-    const editForm = 'editForm';
+    const editForm = 'editForm' as FormattableEditFieldComponent;
 
     service.addToFormsWithModelChanges(editForm);
 
@@ -26,8 +27,8 @@ describe('GlobalEditFormChangesTrackerService', () => {
   });
 
   it('should have model changes while there are forms registered', () => {
-    const editForm = 'editForm';
-    const editForm2 = 'editForm2';
+    const editForm = 'editForm' as FormattableEditFieldComponent;
+    const editForm2 = 'editForm2' as FormattableEditFieldComponent;
 
     service.addToFormsWithModelChanges(editForm);
     service.addToFormsWithModelChanges(editForm2);
@@ -37,8 +38,8 @@ describe('GlobalEditFormChangesTrackerService', () => {
   });
 
   it('should not have model changes when all the form have been removed', () => {
-    const editForm = 'editForm';
-    const editForm2 = 'editForm2';
+    const editForm = 'editForm' as FormattableEditFieldComponent;
+    const editForm2 = 'editForm2' as FormattableEditFieldComponent;
 
     service.addToFormsWithModelChanges(editForm);
     service.addToFormsWithModelChanges(editForm2);

--- a/frontend/src/app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.spec.ts
+++ b/frontend/src/app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.spec.ts
@@ -1,9 +1,16 @@
 import { TestBed } from '@angular/core/testing';
 import { GlobalEditFormChangesTrackerService } from './global-edit-form-changes-tracker.service';
-import {FormattableEditFieldComponent} from "core-app/modules/fields/edit/field-types/formattable-edit-field.component";
+import {EditFormComponent} from "core-app/modules/fields/edit/edit-form/edit-form.component";
 
 describe('GlobalEditFormChangesTrackerService', () => {
   let service:GlobalEditFormChangesTrackerService;
+  const createForm = (changed?:boolean) => {
+    return {
+      change: {
+        isEmpty: () => !changed
+      }
+    } as EditFormComponent;
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
@@ -14,38 +21,64 @@ describe('GlobalEditFormChangesTrackerService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should not have model changes when created', () => {
-    expect(service.hasModelChanges).toBeFalsy();
+  it('should report no changes when empty', () => {
+    expect(service.thereAreFormsWithUnsavedChanges).toBeFalse();
   });
 
-  it('should have model changes when one form is added', () => {
-    const editForm = 'editForm' as FormattableEditFieldComponent;
+  it('should report no changes when one form has no changes', () => {
+    const form = createForm();
 
-    service.addToFormsWithModelChanges(editForm);
+    service.addToActiveForms(form);
 
-    expect(service.hasModelChanges).toBeTruthy();
+    expect(service.thereAreFormsWithUnsavedChanges).toBeFalse();
   });
 
-  it('should have model changes while there are forms registered', () => {
-    const editForm = 'editForm' as FormattableEditFieldComponent;
-    const editForm2 = 'editForm2' as FormattableEditFieldComponent;
+  it('should report no changes when multiple forms have no changes', () => {
+    const form = createForm();
+    const form2 = createForm();
+    const form3 = createForm();
 
-    service.addToFormsWithModelChanges(editForm);
-    service.addToFormsWithModelChanges(editForm2);
-    service.removeFromFormsWithModelChanges(editForm);
+    service.addToActiveForms(form);
+    service.addToActiveForms(form2);
+    service.addToActiveForms(form3);
 
-    expect(service.hasModelChanges).toBeTruthy();
+    expect(service.thereAreFormsWithUnsavedChanges).toBeFalse();
   });
 
-  it('should not have model changes when all the form have been removed', () => {
-    const editForm = 'editForm' as FormattableEditFieldComponent;
-    const editForm2 = 'editForm2' as FormattableEditFieldComponent;
+  it('should report no changes when the only form with changes is removed', () => {
+    const form = createForm(true);
 
-    service.addToFormsWithModelChanges(editForm);
-    service.addToFormsWithModelChanges(editForm2);
-    service.removeFromFormsWithModelChanges(editForm);
-    service.removeFromFormsWithModelChanges(editForm2);
+    service.addToActiveForms(form);
+    service.removeFromActiveForms(form);
 
-    expect(service.hasModelChanges).toBeFalsy();
+    expect(service.thereAreFormsWithUnsavedChanges).toBeFalse();
+  });
+
+  it('should report changes when one form has changes', () => {
+    const form = createForm(true);
+
+    service.addToActiveForms(form);
+
+    expect(service.thereAreFormsWithUnsavedChanges).toBeTrue();
+  });
+
+  it('should report forms with changes when multiple form have changes', () => {
+    const form = createForm(true);
+    const form2 = createForm(true);
+    const form3 = createForm();
+
+    service.addToActiveForms(form);
+    service.addToActiveForms(form2);
+    service.addToActiveForms(form3);
+
+    expect(service.thereAreFormsWithUnsavedChanges).toBeTrue();
+  });
+
+  it('should call thereAreFormsWithUnsavedChangesSpy on beforeunload', () => {
+    const thereAreFormsWithUnsavedChangesSpy = spyOnProperty(service, 'thereAreFormsWithUnsavedChanges', 'get');
+
+    window.dispatchEvent(new Event('beforeunload'));
+
+    expect(thereAreFormsWithUnsavedChangesSpy).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.spec.ts
+++ b/frontend/src/app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { GlobalEditFormChangesTrackerService } from './global-edit-form-changes-tracker.service';
+
+describe('GlobalEditFormChangesTrackerService', () => {
+  let service:GlobalEditFormChangesTrackerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GlobalEditFormChangesTrackerService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should not have model changes when created', () => {
+    expect(service.hasModelChanges).toBeFalsy();
+  });
+
+  it('should have model changes when one form is added', () => {
+    const editForm = 'editForm';
+
+    service.addToFormsWithModelChanges(editForm);
+
+    expect(service.hasModelChanges).toBeTruthy();
+  });
+
+  it('should have model changes while there are forms registered', () => {
+    const editForm = 'editForm';
+    const editForm2 = 'editForm2';
+
+    service.addToFormsWithModelChanges(editForm);
+    service.addToFormsWithModelChanges(editForm2);
+    service.removeFromFormsWithModelChanges(editForm);
+
+    expect(service.hasModelChanges).toBeTruthy();
+  });
+
+  it('should not have model changes when all the form have been removed', () => {
+    const editForm = 'editForm';
+    const editForm2 = 'editForm2';
+
+    service.addToFormsWithModelChanges(editForm);
+    service.addToFormsWithModelChanges(editForm2);
+    service.removeFromFormsWithModelChanges(editForm);
+    service.removeFromFormsWithModelChanges(editForm2);
+
+    expect(service.hasModelChanges).toBeFalsy();
+  });
+});

--- a/frontend/src/app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.ts
+++ b/frontend/src/app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GlobalEditFormChangesTrackerService {
+  private formsWithModelChanges = new Map();
+
+  public get hasModelChanges() {
+    return this.formsWithModelChanges.size !== 0;
+  }
+
+  public addToFormsWithModelChanges(form:any) {
+    this.formsWithModelChanges.set(form, true);
+
+    window.OpenProject.editFormsContainModelChanges = true;
+  }
+
+  public removeFromFormsWithModelChanges(form:any) {
+    this.formsWithModelChanges.delete(form);
+
+    if (!this.hasModelChanges) {
+      window.OpenProject.editFormsContainModelChanges = false;
+    }
+  }
+}

--- a/frontend/src/app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.ts
+++ b/frontend/src/app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import {EditFormComponent} from "core-app/modules/fields/edit/edit-form/edit-form.component";
 
 @Injectable({
   providedIn: 'root'
@@ -10,13 +11,13 @@ export class GlobalEditFormChangesTrackerService {
     return this.formsWithModelChanges.size !== 0;
   }
 
-  public addToFormsWithModelChanges(form:any) {
+  public addToFormsWithModelChanges(form:EditFormComponent) {
     this.formsWithModelChanges.set(form, true);
 
     window.OpenProject.editFormsContainModelChanges = true;
   }
 
-  public removeFromFormsWithModelChanges(form:any) {
+  public removeFromFormsWithModelChanges(form:EditFormComponent) {
     this.formsWithModelChanges.delete(form);
 
     if (!this.hasModelChanges) {

--- a/frontend/src/app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.ts
+++ b/frontend/src/app/modules/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.ts
@@ -1,27 +1,37 @@
 import { Injectable } from '@angular/core';
 import {EditFormComponent} from "core-app/modules/fields/edit/edit-form/edit-form.component";
+import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 
 @Injectable({
   providedIn: 'root'
 })
 export class GlobalEditFormChangesTrackerService {
-  private formsWithModelChanges = new Map();
+  private activeForms = new Map<EditFormComponent, boolean>();
 
-  public get hasModelChanges() {
-    return this.formsWithModelChanges.size !== 0;
+  get thereAreFormsWithUnsavedChanges () {
+    return Array.from(this.activeForms.keys()).some(form => {
+      return !form.change.isEmpty();
+    });
   }
 
-  public addToFormsWithModelChanges(form:EditFormComponent) {
-    this.formsWithModelChanges.set(form, true);
-
-    window.OpenProject.editFormsContainModelChanges = true;
+  constructor(
+    private i18nService:I18nService,
+  ) {
+    // Global beforeunload hook to show a data loss warn
+    // when the user clicks on a link out of the Angular app
+    window.addEventListener('beforeunload', (event) => {
+      if (this.thereAreFormsWithUnsavedChanges) {
+        event.preventDefault();
+        event.returnValue = this.i18nService.t('js.work_packages.confirm_edit_cancel');
+      }
+    });
   }
 
-  public removeFromFormsWithModelChanges(form:EditFormComponent) {
-    this.formsWithModelChanges.delete(form);
+  public addToActiveForms(form:EditFormComponent) {
+    this.activeForms.set(form, true);
+  }
 
-    if (!this.hasModelChanges) {
-      window.OpenProject.editFormsContainModelChanges = false;
-    }
+  public removeFromActiveForms(form:EditFormComponent) {
+    this.activeForms.delete(form);
   }
 }


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/25683

This pull request:

 Warns the user about a possible data loss on the Angular forms (EditFormComponent) when moving out of the Angular app (ie: clicking on the main side menu items).
 Adds a GlobalEditFormChangesTrackerService that tracks the changes on all the EditFormComponent active in the app.
Note:
This pull request solves the bug but only on the changes made inside and EditFormComponent (ie: wp description). Changes made out of them, like comments on a work package, are not registered on the GlobalEditFormChangesTrackerService and would be lost without any warning when clicking on a link out of the Angular app.

I created a new [work package](https://community.openproject.com/projects/openproject/work_packages/34551) to cover these cases too.