### PR TITLE
[35506] disable notifications for placeholders

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -683,9 +683,10 @@ class WorkPackage < ApplicationRecord
     related = [author]
 
     [responsible, assigned_to].each do |user|
-      if user.is_a?(Group)
+      case user
+      when Group
         related += user.users
-      else
+      when User
         related << user
       end
     end

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -136,4 +136,23 @@ describe 'Watcher tab', js: true, selenium: true do
       expect(page).to have_selector('.wp-tabs-count',  text: 1)
     end
   end
+
+  context 'with a placeholder user in the project' do
+    let!(:placeholder) { FactoryBot.create :placeholder_user, name: 'PLACEHOLDER' }
+    let(:wp_page) { Pages::FullWorkPackage.new(work_package) }
+
+    before do
+      login_as(user)
+      wp_page.visit_tab! :watchers
+    end
+
+    it 'should not show the placeholder user as an option' do
+      autocomplete = find('.wp-watcher--autocomplete')
+      target_dropdown = search_autocomplete autocomplete,
+                                            query: ''
+
+      expect(target_dropdown).to have_selector(".ng-option", text: user.name)
+      expect(target_dropdown).to have_no_selector(".ng-option", text: placeholder.name)
+    end
+  end
 end

--- a/spec/services/notifications/journal_wp_mail_service_spec.rb
+++ b/spec/services/notifications/journal_wp_mail_service_spec.rb
@@ -102,6 +102,25 @@ describe Notifications::JournalWpMailService do
 
   it_behaves_like 'sends mail'
 
+  context 'assignee is placeholder user' do
+    let(:recipient) { FactoryBot.create :placeholder_user }
+
+    it_behaves_like 'sends no mail'
+  end
+
+  context 'responsible is placeholder user' do
+    let(:recipient) { FactoryBot.create :placeholder_user }
+    let(:work_package) do
+      FactoryBot.create(:work_package,
+                        project: project,
+                        author: author,
+                        responsible: recipient,
+                        type: project.types.first)
+    end
+
+    it_behaves_like 'sends no mail'
+  end
+
   context 'notification for work_package_added disabled' do
     let(:notification_setting) { %w(work_package_updated work_package_note_added) }
 


### PR DESCRIPTION
:warning: Includes https://github.com/opf/openproject/pull/8961/files

In my tests, only active users can become watchers so that excludes placeholders. They cannot be authors or meeting participants either due to authorization checks for only active users. So right now, the only way a placeholder user can be notified is through being assigned or responsible in a work package.

There is a bit of confusion for me in the differences and code locations for:

- `recipients` (`acts_as_event`), overridden in case of work package
- `watcher_recipients` (`acts_as_watchable`)
- `JournalWpNotificationService` for identifying notifiable users / mentioned users.

There is also a potential performance drag in that all these user objects are instantiated in Rails and mostly only their ID is being used. It might make sense to rewrite all that into a single query and simply exclude placeholders.

However, this might prove too big for 11.2 so what I did is check for work package watchers, and removed placeholders for the work package attribute fields.

https://community.openproject.com/wp/35506