### PR TITLE
Fix 34987: Don't link "String" and "Text" fields in WP form

### DIFF
--- a/frontend/src/app/components/wp-new/wp-create.service.ts
+++ b/frontend/src/app/components/wp-new/wp-create.service.ts
@@ -315,7 +315,16 @@ export class WorkPackageCreateService extends UntilDestroyedMixin {
     let links:string[] = [];
 
     Object.keys(schema.$source).forEach(attribute => {
-      if (!['Integer', 'Float', 'Date', 'DateTime', 'Duration', 'Formattable', 'Boolean', undefined].includes(schema.$source[attribute].type)) {
+      if (!['Integer',
+            'Float',
+            'Date',
+            'DateTime',
+            'Duration',
+            'Formattable',
+            'Boolean',
+            'String',
+            'Text',
+            undefined].includes(schema.$source[attribute].type)) {
         links.push(attribute);
       }
     });


### PR DESCRIPTION
Trying to fix
https://community.openproject.com/wp/34987