### PR TITLE
Feature: Optimize memory for pdf exports with attachments

### DIFF
--- a/app/models/work_package/pdf_export/attachments.rb
+++ b/app/models/work_package/pdf_export/attachments.rb
@@ -69,6 +69,8 @@ module WorkPackage::PDFExport::Attachments
     image.resize("x325")
     image.write(resized_file_path)
 
+    @resized_image_paths << resized_file_path
+
     resized_file_path
   end
 
@@ -82,5 +84,11 @@ module WorkPackage::PDFExport::Attachments
 
   def pdf_embeddable?(attachment)
     %w[image/jpeg image/png].include?(attachment.content_type)
+  end
+
+  def delete_all_resized_images
+    @resized_image_paths.each do |file_path|
+      File.delete(file_path)
+    end
   end
 end

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -99,7 +99,7 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
 
   def merge_pdfs
     merged_pdf = Tempfile.new
-    # We use the command line tool "pdfunite" for concatinating the PDFs.
+    # We use the command line tool "pdfunite" for concatenating the PDFs.
     # That tool comes with the system package "poppler-utils" which we
     # fortunately already have installed for text extraction purposes.
     Open3.capture2e("pdfunite", *@batch_files.map(&:path), merged_pdf.path)

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -28,7 +28,19 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
+# Exporter for work package table.
+#
+# It can optionally export a work package with
+# - description, or with
+# - attached images, or with
+# - description and attached images.
+#
+# When exporting with attached images then the memory consumption can quickly
+# grow beyond limits. Therefore we create multiple smaller PDFs that we finally
+# merge do one file.
+
 require 'mini_magick'
+require 'open3'
 
 class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
   include WorkPackage::PDFExport::Common
@@ -37,26 +49,29 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
   attr_accessor :pdf,
                 :options
 
+  WORK_PACKAGES_PER_BATCH = 100
+
   def initialize(object, options = {})
     super
 
     @cell_padding = options.delete(:cell_padding)
 
-    self.pdf = get_pdf(current_language)
-
-    configure_page_size
-    configure_markup
-  end
-
-  def configure_page_size
-    pdf.options[:page_size] = 'EXECUTIVE'
-    pdf.options[:page_layout] = :landscape
+    @total_wp_count = query.results.work_package_count
+    @batches_count = @total_wp_count.fdiv(WORK_PACKAGES_PER_BATCH).ceil
+    @batch_files = []
+    @page_count = -1
   end
 
   def render!
-    write_content!
+    (1..@batches_count).each do |batch_index|
+      run_batch!(batch_index)
+    end
 
-    success(pdf.render)
+    @merged_pdf_file = merge_pdfs
+    merged_file_content = @merged_pdf_file.read
+    delete_tmp_files
+
+    success(merged_file_content)
   rescue Prawn::Errors::CannotFit
     error(I18n.t(:error_pdf_export_too_many_columns))
   rescue StandardError => e
@@ -64,12 +79,58 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
     error(I18n.t(:error_pdf_failed_to_export, error: e.message))
   end
 
-  def write_content!
+  private
+
+  def on_first_batch(batch_index)
+    return unless batch_index == 1
+
     write_title!
     write_headers!
-    write_work_packages!
+  end
 
+  def delete_tmp_files
+    files_to_delete = [@merged_pdf_file] + @batch_files
+    files_to_delete.each(&:delete)
+  end
+
+  def configure_page_size
+    pdf.options[:page_size] = 'EXECUTIVE'
+    pdf.options[:page_layout] = :landscape
+  end
+
+  def merge_pdfs
+    merged_pdf = Tempfile.new
+    # We use the command line tool "pdfunite" for concatinating the PDFs.
+    # That tool comes with the system package "poppler-utils" which we
+    # fortunately already have installed for text extraction purposes.
+    Open3.capture2e("pdfunite", *@batch_files.map(&:path), merged_pdf.path)
+
+    merged_pdf
+  end
+
+  def run_batch!(batch_index)
+    initialize_batch_page
+
+    batch_file = render_batch!(batch_index)
+
+    @page_count += pdf.page_count
+    batch_file.close
+    @batch_files << batch_file
+  end
+
+  def render_batch!(batch_index)
+    @resized_image_paths = []
+
+    on_first_batch(batch_index)
+    write_work_packages!(batch_index)
     write_footers!
+
+    batch_file = Tempfile.new("pdf_batch_#{batch_index}")
+    pdf.render_file(batch_file.path)
+
+    delete_all_resized_images
+
+    batch_file
   end
 
   def project
@@ -98,11 +159,13 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
   end
 
   def write_footers!
+    @page_count += 1
     pdf.number_pages format_date(Date.today),
                      at: [pdf.bounds.left, 0],
                      style: :italic
 
-    pdf.number_pages "<page>/<total>",
+    pdf.number_pages "<page>",
+                     start_count_at: @page_count,
                      at: [pdf.bounds.right - 25, 0],
                      style: :italic
   end
@@ -140,11 +203,11 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
     end
   end
 
-  def write_work_packages!
+  def write_work_packages!(batch_index)
     pdf.font style: :normal, size: 8
     previous_group = nil
 
-    work_packages.each do |work_package|
+    work_packages_batch(batch_index).each do |work_package|
       previous_group = write_group_header!(work_package, previous_group)
 
       write_attributes!(work_package)
@@ -157,6 +220,14 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
         write_attachments!(work_package)
       end
     end
+  end
+
+  def work_packages_batch(batch_index)
+    query
+        .results
+        .work_packages
+        .page(batch_index)
+        .per_page(WORK_PACKAGES_PER_BATCH)
   end
 
   def write_attributes!(work_package)
@@ -219,5 +290,12 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
 
     pdf.make_cell values.map(&:formatted_value).join(', '),
                   padding: cell_padding
+  end
+
+  def initialize_batch_page
+    self.pdf = get_pdf(current_language)
+
+    configure_page_size
+    configure_markup
   end
 end

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -68,10 +68,10 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
     end
 
     @merged_pdf_file = merge_pdfs
-    merged_file_content = @merged_pdf_file.read
+
     delete_tmp_files
 
-    success(merged_file_content)
+    success(@merged_pdf_file)
   rescue Prawn::Errors::CannotFit
     error(I18n.t(:error_pdf_export_too_many_columns))
   rescue StandardError => e
@@ -89,8 +89,7 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exporter::Base
   end
 
   def delete_tmp_files
-    files_to_delete = [@merged_pdf_file] + @batch_files
-    files_to_delete.each(&:delete)
+    @batch_files.each(&:delete)
   end
 
   def configure_page_size

--- a/app/workers/work_packages/exports/export_job.rb
+++ b/app/workers/work_packages/exports/export_job.rb
@@ -31,8 +31,14 @@ module WorkPackages
         exporter.list(query, options) do |export_result|
           if export_result.error?
             raise export_result.message
-          elsif [File, Tempfile].any? { |klass| export_result.content.is_a? klass }
+          elsif export_result.content.is_a? File
             store_attachment(export, export_result.content)
+          elsif export_result.content.is_a? Tempfile
+            renamed_file_path = File.join(File.dirname(export_result.content.path), export_result.title)
+            File.rename(export_result.content.path, renamed_file_path)
+            file = File.open(renamed_file_path)
+            store_attachment(export, file)
+            file.close
           else
             store_from_string(export, export_result)
           end

--- a/app/workers/work_packages/exports/export_job.rb
+++ b/app/workers/work_packages/exports/export_job.rb
@@ -34,15 +34,19 @@ module WorkPackages
           elsif export_result.content.is_a? File
             store_attachment(export, export_result.content)
           elsif export_result.content.is_a? Tempfile
-            renamed_file_path = File.join(File.dirname(export_result.content.path), export_result.title)
-            File.rename(export_result.content.path, renamed_file_path)
-            file = File.open(renamed_file_path)
-            store_attachment(export, file)
-            file.close
+            store_from_tempfile(export, export_result)
           else
             store_from_string(export, export_result)
           end
         end
+      end
+
+      def store_from_tempfile(export, export_result)
+        renamed_file_path = File.join(File.dirname(export_result.content.path), export_result.title)
+        File.rename(export_result.content.path, renamed_file_path)
+        file = File.open(renamed_file_path)
+        store_attachment(export, file)
+        file.close
       end
 
       def schedule_cleanup

--- a/app/workers/work_packages/exports/export_job.rb
+++ b/app/workers/work_packages/exports/export_job.rb
@@ -31,7 +31,7 @@ module WorkPackages
         exporter.list(query, options) do |export_result|
           if export_result.error?
             raise export_result.message
-          elsif export_result.content.is_a? File
+          elsif [File, Tempfile].any? { |klass| export_result.content.is_a? klass }
             store_attachment(export, export_result.content)
           else
             store_from_string(export, export_result)


### PR DESCRIPTION
https://community.openproject.com/wp/35327

In order to keep memory consumption low when
exporting WP as list in PDF, we split the work
in batches of 100 work packages. In every batch
we resize the attached photos and create a PDF.
When all batches have been processed, we merge
the PDF files via the command line tool
`pdfunite` which fortunately comes with a package
that we already require for text extraction.

In every batch, we make sure that we remove
all minimized images afterwards. And after
merging the batch PDF files to the final
PDF we also delete all batch PDFs. 