### PR TITLE
Chore/replace activemodel mocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -201,9 +201,6 @@ group :test do
   gem 'database_cleaner', '~> 1.8'
   gem 'rack_session_access'
   gem 'rspec', '~> 3.10.0'
-  # TODO: replace mock_model by calls to factory or simple double
-  # and remove this dependency
-  gem 'rspec-activemodel-mocks', '~> 1.1.0', git: 'https://github.com/rspec/rspec-activemodel-mocks'
   # also add to development group, so "spec" rake task gets loaded
   gem 'rspec-rails', '~> 4.0.0', group: :development
 

--- a/Gemfile
+++ b/Gemfile
@@ -201,7 +201,7 @@ group :test do
   gem 'database_cleaner', '~> 1.8'
   gem 'rack_session_access'
   gem 'rspec', '~> 3.10.0'
-  # TODO: replace stub_model and mock_model by calls to factory or simple double
+  # TODO: replace mock_model by calls to factory or simple double
   # and remove this dependency
   gem 'rspec-activemodel-mocks', '~> 1.1.0', git: 'https://github.com/rspec/rspec-activemodel-mocks'
   # also add to development group, so "spec" rake task gets loaded

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,15 +35,6 @@ GIT
       mixlib-shellout (~> 2.1.0)
       rubyzip
 
-GIT
-  remote: https://github.com/rspec/rspec-activemodel-mocks
-  revision: 0338d50039cad672bbe695fff5591da1ba849308
-  specs:
-    rspec-activemodel-mocks (1.1.0)
-      activemodel (>= 3.0)
-      activesupport (>= 3.0)
-      rspec-mocks (>= 2.99, < 4.0)
-
 PATH
   remote: modules/auth_plugins
   specs:
@@ -1051,7 +1042,6 @@ DEPENDENCIES
   roar (~> 1.1.0)
   rouge (~> 3.25.0)
   rspec (~> 3.10.0)
-  rspec-activemodel-mocks (~> 1.1.0)!
   rspec-rails (~> 4.0.0)
   rspec-retry (~> 0.6.1)
   rubocop

--- a/modules/costs/spec/lib/api/v3/costs_api_user_permission_check_spec.rb
+++ b/modules/costs/spec/lib/api/v3/costs_api_user_permission_check_spec.rb
@@ -39,9 +39,9 @@ describe API::V3::CostsApiUserPermissionCheck do
     include API::V3::CostsApiUserPermissionCheck
   end
 
-  let(:user) { mock_model('User') }
-  let(:project) { mock_model('Project') }
-  let(:work_package) { mock_model('WorkPackage', project: project) }
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:project) { FactoryBot.build_stubbed(:project) }
+  let(:work_package) { FactoryBot.build_stubbed(:work_package, project: project) }
 
   before do
     allow(subject)

--- a/modules/meeting/spec/controllers/meetings_controller_spec.rb
+++ b/modules/meeting/spec/controllers/meetings_controller_spec.rb
@@ -41,7 +41,9 @@ describe MeetingsController, type: :controller do
   describe 'GET' do
     describe 'index' do
       before(:each) do
-        @ms = [mock_model(Meeting), mock_model(Meeting), mock_model(Meeting)]
+        @ms = [FactoryBot.build_stubbed(:meeting),
+               FactoryBot.build_stubbed(:meeting),
+               FactoryBot.build_stubbed(:meeting)]
         allow(@ms).to receive(:from_tomorrow).and_return(@ms)
 
         allow(project).to receive(:meetings).and_return(@ms)
@@ -62,10 +64,8 @@ describe MeetingsController, type: :controller do
 
     describe 'show' do
       before(:each) do
-        @m = mock_model(Meeting)
+        @m = FactoryBot.build_stubbed(:meeting, project: project, agenda: nil)
         allow(Meeting).to receive_message_chain(:includes, :find).and_return(@m)
-        allow(@m).to receive(:project).and_return(project)
-        allow(allow(@m).to receive(:agenda)).to receive(:present?).and_return(false)
       end
       describe 'html' do
         before(:each) do
@@ -78,9 +78,7 @@ describe MeetingsController, type: :controller do
     describe 'new' do
       before(:each) do
         allow(Project).to receive(:find).and_return(project)
-        @m = mock_model(Meeting)
-        allow(@m).to receive(:project=)
-        allow(@m).to receive(:author=)
+        @m = FactoryBot.build_stubbed(:meeting)
         allow(Meeting).to receive(:new).and_return(@m)
       end
       describe 'html' do
@@ -94,9 +92,8 @@ describe MeetingsController, type: :controller do
 
     describe 'edit' do
       before(:each) do
-        @m = mock_model(Meeting)
+        @m = FactoryBot.build_stubbed(:meeting, project: project)
         allow(Meeting).to receive_message_chain(:includes, :find).and_return(@m)
-        allow(@m).to receive(:project).and_return(project)
       end
       describe 'html' do
         before(:each) do

--- a/modules/two_factor_authentication/spec/models/login_token_spec.rb
+++ b/modules/two_factor_authentication/spec/models/login_token_spec.rb
@@ -3,7 +3,7 @@ require_relative '../spec_helper'
 describe TwoFactorAuthentication::LoginToken, with_2fa_ee: true do
 
   before(:each) do
-    @user = mock_model(User, :login => "john", :password => "doe")
+    @user = FactoryBot.build_stubbed(:user, login: "john", password: "doe")
     allow(@user).to receive(:new_record?).and_return(false)
     allow(@user).to receive(:force_password_reset).and_return(false)
     allow(@user).to receive(:password_expired?).and_return(false)

--- a/spec/models/queries/work_packages/columns/custom_field_column_spec.rb
+++ b/spec/models/queries/work_packages/columns/custom_field_column_spec.rb
@@ -32,8 +32,10 @@ require_relative 'shared_query_column_specs'
 describe Queries::WorkPackages::Columns::CustomFieldColumn, type: :model do
   let(:project) { FactoryBot.build_stubbed(:project) }
   let(:custom_field) do
-    mock_model(CustomField, field_format: 'string',
-                            order_statements: nil)
+    double('CustomField',
+           field_format: 'string',
+           id: 5,
+           order_statements: nil)
   end
   let(:instance) { described_class.new(custom_field) }
 

--- a/spec/services/add_work_package_note_service_spec.rb
+++ b/spec/services/add_work_package_note_service_spec.rb
@@ -49,9 +49,14 @@ describe AddWorkPackageNoteService, type: :model do
              new: mock_contract_instance)
     end
     let(:mock_contract_instance) do
-      mock_model(WorkPackages::CreateNoteContract)
+      double(WorkPackages::CreateNoteContract,
+             errors: contract_errors,
+             validate: valid_contract)
     end
     let(:valid_contract) { true }
+    let(:contract_errors) do
+      double('contract errors')
+    end
 
     let(:send_notifications) { false }
 
@@ -63,7 +68,6 @@ describe AddWorkPackageNoteService, type: :model do
 
       allow(instance).to receive(:contract_class).and_return(mock_contract)
       allow(work_package).to receive(:save_journals).and_return true
-      allow(mock_contract_instance).to receive(:validate).and_return valid_contract
     end
 
     subject { instance.call('blubs', send_notifications: send_notifications) }

--- a/spec/services/authorization/enterprise_service_spec.rb
+++ b/spec/services/authorization/enterprise_service_spec.rb
@@ -38,7 +38,7 @@ describe Authorization::EnterpriseService do
 
     token
   end
-  let(:token) { mock_model(EnterpriseToken, token_object: token_object) }
+  let(:token) { double('EnterpriseToken', token_object: token_object) }
   let(:instance) { described_class.new(token) }
   let(:result) { instance.call(action) }
   let(:action) { :an_action }

--- a/spec/services/update_user_email_settings_service_spec.rb
+++ b/spec/services/update_user_email_settings_service_spec.rb
@@ -29,29 +29,38 @@
 require 'spec_helper'
 
 describe UpdateUserEmailSettingsService, type: :model do
-  let(:user) { stub_model(User) }
+  let(:user_save_success) { true }
+  let(:user_pref_save_success) { true }
+
+  let(:user) do
+    FactoryBot.build_stubbed(:user).tap do |u|
+      allow(u).to receive(:save).and_return(user_save_success)
+      allow(u.pref).to receive(:save).and_return(user_pref_save_success)
+    end
+  end
   let(:service) { described_class.new(user) }
 
   describe '#call' do
-    it 'returns true if saving is successful' do
-      allow(user).to receive(:save).and_return(true)
-      allow(user.pref).to receive(:save).and_return(true)
-
-      expect(service.call).to be_truthy
+    context 'saving is successful' do
+      it 'returns true' do
+        expect(service.call).to be_truthy
+      end
     end
 
-    it 'returns false if saving of user is unsuccessful' do
-      allow(user).to receive(:save).and_return(false)
-      allow(user.pref).to receive(:save).and_return(true)
+    context 'saving user is unsuccessful' do
+      let(:user_save_success) { false }
 
-      expect(service.call).to be_falsey
+      it 'returns false' do
+        expect(service.call).to be_falsey
+      end
     end
 
-    it 'returns false if saving of user preference is unsuccessful' do
-      allow(user).to receive(:save).and_return(true)
-      allow(user.pref).to receive(:save).and_return(false)
+    context 'saving user preferences is unsuccessful' do
+      let(:user_pref_save_success) { false }
 
-      expect(service.call).to be_falsey
+      it 'returns false' do
+        expect(service.call).to be_falsey
+      end
     end
 
     it 'sets the mail_notification if provided' do
@@ -61,7 +70,7 @@ describe UpdateUserEmailSettingsService, type: :model do
 
     it 'does not alter mail_notification if not provided' do
       expect(user).to_not receive(:mail_notification=)
-      service.call()
+      service.call
     end
 
     it 'sets self_notified if provided' do
@@ -71,13 +80,11 @@ describe UpdateUserEmailSettingsService, type: :model do
 
     it 'does not alter no_self_notified if not provided' do
       expect(user.pref).not_to receive(:[]=)
-      service.call()
+      service.call
     end
 
     it 'set the notified_project_ids on successful saving and mail_notifications is "selected"' do
       allow(user).to receive(:mail_notification).and_return 'selected'
-      allow(user).to receive(:save).and_return true
-      allow(user.pref).to receive(:save).and_return true
 
       expect(user).to receive(:notified_project_ids=).with([1,2,3])
 

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -55,15 +55,15 @@ describe WorkPackages::SetAttributesService, type: :model do
            new: mock_contract_instance)
   end
   let(:mock_contract_instance) do
-    mock = mock_model(contract_class,
-                      assignable_statuses: statuses)
-    allow(mock)
-      .to receive(:validate)
-      .and_return contract_valid
-
-    mock
+    double(contract_class,
+           assignable_statuses: statuses,
+           errors: contract_errors,
+           validate: contract_valid)
   end
   let(:contract_valid) { true }
+  let(:contract_errors) do
+    double('contract_errors')
+  end
   let(:instance) do
     described_class.new(user: user,
                         model: work_package,

--- a/spec/views/wiki/new.html.erb_spec.rb
+++ b/spec/views/wiki/new.html.erb_spec.rb
@@ -29,11 +29,11 @@
 require 'spec_helper'
 
 describe 'wiki/new', type: :view do
-  let(:project) { stub_model(Project) }
-  let(:wiki)    { stub_model(Wiki) }
-  let(:page)    { stub_model(WikiPage, title: 'foo') }
-  let(:content) { stub_model(WikiContent) }
-  let(:user)    { stub_model(User) }
+  let(:project) { FactoryBot.build_stubbed(:project) }
+  let(:wiki)    { FactoryBot.build_stubbed(:wiki, project: project) }
+  let(:page)    { FactoryBot.build_stubbed(:wiki_page_with_content, wiki: wiki, title: 'foo') }
+  let(:content) { page.content }
+  let(:user)    { FactoryBot.build_stubbed(:user) }
 
   before do
     assign(:project, project)


### PR DESCRIPTION
Replaces all occurrences of `mock_model` and `stub_model` and then removes the rspec-activemodel-mocks dependency.