### PR TITLE
Fixed: Ordering widgets when a single board is requested

### DIFF
--- a/frontend/src/app/modules/apiv3/virtual/apiv3-board-path.ts
+++ b/frontend/src/app/modules/apiv3/virtual/apiv3-board-path.ts
@@ -47,7 +47,13 @@ export class APIv3BoardPath extends CachableAPIV3Resource<Board> {
       .id(this.id)
       .get()
       .pipe(
-        map(grid => new Board(grid))
+        map(grid => {
+          const newBoard = new Board(grid);
+
+          newBoard.sortWidgets();
+
+          return newBoard;
+        })
       );
   }
 

--- a/frontend/src/app/modules/boards/board/board-partitioned-page/board-list-container.component.html
+++ b/frontend/src/app/modules/boards/board/board-partitioned-page/board-list-container.component.html
@@ -20,7 +20,8 @@
             cdkDragHandle></span>
       <board-list [resource]="queryWidget"
                   [board]="board"
-                  (onRemove)="removeList(board, queryWidget)"></board-list>
+                  (onRemove)="removeList(board, queryWidget)">
+      </board-list>
     </div>
 
     <div class="boards-list--add-item -no-text-select"


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/35004

This pull request:

- [x] Fixes the random error of board lists not keeping their order.


**NOTES**
It was due to the boards being refreshed by two different methods: method A (this.apiV3Service.boards.allInScope) ordered the widgets while method B (this.apiV3Service.boards.id(id).requireAndStream) didn't. Because of both being asynchronous, only a few times the method B resolved before method A, producing the error.