### PR TITLE
prevent css styles of form--section to affect table

### DIFF
--- a/app/views/work_packages/reports/_report_category.html.erb
+++ b/app/views/work_packages/reports/_report_category.html.erb
@@ -36,6 +36,6 @@ See docs/COPYRIGHT.rdoc for more details.
                 title: t(:text_analyze, subject: WorkPackage.human_attribute_name(report.report_type)),
                 class: 'no-decoration-on-hover') %></span>
   </div>
-  <%= render partial: 'report', locals: { report: report } %>
-  <br />
 </div>
+
+<%= render partial: 'report', locals: { report: report } %>


### PR DESCRIPTION
In the summary page, the report tables are wrapped within a div with the form--section class even though those reports are not actually part of a from. Ideally, a new class would be styled containing only the desired css rules. But as the view is deemed to be replaced anyway, the quick and dirty way is to simply take the table out of the form--field's dom structure.

https://community.openproject.com/wp/35679