### PR TITLE
hcaptcha support

### DIFF
--- a/modules/recaptcha/app/views/recaptcha/request/perform.html.erb
+++ b/modules/recaptcha/app/views/recaptcha/request/perform.html.erb
@@ -4,13 +4,27 @@
   <%= styled_form_tag({ action: :verify }, { :autocomplete => "off", :id => 'submit_captcha' }) do %>
     <h2><%= t 'recaptcha.verify_account' %></h2>
     <% if recaptcha_settings[:recaptcha_type] == ::OpenProject::Recaptcha::TYPE_V2 %>
-      <input type="hidden" name="g-recaptcha-response" />
-      <%= recaptcha_tags nonce: content_security_policy_script_nonce,
-                          callback: 'submitRecaptchaForm',
-                         site_key: recaptcha_settings[:website_key] %>
+      <% input_name = "g-recaptcha-response" %>
+      <input type="hidden" name="<%= input_name %>" />
+      <%= recaptcha_tags(
+        nonce: content_security_policy_script_nonce,
+        callback: 'submitRecaptchaForm',
+        site_key: recaptcha_settings[:website_key]
+      ) %>
+
       <%= nonced_javascript_tag do %>
         function submitRecaptchaForm(val) {
-          document.getElementById('g-recaptcha-response').value = val;
+          var input = document.getElementById('<%= input_name %>');
+
+          if (!input) { // hcaptcha uses name, not ID
+            var inputs = document.getElementsByName('<%= input_name %>');
+
+            if (inputs.length > 0) {
+              input = inputs[0];
+            }
+          }
+
+          input.value = val;
           document.getElementById('submit_captcha').submit();
         }
       <% end %>

--- a/modules/recaptcha/config/initializers/recaptcha.rb
+++ b/modules/recaptcha/config/initializers/recaptcha.rb
@@ -1,0 +1,16 @@
+Recaptcha.configure do |config|
+  # site_key and secret_key are defined via ENV already (RECAPTCHA_SITE_KEY, RECAPTCHA_SECRET_KEY)
+
+  config.verify_url = OpenProject::Recaptcha.verify_url_override || config.verify_url
+  config.api_server_url = OpenProject::Recaptcha.api_server_url_override || config.api_server_url
+end
+
+module RecaptchaLimitOverride
+  def invalid_response?(resp)
+    return super unless OpenProject::Recaptcha::use_hcaptcha?
+
+    resp.empty? || resp.length > ::OpenProject::Recaptcha.hcaptcha_response_limit
+  end
+end
+
+Recaptcha.singleton_class.prepend RecaptchaLimitOverride

--- a/modules/recaptcha/lib/open_project/recaptcha.rb
+++ b/modules/recaptcha/lib/open_project/recaptcha.rb
@@ -5,5 +5,8 @@ module OpenProject
     TYPE_V3 ||= 'v3'
 
     require "open_project/recaptcha/engine"
+    require "open_project/recaptcha/configuration"
+
+    extend Configuration
   end
 end

--- a/modules/recaptcha/lib/open_project/recaptcha/configuration.rb
+++ b/modules/recaptcha/lib/open_project/recaptcha/configuration.rb
@@ -1,0 +1,31 @@
+module OpenProject
+  module Recaptcha
+    module Configuration
+      extend self
+
+      def use_hcaptcha?
+        OpenProject::Configuration['recaptcha_via_hcaptcha']
+      end
+
+      def hcaptcha_response_limit
+        @hcaptcha_response_limit ||= (ENV["RECAPTCHA_RESPONSE_LIMIT"].presence || 5000).to_i
+      end
+
+      def api_server_url_override
+        ENV["RECAPTCHA_API_SERVER_URL"].presence || ((use_hcaptcha? || nil) && hcaptcha_api_server_url)
+      end
+
+      def verify_url_override
+        ENV["RECAPTCHA_VERIFY_URL"].presence || ((use_hcaptcha? || nil) && hcaptcha_verify_url)
+      end
+
+      def hcaptcha_verify_url
+        "https://hcaptcha.com/siteverify"
+      end
+
+      def hcaptcha_api_server_url
+        "https://hcaptcha.com/1/api.js"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows using hcaptcha as a drop-in replacement instead of recaptcha's actual services by configuring `OPENPROJECT_RECAPTCHA__VIA__HCAPTCHA=true`.