### PR TITLE
fix # of elements in wp list not matching pagination

### DIFF
--- a/app/models/custom_field/order_statements.rb
+++ b/app/models/custom_field/order_statements.rb
@@ -123,7 +123,7 @@ module CustomField::OrderStatements
 
   def select_custom_values_joined_options_as_group
     <<-SQL
-      COALESCE((SELECT string_agg(co_sort.value, '.' ORDER BY co_sort.position ASC) FROM #{CustomOption.table_name} co_sort
+      COALESCE((SELECT string_agg(co_sort.value, '.' ORDER BY co_sort.position) FROM #{CustomOption.table_name} co_sort
         LEFT JOIN #{CustomValue.table_name} cv_sort
         ON cv_sort.value IS NOT NULL AND co_sort.id = cv_sort.value::numeric
         WHERE #{cv_sort_only_custom_field_condition_sql}), '')

--- a/app/models/queries/work_packages/columns/manual_sorting_column.rb
+++ b/app/models/queries/work_packages/columns/manual_sorting_column.rb
@@ -34,7 +34,7 @@ class Queries::WorkPackages::Columns::ManualSortingColumn < Queries::WorkPackage
   def initialize
     super :manual_sorting,
           default_order: 'asc',
-          sortable: "#{OrderedWorkPackage.table_name}.position NULLS LAST, #{WorkPackage.table_name}.id"
+          sortable: ["#{OrderedWorkPackage.table_name}.position NULLS LAST", "#{WorkPackage.table_name}.id"]
   end
 
   def sortable_join_statement(query)

--- a/modules/backlogs/lib/open_project/backlogs/query_backlogs_column.rb
+++ b/modules/backlogs/lib/open_project/backlogs/query_backlogs_column.rb
@@ -42,7 +42,8 @@ module OpenProject::Backlogs
       position: {
         default_order: 'asc',
         # Sort by position only, always show work_packages without a position at the end
-        sortable: "CASE WHEN #{WorkPackage.table_name}.position IS NULL THEN 1 ELSE 0 END ASC, #{WorkPackage.table_name}.position"
+        sortable: ["CASE WHEN #{WorkPackage.table_name}.position IS NULL THEN 1 ELSE 0 END ASC",
+                   "#{WorkPackage.table_name}.position"]
       }
     }
 

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -32,7 +32,7 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
   include API::V3::Utilities::PathHelper
 
   let(:self_base_link) { '/api/v3/example' }
-  let(:work_packages) { WorkPackage.all }
+  let(:work_packages) { WorkPackage.all.order(id: :asc) }
   let(:user) { FactoryBot.build_stubbed(:user) }
 
   let(:query) { {} }


### PR DESCRIPTION
Because of a LEFT JOIN, work package records can be present twice in the result returned by the SQL to fetch the work packages. As there is a chain of queries, having duplicates in the first query, which is used to fetch the ids for later querying will then result in those duplicates to be removed again when the work packages are actually filtered for (by the ids returned in the first query). But because of the duplicates begin removed, the number of elements does not match the number of specified elements, e.g. a only 35 elements returned for a pages size of 50.

Applying DISTINCT to the query for the ids solves the problem but requires to have all columns used for the ORDER BY present in the SELECT projection. This is done via a hack.

https://community.openproject.org/projects/openproject/work_packages/35045