### PR TITLE
avoid updating the lock version on finishing an attachment upload

### DIFF
--- a/spec/workers/attachments/finish_direct_upload_job_integration_spec.rb
+++ b/spec/workers/attachments/finish_direct_upload_job_integration_spec.rb
@@ -93,7 +93,7 @@ describe Attachments::FinishDirectUploadJob, 'integration', type: :job do
       container.reload
 
       expect(container.lock_version)
-        .to eql 1
+        .to eql 0
     end
   end
 


### PR DESCRIPTION
If the lock version is increased, it might happen while the user is still editing the description. The user might have added an image to the description and continues typing. In the backend, the FinishDirectUploadJob is run before the user presses the checkmark to send the updated description. In that case, a 409 conflict would be signaled if the lock version were to be updated in the meantime.

To reproduce:
* Click to edit the description and upload an attachment via the description. Do not save the description.
* Run the background job
* Save the description
=> A conflict is displayed without the fix.

https://community.openproject.com/wp/35957