### PR TITLE
Fix/35238 429 error on boards

### DIFF
--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -47,7 +47,7 @@ import {StateService, TransitionService} from "@uirouter/core";
 import {WorkPackageViewFocusService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-focus.service";
 import {WorkPackageViewSelectionService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-selection.service";
 import {BoardListCrossSelectionService} from "core-app/modules/boards/board/board-list/board-list-cross-selection.service";
-import {debounceTime, filter, map} from "rxjs/operators";
+import {debounceTime, filter, map, retry} from "rxjs/operators";
 import {HalEvent, HalEventsService} from "core-app/modules/hal/services/hal-events.service";
 import {ChangeItem} from "core-app/modules/fields/changeset/changeset";
 import {SchemaCacheService} from "core-components/schemas/schema-cache.service";
@@ -391,7 +391,10 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     let observable = this
       .apiv3Service
       .queries
-      .find(this.columnsQueryProps, this.queryId);
+      .find(this.columnsQueryProps, this.queryId)
+      .pipe(
+        retry(3)
+      );
 
     // Spread arguments on pipe does not work:
     // https://github.com/ReactiveX/rxjs/issues/3989

--- a/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/modules/boards/board/board-list/board-list.component.ts
@@ -224,8 +224,6 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
         this.loadActionAttribute(query);
         this.cdRef.detectChanges();
       });
-
-    this.updateQuery();
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/35238/activity

This pull request:

- [x] Removes a useless query update on the BoardListComponent ngOnInit. Because the only way of loading a board is by link/routing (as far as I could see), the routed component BoardPartitionedPageComponent is always calling this.boardFilters.filters.putValue(...) and the BoardListComponent is updating the query on every boardFilters.filters, the this.updateQuery on the ngOnInit was causing duplicated calls to the backend. Removing it reduces the calls and so the probabilities of a 429 error.

- [x] Retries 3 times when an error is raised when getting the query which helps to reduce the probabilities of a 429 error.