### PR TITLE
Use the configured variable for expiry

### DIFF
--- a/lib/api/helpers/attachment_renderer.rb
+++ b/lib/api/helpers/attachment_renderer.rb
@@ -43,9 +43,7 @@ module API
 
           get do
             attachment = instance_exec(&block)
-            # Cache that value at max 604799 seconds, which is the max
-            # allowed expiry time for AWS generated links
-            respond_with_attachment attachment, cache_seconds: max_aws_cache_seconds
+            respond_with_attachment attachment, cache_seconds: fog_cache_seconds
           end
         }
       end
@@ -100,8 +98,11 @@ module API
         end
       end
 
-      def max_aws_cache_seconds
-        604799
+      def fog_cache_seconds
+        [
+          0,
+          OpenProject::Configuration.fog_download_url_expires_in.to_i - 10
+        ].max
       end
 
       def avatar_link_expires_in

--- a/modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb
@@ -204,13 +204,15 @@ describe 'BCF 2.1 viewpoints resource', type: :request, content_type: :json, wit
         expect(subject.status).to eq 200
         expect(subject.headers['Content-Type']).to eq 'image/jpeg'
 
-        expect(subject.headers["Cache-Control"]).to eq "public, max-age=604799"
+        max_age = OpenProject::Configuration.fog_download_url_expires_in - 10
+
+        expect(subject.headers["Cache-Control"]).to eq "public, max-age=#{max_age}"
         expect(subject.headers["Expires"]).to be_present
 
         expires_time = Time.parse response.headers["Expires"]
 
-        expect(expires_time < Time.now.utc + 604799).to be_truthy
-        expect(expires_time > Time.now.utc + 604799 - 60).to be_truthy
+        expect(expires_time < Time.now.utc + max_age).to be_truthy
+        expect(expires_time > Time.now.utc + max_age - 60).to be_truthy
       end
     end
 

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -415,13 +415,15 @@ shared_examples 'an APIv3 attachment resource', type: :request, content_type: :j
           expect(subject.headers['Content-Type'])
             .to eql mock_file.content_type
 
-          expect(subject.headers["Cache-Control"]).to eq "public, max-age=604799"
+          max_age = OpenProject::Configuration.fog_download_url_expires_in.to_i - 10
+
+          expect(subject.headers["Cache-Control"]).to eq "public, max-age=#{max_age}"
           expect(subject.headers["Expires"]).to be_present
 
           expires_time = Time.parse response.headers["Expires"]
 
-          expect(expires_time < Time.now.utc + 604799).to be_truthy
-          expect(expires_time > Time.now.utc + 604799 - 60).to be_truthy
+          expect(expires_time < Time.now.utc + max_age).to be_truthy
+          expect(expires_time > Time.now.utc + max_age - 60).to be_truthy
         end
 
         it 'sends the file in binary' do
@@ -472,13 +474,15 @@ shared_examples 'an APIv3 attachment resource', type: :request, content_type: :j
           expect(subject.headers['Location'])
             .to eql external_url
 
-          expect(subject.headers["Cache-Control"]).to eq "public, max-age=604799"
+          max_age = OpenProject::Configuration.fog_download_url_expires_in.to_i - 10
+
+          expect(subject.headers["Cache-Control"]).to eq "public, max-age=#{max_age}"
           expect(subject.headers["Expires"]).to be_present
 
           expires_time = Time.parse response.headers["Expires"]
 
-          expect(expires_time < Time.now.utc + 604799).to be_truthy
-          expect(expires_time > Time.now.utc + 604799 - 60).to be_truthy
+          expect(expires_time < Time.now.utc + max_age).to be_truthy
+          expect(expires_time > Time.now.utc + max_age - 60).to be_truthy
         end
       end
     end

--- a/spec/support/pages/projects/destroy.rb
+++ b/spec/support/pages/projects/destroy.rb
@@ -25,6 +25,7 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
+require_relative '../page'
 
 module Pages
   module Projects


### PR DESCRIPTION
In https://github.com/opf/openproject/pull/8941 a configuration was introduced, limiting the max cached value for fog/aws links. But the Attachment API was not updated appropriately so its expires cache value is larger than the AWS link value, resulting in invalid links.