### PR TITLE
fix role api permission checks

### DIFF
--- a/lib/api/v3/roles/roles_api.rb
+++ b/lib/api/v3/roles/roles_api.rb
@@ -32,13 +32,15 @@ module API
     module Roles
       class RolesAPI < ::API::OpenProjectAPI
         resources :roles do
+          after_validation do
+            authorize_any(%i[view_members manage_members], global: true)
+          end
+
           get &::API::V3::Utilities::Endpoints::Index.new(model: Role).mount
 
           route_param :id, type: Integer, desc: 'Role ID' do
-            before do
-              authorize_any(%i[view_members manage_members], global: true)
-
-              @role = Role.find(params[:id])
+            after_validation do
+              @role = Role.find(declared_params[:id])
             end
 
             get &::API::V3::Utilities::Endpoints::Show.new(model: Role).mount

--- a/spec/requests/api/v3/role_resource_spec.rb
+++ b/spec/requests/api/v3/role_resource_spec.rb
@@ -36,10 +36,11 @@ describe 'API v3 roles resource', type: :request do
   let(:current_user) do
     FactoryBot.create(:user,
                       member_in_project: project,
-                      member_with_permissions: permissions)
+                      member_through_role: role)
   end
   let(:role) do
-    FactoryBot.create(:role)
+    FactoryBot.create(:role,
+                      permissions: permissions)
   end
   let(:permissions) { %i[view_members manage_members] }
   let(:project) { FactoryBot.create(:project) }
@@ -53,6 +54,8 @@ describe 'API v3 roles resource', type: :request do
 
     before do
       roles
+
+      login_as(current_user)
 
       get get_path
     end
@@ -107,6 +110,15 @@ describe 'API v3 roles resource', type: :request do
         expect(subject.body)
           .to be_json_eql(role.id.to_json)
           .at_path('_embedded/elements/0/id')
+      end
+    end
+
+    context 'without the necessary permissions' do
+      let(:permissions) { [] }
+
+      it 'returns 403' do
+        expect(subject.status)
+          .to eql(403)
       end
     end
   end


### PR DESCRIPTION
The authorization on the individual get was handled to early (before instead of after_validation) so that the current user wasn`t set correctly yet. Additionally, there was not dedicated authorization check on the index get action