### PR TITLE
avoid embedded table overlapping toc

### DIFF
--- a/frontend/src/global_styles/content/user-content/_macros.sass
+++ b/frontend/src/global_styles/content/user-content/_macros.sass
@@ -1,3 +1,4 @@
-.op-uc-embedded-table 
+.op-uc-embedded-table
   clear: both
+  display: block
 

--- a/frontend/src/global_styles/content/user-content/_table.sass
+++ b/frontend/src/global_styles/content/user-content/_table.sass
@@ -3,9 +3,7 @@
   border-collapse: collapse
   border-spacing: 0
   width: 100%
-
-  @at-root .op-uc-container_editing &
-    border: 1px solid rgba(0, 0, 0, 0.1)
+  border: 1px solid rgba(0, 0, 0, 0.1)
 
   &--row
     &:not(:last-child)


### PR DESCRIPTION
By turning the macro into a block, it is moved to the next line after the toc. This prevents the loading-indicator with its position: relative to overlap the toc.

https://community.openproject.com/wp/35611