### PR TITLE
fix row rerendering with limited permissions

### DIFF
--- a/frontend/src/app/components/wp-fast-table/builders/cell-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/cell-builder.ts
@@ -1,6 +1,5 @@
 import {WorkPackageResource} from 'core-app/modules/hal/resources/work-package-resource';
 import {
-  displayClassName,
   DisplayFieldRenderer,
   editFieldContainerClass
 } from "core-app/modules/fields/display/display-field-renderer";

--- a/frontend/src/app/components/wp-fast-table/builders/drag-and-drop/drag-drop-handle-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/drag-and-drop/drag-drop-handle-builder.ts
@@ -25,11 +25,13 @@ export class DragDropHandleBuilder {
     // Append sort handle
     let td = document.createElement('td');
 
+    td.classList.add(tdClassName, internalSortColumn.id);
+
     if (!this.actionService.canPickup(workPackage)) {
       return td;
     }
 
-    td.classList.add(tdClassName, 'wp-table--sort-td', internalSortColumn.id,  'hide-when-print');
+    td.classList.add('wp-table--sort-td', internalSortColumn.id,  'hide-when-print');
 
     // Wrap handle as span
     let span = document.createElement('span');

--- a/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
+++ b/frontend/src/app/components/wp-fast-table/builders/rows/single-row-builder.ts
@@ -152,7 +152,10 @@ export class SingleRowBuilder {
 
       // Treat internal columns specially
       // and skip the replacement of the column if this is being edited.
-      if (column.id.startsWith('__internal') || this.isColumnBeingEdited(workPackage, column)) {
+      // But only do that, if the column existed before. Sometimes, e.g. when lacking permissions
+      // the column was not correctly created (with the intended classes). This code then
+      // increases the robustness.
+      if ((column.id.startsWith('__internal') || this.isColumnBeingEdited(workPackage, column)) && oldTd.length) {
         newCells.push(oldTd[0]);
         return;
       }


### PR DESCRIPTION
If the user has limited permission, e.g. no right to reorder, the first row, used for sorting, has had a different class set. When rerendering that row, the class set is expected but not found. The patch

* Adds the expected classes
* Increases the robustness whenever the expectation is not met in case other places make the same mistake of not adding the necessary classes

https://community.openproject.org/projects/openproject/work_packages/36330