### PR TITLE
Fix #35131:  Cleanup migration for BIM themes

### DIFF
--- a/app/models/design_color.rb
+++ b/app/models/design_color.rb
@@ -28,10 +28,10 @@
 
 class DesignColor < ApplicationRecord
   after_commit -> do
-    # CustomStyle.current.updated_at determins the cache key for inline_css
+    # CustomStyle.current.updated_at determines the cache key for inline_css
     # in which the CSS color variables will be overwritten. That is why we need
     # to ensure that a CustomStyle.current exists and that the time stamps change
-    # whenever we chagen a color_variable.
+    # whenever we change a color_variable.
     if CustomStyle.current
       CustomStyle.current.touch
     else

--- a/db/migrate/20200114091135_add_theme_name_to_custom_styles.rb
+++ b/db/migrate/20200114091135_add_theme_name_to_custom_styles.rb
@@ -1,5 +1,8 @@
 class AddThemeNameToCustomStyles < ActiveRecord::Migration[6.0]
   def change
-    add_column :custom_styles, :theme, :string, default: "OpenProject"
+    add_column :custom_styles,
+               :theme,
+               :string,
+               default: OpenProject::CustomStyles::ColorThemes::DEFAULT_THEME_NAME
   end
 end

--- a/lib/open_project/custom_styles/color_themes.rb
+++ b/lib/open_project/custom_styles/color_themes.rb
@@ -29,9 +29,11 @@
 
 module OpenProject::CustomStyles
   class ColorThemes
+    OpenProject::CustomStyles::ColorThemes::DEFAULT_THEME_NAME = 'OpenProject'.freeze
+
     THEMES = [
       {
-        theme: 'OpenProject',
+        theme: OpenProject::CustomStyles::ColorThemes::DEFAULT_THEME_NAME,
         colors: {
           'primary-color' => "#1A67A3",
           'primary-color-dark' => "#175A8E",

--- a/modules/bim/db/migrate/20201105154216_seed_custom_style_with_bim_theme.rb
+++ b/modules/bim/db/migrate/20201105154216_seed_custom_style_with_bim_theme.rb
@@ -60,12 +60,25 @@ class SeedCustomStyleWithBimTheme < ActiveRecord::Migration[6.0]
 
   def seed_bim_theme
     CustomStyle.transaction do
-      set_logo
-      set_colors
-      set_theme
-
-      custom_style.save!
+      set_custom_style
+      set_design_colors
     end
+  end
+
+  def set_design_colors
+    # There should not be any DesignColors present. However, we want to make sure.
+    DesignColor.delete_all
+
+    theme[:colors].each do |param_variable, param_hexcode|
+      DesignColor.create variable: param_variable, hexcode: param_hexcode
+    end
+  end
+
+  def set_custom_style
+    custom_style = (CustomStyle.current || CustomStyle.create!)
+    custom_style.attributes = { theme: theme[:theme], theme_logo: theme[:logo] }
+    custom_style.save!
+    custom_style
   end
 
   def theme
@@ -84,28 +97,5 @@ class SeedCustomStyleWithBimTheme < ActiveRecord::Migration[6.0]
       },
       logo: 'bim/logo_openproject_bim_big.png'
     }
-  end
-
-  def set_logo
-    custom_style.theme_logo = theme[:logo].presence
-  end
-
-  def set_colors
-    # There should not be any DesignColors be present. However, we want to make sure.
-    DesignColor.delete_all
-
-    theme[:colors].each do |param_variable, param_hexcode|
-      # create that design_color
-      design_color = DesignColor.new variable: param_variable, hexcode: param_hexcode
-      design_color.save
-    end
-  end
-
-  def set_theme
-    custom_style.theme = theme[:theme]
-  end
-
-  def custom_style
-    @custom_style ||= (CustomStyle.current || CustomStyle.create!)
   end
 end

--- a/modules/bim/db/migrate/20201105154216_seed_custom_style_with_bim_theme.rb
+++ b/modules/bim/db/migrate/20201105154216_seed_custom_style_with_bim_theme.rb
@@ -1,0 +1,111 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+# This migration cleans up messed up themes. Sometimes in the past
+# the BIM theme was not set where it should have been set.
+class SeedCustomStyleWithBimTheme < ActiveRecord::Migration[6.0]
+
+  def up
+    # When
+    #   migrating BIM instances
+    #     that did not have any custom styles OR
+    #       that do not have any design colors set and no custom logo/touch-icon/favicon
+    #       (this basically means that no theme actually got applied)
+    # then
+    #   add a custom style with the BIM theme set. This will write the theme's colors
+    #   as DesignColor entries to the DB which is necessary for the theme to actually
+    #   have an effect.
+    if OpenProject::Configuration.bim? &&
+       (CustomStyle.current.nil? ||
+           (DesignColor.count == 0 &&
+               CustomStyle.current.favicon.nil? &&
+               CustomStyle.current.logo.nil? &&
+               CustomStyle.current.touch_icon.nil?))
+      seed_bim_theme
+    end
+  end
+
+  def down
+    # nop
+  end
+
+  private
+
+  def seed_bim_theme
+    CustomStyle.transaction do
+      set_logo
+      set_colors
+      set_theme
+
+      custom_style.save!
+    end
+  end
+
+  def theme
+    {
+      theme: 'OpenProject BIM',
+      colors: {
+        'primary-color' => "#3270DB",
+        'primary-color-dark' => "#163473",
+        'alternative-color' => "#349939",
+        'header-bg-color' => "#05002C",
+        'header-item-bg-hover-color' => "#163473",
+        'content-link-color' => "#275BB5",
+        'main-menu-bg-color' => "#0E2045",
+        'main-menu-bg-selected-background' => "#3270DB",
+        'main-menu-bg-hover-background' => "#163473"
+      },
+      logo: 'bim/logo_openproject_bim_big.png'
+    }
+  end
+
+  def set_logo
+    custom_style.theme_logo = theme[:logo].presence
+  end
+
+  def set_colors
+    # There should not be any DesignColors be present. However, we want to make sure.
+    DesignColor.delete_all
+
+    theme[:colors].each do |param_variable, param_hexcode|
+      # create that design_color
+      design_color = DesignColor.new variable: param_variable, hexcode: param_hexcode
+      design_color.save
+    end
+  end
+
+  def set_theme
+    custom_style.theme = theme[:theme]
+  end
+
+  def custom_style
+    @custom_style ||= (CustomStyle.current || CustomStyle.create!)
+  end
+end


### PR DESCRIPTION
After the theme migrations elder BIM instances got "OpenProject" set instead of the "OpenProject BIM" theme. This is because "OpenProject" became the default for the `theme` column.

Fix:

BIM instances need to get the theme set in a new
CustomStyle entry AND its colors need to get
written to DB.

When digging around on Saas there were also BIM
instances that had a theme set in a CustomStyle
but did not have the colors written out to DB.

https://community.openproject.com/wp/35131