### PR TITLE
don't fail starting the application when parallel_tests is missing

### DIFF
--- a/lib/tasks/parallel_testing.rake
+++ b/lib/tasks/parallel_testing.rake
@@ -30,6 +30,12 @@
 require 'optparse'
 require 'plugins/load_path_helper'
 
+begin
+  Bundler.gem('parallel_tests')
+rescue Gem::LoadError
+  # In case parallel_tests is not provided, the whole of the parallel task group will not work.
+  return
+end
 
 require 'parallel_tests/tasks'
 # Remove task added by parallel_tests as it conflicts with our own.


### PR DESCRIPTION
This might happen if the 'test' group is excluded from the bundler run, e.g. in production settings