### PR TITLE
Typo correction in version verification

### DIFF
--- a/docs/development/development-environment-osx/README.md
+++ b/docs/development/development-environment-osx/README.md
@@ -115,7 +115,7 @@ ruby 2.7.2p137 (2020-03-31 revision a0c7c23c9c) [x86_64-darwin16]
 $ bundler --version
 Bundler version 2.0.2
 
-$ npm --version
+$ node --version
 12.16.1
 ```
 

--- a/docs/development/development-environment-osx/README.md
+++ b/docs/development/development-environment-osx/README.md
@@ -97,11 +97,11 @@ $ nodenv init
 
 You can find the latest LTS version here: https://nodejs.org/en/download/
 
-At the time of writing this is v12.16.1. Install and activate it with:
+At the time of writing this is v14.16.0. Install and activate it with:
 
 ```bash
-nodenv install 12.16.1
-nodenv global 12.16.1
+nodenv install 14.16.0
+nodenv global 14.16.0
 ```
 
 ## Verify your installation
@@ -116,7 +116,7 @@ $ bundler --version
 Bundler version 2.0.2
 
 $ node --version
-12.16.1
+14.16.0
 ```
 
 # Install OpenProject


### PR DESCRIPTION
Just changed the npm --version command to the one I suppose is more correct (check node version).

PS: Thanks for your work, just digging onto your documentation today!