### PR TITLE
Group API

### DIFF
--- a/app/contracts/groups/add_users_contract.rb
+++ b/app/contracts/groups/add_users_contract.rb
@@ -27,11 +27,12 @@
 #++
 
 module Groups
-  class AddUsersContract < Groups::BaseContract
+  class AddUsersContract < ::ModelContract
+    include RequiresAdminGuard
+
     protected
 
     # No need to validate the whole of the group when we only want to ensure that the user is an admin.
-    # In case more conditions are added to the BaseContract, we might need an extra AdminOnlyContract
     def validate_model?
       false
     end

--- a/app/contracts/groups/create_contract.rb
+++ b/app/contracts/groups/create_contract.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -27,26 +29,16 @@
 #++
 
 module Groups
-  class BaseContract < ::ModelContract
-    include RequiresAdminGuard
+  class CreateContract < BaseContract
+    attribute :type
 
-    # attribute_alias is broken in the sense
-    # that `model#changed` includes only the non-aliased name
-    # hence we need to put "lastname" as an attribute here
-    attribute :name
-    attribute :lastname
-
-    validate :validate_unique_users
+    validate :type_is_group
 
     private
 
-    # Validating on the group_users since those are dealt with in the
-    # corresponding services.
-    def validate_unique_users
-      user_ids = model.group_users.map(&:user_id)
-
-      if user_ids.uniq.length < user_ids.length
-        errors.add(:group_users, :taken)
+    def type_is_group
+      unless model.type == Group.name
+        errors.add(:type, 'Type and class mismatch')
       end
     end
   end

--- a/app/contracts/groups/delete_contract.rb
+++ b/app/contracts/groups/delete_contract.rb
@@ -28,36 +28,8 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Groups
-      class GroupRepresenter < ::API::V3::Principals::PrincipalRepresenter
-        include API::Decorators::LinkedResource
-
-        def _type
-          'Group'
-        end
-
-        link :delete,
-             cache_if: -> { current_user.admin? } do
-          {
-            href: api_v3_paths.group(represented.id),
-            method: :delete
-          }
-        end
-
-        link :updateImmediately,
-             cache_if: -> { current_user.admin? } do
-          {
-            href: api_v3_paths.group(represented.id),
-            method: :patch
-          }
-        end
-
-        associated_resources :users,
-                             as: :members,
-                             skip_render: -> { !current_user.allowed_to_globally?(:manage_members) }
-      end
-    end
+module Groups
+  class DeleteContract < ::DeleteContract
+    delete_permission -> { user.active? && user.admin? }
   end
 end

--- a/app/contracts/groups/update_contract.rb
+++ b/app/contracts/groups/update_contract.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -26,36 +28,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Groups
-      class GroupsAPI < ::API::OpenProjectAPI
-        resources :groups do
-          after_validation do
-            authorize_any %i[view_members manage_members], global: true
-          end
-
-          get &::API::V3::Utilities::Endpoints::Index
-                 .new(model: Group)
-                 .mount
-          post &::API::V3::Utilities::Endpoints::Create
-                  .new(model: Group)
-                  .mount
-
-          route_param :id, type: Integer, desc: 'Group ID' do
-            after_validation do
-              @group = Group.visible(current_user).find(params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-                   .new(model: Group)
-                   .mount
-            patch &::API::V3::Utilities::Endpoints::Update
-                     .new(model: Group)
-                     .mount
-          end
-        end
-      end
-    end
+module Groups
+  class UpdateContract < BaseContract
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -141,8 +141,8 @@ class GroupsController < ApplicationController
   end
 
   def remove_user
-    @group = Group.includes(:users).find(params[:id])
-    @group.users.delete(User.includes(:memberships).find(params[:user_id]))
+    @group = Group.includes(:group_users).find(params[:id])
+    @group.group_users.destroy(GroupUser.find_by(user_id: params[:user_id], group_id: @group.id))
 
     I18n.t :notice_successful_update
     redirect_to controller: '/groups', action: 'edit', id: @group, tab: 'users'

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -300,7 +300,7 @@ class UserMailer < BaseMailer
 
     with_locale_for(user) do
       subject = if @group
-                  t(:mail_subject_group_reminder, count: @issues.size, days: @days, group: @group.groupname)
+                  t(:mail_subject_group_reminder, count: @issues.size, days: @days, group: @group.name)
                 else
                   t(:mail_subject_reminder, count: @issues.size, days: @days)
                 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -31,17 +31,21 @@
 class Group < Principal
   include ::Scopes::Scoped
 
-  has_and_belongs_to_many :users,
-                          join_table: "#{table_name_prefix}group_users#{table_name_suffix}",
-                          before_add: :fail_add,
-                          after_remove: :user_removed
+  has_many :group_users,
+           autosave: true,
+           dependent: :destroy,
+           after_remove: :user_removed
+
+  has_many :users,
+           through: :group_users,
+           before_add: :fail_add
 
   acts_as_customizable
 
-  alias_attribute(:groupname, :lastname)
-  validates_presence_of :groupname
-  validate :uniqueness_of_groupname
-  validates_length_of :groupname, maximum: 256
+  alias_attribute(:name, :lastname)
+  validates_presence_of :name
+  validate :uniqueness_of_name
+  validates_length_of :name, maximum: 256
 
   # HACK: We want to have the :preference association on the Principal to allow
   # for eager loading preferences.
@@ -60,12 +64,12 @@ class Group < Principal
   scopes :visible
 
   def to_s
-    lastname.to_s
+    lastname
   end
 
-  alias :name :to_s
+  def user_removed(group_user)
+    user = group_user.user
 
-  def user_removed(user)
     member_roles = MemberRole
                    .includes(member: :member_roles)
                    .where(inherited_from: members.joins(:member_roles).select('member_roles.id'))
@@ -96,10 +100,10 @@ class Group < Principal
 
   private
 
-  def uniqueness_of_groupname
-    groups_with_name = Group.where('lastname = ? AND id <> ?', groupname, id || 0).count
+  def uniqueness_of_name
+    groups_with_name = Group.where('lastname = ? AND id <> ?', name, id || 0).count
     if groups_with_name > 0
-      errors.add :groupname, :taken
+      errors.add :name, :taken
     end
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -29,6 +29,8 @@
 #++
 
 class Group < Principal
+  include ::Scopes::Scoped
+
   has_and_belongs_to_many :users,
                           join_table: "#{table_name_prefix}group_users#{table_name_suffix}",
                           before_add: :fail_add,
@@ -54,6 +56,8 @@ class Group < Principal
                :create_preference!
 
   include Destroy
+
+  scopes :visible
 
   def to_s
     lastname.to_s

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -29,8 +29,7 @@
 #++
 
 class GroupUser < ApplicationRecord
-  self.table_name = "#{table_name_prefix}group_users#{table_name_suffix}"
-
-  belongs_to :group
+  belongs_to :group,
+             touch: true
   belongs_to :user
 end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -30,4 +30,7 @@
 
 class GroupUser < ApplicationRecord
   self.table_name = "#{table_name_prefix}group_users#{table_name_suffix}"
+
+  belongs_to :group
+  belongs_to :user
 end

--- a/app/models/groups/scopes/visible.rb
+++ b/app/models/groups/scopes/visible.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -26,28 +28,17 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Groups
-      class GroupsAPI < ::API::OpenProjectAPI
-        resources :groups do
-          after_validation do
-            authorize_any %i[view_members manage_members], global: true
-          end
+module Groups::Scopes
+  module Visible
+    extend ActiveSupport::Concern
 
-          get &::API::V3::Utilities::Endpoints::Index
-                 .new(model: Group)
-                 .mount
-
-          route_param :id, type: Integer, desc: 'Group ID' do
-            after_validation do
-              @group = Group.visible(current_user).find(params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-                   .new(model: Group)
-                   .mount
-          end
+    class_methods do
+      def visible(current_user = User.current)
+        if current_user.allowed_to_globally?(:manage_members)
+          Group.all
+        else
+          Group
+            .in_project(Project.allowed_to(current_user, :view_members))
         end
       end
     end

--- a/app/models/queries/groups.rb
+++ b/app/models/queries/groups.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -26,30 +28,9 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Groups
-      class GroupsAPI < ::API::OpenProjectAPI
-        resources :groups do
-          after_validation do
-            authorize_any %i[view_members manage_members], global: true
-          end
+module Queries::Groups
+  order_ns = Queries::Members::Orders
+  query = Queries::Members::MemberQuery
 
-          get &::API::V3::Utilities::Endpoints::Index
-                 .new(model: Group)
-                 .mount
-
-          route_param :id, type: Integer, desc: 'Group ID' do
-            after_validation do
-              @group = Group.visible(current_user).find(params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-                   .new(model: Group)
-                   .mount
-          end
-        end
-      end
-    end
-  end
+  Queries::Register.order query, order_ns::DefaultOrder
 end

--- a/app/models/queries/groups/group_query.rb
+++ b/app/models/queries/groups/group_query.rb
@@ -26,30 +26,12 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Groups
-      class GroupsAPI < ::API::OpenProjectAPI
-        resources :groups do
-          after_validation do
-            authorize_any %i[view_members manage_members], global: true
-          end
+class Queries::Groups::GroupQuery < Queries::BaseQuery
+  def self.model
+    Group
+  end
 
-          get &::API::V3::Utilities::Endpoints::Index
-                 .new(model: Group)
-                 .mount
-
-          route_param :id, type: Integer, desc: 'Group ID' do
-            after_validation do
-              @group = Group.visible(current_user).find(params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-                   .new(model: Group)
-                   .mount
-          end
-        end
-      end
-    end
+  def default_scope
+    Group.visible(User.current)
   end
 end

--- a/app/models/queries/groups/orders/default_order.rb
+++ b/app/models/queries/groups/orders/default_order.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -26,30 +28,10 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Groups
-      class GroupsAPI < ::API::OpenProjectAPI
-        resources :groups do
-          after_validation do
-            authorize_any %i[view_members manage_members], global: true
-          end
+class Queries::Groups::Orders::DefaultOrder < Queries::BaseOrder
+  self.model = Group
 
-          get &::API::V3::Utilities::Endpoints::Index
-                 .new(model: Group)
-                 .mount
-
-          route_param :id, type: Integer, desc: 'Group ID' do
-            after_validation do
-              @group = Group.visible(current_user).find(params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-                   .new(model: Group)
-                   .mount
-          end
-        end
-      end
-    end
+  def self.key
+    /\A(id|created_at|updated_at)\z/
   end
 end

--- a/app/services/groups/create_service.rb
+++ b/app/services/groups/create_service.rb
@@ -28,19 +28,4 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Groups::CreateService < ::BaseServices::Create
-  protected
-
-  def after_perform(call)
-    # TODO: check if the AddUsersService itself can be removed
-    # TODO: check if the call to the AddUsersService can be removed from here
-    #       if a newly created group cannot have a membership in any project
-    db_call = ::Groups::AddUsersService
-              .new(call.result, current_user: user)
-              .call(ids: call.result.group_users.select(&:new_record?).map(&:user_id))
-
-    call.add_dependent!(db_call)
-
-    call
-  end
-end
+class Groups::CreateService < ::BaseServices::Create; end

--- a/app/services/groups/delete_service.rb
+++ b/app/services/groups/delete_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -28,36 +26,4 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Groups
-      class GroupRepresenter < ::API::V3::Principals::PrincipalRepresenter
-        include API::Decorators::LinkedResource
-
-        def _type
-          'Group'
-        end
-
-        link :delete,
-             cache_if: -> { current_user.admin? } do
-          {
-            href: api_v3_paths.group(represented.id),
-            method: :delete
-          }
-        end
-
-        link :updateImmediately,
-             cache_if: -> { current_user.admin? } do
-          {
-            href: api_v3_paths.group(represented.id),
-            method: :patch
-          }
-        end
-
-        associated_resources :users,
-                             as: :members,
-                             skip_render: -> { !current_user.allowed_to_globally?(:manage_members) }
-      end
-    end
-  end
-end
+class Groups::DeleteService < ::BaseServices::Delete; end

--- a/app/services/groups/set_attributes_service.rb
+++ b/app/services/groups/set_attributes_service.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -27,26 +29,36 @@
 #++
 
 module Groups
-  class BaseContract < ::ModelContract
-    include RequiresAdminGuard
-
-    # attribute_alias is broken in the sense
-    # that `model#changed` includes only the non-aliased name
-    # hence we need to put "lastname" as an attribute here
-    attribute :name
-    attribute :lastname
-
-    validate :validate_unique_users
-
+  class SetAttributesService < ::BaseServices::SetAttributes
     private
 
-    # Validating on the group_users since those are dealt with in the
-    # corresponding services.
-    def validate_unique_users
-      user_ids = model.group_users.map(&:user_id)
+    def set_attributes(params)
+      set_users(params)
+      super
+    end
 
-      if user_ids.uniq.length < user_ids.length
-        errors.add(:group_users, :taken)
+    # We do not want to persist the associated users (members) in a
+    # SetAttributesService. Therefore we are building the association here.
+    #
+    # Note that due to the way we handle members, via a specific AddUsersService
+    # the group should no longer simply be saved after group_users have been added.
+    def set_users(params)
+      user_ids = params.delete(:user_ids) || []
+
+      existing_user_ids = model.group_users.map(&:user_id)
+      build_new_users user_ids - existing_user_ids
+      mark_outdated_users existing_user_ids - user_ids
+    end
+
+    def build_new_users(new_user_ids)
+      new_user_ids.each do |id|
+        model.group_users.build(user_id: id)
+      end
+    end
+
+    def mark_outdated_users(removed_user_ids)
+      removed_user_ids.each do |id|
+        model.group_users.find { |gu| gu.user_id == id }.mark_for_destruction
       end
     end
   end

--- a/app/services/groups/set_attributes_service.rb
+++ b/app/services/groups/set_attributes_service.rb
@@ -43,7 +43,7 @@ module Groups
     # Note that due to the way we handle members, via a specific AddUsersService
     # the group should no longer simply be saved after group_users have been added.
     def set_users(params)
-      user_ids = params.delete(:user_ids) || []
+      user_ids = (params.delete(:user_ids) || []).map(&:to_i)
 
       existing_user_ids = model.group_users.map(&:user_id)
       build_new_users user_ids - existing_user_ids

--- a/app/services/groups/update_service.rb
+++ b/app/services/groups/update_service.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -26,36 +28,20 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Groups
-      class GroupsAPI < ::API::OpenProjectAPI
-        resources :groups do
-          after_validation do
-            authorize_any %i[view_members manage_members], global: true
-          end
+class Groups::UpdateService < ::BaseServices::Update
+  protected
 
-          get &::API::V3::Utilities::Endpoints::Index
-                 .new(model: Group)
-                 .mount
-          post &::API::V3::Utilities::Endpoints::Create
-                  .new(model: Group)
-                  .mount
+  def after_perform(call)
+    new_user_ids = call.result.group_users.select(&:saved_changes?).map(&:user_id)
 
-          route_param :id, type: Integer, desc: 'Group ID' do
-            after_validation do
-              @group = Group.visible(current_user).find(params[:id])
-            end
+    if new_user_ids.any?
+      db_call = ::Groups::AddUsersService
+                  .new(call.result, current_user: user)
+                  .call(ids: new_user_ids)
 
-            get &::API::V3::Utilities::Endpoints::Show
-                   .new(model: Group)
-                   .mount
-            patch &::API::V3::Utilities::Endpoints::Update
-                     .new(model: Group)
-                     .mount
-          end
-        end
-      end
+      call.add_dependent!(db_call)
     end
+
+    call
   end
 end

--- a/app/views/user_mailer/reminder_mail.html.erb
+++ b/app/views/user_mailer/reminder_mail.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<p><%= @group.nil? ? t(:mail_body_reminder, count: @issues.size, days: @days) : t(:mail_body_group_reminder, count: @issues.size, days: @days, group: @group.groupname) %></p>
+<p><%= @group.nil? ? t(:mail_body_reminder, count: @issues.size, days: @days) : t(:mail_body_group_reminder, count: @issues.size, days: @days, group: @group.name) %></p>
 <ul>
   <% @issues.each do |issue| -%>
     <li><%= issue.project %> - <%= link_to "#{issue.type} ##{issue.id}", work_package_url(issue) %>: <%= issue.subject %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -833,7 +833,7 @@ en:
     firstname: "First name"
     group: "Group"
     groups: "Groups"
-    groupname: "Group name"
+    name: "Group name"
     id: "ID"
     is_default: "Default value"
     is_for_all: "For all projects"

--- a/db/migrate/20210221230446_add_group_user_primary_key.rb
+++ b/db/migrate/20210221230446_add_group_user_primary_key.rb
@@ -1,0 +1,9 @@
+class AddGroupUserPrimaryKey < ActiveRecord::Migration[6.1]
+  def change
+    # Adding a primary key will automatically fill that column with values.
+    # Therefore, there is no need to assign it manually.
+    add_column :group_users, :id, :primary_key
+
+    add_index :group_users, %i[user_id group_id], unique: true
+  end
+end

--- a/docs/api/apiv3/endpoints/groups.apib
+++ b/docs/api/apiv3/endpoints/groups.apib
@@ -9,18 +9,19 @@ This resource is currently a stub.
 None
 
 ## Linked Properties
-|  Link       | Description                                                                                                                                                           | Type              | Constraints           | Supported operations | Condition                                                     |
-|:-----------:|--------------------------------------------------------------                                                                                                         | -------------     | --------------------- | -------------------- | -----------------------------------------                     |
-| self        | This group                                                                                                                                                            | Group             | not null              | READ                 |                                                               |
-| members     | Link to collection of all the group's memberships. The list will only include the memberships in projects in which the requesting user has the necessary permissions. | MemberCollection  |                       | READ                 | **Permission**: view members or manage members in any project |
+|  Link           | Description                                                                                                                                                           | Type              | Constraints           | Supported operations | Condition                                                     |
+|:-----------:    |--------------------------------------------------------------                                                                                                         | -------------     | --------------------- | -------------------- | -----------------------------------------                     |
+| self            | This group                                                                                                                                                            | Group             | not null              | READ                 |                                                               |
+| memberships     | Link to collection of all the group's memberships. The list will only include the memberships in projects in which the requesting user has the necessary permissions. | MemberCollection  |                       | READ                 | **Permission**: view members or manage members in any project |
+| members         | The list all all the users that are members of the group                                                                                                              | UserCollection    |                       | READ                 | **Permission**: manage members in any project                 |
 
 ## Local Properties
 | Property     | Description                                                | Type     | Constraints                                          | Supported operations | Condition                                                                           |
 | :----------: | ---------------------------------------------------------  | -------- | ---------------------------------------------------- | -------------------- | -----------------------------------------------------------                         |
 | id           | Group's id                                                 | Integer  | x > 0                                                | READ                 |                                                                                     |
 | name         | Group's full name, formatting depends on instance settings | String   |                                                      | READ                 |                                                                                     |
-| createdAt    | Time of creation                                           | DateTime |                                                      | READ                 |                                                                                     |
-| updatedAt    | Time of the most recent change to the user                 | DateTime |                                                      | READ                 |                                                                                     |
+| createdAt    | Time of creation                                           | DateTime |                                                      | READ                 | Only visible by admins                                                              |
+| updatedAt    | Time of the most recent change to the user                 | DateTime |                                                      | READ                 | Only visible by admins                                                              |
 
 ## Group [/api/v3/groups/{id}]
 
@@ -37,7 +38,21 @@ None
                     "self": {
                         "href": "/api/v3/groups/9",
                         "title": "The group"
-                    }
+                    },
+                    "memberships": {
+                        "href": "/api/v3/memberships?filters=[{"principal":{"operator":"=","values":["9"]}}]",
+                        "title": "Memberships"
+                    },
+                    "members": [
+                        {
+                            "href": "/api/v3/users/363",
+                            "title": "First user"
+                        },
+                        {
+                            "href": "/api/v3/users/60",
+                            "title": "Second user"
+                        }
+                    ]
                 }
             }
 

--- a/docs/api/apiv3/endpoints/groups.apib
+++ b/docs/api/apiv3/endpoints/groups.apib
@@ -10,6 +10,7 @@ to work with this resource.
 ## Actions
 | Link                | Description                                                          | Condition                                                        |
 |:-------------------:| -------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| delete              | Deletes the group.                                                   | **Permission**: Administrator                                    |
 | updateImmediately   | Updates the group's attributes.                                      | **Permission**: Administrator                                    |
 
 ## Linked Properties
@@ -43,6 +44,10 @@ to work with this resource.
                         "href": "/api/v3/groups/9",
                         "title": "The group"
                     },
+                    "delete": {
+                        "href": "/api/v3/group/9",
+                        "method": "delete"
+                    },
                     "memberships": {
                         "href": "/api/v3/memberships?filters=[{"principal":{"operator":"=","values":["9"]}}]",
                         "title": "Memberships"
@@ -50,7 +55,7 @@ to work with this resource.
                     "updateImmediately": {
                         "href": "/api/v3/group/9",
                         "method": "patch"
-                    }
+                    },
                     "members": [
                         {
                             "href": "/api/v3/users/363",
@@ -254,6 +259,54 @@ Updates the given group by applying the attributes provided in the body.
                     }
                 }
             }
+
+## Delete group [/api/v3/group/{id}]
+
+## Delete group [DELETE]
+
+Deletes the group.
+
++ Parameters
+    + id (required, integer, `1`) ... Group id
+
++ Response 204 (application/hal+json)
+
+    Returned if the group was successfully deleted
+
+    + Body
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions.
+
+    **Required permission:** Administrator
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not authorized to access this resource."
+            }
+
++ Response 404 (application/hal+json)
+
+    Returned if the group does not exist or the client does not have sufficient permissions
+    to see it.
+
+    **Required permission:** Administrator
+
+    *Note: A client without sufficient permissions shall not be able to test for the existence of
+    a version. That's why a 404 is returned here, even if a 403 might be more appropriate.*
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The requested resource could not be found."
+            }
+
 
 ## List groups [/api/v3/groups{?sortBy}]
 

--- a/docs/api/apiv3/endpoints/groups.apib
+++ b/docs/api/apiv3/endpoints/groups.apib
@@ -80,6 +80,79 @@ None
                 "message": "The requested resource could not be found."
             }
 
+## Create group [/api/v3/groups]
+
+## Create group [POST]
+
+Creates a new group applying the attributes provided in the body.
+
++ Request Create group
+
+    + Body
+
+            {
+                "name": "The group",
+                "_links": {
+                    "members": [
+                        {
+                            "href": "/api/v3/users/363"
+                        },
+                        {
+                            "href": "/api/v3/users/60"
+                        }
+                    ]
+                }
+            }
+
++ Response 201
+
+    [View group][]
+
++ Response 400 (application/hal+json)
+
+    Occurs when the client did not send a valid JSON object in the request body.
+
+    + Body
+
+            {
+                "_type": "Error",
+                 "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidRequestBody",
+                "message": "The request body was not a single JSON object."
+            }
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions.
+
+    **Required permission:** Admin
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not authorized to access this resource."
+            }
+
++ Response 422 (application/hal+json)
+
+    Returned if:
+
+    * a constraint for a property was violated (`PropertyConstraintViolation`)
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:PropertyConstraintViolation",
+                "message": "Name can't be blank.",
+                "_embedded": {
+                    "details": {
+                        "attribute": "name"
+                    }
+                }
+            }
+
 ## List groups [/api/v3/groups{?sortBy}]
 
 + Model

--- a/docs/api/apiv3/endpoints/groups.apib
+++ b/docs/api/apiv3/endpoints/groups.apib
@@ -2,26 +2,30 @@
 
 Groups are collections of users. They support assigning/unassigning multiple users to/from a project in one operation.
 
-This resource is currently a stub.
+This resource does not yet have the form and schema endpoints. But as all properties are static, clients should still be able
+to work with this resource.
 
 ## Actions
 
-None
+## Actions
+| Link                | Description                                                          | Condition                                                        |
+|:-------------------:| -------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| updateImmediately   | Updates the group's attributes.                                      | **Permission**: Administrator                                    |
 
 ## Linked Properties
-|  Link           | Description                                                                                                                                                           | Type              | Constraints           | Supported operations | Condition                                                     |
-|:-----------:    |--------------------------------------------------------------                                                                                                         | -------------     | --------------------- | -------------------- | -----------------------------------------                     |
-| self            | This group                                                                                                                                                            | Group             | not null              | READ                 |                                                               |
-| memberships     | Link to collection of all the group's memberships. The list will only include the memberships in projects in which the requesting user has the necessary permissions. | MemberCollection  |                       | READ                 | **Permission**: view members or manage members in any project |
-| members         | The list all all the users that are members of the group                                                                                                              | UserCollection    |                       | READ                 | **Permission**: manage members in any project                 |
+|  Link              | Description                                                                                                                                                           | Type              | Constraints           | Supported operations | Condition                                                                |
+|:-----------:       |--------------------------------------------------------------                                                                                                         | -------------     | --------------------- | -------------------- | -----------------------------------------                                |
+| self               | This group                                                                                                                                                            | Group             | not null              | READ                 |                                                                          |
+| memberships        | Link to collection of all the group's memberships. The list will only include the memberships in projects in which the requesting user has the necessary permissions. | MemberCollection  |                       | READ                 | **Permission**: view members or manage members in any project            |
+| members            | The list all all the users that are members of the group                                                                                                              | UserCollection    |                       | READ/WRITE           | **Permission**: manage members in any project to read & admin to write   |
 
 ## Local Properties
-| Property     | Description                                                | Type     | Constraints                                          | Supported operations | Condition                                                                           |
-| :----------: | ---------------------------------------------------------  | -------- | ---------------------------------------------------- | -------------------- | -----------------------------------------------------------                         |
-| id           | Group's id                                                 | Integer  | x > 0                                                | READ                 |                                                                                     |
-| name         | Group's full name, formatting depends on instance settings | String   |                                                      | READ                 |                                                                                     |
-| createdAt    | Time of creation                                           | DateTime |                                                      | READ                 | Only visible by admins                                                              |
-| updatedAt    | Time of the most recent change to the user                 | DateTime |                                                      | READ                 | Only visible by admins                                                              |
+| Property     | Description                                                | Type     | Constraints                                          | Supported operations | Condition                                                      |
+| :----------: | ---------------------------------------------------------  | -------- | ---------------------------------------------------- | -------------------- | -----------------------------------------------------------    |
+| id           | Group's id                                                 | Integer  | x > 0                                                | READ                 |                                                                |
+| name         | Group's full name, formatting depends on instance settings | String   |                                                      | READ/WRITE           | Admin to write                                                 |
+| createdAt    | Time of creation                                           | DateTime |                                                      | READ                 | Only visible by admins                                         |
+| updatedAt    | Time of the most recent change to the user                 | DateTime |                                                      | READ                 | Only visible by admins                                         |
 
 ## View group [/api/v3/groups/{id}]
 
@@ -43,6 +47,10 @@ None
                         "href": "/api/v3/memberships?filters=[{"principal":{"operator":"=","values":["9"]}}]",
                         "title": "Memberships"
                     },
+                    "updateImmediately": {
+                        "href": "/api/v3/group/9",
+                        "method": "patch"
+                    }
                     "members": [
                         {
                             "href": "/api/v3/users/363",
@@ -124,7 +132,7 @@ Creates a new group applying the attributes provided in the body.
 
     Returned if the client does not have sufficient permissions.
 
-    **Required permission:** Admin
+    **Required permission:** Administrator
 
     + Body
 
@@ -149,6 +157,100 @@ Creates a new group applying the attributes provided in the body.
                 "_embedded": {
                     "details": {
                         "attribute": "name"
+                    }
+                }
+            }
+
+## Update group [/api/v3/groups/{id}]
+
+## Update group [PATCH]
+
+Updates the given group by applying the attributes provided in the body.
+
++ Parameters
+    + id (required, integer, `1`) ... Group id
+
++ Request Update membership
+
+    + Body
+
+            {
+                "_links": {
+                    "members": [
+                        {
+                            "href": "/api/v3/users/363"
+                        },
+                        {
+                            "href": "/api/v3/users/60"
+                        }
+                    ]
+                }
+            }
+
++ Response 200
+
+    [View group][]
+
++ Response 400 (application/hal+json)
+
+    Occurs when the client did not send a valid JSON object in the request body.
+
+    + Body
+
+            {
+                "_type": "Error",
+                 "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidRequestBody",
+                "message": "The request body was not a single JSON object."
+            }
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions.
+
+    **Required permission:** Administrator
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not authorized to access this resource."
+            }
+
++ Response 404 (application/hal+json)
+
+    Returned if the membership does not exist or the client does not have sufficient permissions
+    to see it.
+
+    **Required permission** If the user has the *manage members* permission in at least one project the user will be able to query all groups. If not, the user
+    will be able to query all groups which are members in projects, he has the *view members* permission in.
+
+    *Note: A client without sufficient permissions shall not be able to test for the existence of
+    a version. That's why a 404 is returned here, even if a 403 might be more appropriate.*
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The requested resource could not be found."
+            }
+
++ Response 422 (application/hal+json)
+
+    Returned if:
+
+    * a constraint for a property was violated (`PropertyConstraintViolation`)
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:PropertyConstraintViolation",
+                "message": "Member is already taken.",
+                "_embedded": {
+                    "details": {
+                        "attribute": "members"
                     }
                 }
             }

--- a/docs/api/apiv3/endpoints/groups.apib
+++ b/docs/api/apiv3/endpoints/groups.apib
@@ -23,7 +23,7 @@ None
 | createdAt    | Time of creation                                           | DateTime |                                                      | READ                 | Only visible by admins                                                              |
 | updatedAt    | Time of the most recent change to the user                 | DateTime |                                                      | READ                 | Only visible by admins                                                              |
 
-## Group [/api/v3/groups/{id}]
+## View group [/api/v3/groups/{id}]
 
 + Model
     + Body
@@ -63,7 +63,7 @@ None
 
 + Response 200 (application/hal+json)
 
-    [Group][]
+    [View group][]
 
 + Response 404 (application/hal+json)
 
@@ -80,3 +80,104 @@ None
                 "message": "The requested resource could not be found."
             }
 
+## List groups [/api/v3/groups{?sortBy}]
+
++ Model
+    + Body
+
+            {
+                "_links": {
+                    "self": { "href": "/api/v3/groups" }
+                },
+                "total": 2,
+                "count": 2,
+                "_type": "Collection",
+                "_embedded":
+                {
+                    "elements": [
+                        {
+                            "_type": "Group",
+                            "id": 9,
+                            "name": "The group",
+                            "createdAt": "2015-09-23T11:06:36Z",
+                            "updatedAt": "2015-09-23T11:06:36Z",
+                            "_links": {
+                                "self": {
+                                    "href": "/api/v3/groups/9",
+                                    "title": "The group"
+                                },
+                                "memberships": {
+                                    "href": "/api/v3/memberships?filters=[{"principal":{"operator":"=","values":["9"]}}]",
+                                    "title": "Memberships"
+                                },
+                                "members": [
+                                    {
+                                        "href": "/api/v3/users/363",
+                                        "title": "First user"
+                                    },
+                                    {
+                                        "href": "/api/v3/users/60",
+                                        "title": "Second user"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "_type": "Group",
+                            "id": 123,
+                            "name": "Another group",
+                            "createdAt": "2018-09-23T11:06:36Z",
+                            "updatedAt": "2019-09-23T11:06:36Z",
+                            "_links": {
+                                "self": {
+                                    "href": "/api/v3/groups/123",
+                                    "title": "Another group"
+                                },
+                                "memberships": {
+                                    "href": "/api/v3/memberships?filters=[{"principal":{"operator":"=","values":["123"]}}]",
+                                    "title": "Memberships"
+                                },
+                                "members": [
+                                    {
+                                        "href": "/api/v3/users/343",
+                                        "title": "Third user"
+                                    },
+                                    {
+                                        "href": "/api/v3/users/60",
+                                        "title": "Second user"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+
+## List groups [GET]
+
+Returns a collection of groups. The client can choose to filter the groups similar to how work packages are filtered. In addition to the provided filters, the server will reduce the result set to only contain groups, for which the requesting client has sufficient permissions (*view_members*, *manage_members*).
+
++ Parameters
+    + sortBy = ["id", "asc"] (optional, string, `[["id", "asc"]]`) ... JSON specifying sort criteria.
+    Accepts the same format as returned by the [queries](#queries) endpoint. Currently supported sorts are:
+      + id: Sort by primary key
+      + created_at: Sort by group creation datetime
+      + updated_at: Sort by the time the group was updated last
+
++ Response 200 (application/hal+json)
+
+    [List groups][]
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions.
+
+    **Required permission:** View members or manage members in any project
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not authorized to access this resource."
+            }

--- a/docs/api/apiv3/endpoints/members.apib
+++ b/docs/api/apiv3/endpoints/members.apib
@@ -320,7 +320,7 @@ Deletes the membership.
                 "message": "The requested resource could not be found."
             }
 
-## List memberships [/api/v3/memberships{?filters}]
+## List memberships [/api/v3/memberships{?filters,sortBy}]
 
 + Model
     + Body
@@ -413,6 +413,15 @@ Returns a collection of memberships. The client can choose to filter the members
       + status: filters memberships based on the status of the principal.
       + created_at: filters memberships based on the time the membership was created.
       + updated_at: filters memberships based on the time the membership was updated last.
+
+    + sortBy = ["id", "asc"] (optional, string, `[["id", "asc"]]`) ... JSON specifying sort criteria.
+    Accepts the same format as returned by the [queries](#queries) endpoint. Currently supported sorts are:
+      + id: Sort by primary key
+      + name: Sort by the name of the principal. Note that this depends on the setting for how the name is to be displayed at least for users.
+      + email: Sort by the email address of the principal. Groups and principal users, which do not have an email, are sorted last.
+      + status: Sort by the status of the principal. Groups and principal users, which do not have a status, are sorted together with the active users.
+      + created_at: Sort by membership creation datetime
+      + updated_at: Sort by the time the membership was updated last
 
 + Response 200 (application/hal+json)
 

--- a/lib/api/v3/groups/group_collection_representer.rb
+++ b/lib/api/v3/groups/group_collection_representer.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -29,26 +31,8 @@
 module API
   module V3
     module Groups
-      class GroupsAPI < ::API::OpenProjectAPI
-        resources :groups do
-          after_validation do
-            authorize_any %i[view_members manage_members], global: true
-          end
-
-          get &::API::V3::Utilities::Endpoints::Index
-                 .new(model: Group)
-                 .mount
-
-          route_param :id, type: Integer, desc: 'Group ID' do
-            after_validation do
-              @group = Group.visible(current_user).find(params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-                   .new(model: Group)
-                   .mount
-          end
-        end
+      class GroupCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
+        element_decorator ::API::V3::Groups::GroupRepresenter
       end
     end
   end

--- a/lib/api/v3/groups/group_payload_representer.rb
+++ b/lib/api/v3/groups/group_payload_representer.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -26,27 +28,11 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Groups
-  class BaseContract < ::ModelContract
-    include RequiresAdminGuard
-
-    # attribute_alias is broken in the sense
-    # that `model#changed` includes only the non-aliased name
-    # hence we need to put "lastname" as an attribute here
-    attribute :name
-    attribute :lastname
-
-    validate :validate_unique_users
-
-    private
-
-    # Validating on the group_users since those are dealt with in the
-    # corresponding services.
-    def validate_unique_users
-      user_ids = model.group_users.map(&:user_id)
-
-      if user_ids.uniq.length < user_ids.length
-        errors.add(:group_users, :taken)
+module API
+  module V3
+    module Groups
+      class GroupPayloadRepresenter < GroupRepresenter
+        include ::API::Utilities::PayloadRepresenter
       end
     end
   end

--- a/lib/api/v3/groups/group_representer.rb
+++ b/lib/api/v3/groups/group_representer.rb
@@ -41,7 +41,6 @@ module API
         associated_resources :users,
                              as: :members,
                              skip_render: -> { !current_user.allowed_to_globally?(:manage_members) }
-
       end
     end
   end

--- a/lib/api/v3/groups/group_representer.rb
+++ b/lib/api/v3/groups/group_representer.rb
@@ -38,6 +38,14 @@ module API
           'Group'
         end
 
+        link :updateImmediately,
+             cache_if: -> { current_user.admin? } do
+          {
+            href: api_v3_paths.group(represented.id),
+            method: :patch
+          }
+        end
+
         associated_resources :users,
                              as: :members,
                              skip_render: -> { !current_user.allowed_to_globally?(:manage_members) }

--- a/lib/api/v3/groups/group_representer.rb
+++ b/lib/api/v3/groups/group_representer.rb
@@ -32,9 +32,16 @@ module API
   module V3
     module Groups
       class GroupRepresenter < ::API::V3::Principals::PrincipalRepresenter
+        include API::Decorators::LinkedResource
+
         def _type
           'Group'
         end
+
+        associated_resources :users,
+                             as: :members,
+                             skip_render: -> { !current_user.allowed_to_globally?(:manage_members) }
+
       end
     end
   end

--- a/lib/api/v3/groups/groups_api.rb
+++ b/lib/api/v3/groups/groups_api.rb
@@ -53,6 +53,9 @@ module API
             patch &::API::V3::Utilities::Endpoints::Update
                      .new(model: Group)
                      .mount
+            delete &::API::V3::Utilities::Endpoints::Delete
+                     .new(model: Group)
+                     .mount
           end
         end
       end

--- a/lib/api/v3/groups/groups_api.rb
+++ b/lib/api/v3/groups/groups_api.rb
@@ -38,6 +38,9 @@ module API
           get &::API::V3::Utilities::Endpoints::Index
                  .new(model: Group)
                  .mount
+          post &::API::V3::Utilities::Endpoints::Create
+                  .new(model: Group)
+                  .mount
 
           route_param :id, type: Integer, desc: 'Group ID' do
             after_validation do

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -370,17 +370,12 @@ module API
           index :user
           show :user
 
-          class << self
-            alias :groups :users
-          end
-
           def self.user_lock(id)
             "#{user(id)}/lock"
           end
 
-          def self.group(id)
-            "#{root}/groups/#{id}"
-          end
+          index :group
+          show :group
 
           resources :version
 

--- a/modules/boards/spec/features/action_boards/assignee_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/assignee_board_spec.rb
@@ -67,7 +67,7 @@ describe 'Assignee action board',
   end
 
   let!(:group) do
-    FactoryBot.create(:group, groupname: 'Grouped').tap do |group|
+    FactoryBot.create(:group, name: 'Grouped').tap do |group|
       FactoryBot.create(:member,
                         principal: group,
                         project: project,

--- a/modules/dashboards/spec/features/members_principals_spec.rb
+++ b/modules/dashboards/spec/features/members_principals_spec.rb
@@ -51,7 +51,7 @@ describe 'Dashboard page members', type: :feature, js: true, with_mail: false do
 
   shared_let(:group) do
     FactoryBot.create(:group,
-                      groupname: 'DEV Team',
+                      name: 'DEV Team',
                       member_in_project: project,
                       member_with_permissions: permissions)
   end

--- a/modules/ldap_groups/lib/open_project/ldap_groups/synchronize_filter.rb
+++ b/modules/ldap_groups/lib/open_project/ldap_groups/synchronize_filter.rb
@@ -76,7 +76,7 @@ module OpenProject::LdapGroups
         Group.where(id: sync.group_id).update_all(lastname: name)
       else
         # Create an OpenProject group
-        sync.group = Group.find_or_create_by!(groupname: name)
+        sync.group = Group.find_or_create_by!(name: name)
       end
     end
   end

--- a/spec/contracts/groups/update_contract_spec.rb
+++ b/spec/contracts/groups/update_contract_spec.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -26,35 +28,31 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module API
-  module V3
-    module Groups
-      class GroupsAPI < ::API::OpenProjectAPI
-        resources :groups do
-          after_validation do
-            authorize_any %i[view_members manage_members], global: true
-          end
+require 'spec_helper'
+require 'contracts/shared/model_contract_shared_context'
+require_relative 'shared_contract_examples'
 
-          get &::API::V3::Utilities::Endpoints::Index
-                 .new(model: Group)
-                 .mount
-          post &::API::V3::Utilities::Endpoints::Create
-                  .new(model: Group)
-                  .mount
+describe Groups::UpdateContract do
+  include_context 'ModelContract shared context'
 
-          route_param :id, type: Integer, desc: 'Group ID' do
-            after_validation do
-              @group = Group.visible(current_user).find(params[:id])
-            end
+  it_behaves_like 'group contract' do
+    let(:group) do
+      FactoryBot.build_stubbed(:group,
+                               name: group_name,
+                               group_users: group_users)
+    end
 
-            get &::API::V3::Utilities::Endpoints::Show
-                   .new(model: Group)
-                   .mount
-            patch &::API::V3::Utilities::Endpoints::Update
-                     .new(model: Group)
-                     .mount
-          end
+    let(:contract) { described_class.new(group, current_user) }
+
+    describe 'validations' do
+      let(:current_user) { FactoryBot.build_stubbed :admin }
+
+      describe 'type' do
+        before do
+          group.type = 'A new type'
         end
+
+        it_behaves_like 'contract is invalid', type: :error_readonly
       end
     end
   end

--- a/spec/contracts/placeholder_users/create_contract_spec.rb
+++ b/spec/contracts/placeholder_users/create_contract_spec.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH

--- a/spec/factories/group_user_factory.rb
+++ b/spec/factories/group_user_factory.rb
@@ -26,28 +26,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Groups
-  class BaseContract < ::ModelContract
-    include RequiresAdminGuard
-
-    # attribute_alias is broken in the sense
-    # that `model#changed` includes only the non-aliased name
-    # hence we need to put "lastname" as an attribute here
-    attribute :name
-    attribute :lastname
-
-    validate :validate_unique_users
-
-    private
-
-    # Validating on the group_users since those are dealt with in the
-    # corresponding services.
-    def validate_unique_users
-      user_ids = model.group_users.map(&:user_id)
-
-      if user_ids.uniq.length < user_ids.length
-        errors.add(:group_users, :taken)
-      end
-    end
+FactoryBot.define do
+  factory :group_user do
   end
 end

--- a/spec/features/custom_fields/multi_user_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_user_custom_field_spec.rb
@@ -46,7 +46,7 @@ describe "multi select custom values", js: true do
 
     let!(:group) do
       FactoryBot.create :group,
-                        groupname: 'groupfoo',
+                        name: 'groupfoo',
                         member_in_project: project,
                         member_through_role: role
     end

--- a/spec/lib/api/v3/groups/group_representer_spec.rb
+++ b/spec/lib/api/v3/groups/group_representer_spec.rb
@@ -40,7 +40,8 @@ describe ::API::V3::Groups::GroupRepresenter, 'rendering' do
         .and_return(members)
     end
   end
-  let(:current_user) { FactoryBot.build_stubbed(:user) }
+  let(:current_user_admin) { false }
+  let(:current_user) { FactoryBot.build_stubbed(:user, admin: current_user_admin) }
   let(:representer) { described_class.new(group, current_user: current_user, embed_links: embed_links) }
   let(:members) { 2.times.map { FactoryBot.build_stubbed(:user) } }
   let(:permissions) { [:manage_members] }
@@ -63,9 +64,10 @@ describe ::API::V3::Groups::GroupRepresenter, 'rendering' do
     end
 
     describe 'members' do
+      let(:link) { 'members' }
+
       context 'with the necessary permissions' do
         it_behaves_like 'has a link collection' do
-          let(:link) { 'members' }
           let(:hrefs) do
             members.map do |member|
               {
@@ -80,9 +82,25 @@ describe ::API::V3::Groups::GroupRepresenter, 'rendering' do
       context 'without the necessary permissions' do
         let(:permissions) { [] }
 
-        it_behaves_like 'has no link' do
-          let(:link) { 'members' }
+        it_behaves_like 'has no link'
+      end
+    end
+
+    describe 'updateImmediately' do
+      let(:link) { 'updateImmediately' }
+
+      context 'with the necessary permissions' do
+        let(:current_user_admin) { true }
+
+        it_behaves_like 'has an untitled link' do
+          let(:href) { api_v3_paths.group group.id }
         end
+      end
+
+      context 'without the necessary permissions' do
+        let(:current_user_admin) { false }
+
+        it_behaves_like 'has no link'
       end
     end
   end

--- a/spec/lib/api/v3/groups/group_representer_spec.rb
+++ b/spec/lib/api/v3/groups/group_representer_spec.rb
@@ -103,6 +103,24 @@ describe ::API::V3::Groups::GroupRepresenter, 'rendering' do
         it_behaves_like 'has no link'
       end
     end
+
+    describe 'delete' do
+      let(:link) { 'delete' }
+
+      context 'with the necessary permissions' do
+        let(:current_user_admin) { true }
+
+        it_behaves_like 'has an untitled link' do
+          let(:href) { api_v3_paths.group group.id }
+        end
+      end
+
+      context 'without the necessary permissions' do
+        let(:current_user_admin) { false }
+
+        it_behaves_like 'has no link'
+      end
+    end
   end
 
   describe 'properties' do

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -425,11 +425,8 @@ describe ::API::V3::Utilities::PathHelper do
   end
 
   describe 'group paths' do
-    describe '#group' do
-      subject { helper.group 1 }
-
-      it_behaves_like 'api v3 path', '/groups/1'
-    end
+    it_behaves_like 'index', :group
+    it_behaves_like 'show', :group
   end
 
   describe 'version paths' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -49,7 +49,7 @@ describe Group, type: :model do
 
   describe 'with long but allowed attributes' do
     it 'is valid' do
-      group.groupname = 'a' * 256
+      group.name = 'a' * 256
       expect(group).to be_valid
       expect(group.save).to be_truthy
     end
@@ -57,7 +57,7 @@ describe Group, type: :model do
 
   describe 'with a name too long' do
     it 'is invalid' do
-      group.groupname = 'a' * 257
+      group.name = 'a' * 257
       expect(group).not_to be_valid
       expect(group.save).to be_falsey
     end
@@ -118,7 +118,7 @@ describe Group, type: :model do
           group.valid?
         end
 
-        it { expect(group.errors.full_messages[0]).to include I18n.t('attributes.groupname') }
+        it { expect(group.errors.full_messages[0]).to include I18n.t('attributes.name') }
       end
     end
   end
@@ -135,8 +135,8 @@ describe Group, type: :model do
     end
   end
 
-  describe '#groupname' do
-    it { expect(group).to validate_presence_of :groupname }
-    it { expect(group).to validate_uniqueness_of :groupname }
+  describe '#name' do
+    it { expect(group).to validate_presence_of :name }
+    it { expect(group).to validate_uniqueness_of :name }
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -71,6 +71,30 @@ describe Group, type: :model do
     end
   end
 
+  describe '#group_users' do
+    context 'when adding a user' do
+      it 'updates the timestamp' do
+        updated_at = group.updated_at
+        group.group_users.create(user: user)
+
+        expect(updated_at < group.reload.updated_at)
+          .to be_truthy
+      end
+    end
+
+    context 'when removing a user' do
+      it 'updates the timestamp' do
+        group.group_users.create(user: user)
+        updated_at = group.reload.updated_at
+
+        group.group_users.destroy_all
+
+        expect(updated_at < group.reload.updated_at)
+          .to be_truthy
+      end
+    end
+  end
+
   describe 'from legacy specs' do
     let!(:roles) { FactoryBot.create_list :role, 2 }
     let!(:role_ids) { roles.map(&:id).sort }

--- a/spec/models/principals/scopes/ordered_by_name_spec.rb
+++ b/spec/models/principals/scopes/ordered_by_name_spec.rb
@@ -35,7 +35,7 @@ describe Principals::Scopes::OrderedByName, type: :model do
     shared_let(:alice) { FactoryBot.create(:user, login: 'alice', firstname: 'Alice', lastname: 'Zetop') }
     shared_let(:eve) { FactoryBot.create(:user, login: 'eve', firstname: 'Eve', lastname: 'Baddie') }
 
-    shared_let(:group) { FactoryBot.create(:group, groupname: 'Core Team') }
+    shared_let(:group) { FactoryBot.create(:group, name: 'Core Team') }
     shared_let(:placeholder_user) { FactoryBot.create(:placeholder_user, name: 'Developers') }
 
     subject { Principal.ordered_by_name(desc: descending).pluck(:id) }

--- a/spec/services/base_services/behaves_like_update_service.rb
+++ b/spec/services/base_services/behaves_like_update_service.rb
@@ -66,22 +66,22 @@ shared_examples 'BaseServices update service' do
 
     allow(set_attributes_class)
       .to receive(:new)
-            .with(user: user,
-                  model: model_instance,
-                  contract_class: contract_class,
-                  contract_options: {})
-            .and_return(service)
+      .with(user: user,
+            model: model_instance,
+            contract_class: contract_class,
+            contract_options: {})
+      .and_return(service)
 
     allow(service)
       .to receive(:call)
-            .and_return(set_attributes_result)
+      .and_return(set_attributes_result)
   end
 
   before do
     allow(model_instance).to receive(:save).and_return(true)
   end
 
-  subject { instance.call(call_attributes) }
+  subject(:instance_call) { instance.call(call_attributes) }
 
   describe '#user' do
     it 'exposes a user which is available as a getter' do
@@ -98,7 +98,7 @@ shared_examples 'BaseServices update service' do
   describe "#call" do
     context 'when the model instance is valid' do
       it 'is a successful call', :aggregate_failures do
-        expect(subject.success?).to be_truthy
+        expect(subject).to be_success
         expect(subject).to eql set_attributes_result
         expect(subject.result).to eql model_instance
       end
@@ -110,7 +110,7 @@ shared_examples 'BaseServices update service' do
       it 'is unsuccessful', :aggregate_failures do
         expect(model_instance).not_to receive(:save)
 
-        expect(subject.success?).to be_falsey
+        expect(subject).to be_failure
         expect(subject).to eql set_attributes_result
 
         expect(model_instance).to_not receive(:save)
@@ -127,7 +127,7 @@ shared_examples 'BaseServices update service' do
       end
 
       it 'is unsuccessful and returns the errors', :aggregate_failures do
-        expect(subject.success?).to be_falsey
+        expect(subject).to be_failure
         expect(subject.errors).to eql model_instance.errors
       end
     end

--- a/spec/services/groups/set_attributes_service_spec.rb
+++ b/spec/services/groups/set_attributes_service_spec.rb
@@ -1,0 +1,162 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Groups::SetAttributesService, type: :model do
+  subject(:service_call) { instance.call(call_attributes) }
+
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:contract_class) do
+    contract = double('contract_class')
+
+    allow(contract)
+      .to receive(:new)
+      .with(group, user, options: { changed_by_system: [] })
+      .and_return(contract_instance)
+
+    contract
+  end
+  let(:contract_instance) do
+    instance_double(ModelContract, validate: contract_valid, errors: contract_errors)
+  end
+  let(:contract_valid) { true }
+  let(:contract_errors) do
+    instance_double(ActiveRecord::ActiveRecordError)
+  end
+  let(:group_valid) { true }
+  let(:instance) do
+    described_class.new(user: user,
+                        model: group,
+                        contract_class: contract_class)
+  end
+  let(:call_attributes) { {} }
+  let(:group) do
+    FactoryBot.build_stubbed(:group) do |g|
+      # To later check that it has not been called
+      allow(g)
+        .to receive(:save)
+    end
+  end
+
+  describe 'call' do
+    let(:call_attributes) do
+      {
+        name: 'The name'
+      }
+    end
+
+    before do
+      allow(group)
+        .to receive(:valid?)
+        .and_return(group_valid)
+
+      allow(contract_instance)
+        .to receive(:validate)
+        .and_return(contract_valid)
+    end
+
+    it 'is successful' do
+      expect(service_call)
+        .to be_success
+    end
+
+    it 'sets the attributes' do
+      service_call
+
+      expect(group.lastname)
+        .to eql call_attributes[:name]
+    end
+
+    it 'does not persist the group' do
+      service_call
+
+      expect(group)
+        .not_to have_received(:save)
+    end
+
+    context 'with changes to the roles do' do
+      let(:first_user) { FactoryBot.build_stubbed(:user) }
+      let(:second_user) { FactoryBot.build_stubbed(:user) }
+      let(:third_user) { FactoryBot.build_stubbed(:user) }
+
+      let(:call_attributes) do
+        {
+          user_ids: [second_user.id, third_user.id]
+        }
+      end
+
+      context 'with a persisted record' do
+        let(:first_group_user) { FactoryBot.build_stubbed(:group_user, user: first_user) }
+        let(:second_group_user) { FactoryBot.build_stubbed(:group_user, user: second_user) }
+
+        let(:group) do
+          FactoryBot.build_stubbed(:group, group_users: [first_group_user, second_group_user])
+        end
+
+        it 'adds the new users' do
+          expect(service_call.result.group_users.map(&:user_id))
+            .to eql [first_user.id, second_user.id, third_user.id]
+        end
+
+        it 'does not persist the new association' do
+          expect(service_call.result.group_users.find { |gu| gu.user_id == third_user.id })
+            .to be_new_record
+        end
+
+        it 'keeps the association already existing before' do
+          expect(service_call.result.group_users.find { |gu| gu.user_id == second_user.id })
+            .not_to be_marked_for_destruction
+        end
+
+        it 'marks not mentioned users to be removed' do
+          expect(service_call.result.group_users.find { |gu| gu.user_id == first_user.id })
+            .to be_marked_for_destruction
+        end
+      end
+
+      context 'with a new record' do
+        let(:group) do
+          Group.new
+        end
+
+        it 'sets the user' do
+          expect(service_call.result.group_users.map(&:user_id))
+            .to eql [second_user.id, third_user.id]
+        end
+
+        it 'does not persist the association' do
+          expect(service_call.result.group_users.all(&:new_record?))
+            .to be_truthy
+        end
+      end
+    end
+  end
+end

--- a/spec/services/groups/set_attributes_service_spec.rb
+++ b/spec/services/groups/set_attributes_service_spec.rb
@@ -102,7 +102,7 @@ describe Groups::SetAttributesService, type: :model do
         .not_to have_received(:save)
     end
 
-    context 'with changes to the roles do' do
+    context 'with changes to the users do' do
       let(:first_user) { FactoryBot.build_stubbed(:user) }
       let(:second_user) { FactoryBot.build_stubbed(:user) }
       let(:third_user) { FactoryBot.build_stubbed(:user) }
@@ -113,7 +113,7 @@ describe Groups::SetAttributesService, type: :model do
         }
       end
 
-      context 'with a persisted record' do
+      shared_examples_for 'updates the users' do
         let(:first_group_user) { FactoryBot.build_stubbed(:group_user, user: first_user) }
         let(:second_group_user) { FactoryBot.build_stubbed(:group_user, user: second_user) }
 
@@ -140,6 +140,26 @@ describe Groups::SetAttributesService, type: :model do
           expect(service_call.result.group_users.find { |gu| gu.user_id == first_user.id })
             .to be_marked_for_destruction
         end
+      end
+
+      context 'with a persisted record and integer values' do
+        let(:call_attributes) do
+          {
+            user_ids: [second_user.id, third_user.id]
+          }
+        end
+
+        it_behaves_like 'updates the users'
+      end
+
+      context 'with a persisted record and string values' do
+        let(:call_attributes) do
+          {
+            user_ids: [second_user.id.to_s, third_user.id.to_s]
+          }
+        end
+
+        it_behaves_like 'updates the users'
       end
 
       context 'with a new record' do

--- a/spec/services/groups/update_service_spec.rb
+++ b/spec/services/groups/update_service_spec.rb
@@ -1,0 +1,119 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'services/base_services/behaves_like_update_service'
+
+describe Groups::UpdateService, type: :model do
+  it_behaves_like 'BaseServices update service' do
+    let(:add_service_result) do
+      ServiceResult.new success: true
+    end
+    let!(:add_users_service) do
+      add_service = instance_double(Groups::AddUsersService)
+
+      allow(Groups::AddUsersService)
+        .to receive(:new)
+        .with(model_instance, current_user: user)
+        .and_return(add_service)
+
+      allow(add_service)
+        .to receive(:call)
+        .and_return(add_service_result)
+
+      add_service
+    end
+
+    context 'with newly created group_users' do
+      let(:old_group_user) { FactoryBot.build_stubbed(:group_user, user_id: 3) }
+      let(:new_group_user) do
+        FactoryBot.build_stubbed(:group_user, user_id: 5).tap do |gu|
+          allow(gu)
+            .to receive(:saved_changes?)
+            .and_return(true)
+        end
+      end
+      let(:group_users) { [old_group_user, new_group_user] }
+
+      before do
+        allow(model_instance)
+          .to receive(:group_users)
+          .and_return(group_users)
+      end
+
+      context 'with the AddUsersService being successful' do
+        it 'is successful' do
+          expect(instance_call).to be_success
+        end
+
+        it 'calls the AddUsersService' do
+          instance_call
+
+          expect(add_users_service)
+            .to have_received(:call)
+            .with(ids: [new_group_user.user_id])
+        end
+      end
+
+      context 'with the AddUsersService being unsuccessful' do
+        let(:add_service_result) do
+          ServiceResult.new success: false
+        end
+
+        it 'is failure' do
+          expect(instance_call).to be_failure
+        end
+
+        it 'calls the AddUsersService' do
+          instance_call
+
+          expect(add_users_service)
+            .to have_received(:call)
+            .with(ids: [new_group_user.user_id])
+        end
+      end
+
+      context 'without any new group_users' do
+        let(:group_users) { [old_group_user] }
+
+        it 'is successful' do
+          expect(instance_call).to be_success
+        end
+
+        it 'does not call the AddUsersService' do
+          instance_call
+
+          expect(add_users_service)
+            .not_to have_received(:call)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Turn groups api from a stub into a fully functional API (excluding from and schema):

- [x] GET `/api/v3/groups/:id`
  - [x] Include group members
- [x] GET `/api/v3/groups`
- [x] POST `/api/v3/groups`
- [x] PATCH `/api/v3/groups/:id`
- [x] DELETE `/api/v3/groups/:id`

This PR can be merged whenever one endpoint has been added. Whatever is missing, can be added in subsequent PRs.

Implements https://community.openproject.org/wp/18812 and https://community.openproject.org/projects/openproject/work_packages/33686 with the exception of "List groups of a user". The last was already possible by applying a "group" filter to the users endpoint. 