### PR TITLE
Change output format in migrate-from-pre-8.sh

### DIFF
--- a/script/migration/migrate-from-pre-8.sh
+++ b/script/migration/migrate-from-pre-8.sh
@@ -178,6 +178,7 @@ echo "2.2) Migrating from MySQL to Postgres (and 8 to 10)"
 
 docker run \
   --rm \
+  -v $PWD:/data \
   --name migrate8to10 \
   -e MYSQL_DATABASE_URL="mysql2://$MYSQL_USER:$MYSQL_PWD@$DOCKER_HOST_IP:$MYSQL_PORT/$DATABASE" \
   -e DATABASE_URL="postgresql://postgres:postgres@$DOCKER_HOST_IP:$POSTGRES_PORT/$DATABASE" \
@@ -228,7 +229,7 @@ else
 fi
 
 echo
-echo "2.4) Dumping migrated database to $DATABASE-migrated.sql"
+echo "2.4) Dumping migrated database to $DATABASE-migrated.dump"
 
 # using the running docker image to dump the database to ensure we use the same
 # postgres client version and also so that a postgres client is not necessary to run this script
@@ -237,7 +238,8 @@ docker exec -e PGPASSWORD=postgres -it migrate8to10 pg_dump \
   -p $POSTGRES_PORT \
   -U postgres \
   -d $DATABASE \
-  > $DATABASE-migrated.sql
+  -F custom \
+  -f /data/$DATABASE-migrated.dump
 
 if [[ $? -gt 0 ]]; then
   echo "  Could not dump database"


### PR DESCRIPTION
This is more aligned with later steps in https://docs.openproject.org/installation-and-operations/misc/upgrading-older-openproject-versions/ 

Currently the script creates an sql file, while the documentation describes pg_restore to restore it. This would not work, as pg_restore cannot restore sql files.