### PR TITLE
handle deleted user on labor budget item

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -137,4 +137,8 @@ module UsersHelper
   def user_mail_notification_options(user)
     user.valid_notification_options.map { |o| [I18n.t(o.last), o.first] }
   end
+
+  def user_name(user)
+    user ? user.name : I18n.t('user.deleted')
+  end
 end

--- a/modules/budgets/app/views/budgets/_show.html.erb
+++ b/modules/budgets/app/views/budgets/_show.html.erb
@@ -281,7 +281,7 @@ See docs/COPYRIGHT.rdoc for more details.
                 <% @budget.labor_budget_items.each do |labor_budget_item| %>
                 <tr>
                   <td class="hours"><%= l_hours(labor_budget_item.hours) %></td>
-                  <td><%=h labor_budget_item.principal.name %></td>
+                  <td><%=h user_name(labor_budget_item.principal) %></td>
                   <td class="comments"><%=h labor_budget_item.comments %></td>
                   <% if labor_budget_item.costs_visible_by?(User.current) %>
                     <td class="currency">


### PR DESCRIPTION
In case a deleted user is assigned to a labor budget item, display the deleted user name instead of running into a nil error.

https://community.openproject.com/wp/35670