### PR TITLE
Fix EXPOSE of Dockerfile for prod

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -57,7 +57,7 @@ COPY . .
 RUN ./docker/prod/setup/postinstall.sh
 
 # Expose ports for apache and postgres
-EXPOSE 80 5432
+EXPOSE 8080 5432
 
 # Expose the postgres data directory and OpenProject data directory as volumes
 VOLUME ["$PGDATA", "$APP_DATA_PATH"]


### PR DESCRIPTION
Proxy and web are listening 8080 port.
So the Dockerfile should expose 8080 port.