### PR TITLE
Change the date format from locale week to ISO week

### DIFF
--- a/frontend/src/app/components/wp-table/timeline/header/wp-timeline-header.directive.ts
+++ b/frontend/src/app/components/wp-table/timeline/header/wp-timeline-header.directive.ts
@@ -103,7 +103,7 @@ export class WorkPackageTimelineHeaderController implements OnInit {
     });
 
     this.renderTimeSlices(vp, 'week', 13, vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      cell.innerHTML = start.format('ww');
+      cell.innerHTML = start.format('WW');
       cell.classList.add('-top-border');
       cell.style.height = '32px';
     });
@@ -127,7 +127,7 @@ export class WorkPackageTimelineHeaderController implements OnInit {
     });
 
     this.renderTimeSlices(vp, 'week', 15, vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      cell.innerHTML = start.format('ww');
+      cell.innerHTML = start.format('WW');
       cell.classList.add('-top-border');
       cell.style.height = '22px';
     });
@@ -151,7 +151,7 @@ export class WorkPackageTimelineHeaderController implements OnInit {
     });
 
     this.renderTimeSlices(vp, 'week', 25, vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      cell.innerHTML = start.format('ww');
+      cell.innerHTML = start.format('WW');
       cell.classList.add('wp-timeline--header-middle-element');
     });
   }


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/35333

This pull request:

- [x] Change the format of the weeks from locale week to ISO week so the last week of 2020 is shown as the 53. ISO rules state that "week 1 contains the first Thursday of the year". 

NOTES:
- I'm not sure why it was working fine for other languages (timezones?). I have tested also in German and Spanish languages nad it seems to work fine.  
- Moment docs: https://momentjs.com/docs/#/parsing/string-format