### PR TITLE
Fix/35144 milestones due dates not highlighted

### DIFF
--- a/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
+++ b/frontend/src/app/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
@@ -112,9 +112,8 @@ export class WpTableConfigurationHighlightingTab implements TabComponent {
 
   private setSelectedValues() {
     const currentValues = this.wpTableHighlight.current.selectedAttributes;
-    if (currentValues === undefined) {
-      this.selectedAttributes = this.availableInlineHighlightedAttributes;
-    } else {
+
+    if (currentValues) {
       this.selectedAttributes = currentValues;
     }
   }

--- a/frontend/src/app/modules/fields/display/field-types/highlightable-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/highlightable-display-field.module.ts
@@ -31,16 +31,33 @@ import {WorkPackageViewHighlightingService} from "core-app/modules/work_packages
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 
 export class HighlightableDisplayField extends DisplayField {
-
   /** Optionally test if we can inject highlighting service */
   @InjectField(WorkPackageViewHighlightingService, null) viewHighlighting:WorkPackageViewHighlightingService;
+
+  get isMilestone():boolean {
+    return this.resource?.type?.id  === '2';
+  }
+
+  // DisplayFieldRenderer.attributeName returns the 'date' name for the
+  // 'dueDate' field because it is its schema.mappedName. In the
+  // query.highlightedAttributes (used to decide if a field is highlighted)
+  // the attribute has the name 'dueDate', so we need to change it back to get
+  // it highlighted.
+  get highlightName () {
+    if (this.isMilestone && this.name === 'date') {
+      return 'dueDate';
+    } else {
+      return this.name;
+    }
+  }
 
   public get shouldHighlight() {
     if (this.context.options.colorize === false) {
       return false;
     }
 
-    const shouldHighlight = !!this.viewHighlighting && this.viewHighlighting.shouldHighlightInline(this.name);
+    const shouldHighlight = !!this.viewHighlighting && this.viewHighlighting.shouldHighlightInline(this.highlightName);
+
     return this.context.container !== 'table' || shouldHighlight;
   }
 }

--- a/frontend/src/app/modules/fields/display/field-types/highlightable-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/highlightable-display-field.module.ts
@@ -34,17 +34,14 @@ export class HighlightableDisplayField extends DisplayField {
   /** Optionally test if we can inject highlighting service */
   @InjectField(WorkPackageViewHighlightingService, null) viewHighlighting:WorkPackageViewHighlightingService;
 
-  get isMilestone():boolean {
-    return this.resource?.type?.id  === '2';
-  }
 
   // DisplayFieldRenderer.attributeName returns the 'date' name for the
-  // 'dueDate' field because it is its schema.mappedName. In the
-  // query.highlightedAttributes (used to decide if a field is highlighted)
-  // the attribute has the name 'dueDate', so we need to change it back to get
-  // it highlighted.
+  // 'dueDate' field because it is its schema.mappedName (that allows to display
+  // the correct input type). In the query.highlightedAttributes (used to decide
+  // if a field is highlighted) the attribute has the name 'dueDate', so we need
+  // to return the original name to get it highlighted.
   get highlightName () {
-    if (this.isMilestone && this.name === 'date') {
+    if (this.name === 'date') {
       return 'dueDate';
     } else {
       return this.name;


### PR DESCRIPTION
https://community.openproject.com/projects/openproject/work_packages/35144

This pull request:

- [x] Removes default values in the highlight input (this.availableInlineHighlightedAttributes). They were set even when they were not present in the model (this.wpTableHighlight.current.selectedAttributes) so it was showing wrong information. This is, Status, Priority, and End Date were shown in the input but not applied in the results.
- [x] Sets the DisplayField.name back to dueDate so it matches one of the query.highlightedAttributes and the date is highlighted when it is overdue or about to. The name is changed by its schema.mappedName, so the correct input type is displayed.

**Notes**
- I'd have liked not to hardcode return 'dueDate' but access the resource original name to handle future changes. I could find the way. Any idea of how to access the original resource? 