### PR TITLE
Bim fix 34983: components.coloring.components not Array

### DIFF
--- a/modules/bim/lib/open_project/bim/bcf_json/viewpoint_reader.rb
+++ b/modules/bim/lib/open_project/bim/bcf_json/viewpoint_reader.rb
@@ -161,7 +161,7 @@ module OpenProject::Bim
           entry['color'] = "##{entry['color']}"
 
           # Fix items name
-          entry['components'] = entry.delete('component')
+          entry['components'] = Array.wrap(entry.delete('component'))
           entry
         end
       end

--- a/modules/bim/lib/open_project/bim/bcf_json/viewpoint_reader.rb
+++ b/modules/bim/lib/open_project/bim/bcf_json/viewpoint_reader.rb
@@ -173,7 +173,7 @@ module OpenProject::Bim
 
         # Hoist exceptions components up from the nested XML node
         exceptions = visibility.dig('exceptions', 'component')
-        visibility['exceptions'] = Array(exceptions) if exceptions
+        visibility['exceptions'] = Array.wrap(exceptions) if exceptions
 
         # Move view_setup_hints
         view_setup_hints = hash.dig('components', 'view_setup_hints')


### PR DESCRIPTION
Fixes two BCF XML to JSON transformation bugs. Now it ensures an Array where the XML to JSON transformation did not create Arrays i.e. when it only could see on child XML node.

https://community.openproject.com/wp/34983