### PR TITLE
Default to previous value or 0 when invalid decimal separator

### DIFF
--- a/frontend/src/app/modules/fields/edit/field-types/duration-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/duration-edit-field.component.ts
@@ -51,7 +51,6 @@ export class DurationEditFieldComponent extends EditFieldComponent {
   @InjectField() TimezoneService:TimezoneService;
 
   public parser(value:any, input:any) {
-    if (isNaN(value)) { return value; }
     // Managing decimal separators in a multi-language app is a complex topic:
     // https://www.ctrl.blog/entry/html5-input-number-localization.html
     // Depending on the locale of the OS, the browser or the app itself,
@@ -66,8 +65,6 @@ export class DurationEditFieldComponent extends EditFieldComponent {
     // valid separators (e.g: introducing 1. would set 1 as a value).
     if (value == null && !input.validity.valid) {
       value = this.value || 0;
-    } else {
-      value = parseFloat(value);
     }
 
     return moment.duration(value, 'hours');

--- a/frontend/src/app/modules/fields/edit/field-types/duration-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/duration-edit-field.component.ts
@@ -37,9 +37,10 @@ import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
     <input type="number"
            step="0.01"
            class="inline-edit--field"
+           #input
            [attr.aria-required]="required"
            [ngModel]="formatter(value)"
-           (ngModelChange)="value = parser($event)"
+           (ngModelChange)="value = parser($event, input)"
            [attr.required]="required"
            (keydown)="handler.handleUserKeydown($event)"
            [disabled]="inFlight"
@@ -49,13 +50,27 @@ import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 export class DurationEditFieldComponent extends EditFieldComponent {
   @InjectField() TimezoneService:TimezoneService;
 
-  public parser(value:any) {
-    if (!isNaN(value)) {
-      let floatValue = parseFloat(value);
-      return moment.duration(floatValue, 'hours');
+  public parser(value:any, input:any) {
+    if (isNaN(value)) { return value; }
+    // Managing decimal separators in a multi-language app is a complex topic:
+    // https://www.ctrl.blog/entry/html5-input-number-localization.html
+    // Depending on the locale of the OS, the browser or the app itself,
+    // a decimal separator could be considered valid or invalid.
+    // When a decimal operator is considered invalid (e.g: 1. in Chrome with
+    // 'en' locale), the input emits null as a value and its state is marked
+    // not valid, but the value remains in the input. Adding a value after the
+    // 'invalid' separator (e.g: 1.2) emits a valid value.
+    // In order to allow both decimal separator (period and comma) in any
+    // context, we check the validity of the input and, if it's not valid, we
+    // default to the previous value, emulating the way the browsers work with
+    // valid separators (e.g: introducing 1. would set 1 as a value).
+    if (value == null && !input.validity.valid) {
+      value = this.value || 0;
+    } else {
+      value = parseFloat(value);
     }
 
-    return value;
+    return moment.duration(value, 'hours');
   }
 
   public formatter(value:any) {
@@ -64,7 +79,7 @@ export class DurationEditFieldComponent extends EditFieldComponent {
 
   protected parseValue(val:moment.Moment | null) {
     if (val === null) {
-      return val
+      return val;
     }
 
     let parsedValue;


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/34922

This pull request:

- [x] In order to allow both decimal separators (period and comma) in any context, the input now defaults to its previous value or zero, emulating the way the browsers work with valid separators (e.g: introducing 1. would set 1 as a value).

**Notes**

- Managing decimal separators in a multi-language app is a complex topic ([related article](https://www.ctrl.blog/entry/html5-input-number-localization.html)). Depending on the locale of the OS, the browser, or the app itself a decimal separator could be considered valid or invalid, so it is important to test it in as many environments as we can. I've tested it on Mac (Safari, Firefox and Chrome) and on Windows (Edge, Firefox and Chrome) with spanish OS and english and spanish app settings.
- Since the input type number only allows valid numbers to be entered, and since the formatter (ngModel) is going to return a valid number from a valid string provided by the backend (e.g., PT4H18M), I can't see the need for using isNaN and parseFloat. Any idea about this?