### PR TITLE
add filtering for assignee/responsible with placeholder users

### DIFF
--- a/app/models/queries/work_packages/filter/principal_base_filter.rb
+++ b/app/models/queries/work_packages/filter/principal_base_filter.rb
@@ -34,8 +34,7 @@ class Queries::WorkPackages::Filter::PrincipalBaseFilter <
 
   def allowed_values
     @allowed_values ||= begin
-      values = principal_loader.user_values + principal_loader.group_values
-      me_allowed_value + values.sort
+      me_allowed_value + principal_loader.principal_values
     end
   end
 

--- a/app/models/queries/work_packages/filter/principal_loader.rb
+++ b/app/models/queries/work_packages/filter/principal_loader.rb
@@ -52,6 +52,12 @@ class Queries::WorkPackages::Filter::PrincipalLoader
   end
 
   def principal_values
+    @options ||= principals.map { |s| [s.name, s.id.to_s] }.sort
+  end
+
+  private
+
+  def principals
     if project
       project.principals.sort
     else
@@ -59,9 +65,7 @@ class Queries::WorkPackages::Filter::PrincipalLoader
     end
   end
 
-  private
-
   def principals_by_class
-    @principals_by_class ||= principal_values.group_by(&:class)
+    @principals_by_class ||= principals.group_by(&:class)
   end
 end

--- a/spec/features/work_packages/table/queries/assignee_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/assignee_filter_spec.rb
@@ -1,0 +1,93 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Work package filtering by assignee', js: true do
+  let(:project) { FactoryBot.create :project }
+  let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
+  let(:filters) { ::Components::WorkPackages::Filters.new }
+  let(:role) { FactoryBot.create(:role, permissions: [:view_work_packages, :save_queries]) }
+  let(:other_user) do
+    FactoryBot.create :user,
+                      firstname: 'Other',
+                      lastname: 'User',
+                      member_in_project: project,
+                      member_through_role: role
+  end
+  let(:placeholder_user) do
+    FactoryBot.create :placeholder_user,
+                      member_in_project: project,
+                      member_through_role: role
+  end
+
+  let!(:work_package_user_assignee) do
+    FactoryBot.create :work_package,
+                      project: project,
+                      assigned_to: other_user
+  end
+  let!(:work_package_placeholder_user_assignee) do
+    FactoryBot.create :work_package,
+                      project: project,
+                      assigned_to: placeholder_user
+  end
+
+  current_user do
+    FactoryBot.create :user,
+                      member_in_project: project,
+                      member_through_role: role
+  end
+
+  it 'shows the work package matching the assigned to filter' do
+    wp_table.visit!
+    wp_table.expect_work_package_listed(work_package_user_assignee, work_package_placeholder_user_assignee)
+
+    filters.open
+    filters.add_filter_by('Assignee', 'is', [other_user.name])
+
+    wp_table.ensure_work_package_not_listed!(work_package_placeholder_user_assignee)
+    wp_table.expect_work_package_listed(work_package_user_assignee)
+
+    wp_table.save_as('Subject query')
+
+    wp_table.expect_and_dismiss_notification(message: 'Successful creation.')
+
+    # Revisit query
+    wp_table.visit_query Query.last
+    wp_table.ensure_work_package_not_listed!(work_package_placeholder_user_assignee)
+    wp_table.expect_work_package_listed(work_package_user_assignee)
+
+    filters.open
+    filters.expect_filter_by('Assignee', 'is', [other_user.name])
+    filters.remove_filter 'assignee'
+    filters.add_filter_by('Assignee', 'is', [placeholder_user.name])
+
+    wp_table.ensure_work_package_not_listed!(work_package_user_assignee)
+    wp_table.expect_work_package_listed(work_package_placeholder_user_assignee)
+  end
+end

--- a/spec/features/work_packages/table/queries/responsible_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/responsible_filter_spec.rb
@@ -1,0 +1,93 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Work package filtering by responsible', js: true do
+  let(:project) { FactoryBot.create :project }
+  let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
+  let(:filters) { ::Components::WorkPackages::Filters.new }
+  let(:role) { FactoryBot.create(:role, permissions: [:view_work_packages, :save_queries]) }
+  let(:other_user) do
+    FactoryBot.create :user,
+                      firstname: 'Other',
+                      lastname: 'User',
+                      member_in_project: project,
+                      member_through_role: role
+  end
+  let(:placeholder_user) do
+    FactoryBot.create :placeholder_user,
+                      member_in_project: project,
+                      member_through_role: role
+  end
+
+  let!(:work_package_user_responsible) do
+    FactoryBot.create :work_package,
+                      project: project,
+                      responsible: other_user
+  end
+  let!(:work_package_placeholder_user_responsible) do
+    FactoryBot.create :work_package,
+                      project: project,
+                      responsible: placeholder_user
+  end
+
+  current_user do
+    FactoryBot.create :user,
+                      member_in_project: project,
+                      member_through_role: role
+  end
+
+  it 'shows the work package matching the responsible filter' do
+    wp_table.visit!
+    wp_table.expect_work_package_listed(work_package_user_responsible, work_package_placeholder_user_responsible)
+
+    filters.open
+    filters.add_filter_by('Accountable', 'is', [other_user.name], 'responsible')
+
+    wp_table.ensure_work_package_not_listed!(work_package_placeholder_user_responsible)
+    wp_table.expect_work_package_listed(work_package_user_responsible)
+
+    wp_table.save_as('Responsible query')
+
+    wp_table.expect_and_dismiss_notification(message: 'Successful creation.')
+
+    # Revisit query
+    wp_table.visit_query Query.last
+    wp_table.ensure_work_package_not_listed!(work_package_placeholder_user_responsible)
+    wp_table.expect_work_package_listed(work_package_user_responsible)
+
+    filters.open
+    filters.expect_filter_by('Accountable', 'is', [other_user.name], 'responsible')
+    filters.remove_filter 'responsible'
+    filters.add_filter_by('Accountable', 'is', [placeholder_user.name], 'responsible')
+
+    wp_table.ensure_work_package_not_listed!(work_package_user_responsible)
+    wp_table.expect_work_package_listed(work_package_placeholder_user_responsible)
+  end
+end

--- a/spec/features/work_packages/table/queries/subject_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/subject_filter_spec.rb
@@ -30,7 +30,6 @@ require 'spec_helper'
 
 describe 'Work package filtering by subject', js: true do
   let(:project) { FactoryBot.create :project, public: true }
-  let(:role) { FactoryBot.create :existing_role, permissions: [:view_work_packages] }
   let(:admin) { FactoryBot.create :admin }
   let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
   let(:filters) { ::Components::WorkPackages::Filters.new }

--- a/spec/models/queries/work_packages/filter/assigned_to_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/assigned_to_filter_spec.rb
@@ -61,7 +61,7 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
       before do
         allow(User)
           .to receive(:current)
-                .and_return(assignee)
+          .and_return(assignee)
       end
 
       it 'returns the work package' do
@@ -84,7 +84,7 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
       before do
         allow(User)
           .to receive(:current)
-                .and_return(FactoryBot.create(:user))
+          .and_return(FactoryBot.create(:user))
       end
 
       it 'does not return the work package' do
@@ -106,7 +106,7 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
 
         allow(User)
           .to receive(:current)
-                .and_return(user)
+          .and_return(user)
       end
 
       it 'returns the mapped value' do
@@ -184,42 +184,34 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
     let(:type) { :list_optional }
     let(:class_key) { :assigned_to_id }
 
-    let(:user_1) { FactoryBot.build_stubbed(:user) }
-    let(:group_1) { FactoryBot.build_stubbed(:group) }
+    let(:user) { FactoryBot.build_stubbed(:user) }
+    let(:group) { FactoryBot.build_stubbed(:group) }
+    let(:placeholder_user) { FactoryBot.build_stubbed(:group) }
 
     let(:principal_loader) do
-      loader = double('principal_loader')
-      allow(loader)
-        .to receive(:user_values)
-              .and_return(user_values)
-      allow(loader)
-        .to receive(:group_values)
-              .and_return(group_values)
-
-      loader
+      double('principal_loader', principal_values: principal_values)
     end
-    let(:user_values) { [] }
-    let(:group_values) { [] }
+    let(:principal_values) { [] }
 
     describe '#valid_values!' do
-      let(:user_values) { [[user_1.name, user_1.id.to_s]] }
+      let(:principal_values) { [[user.name, user.id.to_s]] }
 
       before do
-        instance.values = [user_1.id.to_s, '99999']
+        instance.values = [user.id.to_s, '99999']
       end
 
       it 'remove the invalid value' do
         instance.valid_values!
 
-        expect(instance.values).to match_array [user_1.id.to_s]
+        expect(instance.values).to match_array [user.id.to_s]
       end
     end
 
     before do
       allow(Queries::WorkPackages::Filter::PrincipalLoader)
         .to receive(:new)
-              .with(project)
-              .and_return(principal_loader)
+        .with(project)
+        .and_return(principal_loader)
     end
 
     describe '#available?' do
@@ -228,52 +220,76 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
       before do
         allow(User)
           .to receive_message_chain(:current, :logged?)
-                .and_return(logged_in)
+          .and_return(logged_in)
       end
 
       context 'when being logged in' do
-        it 'is true if no other user is available' do
-          expect(instance).to be_available
+        context 'if no value is available' do
+          let(:principal_values) { [] }
+
+          it 'is true' do
+            expect(instance).to be_available
+          end
         end
 
-        it 'is true if there is another user selectable' do
-          allow(principal_loader)
-            .to receive(:user_values)
-                  .and_return([user_1])
+        context 'if a user is available' do
+          let(:principal_values) { [[user.name, user.id.to_s]] }
 
-          expect(instance).to be_available
+          it 'is true' do
+            expect(instance).to be_available
+          end
         end
 
-        it 'is true if there is another group selectable' do
-          allow(principal_loader)
-            .to receive(:group_values)
-                  .and_return([[group_1.name, group_1.id.to_s]])
+        context 'if a placeholder user is available' do
+          let(:principal_values) { [[placeholder_user.name, placeholder_user.id.to_s]] }
 
-          expect(instance).to be_available
+          it 'is true' do
+            expect(instance).to be_available
+          end
+        end
+
+        context 'if another group selectable' do
+          let(:principal_values) { [[group.name, group.id.to_s]] }
+
+          it 'is true' do
+            expect(instance).to be_available
+          end
         end
       end
 
       context 'when not being logged in' do
         let(:logged_in) { false }
 
-        it 'is false if no other user is available' do
-          expect(instance).to_not be_available
+        context 'if no value is available' do
+          let(:principal_values) { [] }
+
+          it 'is false' do
+            expect(instance).not_to be_available
+          end
         end
 
-        it 'is true if there is another user selectable' do
-          allow(principal_loader)
-            .to receive(:user_values)
-                  .and_return([[user_1.name, user_1.id.to_s]])
+        context 'if a user is available' do
+          let(:principal_values) { [[user.name, user.id.to_s]] }
 
-          expect(instance).to be_available
+          it 'is true' do
+            expect(instance).to be_available
+          end
         end
 
-        it 'is true if there is another group selectable' do
-          allow(principal_loader)
-            .to receive(:group_values)
-                  .and_return([[group_1.name, group_1.id.to_s]])
+        context 'if a placeholder user is available' do
+          let(:principal_values) { [[placeholder_user.name, placeholder_user.id.to_s]] }
 
-          expect(instance).to be_available
+          it 'is true' do
+            expect(instance).to be_available
+          end
+        end
+
+        context 'if another group selectable' do
+          let(:principal_values) { [[group.name, group.id.to_s]] }
+
+          it 'is true' do
+            expect(instance).to be_available
+          end
         end
       end
     end
@@ -284,23 +300,19 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
       before do
         allow(User)
           .to receive_message_chain(:current, :logged?)
-                .and_return(logged_in)
+          .and_return(logged_in)
 
         allow(principal_loader)
-          .to receive(:user_values)
-                .and_return([[user_1.name, user_1.id.to_s]])
-
-        allow(principal_loader)
-          .to receive(:group_values)
-                .and_return([[group_1.name, group_1.id.to_s]])
+          .to receive(:principal_values)
+          .and_return([[user.name, user.id.to_s], [group.name, group.id.to_s]])
       end
 
       context 'when being logged in' do
         it 'returns the me value and the available users and groups' do
           expect(instance.allowed_values)
             .to match_array([[I18n.t(:label_me), 'me'],
-                             [user_1.name, user_1.id.to_s],
-                             [group_1.name, group_1.id.to_s]])
+                             [user.name, user.id.to_s],
+                             [group.name, group.id.to_s]])
         end
       end
 
@@ -309,8 +321,8 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
 
         it 'returns the available users' do
           expect(instance.allowed_values)
-            .to match_array([[user_1.name, user_1.id.to_s],
-                             [group_1.name, group_1.id.to_s]])
+            .to match_array([[user.name, user.id.to_s],
+                             [group.name, group.id.to_s]])
         end
       end
     end

--- a/spec/models/queries/work_packages/filter/responsible_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/responsible_filter_spec.rb
@@ -192,10 +192,7 @@ describe Queries::WorkPackages::Filter::ResponsibleFilter, type: :model do
     let(:principal_loader) do
       loader = double('principal_loader')
       allow(loader)
-        .to receive(:user_values)
-        .and_return([])
-      allow(loader)
-        .to receive(:group_values)
+        .to receive(:principal_values)
         .and_return([])
 
       loader
@@ -224,8 +221,8 @@ describe Queries::WorkPackages::Filter::ResponsibleFilter, type: :model do
 
         it 'is true if there is another user selectable' do
           allow(principal_loader)
-            .to receive(:user_values)
-            .and_return([user_1])
+            .to receive(:principal_values)
+            .and_return([user_1.name, user_1.id.to_s])
 
           expect(instance).to be_available
         end
@@ -240,7 +237,7 @@ describe Queries::WorkPackages::Filter::ResponsibleFilter, type: :model do
 
         it 'is true if there is another user selectable' do
           allow(principal_loader)
-            .to receive(:user_values)
+            .to receive(:principal_values)
             .and_return([[user_1.name, user_1.id.to_s]])
 
           expect(instance).to be_available
@@ -258,12 +255,9 @@ describe Queries::WorkPackages::Filter::ResponsibleFilter, type: :model do
           .and_return(logged_in)
 
         allow(principal_loader)
-          .to receive(:user_values)
-          .and_return([[user_1.name, user_1.id.to_s]])
-
-        allow(principal_loader)
-          .to receive(:group_values)
-          .and_return([[group.name, group.id.to_s]])
+          .to receive(:principal_values)
+          .and_return([[user_1.name, user_1.id.to_s],
+                       [group.name, group.id.to_s]])
       end
 
       context 'when being logged in' do

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -29,6 +29,10 @@
 require 'rack_session_access/capybara'
 
 module AuthenticationHelpers
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
   def login_as(user)
     if is_a? RSpec::Rails::FeatureExampleGroup
       # If we want to mock having finished the login process
@@ -54,6 +58,18 @@ module AuthenticationHelpers
 
   def logout
     visit signout_path
+  end
+
+  module ClassMethods
+    # Sets the current user.
+    # Will make the return value available in the specs as current_user (using a let block)
+    # and treat that user as the one currently being logged in
+    # @block [Proc] The user to log in.
+    def current_user(&block)
+      let(:current_user, &block)
+
+      before { login_as current_user }
+    end
   end
 end
 


### PR DESCRIPTION
Introduces filtering work package by placeholder users:

- [x] on Assignee
- [x] on Responsible
- ~on user custom fields~ Since https://github.com/opf/openproject/pull/8972 needs to add the capability to select placeholder users as values first, filtering for it is excluded for the time being 

It also introduces a new method usable in specs

`current_user { FactoryBot.create(:user) }`

It is syntactic sugar and replaces:

```
let(:current_user) { FactoryBot.create(:user) }

before { login_as(current_user) }
```