### PR TITLE
fix scheduling bug if predecessor dates are removed and follower only…

### DIFF
--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -123,7 +123,7 @@ class WorkPackages::SetScheduleService
 
     if delta.zero? && min_start_date
       reschedule_to_date(scheduled, min_start_date)
-    elsif !scheduled.start_date
+    elsif !scheduled.start_date && min_start_date
       schedule_on_missing_dates(scheduled, min_start_date)
     elsif !delta.zero?
       reschedule_by_delta(scheduled, delta, min_start_date)

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -223,7 +223,7 @@ describe WorkPackages::SetScheduleService do
         end
       end
 
-      context 'when the follower has no start date (which should not happen)' do
+      context 'when the follower has no start date' do
         let(:follower1_start_date) { nil }
 
         it_behaves_like 'reschedules' do
@@ -393,6 +393,18 @@ describe WorkPackages::SetScheduleService do
         end
         let(:unchanged) do
           [following_work_package1]
+        end
+      end
+
+      context 'when the follower has no start date but a due date' do
+        let(:follower1_start_date) { nil }
+        let(:follower1_due_date) { Date.today + 15.days }
+
+        it_behaves_like 'reschedules' do
+          # Nothing should be rescheduled
+          let(:expected) do
+            {}
+          end
         end
       end
     end


### PR DESCRIPTION
… has due date set

To reproduce:
* Have two work packages "follower" and "predecessor"
* Add a start date (or finish date) to "predecessor"
* Add a follows relationship so that "follower" follows "predecessor"
* Remove the start date from "follower". Leave the finish date, though.
* Remove the date from "predecessor"


https://community.openproject.com/wp/35352