### PR TITLE
Allow placeholder and group assignment to custom field

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -278,7 +278,7 @@ class CustomField < ApplicationRecord
   def possible_user_values_options(obj)
     mapped_with_deduced_project(obj) do |project|
       if project&.persisted?
-        project.users
+        project.principals
       else
         Principal
           .in_visible_project_or_me(User.current)

--- a/lib/api/v3/principals/associated_subclass_lambda.rb
+++ b/lib/api/v3/principals/associated_subclass_lambda.rb
@@ -66,21 +66,10 @@ module API
             next unless embed_links
 
             instance = represented.send(name)
+            next if instance.nil?
 
-            representer = case instance
-                          when User
-                            ::API::V3::Users::UserRepresenter
-                          when Group
-                            ::API::V3::Groups::GroupRepresenter
-                          when PlaceholderUser
-                            ::API::V3::PlaceholderUsers::PlaceholderUserRepresenter
-                          when NilClass
-                            nil
-                          else
-                            raise "undefined subclass for #{instance}"
-                          end
-
-            representer&.new(represented.send(name), current_user: current_user)
+            ::API::V3::Principals::PrincipalRepresenterFactory
+              .create(represented.send(name), current_user: current_user)
           }
         end
 

--- a/lib/api/v3/principals/principal_representer_factory.rb
+++ b/lib/api/v3/principals/principal_representer_factory.rb
@@ -37,13 +37,18 @@ module API
         # Create the appropriate subclass representer
         # for each principal entity
         def self.create(model, *args)
+          representer_class(model)
+            .create(model, *args)
+        end
+
+        def self.representer_class(model)
           case model.type
           when 'User'
-            ::API::V3::Users::UserRepresenter.new(model, *args)
+            ::API::V3::Users::UserRepresenter
           when 'Group'
-            ::API::V3::Groups::GroupRepresenter.new(model, *args)
+            ::API::V3::Groups::GroupRepresenter
           when 'PlaceholderUser'
-            ::API::V3::PlaceholderUsers::PlaceholderUserRepresenter.new(model, *args)
+            ::API::V3::PlaceholderUsers::PlaceholderUserRepresenter
           else
             raise ArgumentError, "Missing concrete principal representer for #{model}"
           end

--- a/lib/api/v3/principals/principal_representer_factory.rb
+++ b/lib/api/v3/principals/principal_representer_factory.rb
@@ -28,14 +28,27 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CustomValue::UserStrategy < CustomValue::ARObjectStrategy
-  private
+module API
+  module V3
+    module Principals
+      class PrincipalRepresenterFactory
 
-  def ar_class
-    Principal
-  end
-
-  def ar_object(value)
-    Principal.find_by(id: value)
+        ##
+        # Create the appropriate subclass representer
+        # for each principal entity
+        def self.create(model, *args)
+          case model.type
+          when 'User'
+            ::API::V3::Users::UserRepresenter.new(model, *args)
+          when 'Group'
+            ::API::V3::Groups::GroupRepresenter.new(model, *args)
+          when 'PlaceholderUser'
+            ::API::V3::PlaceholderUsers::PlaceholderUserRepresenter.new(model, *args)
+          else
+            raise ArgumentError, "Missing concrete principal representer for #{model}"
+          end
+        end
+      end
+    end
   end
 end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -47,20 +47,14 @@ module API
 
         LINK_FORMATS = %w(list user version).freeze
 
-        PATH_METHOD_MAP = {
-          'user' => :user,
-          'version' => :version,
-          'list' => :custom_option
-        }.freeze
-
         NAMESPACE_MAP = {
-          'user' => 'users',
+          'user' => ['users', 'groups', 'placeholder_users'],
           'version' => 'versions',
           'list' => 'custom_options'
         }.freeze
 
         REPRESENTER_MAP = {
-          'user' => '::API::V3::Users::UserRepresenter',
+          'user' => '::API::V3::Principals::PrincipalRepresenterFactory',
           'version' => '::API::V3::Versions::VersionRepresenter',
           'list' => '::API::V3::CustomOptions::CustomOptionRepresenter'
         }.freeze
@@ -193,15 +187,11 @@ module API
                         options: cf_options(custom_field)
         end
 
-        def path_method_for(custom_field)
-          PATH_METHOD_MAP[custom_field.field_format]
-        end
-
         def inject_link_value(custom_field)
           name = property_name(custom_field.id)
           expected_namespace = NAMESPACE_MAP[custom_field.field_format]
 
-          link = link_value_getter_for(custom_field, path_method_for(custom_field))
+          link = LinkValueGetter.link_for custom_field
           setter = link_value_setter_for(custom_field, name, expected_namespace)
           getter = embedded_link_value_getter(custom_field)
 
@@ -216,10 +206,6 @@ module API
                       link: link,
                       setter: setter,
                       getter: getter)
-        end
-
-        def link_value_getter_for(custom_field, path_method)
-          LinkValueGetter.new custom_field, path_method
         end
 
         def link_value_setter_for(custom_field, property, expected_namespace)
@@ -244,7 +230,7 @@ module API
         end
 
         def embedded_link_value_getter(custom_field)
-          klass = representer_class(custom_field)
+          representer_class = derive_representer_class(custom_field)
 
           proc do
             # Do not embed list or multi values as their links contain all the
@@ -257,8 +243,8 @@ module API
 
             next unless value
 
-            klass
-              .new(value, current_user: current_user)
+            representer_class
+              .create(value, current_user: current_user)
           end
         end
 
@@ -345,7 +331,7 @@ module API
           end
         end
 
-        def representer_class(custom_field)
+        def derive_representer_class(custom_field)
           REPRESENTER_MAP[custom_field.field_format]
             .constantize
         end
@@ -361,9 +347,10 @@ module API
         end
 
         def allowed_users_static_filters
-          [{ status: { operator: '!',
+          [
+            { status: { operator: '!',
                        values: [Principal.statuses[:locked].to_s] } },
-           { type: { operator: '=', values: ['User'] } }]
+          ]
         end
 
         module RepresenterClass

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -350,6 +350,8 @@ module API
           [
             { status: { operator: '!',
                        values: [Principal.statuses[:locked].to_s] } },
+            { type: { operator: '=',
+                        values: %w[User Group PlaceholderUser] } }
           ]
         end
 

--- a/lib/api/v3/utilities/custom_field_injector/link_value_getter.rb
+++ b/lib/api/v3/utilities/custom_field_injector/link_value_getter.rb
@@ -33,14 +33,14 @@ module API
     module Utilities
       class CustomFieldInjector
         module LinkValueGetter
-          def self.new(custom_field, path_method)
+          def self.link_for(custom_field)
             ->(*) do
               next unless represented.available_custom_fields.include?(custom_field)
 
               # we can't use the generated accessor (e.g. represented.send :custom_field_1) here,
               # because we need to generate a link even if the id does not belong to an existing
               # object (that behaviour is only required for form payloads)
-              values = Methods.link_value_getter_values represented, custom_field, path_method
+              values = Methods.link_value_getter_values represented, custom_field
 
               if custom_field.multi_value?
                 values
@@ -58,23 +58,42 @@ module API
 
             module_function
 
-            def link_value_getter_values(represented, custom_field, path_method)
+            def link_value_getter_values(represented, custom_field)
               Array(represented.custom_value_for(custom_field)).flat_map do |custom_value|
                 if custom_value && custom_value.value.present?
                   title = link_value_title(custom_value)
 
-                  # only use ids for url
-                  href = if custom_value.value.to_i.to_s == custom_value.value
-                           api_v3_paths.send(path_method, custom_value.value)
-                         end
                   [{
                     title: title,
-                    href: href
+                    href: link_value_href(custom_field, custom_value)
                   }]
                 else
                   []
                 end
               end
+            end
+
+            def link_value_href(custom_field, custom_value)
+              # only use ids for url
+              return unless custom_value.value.to_i.to_s == custom_value.value
+
+              path_method = link_value_path_method(custom_field, custom_value)
+              api_v3_paths.send(path_method, custom_value.value)
+            end
+
+            def link_value_path_method(custom_field, custom_value)
+              case custom_field.field_format
+              when 'user'
+                derive_principal_path_method(custom_value)
+              when 'list'
+                :custom_option
+              else
+                custom_field.field_format
+              end
+            end
+
+            def derive_principal_path_method(custom_value)
+              custom_value.typed_value.model_name.singular
             end
 
             def link_value_title(custom_value)

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
@@ -109,9 +109,11 @@ describe ::API::V3::TimeEntries::TimeEntryRepresenter, 'rendering' do
         FactoryBot.build_stubbed(:time_entry_custom_field, field_format: 'user')
       end
       let(:custom_value) do
-        CustomValue.new(custom_field: custom_field,
-                        value: '1',
-                        customized: time_entry)
+        double('CustomValue',
+               custom_field: custom_field,
+               customized: time_entry,
+               value: '1',
+               typed_value: user)
       end
       let(:user) do
         FactoryBot.build_stubbed(:user)

--- a/spec/features/custom_fields/multi_user_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_user_custom_field_spec.rb
@@ -2,10 +2,14 @@ require "spec_helper"
 require "support/pages/work_packages/abstract_work_package"
 
 describe "multi select custom values", js: true do
-  let(:type) { FactoryBot.create :type }
-  let(:project) { FactoryBot.create :project, types: [type] }
+  using_shared_fixtures :admin
+  let(:current_user) { admin }
 
-  let(:custom_field) do
+  shared_let(:type) { FactoryBot.create :type }
+  shared_let(:project) { FactoryBot.create :project, types: [type] }
+  shared_let(:role) { FactoryBot.create :role }
+
+  shared_let(:custom_field) do
     FactoryBot.create(
       :user_wp_custom_field,
       name: "Reviewer",
@@ -15,79 +19,148 @@ describe "multi select custom values", js: true do
     )
   end
 
+
+  let(:wp_page) { Pages::FullWorkPackage.new work_package }
+
   let(:cf_edit_field) do
     field = wp_page.edit_field "customField#{custom_field.id}"
     field.field_type = 'create-autocompleter'
     field
   end
 
-  let(:member_names) { ["Billy Nobbler", "Cooper Quatermaine", "Anton Lupin"] }
-
-  # We include an invited member to check at the same time that invited users are properly
-  # offered for user custom fields as they weren't before.
-  let(:member_statuses) do
-    [User.statuses[:active], User.statuses[:active], User.statuses[:invited]]
-  end
-
-  let(:members) do
-    member_names.zip(member_statuses).map do |name, status|
-      first, last = name.split(" ")
-
-      FactoryBot.create :user, firstname: first, lastname: last, status: status
-    end
-  end
-
-  let(:role) { FactoryBot.create :role }
-
-  let(:wp_page) { Pages::FullWorkPackage.new work_package }
-  let(:user) { FactoryBot.create :admin }
-
   before do
-    members.each do |user|
-      project.add_member user, role
-    end
-
-    project.save!
+    login_as current_user
+    wp_page.visit!
+    wp_page.ensure_page_loaded
   end
 
-  context "with existing custom values" do
-    let(:work_package) do
-      wp = FactoryBot.build :work_package, project: project, type: type
+  describe 'with mixed users, group, and placeholdders' do
+    let(:work_package) { FactoryBot.create :work_package, project: project, type: type }
 
-      wp.custom_field_values = {
-        custom_field.id => [members[0].id.to_s, members[2].id.to_s]
-      }
-
-      wp.save
-      wp
+    let!(:user) do
+      FactoryBot.create :user,
+                        firstname: 'Da Real',
+                        lastname: 'User',
+                        member_in_project: project,
+                        member_through_role: role
     end
 
-    before do
-      login_as(user)
+    let!(:group) do
+      FactoryBot.create :group,
+                        groupname: 'groupfoo',
+                        member_in_project: project,
+                        member_through_role: role
+    end
 
-      wp_page.visit!
-      wp_page.ensure_page_loaded
+    let!(:placeholder) do
+      FactoryBot.create :placeholder_user,
+                        name: 'PLACEHOLDER',
+                        member_in_project: project,
+                        member_through_role: role
     end
 
     it "should be shown and allowed to be updated" do
       expect(page).to have_text custom_field.name
-      expect(page).to have_text "Billy Nobbler"
-      expect(page).to have_text "Anton Lupin"
 
-      page.find(".inline-edit--display-field", text: "Billy Nobbler").click
+      cf_edit_field.activate!
+      cf_edit_field.set_value "Da Real"
+      cf_edit_field.set_value "groupfoo"
+      cf_edit_field.set_value "PLACEHOLDER"
 
-      cf_edit_field.unset_value "Anton Lupin", true
-      cf_edit_field.set_value "Cooper Quatermaine"
-
-      click_on "Reviewer: Save"
-
-      expect(page).to have_selector('.custom-option', count: 2)
-      expect(page).to have_text "Successful update"
+      cf_edit_field.submit_by_dashboard
 
       expect(page).to have_text custom_field.name
-      expect(page).to have_text "Billy Nobbler"
-      expect(page).not_to have_text "Anton Lupin"
-      expect(page).to have_text "Cooper Quatermaine"
+      expect(page).to have_text "Da Real"
+      expect(page).to have_text "groupfoo"
+      expect(page).to have_text "PLACEHOLDER"
+
+      wp_page.expect_and_dismiss_notification(message: "Successful update.")
+
+      work_package.reload
+      cvs = work_package
+          .custom_value_for(custom_field)
+          .map(&:typed_value)
+
+      expect(cvs).to contain_exactly(group, user, placeholder)
+
+      cf_edit_field.activate!
+      cf_edit_field.unset_value "Da Real", true
+      cf_edit_field.submit_by_dashboard
+
+      wp_page.expect_and_dismiss_notification(message: "Successful update.")
+
+      expect(page).to have_text "groupfoo"
+      expect(page).to have_text "PLACEHOLDER"
+      expect(page).to have_no_text "Da Real"
+
+      work_package.reload
+      cvs = work_package
+          .custom_value_for(custom_field)
+          .map(&:typed_value)
+
+      expect(cvs).to contain_exactly(group, placeholder)
+    end
+  end
+
+  describe 'with all users' do
+    let!(:user1) do
+      FactoryBot.create :user,
+                        firstname: 'Billy',
+                        lastname: 'Nobbler',
+                        member_in_project: project,
+                        member_through_role: role
+    end
+
+    let!(:user2) do
+      FactoryBot.create :user,
+                        firstname: 'Cooper',
+                        lastname: 'Quatermaine',
+                        member_in_project: project,
+                        member_through_role: role
+    end
+
+    let!(:user3) do
+      FactoryBot.create :user,
+                        firstname: 'Anton',
+                        lastname: 'Lupin',
+                        status: User.statuses[:invited],
+                        member_in_project: project,
+                        member_through_role: role
+    end
+
+
+    context "with existing custom values" do
+      let(:work_package) do
+        wp = FactoryBot.build :work_package, project: project, type: type
+
+        wp.custom_field_values = {
+          custom_field.id => [user1.id.to_s, user3.id.to_s]
+        }
+
+        wp.save
+        wp
+      end
+
+
+      it "should be shown and allowed to be updated" do
+        expect(page).to have_text custom_field.name
+        expect(page).to have_text "Billy Nobbler"
+        expect(page).to have_text "Anton Lupin"
+
+        page.find(".inline-edit--display-field", text: "Billy Nobbler").click
+
+        cf_edit_field.unset_value "Anton Lupin", true
+        cf_edit_field.set_value "Cooper Quatermaine"
+
+        click_on "Reviewer: Save"
+        wp_page.expect_and_dismiss_notification(message: "Successful update.")
+        expect(page).to have_selector('.custom-option', count: 2)
+
+        expect(page).to have_text custom_field.name
+        expect(page).to have_text "Billy Nobbler"
+        expect(page).not_to have_text "Anton Lupin"
+        expect(page).to have_text "Cooper Quatermaine"
+      end
     end
   end
 end

--- a/spec/lib/api/v3/principals/principal_representer_factory_spec.rb
+++ b/spec/lib/api/v3/principals/principal_representer_factory_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -28,14 +26,36 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class CustomValue::UserStrategy < CustomValue::ARObjectStrategy
-  private
+require 'spec_helper'
 
-  def ar_class
-    Principal
-  end
+describe ::API::V3::Principals::PrincipalRepresenterFactory do
+  let(:current_user) { FactoryBot.build_stubbed :user }
 
-  def ar_object(value)
-    Principal.find_by(id: value)
+  describe '.create' do
+    subject { described_class.create principal, current_user: current_user }
+
+    context 'with a user' do
+      let(:principal) { FactoryBot.build_stubbed :user }
+
+      it 'returns a user representer' do
+        expect(subject).to be_a ::API::V3::Users::UserRepresenter
+      end
+    end
+
+    context 'with a group' do
+      let(:principal) { FactoryBot.build_stubbed :group }
+
+      it 'returns a group representer' do
+        expect(subject).to be_a ::API::V3::Groups::GroupRepresenter
+      end
+    end
+
+    context 'with a placeholder user' do
+      let(:principal) { FactoryBot.build_stubbed :placeholder_user }
+
+      it 'returns a user representer' do
+        expect(subject).to be_a ::API::V3::PlaceholderUsers::PlaceholderUserRepresenter
+      end
+    end
   end
 end

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Utilities::CustomFieldInjector do
+describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
   include API::V3::Utilities::PathHelper
 
   let(:cf_path) { "customField#{custom_field.id}" }
@@ -224,7 +224,6 @@ describe ::API::V3::Utilities::CustomFieldInjector do
         let(:href) do
           params = [{ status: { operator: '!',
                                 values: [Principal.statuses[:locked].to_s] } },
-                    { type: { operator: '=', values: ['User'] } },
                     { member: { operator: '=', values: [schema.project_id.to_s] } }]
 
           query = CGI.escape(::JSON.dump(params))
@@ -272,20 +271,25 @@ describe ::API::V3::Utilities::CustomFieldInjector do
     end
 
     context 'user custom field' do
-      let(:value) { FactoryBot.build(:user, id: 2) }
       let(:raw_value) { value.id.to_s }
       let(:typed_value) { value }
       let(:field_format) { 'user' }
 
-      it_behaves_like 'has a titled link' do
-        let(:link) { cf_path }
-        let(:href) { api_v3_paths.user 2 }
-        let(:title) { value.name }
-      end
+      %w[user group placeholder_user].each do |type|
+        describe "#{type} assignment" do
+          let(:value) { FactoryBot.build(type, id: 2) }
 
-      it 'has the user embedded' do
-        is_expected.to be_json_eql('User'.to_json).at_path("_embedded/#{cf_path}/_type")
-        is_expected.to be_json_eql(value.name.to_json).at_path("_embedded/#{cf_path}/name")
+          it_behaves_like 'has a titled link' do
+            let(:link) { cf_path }
+            let(:href) { api_v3_paths.send type, 2 }
+            let(:title) { value.name }
+          end
+
+          it 'has the user embedded' do
+            is_expected.to be_json_eql(type.classify.to_json).at_path("_embedded/#{cf_path}/_type")
+            is_expected.to be_json_eql(value.name.to_json).at_path("_embedded/#{cf_path}/name")
+          end
+        end
       end
 
       context 'value is nil' do
@@ -448,13 +452,18 @@ describe ::API::V3::Utilities::CustomFieldInjector do
 
     context 'reading' do
       let(:value) { '2' }
-      let(:typed_value) { FactoryBot.build_stubbed(:user) }
       let(:field_format) { 'user' }
 
-      it_behaves_like 'has a titled link' do
-        let(:link) { cf_path }
-        let(:href) { api_v3_paths.user 2 }
-        let(:title) { typed_value.name }
+      %w[user group placeholder_user].each do |type|
+        describe "#{type} reading" do
+          let(:typed_value) { FactoryBot.build(type, id: 2) }
+
+          it_behaves_like 'has a titled link' do
+            let(:link) { cf_path }
+            let(:href) { api_v3_paths.send type, 2 }
+            let(:title) { typed_value.name }
+          end
+        end
       end
 
       context 'value is nil' do
@@ -471,12 +480,15 @@ describe ::API::V3::Utilities::CustomFieldInjector do
       let(:value) { nil }
       let(:field_format) { 'user' }
 
-      it 'accepts a valid link' do
-        json = { cf_path => { href: (api_v3_paths.user 2) } }.to_json
-        expected = ['2']
+      %w[user group placeholder_user].each do |type|
+        it "accepts a valid link of type #{type}" do
+          path = api_v3_paths.send type, 2
+          json = { cf_path => { href: path } }.to_json
+          expected = ['2']
 
-        expect(represented).to receive(:"custom_field_#{custom_field.id}=").with(expected)
-        modified_class.new(represented, current_user: nil).from_json(json)
+          expect(represented).to receive(:"custom_field_#{custom_field.id}=").with(expected)
+          modified_class.new(represented, current_user: nil).from_json(json)
+        end
       end
 
       it 'accepts an empty link' do

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -222,9 +222,11 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
       it_behaves_like 'links to allowed values via collection link' do
         let(:path) { cf_path }
         let(:href) do
-          params = [{ status: { operator: '!',
-                                values: [Principal.statuses[:locked].to_s] } },
-                    { member: { operator: '=', values: [schema.project_id.to_s] } }]
+          params = [
+            { status: { operator: '!', values: [Principal.statuses[:locked].to_s] } },
+            { type: { operator: '=', values: %w[User Group PlaceholderUser] } },
+            { member: { operator: '=', values: [schema.project_id.to_s] } }
+          ]
 
           query = CGI.escape(::JSON.dump(params))
 

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -236,8 +236,8 @@ describe CustomFieldFormBuilder do
         resource.custom_field.field_format = 'user'
         resource.customized = project
         allow(project)
-          .to receive(:users)
-                .and_return([user1, user2])
+          .to(receive(:principals))
+          .and_return([user1, user2])
       end
 
       it_behaves_like 'wrapped in container', 'select-container' do

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -194,7 +194,7 @@ describe CustomField, type: :model do
       before do
         field.field_format = 'user'
         allow(project)
-          .to receive(:users)
+          .to receive(:principals)
           .and_return([user1, user2])
 
         allow(Principal)

--- a/spec/models/custom_value/user_strategy_spec.rb
+++ b/spec/models/custom_value/user_strategy_spec.rb
@@ -47,7 +47,7 @@ describe CustomValue::UserStrategy do
       let(:value) { user }
 
       it 'returns the user and sets it for later retrieval' do
-        expect(User)
+        expect(Principal)
           .to_not receive(:find_by)
 
         expect(subject.parse_value(value)).to eql user.id.to_s
@@ -60,7 +60,7 @@ describe CustomValue::UserStrategy do
       let(:value) { user.id.to_s }
 
       it 'returns the string and has to later find the user' do
-        allow(User)
+        allow(Principal)
           .to receive(:find_by)
           .with(id: user.id.to_s)
           .and_return(user)
@@ -75,7 +75,7 @@ describe CustomValue::UserStrategy do
       let(:value) { '' }
 
       it 'is nil and does not look for the user' do
-        expect(User)
+        expect(Principal)
           .to_not receive(:find_by)
 
         expect(subject.parse_value(value)).to be_nil
@@ -88,7 +88,7 @@ describe CustomValue::UserStrategy do
       let(:value) { nil }
 
       it 'is nil and does not look for the user' do
-        expect(User)
+        expect(Principal)
           .to_not receive(:find_by)
 
         expect(subject.parse_value(value)).to be_nil
@@ -107,7 +107,7 @@ describe CustomValue::UserStrategy do
       it 'is the user to_s (without db access)' do
         instance.parse_value(value)
 
-        expect(User)
+        expect(Principal)
           .to_not receive(:find_by)
 
         expect(subject).to eql value.to_s
@@ -118,7 +118,7 @@ describe CustomValue::UserStrategy do
       let(:value) { user.id.to_s }
 
       it 'is the user to_s (with db access)' do
-        allow(User)
+        allow(Principal)
           .to receive(:find_by)
           .with(id: user.id.to_s)
           .and_return(user)


### PR DESCRIPTION
- [x] Allow placeholder users to be passed as user CFs values
- [x] Extend namespace parsing of custom values to allow other hrefs other than `/api/v3/users/*`
- [x] Add a factory in the PrincipalRepresenter to instantiate the correct subclass
- [x] Allow multi selection, seems to be currently broken by the ongoing changes
- [x] ~~Check what this breaks in reporting~~ CF Users are not selectable as groups in reporting
- [x] Allows groups for selection as well
 