### PR TITLE
Optimize memory usage for pdf exports with attachments

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -10,6 +10,7 @@ targets:
       - unrtf
       - tesseract-ocr
       - catdoc
+      - imagemagick
   debian-10:
     <<: *debian9
   ubuntu-16.04:
@@ -22,12 +23,15 @@ targets:
     dependencies:
       - unzip
       - epel-release
+      - ImageMagick
   centos-7:
    dependencies:
       - epel-release
+      - ImageMagick
   sles-12:
     build_dependencies:
       - sqlite3-devel
+      - ImageMagick
 before_precompile: "packaging/setup"
 after_precompile: "packaging/teardown"
 services:

--- a/Gemfile
+++ b/Gemfile
@@ -187,6 +187,8 @@ gem 'rest-client', '~> 2.0'
 
 gem 'ruby-progressbar', '~> 1.10.0', require: false
 
+gem 'mini_magick', '~> 4.11.0', require: false
+
 group :test do
   gem 'launchy', '~> 2.5.0'
   gem 'rack-test', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,6 +617,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
     mimemagic (0.3.5)
+    mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minisyntax (0.2.5)
@@ -1027,6 +1028,7 @@ DEPENDENCIES
   livingstyleguide (~> 2.1.0)
   lograge (~> 0.11.0)
   meta-tags (~> 2.13.0)
+  mini_magick (~> 4.11.0)
   multi_json (~> 1.15.0)
   my_page!
   net-ldap (~> 0.16.0)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -26,6 +26,7 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
+require 'open3'
 
 class AdminController < ApplicationController
   layout 'admin'
@@ -84,6 +85,7 @@ class AdminController < ApplicationController
     @checklist += file_storage_checks
     @checklist += plaintext_extraction_checks
     @checklist += admin_information_hook_checks
+    @checklist += image_conversion_checks
 
     @storage_information = OpenProject::Storage.mount_information
   end
@@ -116,6 +118,14 @@ class AdminController < ApplicationController
     else
       []
     end
+  end
+
+  def image_conversion_checks
+    [[:'image_conversion.imagemagick', image_conversion_libs_available?]]
+  end
+
+  def image_conversion_libs_available?
+    Open3.capture2e('convert', '-version').first.include?('ImageMagick')
   end
 
   def file_storage_checks

--- a/app/models/work_package/pdf_export/attachments.rb
+++ b/app/models/work_package/pdf_export/attachments.rb
@@ -50,11 +50,34 @@ module WorkPackage::PDFExport::Attachments
 
     # Access the local file. For Carrierwave attachments, this will be blocking.
     file_path = attachment.file.local_file.path
+
+    # Let's not include the raw images as the sum of all images can hit the memory limit of the worker process.
+    # As we do not need the full image size when printing small images into the PDF let's reduce it on the fly.
+    # It uses CPU and time. However, we don't expect that feature to get used often.
+    resized_file_path = resize_image(file_path)
+
     # Fit the image roughly in the center of each cell
-    pdf.make_cell(image: file_path, fit: [available_width, 125], position: :center)
+    pdf.make_cell(image: resized_file_path, fit: [available_width, 125], position: :center)
   rescue => e
     Rails.logger.error { "Failed to attach work package image to PDF: #{e} #{e.message}" }
     nil
+  end
+
+  def resize_image(file_path)
+    resized_file_path = extend_file_name_in_path(file_path, '__x325')
+    image = MiniMagick::Image.open(file_path)
+    image.resize("x325")
+    image.write(resized_file_path)
+
+    resized_file_path
+  end
+
+  def extend_file_name_in_path(file_path, name_suffix)
+    dir_path = File.dirname(file_path)
+    file_extension = File.extname(file_path)
+    file_name = File.basename(file_path, '.*')
+
+    File.join(dir_path, "#{file_name}#{name_suffix}#{file_extension}")
   end
 
   def pdf_embeddable?(attachment)

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -28,6 +28,8 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
+require 'mini_magick'
+
 class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
   include WorkPackage::PDFExport::Common
   include WorkPackage::PDFExport::Attachments

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1238,6 +1238,9 @@ en:
       forums: "Community forum"
       newsletter: "Security alerts / Newsletter"
 
+  image_conversion:
+    imagemagick: 'Imagemagick'
+
   journals:
     changes_retracted: "The changes were retracted."
 

--- a/docker/setup/preinstall-common.sh
+++ b/docker/setup/preinstall-common.sh
@@ -18,7 +18,8 @@ apt-get install -y \
 	tesseract-ocr \
 	catdoc \
 	postgresql-9.6 \
-	postgresql-client-9.6
+	postgresql-client-9.6 \
+	imagemagick
 
 rm -rf "$PGDATA_LEGACY"
 

--- a/docs/installation-and-operations/installation/manual/README.md
+++ b/docs/installation-and-operations/installation/manual/README.md
@@ -49,7 +49,8 @@ sudo passwd openproject #(enter desired password)
                     libncurses5-dev automake                        \
                     libtool bison libffi-dev git curl               \
                     poppler-utils unrtf tesseract-ocr catdoc        \
-                    libxml2 libxml2-dev libxslt1-dev # nokogiri
+                    libxml2 libxml2-dev libxslt1-dev # nokogiri     \
+                    imagemagick
 ```
 
 ## Install the caching server (memcached)


### PR DESCRIPTION
https://community.openproject.com/wp/35327

- Installs Imagemagick package for image conversion.
- converts all attachments to a smaller size before
  printing them to the PDF file.
- Ads a installation check to the _Admin -> Information_
  screen.