### PR TITLE
make sure to use latest patch level of ruby base image

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-buster
+FROM ruby:2.7-buster
 MAINTAINER operations@openproject.com
 
 ENV USER=dev

--- a/docker/dev/backend/Dockerfile
+++ b/docker/dev/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-buster as develop
+FROM ruby:2.7-buster as develop
 MAINTAINER operations@openproject.com
 
 ARG DEV_UID=1000

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-buster
+FROM ruby:2.7-buster
 MAINTAINER operations@openproject.com
 
 # Allow platform-specific additions. Valid values are: on-prem,saas,bahn

--- a/docs/development/development-environment-docker/README.md
+++ b/docs/development/development-environment-docker/README.md
@@ -152,3 +152,20 @@ If the backend container is already running, it will be stopped.
 Instead it will be started in the foreground.
 This way you can debug using pry just as if you had started the server locally using `rails s`.
 You can stop it simply with Ctrl + C too.
+
+## Updates
+
+When a dependency of the image or the base image itself is changed you may need
+rebuild the image. For instance when the Ruby version is updated you may run into
+an error like the following when running `bin/compose setup`:
+
+```
+Creating core_backend_run ... done
+Your Ruby version is 2.7.1, but your Gemfile specified ~> 2.7.2
+```
+
+This means that the current image is out-dated. You can update it like this:
+
+```
+bin/comose build --pull
+```


### PR DESCRIPTION
This is to ensure we always use the latest base image provided by Ruby for the minor release we are using (currently 2.7).