### PR TITLE
Fix/34852 wp description with macro not displayed

### DIFF
--- a/frontend/src/app/globals/dynamic-bootstrapper.ts
+++ b/frontend/src/app/globals/dynamic-bootstrapper.ts
@@ -82,17 +82,11 @@ export class DynamicBootstrapper {
    * @param {OptionalBootstrapDefinition[]|undefined} definitions An optional set of components to bootstrap
    */
   public static bootstrapOptionalEmbeddable(appRef:ApplicationRef, element:HTMLElement, definitions = this.optionalBoostrapComponents) {
-    // Avoid bootstrapping the embedded components while the app
-    // is running the Change Detection ("ApplicationRef.tick
-    // is called recursively" error)
-    appRef
-      .isStable
-      .pipe(
-        filter(isStable => isStable),
-        take(1),
-      )
-      .toPromise()
-      .then(() => this.performBootstrap(appRef, element, true, definitions));
+    // Delay the execution to avoid bootstrapping the embedded components while
+    // the app is running the Change Detection ("ApplicationRef.tick is called recursively"
+    // error) caused because of bootstrapOptionalEmbeddable and bootstrapOptionalDocument
+    // calling this.performBootstrap at the same time
+    Promise.resolve().then(() => this.performBootstrap(appRef, element, true, definitions));
   }
 
   /**

--- a/frontend/src/app/globals/dynamic-bootstrapper.ts
+++ b/frontend/src/app/globals/dynamic-bootstrapper.ts
@@ -27,6 +27,7 @@
 
 import {ComponentType} from "@angular/cdk/portal";
 import {ApplicationRef} from "@angular/core";
+import {filter, take} from "rxjs/operators";
 
 /**
  * Optional bootstrap definition to allow selecting all matching
@@ -81,7 +82,17 @@ export class DynamicBootstrapper {
    * @param {OptionalBootstrapDefinition[]|undefined} definitions An optional set of components to bootstrap
    */
   public static bootstrapOptionalEmbeddable(appRef:ApplicationRef, element:HTMLElement, definitions = this.optionalBoostrapComponents) {
-    this.performBootstrap(appRef, element, true, definitions);
+    // Avoid bootstrapping the embedded components while the app
+    // is running the Change Detection ("ApplicationRef.tick
+    // is called recursively" error)
+    appRef
+      .isStable
+      .pipe(
+        filter(isStable => isStable),
+        take(1),
+      )
+      .toPromise()
+      .then(() => this.performBootstrap(appRef, element, true, definitions));
   }
 
   /**

--- a/frontend/src/app/globals/dynamic-bootstrapper.ts
+++ b/frontend/src/app/globals/dynamic-bootstrapper.ts
@@ -83,9 +83,9 @@ export class DynamicBootstrapper {
    */
   public static bootstrapOptionalEmbeddable(appRef:ApplicationRef, element:HTMLElement, definitions = this.optionalBoostrapComponents) {
     // Delay the execution to avoid bootstrapping the embedded components while
-    // the app is running the Change Detection ("ApplicationRef.tick is called recursively"
-    // error) caused because of bootstrapOptionalEmbeddable and bootstrapOptionalDocument
-    // calling this.performBootstrap at the same time
+    // the app is running the Change Detection. This was throwing "ApplicationRef.tick
+    // is called recursively" error because of bootstrapOptionalEmbeddable and
+    // bootstrapOptionalDocument were called too close (ie: ckEditor macros).
     Promise.resolve().then(() => this.performBootstrap(appRef, element, true, definitions));
   }
 


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34852

This pull request:

- [x] Delays the bootstrap of the embedded dynamic components so they are not bootstrapped while the app is running the Change Detection. This was throwing "ApplicationRef.tick is called recursively" error, caused because of bootstrapOptionalEmbeddable and bootstrapOptionalDocument were called too close (ie: ckEditor macros).