### PR TITLE
add rupocop-rails and rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,11 @@
+require:
+  - rubocop-rails
+  - rubocop-rspec
+
 AllCops:
   TargetRubyVersion: 2.7
   Exclude:
     - db/schema.rb
-
 
 Layout/ConditionPosition:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -250,6 +250,8 @@ group :development do
   gem 'spring-commands-rspec'
 
   gem 'rubocop'
+  gem 'rubocop-rails'
+  gem 'rubocop-rspec'
 
   # Gems for living styleguide
   gem 'livingstyleguide', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -799,6 +799,13 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
+    rubocop-rails (2.9.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.90.0, < 2.0)
+    rubocop-rspec (2.2.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-duration (3.2.3)
       activesupport (>= 3.0.0)
       i18n
@@ -1050,6 +1057,8 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0)
   rspec-retry (~> 0.6.1)
   rubocop
+  rubocop-rails
+  rubocop-rspec
   ruby-duration (~> 3.2.0)
   ruby-prof
   ruby-progressbar (~> 1.11.0)


### PR DESCRIPTION
Adds additional rubocop cops specifically targeted at rails and rspec. 

This will obviously cause many additional defects to be detected by rubocop. We don't need to fix them now, however, but can work them off one at a time.

 Additionally, we might want to tweak/disable rules if they don't fit our style of working. 