### PR TITLE
fix bug 35735 height 80px to min-height 84px

### DIFF
--- a/frontend/src/app/modules/backlogs/backlogs-page/styles/taskboard.sass
+++ b/frontend/src/app/modules/backlogs/backlogs-page/styles/taskboard.sass
@@ -122,7 +122,7 @@
     border: none
     display: block
     float: left
-    height: 80px
+    min-height: 84px
     margin: 5px
     padding: 5px
     position: relative


### PR DESCRIPTION
For backlog taskboard story box changed the CSS fixed hight of the yellow box to min-height of 84px.