### PR TITLE
disable direct uploads when use_iam_profile is true

### DIFF
--- a/docs/installation-and-operations/configuration/README.md
+++ b/docs/installation-and-operations/configuration/README.md
@@ -187,7 +187,7 @@ If, for what ever reason, this is undesirable, you can disable this option.
 In that case attachments will be posted as usual to the OpenProject server which then uploads the file
 to the remote storage in an extra step.
 
-**Note**: This only works for S3 right now. When using fog with another provider this configuration will be `false`. The same goes for when no fog storage is configured.
+**Note**: This only works for S3 right now. When using fog with another provider this configuration will be `false`. The same goes for when no fog storage is configured, or when the `use_iam_profile` option is used in the fog credentials when using S3.
 
 ### fog download url expires in
 

--- a/lib/open_project/configuration/helpers.rb
+++ b/lib/open_project/configuration/helpers.rb
@@ -44,9 +44,12 @@ module OpenProject
       ##
       # We only allow direct uploads to S3 as we are using the carrierwave_direct
       # gem which only supports S3 for the time being.
+      #
+      # Do not allow direct uploads when using IAM-profile-based authorization rather
+      # than access-key-based ones since carrierwave_direct does not support that.
       def direct_uploads
-        return false unless remote_storage?
-        return false unless remote_storage_aws?
+        return false unless remote_storage? && remote_storage_aws?
+        return false if use_iam_profile?
 
         self['direct_uploads']
       end
@@ -94,6 +97,10 @@ module OpenProject
 
       def attachments_storage_path
         Rails.root.join(self['attachments_storage_path'] || 'files')
+      end
+
+      def use_iam_profile?
+        fog_credentials[:use_iam_profile]
       end
 
       def fog_credentials


### PR DESCRIPTION
Disable direct uploads when using `use_iam_profile`. It may be possible but `carrierwave_direct` certainly doesn't support it out of the box and my attempts at making it work using the fog connection's temporary AWS credentials were unsucessful too.

So the best option is to prevent the problem by not allowing direct uploads for the time being.