### PR TITLE
Forward CSP extensions to login controller

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -41,6 +41,7 @@ class AccountController < ApplicationController
   # prevents login action to be filtered by check_if_login_required application scope filter
   skip_before_action :check_if_login_required
 
+  before_action :apply_csp_appends, only: %i[login]
   before_action :disable_api
   before_action :check_auth_source_sso_failure, only: :auth_source_sso_failed
 
@@ -576,5 +577,12 @@ class AccountController < ApplicationController
     flash[:error] = I18n.t(:notice_account_invalid_token)
 
     redirect_to home_url
+  end
+
+  def apply_csp_appends
+    appends = flash[:_csp_appends]
+    return unless appends
+
+    append_content_security_policy_directives(appends)
   end
 end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -73,9 +73,3 @@ SecureHeaders::Configuration.default do |config|
     connect_src: connect_src
   }
 end
-
-SecureHeaders::Configuration.named_append(:oauth) do |request|
-  hosts = request.controller_instance.try(:allowed_forms) || []
-
-  { form_action: hosts }
-end

--- a/spec/features/oauth/authorization_code_flow_spec.rb
+++ b/spec/features/oauth/authorization_code_flow_spec.rb
@@ -141,9 +141,20 @@ describe 'OAuth authorization code flow',
         visit oauth_path app.uid, redirect_uri
 
         # Check that the hosts of allowed redirection urls are present in the content security policy
-        expect(page.response_headers['content-security-policy']).to(
-          include("form-action 'self' https://foo.com/ https://bar.com/;")
-        )
+
+        form_csp_header = page
+                            .response_headers['content-security-policy']
+                            .split(';')
+                            .find { |s| s.start_with?(' form-action') }
+
+        expect(form_csp_header)
+          .to include("'self'")
+
+        expect(form_csp_header)
+          .to include('foo.com')
+
+        expect(form_csp_header)
+          .to include('bar.com')
       end
     end
   end

--- a/spec/features/oauth/authorization_code_flow_spec.rb
+++ b/spec/features/oauth/authorization_code_flow_spec.rb
@@ -41,45 +41,7 @@ describe 'OAuth authorization code flow',
     "/oauth/authorize?response_type=code&client_id=#{client_id}&redirect_uri=#{CGI.escape(redirect_url)}&scope=api_v3"
   end
 
-  it 'can authorize and manage an OAuth application grant' do
-    visit oauth_path app.uid, redirect_uri
-
-    # Expect we're guided to the login screen
-    login_with user.login, 'adminADMIN!', visit_signin_path: false
-
-    # We get to the authorization screen
-    expect(page).to have_selector('h2', text: 'Authorize Cool API app!')
-
-    # With the correct scope printed
-    expect(page).to have_selector('li strong', text: I18n.t('oauth.scopes.api_v3'))
-    expect(page).to have_selector('li', text: I18n.t('oauth.scopes.api_v3_text'))
-
-    first = true
-    allow_any_instance_of(::OAuth::AuthBaseController)
-      .to receive(:allowed_forms).and_wrap_original do |m|
-      forms = m.call
-
-      # Multiple requests end up here with one not containing the request url
-      if first
-        expect(forms).to include redirect_uri
-        first = false
-      end
-
-      forms
-    end
-
-    SeleniumHubWaiter.wait
-    # Authorize
-    find('input.button[value="Authorize"]').click
-
-    # Expect auth token
-    code = find('#authorization_code').text
-
-    # And also have a grant for this application
-    user.oauth_grants.reload
-    expect(user.oauth_grants.count).to eq 1
-    expect(user.oauth_grants.first.application).to eq app
-
+  def get_and_test_token(code)
     parameters = {
       client_id: app.uid,
       client_secret: client_secret,
@@ -96,6 +58,34 @@ describe 'OAuth authorization code flow',
     expect(body['access_token']).to be_present
     expect(body['refresh_token']).to be_present
     expect(body['scope']).to eq 'api_v3'
+  end
+
+  it 'can authorize and manage an OAuth application grant' do
+    visit oauth_path app.uid, redirect_uri
+
+    # Expect we're guided to the login screen
+    login_with user.login, 'adminADMIN!', visit_signin_path: false
+
+    # We get to the authorization screen
+    expect(page).to have_selector('h2', text: 'Authorize Cool API app!')
+
+    # With the correct scope printed
+    expect(page).to have_selector('li strong', text: I18n.t('oauth.scopes.api_v3'))
+    expect(page).to have_selector('li', text: I18n.t('oauth.scopes.api_v3_text'))
+
+    SeleniumHubWaiter.wait
+    # Authorize
+    find('input.button[value="Authorize"]').click
+
+    # Expect auth token
+    code = find('#authorization_code').text
+
+    # And also have a grant for this application
+    user.oauth_grants.reload
+    expect(user.oauth_grants.count).to eq 1
+    expect(user.oauth_grants.first.application).to eq app
+
+    get_and_test_token(code)
 
     # Should show that grant in my account
     visit my_account_path
@@ -145,26 +135,64 @@ describe 'OAuth authorization code flow',
     end
 
     context 'with real urls as allowed redirect uris' do
-      let!(:redirect_uri) { "https://foo.com/foo " }
+      let!(:redirect_uri) { "https://foo.com/foo" }
       let!(:allowed_redirect_uri) { "#{redirect_uri} https://bar.com/bar" }
       it 'can authorize and manage an OAuth application grant' do
         visit oauth_path app.uid, redirect_uri
-
-        allow_any_instance_of(::OAuth::AuthBaseController)
-          .to receive(:allowed_forms).and_wrap_original do |m|
-          forms = m.call
-
-          expect(forms).to include 'https://foo.com/'
-          expect(forms).to include 'https://bar.com/'
-
-          forms
-        end
 
         # Check that the hosts of allowed redirection urls are present in the content security policy
         expect(page.response_headers['content-security-policy']).to(
           include("form-action 'self' https://foo.com/ https://bar.com/;")
         )
       end
+    end
+  end
+
+  context 'when redirecting to a stubbed foreign service', driver: :chrome_billy do
+    let!(:redirect_uri) { "https://oauth.example.com/callback" }
+
+    before do
+      proxy
+        .stub("https://oauth.example.com:443/callback")
+        .and_return(code: 200, text: 'Welcome to stubbed response')
+    end
+
+    it 'can be authorized twice (Regression #34554)' do
+      visit oauth_path app.uid, redirect_uri
+
+      # Expect we're guided to the login screen
+      login_with user.login, 'adminADMIN!', visit_signin_path: false
+
+      # We get to the authorization screen
+      expect(page).to have_selector('h2', text: 'Authorize Cool API app!')
+
+      # Authorize
+      find('input.button[value="Authorize"]').click
+
+      # Expect redirect to stubbed URL
+      expect(page).to have_current_path(/#{Regexp.escape(redirect_uri)}\?code\=.+$/, url: true)
+      expect(page).to have_text 'Welcome to stubbed response'
+
+      # Get auth token from URL query
+      code = page.current_url.match(/\?code=(.+)$/)[1]
+      get_and_test_token(code)
+
+      # Log out again
+      logout
+
+      # Try to reauthorize with existing grant
+      visit oauth_path app.uid, redirect_uri
+
+      # Expect we're guided to the login screen
+      login_with user.login, 'adminADMIN!', visit_signin_path: false
+
+      # Expect redirect to stubbed URL
+      expect(page).to have_current_path(/#{Regexp.escape(redirect_uri)}\?code\=.+$/, url: true)
+      expect(page).to have_text 'Welcome to stubbed response'
+
+      # Get auth token from URL query
+      new_code = page.current_url.match(/\?code=(.+)$/)[1]
+      get_and_test_token(new_code)
     end
   end
 end


### PR DESCRIPTION
If the user already has a matching token when requesting /authorize , they get redirected immediately in https://github.com/doorkeeper-gem/doorkeeper/blob/main/app/controllers/doorkeeper/authorizations_controller.rb#L26-L27. 

If the user needs to login first, they will be redirected _after_ the login POST, which causes Chrome (and some other browsers potentially, but not Firefox) to block the request due to our form-actions CSP protections. 

To alleviate this, we need to pass the information which CSP appends are needed to the login request.

https://community.openproject.com/work_packages/34554