### PR TITLE
URLs correction of available assignees and available assignees

### DIFF
--- a/docs/api/apiv3/endpoints/work-packages.apib
+++ b/docs/api/apiv3/endpoints/work-packages.apib
@@ -2116,14 +2116,14 @@ Returns the activity resource
                 "message": "The specified work package does not exist."
             }
 
-## Available Assignees [/api/v3/projects/{project_id}/work_packages/available_assignees]
+## Available Assignees [/api/v3/projects/{project_id}/available_assignees]
 
 + Model
     + Body
 
             {
                 "_links": {
-                    "self": { "href": "/api/v3/projects/42/work_packages/available_assignees" }
+                    "self": { "href": "/api/v3/projects/42/available_assignees" }
                 },
                 "total": 2,
                 "count": 2,
@@ -2230,14 +2230,14 @@ Gets a list of users that can be assigned to work packages in the given project.
                 "message": "The specified project does not exist."
             }
 
-## Available Responsibles [/api/v3/projects/{project_id}/work_packages/available_responsibles]
+## Available Responsibles [/api/v3/projects/{project_id}/available_responsibles]
 
 + Model
     + Body
 
             {
                 "_links": {
-                    "self": { "href": "/api/v3/projects/42/work_packages/available_responsibles" }
+                    "self": { "href": "/api/v3/projects/42/available_responsibles" }
                 },
                 "total": 2,
                 "count": 2,


### PR DESCRIPTION
The concerned URLs of concerned functionalities don't contain "work_packages" string in the reality.