### PR TITLE
set the copying user to be the author of attachments

### DIFF
--- a/app/services/copy/concerns/copy_attachments.rb
+++ b/app/services/copy/concerns/copy_attachments.rb
@@ -4,12 +4,13 @@ module Copy
 
       ##
       # Tries to copy the given attachment between containers
-      def copy_attachments(from_container_id, to_container_id, container_type)
-        Attachment.where(container_id: from_container_id, container_type: container_type).find_each do |old_attachment|
+      def copy_attachments(from_container, to_container_id)
+        Attachment.where(container: from_container).find_each do |old_attachment|
           copied = old_attachment.dup
           old_attachment.file.copy_to(copied)
 
-          copied.container_type = container_type
+          copied.author = user
+          copied.container_type = from_container.class.name
           copied.container_id = to_container_id
 
           unless copied.save

--- a/app/services/projects/copy/wiki_dependent_service.rb
+++ b/app/services/projects/copy/wiki_dependent_service.rb
@@ -65,7 +65,7 @@ module Projects::Copy
         wiki_pages_map.each do |old_page, new_page|
           next unless old_page && new_page
 
-          copy_attachments(old_page.id, new_page.id, new_page.class.name)
+          copy_attachments(old_page, new_page.id)
         end
       end
     end
@@ -77,7 +77,7 @@ module Projects::Copy
       # Relying on ActionMailer::Base.perform_deliveries is violating cohesion
       # but the value is currently not otherwise provided
       service_call = WikiPages::CopyService
-                     .new(user: User.current, model: source_page, contract_class: WikiPages::CopyContract)
+                     .new(user: user, model: source_page, contract_class: WikiPages::CopyContract)
                      .call(wiki: target.wiki,
                            parent: new_parent,
                            send_notifications: ActionMailer::Base.perform_deliveries)

--- a/app/services/projects/copy/work_packages_dependent_service.rb
+++ b/app/services/projects/copy/work_packages_dependent_service.rb
@@ -68,7 +68,7 @@ module Projects::Copy
 
         # Attachments
         if should_copy?(params, :work_package_attachments)
-          copy_attachments(wp.id, new_wp_id, 'WorkPackage')
+          copy_attachments(wp, new_wp_id)
         end
 
         copy_relations(wp, new_wp_id, work_packages_map)

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -319,6 +319,7 @@ describe Projects::CopyService, 'integration', type: :model do
 
             wp = project_copy.work_packages.find_by(subject: work_package.subject)
             expect(wp.attachments.count).to eq(1)
+            expect(wp.attachments.first.author).to eql(current_user)
           end
         end
 


### PR DESCRIPTION
Sets the author of copied attachments to be the copying author. This will be applied to work packages as well as wiki pages because the code is shared.

https://community.openproject.com/wp/35126