### PR TITLE
Fix: compose schema issues

### DIFF
--- a/docker/prod/migration_status
+++ b/docker/prod/migration_status
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+echo "Checking migration status..."
+bundle exec rails runner 'ActiveRecord::Migration.check_pending!'

--- a/docker/prod/seeder
+++ b/docker/prod/seeder
@@ -1,7 +1,15 @@
 #!/bin/bash -e
 
-echo "Executing database migration and database seed..."
-bundle exec rake db:migrate db:seed
+OUTPUT=$(echo "\dt" | psql `echo $DATABASE_URL | cut -d? -f1` 2>&1)
+
+if [[ "$OUTPUT" = "No relations found." ]]; then
+	echo "Initialising database and running seed..."
+	DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:structure:load db:seed
+else
+	echo "Executing database migration and database seed..."
+	bundle exec rake db:migrate db:seed
+fi
+
 if [ "$1" = "--set" ]; then
 	shift
 	echo "Update application settings..."

--- a/docker/prod/setup/postinstall-common.sh
+++ b/docker/prod/setup/postinstall-common.sh
@@ -21,7 +21,7 @@ echo "create database assets; create user assets with encrypted password 'p4ssw0
 sleep 5
 
 # dump schema
-DATABASE_URL=postgres://assets:p4ssw0rd@127.0.0.1/assets RAILS_ENV=production bundle exec rake db:migrate db:schema:dump db:schema:cache:dump
+DATABASE_URL=postgres://assets:p4ssw0rd@127.0.0.1/assets RAILS_ENV=production bundle exec rake db:migrate db:schema:dump db:schema:cache:dump db:structure:dump
 
 # precompile assets
 DATABASE_URL=postgres://assets:p4ssw0rd@127.0.0.1/assets RAILS_ENV=production bundle exec rake assets:precompile

--- a/docker/prod/web
+++ b/docker/prod/web
@@ -15,6 +15,8 @@ fi
 if [ "$MIGRATE" = "true" ]; then
 	echo "Migrating database..."
 	bundle exec rake db:migrate
+else
+	$APP_PATH/docker/prod/migration_status # abort if there are pending migrations
 fi
 
 # see `config/puma.rb` for configuration

--- a/docker/prod/worker
+++ b/docker/prod/worker
@@ -4,4 +4,7 @@ if [ "$1" = "--seed" ]; then
 	shift
 	$APP_PATH/docker/prod/seeder "$@"
 fi
+
+$APP_PATH/docker/prod/migration_status # abort if there are pending migrations
+
 exec bundle exec rake jobs:work


### PR DESCRIPTION
WP [#35673](https://community.openproject.com/projects/openproject/work_packages/35673/activity)

This may help with https://github.com/opf/openproject-deploy/issues/4. But even so we could run into the same issue when there are a lot of migrations to run after an update, I reckon. Maybe it would be best to ensure that the seeder container has done its thing before allowing the other containers to really start the ruby processes?

I've added a check for the migration status to both the worker and web docker scripts which will make the container exit if there are pending migrations. Due to the restart policy the containers should then be restarted until the migrations are done and everything should be in order with the schema cache.

This may make the whole structure load stuff unnecessary. Feel free to drop that if you don't like it.