### PR TITLE
Fix/filename on direct upload

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -267,12 +267,23 @@ class Attachment < ApplicationRecord
 
     # We need to do it like this because `file` is an uploader which expects a File (not a string)
     # to upload usually. But in this case the data has already been uploaded and we just point to it.
-    a[:file] = file_name
+    a[:file] = pending_direct_upload_filename(file_name)
 
     a.save!
     a.reload # necessary so that the fog file uploader path is correct
 
     a
+  end
+
+  class << self
+    private
+
+    # The name has to be in the same format as what Carrierwave will produce later on. If they are different,
+    # Carrierwave will alter the name (both local and remote) whenever the attachment is saved with the remote
+    # file loaded.
+    def pending_direct_upload_filename(file_name)
+      CarrierWave::SanitizedFile.new(nil).send(:sanitize, file_name)
+    end
   end
 
   def pending_direct_upload?

--- a/app/workers/attachments/finish_direct_upload_job.rb
+++ b/app/workers/attachments/finish_direct_upload_job.rb
@@ -33,7 +33,10 @@ class Attachments::FinishDirectUploadJob < ApplicationJob
 
   def perform(attachment_id)
     attachment = Attachment.pending_direct_uploads.find_by(id: attachment_id)
-    local_file = attachment&.file.local_file
+    # An attachment is guaranteed to have a file.
+    # But if the attachment is nil the expression attachment&.file will be nil and attachment&.file.local_file
+    # will throw a NoMethodError: undefined method local_file' for nil:NilClass`.
+    local_file = attachment && attachment.file.local_file
 
     if local_file.nil?
       return Rails.logger.error("File for attachment #{attachment_id} was not uploaded.")

--- a/app/workers/attachments/finish_direct_upload_job.rb
+++ b/app/workers/attachments/finish_direct_upload_job.rb
@@ -32,8 +32,8 @@ class Attachments::FinishDirectUploadJob < ApplicationJob
   queue_with_priority :high
 
   def perform(attachment_id)
-    attachment = Attachment.pending_direct_uploads.where(id: attachment_id).first
-    local_file = attachment && attachment.file.local_file
+    attachment = Attachment.pending_direct_uploads.find_by(id: attachment_id)
+    local_file = attachment&.file.local_file
 
     if local_file.nil?
       return Rails.logger.error("File for attachment #{attachment_id} was not uploaded.")

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -40,17 +40,17 @@ describe Attachment, type: :model do
   let(:attachment) do
     FactoryBot.build(
       :attachment,
-      author:       author,
-      container:    container,
+      author: author,
+      container: container,
       content_type: nil, # so that it is detected
-      file:         file
+      file: file
     )
   end
   let(:stubbed_attachment) do
     FactoryBot.build_stubbed(
       :attachment,
-      author:       stubbed_author,
-      container:    container
+      author: stubbed_author,
+      container: container
     )
   end
 
@@ -203,6 +203,64 @@ describe Attachment, type: :model do
 
       expect(a1.diskfile.path)
         .not_to eql a2.diskfile.path
+    end
+  end
+
+  describe '.create_pending_direct_upload' do
+    let(:file_size) { 6 }
+    let(:file_name) { 'document.png' }
+    let(:content_type) { "application/octet-stream" }
+
+    subject do
+      described_class.create_pending_direct_upload(file_name: file_name,
+                                                   author: author,
+                                                   container: container,
+                                                   content_type: content_type,
+                                                   file_size: file_size)
+    end
+
+    it 'returns the attachment' do
+      expect(subject)
+        .to be_a(Attachment)
+    end
+
+    it 'sets the content_type' do
+      expect(subject.content_type)
+        .to eql content_type
+    end
+
+    it 'sets the file_size' do
+      expect(subject.filesize)
+        .to eql file_size
+    end
+
+    it 'sets the file for carrierwave' do
+      expect(subject.file.file.path)
+        .to end_with "attachment/file/#{subject.id}/#{file_name}"
+    end
+
+    it 'sets the author' do
+      expect(subject.author)
+        .to eql author
+    end
+
+    it 'sets the digest to empty string' do
+      expect(subject.digest)
+        .to eql ""
+    end
+
+    it 'sets the download count to -1' do
+      expect(subject.downloads)
+        .to eql -1
+    end
+
+    context 'with a special character in the filename' do
+      let(:file_name) { "document=number 5.png" }
+
+      it 'sets the file for carrierwave' do
+        expect(subject.file.file.path)
+          .to end_with "attachment/file/#{subject.id}/document_number_5.png"
+      end
     end
   end
 


### PR DESCRIPTION
To reproduce the bug:

Have a file with a space in it, e.g. "Email Out.png". Other special characters like "=" are also problematic (all those not matching _/[^[:word:]\.\-\+]/_)
After the upload is completed, run the background jobs (especially Attachments::FinishDirectUploadJob When in a production setup, e.g. on qa.openproject-edge.com, this will be done automatically.

The attachment will be uploaded to S3 without the special character being replaced. Then, the backgound job will fetch the attachment to deduce some characteristics from it, e.g. the filesize. Because the attachment is saved again at the end of the job with the file being loaded, the mechanisms of Carrierwave will be run. Carrierwave will replace all special characters with an underscore. It will do so on S3 as well as in OpenProject so the data itself is still working. But as the frontend already has the information cached, that updated information will not make it to the front end.

https://community.openproject.com/wp/35180
