### PR TITLE
remove renamed cron job

### DIFF
--- a/db/migrate/20201125121949_remove_renamed_cron_job.rb
+++ b/db/migrate/20201125121949_remove_renamed_cron_job.rb
@@ -1,0 +1,40 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+class RemoveRenamedCronJob < ActiveRecord::Migration[6.0]
+  def up
+    # The job has been renamed to JobStatus::Cron::ClearOldJobStatusJob
+    # the new job will be added on restarting the application but the old will still be in the database
+    # and will cause 'uninitialized constant' errors.
+    Delayed::Job
+      .where('handler LIKE ?', "%job_class: Cron::ClearOldJobStatusJob%")
+      .delete_all
+  end
+end


### PR DESCRIPTION
The Job was renamed in #58562e7 but there might still be a job in the database using the old name. 

https://community.openproject.com/wp/35229