### PR TITLE
More ci actions fixes

### DIFF
--- a/docker/ci/entrypoint.sh
+++ b/docker/ci/entrypoint.sh
@@ -45,8 +45,8 @@ if [ "$1" == "setup-tests" ]; then
 	done
 
 	execute "time bundle install -j$JOBS"
-	execute "TEST_ENV_NUMBER=0 time bundle exec rake db:create db:migrate webdrivers:chromedriver:update webdrivers:geckodriver:update"
-	execute "time bundle exec rake parallel:setup"
+	execute "TEST_ENV_NUMBER=0 time bundle exec rake db:create db:migrate db:schema:dump webdrivers:chromedriver:update webdrivers:geckodriver:update"
+	execute "time bundle exec rake parallel:create parallel:load_schema"
 fi
 
 if [ "$1" == "run-units" ]; then

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -3,10 +3,6 @@ require 'webdrivers/chromedriver'
 
 ::Webdrivers.logger.level = :DEBUG
 
-if ENV['CI']
-  ::Webdrivers::Chromedriver.update
-end
-
 def register_chrome(language, name: :"chrome_#{language}")
   Capybara.register_driver name do |app|
     options = Selenium::WebDriver::Chrome::Options.new

--- a/spec/support/browsers/firefox.rb
+++ b/spec/support/browsers/firefox.rb
@@ -4,11 +4,6 @@ require 'socket'
 
 ::Webdrivers.logger.level = :DEBUG
 
-if ENV['CI']
-  ::Webdrivers::Geckodriver.update
-end
-
-
 def register_firefox(language, name: :"firefox_#{language}")
   require 'selenium/webdriver'
 


### PR DESCRIPTION
- [x] Uses migrate once as before and then instead of `db:setup`, calls `schema_load` to just load the schema without any seeds. `db:setup` also loads the schema but seeds N times, taking a bit more time.
- [x] As we already use the rake tasks to update webdrivers, we can remove the explicit checking if CI=true, as this is performed for each process as well