### PR TITLE
Fix doubled API calls for work packages in the overview

### DIFF
--- a/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.ts
@@ -246,10 +246,7 @@ export class PartitionedQuerySpacePageComponent extends WorkPackagesViewBase imp
     }
 
     if (visibly) {
-      return this.loadingIndicator = promise.then((loadedQuery:QueryResource) => {
-        this.wpStatesInitialization.initialize(loadedQuery, loadedQuery.results);
-        return this.additionalLoadingTime();
-      });
+      return this.loadingIndicator = promise.then(() => this.additionalLoadingTime());
     }
 
     return promise.then((loadedQuery:QueryResource) => {


### PR DESCRIPTION
For some reason, showing the loading indicator triggered a second API call for the work packages, resulting not only on
double the work on the backend but also two separate renders of WP tables.

https://community.openproject.com/wp/34885