### PR TITLE
fix atom export

### DIFF
--- a/frontend/src/app/components/modals/export-modal/wp-table-export.modal.ts
+++ b/frontend/src/app/components/modals/export-modal/wp-table-export.modal.ts
@@ -8,7 +8,7 @@ import {HalLink} from "core-app/modules/hal/hal-link/hal-link";
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {OpModalLocalsToken} from "core-components/op-modals/op-modal.service";
 import * as URI from 'urijs';
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpErrorResponse} from '@angular/common/http';
 import {LoadingIndicatorService} from "core-app/modules/common/loading-indicator/loading-indicator.service";
 import {Observable} from 'rxjs';
 import {NotificationsService} from "core-app/modules/common/notifications/notifications.service";
@@ -105,8 +105,21 @@ export class WpTableExportModal extends OpModalComponent implements OnInit {
     this.service.show(JobStatusModal, 'global', { jobId: jobId });
   }
 
-  private handleError(error:string) {
-    this.notifications.addError(error || this.I18n.t('js.error.internal'));
+  private handleError(error:HttpErrorResponse) {
+    // There was an error but the status code is actually a 200.
+    // If that is the case the response's content-type probably does not match
+    // the expected type (json).
+    // Currently this happens e.g. when exporting Atom which actually is not an export
+    // but rather a feed to follow.
+    if (error.status === 200 && error.url) {
+      window.open(error.url);
+    } else {
+      this.showError(error);
+    }
+  }
+
+  private showError(error:HttpErrorResponse) {
+    this.notifications.addError(error.message || this.I18n.t('js.error.internal'));
   }
 
   private addColumnsToHref(href:string) {

--- a/spec/features/work_packages/export_spec.rb
+++ b/spec/features/work_packages/export_spec.rb
@@ -242,4 +242,31 @@ describe 'work package export', type: :feature do
       end
     end
   end
+
+  # Atom exports are not downloaded. In fact, it is not even a download but rather
+  # a feed one can follow.
+  context 'Atom export', js: true do
+    let(:export_type) { 'Atom' }
+    context 'with default filter' do
+      before do
+        work_packages_page.visit_index
+        filters.expect_filter_count 1
+        filters.open
+      end
+
+      it 'shows an xml with work packages' do
+        settings_menu.open_and_choose 'Export ...'
+
+        # The feed is opened in a new tab
+        new_window = window_opened_by { click_on export_type }
+
+        within_window new_window do
+          expect(page).to have_text(wp_1.description)
+          expect(page).to have_text(wp_2.description)
+          expect(page).to have_text(wp_3.description)
+          expect(page).to have_text(wp_4.description)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
The feed is opened in a new window so that the url can then be copied into a client while the original view persisted.

The solution is not optimal as it requires to call the backend twice but as this function should be used very little, it should be enough

https://community.openproject.com/wp/36052