### PR TITLE
Fix/parent filter

### DIFF
--- a/frontend/src/app/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
+++ b/frontend/src/app/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
@@ -33,9 +33,6 @@ export interface FilterConditions {name:string; operator:FilterOperator; values:
 
 export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit {
   @Input() public filter:QueryFilterInstanceResource;
-  @Input() public filterConditions?:FilterConditions[];
-  @Input() public filterResource:'work_packages' | 'users';
-  @Input() public filterSearchKey?:string;
   @Input() public shouldFocus:boolean = false;
   @Output() public filterChanged = new EventEmitter<QueryFilterInstanceResource>();
 
@@ -104,7 +101,7 @@ export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMix
   }
 
   public loadAvailable(matching:string):Observable<HalResource[]> {
-    const filters:ApiV3FilterBuilder = this.createFilters([], matching);
+    const filters:ApiV3FilterBuilder = this.createFilters(matching);
     const href = (this.filter.currentSchema!.values!.allowedValues as any).$href;
 
     const filteredData = (this.apiV3Service.collectionFromString(href) as
@@ -116,15 +113,13 @@ export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMix
     return filteredData;
   }
 
-  protected createFilters(filterConditions:FilterConditions[], matching:string) {
+  protected createFilters(matching:string) {
     const filters = new ApiV3FilterBuilder();
 
-    for (const condition of filterConditions) {
-      filters.add(condition.name, condition.operator, condition.values);
-    }
     if (matching) {
-      filters.add(this.filterSearchKey ?? '', '**', [matching]);
+      filters.add('subjectOrId', '**', [matching]);
     }
+
     return filters;
   }
 

--- a/frontend/src/app/components/filters/query-filter/query-filter.component.html
+++ b/frontend/src/app/components/filters/query-filter/query-filter.component.html
@@ -76,9 +76,6 @@
       <filter-searchable-multiselect-value *ngSwitchCase="'[]WorkPackage'"
                            (filterChanged)="onFilterUpdated($event)"
                            [shouldFocus]="shouldFocus"
-                           [filterConditions]="parentFilter.filters"
-                           [filterResource]="parentFilter.resource"
-                           [filterSearchKey]="parentFilter.searchKey"
                            [filter]="filter"></filter-searchable-multiselect-value>
 
       <filter-toggled-multiselect-value *ngSwitchDefault

--- a/frontend/src/app/components/filters/query-filter/query-filter.component.ts
+++ b/frontend/src/app/components/filters/query-filter/query-filter.component.ts
@@ -74,13 +74,6 @@ export class QueryFilterComponent implements OnInit {
     this.filterChanged.emit(this.filter);
   }
 
-  public parentFilter = {
-    filters:[{name:'is_milestone', operator:'=', values:false},
-    {name:'project', operator:'=', values:[this.currentProject.id]}],
-    resource:'work_packages',
-    searchKey:'subjectOrId'
-    };
-
   public removeThisFilter() {
     this.deactivateFilter.emit(this.filter);
   }

--- a/frontend/src/app/modules/apiv3/api-v3.service.ts
+++ b/frontend/src/app/modules/apiv3/api-v3.service.ts
@@ -145,6 +145,12 @@ export class APIV3Service {
     }
   }
 
+  public collectionFromString(fullPath:string) {
+    const path = fullPath.replace(this.pathHelper.api.v3.apiV3Base + '/', '');
+
+    return this.apiV3CollectionEndpoint(path);
+  }
+
   private apiV3CollectionEndpoint<V extends HalResource, T extends APIv3GettableResource<V>>(segment:string, resource?:Constructor<T>) {
     return new APIv3ResourceCollection<V, T>(this, this.pathHelper.api.v3.apiV3Base, segment, resource);
   }

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
@@ -57,7 +57,10 @@ export class WorkPackageViewFiltersService extends WorkPackageQueryStateService<
     'requires',
     'required',
     'search',
+    // The filter should be named subjectOrId but for some reason
+    // it is only named subjectOr
     'subjectOrId',
+    'subjectOr',
     'manualSort'
   ];
 

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
@@ -43,7 +43,6 @@ import {mapTo, take} from "rxjs/operators";
 @Injectable()
 export class WorkPackageViewFiltersService extends WorkPackageQueryStateService<QueryFilterInstanceResource[]> {
   public hidden:string[] = [
-    'id',
     'datesInterval',
     'precedes',
     'follows',

--- a/spec/features/work_packages/table/queries/id_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/id_filter_spec.rb
@@ -1,0 +1,79 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Work package filtering by id', js: true do
+  let(:project) { FactoryBot.create :project }
+  let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
+  let(:filters) { ::Components::WorkPackages::Filters.new }
+  let(:role) { FactoryBot.create(:role, permissions: %i[view_work_packages save_queries]) }
+
+  let!(:work_package) do
+    FactoryBot.create :work_package,
+                      project: project
+  end
+  let!(:other_work_package) do
+    FactoryBot.create :work_package,
+                      project: project
+
+  end
+
+  current_user do
+    FactoryBot.create :user,
+                      member_in_project: project,
+                      member_through_role: role
+  end
+
+  it 'shows the work package matching the id filter' do
+    wp_table.visit!
+    wp_table.expect_work_package_listed(work_package, other_work_package)
+
+    filters.open
+    filters.add_filter_by('ID', 'is', [work_package.subject])
+
+    wp_table.ensure_work_package_not_listed!(other_work_package)
+    wp_table.expect_work_package_listed(work_package)
+
+    wp_table.save_as('Id query')
+
+    wp_table.expect_and_dismiss_notification(message: 'Successful creation.')
+
+    # Revisit query
+    wp_table.visit_query Query.last
+    wp_table.ensure_work_package_not_listed!(other_work_package)
+    wp_table.expect_work_package_listed(work_package)
+
+    filters.open
+    filters.expect_filter_by('ID', 'is', [work_package.subject])
+    filters.remove_filter 'id'
+    filters.add_filter_by('ID', 'is not', [work_package.subject, other_work_package.subject])
+
+    wp_table.expect_no_work_package_listed
+  end
+end


### PR DESCRIPTION
Fixes:
* parent filter not working on global work packages / my page because a parent filter with value [null] was provided. To avoid such problems, the url already provided by the backend is taken which already distinguishes between project/global. A couple of configuration options have been removed doing this as there is currently no need for them.
https://community.openproject.org/projects/openproject/work_packages/36287
https://community.openproject.org/projects/openproject/work_packages/36288
* The "subject or id" filter is now hidden correctly.
* Because it was trivial, the 'ID' filter is now displayed. This has been a functionality, long missed by myself.  