### PR TITLE
allow pageSize = 0 on manually sorted queries

### DIFF
--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -81,10 +81,12 @@ module API
           if query.manually_sorted?
             params[:query_id] = query.id
             params[:offset] = 1
-            params[:pageSize] = Setting.forced_single_page_size
+            # Force the setting value in all cases except when 0 is requested explictly. Fetching with pageSize = 0
+            # is done for performance reasons to simply get the query without the results.
+            params[:pageSize] = pageSizeParam(params) == 0 ? pageSizeParam(params) : Setting.forced_single_page_size
           else
             params[:offset] = to_i_or_nil(params[:offset])
-            params[:pageSize] = to_i_or_nil(params[:pageSize])
+            params[:pageSize] = pageSizeParam(params)
           end
         end
       end
@@ -159,6 +161,10 @@ module API
 
       def to_i_or_nil(value)
         value ? value.to_i : nil
+      end
+
+      def pageSizeParam(params)
+        to_i_or_nil(params[:pageSize])
       end
 
       def self_link(project)

--- a/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
+++ b/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
@@ -33,13 +33,18 @@ describe ::API::V3::WorkPackageCollectionFromQueryService,
   include API::V3::Utilities::PathHelper
 
   let(:query) do
-    query = FactoryBot.build_stubbed(:query)
-    allow(query)
-      .to receive(:results)
-      .and_return(results)
+    FactoryBot.build_stubbed(:query).tap do |query|
+      allow(query)
+        .to receive(:results)
+        .and_return(results)
 
-    query
+      allow(query)
+        .to receive(:manually_sorted?)
+        .and_return(query_manually_sorted)
+
+    end
   end
+  let(:query_manually_sorted) { false }
 
   let(:results) do
     results = double('results')
@@ -392,6 +397,33 @@ describe ::API::V3::WorkPackageCollectionFromQueryService,
           it 'is that value' do
             expect(subject.query[:pageSize])
               .to be(100)
+          end
+        end
+
+        context 'with the query sorted manually', with_settings: { forced_single_page_size: 42 } do
+          let(:query_manually_sorted) { true }
+
+          it 'is the setting value' do
+            expect(subject.query[:pageSize])
+              .to be(42)
+          end
+
+          context 'with a provided value' do
+            let(:params) { { 'pageSize' => 100 } }
+
+            it 'is the setting value' do
+              expect(subject.query[:pageSize])
+                .to be(42)
+            end
+          end
+
+          context 'with a provided value of 0' do
+            let(:params) { { 'pageSize' => 0 } }
+
+            it 'is the provided value' do
+              expect(subject.query[:pageSize])
+                .to be(0)
+            end
           end
         end
       end


### PR DESCRIPTION
This allows fetching the query without the added burden of having to
render the work packages. Rendering the work packages increases the
response time heavily.

Belongs to but does not fix https://community.openproject.com/projects/openproject/work_packages/34840