### PR TITLE
Firefox fix for aligning table and Gantt chart rows

### DIFF
--- a/frontend/src/global_styles/content/work_packages/timelines/_timelines.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/_timelines.sass
@@ -76,9 +76,18 @@
   &.-collapsed
     display: none
 
-// Add margin to timeline when inline-create link is showing in table
-.wp-table-timeline--body.-inline-create-mirror
+// Add margin (row's height) to the timeline on split view
+// to compensate the 'wpTableSumsRow' row that the work
+// packages table has. If not, when scrolling down the last
+// rows are misaligned.
+.wp-table-timeline--body
   margin-bottom: var(--table-timeline--row-height)
+
+// Add an extra margin (row's height) to the timeline when the
+// wpInlineCreate row is shown in work packages table. If not, when
+// scrolling down the last rows are misaligned.
+.wp-table-timeline--body.-inline-create-mirror
+  margin-bottom: calc(var(--table-timeline--row-height) * 2)
 
 .children-duration-bar
   position: absolute

--- a/frontend/src/global_styles/layout/work_packages/_table.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table.sass
@@ -131,9 +131,7 @@
   will-change: transform
   // Hinter browser that the content of the flex is contained except for size
   contain: strict
-  // Added on split view to compensate the 'wpTableSumsRow' that the left table has.
-  // If not, when scrolling down the last rows are misaligned
-  padding-bottom: calc(var(--table-timeline--row-height) - 1px)
+
 
 .work-package--attachments--files
   margin-bottom: 1rem


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34828

This pull request:

- [x] Changes some styles so Firefox doesn't overlap margin-bottom and padding-bottom and the Table and Gantt chart rows are aligned.  