### PR TITLE
require login to finish direct upload (and set file name)

### DIFF
--- a/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
@@ -37,8 +37,8 @@ module Bim
       before_action :find_ifc_model_object, only: %i[edit update destroy]
       before_action :find_all_ifc_models, only: %i[show defaults index]
 
-      before_action :authorize, except: [:set_direct_upload_file_name, :direct_upload_finished]
-      skip_before_action :verify_authenticity_token, only: [:set_direct_upload_file_name]
+      before_action :authorize
+      skip_before_action :verify_authenticity_token, only: [:set_direct_upload_file_name, :direct_upload_finished]
 
       menu_item :ifc_models
 

--- a/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
@@ -37,8 +37,11 @@ module Bim
       before_action :find_ifc_model_object, only: %i[edit update destroy]
       before_action :find_all_ifc_models, only: %i[show defaults index]
 
-      before_action :authorize
-      skip_before_action :verify_authenticity_token, only: [:set_direct_upload_file_name, :direct_upload_finished]
+      # Callback done by AWS so can't be authenticated. Don't have to be either, though.
+      # It only actually does anything if there is a pending upload with the key passed by AWS.
+      before_action :authorize, except: [:direct_upload_finished, :set_direct_upload_file_name]
+      before_action :require_login, only: [:set_direct_upload_file_name]
+      skip_before_action :verify_authenticity_token, only: [:set_direct_upload_file_name] # AJAX request in page, so skip authenticity token
 
       menu_item :ifc_models
 

--- a/modules/bim/app/views/bim/ifc_models/ifc_models/_form.html.erb
+++ b/modules/bim/app/views/bim/ifc_models/ifc_models/_form.html.erb
@@ -59,7 +59,6 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= nonced_javascript_tag do %>
   jQuery(document).ready(function() {
     var setDirectUploadFileName = function () {
-
       var fileNameField = jQuery('input[type=file]')
       var fileName = '';
       if (fileNameField.length > 0 && fileNameField[0].files && fileNameField[0].files[0]) {
@@ -81,13 +80,23 @@ See doc/COPYRIGHT.rdoc for more details.
         title = fileName;
       }
 
-      return jQuery.post(
-        "<%= set_direct_upload_file_name_bcf_project_ifc_models_path %>",
-        {
+      return jQuery.ajax({
+        type: "post",
+        url: "<%= set_direct_upload_file_name_bcf_project_ifc_models_path %>",
+        dataType: "json",
+        xhrFields: {
+          withCredentials: true
+        },
+        data: {
           title: title,
           isDefault: jQuery("#bim_ifc_models_ifc_model_is_default").is(":checked") ? 1 : 0
+        },
+        statusCode: {
+          401: function(resp, status, error) {
+            document.location.reload(); // reload to make user login again
+          }
         }
-      );
+      });
     };
     jQuery("input[type=file]").change(function(e){
       setDirectUploadFileName();


### PR DESCRIPTION
Without this there is an edge case where the user's session could run out while still on the page and then the direct upload would be finished by an anonymous user which would break conversion among other things.