### PR TITLE
Update codeclimate config to run rubocop again

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -27,7 +27,7 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-1-9
+    channel: rubocop-1-9-1
   # Codeclimate uses brakeman 4.3.1 which does not support rails 6
   # Check https://docs.codeclimate.com/docs/brakeman for updates.
   brakeman:


### PR DESCRIPTION
The "rubocop-1-9" channel could not be found by codeclimate, as it's name is actually "rubocop-1-9-1". (or, more likely, the `rubocop-1-9` channel was removed due to bugs).

![Screenshot 2021-02-10 at 14 56 53](https://user-images.githubusercontent.com/206108/107521321-b336dd00-6bb2-11eb-86a7-d0e5066748c9.png)

After updating, of course, it surfaces that rubocop fails spectacularly for a while already 💥

![Screenshot 2021-02-10 at 15 44 48](https://user-images.githubusercontent.com/206108/107525367-162a7300-6bb7-11eb-98b3-bb2cbde1f109.png)

I see two options:

1. let rubocop auto-fix as many things as possible trusting in it being good enough
2. disable anything that was introduced as a change/new cop since rubocop silently failed on codeclimate

I would personally go with 1. ( in a slight variation)

* update rubocop from 1.9.0 to 1.9.1 (fixing some rubocop bugs that are triggered by scanning our code)
* let the auto-fixer run all the fixes && commit this PR as fast as possible
   I did this locally and it fixes the majority of the things:
   ```
   4477 files inspected, 1878 offenses detected, 1 offense corrected

   Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
     * rubocop-rails (http://github.com/rubocop-hq/rubocop-rails)
     * rubocop-rspec (http://github.com/rubocop-hq/rubocop-rspec)
   ```

   1877 issues are left from 5586 - most of them seem to be easy fixes (line too long etc.)
* add a rubocop-todo.yml to disable the currently know lint failures
* enable rubocop again for all future PRs
* later:
  * fix the other issues one lint after the other in additional PRs
  * Take the rubocop-tip it gives us above serious and add `rubocop-rails` and `rubocop-rspec`.

What do you think?