### PR TITLE
set default role when copying project as non admin

### DIFF
--- a/app/services/projects/concerns/new_project_service.rb
+++ b/app/services/projects/concerns/new_project_service.rb
@@ -1,0 +1,74 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module Projects::Concerns
+  module NewProjectService
+    private
+
+    def after_perform(attributes_call)
+      new_project = attributes_call.result
+
+      set_default_role(new_project) unless user.admin?
+      notify_project_created(new_project)
+
+      super
+    end
+
+    # Add default role to the newly created project
+    # based on the setting ('new_project_user_role_id')
+    # defined in the administration. Will either create a new membership
+    # or add a role to an already existing one.
+    def set_default_role(new_project)
+      role = Role.in_new_project
+
+      return unless role && new_project.persisted?
+
+      # Assuming the members are loaded anyway
+      user_member = new_project.members.detect { |m| m.principal == user }
+
+      if user_member
+        Members::UpdateService
+          .new(user: user, model: user_member, contract_class: EmptyContract)
+          .call(roles: user_member.roles + [role])
+      else
+        Members::CreateService
+          .new(user: user, contract_class: EmptyContract)
+          .call(roles: [role], project: new_project, principal: user)
+      end
+    end
+
+    def notify_project_created(new_project)
+      OpenProject::Notifications.send(
+        OpenProject::Events::PROJECT_CREATED,
+        project: new_project
+      )
+    end
+  end
+end

--- a/app/services/projects/copy/work_packages_dependent_service.rb
+++ b/app/services/projects/copy/work_packages_dependent_service.rb
@@ -84,7 +84,7 @@ module Projects::Copy
         .new(user: user,
              work_package: source_work_package,
              contract_class: WorkPackages::CopyProjectContract)
-        .call(overrides)
+        .call(**overrides)
 
       if service_call.success?
         service_call.result

--- a/app/services/projects/copy_service.rb
+++ b/app/services/projects/copy_service.rb
@@ -30,6 +30,7 @@
 
 module Projects
   class CopyService < ::BaseServices::Copy
+    include Projects::Concerns::NewProjectService
 
     ##
     # In case a rollback is needed,

--- a/app/services/projects/create_service.rb
+++ b/app/services/projects/create_service.rb
@@ -30,15 +30,6 @@
 
 module Projects
   class CreateService < ::BaseServices::Create
-    def after_perform(attributes_call)
-      attributes_call.result.add_member!(user, Role.in_new_project) unless user.admin?
-
-      OpenProject::Notifications.send(
-        OpenProject::Events::PROJECT_CREATED,
-        project: attributes_call.result
-      )
-
-      super
-    end
+    include Projects::Concerns::NewProjectService
   end
 end

--- a/app/services/work_packages/copy_service.rb
+++ b/app/services/work_packages/copy_service.rb
@@ -68,7 +68,7 @@ class WorkPackages::CopyService
     WorkPackages::CreateService
       .new(user: user,
            contract_class: contract_class)
-      .call(attributes.merge(send_notifications: send_notifications).symbolize_keys)
+      .call(**attributes.merge(send_notifications: send_notifications).symbolize_keys)
   end
 
   def copied_attributes(wp, override)

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -107,7 +107,7 @@ describe 'Projects copy',
                         done_ratio: 20,
                         category: category,
                         version: version,
-                        description: 'Some desciption',
+                        description: 'Some description',
                         custom_field_values: { wp_custom_field.id => 'Some wp cf text' })
     end
 

--- a/spec/services/projects/create_service_spec.rb
+++ b/spec/services/projects/create_service_spec.rb
@@ -112,9 +112,18 @@ describe Projects::CreateService, type: :model do
         .to receive(:in_new_project)
         .and_return(new_project_role)
 
-      expect(created_project)
-        .to receive(:add_member!)
-        .with(user, new_project_role)
+      create_member_instance = double('Members::CreateService instance')
+
+      expect(Members::CreateService)
+        .to receive(:new)
+        .with(user: user, contract_class: EmptyContract)
+        .and_return(create_member_instance)
+
+      expect(create_member_instance)
+        .to receive(:call)
+        .with(principal: user,
+              project: instance_of(Project),
+              roles: [new_project_role])
 
       subject
     end


### PR DESCRIPTION
Adds the role configured to be the default role for non admins when creating projects also for copied projects. This is done regardless of whether they are templates. Also fixes sending out notifications on copying projects which will result in webhook post requests now being sent if a project is copied.

https://community.openproject.com/wp/35127