### PR TITLE
hide manualSort filter from user visible filters

### DIFF
--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
@@ -57,7 +57,8 @@ export class WorkPackageViewFiltersService extends WorkPackageQueryStateService<
     'requires',
     'required',
     'search',
-    'subjectOrId'
+    'subjectOrId',
+    'manualSort'
   ];
 
   /** Flag state to determine whether the filters are incomplete */


### PR DESCRIPTION
The manual sort filter should not be visible in the filters section as it is an internal filter.