### PR TITLE
use AR`s scope method instead of singleton class method

### DIFF
--- a/app/models/activities/base_activity_provider.rb
+++ b/app/models/activities/base_activity_provider.rb
@@ -250,7 +250,7 @@ class Activities::BaseActivityProvider
   def aggregated_journal_query
     # As AggregatedJournal wraps the provided sql statement inside brackets we
     # need to provide a fully valid statement and not only the alias string.
-    Journal::Scopes::AggregatedJournal.fetch(sql: "SELECT * FROM #{aggregated_journals_alias}").arel
+    Journal.aggregated_journal(sql: "SELECT * FROM #{aggregated_journals_alias}").arel
   end
 
   def add_event_selection_query_as_cte(query, user, from, to, options)

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -33,6 +33,7 @@ class Journal < ApplicationRecord
   include ::JournalChanges
   include ::JournalFormatter
   include ::Acts::Journalized::FormatHooks
+  include ::Journal::Scopes::AggregatedJournal
 
   register_journal_formatter :diff, OpenProject::JournalFormatter::Diff
   register_journal_formatter :attachment, OpenProject::JournalFormatter::Attachment

--- a/app/models/journal/scopes/aggregated_journal.rb
+++ b/app/models/journal/scopes/aggregated_journal.rb
@@ -31,16 +31,17 @@
 # Scope to fetch all fields necessary to populated AggregatedJournal collections.
 # See the AggregatedJournal model class for a description.
 module Journal::Scopes
-  class AggregatedJournal
-    class << self
-      def fetch(journable: nil, sql: nil, until_version: nil)
+  module AggregatedJournal
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def aggregated_journal(journable: nil, sql: nil, until_version: nil)
         journals_preselection = raw_journals_subselect(journable, sql, until_version)
 
         # We wrap the sql with a subselect so that outside of this class,
         # The fields native to journals (e.g. id, version) can be referenced, without
         # having to also use a CASE/COALESCE statement.
-        Journal
-          .from(select_sql(journals_preselection))
+        from(select_sql(journals_preselection))
           .select("DISTINCT *")
       end
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -50,11 +50,12 @@ class Member < ApplicationRecord
   after_save :save_notification
   after_destroy :destroy_notification
 
-  scope_classes Members::Scopes::Global,
-                Members::Scopes::Visible,
-                Members::Scopes::Of,
-                Members::Scopes::Assignable,
-                Members::Scopes::NotLocked
+
+  scopes :assignable,
+         :global,
+         :not_locked,
+         :of,
+         :visible
 
   def name
     principal.name

--- a/app/models/members/scopes/assignable.rb
+++ b/app/models/members/scopes/assignable.rb
@@ -28,16 +28,19 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-# Find all members that are whose principals are not locked and have an
-# assignable role.
 module Members::Scopes
-  class Assignable
-    def self.fetch
-      Member
-        .not_locked
-        .includes(:roles)
-        .references(:roles)
-        .where(roles: { assignable: true })
+  module Assignable
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Find all members that are whose principals are not locked and have an
+      # assignable role.
+      def assignable
+        not_locked
+          .includes(:roles)
+          .references(:roles)
+          .where(roles: { assignable: true })
+      end
     end
   end
 end

--- a/app/models/members/scopes/global.rb
+++ b/app/models/members/scopes/global.rb
@@ -28,11 +28,15 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-# Find all members that are global, i.e. have not project
 module Members::Scopes
-  class Global
-    def self.fetch
-      Member.where(project: nil)
+  module Global
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Find all members that are global, i.e. have not project
+      def global
+        where(project: nil)
+      end
     end
   end
 end

--- a/app/models/members/scopes/not_locked.rb
+++ b/app/models/members/scopes/not_locked.rb
@@ -28,14 +28,17 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-# Find all members whose principals are not locked.
 module Members::Scopes
-  class NotLocked
-    def self.fetch
-      Member
-        .includes(:principal)
-        .references(:principals)
-        .merge(Principal.not_locked, rewhere: true)
+  module NotLocked
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Find all members whose principals are not locked.
+      def not_locked
+        includes(:principal)
+          .references(:principals)
+          .merge(Principal.not_locked, rewhere: true)
+      end
     end
   end
 end

--- a/app/models/members/scopes/of.rb
+++ b/app/models/members/scopes/of.rb
@@ -28,11 +28,15 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-# Find all members of a project
 module Members::Scopes
-  class Of
-    def self.fetch(project)
-      Member.where(project_id: project)
+  module Of
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Find all members of a project
+      def of(project)
+        where(project_id: project)
+      end
     end
   end
 end

--- a/app/models/members/scopes/visible.rb
+++ b/app/models/members/scopes/visible.rb
@@ -28,11 +28,13 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-# Find all members visible to the inquiring user
 module Members::Scopes
-  class Visible
-    class << self
-      def fetch(user)
+  module Visible
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Find all members visible to the inquiring user
+      def visible(user)
         if user.admin?
           visible_for_admins
         else

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -57,12 +57,12 @@ class Principal < ApplicationRecord
   has_many :projects, through: :memberships
   has_many :categories, foreign_key: 'assigned_to_id', dependent: :nullify
 
-  scope_classes Principals::Scopes::NotBuiltin,
-                Principals::Scopes::User,
-                Principals::Scopes::Human,
-                Principals::Scopes::Like,
-                Principals::Scopes::PossibleMember,
-                Principals::Scopes::PossibleAssignee
+  scopes :like,
+         :human,
+         :not_builtin,
+         :possible_assignee,
+         :possible_member,
+         :user
 
   scope :not_locked, -> {
     not_builtin.where.not(status: statuses[:locked])

--- a/app/models/principals/scopes/human.rb
+++ b/app/models/principals/scopes/human.rb
@@ -33,10 +33,14 @@
 #   * User
 #   * Group
 module Principals::Scopes
-  class Human
-    def self.fetch
-      Principal.where(type: [::User.name,
-                             Group.name])
+  module Human
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def human
+        where(type: [::User.name,
+                     Group.name])
+      end
     end
   end
 end

--- a/app/models/principals/scopes/like.rb
+++ b/app/models/principals/scopes/like.rb
@@ -34,20 +34,23 @@
 # * lastname
 # matches the provided string
 module Principals::Scopes
-  class Like
-    def self.fetch(search_string)
-      firstnamelastname = "((firstname || ' ') || lastname)"
-      lastnamefirstname = "((lastname || ' ') || firstname)"
+  module Like
+    extend ActiveSupport::Concern
 
-      s = "%#{search_string.to_s.downcase.strip.tr(',', '')}%"
+    class_methods do
+      def like(query)
+        firstnamelastname = "((firstname || ' ') || lastname)"
+        lastnamefirstname = "((lastname || ' ') || firstname)"
 
-      Principal
-        .where(['LOWER(login) LIKE :s OR ' +
-                "LOWER(#{firstnamelastname}) LIKE :s OR " +
-                "LOWER(#{lastnamefirstname}) LIKE :s OR " +
-                'LOWER(mail) LIKE :s',
-             { s: s }])
-        .order(:type, :login, :lastname, :firstname, :mail)
+        s = "%#{query.to_s.downcase.strip.tr(',', '')}%"
+
+        where(['LOWER(login) LIKE :s OR ' +
+               "LOWER(#{firstnamelastname}) LIKE :s OR " +
+               "LOWER(#{lastnamefirstname}) LIKE :s OR " +
+               'LOWER(mail) LIKE :s',
+                  { s: s }])
+          .order(:type, :login, :lastname, :firstname, :mail)
+      end
     end
   end
 end

--- a/app/models/principals/scopes/not_builtin.rb
+++ b/app/models/principals/scopes/not_builtin.rb
@@ -35,11 +35,15 @@
 #   * SystemUser
 #   * AnonymousUser
 module Principals::Scopes
-  class NotBuiltin
-    def self.fetch
-      Principal.where.not(type: [SystemUser.name,
-                                 AnonymousUser.name,
-                                 DeletedUser.name])
+  module NotBuiltin
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def not_builtin
+        where.not(type: [SystemUser.name,
+                         AnonymousUser.name,
+                         DeletedUser.name])
+      end
     end
   end
 end

--- a/app/models/principals/scopes/possible_assignee.rb
+++ b/app/models/principals/scopes/possible_assignee.rb
@@ -29,24 +29,27 @@
 #++
 
 module Principals::Scopes
-  class PossibleAssignee
-    # Returns principals eligible to be assigned to a work package as:
-    # * assignee
-    # * responsible
-    # Those principals can be of class
-    # * User
-    # * PlaceholderUser
-    # * Group
-    # User instances need to be non locked (status).
-    # Only principals with a role marked as assignable in the project are returned.
-    # @project [Project] The project for which eligible candidates are to be searched
-    # @return [ActiveRecord::Relation] A scope of eligible candidates
-    def self.fetch(project)
-      Principal
-        .not_locked
-        .includes(:members)
-        .references(:members)
-        .merge(Member.assignable.of(project))
+  module PossibleAssignee
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Returns principals eligible to be assigned to a work package as:
+      # * assignee
+      # * responsible
+      # Those principals can be of class
+      # * User
+      # * PlaceholderUser
+      # * Group
+      # User instances need to be non locked (status).
+      # Only principals with a role marked as assignable in the project are returned.
+      # @project [Project] The project for which eligible candidates are to be searched
+      # @return [ActiveRecord::Relation] A scope of eligible candidates
+      def possible_assignee(project)
+        not_locked
+          .includes(:members)
+          .references(:members)
+          .merge(Member.assignable.of(project))
+      end
     end
   end
 end

--- a/app/models/principals/scopes/possible_member.rb
+++ b/app/models/principals/scopes/possible_member.rb
@@ -29,21 +29,25 @@
 #++
 
 module Principals::Scopes
-  class PossibleMember
-    # Returns principals eligible to become project members. Those principals can be of class
-    # * User
-    # * PlaceholderUser
-    # * Group
-    # User instances need to be non locked (status)
-    # Principals which already are project members are are returned.
-    # @project [Project] The project for which eligible candidates are to be searched
-    # @return [ActiveRecord::Relation] A scope of eligible candidates
-    def self.fetch(project)
-      Queries::Principals::PrincipalQuery
-        .new(user: ::User.current)
-        .where(:member, '!', [project.id])
-        .where(:status, '!', [Principal.statuses[:locked]])
-        .results
+  module PossibleMember
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Returns principals eligible to become project members. Those principals can be of class
+      # * User
+      # * PlaceholderUser
+      # * Group
+      # User instances need to be non locked (status)
+      # Principals which already are project members are are returned.
+      # @project [Project] The project for which eligible candidates are to be searched
+      # @return [ActiveRecord::Relation] A scope of eligible candidates
+      def possible_member(project)
+        Queries::Principals::PrincipalQuery
+          .new(user: ::User.current)
+          .where(:member, '!', [project.id])
+          .where(:status, '!', [statuses[:locked]])
+          .results
+      end
     end
   end
 end

--- a/app/models/principals/scopes/user.rb
+++ b/app/models/principals/scopes/user.rb
@@ -30,11 +30,15 @@
 
 # Only return Principals that are of type User
 module Principals::Scopes
-  class User
-    def self.fetch
-      # Have to use the User model here so that the scopes defined on User
-      # are also available after the scope is used.
-      ::User.where(type: [::User.name])
+  module User
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def user
+        # Have to use the User model here so that the scopes defined on User
+        # are also available after the scope is used.
+        where(type: [::User.name])
+      end
     end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -134,8 +134,8 @@ class Project < ApplicationRecord
   scope :newest, -> { order(created_at: :desc) }
   scope :active, -> { where(active: true) }
 
-  scope_classes Projects::Scopes::ActivatedTimeActivity,
-                Projects::Scopes::VisibleWithActivatedTimeActivity
+  scopes :activated_time_activity,
+         :visible_with_activated_time_activity
 
   def visible?(user = User.current)
     active? and (public? or user.admin? or user.member_of?(self))

--- a/app/models/projects/scopes/activated_time_activity.rb
+++ b/app/models/projects/scopes/activated_time_activity.rb
@@ -29,23 +29,27 @@
 #++
 
 module Projects::Scopes
-  class ActivatedTimeActivity
-    def self.fetch(time_entry_activity)
-      join_condition = <<-SQL
-        LEFT OUTER JOIN time_entry_activities_projects
-          ON projects.id = time_entry_activities_projects.project_id
-          AND time_entry_activities_projects.activity_id = #{time_entry_activity.id}
-      SQL
+  module ActivatedTimeActivity
+    extend ActiveSupport::Concern
 
-      join_scope = Project.joins(join_condition)
+    class_methods do
+      def activated_time_activity(time_entry_activity)
+        join_condition = <<-SQL
+          LEFT OUTER JOIN time_entry_activities_projects
+            ON projects.id = time_entry_activities_projects.project_id
+            AND time_entry_activities_projects.activity_id = #{time_entry_activity.id}
+        SQL
 
-      result_scope = join_scope.where(time_entry_activities_projects: { active: true })
+        join_scope = joins(join_condition)
 
-      if time_entry_activity.active?
-        result_scope
-          .or(join_scope.where(time_entry_activities_projects: { project_id: nil }))
-      else
-        result_scope
+        result_scope = join_scope.where(time_entry_activities_projects: { active: true })
+
+        if time_entry_activity.active?
+          result_scope
+            .or(join_scope.where(time_entry_activities_projects: { project_id: nil }))
+        else
+          result_scope
+        end
       end
     end
   end

--- a/app/models/projects/scopes/visible_with_activated_time_activity.rb
+++ b/app/models/projects/scopes/visible_with_activated_time_activity.rb
@@ -29,23 +29,20 @@
 #++
 
 module Projects::Scopes
-  class VisibleWithActivatedTimeActivity
-    class << self
-      def fetch(activity)
+  module VisibleWithActivatedTimeActivity
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def visible_with_activated_time_activity(activity)
         allowed_scope
-          .where(id: activated_projects(activity).select(:id))
+          .where(id: activated_time_activity(activity).select(:id))
       end
 
       private
 
-      def activated_projects(activity)
-        Project.activated_time_activity(activity)
-      end
-
       def allowed_scope
-        Project
-          .where(id: Project.allowed_to(User.current, :view_time_entries).select(:id))
-          .or(Project.where(id: Project.allowed_to(User.current, :view_own_time_entries).select(:id)))
+        where(id: allowed_to(User.current, :view_time_entries).select(:id))
+          .or(where(id: Project.allowed_to(User.current, :view_own_time_entries).select(:id)))
       end
     end
   end

--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -97,7 +97,7 @@ class Queries::WorkPackages::Columns::PropertyColumn < Queries::WorkPackages::Co
     },
     version: {
       association: 'version',
-      sortable: [->(table_name = Version.table_name) { Versions::Scopes::OrderBySemverName.semver_sql(table_name) }, 'name'],
+      sortable: [->(table_name = Version.table_name) { Version.semver_sql(table_name) }, 'name'],
       default_order: 'ASC',
       null_handling: 'NULLS LAST',
       groupable: "#{WorkPackage.table_name}.version_id"

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -33,7 +33,7 @@ class Relation < ApplicationRecord
 
   include ::Scopes::Scoped
 
-  scope_classes Relations::Scopes::FollowsNonManualAncestors
+  scopes :follows_non_manual_ancestors
 
   scope :of_work_package,
         ->(work_package) { where('from_id = ? OR to_id = ?', work_package, work_package) }

--- a/app/models/scopes/scoped.rb
+++ b/app/models/scopes/scoped.rb
@@ -30,11 +30,9 @@ module Scopes::Scoped
   extend ActiveSupport::Concern
 
   included do
-    def self.scope_classes(*classes)
+    def self.scopes(*classes)
       classes.each do |klass|
-        scope_name = klass.name.demodulize.underscore
-
-        scope(scope_name, klass.method(:fetch))
+        include "#{name.pluralize}::Scopes::#{klass.to_s.camelize}".constantize
       end
     end
   end

--- a/app/models/scopes/scoped.rb
+++ b/app/models/scopes/scoped.rb
@@ -32,11 +32,9 @@ module Scopes::Scoped
   included do
     def self.scope_classes(*classes)
       classes.each do |klass|
-        scope = klass.name.demodulize.underscore
+        scope_name = klass.name.demodulize.underscore
 
-        define_singleton_method(scope) do |*args|
-          klass.fetch(*args)
-        end
+        scope(scope_name, klass.method(:fetch))
       end
     end
   end

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -66,7 +66,7 @@ class ::Type < ApplicationRecord
 
   validates_inclusion_of :is_default, :is_milestone, in: [true, false]
 
-  scope_classes Types::Scopes::Milestone
+  scopes :milestone
 
   default_scope { order('position ASC') }
 

--- a/app/models/types/scopes/milestone.rb
+++ b/app/models/types/scopes/milestone.rb
@@ -29,10 +29,12 @@
 #++
 
 module Types::Scopes
-  class Milestone
-    class << self
-      def fetch
-        Type.where(is_milestone: true)
+  module Milestone
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def milestone
+        where(is_milestone: true)
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,8 +87,8 @@ class User < Principal
   scope :blocked, -> { create_blocked_scope(self, true) }
   scope :not_blocked, -> { create_blocked_scope(self, false) }
 
-  scope_classes Users::Scopes::FindByLogin,
-                Users::Scopes::Newest
+  scopes :find_by_login,
+         :newest
 
   def self.create_blocked_scope(scope, blocked)
     scope.where(blocked_condition(blocked))

--- a/app/models/users/scopes/find_by_login.rb
+++ b/app/models/users/scopes/find_by_login.rb
@@ -30,9 +30,13 @@
 
 # Find a user account by matching case-insensitive.
 module Users::Scopes
-  class FindByLogin
-    def self.fetch(login)
-      User.where(["LOWER(login) = ?", login.to_s.downcase]).first
+  module FindByLogin
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def self.find_by_login(login)
+        where(["LOWER(login) = ?", login.to_s.downcase]).first
+      end
     end
   end
 end

--- a/app/models/users/scopes/newest.rb
+++ b/app/models/users/scopes/newest.rb
@@ -28,12 +28,16 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-# Returns users sorted by their creation date. Inheriting classes are
-# excluded.
 module Users::Scopes
-  class Newest
-    def self.fetch
-      User.user.order(created_at: :desc)
+  module Newest
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Returns users sorted by their creation date. Inheriting classes are
+      # excluded.
+      def newest
+        user.order(created_at: :desc)
+      end
     end
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -48,7 +48,7 @@ class Version < ApplicationRecord
   validates_inclusion_of :status, in: VERSION_STATUSES
   validate :validate_start_date_before_effective_date
 
-  scope_classes ::Versions::Scopes::OrderBySemverName
+  scopes :order_by_semver_name
 
   scope :visible, ->(*args) {
     joins(:project)

--- a/app/models/versions/scopes/order_by_semver_name.rb
+++ b/app/models/versions/scopes/order_by_semver_name.rb
@@ -29,10 +29,12 @@
 #++
 
 module Versions::Scopes
-  class OrderBySemverName
-    class << self
-      def fetch
-        Version.reorder semver_sql, :name
+  module OrderBySemverName
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def order_by_semver_name
+        reorder semver_sql, :name
       end
 
       # Returns an sql for ordering which:

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -117,10 +117,10 @@ class WorkPackage < ApplicationRecord
     where(author_id: author.id)
   }
 
-  scope_classes WorkPackages::Scopes::ForScheduling,
-                WorkPackages::Scopes::IncludeSpentTime,
-                WorkPackages::Scopes::IncludeDerivedDates,
-                WorkPackages::Scopes::LeftJoinSelfAndDescendants
+  scopes :for_scheduling,
+         :include_derived_dates,
+         :include_spent_time,
+         :left_join_self_and_descendants
 
   acts_as_watchable
 

--- a/app/models/work_packages/scopes/for_scheduling.rb
+++ b/app/models/work_packages/scopes/for_scheduling.rb
@@ -30,8 +30,10 @@
 #
 
 module WorkPackages::Scopes
-  class ForScheduling
-    class << self
+  module ForScheduling
+    extend ActiveSupport::Concern
+
+    class_methods do
       # Fetches all work packages that need to be evaluated for eventual rescheduling after a related (i.e. follows/precedes
       # and hierarchy) work package is modified or created.
       #
@@ -74,8 +76,8 @@ module WorkPackages::Scopes
       #
       # @param work_packages WorkPackage[] A set of work packages for which the set of related work packages that might
       # be subject to reschedule is fetched.
-      def fetch(work_packages)
-        return WorkPackage.none if work_packages.empty?
+      def for_scheduling(work_packages)
+        return none if work_packages.empty?
 
         sql = <<~SQL
           WITH
@@ -88,8 +90,7 @@ module WorkPackages::Scopes
               NOT to_schedule.manually
         SQL
 
-        WorkPackage
-          .where("id IN (#{sql})")
+        where("id IN (#{sql})")
           .where.not(id: work_packages)
       end
 

--- a/app/models/work_packages/scopes/include_derived_dates.rb
+++ b/app/models/work_packages/scopes/include_derived_dates.rb
@@ -28,14 +28,12 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class WorkPackages::Scopes::IncludeDerivedDates
-  attr_accessor :user,
-                :work_package
+module WorkPackages::Scopes::IncludeDerivedDates
+  extend ActiveSupport::Concern
 
-  class << self
-    def fetch
-      WorkPackage
-        .left_joins(:descendants)
+  class_methods do
+    def include_derived_dates
+      left_joins(:descendants)
         .select(*select_statement)
         .group(:id)
     end

--- a/app/models/work_packages/scopes/include_spent_time.rb
+++ b/app/models/work_packages/scopes/include_spent_time.rb
@@ -28,13 +28,14 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class WorkPackages::Scopes::IncludeSpentTime
-  class << self
-    def fetch(user, work_package = nil)
+module WorkPackages::Scopes::IncludeSpentTime
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def include_spent_time(user, work_package = nil)
       query = join_time_entries(user)
 
-      scope = WorkPackage
-              .left_join_self_and_descendants(user, work_package)
+      scope = left_join_self_and_descendants(user, work_package)
               .joins(query.join_sources)
               .group(:id)
               .select('SUM(time_entries.hours) AS hours')
@@ -63,7 +64,7 @@ class WorkPackages::Scopes::IncludeSpentTime
     end
 
     def wp_table
-      @wp_table ||= WorkPackage.arel_table
+      @wp_table ||= arel_table
     end
 
     def wp_descendants

--- a/app/models/work_packages/scopes/left_join_self_and_descendants.rb
+++ b/app/models/work_packages/scopes/left_join_self_and_descendants.rb
@@ -28,10 +28,12 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class WorkPackages::Scopes::LeftJoinSelfAndDescendants
-  class << self
-    def fetch(user, work_package = nil)
-      WorkPackage.joins(join_descendants(user, work_package).join_sources)
+module WorkPackages::Scopes::LeftJoinSelfAndDescendants
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def left_join_self_and_descendants(user, work_package = nil)
+      joins(join_descendants(user, work_package).join_sources)
     end
 
     private

--- a/modules/costs/app/contracts/time_entries/base_contract.rb
+++ b/modules/costs/app/contracts/time_entries/base_contract.rb
@@ -65,7 +65,7 @@ module TimeEntries
       if !model.project
         TimeEntryActivity.none
       else
-        TimeEntryActivity::Scopes::ActiveInProject.fetch(model.project)
+        TimeEntryActivity.active_in_project(model.project)
       end
     end
 

--- a/modules/costs/app/models/time_entries/scopes/of_user_and_day.rb
+++ b/modules/costs/app/models/time_entries/scopes/of_user_and_day.rb
@@ -28,17 +28,23 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module TimeEntry::Scopes
-  class Visible
-    def self.fetch(user = User.current)
-      all_scope = TimeEntry
-                  .where(project_id: Project.allowed_to(user, :view_time_entries))
+module TimeEntries::Scopes
+  module OfUserAndDay
+    extend ActiveSupport::Concern
 
-      own_scope = TimeEntry
-                  .where(project_id: Project.allowed_to(user, :view_own_time_entries))
-                  .where(user_id: user)
+    class_methods do
+      def of_user_and_day(user, date, excluding: nil)
+        scope = TimeEntry
+                  .where(spent_on: date,
+                         user: user)
 
-      all_scope.or(own_scope)
+        if excluding
+          scope = scope.where.not(id: excluding.id)
+        end
+
+        scope
+      end
+
     end
   end
 end

--- a/modules/costs/app/models/time_entries/time_entry_scopes.rb
+++ b/modules/costs/app/models/time_entries/time_entry_scopes.rb
@@ -1,4 +1,4 @@
-class TimeEntry
+module TimeEntries
   module TimeEntryScopes
     include ::CostScopes
 

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -48,12 +48,12 @@ class TimeEntry < ApplicationRecord
   scope :on_work_packages, ->(work_packages) { where(work_package_id: work_packages) }
 
   include ::Scopes::Scoped
-  extend ::TimeEntry::TimeEntryScopes
+  extend ::TimeEntries::TimeEntryScopes
   include Entry::Costs
   include Entry::SplashedDates
 
-  scope_classes TimeEntry::Scopes::OfUserAndDay,
-                TimeEntry::Scopes::Visible
+  scopes :of_user_and_day,
+         :visible
 
   # TODO: move into service
   before_save :update_costs

--- a/modules/costs/app/models/time_entry_activity.rb
+++ b/modules/costs/app/models/time_entry_activity.rb
@@ -29,12 +29,16 @@
 #++
 
 class TimeEntryActivity < Enumeration
+  include ::Scopes::Scoped
+
   has_many :time_entries, foreign_key: 'activity_id'
   has_many :time_entry_activities_projects, foreign_key: 'activity_id', dependent: :delete_all
 
   validates :parent, absence: true
 
   OptionName = :enumeration_activities
+
+  scopes :active_in_project
 
   def option_name
     OptionName

--- a/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
+++ b/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
@@ -76,18 +76,18 @@ shared_examples_for 'time entry contract' do
         .and_return(work_package_visible)
     end
 
-    allow(TimeEntryActivity::Scopes::ActiveInProject)
-      .to receive(:fetch)
+    allow(TimeEntryActivity)
+      .to receive(:active_in_project)
       .and_return(TimeEntryActivity.none)
 
     of_user_and_day_scope = double('of_user_and_day_scope')
 
-    allow(TimeEntry::Scopes::OfUserAndDay)
-      .to receive(:fetch)
+    allow(TimeEntry)
+      .to receive(:of_user_and_day)
       .and_return(TimeEntry.none)
 
-    allow(TimeEntry::Scopes::OfUserAndDay)
-      .to receive(:fetch)
+    allow(TimeEntry)
+      .to receive(:of_user_and_day)
       .with(time_entry.user, time_entry_spent_on, excluding: time_entry)
       .and_return(of_user_and_day_scope)
 
@@ -96,8 +96,8 @@ shared_examples_for 'time entry contract' do
       .with(:hours)
       .and_return(time_entry_day_sum)
 
-    allow(TimeEntryActivity::Scopes::ActiveInProject)
-      .to receive(:fetch)
+    allow(TimeEntryActivity)
+      .to receive(:active_in_project)
       .with(time_entry_project)
       .and_return(activities_scope)
   end

--- a/modules/costs/spec/contracts/time_entries/update_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/update_contract_spec.rb
@@ -57,8 +57,8 @@ describe TimeEntries::UpdateContract do
     context 'if project changed' do
       let(:new_project) do
         FactoryBot.build_stubbed(:project).tap do |p|
-          allow(TimeEntryActivity::Scopes::ActiveInProject)
-            .to receive(:fetch)
+          allow(TimeEntryActivity)
+            .to receive(:active_in_project)
             .with(p)
             .and_return(activities_scope)
 

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entries_activity_representer_rendering_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entries_activity_representer_rendering_spec.rb
@@ -54,8 +54,8 @@ describe ::API::V3::TimeEntries::TimeEntriesActivityRepresenter, 'rendering' do
       let(:project2) { FactoryBot.build_stubbed(:project) }
 
       before do
-        allow(::Projects::Scopes::VisibleWithActivatedTimeActivity)
-          .to receive(:fetch)
+        allow(::Project)
+          .to receive(:visible_with_activated_time_activity)
           .with(activity)
           .and_return([project1,
                        project2])

--- a/modules/costs/spec/models/time_entries/scopes/visible_spec.rb
+++ b/modules/costs/spec/models/time_entries/scopes/visible_spec.rb
@@ -30,7 +30,7 @@
 
 require 'spec_helper'
 
-describe TimeEntry::Scopes::Visible, type: :model do
+describe TimeEntries::Scopes::Visible, type: :model do
   let(:project) { FactoryBot.create(:project) }
   let(:user) do
     FactoryBot.create(:user,
@@ -67,8 +67,8 @@ describe TimeEntry::Scopes::Visible, type: :model do
                       user: user)
   end
 
-  describe '.fetch' do
-    subject { described_class.fetch(user) }
+  describe '.visible' do
+    subject { TimeEntry.visible(user) }
 
     context 'for a user having the view_time_entries permission' do
       it 'retrieves all the time entries of projects the user has the permissions in' do

--- a/modules/costs/spec/models/time_entry_activities/scopes/active_in_project_spec.rb
+++ b/modules/costs/spec/models/time_entry_activities/scopes/active_in_project_spec.rb
@@ -30,14 +30,14 @@
 
 require 'spec_helper'
 
-describe TimeEntryActivity::Scopes::ActiveInProject, type: :model do
+describe TimeEntryActivities::Scopes::ActiveInProject, type: :model do
   let!(:activity) { FactoryBot.create(:time_entry_activity) }
   let!(:other_activity) { FactoryBot.create(:time_entry_activity) }
   let(:project) { FactoryBot.create(:project) }
   let(:other_project) { FactoryBot.create(:project) }
 
-  describe '.fetch' do
-    subject { described_class.fetch(project) }
+  describe '.active_in_project' do
+    subject { TimeEntryActivity.active_in_project(project) }
 
     context 'without a project configuration' do
       context 'with the activity being active' do

--- a/spec/models/members/scopes/not_locked_spec.rb
+++ b/spec/models/members/scopes/not_locked_spec.rb
@@ -66,7 +66,7 @@ describe Members::Scopes::NotLocked, type: :model do
   end
 
   describe '.fetch' do
-    subject { described_class.fetch }
+    subject { Member.not_locked }
 
     it 'returns only actual users and groups' do
       expect(subject)

--- a/spec/models/principals/scopes/human_spec.rb
+++ b/spec/models/principals/scopes/human_spec.rb
@@ -31,7 +31,7 @@
 require 'spec_helper'
 
 describe Principals::Scopes::Human, type: :model, with_clean_fixture: true do
-  describe '.fetch' do
+  describe '.human' do
     let!(:anonymous_user) { FactoryBot.create(:anonymous) }
     let!(:system_user) { FactoryBot.create(:system) }
     let!(:deleted_user) { FactoryBot.create(:deleted_user) }
@@ -39,7 +39,7 @@ describe Principals::Scopes::Human, type: :model, with_clean_fixture: true do
     let!(:user) { FactoryBot.create(:user) }
     let!(:placeholder_user) { FactoryBot.create(:placeholder_user) }
 
-    subject { described_class.fetch }
+    subject { Principal.human }
 
     it 'returns only actual users and groups' do
       expect(subject)

--- a/spec/models/principals/scopes/like_spec.rb
+++ b/spec/models/principals/scopes/like_spec.rb
@@ -31,7 +31,7 @@
 require 'spec_helper'
 
 describe Principals::Scopes::Like, type: :model, with_clean_fixture: true do
-  describe '.fetch' do
+  describe '.like' do
     let!(:login) do
       FactoryBot.create(:principal, login: 'login')
     end
@@ -58,22 +58,22 @@ describe Principals::Scopes::Like, type: :model, with_clean_fixture: true do
     end
 
     it 'finds by login' do
-      expect(described_class.fetch('login'))
+      expect(Principal.like('login'))
         .to match_array [login, login2]
     end
 
     it 'finds by firstname' do
-      expect(described_class.fetch('firstname'))
+      expect(Principal.like('firstname'))
         .to match_array [firstname, firstname2]
     end
 
     it 'finds by lastname' do
-      expect(described_class.fetch('lastname'))
+      expect(Principal.like('lastname'))
         .to match_array [lastname, lastname2]
     end
 
     it 'finds by mail' do
-      expect(described_class.fetch('mail'))
+      expect(Principal.like('mail'))
         .to match_array [mail, mail2]
     end
   end

--- a/spec/models/principals/scopes/not_builtin_spec.rb
+++ b/spec/models/principals/scopes/not_builtin_spec.rb
@@ -31,7 +31,7 @@
 require 'spec_helper'
 
 describe Principals::Scopes::NotBuiltin, type: :model, with_clean_fixture: true do
-  describe '.fetch' do
+  describe '.not_builtin' do
     let!(:anonymous_user) { FactoryBot.create(:anonymous) }
     let!(:system_user) { FactoryBot.create(:system) }
     let!(:deleted_user) { FactoryBot.create(:deleted_user) }
@@ -39,7 +39,7 @@ describe Principals::Scopes::NotBuiltin, type: :model, with_clean_fixture: true 
     let!(:user) { FactoryBot.create(:user) }
     let!(:placeholder_user) { FactoryBot.create(:placeholder_user) }
 
-    subject { described_class.fetch }
+    subject { Principal.not_builtin }
 
     it 'returns only actual users and groups' do
       expect(subject)

--- a/spec/models/principals/scopes/possible_assignee_spec.rb
+++ b/spec/models/principals/scopes/possible_assignee_spec.rb
@@ -58,8 +58,8 @@ describe Principals::Scopes::PossibleAssignee, type: :model, with_clean_fixture:
                       member_through_role: role)
   end
 
-  describe '.fetch' do
-    subject { described_class.fetch(project) }
+  describe '.possible_assignee' do
+    subject { Principal.possible_assignee(project) }
 
     context 'with the role being assignable' do
       context 'with the user status being active' do

--- a/spec/models/principals/scopes/possible_member_spec.rb
+++ b/spec/models/principals/scopes/possible_member_spec.rb
@@ -56,8 +56,8 @@ describe Principals::Scopes::PossibleMember, type: :model, with_clean_fixture: t
                       member_through_role: role)
   end
 
-  describe '.fetch' do
-    subject { described_class.fetch(project) }
+  describe '.possible_member' do
+    subject { Principal.possible_member(project) }
 
     it 'returns non locked users, groups and placeholder users not part of the project yet' do
       is_expected

--- a/spec/models/principals/scopes/user_spec.rb
+++ b/spec/models/principals/scopes/user_spec.rb
@@ -31,7 +31,7 @@
 require 'spec_helper'
 
 describe Principals::Scopes::User, type: :model, with_clean_fixture: true do
-  describe '.fetch' do
+  describe '.user' do
     let!(:anonymous_user) { FactoryBot.create(:anonymous) }
     let!(:system_user) { FactoryBot.create(:system) }
     let!(:deleted_user) { FactoryBot.create(:deleted_user) }
@@ -39,7 +39,7 @@ describe Principals::Scopes::User, type: :model, with_clean_fixture: true do
     let!(:user) { FactoryBot.create(:user) }
     let!(:placeholder_user) { FactoryBot.create(:placeholder_user) }
 
-    subject { described_class.fetch }
+    subject { Principal.user }
 
     it 'returns only actual users and groups' do
       expect(subject)

--- a/spec/models/projects/scopes/activated_time_activity_spec.rb
+++ b/spec/models/projects/scopes/activated_time_activity_spec.rb
@@ -35,8 +35,8 @@ describe Projects::Scopes::ActivatedTimeActivity, type: :model do
   let!(:project) { FactoryBot.create(:project) }
   let!(:other_project) { FactoryBot.create(:project) }
 
-  describe '.fetch' do
-    subject { described_class.fetch(activity) }
+  describe '.activated_time_activity' do
+    subject { Project.activated_time_activity(activity) }
 
     context 'without project specific overrides' do
       context 'and being active' do

--- a/spec/models/projects/scopes/visible_with_activated_time_activity_spec.rb
+++ b/spec/models/projects/scopes/visible_with_activated_time_activity_spec.rb
@@ -55,7 +55,7 @@ describe Projects::Scopes::VisibleWithActivatedTimeActivity, type: :model do
   end
 
   describe '.fetch' do
-    subject { described_class.fetch(activity) }
+    subject { Project.visible_with_activated_time_activity(activity) }
 
     context 'without project specific overrides' do
       context 'and being active' do

--- a/spec/models/types/scopes/milestone_spec.rb
+++ b/spec/models/types/scopes/milestone_spec.rb
@@ -34,8 +34,8 @@ describe Types::Scopes::Milestone, type: :model do
   let!(:milestone) { FactoryBot.create(:type, is_milestone: true) }
   let!(:other_type) { FactoryBot.create(:type, is_milestone: false) }
 
-  describe '.fetch' do
-    subject { described_class.fetch }
+  describe '.milestone' do
+    subject { Type.milestone }
 
     it 'returns only milestones' do
       is_expected

--- a/spec/models/users/scopes/find_by_login_spec.rb
+++ b/spec/models/users/scopes/find_by_login_spec.rb
@@ -37,8 +37,8 @@ describe Users::Scopes::FindByLogin, type: :model do
   let(:login) { 'Some string' }
   let(:search_login) { login }
 
-  describe '.fetch' do
-    subject { described_class.fetch(search_login) }
+  describe '.find_by_login' do
+    subject { User.find_by_login(search_login) }
 
     context 'with the exact same login' do
       it 'returns the user' do

--- a/spec/models/users/scopes/newest_spec.rb
+++ b/spec/models/users/scopes/newest_spec.rb
@@ -31,7 +31,7 @@
 require 'spec_helper'
 
 describe Users::Scopes::Newest, type: :model, with_clean_fixture: true do
-  describe '.fetch' do
+  describe '.newest' do
     let!(:anonymous_user) { FactoryBot.create(:anonymous) }
     let!(:system_user) { FactoryBot.create(:system) }
     let!(:deleted_user) { FactoryBot.create(:deleted_user) }
@@ -41,7 +41,7 @@ describe Users::Scopes::Newest, type: :model, with_clean_fixture: true do
     let!(:user3) { FactoryBot.create(:user) }
     let!(:placeholder_user) { FactoryBot.create(:placeholder_user) }
 
-    subject { described_class.fetch }
+    subject { User.newest }
 
     it 'returns only actual users ordered by creation date desc' do
       expect(subject.to_a)

--- a/spec/models/versions/scopes/order_by_semver_name_spec.rb
+++ b/spec/models/versions/scopes/order_by_semver_name_spec.rb
@@ -24,13 +24,10 @@ describe Versions::Scopes::OrderBySemverName, type: :model do
     FactoryBot.create(:version, name: "1.1. aaa", project: project)
   end
 
-  it 'returns the versions in semver order' do
-    expect(described_class.fetch.to_a)
-      .to eql [version6, version7, version4, version5, version3, version2, version1]
-  end
+  subject { Version.order_by_semver_name }
 
-  it 'is also callable on the version class' do
-    expect(Version.order_by_semver_name.to_a)
+  it 'returns the versions in semver order' do
+    expect(subject.to_a)
       .to eql [version6, version7, version4, version5, version3, version2, version1]
   end
 end

--- a/spec/models/work_packages/scopes/for_scheduling_spec.rb
+++ b/spec/models/work_packages/scopes/for_scheduling_spec.rb
@@ -103,15 +103,17 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
   end
   let(:existing_work_packages) { [] }
 
-  describe '.fetch' do
+  subject { }
+
+  describe '.for_scheduling' do
     it 'is a AR scope' do
-      expect(described_class.fetch([origin]))
+      expect(WorkPackage.for_scheduling([origin]))
         .to be_a ActiveRecord::Relation
     end
 
     context 'for an empty array' do
       it 'is empty' do
-        expect(described_class.fetch([]))
+        expect(WorkPackage.for_scheduling([]))
           .to be_empty
       end
     end
@@ -120,7 +122,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
       let!(:existing_work_packages) { [predecessor] }
 
       it 'is empty' do
-        expect(described_class.fetch([origin]))
+        expect(WorkPackage.for_scheduling([origin]))
           .to be_empty
       end
     end
@@ -129,7 +131,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
       let!(:existing_work_packages) { [parent] }
 
       it 'consists of the parent' do
-        expect(described_class.fetch([origin]))
+        expect(WorkPackage.for_scheduling([origin]))
           .to match_array([parent])
       end
     end
@@ -138,7 +140,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
       let!(:existing_work_packages) { [successor] }
 
       it 'consists of the successor' do
-        expect(described_class.fetch([origin]))
+        expect(WorkPackage.for_scheduling([origin]))
           .to match_array([successor])
       end
     end
@@ -147,7 +149,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
       let!(:existing_work_packages) { [blocker] }
 
       it 'is empty' do
-        expect(described_class.fetch([origin]))
+        expect(WorkPackage.for_scheduling([origin]))
           .to be_empty
       end
     end
@@ -156,7 +158,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
       let!(:existing_work_packages) { [includer] }
 
       it 'is empty' do
-        expect(described_class.fetch([origin]))
+        expect(WorkPackage.for_scheduling([origin]))
           .to be_empty
       end
     end
@@ -166,7 +168,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
 
       context 'with all scheduled automatically' do
         it 'consists of the successor, its child and parent' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([successor, successor_child, successor_parent])
         end
       end
@@ -177,7 +179,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'is empty' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to be_empty
         end
       end
@@ -188,7 +190,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'consists of the successor and its child' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([successor, successor_child])
         end
       end
@@ -199,7 +201,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'is empty' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to be_empty
         end
       end
@@ -214,7 +216,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
 
       context 'with all scheduled automatically' do
         it 'consists of the successor, its child and parent and the successor successor' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([successor, successor_child, successor_parent, successor_successor])
         end
       end
@@ -225,7 +227,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'consists of the successor, its child and successor successor' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([successor, successor_child, successor_successor])
         end
       end
@@ -236,7 +238,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'is empty' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to be_empty
         end
       end
@@ -251,7 +253,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
 
       context 'with all scheduled automatically' do
         it 'consists of the successor, its child and parent' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([successor, successor_parent])
         end
       end
@@ -262,7 +264,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'is empty (hierarchy over relationships)' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to be_empty
         end
       end
@@ -273,7 +275,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'consists of the successor' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([successor])
         end
       end
@@ -285,7 +287,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'is empty' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to be_empty
         end
       end
@@ -296,7 +298,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
 
       context 'with all scheduled automatically' do
         it 'consists of the successor, its child and the successor˚s successor' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([successor, successor_child, successor_child2, successor_successor])
         end
       end
@@ -307,7 +309,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'consists of the successor, its automatically scheduled child and the successor˚s successor' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([successor_child, successor, successor_successor])
         end
       end
@@ -319,7 +321,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'is empty' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to be_empty
         end
       end
@@ -329,7 +331,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
       let!(:existing_work_packages) { [parent, grandparent] }
 
       it 'consists of the parent, grandparent' do
-        expect(described_class.fetch([origin]))
+        expect(WorkPackage.for_scheduling([origin]))
           .to match_array([parent, grandparent])
       end
     end
@@ -338,7 +340,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
       let!(:existing_work_packages) { [parent, parent_successor] }
 
       it 'consists of the parent, parent successor' do
-        expect(described_class.fetch([origin]))
+        expect(WorkPackage.for_scheduling([origin]))
           .to match_array([parent, parent_successor])
       end
     end
@@ -348,7 +350,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
 
       context 'with all scheduled automatically' do
         it 'consists of the parent, self and the whole parent successor hierarchy' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([parent, parent_successor, parent_successor_parent, parent_successor_child])
         end
       end
@@ -359,7 +361,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'consists of the parent' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([parent])
         end
       end
@@ -370,7 +372,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'is empty' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to be_empty
         end
       end
@@ -381,7 +383,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'contains the parent and self' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([parent])
         end
       end
@@ -392,7 +394,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
 
       context 'with all scheduled automatically' do
         it 'consists of both successors' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([successor, successor_successor])
         end
       end
@@ -403,7 +405,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'is empty' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to be_empty
         end
       end
@@ -414,7 +416,7 @@ describe WorkPackages::Scopes::ForScheduling, 'allowed scope' do
         end
 
         it 'contains the successor' do
-          expect(described_class.fetch([origin]))
+          expect(WorkPackage.for_scheduling([origin]))
             .to match_array([successor])
         end
       end

--- a/spec/requests/api/v3/role_resource_spec.rb
+++ b/spec/requests/api/v3/role_resource_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'rack/test'
 
-describe 'API v3 roles resource', type: :request do
+describe 'API v3 roles resource', type: :request, with_clean_fixture: true do
   include Rack::Test::Methods
   include API::V3::Utilities::PathHelper
 


### PR DESCRIPTION
Transforms all scope classes into modules so that polymorphism works again.

I'd rather have kept the scopes as separate entities without the possibility of name clashes but this causes problems with AR entities like Principal and User which rely on STI.