### PR TITLE
Fixed broken overflow for wysiwyg popups on project create page

### DIFF
--- a/app/views/projects/form/_project_attributes.html.erb
+++ b/app/views/projects/form/_project_attributes.html.erb
@@ -54,7 +54,7 @@ See docs/COPYRIGHT.rdoc for more details.
                locals: { form: form } %>
     <%= render partial: "projects/form/attributes/public",
                locals: { form: form } %>
-<%= render partial: "projects/form/attributes/status",
+    <%= render partial: "projects/form/attributes/status",
                locals: { form: form } %>
     <% unless all_fields %>
       <%= render partial: "customizable/form",

--- a/app/views/projects/form/attributes/_status.html.erb
+++ b/app/views/projects/form/attributes/_status.html.erb
@@ -40,7 +40,7 @@ See docs/COPYRIGHT.rdoc for more details.
                            include_blank: true,
                            container_class: '-wide' %>
   </div>
-  <div class="form--field">
+  <div class="form--field -visible-overflow">
     <%= status_form.text_area :explanation,
                               with_text_formatting: true,
                               macros: false,


### PR DESCRIPTION
This adds -overflow-visible as a modifier to the form field. It's relatively ad-hoc, but is in line with existing forms. A longer-term solution would be to overhaul form-fields, making them always allow overflows.

Closes https://community.openproject.com/projects/openproject/work_packages/31502/activity?query_id=491