### PR TITLE
[34273] Differentiate between pagination and query changes

### DIFF
--- a/frontend/src/app/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/components/wp-query/url-params-helper.ts
@@ -64,6 +64,11 @@ export class UrlParamsHelperService {
   }
 
   public encodeQueryJsonParams(query:QueryResource, additional:any = {}) {
+    let paramsData = this.queryJsonParams(query, additional);
+    return JSON.stringify(paramsData);
+  }
+
+  public queryJsonParams(query:QueryResource, additional:any = {}) {
     let paramsData:any = {};
 
     paramsData = this.encodeColumns(paramsData, query);
@@ -79,7 +84,7 @@ export class UrlParamsHelperService {
     paramsData.pp = additional.perPage;
     paramsData.dr = query.displayRepresentation;
 
-    return JSON.stringify(paramsData);
+    return paramsData;
   }
 
   private encodeColumns(paramsData:any, query:QueryResource) {

--- a/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.ts
@@ -119,7 +119,7 @@ export class PartitionedQuerySpacePageComponent extends WorkPackagesViewBase imp
     this.removeTransitionSubscription = this.$transitions.onSuccess({}, (transition):any => {
       const params = transition.params('to');
       const toState = transition.to();
-      this.showToolbarSaveButton = !!params.query_props;
+      this.showToolbarSaveButton = this.shouldShowSaveButton(params);
       this.setPartition(toState);
       this.cdRef.detectChanges();
     });
@@ -152,6 +152,16 @@ export class PartitionedQuerySpacePageComponent extends WorkPackagesViewBase imp
     ).subscribe((query) => {
       this.onQueryUpdated(query);
     });
+  }
+
+  /**
+   * Should we show the save button after the route changed?
+   *
+   * @param params The current router props
+   * @protected
+   */
+  protected shouldShowSaveButton(params:{ [p:string]:any }) {
+    return !!params.query_props;
   }
 
   /**

--- a/frontend/src/app/modules/work_packages/routing/wp-view-page/wp-view-page.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-page/wp-view-page.component.ts
@@ -111,6 +111,10 @@ export class WorkPackageViewPageComponent extends PartitionedQuerySpacePageCompo
     }
   }
 
+  protected shouldShowSaveButton(params:{ [p:string]:any }):boolean {
+    return super.shouldShowSaveButton(params) && !!this.currentQuery && !this.wpListChecksumService.onlyPaginationChanges;
+  }
+
   protected shouldUpdateHtmlTitle():boolean {
     return this.$state.current.name === 'work-packages.partitioned.list';
   }


### PR DESCRIPTION
The checksum service currently does not differentiate between pagination-only changes and true changes to the query.

When updating the checksum, we can keep tabs on the changes and remember if we're just updating the pagination

https://community.openproject.com/wp/34273