### PR TITLE
[36136] Rework members page to show name and avatars for principals

### DIFF
--- a/app/cells/members/row_cell.rb
+++ b/app/cells/members/row_cell.rb
@@ -1,5 +1,6 @@
 module Members
   class RowCell < ::RowCell
+    include AvatarHelper
     include UsersHelper
 
     property :principal
@@ -18,12 +19,17 @@ module Members
       "member #{group}".strip
     end
 
-    def lastname
-      link_to principal.lastname, user_path(principal) if user?
-    end
+    def name
+      icon = avatar principal, class: 'avatar-mini'
 
-    def firstname
-      link_to principal.firstname, user_path(principal) if user?
+      link =
+        if user?
+          link_to principal.name, user_path(principal)
+        else
+          h(principal.name)
+        end
+
+      icon + link
     end
 
     def mail

--- a/app/cells/members/row_cell.rb
+++ b/app/cells/members/row_cell.rb
@@ -26,7 +26,7 @@ module Members
         if user?
           link_to principal.name, user_path(principal)
         else
-          h(principal.name)
+          content_tag :span, principal.name
         end
 
       icon + link

--- a/app/cells/members/row_cell.rb
+++ b/app/cells/members/row_cell.rb
@@ -14,22 +14,13 @@ module Members
     end
 
     def row_css_class
-      group = user? ? "" : "group"
-
-      "member #{group}".strip
+      "member #{principal_class_name}".strip
     end
 
     def name
       icon = avatar principal, class: 'avatar-mini'
 
-      link =
-        if user?
-          link_to principal.name, user_path(principal)
-        else
-          content_tag :span, principal.name
-        end
-
-      icon + link
+      icon + principal_link
     end
 
     def mail
@@ -76,8 +67,6 @@ module Members
     def groups
       if user?
         principal.groups.map(&:name).join(", ")
-      else
-        model.principal.name
       end
     end
 
@@ -153,6 +142,21 @@ module Members
       else
         super
       end
+    end
+
+    def principal_link
+      case Principal
+      when User
+        link_to principal.name, user_path(principal)
+      when Group
+        link_to principal.name, show_group_path(principal)
+      else
+        content_tag :span, principal.name
+      end
+    end
+
+    def principal_class_name
+      principal.model_name.singular
     end
 
     def user?

--- a/app/cells/members/table_cell.rb
+++ b/app/cells/members/table_cell.rb
@@ -1,11 +1,11 @@
 module Members
   class TableCell < ::TableCell
     options :authorize_update, :available_roles
-    columns :lastname, :firstname, :mail, :roles, :groups, :status
-    sortable_columns :lastname, :firstname, :mail
+    columns :name, :mail, :roles, :groups, :status
+    sortable_columns :name, :mail
 
     def initial_sort
-      [:lastname, :desc]
+      [:name, :desc]
     end
 
     def headers

--- a/app/cells/members/table_cell.rb
+++ b/app/cells/members/table_cell.rb
@@ -5,7 +5,7 @@ module Members
     sortable_columns :name, :mail
 
     def initial_sort
-      [:name, :desc]
+      %i[name asc]
     end
 
     def headers

--- a/app/cells/members/table_cell.rb
+++ b/app/cells/members/table_cell.rb
@@ -1,6 +1,6 @@
 module Members
   class TableCell < ::TableCell
-    options :authorize_update, :available_roles
+    options :authorize_update, :available_roles, :is_filtered
     columns :name, :mail, :roles, :groups, :status
     sortable_columns :name, :mail
 
@@ -27,6 +27,14 @@ module Members
 
     def join_users(query)
       query.joins(:principal).references(:principal)
+    end
+
+    def empty_row_message
+      if is_filtered
+        I18n.t :notice_no_principals_found
+      else
+        super
+      end
     end
   end
 end

--- a/app/cells/members/table_cell.rb
+++ b/app/cells/members/table_cell.rb
@@ -33,7 +33,7 @@ module Members
       if is_filtered
         I18n.t :notice_no_principals_found
       else
-        super
+        I18n.t :'members.index.no_results_title_text'
       end
     end
   end

--- a/app/cells/members/table_cell.rb
+++ b/app/cells/members/table_cell.rb
@@ -2,7 +2,7 @@ module Members
   class TableCell < ::TableCell
     options :authorize_update, :available_roles, :is_filtered
     columns :name, :mail, :roles, :groups, :status
-    sortable_columns :name, :mail
+    sortable_columns :name, :mail, :status
 
     def initial_sort
       %i[name asc]

--- a/app/cells/table_cell.rb
+++ b/app/cells/table_cell.rb
@@ -83,14 +83,22 @@ class TableCell < RailsCell
   def initialize_sorted_model
     sort_init *initial_sort.map(&:to_s)
     sort_update sortable_columns.map(&:to_s)
-    @model = sort_and_paginate_collection model
+    @model = paginate_collection apply_sort(model)
   end
 
-  def sort_and_paginate_collection(ar_collection)
-    return ar_collection unless ar_collection.is_a? ActiveRecord::QueryMethods
-
-    # sort_clause from SortHelper
-    paginate_collection sort_collection(ar_collection, sort_clause, sort_columns.map(&:to_sym))
+  def apply_sort(model)
+    case model
+    when ActiveRecord::QueryMethods
+      sort_collection(model, sort_clause)
+      model
+        .order sort_clause
+    when Queries::BaseQuery
+      model
+        .order(@sort_criteria.to_query_hash)
+        .results
+    else
+      raise ArgumentError, "Cannot sort the given model class #{model.class}"
+    end
   end
 
   ##
@@ -98,8 +106,7 @@ class TableCell < RailsCell
   #
   # @param query [ActiveRecord::QueryMethods] An active record collection.
   # @param sort_clause [String] The SQL used as the sort clause.
-  # @param _sort_columns [Array[Symbol]] Columns that are used to sort.
-  def sort_collection(query, sort_clause, _sort_columns)
+  def sort_collection(query, sort_clause)
     query
       .reorder(sort_clause)
       .order(Arel.sql(initial_order))

--- a/app/cells/table_cell.rb
+++ b/app/cells/table_cell.rb
@@ -90,8 +90,6 @@ class TableCell < RailsCell
     case model
     when ActiveRecord::QueryMethods
       sort_collection(model, sort_clause)
-      model
-        .order sort_clause
     when Queries::BaseQuery
       model
         .order(@sort_criteria.to_query_hash)

--- a/app/cells/user_filter_cell.rb
+++ b/app/cells/user_filter_cell.rb
@@ -5,7 +5,7 @@ class UserFilterCell < RailsCell
   options :groups, :status, :roles, :clear_url, :project
 
   class << self
-    def filter(params)
+    def query(params)
       q = base_query.new
 
       filter_project q, params[:project_id]
@@ -14,7 +14,11 @@ class UserFilterCell < RailsCell
       filter_group q, params[:group_id]
       filter_role q, params[:role_id]
 
-      q.results
+      q
+    end
+
+    def filter(params)
+      query(params).results
     end
 
     def filtered?(params)

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -123,7 +123,8 @@ class MembersController < ApplicationController
     {
       project: @project,
       available_roles: roles,
-      authorize_update: authorize_for('members', 'update')
+      authorize_update: authorize_for('members', 'update'),
+      is_filtered: Members::UserFilterCell.filtered?(params)
     }
   end
 
@@ -154,7 +155,6 @@ class MembersController < ApplicationController
   def set_index_data!
     set_roles_and_principles!
 
-    @is_filtered = Members::UserFilterCell.filtered? params
     @members = index_members
     @members_table_options = members_table_options @roles
     @members_filter_options = members_filter_options @roles
@@ -177,9 +177,7 @@ class MembersController < ApplicationController
     filters = params.slice(:name, :group_id, :role_id, :status)
     filters[:project_id] = @project.id.to_s
 
-    @members = Member
-               .where(id: Members::UserFilterCell.filter(filters))
-               .includes(:roles, :principal, :member_roles)
+    @members_query = Members::UserFilterCell.query(filters)
   end
 
   def new_members_from_params(member_params)

--- a/app/helpers/sort_helper.rb
+++ b/app/helpers/sort_helper.rb
@@ -125,6 +125,11 @@ module SortHelper
         .compact
     end
 
+    def to_query_hash
+      criteria_with_direction
+        .to_h
+    end
+
     def map_each
       to_a.map { |criteria| yield criteria }
     end
@@ -188,7 +193,11 @@ module SortHelper
     end
 
     def to_json_param
-      JSON::dump(@criteria.map { |k, o| [k, o ? 'asc' : 'desc'] })
+      JSON::dump(criteria_with_direction)
+    end
+
+    def criteria_with_direction
+      @criteria.map { |k, o| [k, o ? :asc : :desc] }
     end
 
     def to_sort_param

--- a/app/models/custom_actions/actions/assigned_to.rb
+++ b/app/models/custom_actions/actions/assigned_to.rb
@@ -55,7 +55,7 @@ class CustomActions::Actions::AssignedTo < CustomActions::Actions::Base
     principal_class
       .not_locked
       .select(:id, :firstname, :lastname, :type)
-      .order_by_name
+      .ordered_by_name
       .map { |u| [u.id, u.name] }
   end
 

--- a/app/models/custom_actions/actions/notify.rb
+++ b/app/models/custom_actions/actions/notify.rb
@@ -64,6 +64,6 @@ class CustomActions::Actions::Notify < CustomActions::Actions::Base
     Principal
       .not_locked
       .select(:id, :firstname, :lastname, :type)
-      .order_by_name
+      .ordered_by_name
   end
 end

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -62,7 +62,8 @@ class Principal < ApplicationRecord
          :not_builtin,
          :possible_assignee,
          :possible_member,
-         :user
+         :user,
+         :ordered_by_name
 
   scope :not_locked, -> {
     not_builtin.where.not(status: statuses[:locked])
@@ -86,10 +87,6 @@ class Principal < ApplicationRecord
     not_locked.like(query).not_in_project(project)
   end
 
-  def self.order_by_name(desc: false)
-    OpenProject::Deprecation.warn "Use Queries::Principals with .order('name') instead"
-    order Queries::Principals::Orders::NameOrder.name_order_statements(desc)
-  end
 
   def self.me
     where(id: User.current.id)

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -87,7 +87,13 @@ class Principal < ApplicationRecord
   end
 
   def self.order_by_name
-    order(User::USER_FORMATS_STRUCTURE[Setting.user_format].map { |format| "#{Principal.table_name}.#{format}" })
+    formats = User::USER_FORMATS_STRUCTURE[Setting.user_format]
+      .map do |format|
+      attr = "#{Principal.table_name}.#{format}"
+      Arel.sql("NULLIF(#{attr}, '') NULLS LAST")
+    end
+
+    order formats
   end
 
   def self.me

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -86,6 +86,11 @@ class Principal < ApplicationRecord
     not_locked.like(query).not_in_project(project)
   end
 
+  def self.order_by_name(desc: false)
+    OpenProject::Deprecation.warn "Use Queries::Principals with .order('name') instead"
+    order Queries::Principals::Orders::NameOrder.name_order_statements(desc)
+  end
+
   def self.me
     where(id: User.current.id)
   end

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -86,16 +86,6 @@ class Principal < ApplicationRecord
     not_locked.like(query).not_in_project(project)
   end
 
-  def self.order_by_name
-    formats = User::USER_FORMATS_STRUCTURE[Setting.user_format]
-      .map do |format|
-      attr = "#{Principal.table_name}.#{format}"
-      Arel.sql("NULLIF(#{attr}, '') NULLS LAST")
-    end
-
-    order formats
-  end
-
   def self.me
     where(id: User.current.id)
   end

--- a/app/models/queries/members.rb
+++ b/app/models/queries/members.rb
@@ -47,4 +47,5 @@ module Queries::Members
 
   Queries::Register.order query, order_ns::DefaultOrder
   Queries::Register.order query, order_ns::NameOrder
+  Queries::Register.order query, order_ns::EmailOrder
 end

--- a/app/models/queries/members/member_query.rb
+++ b/app/models/queries/members/member_query.rb
@@ -31,6 +31,11 @@ class Queries::Members::MemberQuery < Queries::BaseQuery
     Member
   end
 
+  def results
+    super
+      .includes(:roles, :principal, :member_roles)
+  end
+
   def default_scope
     Member.visible(User.current)
   end

--- a/app/models/queries/members/orders/email_order.rb
+++ b/app/models/queries/members/orders/email_order.rb
@@ -29,10 +29,14 @@
 #++
 
 class Queries::Members::Orders::EmailOrder < Queries::BaseOrder
-  self.model = Principal
+  self.model = Member
 
   def self.key
     :mail
+  end
+
+  def joins
+    :principal
   end
 
   private

--- a/app/models/queries/members/orders/name_order.rb
+++ b/app/models/queries/members/orders/name_order.rb
@@ -28,23 +28,22 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Queries::Members
-  query = Queries::Members::MemberQuery
-  filter_ns = Queries::Members::Filters
+class Queries::Members::Orders::NameOrder < Queries::BaseOrder
+  self.model = Principal
 
-  Queries::Register.filter query, filter_ns::NameFilter
-  Queries::Register.filter query, filter_ns::AnyNameAttributeFilter
-  Queries::Register.filter query, filter_ns::ProjectFilter
-  Queries::Register.filter query, filter_ns::StatusFilter
-  Queries::Register.filter query, filter_ns::BlockedFilter
-  Queries::Register.filter query, filter_ns::GroupFilter
-  Queries::Register.filter query, filter_ns::RoleFilter
-  Queries::Register.filter query, filter_ns::PrincipalFilter
-  Queries::Register.filter query, filter_ns::CreatedAtFilter
-  Queries::Register.filter query, filter_ns::UpdatedAtFilter
+  def self.key
+    :name
+  end
 
-  order_ns = Queries::Members::Orders
+  private
 
-  Queries::Register.order query, order_ns::DefaultOrder
-  Queries::Register.order query, order_ns::NameOrder
+  def order
+    ordered = self.model.order_by_name
+
+    if direction == :desc
+      ordered = ordered.reverse_order
+    end
+
+    ordered
+  end
 end

--- a/app/models/queries/members/orders/name_order.rb
+++ b/app/models/queries/members/orders/name_order.rb
@@ -28,10 +28,20 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::Members::Orders::NameOrder < Queries::Principals::Orders::NameOrder
+class Queries::Members::Orders::NameOrder < Queries::BaseOrder
   self.model = Member
+
+  def self.key
+    :name
+  end
 
   def joins
     :principal
+  end
+
+  protected
+
+  def order
+    model.merge Principal.ordered_by_name(desc: direction == :desc)
   end
 end

--- a/app/models/queries/members/orders/name_order.rb
+++ b/app/models/queries/members/orders/name_order.rb
@@ -29,16 +29,20 @@
 #++
 
 class Queries::Members::Orders::NameOrder < Queries::BaseOrder
-  self.model = Principal
+  self.model = Member
 
   def self.key
     :name
   end
 
+  def joins
+    :principals
+  end
+
   private
 
   def order
-    ordered = self.model.order_by_name
+    ordered = Principal.order_by_name
 
     if direction == :desc
       ordered = ordered.reverse_order

--- a/app/models/queries/members/orders/name_order.rb
+++ b/app/models/queries/members/orders/name_order.rb
@@ -28,26 +28,10 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::Members::Orders::NameOrder < Queries::BaseOrder
+class Queries::Members::Orders::NameOrder < Queries::Principals::Orders::NameOrder
   self.model = Member
 
-  def self.key
-    :name
-  end
-
   def joins
-    :principals
-  end
-
-  private
-
-  def order
-    ordered = Principal.order_by_name
-
-    if direction == :desc
-      ordered = ordered.reverse_order
-    end
-
-    ordered
+    :principal
   end
 end

--- a/app/models/queries/members/orders/status_order.rb
+++ b/app/models/queries/members/orders/status_order.rb
@@ -28,25 +28,18 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Queries::Members
-  query = Queries::Members::MemberQuery
-  filter_ns = Queries::Members::Filters
+class Queries::Members::Orders::StatusOrder < Queries::BaseOrder
+  self.model = Member
 
-  Queries::Register.filter query, filter_ns::NameFilter
-  Queries::Register.filter query, filter_ns::AnyNameAttributeFilter
-  Queries::Register.filter query, filter_ns::ProjectFilter
-  Queries::Register.filter query, filter_ns::StatusFilter
-  Queries::Register.filter query, filter_ns::BlockedFilter
-  Queries::Register.filter query, filter_ns::GroupFilter
-  Queries::Register.filter query, filter_ns::RoleFilter
-  Queries::Register.filter query, filter_ns::PrincipalFilter
-  Queries::Register.filter query, filter_ns::CreatedAtFilter
-  Queries::Register.filter query, filter_ns::UpdatedAtFilter
+  def self.key
+    :status
+  end
 
-  order_ns = Queries::Members::Orders
+  def joins
+    :principal
+  end
 
-  Queries::Register.order query, order_ns::DefaultOrder
-  Queries::Register.order query, order_ns::NameOrder
-  Queries::Register.order query, order_ns::EmailOrder
-  Queries::Register.order query, order_ns::StatusOrder
+  def name
+    "#{Principal.table_name}.status"
+  end
 end

--- a/app/models/queries/principals/orders/name_order.rb
+++ b/app/models/queries/principals/orders/name_order.rb
@@ -35,15 +35,22 @@ class Queries::Principals::Orders::NameOrder < Queries::BaseOrder
     :name
   end
 
-  private
+  ##
+  # Returns the selected user format as an array
+  # of SQL strings, i.e. "NULLIF(firstname, '') ASC NULLS LAST"
+  def self.name_order_statements(desc = false)
+    User::USER_FORMATS_STRUCTURE[Setting.user_format]
+        .map do |format|
+      attr = "#{Principal.table_name}.#{format}"
+      direction = desc ? "DESC" : "ASC"
+
+      Arel.sql("NULLIF(#{attr}, '') #{direction} NULLS LAST")
+    end
+  end
+
+  protected
 
   def order
-    ordered = self.model.order_by_name
-
-    if direction == :desc
-      ordered = ordered.reverse_order
-    end
-
-    ordered
+    model.order self.class.name_order_statements(direction == :desc)
   end
 end

--- a/app/models/queries/principals/orders/name_order.rb
+++ b/app/models/queries/principals/orders/name_order.rb
@@ -35,22 +35,9 @@ class Queries::Principals::Orders::NameOrder < Queries::BaseOrder
     :name
   end
 
-  ##
-  # Returns the selected user format as an array
-  # of SQL strings, i.e. "NULLIF(firstname, '') ASC NULLS LAST"
-  def self.name_order_statements(desc = false)
-    User::USER_FORMATS_STRUCTURE[Setting.user_format]
-        .map do |format|
-      attr = "#{Principal.table_name}.#{format}"
-      direction = desc ? "DESC" : "ASC"
-
-      Arel.sql("NULLIF(#{attr}, '') #{direction} NULLS LAST")
-    end
-  end
-
   protected
 
   def order
-    model.order self.class.name_order_statements(direction == :desc)
+    model.ordered_by_name(desc: direction == :desc)
   end
 end

--- a/app/models/queries/users/orders/name_order.rb
+++ b/app/models/queries/users/orders/name_order.rb
@@ -28,22 +28,8 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::Users::Orders::NameOrder < Queries::BaseOrder
-  self.model = User
-
-  def self.key
-    :name
-  end
-
-  private
-
-  def order
-    ordered = User.order_by_name
-
-    if direction == :desc
-      ordered = ordered.reverse_order
-    end
-
-    ordered
-  end
+class Queries::Users::Orders::NameOrder < Queries::Principals::Orders::NameOrder
+  # .user is important here as it forces
+  # "AND users.type = 'User'" which otherwise gets lost for some reason
+  self.model = User.user
 end

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -34,7 +34,10 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <div class="form--field">
   <%= f.select :assigned_to_id,
-               Principal.possible_assignee(@project).order_by_name.collect{|u| [u.name, u.id]},
+               Principal
+                   .possible_assignee(@project)
+                   .ordered_by_name
+                   .collect{|u| [u.name, u.id]},
                include_blank: true,
                container_class: '-slim' %>
 </div>

--- a/app/views/members/_member_form.html.erb
+++ b/app/views/members/_member_form.html.erb
@@ -30,8 +30,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= labelled_tabular_form_for(:member, url: main_app.project_members_path,
                               method: :post,
                               html: { id: "members_add_form", class: "form -vertical -bordered -medium-compressed" }) do |f| %>
-    <a title="<%= t('js.close_form_title') %>" class="hide-add-member-form-link form--close icon-context icon-close"></a>
-    <% csp_onclick('hideAddMemberForm()', '.hide-add-member-form-link') %>
+    <a title="<%= t('js.close_form_title') %>" class="hide-member-form-button form--close icon-context icon-close"></a>
     <div id="new-member-message"></div>
     <div class="grid-block">
       <div class="grid-content medium-5 small-12 collapse -flex">

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -32,8 +32,6 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <% html_title t(:label_member_plural) -%>
 
-<% any_members = @members.any? %>
-
 <%= toolbar title: t(:label_member_plural) do %>
   <% if authorize_for(:members, :new) %>
     <li class="toolbar-item">
@@ -47,16 +45,14 @@ See docs/COPYRIGHT.rdoc for more details.
       </button>
     </li>
   <% end %>
-  <% if any_members %>
-    <li class="toolbar-item">
-      <button id="filter-member-button"
-              focus
-              title="<%= I18n.t(:description_filter) %>"
-              class="toggle-member-filter-link button">
-        <%= op_icon('button--icon icon-filter') %>
-      </button>
-    </li>
-  <% end %>
+  <li class="toolbar-item">
+    <button id="filter-member-button"
+            focus
+            title="<%= I18n.t(:description_filter) %>"
+            class="toggle-member-filter-link button">
+      <%= op_icon('button--icon icon-filter') %>
+    </button>
+  </li>
 <% end %>
 
 <%= error_messages_for 'member' %>
@@ -75,13 +71,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <div>
   <%= cell Members::UserFilterCell, params, @members_filter_options %>
-  <% if any_members %>
-    <%= cell Members::TableCell, @members, @members_table_options %>
-  <% elsif @is_filtered %>
-    <%= no_results_box custom_title: t(:notice_no_principals_found) %>
-  <% else %>
-    <%= no_results_box %>
-  <% end %>
+  <%= cell Members::TableCell, @members, @members_table_options %>
 </div>
 
 

--- a/frontend/src/global_styles/content/_tables.sass
+++ b/frontend/src/global_styles/content/_tables.sass
@@ -138,8 +138,6 @@ tr
         white-space: nowrap
 
   &.user
-    td
-      white-space: nowrap
     &.locked, &.registered, &.locked a, &.registered a
       color: #aaa
 

--- a/lib/open_project/deprecation.rb
+++ b/lib/open_project/deprecation.rb
@@ -39,6 +39,8 @@ module OpenProject::Deprecation
       end
     end
 
+    delegate :warn, to: :deprecator
+
     ##
     # Deprecate the given method with a notice regarding future removal
     #

--- a/modules/avatars/lib/open_project/avatars/patches/avatar_helper_patch.rb
+++ b/modules/avatars/lib/open_project/avatars/patches/avatar_helper_patch.rb
@@ -36,16 +36,18 @@ AvatarHelper.class_eval do
   module InstanceMethods
     # Returns the avatar image tag for the given +user+ if avatars are enabled
     # +user+ can be a User or a string that will be scanned for an email address (eg. 'joe <joe@foo.bar>')
-    def avatar(user, options = {})
-      if local_avatar? user
-        local_avatar_image_tag user, options
+    def avatar(principal, options = {})
+      return build_default_avatar_image_tag(principal, options) unless principal.is_a?(User)
+
+      if local_avatar? principal
+        local_avatar_image_tag principal, options
       elsif avatar_manager.gravatar_enabled?
-        build_gravatar_image_tag user, options
+        build_gravatar_image_tag principal, options
       else
-        build_default_avatar_image_tag user, options
+        build_default_avatar_image_tag principal, options
       end
     rescue StandardError => e
-      Rails.logger.error "Failed to create avatar for #{user}: #{e}"
+      Rails.logger.error "Failed to create avatar for #{principal}: #{e}"
       ''.html_safe
     end
 

--- a/spec/features/members/membership_spec.rb
+++ b/spec/features/members/membership_spec.rb
@@ -87,7 +87,7 @@ feature 'Administrating memberships via the project settings', type: :feature, j
       SeleniumHubWaiter.wait
       members_page.sort_by 'email'
       members_page.expect_sorted_by 'email'
-      expect(members_page.contents('email')).to eq [group.name, hannibal.mail, peter.mail]
+      expect(members_page.contents('email')).to eq [hannibal.mail, peter.mail]
 
       # Cannot sort by group, roles or status
       expect(page).to have_no_selector('.generic-table--sort-header a', text: 'ROLES')

--- a/spec/features/members/membership_spec.rb
+++ b/spec/features/members/membership_spec.rb
@@ -77,17 +77,17 @@ feature 'Administrating memberships via the project settings', type: :feature, j
 
     scenario 'sorting the page' do
       members_page.expect_sorted_by 'name'
-      expect(members_page.contents('name')).to eq ['', peter.name, hannibal.name]
+      expect(members_page.contents('name')).to eq [group.name, hannibal.name, peter.name]
 
       SeleniumHubWaiter.wait
       members_page.sort_by 'name'
       members_page.expect_sorted_by 'name', desc: true
-      expect(members_page.contents('name')).to eq [hannibal.name, peter.name, group.name]
+      expect(members_page.contents('name')).to eq [peter.name, hannibal.name, group.name]
 
       SeleniumHubWaiter.wait
       members_page.sort_by 'email'
       members_page.expect_sorted_by 'email'
-      expect(members_page.contents('email')).to eq ['', hannibal.mail, peter.mail]
+      expect(members_page.contents('email')).to eq [group.name, hannibal.mail, peter.mail]
 
       # Cannot sort by group, roles or status
       expect(page).to have_no_selector('.generic-table--sort-header a', text: 'ROLES')

--- a/spec/features/members/membership_spec.rb
+++ b/spec/features/members/membership_spec.rb
@@ -76,20 +76,13 @@ feature 'Administrating memberships via the project settings', type: :feature, j
     let!(:existing_members) { [member1, member2, member3] }
 
     scenario 'sorting the page' do
-      members_page.sort_by 'last name'
-      members_page.expect_sorted_by 'last name'
-
-      expect(members_page.contents('lastname')).to eq ['', peter.lastname, hannibal.lastname]
+      members_page.expect_sorted_by 'name'
+      expect(members_page.contents('name')).to eq ['', peter.name, hannibal.name]
 
       SeleniumHubWaiter.wait
-      members_page.sort_by 'last name'
-      members_page.expect_sorted_by 'last name', desc: true
-      expect(members_page.contents('lastname')).to eq [hannibal.lastname, peter.lastname, '']
-
-      SeleniumHubWaiter.wait
-      members_page.sort_by 'first name'
-      members_page.expect_sorted_by 'first name'
-      expect(members_page.contents('firstname')).to eq ['', hannibal.firstname, peter.firstname]
+      members_page.sort_by 'name'
+      members_page.expect_sorted_by 'name', desc: true
+      expect(members_page.contents('name')).to eq [hannibal.name, peter.name, group.name]
 
       SeleniumHubWaiter.wait
       members_page.sort_by 'email'

--- a/spec/features/members/membership_spec.rb
+++ b/spec/features/members/membership_spec.rb
@@ -89,7 +89,7 @@ feature 'Administrating memberships via the project settings', type: :feature, j
 
     scenario 'sorting the page' do
       members_page.expect_sorted_by 'name'
-      expect(members_page.contents('name')).to eq [hannibal.name, peter.name, group.name]
+      expect(members_page.contents('name')).to eq [group.name, hannibal.name, peter.name]
 
       SeleniumHubWaiter.wait
       members_page.sort_by 'name'

--- a/spec/features/members/membership_spec.rb
+++ b/spec/features/members/membership_spec.rb
@@ -37,8 +37,20 @@ feature 'Administrating memberships via the project settings', type: :feature, j
   end
   let!(:project) { FactoryBot.create :project }
 
-  let!(:peter)    { FactoryBot.create :user, firstname: 'Peter', lastname: 'Pan', mail: 'foo@example.org' }
-  let!(:hannibal) { FactoryBot.create :user, firstname: 'Hannibal', lastname: 'Smith', mail: 'boo@bar.org' }
+  let!(:peter) do
+    FactoryBot.create :user,
+                      status: User.statuses[:active],
+                      firstname: 'Peter',
+                      lastname: 'Pan',
+                      mail: 'foo@example.org'
+  end
+  let!(:hannibal) do
+    FactoryBot.create :user,
+                      status: User.statuses[:invited],
+                      firstname: 'Hannibal',
+                      lastname: 'Smith',
+                      mail: 'boo@bar.org'
+  end
   let!(:developer_placeholder) { FactoryBot.create :placeholder_user, name: 'Developer 1' }
   let!(:crash) do
     FactoryBot.create :user,
@@ -77,7 +89,7 @@ feature 'Administrating memberships via the project settings', type: :feature, j
 
     scenario 'sorting the page' do
       members_page.expect_sorted_by 'name'
-      expect(members_page.contents('name')).to eq [group.name, hannibal.name, peter.name]
+      expect(members_page.contents('name')).to eq [hannibal.name, peter.name, group.name]
 
       SeleniumHubWaiter.wait
       members_page.sort_by 'name'
@@ -89,10 +101,19 @@ feature 'Administrating memberships via the project settings', type: :feature, j
       members_page.expect_sorted_by 'email'
       expect(members_page.contents('email')).to eq [hannibal.mail, peter.mail]
 
+      SeleniumHubWaiter.wait
+      members_page.sort_by 'status'
+      members_page.expect_sorted_by 'status'
+      expect(members_page.contents('status', raw: true)).to eq %w(active active invited)
+
+      SeleniumHubWaiter.wait
+      members_page.sort_by 'status'
+      members_page.expect_sorted_by 'status', desc: true
+      expect(members_page.contents('status', raw: true)).to eq %w(invited active active)
+
       # Cannot sort by group, roles or status
       expect(page).to have_no_selector('.generic-table--sort-header a', text: 'ROLES')
       expect(page).to have_no_selector('.generic-table--sort-header a', text: 'GROUP')
-      expect(page).to have_no_selector('.generic-table--sort-header a', text: 'STATUS')
     end
   end
 
@@ -114,7 +135,7 @@ feature 'Administrating memberships via the project settings', type: :feature, j
 
     SeleniumHubWaiter.wait
     members_page.remove_user! 'Hannibal Smith'
-    expect(page).to have_text 'Removed Hannibal Smith from project'
+    expect(page).to have_text 'Hannibal Smith has been removed from the project and deleted.'
     expect(page).to have_text 'There are currently no members part of this project.'
   end
 

--- a/spec/features/members/pagination_spec.rb
+++ b/spec/features/members/pagination_spec.rb
@@ -53,11 +53,12 @@ feature 'members pagination', type: :feature, js: true do
 
     members_page.visit!
     SeleniumHubWaiter.wait
+    expect(members_page).to have_user 'Alice Alison' # members are sorted by last name desc
     members_page.add_user! 'Peter Pan', as: 'Manager'
 
     SeleniumHubWaiter.wait
     members_page.go_to_page! 2
-    expect(members_page).to have_user 'Alice Alison' # members are sorted by last name desc
+    expect(members_page).to have_user 'Peter Pan'
   end
 
   scenario 'Paginating after removing a member' do
@@ -66,12 +67,12 @@ feature 'members pagination', type: :feature, js: true do
 
     members_page.visit!
     SeleniumHubWaiter.wait
-    members_page.remove_user! 'Peter Pan'
+    members_page.remove_user! 'Alice Alison'
     expect(members_page).to have_user 'Bob Bobbit'
 
     SeleniumHubWaiter.wait
     members_page.go_to_page! 2
-    expect(members_page).to have_user 'Alice Alison'
+    expect(members_page).to have_user 'Peter Pan'
   end
 
   scenario 'Paginating after updating a member' do
@@ -79,12 +80,13 @@ feature 'members pagination', type: :feature, js: true do
 
     members_page.visit!
     SeleniumHubWaiter.wait
+    members_page.go_to_page! 2
     members_page.edit_user! 'Bob Bobbit', add_roles: ['Developer']
     expect(page).to have_text 'Successful update'
     expect(members_page).to have_user 'Bob Bobbit', roles: ['Developer', 'Manager']
 
     SeleniumHubWaiter.wait
-    members_page.go_to_page! 2
+    members_page.go_to_page! 1
     expect(members_page).to have_user 'Alice Alison'
   end
 end

--- a/spec/models/custom_actions/actions/assigned_to_spec.rb
+++ b/spec/models/custom_actions/actions/assigned_to_spec.rb
@@ -35,7 +35,7 @@ describe CustomActions::Actions::AssignedTo, type: :model do
     users = [FactoryBot.build_stubbed(:user),
              FactoryBot.build_stubbed(:group)]
     allow(Principal)
-      .to receive_message_chain(:not_locked, :select, :order_by_name)
+      .to receive_message_chain(:not_locked, :select, :ordered_by_name)
       .and_return(users)
 
     [{ value: nil, label: '-' },

--- a/spec/models/custom_actions/actions/notify_spec.rb
+++ b/spec/models/custom_actions/actions/notify_spec.rb
@@ -36,7 +36,7 @@ describe CustomActions::Actions::Notify, type: :model do
              FactoryBot.build_stubbed(:group)]
 
     allow(Principal)
-      .to receive_message_chain(:not_locked, :select, :order_by_name)
+      .to receive_message_chain(:not_locked, :select, :ordered_by_name)
             .and_return(users)
 
     [{ value: nil, label: '-' },
@@ -65,7 +65,7 @@ describe CustomActions::Actions::Notify, type: :model do
                       FactoryBot.build_stubbed(:user)]
 
         allow(Principal)
-          .to receive_message_chain(:not_locked, :select, :order_by_name, :where)
+          .to receive_message_chain(:not_locked, :select, :ordered_by_name, :where)
           .and_return(principals)
 
         instance.values = principals.map(&:id)

--- a/spec/models/custom_actions/actions/responsible_spec.rb
+++ b/spec/models/custom_actions/actions/responsible_spec.rb
@@ -36,7 +36,7 @@ describe CustomActions::Actions::Responsible, type: :model do
              FactoryBot.build_stubbed(:group)]
 
     allow(User)
-      .to receive_message_chain(:not_locked, :select, :order_by_name)
+      .to receive_message_chain(:not_locked, :select, :ordered_by_name)
             .and_return(principals)
 
     [{ value: nil, label: '-' },

--- a/spec/models/principals/scopes/ordered_by_name_spec.rb
+++ b/spec/models/principals/scopes/ordered_by_name_spec.rb
@@ -1,0 +1,88 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Principals::Scopes::OrderedByName, type: :model do
+  describe '.ordered_by_name' do
+    shared_let(:alice) { FactoryBot.create(:user, login: 'alice', firstname: 'Alice', lastname: 'Zetop') }
+    shared_let(:eve) { FactoryBot.create(:user, login: 'eve', firstname: 'Eve', lastname: 'Baddie') }
+
+    shared_let(:group) { FactoryBot.create(:group, groupname: 'Core Team') }
+    shared_let(:placeholder_user) { FactoryBot.create(:placeholder_user, name: 'Developers') }
+
+    let(:descending) { false }
+
+    subject { Principal.ordered_by_name(desc: descending).pluck(:id) }
+
+    shared_examples 'sorted results' do
+      it 'returns the correct ascending sort' do
+        expect(subject).to eq order
+      end
+
+      context 'reversed' do
+        let(:descending) { true }
+        it 'returns the correct descending sort' do
+          expect(subject).to eq order.reverse
+        end
+      end
+    end
+
+    context 'with default user sort', with_settings: {user_format: :firstname_lastname} do
+      it_behaves_like 'sorted results' do
+        let(:order) { [alice.id, group.id, placeholder_user.id, eve.id] }
+      end
+    end
+
+    context 'with lastname_firstname user sort', with_settings: {user_format: :lastname_firstname} do
+      it_behaves_like 'sorted results' do
+        let(:order) { [eve.id, group.id, placeholder_user.id, alice.id] }
+      end
+    end
+
+    context 'with lastname_coma_firstname user sort', with_settings: {user_format: :lastname_coma_firstname} do
+      it_behaves_like 'sorted results' do
+        let(:order) { [eve.id, group.id, placeholder_user.id, alice.id] }
+      end
+    end
+
+    context 'with firstname user sort', with_settings: {user_format: :firstname} do
+      it_behaves_like 'sorted results' do
+        let(:order) { [alice.id, group.id, placeholder_user.id, eve.id] }
+      end
+    end
+
+    context 'with login user sort', with_settings: {user_format: :login} do
+      it_behaves_like 'sorted results' do
+        let(:order) { [alice.id, group.id, placeholder_user.id, eve.id] }
+      end
+    end
+  end
+end

--- a/spec/models/queries/users/user_query_spec.rb
+++ b/spec/models/queries/users/user_query_spec.rb
@@ -180,9 +180,13 @@ describe Queries::Users::UserQuery, type: :model do
       instance.order(name: :desc)
     end
 
-    describe '#results' do
+    describe '#results', with_settings: { user_format: :firstname_lastname } do
       it 'is the same as handwriting the query' do
-        expected = User.user.merge(User.order_by_name.reverse_order).order(id: :desc)
+        expected = User
+            .user
+            .order(Arel.sql("NULLIF(users.firstname, '') DESC NULLS LAST"))
+            .order(Arel.sql("NULLIF(users.lastname, '') DESC NULLS LAST"))
+            .order(id: :desc)
 
         expect(instance.results.to_sql).to eql expected.to_sql
       end

--- a/spec/requests/api/v3/principals/principals_resource_spec.rb
+++ b/spec/requests/api/v3/principals/principals_resource_spec.rb
@@ -106,20 +106,21 @@ describe 'API v3 Principals resource', type: :request do
         .to eql(200)
     end
 
-    it_behaves_like 'API V3 collection response', 4, 4, 'User' do
+    it_behaves_like 'API V3 collection response', 4, 4 do
       let(:response) { last_response }
 
-      # The order_by_name scope currently has a bug in that it does not correctly handle
-      # null values (no first names for group and placeholder users) in the db.
-      # A user would expect placeholder and user to be sorted the other way around.
-      it 'has the group as the last and the placeholder as the second to last element' do
+      it 'has the group as the last and the placeholder as the second to last element', :aggregate_failures do
         is_expected
           .to be_json_eql('PlaceholderUser'.to_json)
-          .at_path('_embedded/elements/2/_type')
+          .at_path('_embedded/elements/0/_type')
 
         is_expected
           .to be_json_eql('Group'.to_json)
-          .at_path('_embedded/elements/3/_type')
+          .at_path('_embedded/elements/1/_type')
+
+        is_expected
+            .to be_json_eql('User'.to_json)
+                    .at_path('_embedded/elements/2/_type')
       end
     end
 
@@ -128,7 +129,7 @@ describe 'API v3 Principals resource', type: :request do
         [{ member: { operator: '=', values: [project.id.to_s] } }]
       end
 
-      it_behaves_like 'API V3 collection response', 3, 3, 'User' do
+      it_behaves_like 'API V3 collection response', 3, 3 do
         let(:response) { last_response }
       end
     end
@@ -138,7 +139,7 @@ describe 'API v3 Principals resource', type: :request do
         [{ type: { operator: '=', values: ['User'] } }]
       end
 
-      it_behaves_like 'API V3 collection response', 2, 2, 'User' do
+      it_behaves_like 'API V3 collection response', 2, 2, nil do
         let(:response) { last_response }
       end
     end

--- a/spec/requests/api/v3/support/api_v3_collection_response.rb
+++ b/spec/requests/api/v3/support/api_v3_collection_response.rb
@@ -58,7 +58,7 @@ shared_examples_for 'API V3 collection response' do |total, count, type|
       expect(subject).to be_json_eql(total_number.to_json).at_path('total')
       expect(subject).to have_json_size(count_number).at_path('_embedded/elements')
 
-      if count_number > 0
+      if type && count_number > 0
         expect(subject).to be_json_eql(type.to_json).at_path('_embedded/elements/0/_type')
       end
     end

--- a/spec/requests/api/v3/user/user_resource_spec.rb
+++ b/spec/requests/api/v3/user/user_resource_spec.rb
@@ -117,7 +117,7 @@ describe 'API v3 User resource',
 
       context 'on sorting' do
         let(:users_by_name_order) do
-          User.human.order_by_name(desc: true)
+          User.human.ordered_by_name(desc: true)
         end
 
         let(:get_path) do

--- a/spec/requests/api/v3/user/user_resource_spec.rb
+++ b/spec/requests/api/v3/user/user_resource_spec.rb
@@ -117,7 +117,7 @@ describe 'API v3 User resource',
 
       context 'on sorting' do
         let(:users_by_name_order) do
-          User.human.order_by_name.reverse_order
+          User.human.order_by_name(desc: true)
         end
 
         let(:get_path) do

--- a/spec/support/pages/members.rb
+++ b/spec/support/pages/members.rb
@@ -115,7 +115,7 @@ module Pages
     end
 
     def find_user(name)
-      find('tr', text: user_name_to_text(name))
+      find('tr', text: name)
     end
 
     def find_mail(mail)
@@ -123,13 +123,13 @@ module Pages
     end
 
     def find_group(name)
-      find('tr.group', text: user_name_to_text(name))
+      find('tr.group', text: name)
     end
 
     ##
     # Get contents of all cells sorted
     def contents(column)
-      all("td.#{column}").map(&:text)
+      all("td.#{column} a, td.#{column} span").map(&:text)
     end
 
     def user_name_to_text(name)

--- a/spec/support/pages/members.rb
+++ b/spec/support/pages/members.rb
@@ -227,7 +227,7 @@ module Pages
     end
 
     def go_to_page!(number)
-      find('.pagination a', text: number.to_s).click
+      find('.pagination--pages a', text: number.to_s).click
     end
   end
 end

--- a/spec/support/pages/members.rb
+++ b/spec/support/pages/members.rb
@@ -128,8 +128,15 @@ module Pages
 
     ##
     # Get contents of all cells sorted
-    def contents(column)
-      all("td.#{column} a, td.#{column} span").map(&:text)
+    def contents(column, raw: false)
+      nodes =
+        if raw
+          all("td.#{column}")
+        else
+          all("td.#{column} a, td.#{column} span")
+        end
+
+      nodes.map(&:text)
     end
 
     def user_name_to_text(name)

--- a/spec/support/pages/projects/destroy.rb
+++ b/spec/support/pages/projects/destroy.rb
@@ -25,6 +25,7 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
+require_relative '../page'
 
 module Pages
   module Projects

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -35,7 +35,7 @@ describe 'users/index', type: :view do
   before do
     User.system # create system user which is active but should not count towards limit
 
-    assign(:users, [admin, user])
+    assign(:users, User.where(id: [admin.id, user.id]))
     assign(:status, "all")
     assign(:groups, Group.all)
 


### PR DESCRIPTION
- [x] Output avatar for all types of principals
- [x] Remove first and lastname, add common name column that remains sortable
- [x] Extend members specs for this change 

https://community.openproject.com/wp/36136