### PR TITLE
rework changed_by_system

### DIFF
--- a/app/contracts/model_contract.rb
+++ b/app/contracts/model_contract.rb
@@ -67,26 +67,18 @@ class ModelContract < BaseContract
   private
 
   def readonly_attributes_unchanged
-    invalid_changes = attributes_changed_by_user - writable_attributes
-
-    invalid_changes.each do |attribute|
+    unauthenticated_changed.each do |attribute|
       outside_attribute = collect_ancestor_attribute_aliases[attribute] || attribute
 
       errors.add outside_attribute, :error_readonly
     end
   end
 
-  def attributes_changed_by_user
-    changed = changed_attributes
-
-    if options[:changed_by_system]
-      changed -= options[:changed_by_system]
-    end
-
-    changed
+  def unauthenticated_changed
+    changed_by_user - writable_attributes
   end
 
-  def changed_attributes
-    model.changed
+  def changed_by_user
+    model.respond_to?(:changed_by_user) ? model.changed_by_user : model.changed
   end
 end

--- a/app/contracts/wiki_pages/base_contract.rb
+++ b/app/contracts/wiki_pages/base_contract.rb
@@ -70,8 +70,14 @@ module WikiPages
       end
     end
 
-    def changed_attributes
-      model.changed + (model.content&.changed || [])
+    def changed_by_user
+      content_changed = if model.content
+                          model.content.respond_to?(:changed_by_user) ? model.content.changed_by_user : model.content.changed
+                        else
+                          []
+                        end
+
+      super + content_changed
     end
   end
 end

--- a/app/services/base_services/base_contracted.rb
+++ b/app/services/base_services/base_contracted.rb
@@ -36,6 +36,7 @@ module BaseServices
     attr_reader :user
 
     def initialize(user:, contract_class: nil, contract_options: {})
+      super()
       @user = user
       self.contract_class = contract_class || default_contract_class
       self.contract_options = contract_options

--- a/app/services/base_services/set_attributes.rb
+++ b/app/services/base_services/set_attributes.rb
@@ -34,7 +34,7 @@ module BaseServices
 
     def initialize(user:, model:, contract_class:, contract_options: {})
       self.user = user
-      self.model = model
+      self.model = prepare_model(model)
 
       self.contract_class = contract_class
       self.contract_options = contract_options
@@ -68,6 +68,11 @@ module BaseServices
       ServiceResult.new(success: success,
                         errors: errors,
                         result: model)
+    end
+
+    def prepare_model(model)
+      model.extend(OpenProject::ChangedBySystem)
+      model
     end
   end
 end

--- a/app/services/concerns/contracted.rb
+++ b/app/services/concerns/contracted.rb
@@ -43,30 +43,10 @@ module Contracted
       @contract_class = cls
     end
 
-    def changed_by_system(attributes = nil)
-      @changed_by_system ||= []
-
-      if attributes
-        @changed_by_system += Array(attributes)
-      end
-
-      @changed_by_system
-    end
-
-    def change_by_system
-      prior_changes = non_no_op_changes
-
-      ret = yield
-
-      changed_by_system(changed_compared_to(prior_changes))
-
-      ret
-    end
-
     private
 
     def instantiate_contract(object, user, options: {})
-      contract_class.new(object, user, options: { changed_by_system: changed_by_system }.merge(options))
+      contract_class.new(object, user, options: options)
     end
 
     def validate_and_save(object, user, options: {})
@@ -95,18 +75,6 @@ module Contracted
         # as object.valid? is already called in the contract
         true
       end
-    end
-
-    def non_no_op_changes
-      model.changes.reject { |_, (old, new)| old == 0 && new.nil? }
-    end
-
-    def changed_compared_to(prior_changes)
-      changed_attributes.select { |c| !prior_changes[c] || prior_changes[c].last != model.changes[c].last }
-    end
-
-    def changed_attributes
-      model.changed
     end
   end
 end

--- a/app/services/messages/set_attributes_service.rb
+++ b/app/services/messages/set_attributes_service.rb
@@ -40,7 +40,7 @@ module Messages
     end
 
     def set_default_author
-      change_by_system do
+      model.change_by_system do
         model.author = user
       end
     end

--- a/app/services/wiki_pages/set_attributes_service.rb
+++ b/app/services/wiki_pages/set_attributes_service.rb
@@ -53,8 +53,11 @@ class WikiPages::SetAttributesService < ::BaseServices::SetAttributes
   end
 
   def set_default_attributes(_params)
-    change_by_system do
-      model.build_content author: user
+    model.build_content
+    model.content.extend(OpenProject::ChangedBySystem)
+
+    model.content.change_by_system do
+      model.content.author = user
     end
   end
 
@@ -64,9 +67,5 @@ class WikiPages::SetAttributesService < ::BaseServices::SetAttributes
 
   def split_page_and_content_params(params)
     params.partition { |p, _| WikiContent.column_names.include?(p) }.map(&:to_h)
-  end
-
-  def changed_attributes
-    super + (model.content&.changed || [])
   end
 end

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -37,14 +37,14 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
     set_attachments_attributes(attributes)
     set_static_attributes(attributes)
 
-    change_by_system do
+    model.change_by_system do
       set_default_attributes(attributes)
       update_project_dependent_attributes
     end
 
     set_custom_attributes(attributes)
 
-    change_by_system do
+    model.change_by_system do
       update_dates
       reassign_invalid_status_if_type_changed
       set_templated_description
@@ -160,7 +160,7 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
   def update_project_dependent_attributes
     return unless work_package.project_id_changed? && work_package.project_id
 
-    change_by_system do
+    model.change_by_system do
       set_version_to_nil
       reassign_category
 

--- a/lib/open_project/changed_by_system.rb
+++ b/lib/open_project/changed_by_system.rb
@@ -1,0 +1,114 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+
+# OpenProject in its contracts has checks to govern which attributes are writable. Only attributes marked to be
+# writable, can be set by a user.
+# In some scenarios however, the system needs to set calculated attributes, e.g. if a default value is set - the current user
+# becomes the author of the work package.
+#
+# While an attribute should not be marked as writable, is sometimes still needs to be changed, thus.
+# Such attributes can be changed using this module.
+#
+# The flow would be
+#
+#   # The model is an AR class like work package
+#   model.extend(OpenProject::ChangedBySystem)
+#   model.change_by_system do
+#     model.author = current_user
+#   end
+#
+# The contract checking later on can then query for
+#
+#  model.changed_by_system
+#
+# This method will return the changes carried out inside a change_by_system block. It returns a hash of all the
+# changed attributes as well as the value it was changed from and the value it was changed to.
+#
+# Querying
+#
+#   model.changed_by_user
+#
+# will return all attributes changed by the user instead.
+
+module OpenProject
+  module ChangedBySystem
+    def changed_by_system(attributes = nil)
+      @changed_by_system ||= {}
+
+      if attributes
+        @changed_by_system.merge!(attributes)
+      end
+
+      @changed_by_system
+    end
+
+    # Wrapper to track changes carried out in the context of the system.
+    #
+    #   model.change_by_system do
+    #     model.attribute = 1
+    #   end
+    #
+    # Attribute changes carried out within such a scope will not count to be changed
+    # by the user. It can therefore be used to set calculated or default values.
+    #
+    # This should never be used with user provided values.
+    #
+    # No only the attribute is tracked but also the values. So it is safe to e.g. first
+    # set a default value, and then mass assign attributes. If the default value is overwritten
+    # by the mass assignment the change in value will give that away.
+    def change_by_system
+      prior_changes = non_no_op_changes
+
+      ret = yield
+
+      changed_by_system(changes_compared_to(prior_changes))
+
+      ret
+    end
+
+    # Similar to #changed from ActiveRecord this returns all attributes that are
+    # currently changed. But it will only include those attributes, that have not
+    # been changed within a #change_by_system block and as such are caused by user input.
+    def changed_by_user
+      (changes.reject { |key, change| changed_by_system[key] == change }).keys
+    end
+
+    private
+
+    def non_no_op_changes
+      changes.reject { |_, (old, new)| old == 0 && new.nil? }
+    end
+
+    def changes_compared_to(prior_changes)
+      changes.select { |c| !prior_changes[c] || prior_changes[c].last != changes[c].last }
+    end
+  end
+end

--- a/modules/bim/app/services/bim/ifc_models/set_attributes_service.rb
+++ b/modules/bim/app/services/bim/ifc_models/set_attributes_service.rb
@@ -38,7 +38,7 @@ module Bim
 
         super
 
-        change_by_system do
+        model.change_by_system do
           model.uploader = model.ifc_attachment&.author if model.ifc_attachment&.new_record? || model.ifc_attachment&.pending_direct_upload?
         end
       end

--- a/modules/bim/spec/contracts/ifc_models/create_contract_spec.rb
+++ b/modules/bim/spec/contracts/ifc_models/create_contract_spec.rb
@@ -36,14 +36,16 @@ describe Bim::IfcModels::CreateContract do
     let(:ifc_model) do
       ::Bim::IfcModels::IfcModel.new(project: model_project,
                                      title: model_title,
-                                     uploader: model_user)
+                                     uploader: model_user).tap do |m|
+        m.extend(OpenProject::ChangedBySystem)
+        m.changed_by_system("uploader_id" => [nil, model_user.id])
+      end
     end
     let(:permissions) { %i(manage_ifc_models) }
     let(:other_user) { FactoryBot.build_stubbed(:user) }
-    let(:changed_by_system) { %w(uploader_id) }
 
     subject(:contract) do
-      described_class.new(ifc_model, current_user, options: { changed_by_system: changed_by_system })
+      described_class.new(ifc_model, current_user, options: {})
     end
   end
 end

--- a/modules/bim/spec/contracts/ifc_models/update_contract_spec.rb
+++ b/modules/bim/spec/contracts/ifc_models/update_contract_spec.rb
@@ -33,15 +33,20 @@ require_relative './shared_contract_examples'
 
 describe Bim::IfcModels::UpdateContract do
   it_behaves_like 'ifc model contract' do
+    subject(:contract) { described_class.new(ifc_model, current_user) }
+
     let(:ifc_model) do
       FactoryBot.build_stubbed(:ifc_model,
                                uploader: model_user,
                                title: model_title,
                                project: model_project).tap do |model|
-        model.uploader = uploader_user
+        model.extend(OpenProject::ChangedBySystem)
+
+        model.change_by_system do
+          model.uploader = uploader_user
+        end
       end
     end
-    subject(:contract) { described_class.new(ifc_model, current_user, options: { changed_by_system: %w(uploader_id) }) }
     let(:permissions) { %i(manage_ifc_models) }
     let(:uploader_user) { model_user }
 

--- a/modules/bim/spec/services/bcf/viewpoints/set_attributes_service_spec.rb
+++ b/modules/bim/spec/services/bcf/viewpoints/set_attributes_service_spec.rb
@@ -37,7 +37,7 @@ describe Bim::Bcf::Viewpoints::SetAttributesService, type: :model do
 
     allow(contract)
       .to receive(:new)
-      .with(viewpoint, user, options: { changed_by_system: [] })
+      .with(viewpoint, user, options: {})
       .and_return(contract_instance)
 
     contract

--- a/modules/bim/spec/services/ifc_models/set_attributes_service_spec.rb
+++ b/modules/bim/spec/services/ifc_models/set_attributes_service_spec.rb
@@ -38,12 +38,11 @@ describe Bim::IfcModels::SetAttributesService, type: :model do
 
     allow(contract)
       .to receive(:new)
-      .with(model, user, options: { changed_by_system: changed_by_system })
+      .with(model, user, options: {})
       .and_return(contract_instance)
 
     contract
   end
-  let(:changed_by_system) { [] }
   let(:contract_instance) do
     double('contract_instance', validate: contract_valid, errors: contract_errors)
   end
@@ -113,8 +112,6 @@ describe Bim::IfcModels::SetAttributesService, type: :model do
       end
 
       context 'with an ifc_attachment' do
-        let(:changed_by_system) { %w(uploader_id) }
-
         let(:call_attributes) do
           {
             ifc_attachment: ifc_file
@@ -143,8 +140,6 @@ describe Bim::IfcModels::SetAttributesService, type: :model do
 
     context 'for an existing model' do
       context 'with an ifc_attachment' do
-        let(:changed_by_system) { %w(uploader_id) }
-
         let(:call_attributes) do
           {
             ifc_attachment: ifc_file

--- a/modules/costs/app/services/time_entries/set_attributes_service.rb
+++ b/modules/costs/app/services/time_entries/set_attributes_service.rb
@@ -49,7 +49,7 @@ module TimeEntries
     end
 
     def set_default_user
-      change_by_system do
+      model.change_by_system do
         model.user = user
       end
     end

--- a/modules/costs/spec/services/time_entries/set_attributes_service_spec.rb
+++ b/modules/costs/spec/services/time_entries/set_attributes_service_spec.rb
@@ -61,7 +61,7 @@ describe TimeEntries::SetAttributesService, type: :model do
   let(:contract_class) do
     allow(TimeEntries::CreateContract)
       .to receive(:new)
-      .with(anything, user, options: { changed_by_system: ["user_id"] })
+      .with(anything, user, options: {})
       .and_return(contract_instance)
 
     TimeEntries::CreateContract
@@ -97,8 +97,8 @@ describe TimeEntries::SetAttributesService, type: :model do
   it 'notes the user to be system changed' do
     subject
 
-    expect(instance.changed_by_system)
-      .to include('user_id')
+    expect(time_entry_instance.changed_by_system['user_id'])
+      .to eql [nil, user.id]
   end
 
   it 'assigns the default TimeEntryActivity' do

--- a/modules/grids/spec/services/grids/set_attributes_service_spec.rb
+++ b/modules/grids/spec/services/grids/set_attributes_service_spec.rb
@@ -37,7 +37,7 @@ describe Grids::SetAttributesService, type: :model do
 
     allow(contract)
       .to receive(:new)
-      .with(grid, user, options: { changed_by_system: [] })
+      .with(grid, user, options: {})
       .and_return(contract_instance)
 
     contract

--- a/spec/contracts/custom_fields/create_contract_spec.rb
+++ b/spec/contracts/custom_fields/create_contract_spec.rb
@@ -36,7 +36,7 @@ describe CustomFields::CreateContract do
 
   let(:cf) { FactoryBot.build :project_custom_field }
   let(:contract) do
-    described_class.new(cf, current_user, options: { changed_by_system: [] })
+    described_class.new(cf, current_user, options: {})
   end
 
   it_behaves_like 'contract is valid for active admins and invalid for regular users'

--- a/spec/contracts/custom_fields/update_contract_spec.rb
+++ b/spec/contracts/custom_fields/update_contract_spec.rb
@@ -36,7 +36,7 @@ describe CustomFields::UpdateContract do
 
   let(:cf) { FactoryBot.build :project_custom_field }
   let(:contract) do
-    described_class.new(cf, current_user, options: { changed_by_system: [] })
+    described_class.new(cf, current_user)
   end
 
   it_behaves_like 'contract is valid for active admins and invalid for regular users'

--- a/spec/contracts/messages/create_contract_spec.rb
+++ b/spec/contracts/messages/create_contract_spec.rb
@@ -41,12 +41,14 @@ describe Messages::CreateContract do
                   author: message_author,
                   last_reply: message_last_reply,
                   locked: message_locked,
-                  sticky: message_sticky)
+                  sticky: message_sticky).tap do |m|
+        m.extend(OpenProject::ChangedBySystem)
+        m.changed_by_system("author_id" => [nil, message_author.id])
+      end
     end
-    let(:changed_by_system) { %w(author_id) }
 
     subject(:contract) do
-      described_class.new(message, current_user, options: { changed_by_system: changed_by_system })
+      described_class.new(message, current_user)
     end
   end
 end

--- a/spec/contracts/work_packages/create_contract_spec.rb
+++ b/spec/contracts/work_packages/create_contract_spec.rb
@@ -32,7 +32,11 @@ require 'spec_helper'
 require 'contracts/work_packages/shared_base_contract'
 
 describe WorkPackages::CreateContract do
-  let(:work_package) { WorkPackage.new project: work_package_project }
+  let(:work_package) do
+    WorkPackage.new(project: work_package_project).tap do |wp|
+      wp.extend(OpenProject::ChangedBySystem)
+    end
+  end
   let(:work_package_project) { project }
   let(:project) { FactoryBot.build_stubbed(:project) }
   let(:user) { FactoryBot.build_stubbed(:user) }
@@ -122,10 +126,12 @@ describe WorkPackages::CreateContract do
     end
 
     context 'if the user is set by the system and the user is the user the contract is evaluated for' do
-      subject(:contract) { described_class.new(work_package, user, options: { changed_by_system: ['author_id'] }) }
+      subject(:contract) { described_class.new(work_package, user) }
 
       it 'is valid' do
-        work_package.author = user
+        work_package.change_by_system do
+          work_package.author = user
+        end
 
         expect(validated_contract.errors[:author_id]).to be_empty
       end

--- a/spec/services/custom_actions/update_work_package_service_spec.rb
+++ b/spec/services/custom_actions/update_work_package_service_spec.rb
@@ -94,7 +94,7 @@ describe CustomActions::UpdateWorkPackageService do
 
     allow(WorkPackages::UpdateContract)
       .to receive(:new)
-      .with(work_package, user, options: { changed_by_system: [] })
+      .with(work_package, user, options: {})
       .and_return(contract)
 
     allow(contract)

--- a/spec/services/custom_fields/set_attributes_service_spec.rb
+++ b/spec/services/custom_fields/set_attributes_service_spec.rb
@@ -55,7 +55,7 @@ describe CustomFields::SetAttributesService, type: :model do
   let(:contract_class) do
     allow(CustomFields::CreateContract)
       .to receive(:new)
-      .with(cf_instance, user, options: { changed_by_system: [] })
+      .with(cf_instance, user, options: {})
     .and_return(contract_instance)
 
     CustomFields::CreateContract

--- a/spec/services/groups/set_attributes_service_spec.rb
+++ b/spec/services/groups/set_attributes_service_spec.rb
@@ -39,7 +39,7 @@ describe Groups::SetAttributesService, type: :model do
 
     allow(contract)
       .to receive(:new)
-      .with(group, user, options: { changed_by_system: [] })
+      .with(group, user, options: {})
       .and_return(contract_instance)
 
     contract

--- a/spec/services/members/set_attributes_service_spec.rb
+++ b/spec/services/members/set_attributes_service_spec.rb
@@ -37,7 +37,7 @@ describe Members::SetAttributesService, type: :model do
 
     allow(contract)
       .to receive(:new)
-      .with(member, user, options: { changed_by_system: [] })
+      .with(member, user, options: {})
       .and_return(contract_instance)
 
     contract

--- a/spec/services/messages/set_attributes_service_spec.rb
+++ b/spec/services/messages/set_attributes_service_spec.rb
@@ -56,7 +56,7 @@ describe Messages::SetAttributesService, type: :model do
   let(:contract_class) do
     allow(Messages::CreateContract)
       .to receive(:new)
-      .with(message_instance, user, options: { changed_by_system: ["author_id"] })
+      .with(message_instance, user, options: {})
       .and_return(contract_instance)
 
     Messages::CreateContract
@@ -92,8 +92,8 @@ describe Messages::SetAttributesService, type: :model do
   it 'notes the author to be system changed' do
     subject
 
-    expect(instance.changed_by_system)
-      .to include('author_id')
+    expect(message_instance.changed_by_system['author_id'])
+      .to eql [nil, user.id]
   end
 
   context 'with params' do

--- a/spec/services/projects/schedule_deletion_service_spec.rb
+++ b/spec/services/projects/schedule_deletion_service_spec.rb
@@ -34,7 +34,7 @@ describe ::Projects::ScheduleDeletionService, type: :model do
 
     allow(contract)
       .to receive(:new)
-      .with(project, user, options: { changed_by_system: [] })
+      .with(project, user, options: {})
       .and_return(contract_instance)
 
     contract

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -37,7 +37,7 @@ describe Projects::SetAttributesService, type: :model do
 
     allow(contract)
       .to receive(:new)
-      .with(project, user, options: { changed_by_system: [] })
+      .with(project, user, options: {})
       .and_return(contract_instance)
 
     contract

--- a/spec/services/relations/create_service_spec.rb
+++ b/spec/services/relations/create_service_spec.rb
@@ -86,7 +86,7 @@ describe Relations::CreateService do
 
     allow(Relations::CreateContract)
       .to receive(:new)
-      .with(relation, user, options: { changed_by_system: [] })
+      .with(relation, user, options: {})
       .and_return(contract)
     allow(contract)
       .to receive(:validate)

--- a/spec/services/relations/update_service_spec.rb
+++ b/spec/services/relations/update_service_spec.rb
@@ -86,7 +86,7 @@ describe Relations::UpdateService do
 
     allow(Relations::UpdateContract)
       .to receive(:new)
-      .with(relation, user, options: { changed_by_system: [] })
+      .with(relation, user, options: {})
       .and_return(contract)
     allow(contract)
       .to receive(:validate)

--- a/spec/services/wiki_pages/set_attributes_service_spec.rb
+++ b/spec/services/wiki_pages/set_attributes_service_spec.rb
@@ -37,7 +37,7 @@ describe WikiPages::SetAttributesService, type: :model do
 
     allow(contract)
       .to receive(:new)
-      .with(wiki_page, user, options: { changed_by_system: [] })
+      .with(wiki_page, user, options: {})
       .and_return(contract_instance)
 
     contract
@@ -104,6 +104,26 @@ describe WikiPages::SetAttributesService, type: :model do
           .not_to receive(:save)
 
         subject
+      end
+    end
+
+    context 'for a new wiki page' do
+      let(:wiki_page) do
+        WikiPage.new
+      end
+
+      it 'initializes the content with the user being the author' do
+        subject
+
+        expect(wiki_page.content.author)
+          .to eql user
+      end
+
+      it 'marks the content author to be system changed' do
+        subject
+
+        expect(wiki_page.content.changed_by_system['author_id'])
+          .to eql [nil, user.id]
       end
     end
   end

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -40,7 +40,7 @@ describe WorkPackages::SetAttributesService, type: :model do
   end
   let(:work_package) do
     wp = FactoryBot.build_stubbed(:work_package, project: project)
-    wp.type = FactoryBot.build_stubbed(:type)
+    wp.type = initial_type
     wp.send(:clear_changes_information)
 
     wp
@@ -48,6 +48,7 @@ describe WorkPackages::SetAttributesService, type: :model do
   let(:new_work_package) do
     WorkPackage.new
   end
+  let(:initial_type) { FactoryBot.build_stubbed(:type) }
   let(:statuses) { [] }
   let(:contract_class) { WorkPackages::UpdateContract }
   let(:mock_contract) do
@@ -222,8 +223,8 @@ describe WorkPackages::SetAttributesService, type: :model do
           it 'notes the author to be system changed' do
             subject
 
-            expect(instance.changed_by_system)
-              .to include('author_id')
+            expect(work_package.changed_by_system['author_id'])
+              .to eql [0, user.id]
           end
         end
       end
@@ -756,8 +757,8 @@ describe WorkPackages::SetAttributesService, type: :model do
             it 'adds change to system changes' do
               subject
 
-              expect(instance.changed_by_system)
-                .to include('category_id')
+              expect(work_package.changed_by_system['category_id'])
+                .to eql [nil, new_category.id]
             end
           end
         end
@@ -785,8 +786,8 @@ describe WorkPackages::SetAttributesService, type: :model do
             it 'adds change to system changes' do
               subject
 
-              expect(instance.changed_by_system)
-                .to include('type_id')
+              expect(work_package.changed_by_system['type_id'])
+                .to eql [initial_type.id, default_type.id]
             end
           end
 
@@ -803,8 +804,8 @@ describe WorkPackages::SetAttributesService, type: :model do
             it 'adds change to system changes' do
               subject
 
-              expect(instance.changed_by_system)
-                .to include('type_id')
+              expect(work_package.changed_by_system['type_id'])
+                .to eql [initial_type.id, other_type.id]
             end
           end
 
@@ -821,7 +822,7 @@ describe WorkPackages::SetAttributesService, type: :model do
             it 'does not set the change to system changes' do
               subject
 
-              expect(instance.changed_by_system)
+              expect(work_package.changed_by_system)
                 .not_to include('type_id')
             end
           end


### PR DESCRIPTION
Before, it was implemented by passing the changed attribut keys over to
the contract to whitelist them.

This lead to:
  * The contract interface becoming bloated
  * Having to rely on the knowledge of the developer not to falsely
    whitelist an attribute. The developer would also have to make sure
    to not perform a mass assignment after the attribute has been
    whitelisted

The new approach it to integrate the behaviour into the model which is
first altered in the service before it is scrutinized in the contract.

The information about the changed attributes is now stored inside the
model which removes the necessity to flag the whitelisted attribute
separately. Additionally, the exact change is tracked. So if an
attribute is set to one value inside a whitelisted block there is no
risk in later on performing a mass assignment.

This comes at the cost of extending the models which is weird also it is
build into the default SetAttributesService so child classes do not have
to worry. One might include the module into every AR model but currently
we only need it for a very specific use case.