### PR TITLE
Fix/search for projects

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -178,7 +178,7 @@ class SearchController < ApplicationController
   end
 
   def provision_gon
-    available_search_types = Redmine::Search.available_search_types.dup.push('all')
+    available_search_types = search_types.dup.push('all')
 
     gon.global_search = {
       search_term: @question,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -148,6 +148,12 @@ class Project < ApplicationRecord
                      project_key: 'id',
                      permission: nil
 
+  # Necessary for acts_as_searchable which depends on the event_datetime method for sorting
+  acts_as_event title: Proc.new { |o| "#{Project.model_name.human}: #{o.name}" },
+                url: Proc.new { |o| { controller: 'overviews/overviews', action: 'show', project_id: o } },
+                author: nil,
+                datetime: :created_at
+
   validates :name,
             presence: true,
             length: { maximum: 255 }

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -167,7 +167,7 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
     end
   end
 
-  describe 'work package search' do
+  describe 'search for work packages' do
     context 'search in all projects' do
       let(:params) { [project, { q: query, work_packages: 1 }] }
 
@@ -338,6 +338,29 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
         filters.expect_open
         # As the current project (the subproject) has no subprojects, the filter for subprojectId is expected to be unavailable.
         filters.expect_no_filter_by 'subprojectId', 'subprojectId'
+      end
+    end
+  end
+
+  describe 'search for projects' do
+    let!(:searched_for_project) { FactoryBot.create(:project, name: 'Searched for project') }
+    let!(:other_project) { FactoryBot.create(:project, name: 'Other project') }
+
+    context 'globally' do
+      it 'finds the project' do
+        select_autocomplete(page.find('.top-menu-search--input'),
+                            query: "Searched",
+                            select_text: "In all projects ↵")
+
+        within '.global-search--tabs' do
+          click_on 'Projects'
+        end
+
+        expect(page)
+          .to have_link(searched_for_project.name)
+
+        expect(page)
+          .to have_no_link(other_project.name)
       end
     end
   end


### PR DESCRIPTION
Fixes:
* searching for projects globally (https://community.openproject.com/wp/34999)
* when searching within a project, only having the scopes (e.g. wiki, changeset, ...) available that are active in the project