### PR TITLE
Do not include global roles in memberships list

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -74,6 +74,7 @@ class UsersController < ApplicationController
   def show
     # show projects based on current user visibility
     @memberships = @user.memberships
+                        .where.not(project_id: nil)
                         .visible(current_user)
 
     events = Activities::Fetcher.new(User.current, author: @user).events(nil, nil, limit: 10)


### PR DESCRIPTION
With a user and a global role set, the users/show method will fail as it tries to render a project for every membership.

The error occurs in this line: https://github.com/opf/openproject/blob/7f34799a33e5c9fa7c66d7ec3ea88ac6d4501ee4/app/views/users/show.html.erb#L66