### PR TITLE
Feature/36051 open pdf link in new tab

### DIFF
--- a/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.ts
+++ b/frontend/src/app/modules/job-status/job-status-modal/job-status.modal.ts
@@ -4,8 +4,8 @@ import {OpModalComponent} from 'core-components/op-modals/op-modal.component';
 import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {OpModalLocalsToken} from "core-components/op-modals/op-modal.service";
 import {HttpClient, HttpErrorResponse, HttpResponse} from '@angular/common/http';
-import {interval, Observable, timer} from "rxjs";
-import {map, switchMap, takeUntil, takeWhile} from "rxjs/operators";
+import {Observable, timer} from "rxjs";
+import {switchMap, takeWhile} from "rxjs/operators";
 import {
   LoadingIndicatorService,
   withDelayedLoadingIndicator
@@ -151,11 +151,20 @@ export class JobStatusModal extends OpModalComponent implements OnInit {
     }
   }
 
-  private handleDownload(downloadUrl?:string) {
-    if (downloadUrl !== undefined) {
-      this.downloadHref = downloadUrl;
-      // Click download link manually
-      setTimeout(() => this.downloadLink.nativeElement.click(), 50);
+  private handleDownload(redirectionUrl?:string) {
+    if (redirectionUrl !== undefined) {
+      // Get the file url from the redirectionUrl
+      this.httpClient
+        .get(redirectionUrl, {
+          observe: 'response',
+          responseType: 'text'
+        })
+        .subscribe(response => {
+          this.downloadHref = response.url;
+
+          this.cdRef.detectChanges();
+          this.downloadLink.nativeElement.click();
+        });
     }
   }
 

--- a/frontend/src/global_styles/content/_projects_list.sass
+++ b/frontend/src/global_styles/content/_projects_list.sass
@@ -143,8 +143,10 @@ form.project-filters
   .generic-table--header-outer:hover
     background: initial
 
-  td.name a
-    white-space: nowrap
+  td.name
+    @include text-shortener
+    a
+      white-space: nowrap
 
   td.project--hierarchy
     white-space: nowrap

--- a/frontend/src/global_styles/layout/_top_menu.sass
+++ b/frontend/src/global_styles/layout/_top_menu.sass
@@ -26,9 +26,6 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-$hamburger-right: -3px
-$hamburger-width: 50px
-
 %top-menu-hover-styles
   background: var(--header-item-bg-hover-color)
   color: var(--header-item-font-hover-color)

--- a/frontend/src/global_styles/openproject/_variables.scss
+++ b/frontend/src/global_styles/openproject/_variables.scss
@@ -209,6 +209,8 @@
   --grid-background-color: #F3F6F8;
   --work-package-details--tab-height: 40px;
   --warn:#C92A2A;
+  --hamburger-right: -3px;
+  --hamburger-width: 50px;
 }
 
 // SCSS variables needed for foundation, but that are set in css variables now only


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/36051

This pull request:

- [x] Changes the export links to point to the original source file (skipping redirection) so the download is opened in a new tab.

**Notes**
- Currently, we GET to `[domain]/api/v3/job_statuses/[jobId]` in order to get an url (`[domain]/api/v3/attachments/[attachmentId]/content`) that when called redirects to the Amazon url of the file ( `https://openproject-edge-com-data.s3.eu-west-1.amazonaws.com/qa/attachment/file/...`). 
- This redirection seems to cause the "download" attribute to not work properly, probably because of CORS issues, opening the file in the same tab.
- In the current fix, in order to get the Amazon url of the file, we read the response headers of the redirection call. Maybe it would be a better approach that the backend would return the Amazon url directly from `[domain]/api/v3/job_statuses/[jobId]` and skip redirection.