### PR TITLE
Early Preview: Let GitHub integration show changes in a separate tab 

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -930,6 +930,7 @@ en:
         relations: Relations
         watchers: Watchers
         attachments: Attachments
+        additional_tabs: Additional Tabs
       time_relative:
         days: "days"
         weeks: "weeks"

--- a/docs/api/apiv3/endpoints/work-packages.apib
+++ b/docs/api/apiv3/endpoints/work-packages.apib
@@ -7,6 +7,7 @@
 | addAttachment       | Attach a file to the WP                                                  | **Permission**: edit work package      |
 | addComment          | Post comment to WP                                                       | **Permission**: add work package notes |
 | addRelation         | Adds a relation to this work package.                                    | **Permission**: manage wp relations    |
+| additionalTabs      | List of additional accessible work package tabs. Extended by plugins.    | **Permission**: defined by plugins     |
 | addWatcher          | Add any user to WP watchers                                              | **Permission**: add watcher            |
 | customActions       | Collection of predefined changes that can be applied to the work package |                                        |
 | previewMarkup       | Post markup (in markdown) here to receive an HTML-rendered response      |                                        |
@@ -125,6 +126,10 @@ and [update](#work-packages-work-package-patch). The attachments the work packag
                     "addAttachment": {
                         "href": "/api/v3/work_packages/1528/attachments",
                         "method": "post"
+                    },
+                    "additionalTabs": {
+                        "href": "/work_packages/1528/additionalTabs/github",
+                        "title": "github"
                     },
                     "author": {
                         "href": "/api/v3/users/1",

--- a/docs/development/concepts/translations/README.md
+++ b/docs/development/concepts/translations/README.md
@@ -31,7 +31,7 @@ The OpenProject localizable strings are stored in the [Rails-standard I18n YAML 
 
 Additionally, modules can define their own translations, such as `modules/budgets/config/locales/en.yml`. 
 
-The `js-en.yml` are not special on their own, but are simply prefixed with the `js:` key at the beginning of the while. This means all translations within are prefixed with the `js.` key.  This is picked up by [`I18n.js`](https://github.com/fnando/i18n-js), a Ruby gem and frontend library that helps outputting javascript objects for the frontend. Only strings that are prefixed with `js.` and some internals will end up in the frontend due to the config we applied in [`config/i18n-js.yml`](https://github.com/opf/openproject/blob/dev/config/i18n-js.yml). The translations are output by the take task `./bin/rails i18n:js:export` and are output to `frontend/src/locales/{language}.js`.
+The `js-en.yml` are not special on their own, but are simply prefixed with the `js:` key at the beginning of the file. This means all translations within are prefixed with the `js.` key. This is picked up by [`I18n.js`](https://github.com/fnando/i18n-js), a Ruby gem and frontend library that helps outputting javascript objects for the frontend. Only strings that are prefixed with `js.` and some internals will end up in the frontend due to the config we applied in [`config/i18n-js.yml`](https://github.com/opf/openproject/blob/dev/config/i18n-js.yml). The translations are output by the take task `./bin/rails i18n:js:export` and are output to `frontend/src/locales/{language}.js`.
 
 
 

--- a/frontend/src/app/components/wp-single-view-tabs/additional-tab/additional-tab.component.ts
+++ b/frontend/src/app/components/wp-single-view-tabs/additional-tab/additional-tab.component.ts
@@ -1,0 +1,95 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2021 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+//++
+
+import {Transition} from '@uirouter/core';
+import {AfterViewInit, Component, ComponentFactoryResolver, Input, OnInit, ViewChild, ViewContainerRef} from '@angular/core';
+import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
+import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
+import {HookService} from 'core-app/modules/plugins/hook-service';
+import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import {APIV3Service} from "core-app/modules/apiv3/api-v3.service";
+import { TabComponent } from './tab.component';
+import { Tab } from './tab';
+
+@Component({
+  templateUrl: './additional-tab.html',
+  selector: 'wp-additional-tab',
+})
+export class WorkPackageAdditionalTabComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit {
+  @Input() public workPackageId?:string;
+  @ViewChild('additionalTabContent', { read: ViewContainerRef }) additionalTabContent: ViewContainerRef;
+
+  public additionalTab:Tab|undefined;
+  public workPackage:WorkPackageResource;
+
+  public constructor(readonly I18n:I18nService,
+                     readonly $transition:Transition,
+                     readonly apiV3Service:APIV3Service,
+                     readonly HookService:HookService,
+                     private componentFactoryResolver: ComponentFactoryResolver) {
+    super();
+  }
+
+  findTab() {
+    const additionalTabIdentifier = this.$transition.params('to').additionalTabIdentifier;
+    const registeredAdditionalTabs = this.HookService.call('workPackageAdditionalTabs');
+    const additionalTabs = this.workPackage.additionalTabs(registeredAdditionalTabs);
+    this.additionalTab = _.find(additionalTabs, ({identifier: id}) => id === additionalTabIdentifier);
+  }
+
+  ngOnInit() {
+    const wpId = this.workPackageId || this.$transition.params('to').workPackageId;
+    this
+      .apiV3Service
+      .work_packages
+      .id(wpId)
+      .requireAndStream()
+      .pipe(
+        this.untilDestroyed()
+      )
+      .subscribe((wp) => {
+        this.workPackageId = wp.id!;
+        this.workPackage = wp;
+        this.findTab();
+      });
+  }
+
+  ngAfterViewInit() {
+    setTimeout(() => { // TODO: setTimeout is a crazy hack, but without it `additionalTabContent` is undefined. Don't know why, according to the internet it should work just fine. Could need help debugging this.
+      if (this.additionalTab === undefined) {
+        // Tab was not found - e.g. because the user typed a random tab-url or does not have view permissions for this tab.
+        return
+      }
+
+      const componentFactory = this.componentFactoryResolver.resolveComponentFactory<TabComponent>(this.additionalTab.component);
+      this.additionalTabContent.clear();
+      const componentRef = this.additionalTabContent.createComponent<TabComponent>(componentFactory);
+      componentRef.instance.workPackage = this.workPackage;
+    }, 0);
+  }
+}

--- a/frontend/src/app/components/wp-single-view-tabs/additional-tab/additional-tab.html
+++ b/frontend/src/app/components/wp-single-view-tabs/additional-tab/additional-tab.html
@@ -1,0 +1,6 @@
+<div class="detail-panel-description detail-panel--integration detail-panel--autocomplete-target"
+     *ngIf="workPackage">
+  <div class="detail-panel-description-content">
+    <ng-container #additionalTabContent></ng-container>
+  </div>
+</div>

--- a/frontend/src/app/components/wp-single-view-tabs/additional-tab/tab.component.ts
+++ b/frontend/src/app/components/wp-single-view-tabs/additional-tab/tab.component.ts
@@ -1,0 +1,6 @@
+import { Component } from "@angular/core";
+import { WorkPackageResource } from "core-app/modules/hal/resources/work-package-resource";
+
+export interface TabComponent extends Component {
+  workPackage:WorkPackageResource;
+}

--- a/frontend/src/app/components/wp-single-view-tabs/additional-tab/tab.ts
+++ b/frontend/src/app/components/wp-single-view-tabs/additional-tab/tab.ts
@@ -1,0 +1,10 @@
+import { Type } from '@angular/core';
+import { TabComponent } from './tab.component';
+
+export class Tab {
+  constructor(
+    public component: Type<TabComponent>,
+    public displayName: String,
+    public identifier: String,
+  ) {}
+}

--- a/frontend/src/app/modules/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/modules/hal/resources/work-package-resource.ts
@@ -46,6 +46,7 @@ import {WorkPackagesActivityService} from "core-components/wp-single-view-tabs/a
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 import {APIV3Service} from "core-app/modules/apiv3/api-v3.service";
+import { Tab } from 'core-app/components/wp-single-view-tabs/additional-tab/tab';
 
 export interface WorkPackageResourceEmbedded {
   activities:CollectionResource;
@@ -180,6 +181,11 @@ export class WorkPackageBaseResource extends HalResource {
 
   public isParentOf(otherWorkPackage:WorkPackageResource) {
     return otherWorkPackage.parent?.$links.self.$link.href === this.$links.self.$link.href;
+  }
+
+  public additionalTabs(registeredTabs: Tab[]):Tab[] {
+    const allowedTabs = _.map(this.additionalWorkPackageTabs, (halResource) => halResource.name);
+    return _.filter(registeredTabs, (tab) => _.includes(allowedTabs, tab.identifier));
   }
 
   /**

--- a/frontend/src/app/modules/plugins/plugin-context.ts
+++ b/frontend/src/app/modules/plugins/plugin-context.ts
@@ -23,6 +23,7 @@ import {ExternalRelationQueryConfigurationService} from "core-components/wp-tabl
 import {InjectField} from "core-app/helpers/angular/inject-field.decorator";
 import {APIV3Service} from "core-app/modules/apiv3/api-v3.service";
 import {ConfigurationService} from "core-app/modules/common/config/configuration.service";
+import { Tab } from "core-app/components/wp-single-view-tabs/additional-tab/tab";
 
 /**
  * Plugin context bridge for plugins outside the CLI compiler context
@@ -33,7 +34,8 @@ export class OpenProjectPluginContext {
   private _knownHookNames = [
     'workPackageTableContextMenu',
     'workPackageSingleContextMenu',
-    'workPackageNewInitialization'
+    'workPackageNewInitialization',
+    'workPackageAdditionalTabs'
   ];
 
   // Common services referencable by index
@@ -91,6 +93,10 @@ export class OpenProjectPluginContext {
    */
   public runInZone(cb:() => void) {
     this.zone.run(cb);
+  }
+
+  public registerAdditionalWorkPackageTab(tab: Tab) {
+    this.hooks.workPackageAdditionalTabs(() => tab)
   }
 
   /**

--- a/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/modules/work_packages/openproject-work-packages.module.ts
@@ -75,6 +75,7 @@ import {WorkPackageSplitViewToolbarComponent} from 'core-components/wp-details/w
 import {WorkPackageWatcherButtonComponent} from 'core-components/work-packages/wp-watcher-button/wp-watcher-button.component';
 import {WorkPackageSubjectComponent} from 'core-components/work-packages/wp-subject/wp-subject.component';
 import {WorkPackageRelationsTabComponent} from 'core-components/wp-single-view-tabs/relations-tab/relations-tab.component';
+import {WorkPackageAdditionalTabComponent} from 'core-app/components/wp-single-view-tabs/additional-tab/additional-tab.component';
 import {WorkPackageRelationsComponent} from 'core-components/wp-relations/wp-relations.component';
 import {WorkPackageRelationsGroupComponent} from 'core-components/wp-relations/wp-relations-group/wp-relations-group.component';
 import {WorkPackageRelationRowComponent} from 'core-components/wp-relations/wp-relation-row/wp-relation-row.component';
@@ -333,6 +334,9 @@ import {WorkPackageGroupToggleDropdownMenuDirective} from "core-components/op-co
     WorkPackageRelationsHierarchyComponent,
     WorkPackageRelationsAutocomplete,
     WorkPackageBreadcrumbParentComponent,
+
+    // Additional tabs
+    WorkPackageAdditionalTabComponent,
 
     // Split view
     WorkPackageDetailsViewButtonComponent,

--- a/frontend/src/app/modules/work_packages/routing/work-packages-routes.ts
+++ b/frontend/src/app/modules/work_packages/routing/work-packages-routes.ts
@@ -28,6 +28,7 @@
 
 import {WorkPackageActivityTabComponent} from 'core-components/wp-single-view-tabs/activity-panel/activity-tab.component';
 import {WorkPackageRelationsTabComponent} from 'core-components/wp-single-view-tabs/relations-tab/relations-tab.component';
+import {WorkPackageAdditionalTabComponent} from 'core-app/components/wp-single-view-tabs/additional-tab/additional-tab.component';
 import {WorkPackageWatchersTabComponent} from 'core-components/wp-single-view-tabs/watchers-tab/watchers-tab.component';
 import {WorkPackageNewFullViewComponent} from 'core-components/wp-new/wp-new-full-view.component';
 import {WorkPackageCopyFullViewComponent} from 'core-components/wp-copy/wp-copy-full-view.component';
@@ -131,6 +132,15 @@ export const WORK_PACKAGES_ROUTES:Ng2StateDeclaration[] = [
     data: {
       parent: 'work-packages.show',
       menuItem: menuItemClass
+    }
+  },
+  {
+    name: 'work-packages.show.additionalTabs',
+    url: '/additionalTabs/:additionalTabIdentifier',
+    component: WorkPackageAdditionalTabComponent,
+    data: {
+      parent: 'work-packages.show',
+      menuItem: menuItemClass,
     }
   },
   {

--- a/frontend/src/app/modules/work_packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-full-view/wp-full-view.component.ts
@@ -27,6 +27,7 @@
 //++
 
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
+import {HookService} from 'core-app/modules/plugins/hook-service';
 import {StateService} from '@uirouter/core';
 import {Component, Injector, OnInit} from '@angular/core';
 import {WorkPackageViewSelectionService} from 'core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-selection.service';
@@ -34,6 +35,7 @@ import {WorkPackageSingleViewBase} from "core-app/modules/work_packages/routing/
 import {of} from "rxjs";
 import {HalResourceNotificationService} from "core-app/modules/hal/services/hal-resource-notification.service";
 import {WorkPackageNotificationService} from "core-app/modules/work_packages/notifications/work-package-notification.service";
+import { Tab } from 'core-app/components/wp-single-view-tabs/additional-tab/tab';
 
 @Component({
   templateUrl: './wp-full-view.html',
@@ -50,16 +52,26 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
   public displayWatchButton:boolean;
   public watchers:any;
 
+  // additional tabs
+  private registeredAdditionalTabs:Tab[];
+
   stateName$ = of('work-packages.new');
 
   constructor(public injector:Injector,
               public wpTableSelection:WorkPackageViewSelectionService,
-              readonly $state:StateService) {
+              readonly $state:StateService,
+              readonly HookService:HookService) {
     super(injector, $state.params['workPackageId']);
+
+    this.registeredAdditionalTabs = this.HookService.call('workPackageAdditionalTabs');
   }
 
   ngOnInit():void {
     this.observeWorkPackage();
+  }
+
+  public additionalTabs():Tab[] {
+    return this.workPackage.additionalTabs(this.registeredAdditionalTabs);
   }
 
   protected initializeTexts() {

--- a/frontend/src/app/modules/work_packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/modules/work_packages/routing/wp-full-view/wp-full-view.html
@@ -74,6 +74,11 @@
                 <a href="" [textContent]="text.tabs.watchers"></a>
                 <wp-watchers-count [wpId]="workPackage.id"></wp-watchers-count>
               </li>
+              <li *ngFor="let tab of additionalTabs()" uiSref="work-packages.show.additionalTabs"
+                  [uiParams]="{workPackageId: workPackage.id, additionalTabIdentifier: tab.identifier}"
+                  uiSrefActive="selected">
+                <a href="" [textContent]="tab.displayName"></a>
+              </li>
             </ul>
           </div>
           <div class="tabcontent" ui-view>

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/work-package-single-view.base.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/work-package-single-view.base.ts
@@ -143,6 +143,7 @@ export class WorkPackageSingleViewBase extends UntilDestroyedMixin {
    * Recompute the current tab focus label
    */
   public updateFocusAnchorLabel(tabName:string):string {
+    // TODO: what to do there when tabName is "additionalTabs" where do i get the value which tab I have at hand? -> ask oliver
     const tabLabel = this.I18n.t('js.label_work_package_details_you_are_here', {
       tab: this.I18n.t('js.work_packages.tabs.' + tabName),
       type: this.workPackage.type.name,

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -315,6 +315,16 @@ module API
           end
         end
 
+        links :additionalWorkPackageTabs,
+              uncacheable: true do
+          additional_work_package_tabs.map do |tab_identifier|
+            {
+              href: "#{work_package_path(id: represented.id)}/additionalTabs/#{tab_identifier}",
+              title: tab_identifier
+            }
+          end
+        end
+
         property :id,
                  render_nil: true
 
@@ -605,6 +615,12 @@ module API
 
         def load_complete_model(model)
           ::API::V3::WorkPackages::WorkPackageEagerLoadingWrapper.wrap_one(model, current_user)
+        end
+
+        # This method is a hook to be extended by plugins.
+        # See our github integration for an example.
+        def additional_work_package_tabs
+          []
         end
       end
     end

--- a/modules/github_integration/config/locales/js-en.yml
+++ b/modules/github_integration/config/locales/js-en.yml
@@ -1,0 +1,45 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+en:
+  js:
+    github_integration:
+      work_packages:
+        tab_name: "GitHub"
+      pull_request_opened_comment: >
+        **PR Opened:** Pull request %{pr_number} [%{pr_title}](%{pr_url}) for [%{repository}](%{repository_url})
+        has been opened by [%{github_user}](%{github_user_url}).
+      pull_request_closed_comment: >
+        **PR Closed:** Pull request %{pr_number} [%{pr_title}](%{pr_url}) for [%{repository}](%{repository_url})
+        has been closed by [%{github_user}](%{github_user_url}).
+      pull_request_merged_comment: >
+        **PR Merged:** Pull request %{pr_number} [%{pr_title}](%{pr_url}) for [%{repository}](%{repository_url})
+        has been merged by [%{github_user}](%{github_user_url}).
+      pull_request_referenced_comment: >
+        **Referenced in PR:** [%{github_user}](%{github_user_url}) referenced this work package in
+        Pull request %{pr_number} [%{pr_title}](%{pr_url}) on [%{repository}](%{repository_url}).

--- a/modules/github_integration/frontend/module/github-tab/github-tab.component.ts
+++ b/modules/github_integration/frontend/module/github-tab/github-tab.component.ts
@@ -1,0 +1,52 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2021 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+//++
+
+import {Component, Input, OnInit} from "@angular/core";
+import {WorkPackageResource} from "core-app/modules/hal/resources/work-package-resource";
+import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
+import {I18nService} from "core-app/modules/common/i18n/i18n.service";
+import { TabComponent } from '../../../../../components/wp-single-view-tabs/additional-tab/tab.component';
+
+
+@Component({
+  selector: 'github-tab',
+  templateUrl: './github-tab.template.html'
+})
+export class GitHubTabComponent implements OnInit, TabComponent {
+  @Input() public workPackage:WorkPackageResource;
+
+  constructor(readonly PathHelper:PathHelperService,
+              readonly I18n:I18nService) {
+  }
+
+
+  ngOnInit() {
+    // debugger; // when triggered we know we can render ANYTHING here
+  }
+}
+

--- a/modules/github_integration/frontend/module/github-tab/github-tab.template.html
+++ b/modules/github_integration/frontend/module/github-tab/github-tab.template.html
@@ -1,0 +1,1 @@
+<div>Hello from the GitHub integration plugin</div>

--- a/modules/github_integration/frontend/module/main.ts
+++ b/modules/github_integration/frontend/module/main.ts
@@ -1,0 +1,59 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2021 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+
+import {Injector, NgModule} from '@angular/core';
+import {OpenProjectPluginContext} from 'core-app/modules/plugins/plugin-context';
+import {GitHubTabComponent} from './github-tab/github-tab.component';
+import {Tab} from "../../../../components/wp-single-view-tabs/additional-tab/tab";
+
+export function initializeGithubIntegrationPlugin(injector:Injector) {
+  window.OpenProject.getPluginContext().then((pluginContext:OpenProjectPluginContext) => {
+    pluginContext.registerAdditionalWorkPackageTab(
+      new Tab(
+        GitHubTabComponent,
+        I18n.t('js.github_integration.work_packages.tab_name'),
+        "github"
+      )
+    )
+  });
+}
+
+
+@NgModule({
+  providers: [
+  ],
+  declarations: [
+    GitHubTabComponent
+  ]
+})
+export class PluginModule {
+  constructor(injector:Injector) {
+    initializeGithubIntegrationPlugin(injector);
+  }
+}
+
+
+

--- a/modules/github_integration/lib/open_project/github_integration/engine.rb
+++ b/modules/github_integration/lib/open_project/github_integration/engine.rb
@@ -34,6 +34,16 @@ module OpenProject::GithubIntegration
   class Engine < ::Rails::Engine
     engine_name :openproject_github_integration
 
+    # TODO, see: modules/backlogs/lib/open_project/backlogs/engine.rb
+    # def self.settings
+    #   { default: { 'story_types'  => nil,
+    #                'task_type'    => nil,
+    #                'card_spec'    => nil
+    #   },
+    #     partial: 'shared/settings',
+    #     menu_item: :backlogs_settings }
+    # end
+
     include OpenProject::Plugins::ActsAsOpEngine
 
     register 'openproject-github_integration',
@@ -54,5 +64,18 @@ module OpenProject::GithubIntegration
                                              &NotificationHandlers.method(:issue_comment))
     end
 
+    initializer 'github.permissions' do
+      OpenProject::AccessControl.map do |map|
+        map.project_module(:github, {}) do |map|
+          map.permission(:show_github_content, {}, {})
+        end
+      end
+    end
+
+    extend_api_response(:v3, :work_packages, :work_package) do
+      require_relative 'patches/api/v3/additional_work_package_tabs'
+
+      prepend Patches::API::V3::AdditionalWorkPackageTabs
+    end
   end
 end

--- a/modules/github_integration/lib/open_project/github_integration/patches/api/v3/additional_work_package_tabs.rb
+++ b/modules/github_integration/lib/open_project/github_integration/patches/api/v3/additional_work_package_tabs.rb
@@ -1,0 +1,11 @@
+module OpenProject::GithubIntegration::Patches
+  module API::V3::AdditionalWorkPackageTabs
+    def additional_work_package_tabs
+      if represented.project.module_enabled?(:github) && current_user.allowed_to?(:show_github_content, represented.project)
+        super + [:github]
+      else
+        super
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an early preview of my work of enhancing the GitHub Integration.
It demos the new interface to add additional tabs in OP core.

Before reviewing this PR, please take a look at https://github.com/opf/openproject/pull/8988