### PR TITLE
Add common op-principal component and service to render

### DIFF
--- a/frontend/src/app/modules/apiv3/api-v3.service.ts
+++ b/frontend/src/app/modules/apiv3/api-v3.service.ts
@@ -112,6 +112,9 @@ export class APIV3Service {
   // /api/v3/users
   public readonly users = this.apiV3CustomEndpoint(Apiv3UsersPaths);
 
+  // /api/v3/placeholderUsers
+  public readonly placeholder_users = this.apiV3CollectionEndpoint('placeholder_users')
+
   // /api/v3/help_texts
   public readonly help_texts = this.apiV3CustomEndpoint(Apiv3HelpTextsPaths);
 

--- a/frontend/src/app/modules/common/openproject-common.module.ts
+++ b/frontend/src/app/modules/common/openproject-common.module.ts
@@ -84,6 +84,8 @@ import {TimeEntryWorkPackageAutocompleterComponent} from "core-app/modules/commo
 import {DraggableAutocompleteComponent} from "core-app/modules/common/draggable-autocomplete/draggable-autocomplete.component";
 import {DragulaModule} from "ng2-dragula";
 import {SlideToggleComponent} from "core-app/modules/common/slide-toggle/slide-toggle.component";
+import {PrincipalRendererService} from "core-app/modules/common/principal/principal-renderer.service";
+import {OpPrincipalComponent} from "core-app/modules/common/principal/op-principal.component";
 
 export function bootstrapModule(injector:Injector) {
   // Ensure error reporter is run
@@ -197,6 +199,7 @@ export function bootstrapModule(injector:Injector) {
     // filter
 
     SlideToggleComponent,
+    OpPrincipalComponent,
   ],
   declarations: [
     OpDatePickerComponent,
@@ -246,6 +249,7 @@ export function bootstrapModule(injector:Injector) {
 
     // User Avatar
     UserAvatarComponent,
+    OpPrincipalComponent,
 
     PersistentToggleComponent,
     AutocompleteSelectDecorationComponent,

--- a/frontend/src/app/modules/common/path-helper/path-helper.service.ts
+++ b/frontend/src/app/modules/common/path-helper/path-helper.service.ts
@@ -28,6 +28,7 @@
 
 import {Injectable} from '@angular/core';
 import {ApiV3FilterBuilder} from "core-components/api/api-v3/api-v3-filter-builder";
+import {HalResource} from "core-app/modules/hal/resources/hal-resource";
 
 class Apiv3Paths {
   readonly apiV3Base:string;
@@ -224,8 +225,24 @@ export class PathHelperService {
     return `${this.staticBase}/users`;
   }
 
+  public groupsPath() {
+    return `${this.staticBase}/groups`;
+  }
+
+  public placeholderUsersPath() {
+    return `${this.staticBase}/placeholder_users`;
+  }
+
   public userPath(id:string|number) {
     return `${this.usersPath()}/${id}`;
+  }
+
+  public placeholderUserPath(id:string|number) {
+    return `${this.placeholderUsersPath()}/${id}`;
+  }
+
+  public groupPath(id:string|number) {
+    return `${this.groupsPath()}/${id}`;
   }
 
   public versionsPath() {

--- a/frontend/src/app/modules/common/principal/op-principal.component.ts
+++ b/frontend/src/app/modules/common/principal/op-principal.component.ts
@@ -1,0 +1,89 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2021 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+//++
+
+import {Component, ElementRef, Input, OnInit} from '@angular/core';
+import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
+import {PathHelperService} from 'core-app/modules/common/path-helper/path-helper.service';
+import {TimezoneService} from 'core-components/datetime/timezone.service';
+import {APIV3Service} from "core-app/modules/apiv3/api-v3.service";
+import {PrincipalHelper} from "core-app/modules/common/principal/principal-helper";
+import PrincipalPluralType = PrincipalHelper.PrincipalPluralType;
+import {PrincipalLike, PrincipalRendererService} from "core-app/modules/common/principal/principal-renderer.service";
+
+@Component({
+  template: '',
+  selector: 'op-principal',
+  host: {'class': 'op-principal'}
+})
+export class OpPrincipalComponent implements OnInit {
+  /** If coming from angular, pass a principal resource if available */
+  @Input() principal:PrincipalLike;
+  @Input() renderAvatar:boolean = true;
+  @Input() renderName:boolean = true;
+  @Input() avatarClasses:string = '';
+
+  public constructor(readonly elementRef:ElementRef,
+                     readonly PathHelper:PathHelperService,
+                     readonly principalRenderer:PrincipalRendererService,
+                     readonly I18n:I18nService,
+                     readonly apiV3Service:APIV3Service,
+                     readonly timezoneService:TimezoneService) {
+
+  }
+
+  ngOnInit() {
+    const element = this.elementRef.nativeElement;
+
+    if (!this.principal) {
+      this.principal = this.principalFromDataset(element);
+      this.renderAvatar = element.dataset.renderAvatar === 'true';
+      this.renderName = element.dataset.renderName === 'true';
+      this.avatarClasses = element.dataset.avatarClasses ?? '';
+    }
+
+    this.principalRenderer.render(
+      element,
+      this.principal,
+      this.renderName,
+      this.renderAvatar ? { classes: this.avatarClasses } : false
+    );
+  }
+
+  private principalFromDataset(element:HTMLElement) {
+    const id = element.dataset.principalId!;
+    const type = element.dataset.principalType;
+    const plural = type + 's' as PrincipalPluralType;
+    const href = this.apiV3Service[plural].id(id).toString();
+
+    return {
+      id: id,
+      name: element.dataset.principalName!,
+      href: href
+    }
+  }
+}

--- a/frontend/src/app/modules/common/principal/principal-helper.ts
+++ b/frontend/src/app/modules/common/principal/principal-helper.ts
@@ -1,0 +1,43 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2021 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+//++
+
+export namespace PrincipalHelper {
+  export type PrincipalType = 'user'|'placeholder_user'|'group';
+  export type PrincipalPluralType = 'users'|'placeholder_users'|'groups';
+
+  export function typeFromHref(href:string):PrincipalType|null {
+    const match = href.match(/\/(user|group|placeholder_user)s\/\d+$/);
+
+    if (!match) {
+      return null;
+    }
+
+    return match[1] as PrincipalType;
+  }
+}
+

--- a/frontend/src/app/modules/common/principal/principal-renderer.service.ts
+++ b/frontend/src/app/modules/common/principal/principal-renderer.service.ts
@@ -1,0 +1,131 @@
+import {Injectable} from "@angular/core";
+import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
+import {ColorsService} from "core-app/modules/common/colors/colors.service";
+import {APIV3Service} from "core-app/modules/apiv3/api-v3.service";
+import {PrincipalHelper} from "core-app/modules/common/principal/principal-helper";
+import PrincipalType = PrincipalHelper.PrincipalType;
+
+export interface PrincipalLike {
+  id:string;
+  name:string;
+  href:string;
+}
+export interface AvatarOptions {
+  classes:string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PrincipalRendererService {
+
+  constructor(private pathHelper:PathHelperService,
+              private apiV3Service:APIV3Service,
+              private colors:ColorsService) {
+
+  }
+
+  renderMultiple(container:HTMLElement,
+                 users:PrincipalLike[],
+                 renderName:boolean = true,
+                 multiLine:boolean = false) {
+
+    const span = document.createElement('span');
+
+
+    for (let i = 0; i < users.length; i++) {
+      const avatar = document.createElement('span');
+      if (multiLine) {
+        avatar.classList.add('user-avatar--multi-line');
+      }
+
+      this.render(avatar, users[i], renderName);
+
+      if (!multiLine && i < users.length - 1) {
+        const sep = document.createElement('span');
+        sep.textContent = ', ';
+        avatar.appendChild(sep);
+      }
+
+      span.appendChild(avatar);
+    }
+
+    container.appendChild(span);
+  }
+
+  render(container:HTMLElement,
+         principal:PrincipalLike,
+         name:boolean = true,
+         avatar:false|AvatarOptions = { classes: 'avatar-medium' }):void {
+
+    const type = PrincipalHelper.typeFromHref(principal.href)!;
+
+    if (avatar) {
+      const el = this.renderAvatar(principal, avatar, type);
+      container.appendChild(el);
+    }
+
+    if (name) {
+      const el = this.renderName(principal, type);
+      container.appendChild(el);
+    }
+  }
+
+  private renderAvatar(principal:PrincipalLike, avatar:AvatarOptions, type:PrincipalType) {
+    const userInitials = this.getInitials(principal.name);
+    const colorCode = this.colors.toHsl(principal.name);
+
+    let fallback = document.createElement('div');
+    fallback.className = avatar.classes;
+    fallback.classList.add('avatar-default');
+    fallback.textContent = userInitials;
+    fallback.style.background = colorCode;
+
+    // Image avatars are only supported for users
+    if (type === 'user') {
+      this.renderUserAvatar(principal, fallback, avatar);
+    }
+
+    return fallback;
+  }
+
+  private renderUserAvatar(principal:PrincipalLike, fallback:HTMLElement, avatar:AvatarOptions) {
+    const image = new Image();
+    image.className = avatar.classes;
+    image.classList.add('avatar--fallback');
+    image.src = this.apiV3Service.users.id(principal.id).avatar.toString();
+    image.title = principal.name;
+    image.alt = principal.name;
+    image.onload = function () {
+      fallback.replaceWith(image);
+      (fallback as any) = undefined;
+    };
+  }
+
+  private renderName(principal:PrincipalLike, type:PrincipalType) {
+    const link = document.createElement('a');
+    link.textContent = principal.name;
+    link.href = this.principalURL(principal, type);
+    link.target = '_blank';
+
+    return link;
+  }
+
+  private principalURL(principal:PrincipalLike, type:PrincipalType) {
+    switch (type) {
+      case 'group':
+        return this.pathHelper.groupPath(principal.id);
+      case 'placeholder_user':
+        return this.pathHelper.placeholderUserPath(principal.id);
+      case 'user':
+        return this.pathHelper.userPath(principal.id);
+    }
+  }
+
+  private getInitials(name:string) {
+    let characters = [...name];
+    let lastSpace = name.lastIndexOf(' ');
+    let first = characters[0]?.toUpperCase();
+    let last = name[lastSpace + 1]?.toUpperCase();
+
+    return [first, last].join("");
+  }
+}

--- a/frontend/src/app/modules/grids/widgets/members/members.component.html
+++ b/frontend/src/app/modules/grids/widgets/members/members.component.html
@@ -19,22 +19,14 @@
       </div>
 
       <div class="attributes-map--value">
-          <span *ngFor="let principal of usersByRole.users; let last = last">
-
-            <ng-container *ngIf="isGroup(principal)">
-              <span [textContent]="userName(principal)"></span>
-            </ng-container>
-            <ng-container *ngIf="!isGroup(principal)">
-              <user-avatar [user]="principal"
-                           data-class-list="avatar avatar-mini -spaced">
-              </user-avatar>
-              <a [href]="userPath(principal)"
-                 [textContent]="userName(principal)">
-              </a>
-            </ng-container>
-
+          <ng-container *ngFor="let principal of usersByRole.users; let last = last">
+            <op-principal
+                [principal]="principal"
+                avatarClasses="avatar avatar-mini -spaced"
+                >
+            </op-principal>
             <ng-container *ngIf="!last">, </ng-container>
-          </span>
+          </ng-container>
       </div>
     </ng-container>
   </div>

--- a/frontend/src/app/modules/grids/widgets/members/members.component.ts
+++ b/frontend/src/app/modules/grids/widgets/members/members.component.ts
@@ -64,14 +64,6 @@ export class WidgetMembersComponent extends AbstractWidgetComponent implements O
     return false;
   }
 
-  public userPath(user:UserResource) {
-    return this.pathHelper.userPath(user.id!);
-  }
-
-  public userName(user:UserResource) {
-    return user.name;
-  }
-
   public get noMembers() {
     return this.entriesLoaded && !Object.keys(this.entriesByRoles).length;
   }
@@ -95,10 +87,6 @@ export class WidgetMembersComponent extends AbstractWidgetComponent implements O
     return Object.values(this.entriesByRoles);
   }
 
-  public isGroup(principal:UserResource) {
-    return this.apiV3Service.groups.id(principal.id!).toString() === principal.href;
-  }
-
   private partitionEntriesByRole(memberships:MembershipResource[]) {
     memberships.forEach(membership => {
       membership.roles.forEach((role) => {
@@ -114,7 +102,7 @@ export class WidgetMembersComponent extends AbstractWidgetComponent implements O
   private sortUsersByName() {
     Object.values(this.entriesByRoles).forEach(entry => {
       entry.users.sort((a, b) => {
-        return this.userName(a).localeCompare(this.userName(b));
+        return a.name.localeCompare(b.name);
       });
     });
   }

--- a/modules/dashboards/spec/features/members_principals_spec.rb
+++ b/modules/dashboards/spec/features/members_principals_spec.rb
@@ -1,0 +1,89 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+require_relative '../support/pages/overview'
+
+describe 'Overview page members', type: :feature, js: true, with_mail: false do
+  shared_let(:type) { FactoryBot.create :type }
+  shared_let(:project) { FactoryBot.create :project, types: [type], description: 'My **custom** description' }
+
+  shared_let(:permissions) do
+    %i[manage_overview
+       view_members
+      ]
+  end
+
+  shared_let(:user) do
+    FactoryBot.create(:user,
+                      firstname: 'Foo',
+                      lastname: 'Bar',
+                      member_in_project: project,
+                      member_with_permissions: permissions)
+  end
+
+  shared_let(:group) do
+    FactoryBot.create(:group,
+                      groupname: 'DEV Team',
+                      member_in_project: project,
+                      member_with_permissions: permissions)
+  end
+
+  shared_let(:placeholder) do
+    FactoryBot.create(:placeholder_user,
+                      name: 'DEVELOPER PLACEHOLDER',
+                      member_in_project: project,
+                      member_with_permissions: permissions)
+  end
+
+  let(:overview_page) do
+    Pages::Overview.new(project)
+  end
+
+  before do
+    login_as user
+
+    overview_page.visit!
+  end
+
+  it 'renders the default view, allows altering and saving' do
+    members_block = page.find('.widget-box', text: 'MEMBERS')
+
+    within(members_block) do
+      user_link = find('op-principal a', text: user.name)
+      expect(user_link['href']).to end_with user_path(user.id)
+
+      group_link = find('op-principal a', text: group.name)
+      expect(group_link['href']).to end_with show_group_path(group.id)
+
+      placeholder_link = find('op-principal a', text: placeholder.name)
+      expect(placeholder_link['href']).to end_with placeholder_user_path(placeholder.id)
+    end
+  end
+end


### PR DESCRIPTION
The service renders just like avatars for users outside angular as it will also be used for rendering group and placeholder
"avatars" and replace the UserAvatar render service.

Fixes for 11.2
https://community.openproject.com/work_packages/36226

I added some duplicated from `user-avatar` here by design. This is to be resolved when different avatars for users/groups/placeholders are to be added. This was defined into https://community.openproject.com/work_packages/36243