### PR TITLE
Remove ldap group memberships when user is destroyed

### DIFF
--- a/modules/ldap_groups/lib/open_project/ldap_groups/engine.rb
+++ b/modules/ldap_groups/lib/open_project/ldap_groups/engine.rb
@@ -22,6 +22,6 @@ module OpenProject::LdapGroups
 
     add_cron_jobs { LdapGroups::SynchronizationJob }
 
-    patches %i[AuthSource Group]
+    patches %i[AuthSource Group User]
   end
 end

--- a/modules/ldap_groups/lib/open_project/ldap_groups/patches/user_patch.rb
+++ b/modules/ldap_groups/lib/open_project/ldap_groups/patches/user_patch.rb
@@ -1,0 +1,13 @@
+module OpenProject::LdapGroups
+  module Patches
+    module UserPatch
+      def self.included(base) # :nodoc:
+        base.class_eval do
+          has_many :ldap_groups_memberships,
+                   class_name: '::LdapGroups::Membership',
+                   dependent: :destroy
+        end
+      end
+    end
+  end
+end

--- a/modules/ldap_groups/spec/models/membership_spec.rb
+++ b/modules/ldap_groups/spec/models/membership_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe LdapGroups::Membership, type: :model do
+  describe 'destroy' do
+    let(:synchronized_group) { FactoryBot.create :ldap_synchronized_group, group: group }
+    let(:group) { FactoryBot.create :group }
+    let(:user) { FactoryBot.create :user }
+
+    before do
+      User.system.run_given do
+        synchronized_group.add_members! [user]
+      end
+    end
+
+    it 'is removed when the user is destroyed' do
+      expect(user.ldap_groups_memberships.count).to eq 1
+      membership = user.ldap_groups_memberships.first
+      expect(membership.group).to eq(synchronized_group)
+      expect(membership.user).to eq(user)
+      expect(synchronized_group.users.count).to eq(1)
+
+      user.destroy!
+      synchronized_group.reload
+
+      expect { membership.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(synchronized_group.users.count).to eq(0)
+    end
+  end
+end

--- a/modules/ldap_groups/spec/services/synchronize_filter_spec.rb
+++ b/modules/ldap_groups/spec/services/synchronize_filter_spec.rb
@@ -123,7 +123,7 @@ describe LdapGroups::SynchronizeFilterService, with_ee: %i[ldap_groups] do
                         base_dn: 'ou=users,dc=example,dc=com'
     end
 
-    it 'users that base for searching and doesnt find any groups' do
+    it 'uses that base for searching and doesnt find any groups' do
       expect { subject }.not_to raise_error
 
       filter_foo_bar.reload


### PR DESCRIPTION
@machisuji noticed that when a user is destroyed, the LDAP group membership is not cleaned until the next synchronization job runs, leaving some empty table rows that might be confusing