### PR TITLE
Revert removal of groups XML responses

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -38,52 +38,93 @@ class GroupsController < ApplicationController
   before_action :find_group, only: %i[destroy show create_memberships destroy_membership
                                       edit_membership add_users]
 
+  # GET /groups
+  # GET /groups.xml
   def index
     @groups = Group.order(Arel.sql('lastname ASC'))
+
+    respond_to do |format|
+      format.html # index.html.erb
+      format.xml { render xml: @groups }
+    end
   end
 
+  # GET /groups/1
+  # GET /groups/1.xml
   def show
-    @group_users = group_members
-    render layout: 'no_menu'
+    respond_to do |format|
+      format.html do
+        @group_users = group_members
+        render layout: 'no_menu'
+      end
+      format.xml { render xml: @group }
+    end
   end
 
+  # GET /groups/new
+  # GET /groups/new.xml
   def new
     @group = Group.new
+
+    respond_to do |format|
+      format.html # new.html.erb
+      format.xml  { render xml: @group }
+    end
   end
 
+  # GET /groups/1/edit
   def edit
     @group = Group.includes(:members, :users).find(params[:id])
 
     set_filters_for_user_autocompleter
   end
 
+  # POST /groups
+  # POST /groups.xml
   def create
     @group = Group.new permitted_params.group
 
-    if @group.save
-      flash[:notice] = I18n.t(:notice_successful_create)
-      redirect_to(groups_path)
-    else
-      render action: :new
+    respond_to do |format|
+      if @group.save
+        flash[:notice] = I18n.t(:notice_successful_create)
+        format.html { redirect_to(groups_path) }
+        format.xml  { render xml: @group, status: :created, location: @group }
+      else
+        format.html { render action: :new }
+        format.xml  { render xml: @group.errors, status: :unprocessable_entity }
+      end
     end
   end
 
+  # PUT /groups/1
+  # PUT /groups/1.xml
   def update
     @group = Group.includes(:users).find(params[:id])
 
-    if @group.update(permitted_params.group)
-      flash[:notice] = I18n.t(:notice_successful_update)
-      redirect_to action: :index
-    else
-      render action: :edit
+    respond_to do |format|
+      if @group.update(permitted_params.group)
+        flash[:notice] = I18n.t(:notice_successful_update)
+        format.html { redirect_to(groups_path) }
+        format.xml  { head :ok }
+      else
+        format.html { render action: 'edit' }
+        format.xml  { render xml: @group.errors, status: :unprocessable_entity }
+      end
     end
   end
 
+  # DELETE /groups/1
+  # DELETE /groups/1.xml
   def destroy
     ::Principals::DeleteJob.perform_later(@group)
 
-    flash[:info] = I18n.t(:notice_deletion_scheduled)
-    redirect_to action: :index
+    respond_to do |format|
+      format.html do
+        flash[:info] = I18n.t(:notice_deletion_scheduled)
+        redirect_to(action: :index)
+      end
+      format.xml { head 202 }
+    end
   end
 
   def add_users


### PR DESCRIPTION
Reverts the removal of XML responses in the groups controller as part of pull request https://github.com/opf/openproject/pull/8949 that we thought were unused anyway. Turns out they're not, thanks to the feedback of @maxemann96. They will be removed once the APIv3 endpoint for groups can do the same job

There is a minor change in the way `DELETE /groups/:id` works, as with 11.2 groups are deleted asynchronously in the backend. The returned response is 202 Accepted now to match our other API responses with that pattern