### PR TITLE
Fix missing link on single cards

### DIFF
--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.html
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.html
@@ -46,11 +46,13 @@
           [ngClass]="typeHighlightingClass(workPackage)">
     </span>
     <a class="wp-card--id"
+       [href]="fullWorkPackageLink(workPackage)"
        [ngClass]="uiStateLinkClass"
-       (accessibleClick)="emitStateLinkClicked(workPackage)">
+       (accessibleClick)="emitStateLinkClicked(workPackage)"
+       [accessibleClickSkipModifiers]="true">
       #{{workPackage.id}}
     </a>
-    <span [textContent]="wpSubject(workPackage)" 
+    <span [textContent]="wpSubject(workPackage)"
           class="wp-card--subject">
     </span>
     <img *ngIf="this.cardCoverImageShown(workPackage)" 

--- a/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-single-card/wp-single-card.component.ts
@@ -103,6 +103,10 @@ export class WorkPackageSingleCardComponent extends UntilDestroyedMixin implemen
     return wp.project?.name;
   }
 
+  public fullWorkPackageLink(wp:WorkPackageResource) {
+    return this.$state.href('work-packages.show', { workPackageId: wp.id });
+  }
+
   public cardHighlightingClass(wp:WorkPackageResource) {
     return this.cardHighlighting(wp);
   }

--- a/frontend/src/app/modules/a11y/accessible-click.directive.spec.ts
+++ b/frontend/src/app/modules/a11y/accessible-click.directive.spec.ts
@@ -40,6 +40,14 @@ class TestAccessibleClickDirective {
   }
 }
 
+@Component({
+  template: `<div (accessibleClick)="onClick()" [accessibleClickSkipModifiers]="true">Click me</div>`
+})
+class TestAccessibleClickDirectiveSkippedModifiers {
+  public onClick() {
+  }
+}
+
 describe('accessibleByKeyboard component', () => {
 
   beforeEach((() => {
@@ -48,7 +56,8 @@ describe('accessibleByKeyboard component', () => {
     TestBed.configureTestingModule({
       declarations: [
         AccessibleClickDirective,
-        TestAccessibleClickDirective
+        TestAccessibleClickDirective,
+        TestAccessibleClickDirectiveSkippedModifiers
       ]
     }).compileComponents();
   }));
@@ -67,14 +76,31 @@ describe('accessibleByKeyboard component', () => {
       fixture.detectChanges();
 
       // Trigger click
-      const eventBase = { preventDefault: () => undefined, stopPropagation: () => undefined };
-      element.triggerEventHandler('click', _.assign({type: 'click' }, eventBase));
-      element.triggerEventHandler('keydown', _.assign({type: 'keydown', which: 13}, eventBase));
-      element.triggerEventHandler('keydown', _.assign({type: 'keydown', which: 32}, eventBase));
+      element.triggerEventHandler('click', new MouseEvent('click', { ctrlKey: true }));
+      element.triggerEventHandler('click', new MouseEvent('click', { ctrlKey: false }));
+      element.triggerEventHandler('keydown',new KeyboardEvent('keydown', { key: ' ' }));
 
       tick();
       fixture.detectChanges();
       expect(spy).toHaveBeenCalledTimes(3);
+    }));
+
+    it('allows to disable click handling with modifiers', fakeAsync(() => {
+      fixture = TestBed.createComponent(TestAccessibleClickDirectiveSkippedModifiers);
+      app = fixture.debugElement.componentInstance;
+      element = fixture.debugElement.query(By.css('div'));
+
+      const spy = spyOn(app, 'onClick');
+      fixture.detectChanges();
+
+      // Trigger click
+      element.triggerEventHandler('click', new MouseEvent('click', { ctrlKey: true }));
+      element.triggerEventHandler('click', new MouseEvent('click', { ctrlKey: false }));
+      element.triggerEventHandler('keydown',new KeyboardEvent('keydown', { key: ' ' }));
+
+      tick();
+      fixture.detectChanges();
+      expect(spy).toHaveBeenCalledTimes(2);
     }));
   });
 });


### PR DESCRIPTION
Work Package cards have a link to their ID to the full view, which was
handled by ui-router srefs. This was replaced in https://github.com/opf/openproject/pull/8544,
leaving the link without href to use with modifiers.

This PR restores the functionality of using modifiers to copy the
link/open in a new tab