### PR TITLE
Fix: Always allow custom styles when in BIM edition

### DIFF
--- a/app/views/common/_favicons.html.erb
+++ b/app/views/common/_favicons.html.erb
@@ -1,10 +1,10 @@
 <% begin %>
 
-<% unless (EnterpriseToken.allows_to?(:define_custom_style) && CustomStyle.try(:current).present? && CustomStyle.current.favicon.present?) %>
+<% unless apply_custom_favicon? %>
   <%= favicon_link_tag OpenProject::CustomStyles::Design.favicon_asset_path %>
 <% end %>
 
-<% unless (EnterpriseToken.allows_to?(:define_custom_style) && CustomStyle.try(:current).present? && CustomStyle.current.touch_icon.present?) %>
+<% unless apply_custom_touch_icon? %>
   <%# In the future we can add more sizes should we see 404 errors in the logs. %>
   <%= favicon_link_tag "apple-touch-icon-120x120.png", rel: 'apple-touch-icon',
                                                        type: 'image/png',

--- a/app/views/custom_styles/_inline_css_logo.erb
+++ b/app/views/custom_styles/_inline_css_logo.erb
@@ -30,7 +30,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <% cache(CustomStyle.current) do %>
   <style type="text/css">
     <% logo_url = asset_path("logo_openproject_white_big.png") %>
-    <% if EnterpriseToken.allows_to?(:define_custom_style) && CustomStyle.try(:current).present? %>
+    <% if apply_custom_styles? %>
       <%
         if CustomStyle.current.logo.present?
           logo_url = custom_style_logo_path(digest: CustomStyle.current.digest, filename: CustomStyle.current.logo_identifier)

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -85,7 +85,7 @@ See docs/COPYRIGHT.rdoc for more details.
   <!-- page specific tags -->
   <%= content_for(:header_tags) if content_for?(:header_tags) %>
   <%= render partial: "custom_styles/inline_css_logo" %>
-  <% if EnterpriseToken.allows_to?(:define_custom_style) && CustomStyle.try(:current).present? %>
+  <% if apply_custom_styles? %>
     <% cache(CustomStyle.current) do %>
       <%= render partial: "custom_styles/inline_css" %>
       <% if CustomStyle.current.favicon.present? %>

--- a/modules/bim/app/seeders/bim/basic_data/theme_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data/theme_seeder.rb
@@ -30,7 +30,7 @@ module Bim
   module BasicData
     class ThemeSeeder < Seeder
       def seed_data!
-        theme = OpenProject::CustomStyles::ColorThemes.themes.find { |t| t[:theme] == 'OpenProject BIM' }
+        theme = OpenProject::CustomStyles::ColorThemes.themes.find { |t| t[:theme] == OpenProject::CustomStyles::ColorThemes::BIM_THEME_NAME }
 
         ::Design::UpdateDesignService
           .new(theme)

--- a/modules/bim/lib/open_project/bim/patches/color_themes_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/color_themes_patch.rb
@@ -1,5 +1,7 @@
 require 'open_project/custom_styles/design'
 
+OpenProject::CustomStyles::ColorThemes::BIM_THEME_NAME = 'OpenProject BIM'.freeze
+
 module OpenProject::Bim
   module Patches
     module ColorThemesPatch
@@ -20,7 +22,7 @@ module OpenProject::Bim
 
         def bim_theme
           {
-            theme: 'OpenProject BIM',
+            theme: OpenProject::CustomStyles::ColorThemes::BIM_THEME_NAME,
             colors: {
               'primary-color' => "#3270DB",
               'primary-color-dark' => "#163473",

--- a/spec/helpers/custom_styles_helper_spec.rb
+++ b/spec/helpers/custom_styles_helper_spec.rb
@@ -1,0 +1,143 @@
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe CustomStylesHelper, type: :helper do
+  let(:current_theme) { nil }
+  let(:bim_edition?) { false }
+
+  before do
+    allow(CustomStyle).to receive(:current).and_return(current_theme)
+    allow(OpenProject::Configuration).to receive(:bim?).and_return(bim_edition?)
+  end
+
+  describe '.apply_custom_styles?' do
+    subject { helper.apply_custom_styles? }
+
+    context 'no CustomStyle present' do
+      it 'is falsey' do
+        is_expected.to be_falsey
+      end
+    end
+
+    context 'CustomStyle present' do
+      let(:current_theme) { FactoryBot.build_stubbed(:custom_style) }
+
+      context 'without EE' do
+        before do
+          without_enterprise_token
+        end
+
+        context 'no BIM edition' do
+          it 'is falsey' do
+            is_expected.to be_falsey
+          end
+        end
+
+        context 'BIM edition' do
+          let(:bim_edition?) { true }
+
+          it 'is truthy' do
+            is_expected.to be_truthy
+          end
+        end
+      end
+
+      context 'with EE' do
+        before do
+          with_enterprise_token(:define_custom_style)
+        end
+
+        context 'no BIM edition' do
+          it 'is truthy' do
+            is_expected.to be_truthy
+          end
+        end
+
+        context 'BIM edition' do
+          let(:bim_edition?) { true }
+
+          it 'is truthy' do
+            is_expected.to be_truthy
+          end
+        end
+      end
+    end
+  end
+
+  shared_examples(:apply_when_ee_present) do
+    context 'no CustomStyle present' do
+      it 'is falsey' do
+        is_expected.to be_falsey
+      end
+    end
+
+    context 'CustomStyle present' do
+      let(:current_theme) { FactoryBot.build_stubbed(:custom_style) }
+
+      before do
+        allow(current_theme).to receive(:favicon).and_return(true)
+        allow(current_theme).to receive(:touch_icon).and_return(true)
+      end
+
+      context 'without EE' do
+        before do
+          without_enterprise_token
+        end
+
+        it 'is falsey' do
+          is_expected.to be_falsey
+        end
+      end
+
+      context 'with EE' do
+        before do
+          with_enterprise_token(:define_custom_style)
+        end
+
+        it 'is truthy' do
+          is_expected.to be_truthy
+        end
+      end
+    end
+  end
+
+  describe '.apply_custom_favicon?' do
+    subject { helper.apply_custom_favicon? }
+
+    it_behaves_like :apply_when_ee_present
+  end
+
+  describe '.apply_custom_touch_icon?' do
+    subject { helper.apply_custom_touch_icon? }
+
+    it_behaves_like :apply_when_ee_present
+  end
+end


### PR DESCRIPTION
This fixes the following bug with BIM Community
Editions (in other words: no Enterprise Edition,
but BIM Edition).

A package based installation in which the "bim"
edition was selected did not show the BIM theme.
Instead it showed the normal OP theme.

This PR

- extracts the check if custom styles shall be
  applied to a helper.
- adds a spec for the new helper.