### PR TITLE
Introduce visible scope to principals

### DIFF
--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -63,7 +63,8 @@ class Principal < ApplicationRecord
          :possible_assignee,
          :possible_member,
          :user,
-         :ordered_by_name
+         :ordered_by_name,
+         :visible
 
   scope :not_locked, -> {
     not_builtin.where.not(status: statuses[:locked])

--- a/spec/models/principals/scopes/visible_spec.rb
+++ b/spec/models/principals/scopes/visible_spec.rb
@@ -1,0 +1,68 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Principals::Scopes::Visible, type: :model do
+  describe '.visible' do
+    shared_let(:project) { FactoryBot.create :project }
+    shared_let(:other_project) { FactoryBot.create :project }
+    shared_let(:role) { FactoryBot.create :role, permissions: %i[manage_members] }
+
+    shared_let(:other_project_user) { FactoryBot.create :user, member_in_project: other_project, member_through_role: role }
+    shared_let(:global_user) { FactoryBot.create :user }
+
+    subject { ::Principal.visible.to_a }
+
+    context 'when user has manage_members permission' do
+      current_user { FactoryBot.create :user, member_in_project: project, member_through_role: role }
+
+      it 'sees all users' do
+        expect(subject).to match_array [current_user, other_project_user, global_user]
+      end
+    end
+
+    context 'when user has no manage_members permission, but it is in other project' do
+      current_user { FactoryBot.create :user, member_in_project: other_project, member_with_permissions: %i[view_work_packages] }
+
+      it 'sees the other user in the same project' do
+        expect(subject).to match_array [current_user, other_project_user]
+      end
+    end
+
+    context 'when user has no permission' do
+      current_user { FactoryBot.create :user }
+
+      it 'sees only herself' do
+        expect(subject).to match_array [current_user]
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a user has the manage_users permission in any project, they are eligible to view all users for inviting them to the project.

This however is not reflected in the principals API, where only users in all visible projects are found.