### PR TITLE
Fix/journals on direct uploads

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -267,12 +267,23 @@ class Attachment < ApplicationRecord
 
     # We need to do it like this because `file` is an uploader which expects a File (not a string)
     # to upload usually. But in this case the data has already been uploaded and we just point to it.
-    a[:file] = file_name
+    a[:file] = pending_direct_upload_filename(file_name)
 
     a.save!
     a.reload # necessary so that the fog file uploader path is correct
 
     a
+  end
+
+  class << self
+    private
+
+    # The name has to be in the same format as what Carrierwave will produce later on. If they are different,
+    # Carrierwave will alter the name (both local and remote) whenever the attachment is saved with the remote
+    # file loaded.
+    def pending_direct_upload_filename(file_name)
+      CarrierWave::SanitizedFile.new(nil).send(:sanitize, file_name)
+    end
   end
 
   def pending_direct_upload?

--- a/app/workers/attachments/finish_direct_upload_job.rb
+++ b/app/workers/attachments/finish_direct_upload_job.rb
@@ -33,7 +33,10 @@ class Attachments::FinishDirectUploadJob < ApplicationJob
 
   def perform(attachment_id)
     attachment = Attachment.pending_direct_uploads.find_by(id: attachment_id)
-    local_file = attachment&.file.local_file
+    # An attachment is guaranteed to have a file.
+    # But if the attachment is nil the expression attachment&.file will be nil and attachment&.file.local_file
+    # will throw a NoMethodError: undefined method local_file' for nil:NilClass`.
+    local_file = attachment && attachment.file.local_file
 
     if local_file.nil?
       return Rails.logger.error("File for attachment #{attachment_id} was not uploaded.")

--- a/app/workers/attachments/finish_direct_upload_job.rb
+++ b/app/workers/attachments/finish_direct_upload_job.rb
@@ -43,14 +43,45 @@ class Attachments::FinishDirectUploadJob < ApplicationJob
     end
 
     begin
-      attachment.downloads = 0
-      attachment.set_file_size local_file unless attachment.filesize && attachment.filesize > 0
-      attachment.set_content_type local_file unless attachment.content_type.present?
-      attachment.set_digest local_file unless attachment.digest.present?
-
-      attachment.save! if attachment.changed?
+      set_attributes_from_file(attachment, local_file)
+      save_attachment(attachment)
+      journalize_container(attachment)
     ensure
       File.unlink(local_file.path) if File.exist?(local_file.path)
     end
+  end
+
+  private
+
+  def set_attributes_from_file(attachment, local_file)
+    attachment.downloads = 0
+    attachment.set_file_size local_file unless attachment.filesize && attachment.filesize > 0
+    attachment.set_content_type local_file unless attachment.content_type.present?
+    attachment.set_digest local_file unless attachment.digest.present?
+  end
+
+  def save_attachment(attachment)
+    User.execute_as(attachment.author) do
+      attachment.save! if attachment.changed?
+    end
+  end
+
+  def journalize_container(attachment)
+    journable = attachment.container
+
+    return unless journable&.class&.journaled?
+
+    # Touching the journable will lead to the journal created next having its own timestamp.
+    # That timestamp will not adequately reflect the time the attachment was uploaded. This job
+    # right here might be executed way later than the time the attachment was uploaded. Ideally,
+    # the journals would be created bearing the time stamps of the attachment's created_at.
+    # This remains a TODO.
+    # But with the timestamp update in place as it is, at least the collapsing of aggregated journals
+    # from days before with the newly uploaded attachment is prevented.
+    journable.touch
+
+    Journals::CreateService
+      .new(journable, attachment.author)
+      .call
   end
 end

--- a/app/workers/attachments/finish_direct_upload_job.rb
+++ b/app/workers/attachments/finish_direct_upload_job.rb
@@ -32,8 +32,8 @@ class Attachments::FinishDirectUploadJob < ApplicationJob
   queue_with_priority :high
 
   def perform(attachment_id)
-    attachment = Attachment.pending_direct_uploads.where(id: attachment_id).first
-    local_file = attachment && attachment.file.local_file
+    attachment = Attachment.pending_direct_uploads.find_by(id: attachment_id)
+    local_file = attachment&.file.local_file
 
     if local_file.nil?
       return Rails.logger.error("File for attachment #{attachment_id} was not uploaded.")

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -40,17 +40,17 @@ describe Attachment, type: :model do
   let(:attachment) do
     FactoryBot.build(
       :attachment,
-      author:       author,
-      container:    container,
+      author: author,
+      container: container,
       content_type: nil, # so that it is detected
-      file:         file
+      file: file
     )
   end
   let(:stubbed_attachment) do
     FactoryBot.build_stubbed(
       :attachment,
-      author:       stubbed_author,
-      container:    container
+      author: stubbed_author,
+      container: container
     )
   end
 
@@ -203,6 +203,64 @@ describe Attachment, type: :model do
 
       expect(a1.diskfile.path)
         .not_to eql a2.diskfile.path
+    end
+  end
+
+  describe '.create_pending_direct_upload' do
+    let(:file_size) { 6 }
+    let(:file_name) { 'document.png' }
+    let(:content_type) { "application/octet-stream" }
+
+    subject do
+      described_class.create_pending_direct_upload(file_name: file_name,
+                                                   author: author,
+                                                   container: container,
+                                                   content_type: content_type,
+                                                   file_size: file_size)
+    end
+
+    it 'returns the attachment' do
+      expect(subject)
+        .to be_a(Attachment)
+    end
+
+    it 'sets the content_type' do
+      expect(subject.content_type)
+        .to eql content_type
+    end
+
+    it 'sets the file_size' do
+      expect(subject.filesize)
+        .to eql file_size
+    end
+
+    it 'sets the file for carrierwave' do
+      expect(subject.file.file.path)
+        .to end_with "attachment/file/#{subject.id}/#{file_name}"
+    end
+
+    it 'sets the author' do
+      expect(subject.author)
+        .to eql author
+    end
+
+    it 'sets the digest to empty string' do
+      expect(subject.digest)
+        .to eql ""
+    end
+
+    it 'sets the download count to -1' do
+      expect(subject.downloads)
+        .to eql -1
+    end
+
+    context 'with a special character in the filename' do
+      let(:file_name) { "document=number 5.png" }
+
+      it 'sets the file for carrierwave' do
+        expect(subject.file.file.path)
+          .to end_with "attachment/file/#{subject.id}/document_number_5.png"
+      end
     end
   end
 

--- a/spec/workers/attachments/finish_direct_upload_job_integration_spec.rb
+++ b/spec/workers/attachments/finish_direct_upload_job_integration_spec.rb
@@ -1,0 +1,113 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Attachments::FinishDirectUploadJob, 'integration', type: :job do
+  let!(:pending_attachment) do
+    FactoryBot.create(:attachment,
+                      downloads: -1,
+                      digest: '',
+                      container: container)
+  end
+
+  let(:job) { described_class.new }
+
+  shared_examples_for 'turning pending attachment into a standard attachment' do
+    it do
+      job.perform(pending_attachment.id)
+
+      attachment = Attachment.find(pending_attachment.id)
+
+      expect(attachment.downloads)
+        .to eql(0)
+      expect(attachment.content_type)
+        .to eql('application/binary')
+      expect(attachment.digest)
+        .to eql("9473fdd0d880a43c21b7778d34872157")
+    end
+  end
+
+  shared_examples_for "adding a journal to the attachment in the name of the attachment's author" do
+    it do
+      job.perform(pending_attachment.id)
+
+      journals = Attachment.find(pending_attachment.id).journals
+
+      expect(journals.count)
+        .to eql(2)
+
+      expect(journals.last.user)
+        .to eql(pending_attachment.author)
+    end
+  end
+
+  context 'for a journalized container' do
+    let!(:container) { FactoryBot.create(:work_package) }
+    let!(:container_timestamp) { container.updated_at }
+
+    it_behaves_like 'turning pending attachment into a standard attachment'
+    it_behaves_like "adding a journal to the attachment in the name of the attachment's author"
+
+    it "adds a journal to the container in the name of the attachment's author" do
+      job.perform(pending_attachment.id)
+
+      journals = container.journals.reload
+
+      expect(journals.count)
+        .to eql(2)
+
+      expect(journals.last.user)
+        .to eql(pending_attachment.author)
+
+      expect(journals.last.created_at > container_timestamp)
+        .to be_truthy
+
+      container.reload
+
+      expect(container.lock_version)
+        .to eql 1
+    end
+  end
+
+  context 'for a non journalized container' do
+    let!(:container) { FactoryBot.create(:wiki_page) }
+
+    it_behaves_like 'turning pending attachment into a standard attachment'
+    it_behaves_like "adding a journal to the attachment in the name of the attachment's author"
+  end
+
+  context 'for a nil container' do
+    let!(:container) { nil }
+
+    it_behaves_like 'turning pending attachment into a standard attachment'
+    it_behaves_like "adding a journal to the attachment in the name of the attachment's author"
+  end
+end


### PR DESCRIPTION
⚠️ contains #8928 ⚠️ 

In case the container of an attachment is journalized, the container needs to have added a journal to it when an attachment is uploaded. Without that, the attachment is only picked up in the journals once the container is altered again (possibly by a different user). This will then lead to a history which does not reflect the actual upload.

By adding a journal in the job responsible for correcting the attachment attributes, that scenario is prevented. The created journal's timestamp will not match the time stamp of the attachment creation in total as the job will be executed after the journal is created. Ideally, the journal would use the attachments created_at timestamp. But the approximation should be good enough.

https://community.openproject.com/wp/35682