### PR TITLE
[35012] Use reorder in table cell to correct sort order

### DIFF
--- a/app/cells/table_cell.rb
+++ b/app/cells/table_cell.rb
@@ -100,7 +100,9 @@ class TableCell < RailsCell
   # @param sort_clause [String] The SQL used as the sort clause.
   # @param _sort_columns [Array[Symbol]] Columns that are used to sort.
   def sort_collection(query, sort_clause, _sort_columns)
-    query.order sort_clause
+    query
+      .reorder(sort_clause)
+      .order(Arel.sql(initial_order))
   end
 
   def paginate_collection(query)
@@ -127,6 +129,10 @@ class TableCell < RailsCell
 
   def initial_sort
     [columns.first, :asc]
+  end
+
+  def initial_order
+    initial_sort.join(' ')
   end
 
   def paginated?

--- a/spec/features/users/index_spec.rb
+++ b/spec/features/users/index_spec.rb
@@ -28,106 +28,132 @@
 
 require 'spec_helper'
 
-describe 'index users', type: :feature do
-  let!(:current_user) { FactoryBot.create :admin, created_at: 1.hour.ago }
-  let!(:anonymous) { FactoryBot.create :anonymous }
-  let!(:active_user) { FactoryBot.create :user, created_at: 1.minute.ago }
-  let!(:registered_user) { FactoryBot.create :user, status: User.statuses[:registered] }
-  let!(:invited_user) { FactoryBot.create :user, status: User.statuses[:invited] }
+describe 'index users', type: :feature, with_clean_fixture: true do
+  shared_let(:current_user) { FactoryBot.create :admin, firstname: 'admin', lastname: 'admin', created_at: 1.hour.ago }
   let(:index_page) { Pages::Admin::Users::Index.new }
 
   before do
     login_as(current_user)
   end
 
-  it 'shows the users by status and allows status manipulations',
-     with_settings: { brute_force_block_after_failed_logins: 5,
-                      brute_force_block_minutes: 10 } do
-    index_page.visit!
+  describe 'with some sortable users' do
+    let!(:a_user) { FactoryBot.create :user, login: 'a_login', firstname: 'a_first', lastname: 'xxx_a' }
+    let!(:b_user) { FactoryBot.create :user, login: 'b_login', firstname: 'b_first', lastname: 'nnn_b' }
+    let!(:z_user) { FactoryBot.create :user, login: 'z_login', firstname: 'z_first', lastname: 'ccc_z' }
 
-    # Order is by id, asc
-    # so first ones created are on top.
-    index_page.expect_listed(current_user, active_user, registered_user, invited_user)
+    it 'sorts them correctly (Regression #35012)' do
+      index_page.visit!
+      index_page.expect_listed(current_user, a_user, b_user, z_user)
 
-    index_page.order_by('Created on')
-    index_page.expect_listed(invited_user, registered_user, active_user, current_user)
+      index_page.order_by('First name')
+      index_page.expect_order(a_user, current_user, b_user, z_user)
 
-    index_page.order_by('Created on')
-    index_page.expect_listed(current_user, active_user, registered_user, invited_user)
+      index_page.order_by('First name')
+      index_page.expect_order(z_user, b_user, current_user, a_user)
 
-    index_page.lock_user(active_user)
-    index_page.expect_listed(current_user, active_user, registered_user, invited_user)
-    index_page.expect_user_locked(active_user)
+      index_page.order_by('Last name')
+      index_page.expect_order(current_user, z_user, b_user, a_user)
 
-    expect(active_user.reload)
-      .to be_locked
-
-    index_page.filter_by_status('locked permanently')
-    index_page.expect_listed(active_user)
-
-    index_page.filter_by_status('active')
-    index_page.expect_listed(current_user)
-
-    index_page.filter_by_status('locked permanently')
-    index_page.unlock_user(active_user)
-    index_page.expect_non_listed
-
-    index_page.filter_by_status('active')
-    index_page.expect_listed(current_user, active_user)
-
-    index_page.filter_by_name(active_user.lastname[0..-3])
-    index_page.expect_listed(active_user)
-
-    # temporarily block user
-    active_user.update(failed_login_count: 6,
-                                  last_failed_login_on: 9.minutes.ago)
-    index_page.clear_filters
-    index_page.expect_listed(current_user, active_user, registered_user, invited_user)
-
-    index_page.filter_by_status('locked temporarily')
-    index_page.expect_listed(active_user)
-
-    index_page.reset_failed_logins(active_user)
-    index_page.expect_non_listed
-
-    # temporarily block user and lock permanently
-    active_user.reload
-    active_user.update(failed_login_count: 6,
-                                  last_failed_login_on: 9.minutes.ago)
-    index_page.clear_filters
-
-    index_page.filter_by_status('locked temporarily')
-    index_page.expect_listed(active_user)
-
-    index_page.lock_user(active_user)
-    index_page.expect_listed(active_user)
-
-    index_page.filter_by_status('locked permanently')
-    index_page.expect_listed(active_user)
-
-    index_page.unlock_and_reset_user(active_user)
-    index_page.expect_non_listed
-
-    index_page.filter_by_status('active')
-    index_page.expect_listed(current_user, active_user)
-
-    # activate registered user
-    index_page.filter_by_status('registered')
-    index_page.expect_listed(registered_user)
-
-    index_page.activate_user(registered_user)
-    index_page.filter_by_status('active')
-
-    index_page.expect_listed(current_user, active_user, registered_user)
+      index_page.order_by('Last name')
+      index_page.expect_order(a_user, b_user, z_user, current_user)
+    end
   end
 
-  context 'as global user' do
-    using_shared_fixtures :global_add_user
-    let(:current_user) { global_add_user }
+  describe 'with some more status users' do
+    shared_let(:anonymous) { FactoryBot.create :anonymous }
+    shared_let(:active_user) { FactoryBot.create :user, created_at: 1.minute.ago }
+    shared_let(:registered_user) { FactoryBot.create :user, status: User.statuses[:registered] }
+    shared_let(:invited_user) { FactoryBot.create :user, status: User.statuses[:invited] }
 
-    it 'can too visit the page' do
+    it 'shows the users by status and allows status manipulations',
+       with_settings: { brute_force_block_after_failed_logins: 5,
+                        brute_force_block_minutes: 10 } do
       index_page.visit!
+
+      # Order is by id, asc
+      # so first ones created are on top.
       index_page.expect_listed(current_user, active_user, registered_user, invited_user)
+
+      index_page.order_by('Created on')
+      index_page.expect_order(invited_user, registered_user, active_user, current_user)
+
+      index_page.order_by('Created on')
+      index_page.expect_order(current_user, active_user, registered_user, invited_user)
+
+      index_page.lock_user(active_user)
+      index_page.expect_listed(current_user, active_user, registered_user, invited_user)
+      index_page.expect_user_locked(active_user)
+
+      expect(active_user.reload)
+        .to be_locked
+
+      index_page.filter_by_status('locked permanently')
+      index_page.expect_listed(active_user)
+
+      index_page.filter_by_status('active')
+      index_page.expect_listed(current_user)
+
+      index_page.filter_by_status('locked permanently')
+      index_page.unlock_user(active_user)
+      index_page.expect_non_listed
+
+      index_page.filter_by_status('active')
+      index_page.expect_listed(current_user, active_user)
+
+      index_page.filter_by_name(active_user.lastname[0..-3])
+      index_page.expect_listed(active_user)
+
+      # temporarily block user
+      active_user.update(failed_login_count: 6,
+                         last_failed_login_on: 9.minutes.ago)
+      index_page.clear_filters
+      index_page.expect_listed(current_user, active_user, registered_user, invited_user)
+
+      index_page.filter_by_status('locked temporarily')
+      index_page.expect_listed(active_user)
+
+      index_page.reset_failed_logins(active_user)
+      index_page.expect_non_listed
+
+      # temporarily block user and lock permanently
+      active_user.reload
+      active_user.update(failed_login_count: 6,
+                         last_failed_login_on: 9.minutes.ago)
+      index_page.clear_filters
+
+      index_page.filter_by_status('locked temporarily')
+      index_page.expect_listed(active_user)
+
+      index_page.lock_user(active_user)
+      index_page.expect_listed(active_user)
+
+      index_page.filter_by_status('locked permanently')
+      index_page.expect_listed(active_user)
+
+      index_page.unlock_and_reset_user(active_user)
+      index_page.expect_non_listed
+
+      index_page.filter_by_status('active')
+      index_page.expect_listed(current_user, active_user)
+
+      # activate registered user
+      index_page.filter_by_status('registered')
+      index_page.expect_listed(registered_user)
+
+      index_page.activate_user(registered_user)
+      index_page.filter_by_status('active')
+
+      index_page.expect_listed(current_user, active_user, registered_user)
+    end
+
+    context 'as global user' do
+      using_shared_fixtures :global_add_user
+      let(:current_user) { global_add_user }
+
+      it 'can too visit the page' do
+        index_page.visit!
+        index_page.expect_listed(current_user, active_user, registered_user, invited_user)
+      end
     end
   end
 end

--- a/spec/support/pages/admin/users/index.rb
+++ b/spec/support/pages/admin/users/index.rb
@@ -41,6 +41,11 @@ module Pages
           expect(rows.map(&:text)).to include(*users.map(&:login))
         end
 
+        def expect_order(*users)
+          rows = page.all 'td.username'
+          expect(rows.map(&:text)).to eq(users.map(&:login))
+        end
+
         def expect_non_listed
           expect(page)
             .to have_no_selector('tr.user')


### PR DESCRIPTION
In the users table, an implicit order(ID asc) was added before passingto the table cell, which resulting in additional sort orders to only be appended and useless with ID order.

To ensure we sort first by the request attribute, then by ID, a `reorder` is used.

https://community.openproject.com/wp/35012