### PR TITLE
Inputs' blue border removed

### DIFF
--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_edit_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_edit_fields.sass
@@ -26,7 +26,6 @@
     font-size: 14px
     color: var(--body-font-color)
     border-radius: 2px
-    border-color: darkblue
 
   &.-tiny
     input:not([type='checkbox'])


### PR DESCRIPTION
https://community.openproject.com/projects/amg/work_packages/35461

This pull request:

- [x] Removes the blue border shown on inputs that were not checkbox nor selects so all the inputs look the same.