### PR TITLE
bump puma

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -713,7 +713,7 @@ GEM
       eventmachine_httpserver
       http_parser.rb (~> 0.6.0)
       multi_json
-    puma (5.0.2)
+    puma (5.0.4)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-accept (0.4.5)


### PR DESCRIPTION
that way we will profit from the fix

`Pass preloaded application into new workers if available when using preload_app` 

in puma 5.0.4: https://github.com/puma/puma/blob/master/History.md#504--2020-10-27