### PR TITLE
see if we can fix the legacy specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -282,6 +282,7 @@ group :development, :test do
   # Brakeman scanner
   gem 'brakeman', '~> 4.9.0'
   gem 'danger-brakeman'
+  gem 'thin'
 end
 
 gem 'bootsnap', '~> 1.4.5', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -906,6 +906,10 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     test-prof (0.12.2)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -1116,6 +1120,7 @@ DEPENDENCIES
   sys-filesystem (~> 1.3.3)
   table_print (~> 1.5.6)
   test-prof (~> 0.12.0)
+  thin
   timecop (~> 0.9.0)
   typed_dag (~> 2.0.2)
   tzinfo-data (~> 1.2020.1)


### PR DESCRIPTION
Don't merge this. Just checking if the missing thin is the reason for the failing cukes which I believe it is.
If this goes green either merge #8805 if it goes green too or if it doesn't we could, for the time being, fallback to reverting [this](https://github.com/opf/openproject/commit/e7b3a9b401f8b5bdd476a8d6cb062f4dd6d43e47).