### PR TITLE
Remove superfluous asset path replacing

### DIFF
--- a/docker/prod/entrypoint.sh
+++ b/docker/prod/entrypoint.sh
@@ -52,17 +52,6 @@ if [ "$(id -u)" = '0' ]; then
 	  rm -f $APACHE_PIDFILE || true
 	fi
 
-	# Fix assets path if relative URL is used
-	relative_url_root_without_trailing_slash="$(echo $OPENPROJECT_RAILS__RELATIVE__URL__ROOT | sed 's:/*$::')"
-	if [ "$relative_url_root_without_trailing_slash" != "" ]; then
-		for file in $(egrep -lR "/assets/" "$APP_PATH/public"); do
-			# only the font paths in the CSSs need updating
-			sed -i "s|/assets/|${relative_url_root_without_trailing_slash}/assets/|g" $file
-			# the .gz is the one served by puma, so rebuild it
-			gzip --force --keep $file
-		done
-	fi
-
 	if [ ! -z "$ATTACHMENTS_STORAGE_PATH" ]; then
 		mkdir -p "$ATTACHMENTS_STORAGE_PATH"
 		chown -R "$APP_USER:$APP_USER" "$ATTACHMENTS_STORAGE_PATH"


### PR DESCRIPTION
The frontend dynamically responds to a relative URL set via the app base
path / meta tag rendered by Ruby, so we no longer need to replace asset
files statically.

https://community.openproject.com/wp/35775