### PR TITLE
Fix: 36299 -- Allow to modify login when global permission :manage_users present

### DIFF
--- a/app/contracts/users/base_contract.rb
+++ b/app/contracts/users/base_contract.rb
@@ -30,7 +30,8 @@
 
 module Users
   class BaseContract < ::ModelContract
-    attribute :login
+    attribute :login,
+              writeable: ->(*) { user.allowed_to_globally?(:manage_user) && model.id != user.id }
     attribute :firstname
     attribute :lastname
     attribute :name

--- a/app/contracts/users/create_contract.rb
+++ b/app/contracts/users/create_contract.rb
@@ -54,7 +54,8 @@ module Users
     end
 
     ##
-    # Users can only be created by Admins
+    # Users can only be created by Admins or users with
+    # the global right to :manage_user
     def user_allowed_to_add
       unless user.allowed_to_globally?(:manage_user)
         errors.add :base, :error_unauthorized

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -208,8 +208,8 @@ class PermittedParams
       additional_params << :force_password_change if change_password_allowed
       additional_params << :admin
     end
-
-    additional_params << :login if current_user.allowed_to_globally?(:manage_user)
+    
+    additional_params << :login if Users::BaseContract.new(User.new, current_user).writable?(:login)
 
     user additional_params
   end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -207,8 +207,9 @@ class PermittedParams
     if current_user.admin?
       additional_params << :force_password_change if change_password_allowed
       additional_params << :admin
-      additional_params << :login
     end
+
+    additional_params << :login if current_user.allowed_to_globally?(:manage_user)
 
     user additional_params
   end

--- a/spec/contracts/users/create_contract_spec.rb
+++ b/spec/contracts/users/create_contract_spec.rb
@@ -30,81 +30,23 @@
 
 require 'spec_helper'
 require 'contracts/shared/model_contract_shared_context'
+require_relative 'shared_contract_examples'
 
 describe Users::CreateContract do
   include_context 'ModelContract shared context'
 
-  let(:user) { FactoryBot.build_stubbed(:user) }
-  let(:contract) { described_class.new(user, current_user) }
-
-  context 'when admin' do
-    let(:current_user) { FactoryBot.build_stubbed(:admin) }
-
-    it_behaves_like 'contract is valid'
-
-    describe 'requires a password set when active' do
-      before do
-        user.password = nil
-        user.activate
-      end
-
-      it_behaves_like 'contract is invalid', password: :blank
-
-      context 'when password is set' do
-        before do
-          user.password = user.password_confirmation = 'password!password!'
-        end
-
-        it_behaves_like 'contract is valid'
-      end
+  it_behaves_like 'user contract' do
+    let(:user) { User.new(attributes) }
+    let(:contract) { described_class.new(user, current_user) }
+    let(:attributes) do
+      {
+        firstname: user_firstname,
+        lastname: user_lastname,
+        login: user_login,
+        mail: user_mail,
+        password: user_password,
+        password_confirmation: user_password_confirmation
+      }
     end
-  end
-
-  context 'when global user' do
-    shared_let(:current_user) { FactoryBot.create :user, global_permission: :manage_user }
-
-    describe 'can invite user' do
-      before do
-        user.password = user.password_confirmation = nil
-        user.mail = 'foo@example.com'
-        user.invite
-      end
-
-      it_behaves_like 'contract is valid'
-    end
-
-    describe 'cannot set the password' do
-      before do
-        user.password = user.password_confirmation = 'password!password!'
-      end
-
-      it_behaves_like 'contract is invalid', password: :error_readonly
-    end
-
-    describe 'can set the auth_source' do
-      let!(:auth_source) { FactoryBot.create :auth_source }
-
-      before do
-        user.password = user.password_confirmation = nil
-        user.auth_source = auth_source
-      end
-
-      it_behaves_like 'contract is valid'
-    end
-
-    describe 'cannot set the identity url' do
-      before do
-        user.identity_url = 'saml:123412foo'
-      end
-
-      it_behaves_like 'contract is invalid', identity_url: :error_readonly
-
-    end
-  end
-
-  context 'when unauthorized user' do
-    let(:current_user) { FactoryBot.build_stubbed(:user) }
-
-    it_behaves_like 'contract user is unauthorized'
   end
 end

--- a/spec/contracts/users/create_contract_spec.rb
+++ b/spec/contracts/users/create_contract_spec.rb
@@ -48,5 +48,29 @@ describe Users::CreateContract do
         password_confirmation: user_password_confirmation
       }
     end
+
+    context 'when admin' do
+      let(:current_user) { FactoryBot.build_stubbed(:admin) }
+
+      it_behaves_like 'contract is valid'
+
+      describe 'requires a password set when active' do
+        before do
+          user.password = nil
+          user.password_confirmation = nil
+          user.activate
+        end
+
+        it_behaves_like 'contract is invalid', password: :blank
+
+        context 'when password is set' do
+          before do
+            user.password = user.password_confirmation = 'password!password!'
+          end
+
+          it_behaves_like 'contract is valid'
+        end
+      end
+    end
   end
 end

--- a/spec/contracts/users/shared_contract_examples.rb
+++ b/spec/contracts/users/shared_contract_examples.rb
@@ -41,26 +41,9 @@ shared_examples_for 'user contract' do
   it_behaves_like 'contract is valid for active admins and invalid for regular users'
 
   context 'when admin' do
-    let(:current_user) { FactoryBot.build_stubbed(:admin) }
+    let(:current_user) { FactoryBot.build_stubbed :admin }
 
     it_behaves_like 'contract is valid'
-
-    describe 'requires a password set when active' do
-      before do
-        user.password = nil
-        user.activate
-      end
-
-      it_behaves_like 'contract is invalid', password: :blank
-
-      context 'when password is set' do
-        before do
-          user.password = user.password_confirmation = 'password!password!'
-        end
-
-        it_behaves_like 'contract is valid'
-      end
-    end
   end
 
   context 'when global user' do

--- a/spec/contracts/users/shared_contract_examples.rb
+++ b/spec/contracts/users/shared_contract_examples.rb
@@ -1,0 +1,102 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+shared_examples_for 'user contract' do
+  let(:user_firstname) { 'Bob' }
+  let(:user_lastname) { 'Bobbit' }
+  let(:user_login) { 'bob' }
+  let(:user_mail) { 'bobbit@bob.com' }
+  let(:user_password) { 'adminADMIN!' }
+  let(:user_password_confirmation) { 'adminADMIN!' }
+
+  it_behaves_like 'contract is valid for active admins and invalid for regular users'
+
+  context 'when admin' do
+    let(:current_user) { FactoryBot.build_stubbed(:admin) }
+
+    it_behaves_like 'contract is valid'
+
+    describe 'requires a password set when active' do
+      before do
+        user.password = nil
+        user.activate
+      end
+
+      it_behaves_like 'contract is invalid', password: :blank
+
+      context 'when password is set' do
+        before do
+          user.password = user.password_confirmation = 'password!password!'
+        end
+
+        it_behaves_like 'contract is valid'
+      end
+    end
+  end
+
+  context 'when global user' do
+    shared_let(:current_user) { FactoryBot.create :user, global_permission: :manage_user }
+
+    describe 'cannot set the password' do
+      before do
+        user.password = user.password_confirmation = 'password!password!'
+      end
+
+      it_behaves_like 'contract is invalid', password: :error_readonly
+    end
+
+    describe 'can set the auth_source' do
+      let!(:auth_source) { FactoryBot.create :auth_source }
+
+      before do
+        user.password = user.password_confirmation = nil
+        user.auth_source = auth_source
+      end
+
+      it_behaves_like 'contract is valid'
+    end
+
+    describe 'cannot set the identity url' do
+      before do
+        user.identity_url = 'saml:123412foo'
+      end
+
+      it_behaves_like 'contract is invalid', identity_url: :error_readonly
+    end
+  end
+
+  context 'when unauthorized user' do
+    let(:current_user) { FactoryBot.build_stubbed(:user) }
+
+    it_behaves_like 'contract user is unauthorized'
+  end
+end

--- a/spec/contracts/users/shared_contract_examples.rb
+++ b/spec/contracts/users/shared_contract_examples.rb
@@ -64,7 +64,7 @@ shared_examples_for 'user contract' do
   end
 
   context 'when global user' do
-    shared_let(:current_user) { FactoryBot.create :user, global_permission: :manage_user }
+    let(:current_user) { FactoryBot.create :user, global_permission: :manage_user }
 
     describe 'cannot set the password' do
       before do

--- a/spec/contracts/users/update_contract_spec.rb
+++ b/spec/contracts/users/update_contract_spec.rb
@@ -43,17 +43,19 @@ describe Users::UpdateContract do
         firstname: user_firstname,
         lastname: user_lastname,
         login: user_login,
-        mail: user_mail,
-        password: user_password,
-        password_confirmation: user_password_confirmation
+        mail: user_mail
       }
     end
 
     context 'when global user' do
-      shared_let(:current_user) { FactoryBot.create :user, global_permission: :manage_user }
+      let(:current_user) { FactoryBot.create :user, global_permission: :manage_user }
 
       describe 'can set the login' do
         before do
+          # We reset the password from the factory so that it does not appear to be
+          # changed.
+          user.password = user.password_confirmation = nil
+
           user.login = 'new-foo'
         end
 

--- a/spec/contracts/users/update_contract_spec.rb
+++ b/spec/contracts/users/update_contract_spec.rb
@@ -46,21 +46,5 @@ describe Users::UpdateContract do
         mail: user_mail
       }
     end
-
-    context 'when global user' do
-      let(:current_user) { FactoryBot.create :user, global_permission: :manage_user }
-
-      describe 'can set the login' do
-        before do
-          # We reset the password from the factory so that it does not appear to be
-          # changed.
-          user.password = user.password_confirmation = nil
-
-          user.login = 'new-foo'
-        end
-
-        it_behaves_like 'contract is valid'
-      end
-    end
   end
 end

--- a/spec/contracts/users/update_contract_spec.rb
+++ b/spec/contracts/users/update_contract_spec.rb
@@ -1,0 +1,64 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'contracts/shared/model_contract_shared_context'
+require_relative 'shared_contract_examples'
+
+describe Users::UpdateContract do
+  include_context 'ModelContract shared context'
+
+  it_behaves_like 'user contract' do
+    let(:user) { FactoryBot.build_stubbed(:user, attributes) }
+    let(:contract) { described_class.new(user, current_user) }
+    let(:attributes) do
+      {
+        firstname: user_firstname,
+        lastname: user_lastname,
+        login: user_login,
+        mail: user_mail,
+        password: user_password,
+        password_confirmation: user_password_confirmation
+      }
+    end
+
+    context 'when global user' do
+      shared_let(:current_user) { FactoryBot.create :user, global_permission: :manage_user }
+
+      describe 'can set the login' do
+        before do
+          user.login = 'new-foo'
+        end
+
+        it_behaves_like 'contract is valid'
+      end
+    end
+  end
+end

--- a/spec/contracts/users/update_contract_spec.rb
+++ b/spec/contracts/users/update_contract_spec.rb
@@ -46,5 +46,16 @@ describe Users::UpdateContract do
         mail: user_mail
       }
     end
+
+    describe "validations" do
+      describe "#user_allowed_to_update" do
+        context "updated user is current user" do
+          # That scenario is the only that is not covered by the shared examples
+          let(:current_user) { user }
+
+          it_behaves_like 'contract is valid'
+        end
+      end
+    end
   end
 end

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -29,8 +29,8 @@
 require 'spec_helper'
 
 describe PermittedParams, type: :model do
-  let(:user) { FactoryBot.build(:user) }
-  let(:admin) { FactoryBot.build(:admin) }
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:admin) { FactoryBot.build_stubbed(:admin) }
 
   shared_context 'prepare params comparison' do
     let(:params_key) { defined?(hash_key) ? hash_key : attribute }

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -519,13 +519,22 @@ describe PermittedParams, type: :model do
 
     describe :user_create_as_admin do
       let(:attribute) { :user_create_as_admin }
+      let(:default_permissions) { %w[custom_fields firstname lastname language mail mail_notification auth_source_id] }
 
       context 'non-admin' do
         let(:hash) { Hash[all_permissions.zip(all_permissions)] }
 
         it 'permits default permissions' do
-          expect(subject.keys)
-              .to match_array(%w[custom_fields firstname lastname language mail mail_notification auth_source_id])
+          expect(subject.keys).to match_array(default_permissions)
+        end
+      end
+
+      context 'non-admin with global :manage_user permission' do
+        let(:user) { FactoryBot.create(:user, global_permission: :manage_user) }
+        let(:hash) { Hash[all_permissions.zip(all_permissions)] }
+
+        it 'permits default permissions and "login"' do
+          expect(subject.keys).to match_array(default_permissions + ['login'])
         end
       end
 

--- a/spec/requests/api/v3/user/create_user_resource_spec.rb
+++ b/spec/requests/api/v3/user/create_user_resource_spec.rb
@@ -56,7 +56,7 @@ describe ::API::V3::Users::UsersAPI, type: :request do
   end
 
   describe 'admin user' do
-    let(:current_user) { FactoryBot.build(:admin) }
+    let(:current_user) { FactoryBot.create(:admin) }
 
     it_behaves_like 'create user request flow'
 


### PR DESCRIPTION
Fixes https://community.openproject.com/wp/36299

- [x] Add spec for `Users::UpdateContract`
- [x] Add shared examples for create and update contract specs (but no checking for login writability yet)
- [x] Permit parameter :login when user is globally allowed to :manage_user
- [x] Extend spec of permitted parameters to support the case that the current user is a normal user with global permissions to :manage_user