### PR TITLE
Update docker documentation

### DIFF
--- a/docs/development/development-environment-docker/README.md
+++ b/docs/development/development-environment-docker/README.md
@@ -6,7 +6,7 @@ The quickest way to get started developing OpenProject is to use the docker setu
 
 * docker
 
-And nothhing else!
+And nothing else!
 
 ## Quickstart
 

--- a/docs/development/running-tests/README.md
+++ b/docs/development/running-tests/README.md
@@ -343,3 +343,8 @@ at 127.0.0.1 on port 389.
 Setting up the test ldap server is beyond the scope of this documentation.
 The Apache DS project provides a simple LDAP implementation that should work
 good as a test server.
+
+## Running tests locally in Docker
+
+Most of the above applies to running tests locally, with some docker specific setup changes that are discussed [in the
+docker development documentation](../development-environment-docker).

--- a/docs/installation-and-operations/installation/docker/README.md
+++ b/docs/installation-and-operations/installation/docker/README.md
@@ -87,6 +87,11 @@ achieved with the `-d` flag:
 docker run -d -p 8080:80 -e SECRET_KEY_BASE=secret openproject/community:11
 ```
 
+**Note**: We've had reports of people being unable to start OpenProject this way
+because of an [issue regarding pseudo-TTY allocations](https://github.com/moby/moby/issues/31243#issuecomment-406825071)
+and permissions to write to `/dev/stdout`. If you run into this, a workaround
+seems to be to add `-t` to your run command, even if you run in detached mode. 
+
 ### Recommended usage
 
 The one-liner above is great to get started quickly, but if you want to run


### PR DESCRIPTION
Add a cross-link for running tests in local docker environments, and add a note pointing out a report of possible TTY
permission issues when running in production.

Closes https://community.openproject.com/projects/docker/work_packages/35322/activity