### PR TITLE
Fix/for scheduling scope performance

### DIFF
--- a/app/models/work_packages/scopes/for_scheduling.rb
+++ b/app/models/work_packages/scopes/for_scheduling.rb
@@ -35,12 +35,23 @@ module WorkPackages::Scopes
       # Fetches all work packages that need to be evaluated for eventual rescheduling after a related (i.e. follows/precedes
       # and hierarchy) work package is modified or created.
       #
-      # The SQL relies on CTEs which, after constructing the set of all potential work_packages then filter down the
-      # work packages to the actually affected work packages. The set of potentially affected work packages can be diminished by
-      # manually schedule work packages.
+      # The SQL relies on a recursive CTE which will fetch all work packages that are connected to the rescheduled work package
+      # via relations (follows/precedes and/or hierarchy) either directly or transitively. It will do so by increasing the relation path
+      # length one at a time and will stop on that path if the work package evaluated to be added is either:
+      # * itself scheduled manually
+      # * having all of it's children scheduled manually
       #
-      # The first CTE works recursively to fetch all work packages related to the provided work package and the path of
-      # intermediate work packages. The work packages can either be connected via a follows relationship, a hierarchy relationship
+      # The children themselves are scheduled manually if all of their children are scheduled manually which repeats itself down to the leaf
+      # work packages. So another way of putting it, and that is how the sql statement works, is that a work package is considered to
+      # be scheduled manually if *all* of the paths to their leafs have at least one work package that is scheduled manually.
+      # For example in case of the hierarchy:
+      # A and B <- hierarchy (C is parent of both A and B) - C <- hierarchy - D
+      # if A and B are both scheduled manually, C is also scheduled manually and so is D. But if only A is scheduled manually,
+      # B, C and D are scheduled automatically.
+      #
+      # The recursiveness will of course also stop if no more work packages can be added.
+      #
+      # The work packages can either be connected via a follows relationship, a hierarchy relationship
       # or a combination of both.
       # E.g. in a graph of
       #   A  <- follows - B <- hierarchy (C is parent of B) - C <- follows D
@@ -55,56 +66,11 @@ module WorkPackages::Scopes
       #
       # That possible switch in direction means that we cannot simply get all possibly affected work packages by one
       # SQL query which the DAG implementation would have allowed us to do otherwise.
-      # Additionally, we need to get the whole paths (with all intermediate work packages included) which would be possible
-      # with DAG but as we need to rely on a recursive approach already we do not need to complicate the SQL statement any
-      # further. Fetching the whole path (at least in one direction) relying on DAG would be faster though
-      # so we might revisit this if any performance shortcomings are identified.
-      # The first CTE returns all work packages with their path so reusing the example above, the result would be
-      #   id      |   path
-      #   A       | {A}
-      #   B       | {A,B}
-      #   C       | {A,B,C}
-      #   D       | {A,B,C,D}
-      # If the graph where to contain multiple paths to one node work package, because of multiple follows relationship
-      # to the same hierarchical tree, the work package would be returned twice with different paths.
       #
-      # The paths are followed until either:
-      # * no more follows and/or hierarchy relations can be followed
-      # * a manually scheduled work package is encountered.
+      # Currently, we do not rely on DAG for increasing the path length at all. We are still employing it in the check
+      # for whether all paths to the leaf have a manually scheduled work package.
       #
-      # So if, in the example above, B would be manually scheduled, the first CTE would only return
-      #   id      |   path
-      #   A       | {A}
-      #   B       | {A,B}
-      #
-      # The interim result, provided by the first CTE, is thus the set of all work packages, that are in a direct or transitive
-      # follows and/or hierarchy relationship up until the point where the relationships end or a manually scheduled work package
-      # is encountered.
-      #
-      # That set needs to be filtered down because of additional constraints on scheduling:
-      # * Manually scheduled work packages prevent automatic scheduling up the hierarchy chain. So even with an existing follows
-      #   relationship work packages might not be scheduled automatically if their children or descendants are automatically
-      #   scheduled. This is only true for a work package if *all* the children are manually scheduled either directly or because
-      #   their respective children are all scheduled manually. In case of the hierarchy
-      #   A and B <- hierarchy (C is parent of both A and B) C <- D
-      #   if A and B are both scheduled manually, C is also scheduled manually and so is D. But if only A is scheduled manually,
-      #   B, C and D are scheduled automatically.
-      # * the first constraint might cause gaps in the previously established paths. If a work package follows an automatically
-      #   scheduled work package, and that preceding work package has children that are manually scheduled, the preciding
-      #   work package will no longer be automatically scheduled and the same is then true for the following work package.
-      #
-      # To visualize the above:
-      #                                    A  <- follows - B  <- follows C
-      #                                                    |
-      #                                                hierarchy
-      #                                                    v
-      #                                                    D (manually)
-      #   The first, path fetching CTE will return B, C and D. The constraint above will then remove B and D and the second
-      #   constraint will remove C.
-      #
-      # The work packages that are identified to be in a direct or transitive relationship with the provided work packages and
-      # that neither have only manually scheduled children/descendants or would only be reachable via work packages for which
-      # the before mentioned constraint is true are returned. The provided work package is always excluded.
+      # A further improvement in performance might be reachable by also employing DAG mechanisms to increase the path length.
       #
       # @param work_packages WorkPackage[] A set of work packages for which the set of related work packages that might
       # be subject to reschedule is fetched.
@@ -136,20 +102,10 @@ module WorkPackages::Scopes
       # Hierarchy relationships are followed up as well as down (from and to) but follows relations are only followed
       # from the predecessor to the successor (from_id to to_id).
       #
-      # We will need the exact path (meaning all intermediate work packages) for the later filtering so for each
-      # recursive step the statement only adds the all the work packages directly connected to the current step and
-      # does not make use of the abilities of DAG. Using the transitive relationships provided by DAG should be possible
-      # but the constraints caused by PostgreSQL's implementation of recursive CTEs (no outer join of, no duplicate
-      # reference to and no subqueries with the recursive query) makes writing it extremly hard.
-      #
-      # While using DAG should theoretically be faster, as less iterative steps are required, the difference should
-      # not be noticeable.
-      #
       # The CTE starts from the provided work package and for that returns:
       #   * the id of the work package
-      #   * the path to that work package which is again the id but this time as a PostgreSQL array
-      #   * again, a path, same as above but referred to as the path_root (explained below)
       #   * the information, that the starting work package is not manually scheduled.
+      #   * the information, that the starting work package's descendants are not manually scheduled.
       # Whether the starting work package is manually scheduled or in fact automatically scheduled does make no
       # difference but we need those four columns later on.
       #
@@ -157,23 +113,10 @@ module WorkPackages::Scopes
       # packages by a hierarchy (up or down) or follows relationship (only successors). For each such work package
       # the statement returns:
       #   * id of the work package that is currently at the end of a path.
-      #   * the path to the added work package. This is the path of the work package the statement extended the path
-      #     from (joined with) with the added work package appended.
-      #   * the path_root which is the path up to the first work package that is within the current work package
-      #     hierarchy. Whenever a new hierarchy is reached (indicated by joining a follow relationship), a new root
-      #     path is created. If the hierarchy is kept, the root_path is taken from the recursive step before.
-      #     The root_path is later on used to identify all work packages within the result set that are within
-      #     the same hierarchy and that might need to be removed because of manual scheduling bubbling up the
-      #     hierarchy tree. Therefore, follow relationships constructed between members of the same hierarchy are
-      #     no problem as well.
       #   * the flag indicating whether the added work package is automatically or manually scheduled.
+      #   * the flag indicating whether *all* of the added work package's descendants are automatically or manually scheduled.
       #
       # Paths whose ending work package is marked to be manually scheduled are not joined with any more.
-      #
-      # The recursion ends when no more work packages can be added to the set either because:
-      #  * There is no more work package with a relationship to the current set
-      #  * The current paths all end in manually scheduled work packages
-      # Both conditions can also stop the recursion together.
       def paths_sql(work_packages)
         values = work_packages.map { |wp| "(#{wp.id}, false, false)" }.join(', ')
 
@@ -214,127 +157,9 @@ module WorkPackages::Scopes
               JOIN work_packages
               ON
                 work_packages.id = relations.to_id
-                AND (relations.follows = 0 AND "relations"."relates" = 0 AND "relations"."duplicates" = 0 AND "relations"."blocks" = 0 AND "relations"."includes" = 0 AND "relations"."requires" = 0
-                AND (relations.hierarchy + relations.relates + relations.duplicates + relations.follows + relations.blocks + relations.includes + relations.requires = 1))
+                AND relations.follows = 0 AND #{relations_condition_sql(transitive: true)}
               GROUP BY relations.from_id
 					  ) descendants ON work_packages.id = descendants.from_id
-          )
-        SQL
-      end
-
-      # Filters a set of paths (as returned by the recursive path constructing CTE above) to only contain
-      # work packages (and their paths) that are truly automatically scheduled.
-      # Even though a work package is flagged to be automatically scheduled, a work package can in fact be manually scheduled
-      # nonetheless if:
-      # * all of its paths towards their leafs have at least one manually scheduled work package in them.
-      #
-      # As the recursive CTE above terminates a paths once a manually scheduled work package is identified,
-      # those manually scheduled work packages are leafs for the sake of the set inserted into this query but might
-      # very well have children outside of the set.
-      #
-      # Identifying all leafs (for the sake of the set) is complicated by the possibility of having multiple
-      # follow relationships spanning into the same hierarchy tree. E.g. in a graph of
-      #
-      #                  C
-      #                  |
-      #               hierarchy
-      #                  |
-      #                  v
-      #   A <- follows - B
-      #   ^              |
-      #   |            hierarchy
-      #   |              |
-      #   |              v
-      #   |              D (manually)
-      #   |              |
-      #   |            hierarchy
-      #   |              |
-      #   |              v
-      #    -- follows  - E
-      #
-      # D is excluded directly. But B and C also need to be considered manually scheduled as their descendant D is
-      # scheduled manually. But E (which is the actual leaf of that hierarchy) is reached via a different follows
-      # relationship.
-      #
-      # Please not that when D has an automatically scheduled sibling F:
-      #
-      #                  C
-      #                  |
-      #               hierarchy
-      #                  |
-      #                  v
-      #   A <- follows - B - hierarchy -
-      #   ^              |              |
-      #   |            hierarchy        |
-      #   |              |              |
-      #   |              v              v
-      #   |              D (manually)   F
-      #   |              |
-      #   |            hierarchy
-      #   |              |
-      #   |              v
-      #    -- follows  - E
-      #
-      # Neither B nor C are considered manually scheduled any more.
-      #
-      # The query works by joining the paths with itself and with the relations first to identify all paths (calculated by
-      # the CTE before) that lead to descendants of a work package. Here, the root_path is considered to avoid mixing
-      # individual follows relationships jumps.
-      # Next, the paths are joined again to identify those, that have no longer paths.
-      # The result are all paths that lead to descendants of a work packages identified in the path that have no longer paths
-      # which, within the set, are the leafs. Of those, only the paths are returned that do not lead to a manually scheduled
-      # work package.
-      # This step also removes all work packages that are scheduled manually directly.
-      def paths_without_manual_hierarchy_sql
-        <<~SQL
-          paths_without_manual_hierarchy AS (
-            SELECT
-              paths.id,
-              paths.path
-            FROM
-              clean_paths paths
-            LEFT JOIN
-              relations
-            ON
-              relations.from_id = paths.id AND "relations"."follows" = 0 AND (#{relations_condition_sql(transitive: true)})
-            LEFT JOIN
-              clean_paths to_paths
-            ON
-              relations.to_id = to_paths.id AND to_paths.root_path = paths.root_path
-            LEFT JOIN
-              clean_paths longer_paths
-            ON
-              longer_paths.path[1:array_length(longer_paths.path, 1) - 1] = to_paths.path
-              AND to_paths.root_path = longer_paths.root_path
-              AND longer_paths.path <> paths.path
-            WHERE longer_paths.id IS NULL
-            AND NOT (paths.manually OR COALESCE(to_paths.manually, false))
-          )
-        SQL
-      end
-
-      # Returns all paths that do not include intermediary hops (work packages) that are not within the set of paths
-      # themselves.
-      # This serves as a second filter after work packages scheduled manually by transition are removed from the set.
-      # E.g in a graph of
-      #                                    A  <- follows - B  <- follows C
-      #                                                    |
-      #                                                hierarchy
-      #                                                    v
-      #                                                    D (manually)
-      #
-      # The recursive CTE will return A, B, C and D, with D flagged as manually scheduled. The first filter will then remove
-      # D and B from the set. Now, there is no longer a connection between A and C. So the query below removes C from the
-      # result as well.
-      def paths_without_gaps_sql
-        <<~SQL
-          eligible_paths_without_gaps AS (
-            SELECT
-              *
-            FROM
-              paths_without_manual_hierarchy
-            WHERE
-              path <@ (SELECT array_agg(id) FROM paths_without_manual_hierarchy)
           )
         SQL
       end

--- a/spec/models/work_packages/scopes/for_scheduling_spec.rb
+++ b/spec/models/work_packages/scopes/for_scheduling_spec.rb
@@ -295,7 +295,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
       let!(:existing_work_packages) { [successor, successor_child, successor_child2, successor_successor] }
 
       context 'with all scheduled automatically' do
-        it 'consists of the successor, its child and parent' do
+        it 'consists of the successor, its child and the successor˚s successor' do
           expect(described_class.fetch([origin]))
             .to match_array([successor, successor_child, successor_child2, successor_successor])
         end
@@ -306,7 +306,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
           successor_child2.update_column(:schedule_manually, true)
         end
 
-        it 'is empty' do
+        it 'consists of the successor, its automatically scheduled child and the successor˚s successor' do
           expect(described_class.fetch([origin]))
             .to match_array([successor_child, successor, successor_successor])
         end
@@ -391,7 +391,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
       let!(:existing_work_packages) { [successor, successor_successor] }
 
       context 'with all scheduled automatically' do
-        it 'consists of the both successors' do
+        it 'consists of both successors' do
           expect(described_class.fetch([origin]))
             .to match_array([successor, successor_successor])
         end


### PR DESCRIPTION
Improves the performance of the `for_scheduling` scope which fetches all work packages that might need to be rescheduled after a predecessor or child work package have been rescheduled.