### PR TITLE
Removed meanless? .textarea-wrapper class

### DIFF
--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
@@ -1,31 +1,29 @@
-<div>
-  <ng-select [(ngModel)]="selectedOption"
-             [ngClass]="'inline-edit--field -multi-select'"
-             [required]="required"
-             [clearable]="!required"
-             [disabled]="inFlight"
-             [id]="handler.htmlId"
-             [items]="valueOptions"
-             bindLabel="name"
-             [virtualScroll]="true"
-             [clearSearchOnAdd]="true"
-             (keydown)="handler.handleUserKeydown($event, true)"
-             (open)="onOpen()"
-             (close)="onClose()"
-             (add)="repositionDropdown()"
-             (remove)="repositionDropdown()"
-             [multiple]="true"
-             [closeOnSelect]="false"
-             [appendTo]="appendTo"
-             [dropdownPosition]="'top'"
-             [hideSelected]="true">
-  </ng-select>
+<ng-select [(ngModel)]="selectedOption"
+           [ngClass]="'inline-edit--field -multi-select'"
+           [required]="required"
+           [clearable]="!required"
+           [disabled]="inFlight"
+           [id]="handler.htmlId"
+           [items]="valueOptions"
+           bindLabel="name"
+           [virtualScroll]="true"
+           [clearSearchOnAdd]="true"
+           (keydown)="handler.handleUserKeydown($event, true)"
+           (open)="onOpen()"
+           (close)="onClose()"
+           (add)="repositionDropdown()"
+           (remove)="repositionDropdown()"
+           [multiple]="true"
+           [closeOnSelect]="false"
+           [appendTo]="appendTo"
+           [dropdownPosition]="'top'"
+           [hideSelected]="true">
+</ng-select>
 
-  <edit-field-controls [fieldController]="self"
-                       *ngIf="!handler.inEditMode"
-                       (onSave)="handler.handleUserSubmit()"
-                       (onCancel)="handler.handleUserCancel()"
-                       [saveTitle]="text.save"
-                       [cancelTitle]="text.cancel">
-  </edit-field-controls>
-</div>
+<edit-field-controls [fieldController]="self"
+                     *ngIf="!handler.inEditMode"
+                     (onSave)="handler.handleUserSubmit()"
+                     (onCancel)="handler.handleUserCancel()"
+                     [saveTitle]="text.save"
+                     [cancelTitle]="text.cancel">
+</edit-field-controls>

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
@@ -1,4 +1,4 @@
-<div class="textarea-wrapper">
+<div>
   <ng-select [(ngModel)]="selectedOption"
              [ngClass]="'inline-edit--field -multi-select'"
              [required]="required"


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/35145

This pull request:

- [x] Removes  .textarea-wrapper class on multi-selects. It was adding an unwanted extra space below them to "Leave room below textarea for in-place edit controls" (_textareas.saas). Since, as far as I could see, multi-selects doesn't have in-place edit controls, it was meanless.

**NOTES**
The .textarea-wrapper class has been there since 29/05/2018 ([ngClass]="isMultiselect ? 'textarea-wrapper' : ''") so probably I'm missing something.

