### PR TITLE
Fix postgre permission error that macOS Docker user may encounter fol…

### DIFF
--- a/docs/installation-and-operations/installation/docker/README.md
+++ b/docs/installation-and-operations/installation/docker/README.md
@@ -107,7 +107,8 @@ data will be stored across container restarts, and start the container with
 those directories mounted:
 
 ```bash
-sudo mkdir -p /var/lib/openproject/{pgdata,assets}
+# You can also create the two directories in the user-level directory of the host machine in case of "Operation not permitted" error that macOS Docker user may encounter.
+sudo mkdir -p /var/lib/openproject/{pgdata,assets} 
 
 docker run -d -p 8080:80 --name openproject -e SECRET_KEY_BASE=secret \
   -v /var/lib/openproject/pgdata:/var/openproject/pgdata \

--- a/docs/installation-and-operations/installation/docker/README.md
+++ b/docs/installation-and-operations/installation/docker/README.md
@@ -107,7 +107,6 @@ data will be stored across container restarts, and start the container with
 those directories mounted:
 
 ```bash
-# You can also create the two directories in the user-level directory of the host machine in case of "Operation not permitted" error that macOS Docker user may encounter.
 sudo mkdir -p /var/lib/openproject/{pgdata,assets} 
 
 docker run -d -p 8080:80 --name openproject -e SECRET_KEY_BASE=secret \
@@ -117,6 +116,8 @@ docker run -d -p 8080:80 --name openproject -e SECRET_KEY_BASE=secret \
 ```
 
 **Note**: Make sure to replace `secret` with a random string. One way to generate one is to run `head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32 ; echo ''` if you are on Linux.
+
+**Note**: MacOS users might encounter an "Operation not permitted" error on the mounted directories. The fix for this is to create the two directories in a user-owned directory of the host machine.
 
 Since we named the container, you can now stop it by running:
 


### PR DESCRIPTION
macOS Docker users may not be able to successfully run the Openprject container following the current instruction as they may encounter permission errors related to Postgres DB initialization.
```
initdb: could not change permissions of directory "/var/openproject/pgdata": Operation not permitted
       fixing permissions on existing directory /var/openproject/pgdata ... %
```
Such error has been confirmed by a lot of other discussions
see: 
https://github.com/docker-library/postgres/issues/28
https://stackoverflow.com/questions/52211875/docker-volumes-on-mac-with-postgres/52212068