### PR TITLE
Fix the rails cell not using the content_tag helper of ActionView with escaping

### DIFF
--- a/app/cells/members/row_cell.rb
+++ b/app/cells/members/row_cell.rb
@@ -145,7 +145,7 @@ module Members
     end
 
     def principal_link
-      link_to h(principal.name), principal_show_path
+      link_to principal.name, principal_show_path
     end
 
     def principal_class_name

--- a/app/cells/members/row_cell.rb
+++ b/app/cells/members/row_cell.rb
@@ -145,18 +145,22 @@ module Members
     end
 
     def principal_link
-      case Principal
-      when User
-        link_to principal.name, user_path(principal)
-      when Group
-        link_to principal.name, show_group_path(principal)
-      else
-        content_tag :span, principal.name
-      end
+      link_to h(principal.name), principal_show_path
     end
 
     def principal_class_name
       principal.model_name.singular
+    end
+
+    def principal_show_path
+      case principal
+      when User
+        user_path(principal)
+      when Group
+        show_group_path(principal)
+      else
+        placeholder_user_path(principal)
+      end
     end
 
     def user?

--- a/app/cells/rails_cell.rb
+++ b/app/cells/rails_cell.rb
@@ -6,7 +6,12 @@ class RailsCell < Cell::ViewModel
   include SecureHeaders::ViewHelpers
 
   # Delegate to action_view
-  delegates :action_view, :content_for
+  delegate :content_for,
+           :content_tag,
+           :tag_options,
+           to: :action_view
+
+  delegate :request, to: :controller
 
   self.view_paths = ['app/cells/views']
 
@@ -57,18 +62,14 @@ class RailsCell < Cell::ViewModel
   end
 
   def action_view
-    context[:action_view]
-  end
-
-  def protect_against_forgery?
-    controller.send(:protect_against_forgery?)
+    context[:action_view] || controller.view_context
   end
 
   def form_authenticity_token(*args)
     controller.send(:form_authenticity_token, *args)
   end
 
-  def request
-    controller.request
+  def protect_against_forgery?
+    controller.send(:protect_against_forgery?)
   end
 end

--- a/app/views/authentication/authentication_settings.html.erb
+++ b/app/views/authentication/authentication_settings.html.erb
@@ -49,7 +49,7 @@ See docs/COPYRIGHT.rdoc for more details.
     </fieldset>
 
     <% if OpenProject::Configuration.registration_footer.blank? %>
-      <%= cell Settings::NumericSettingCell, "invitation_expiration_days", unit: "days" %>
+      <%= rails_cell Settings::NumericSettingCell, "invitation_expiration_days", unit: "days" %>
 
       <fieldset class="form--fieldset">
         <fieldset id="registration_footer" class="form--fieldset">

--- a/app/views/custom_actions/index.html.erb
+++ b/app/views/custom_actions/index.html.erb
@@ -12,5 +12,5 @@
 <% end %>
 
 <section class="admin--edit-section">
-  <%= cell ::CustomActions::TableCell, @custom_actions %>
+  <%= rails_cell ::CustomActions::TableCell, @custom_actions %>
 </section>

--- a/app/views/enumerations/index.html.erb
+++ b/app/views/enumerations/index.html.erb
@@ -30,5 +30,5 @@ See docs/COPYRIGHT.rdoc for more details.
 <%= toolbar title: t(:label_enumerations) %>
 <% Enumeration.subclasses.each do |klass| %>
   <h3 class="-no-border"><%= t(klass::OptionName) %></h3>
-  <%= cell ::Enumerations::TableCell, klass.shared %>
+  <%= rails_cell ::Enumerations::TableCell, klass.shared %>
 <% end %>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -70,8 +70,8 @@ See docs/COPYRIGHT.rdoc for more details.
 </div>
 
 <div>
-  <%= cell Members::UserFilterCell, params, @members_filter_options %>
-  <%= cell Members::TableCell, @members, @members_table_options %>
+  <%= rails_cell Members::UserFilterCell, params, @members_filter_options %>
+  <%= rails_cell Members::TableCell, @members, @members_table_options %>
 </div>
 
 

--- a/app/views/oauth/applications/index.html.erb
+++ b/app/views/oauth/applications/index.html.erb
@@ -39,4 +39,4 @@ See docs/COPYRIGHT.rdoc for more details.
   </li>
 <% end %>
 
-<%= cell ::OAuth::Applications::TableCell, @applications, current_user: current_user %>
+<%= rails_cell ::OAuth::Applications::TableCell, @applications, current_user: current_user %>

--- a/app/views/placeholder_users/index.html.erb
+++ b/app/views/placeholder_users/index.html.erb
@@ -55,6 +55,6 @@ See docs/COPYRIGHT.rdoc for more details.
   end
 %>
 
-<%= cell PlaceholderUsers::PlaceholderUserFilterCell, params %>
+<%= rails_cell PlaceholderUsers::PlaceholderUserFilterCell, params %>
 &nbsp;
-<%= cell PlaceholderUsers::TableCell, @placeholder_users, project: @project, current_user: current_user %>
+<%= rails_cell PlaceholderUsers::TableCell, @placeholder_users, project: @project, current_user: current_user %>

--- a/app/views/project_settings/versions.html.erb
+++ b/app/views/project_settings/versions.html.erb
@@ -42,7 +42,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <% end %>
 
 <% if @versions.any? %>
-  <%= cell Versions::TableCell, @versions, project: @project %>
+  <%= rails_cell Versions::TableCell, @versions, project: @project %>
 
   <% if @project.versions.any? %>
     <div class="generic-table--action-buttons">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -80,7 +80,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <%= render partial: 'projects/filters/form', locals: { query: @query } %>
 
-<%= cell Projects::TableCell,
+<%= rails_cell Projects::TableCell,
          @projects,
          current_user: current_user,
          orders: @orders,

--- a/app/views/statuses/index.html.erb
+++ b/app/views/statuses/index.html.erb
@@ -48,4 +48,4 @@ See docs/COPYRIGHT.rdoc for more details.
   <% end %>
 <% end %>
 
-<%= cell ::Statuses::TableCell, @statuses %>
+<%= rails_cell ::Statuses::TableCell, @statuses %>

--- a/app/views/users/_consent.html.erb
+++ b/app/views/users/_consent.html.erb
@@ -1,6 +1,6 @@
 <section class="form--section">
   <h3 class="form--section-title"><%=t('consent.title')%></h3>
-  <%= cell ::Components::OnOffStatusCell,
+  <%= rails_cell ::Components::OnOffStatusCell,
            is_on: @user.consented_at.present?,
            on_text: format_time(@user.consented_at),
            on_description: t('consent.user_has_consented'),

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -53,6 +53,6 @@ See docs/COPYRIGHT.rdoc for more details.
   <%= call_hook(:user_admin_action_menu) %>
 <% end %>
 
-<%= cell Users::UserFilterCell, params, groups: @groups, status: @status %>
+<%= rails_cell Users::UserFilterCell, params, groups: @groups, status: @status %>
 &nbsp;
-<%= cell Users::TableCell, @users, project: @project, current_user: current_user %>
+<%= rails_cell Users::TableCell, @users, project: @project, current_user: current_user %>

--- a/modules/bim/app/views/bim/ifc_models/ifc_models/index.html.erb
+++ b/modules/bim/app/views/bim/ifc_models/ifc_models/index.html.erb
@@ -57,4 +57,4 @@ See docs/COPYRIGHT.rdoc for more details.
   <%= render partial: 'no_default_notice', locals: { project: @project } %>
 <% end %>
 
-<%= cell ::Bim::IfcModels::TableCell, @ifc_models %>
+<%= rails_cell ::Bim::IfcModels::TableCell, @ifc_models %>

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_filters/show.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_filters/show.html.erb
@@ -73,6 +73,6 @@
     <% end %>
   </li>
 <% end %>
-  <%= cell ::LdapGroups::SynchronizedGroups::TableCell, @filter.groups, show_inline_create: false, deletable: false %>
+  <%= rails_cell ::LdapGroups::SynchronizedGroups::TableCell, @filter.groups, show_inline_create: false, deletable: false %>
 </section>
 

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/index.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/index.html.erb
@@ -31,11 +31,11 @@
 
 <section class="admin--edit-section">
   <h3 class="form--section-title"><%= t('ldap_groups.synchronized_filters.plural') %></h3>
-  <%= cell ::LdapGroups::SynchronizedFilters::TableCell, @filters %>
+  <%= rails_cell ::LdapGroups::SynchronizedFilters::TableCell, @filters %>
 </section>
 
 <section class="admin--edit-section">
   <h3 class="form--section-title"><%= t('ldap_groups.synchronized_groups.plural') %></h3>
-  <%= cell ::LdapGroups::SynchronizedGroups::TableCell, @groups %>
+  <%= rails_cell ::LdapGroups::SynchronizedGroups::TableCell, @groups %>
 </section>
 

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/show.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/show.html.erb
@@ -38,6 +38,6 @@
 
 <section class="admin--edit-section">
   <h2><%= t :label_user_plural %></h2>
-  <%= cell ::LdapGroups::Memberships::TableCell, @group.users %>
+  <%= rails_cell ::LdapGroups::Memberships::TableCell, @group.users %>
 </section>
 

--- a/modules/openid_connect/app/views/openid_connect/providers/index.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/index.html.erb
@@ -13,4 +13,4 @@
   </li>
 <% end %>
 
-<%= cell ::OpenIDConnect::Providers::TableCell, providers %>
+<%= rails_cell ::OpenIDConnect::Providers::TableCell, providers %>

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/my/two_factor_devices/_two_factor_status.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/my/two_factor_devices/_two_factor_status.html.erb
@@ -1,4 +1,4 @@
-<%= cell ::Components::OnOffStatusCell,
+<%= rails_cell ::Components::OnOffStatusCell,
          is_on: device.present?,
          on_text: t('two_factor_authentication.label_2fa_enabled'),
          on_description: t('two_factor_authentication.text_2fa_enabled'),

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/my/two_factor_devices/index.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/my/two_factor_devices/index.html.erb
@@ -45,7 +45,7 @@
 
 <section class="account--section">
   <h2><%= t 'two_factor_authentication.label_devices' %></h2>
-  <%= cell ::TwoFactorAuthentication::Devices::TableCell, @two_factor_devices, admin_table: false %>
+  <%= rails_cell ::TwoFactorAuthentication::Devices::TableCell, @two_factor_devices, admin_table: false %>
 </section>
 
 <section class="account--section">

--- a/modules/two_factor_authentication/app/views/users/_two_factor_authentication_admin.html.erb
+++ b/modules/two_factor_authentication/app/views/users/_two_factor_authentication_admin.html.erb
@@ -2,7 +2,7 @@
 <% default_device = @user.otp_devices.get_default %>
 
 <section class="admin--edit-section">
-    <%= cell ::Components::OnOffStatusCell,
+    <%= rails_cell ::Components::OnOffStatusCell,
              is_on: default_device.present?,
              on_text: t('two_factor_authentication.label_2fa_enabled'),
              on_description: t('two_factor_authentication.admin.text_2fa_enabled'),
@@ -54,6 +54,6 @@
       <% end %>
   <% end %>
 
-  <%= cell ::TwoFactorAuthentication::Devices::TableCell, devices, admin_table: true || @user != User.current %>
+  <%= rails_cell ::TwoFactorAuthentication::Devices::TableCell, devices, admin_table: true || @user != User.current %>
   </div>
 </section>

--- a/modules/webhooks/app/views/webhooks/outgoing/admin/index.html.erb
+++ b/modules/webhooks/app/views/webhooks/outgoing/admin/index.html.erb
@@ -13,5 +13,5 @@
   </li>
 <% end %>
 
-<%= cell ::Webhooks::Outgoing::Webhooks::TableCell, @webhooks %>
+<%= rails_cell ::Webhooks::Outgoing::Webhooks::TableCell, @webhooks %>
 

--- a/modules/webhooks/app/views/webhooks/outgoing/admin/show.html.erb
+++ b/modules/webhooks/app/views/webhooks/outgoing/admin/show.html.erb
@@ -25,7 +25,7 @@
   </li>
 <% end %>
 
-<%= cell ::Components::OnOffStatusCell,
+<%= rails_cell ::Components::OnOffStatusCell,
          is_on: @webhook.enabled?,
          on_text: t('webhooks.outgoing.status.enabled'),
          on_description: t('webhooks.outgoing.status.enabled_text'),
@@ -68,5 +68,5 @@
 
 <div class="account--section">
   <h2><%= t 'webhooks.outgoing.deliveries.title' %></h2>
-  <%= cell ::Webhooks::Outgoing::Deliveries::TableCell, @webhook.deliveries.newest %>
+  <%= rails_cell ::Webhooks::Outgoing::Deliveries::TableCell, @webhook.deliveries.newest %>
 </div>

--- a/spec/cells/rails_cell_spec.rb
+++ b/spec/cells/rails_cell_spec.rb
@@ -1,0 +1,107 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+require 'spec_helper'
+
+describe ::RailsCell do
+  let(:controller) { double(ApplicationController) }
+  let(:action_view) { ActionView::Base.new(ActionView::LookupContext.new(''), {}, controller) }
+  let(:model) { double('model', foo: '<strong>Some HTML here!</strong>') }
+  let(:context) do
+    { controller: controller }
+  end
+  let(:options) do
+    { context: context }
+  end
+
+  let(:test_cell) do
+    Class.new(described_class) do
+      property :foo
+
+      def link
+        link_to "<strong>HTML</strong>", '/foo/bar'
+      end
+
+      def content
+        content_tag(:div) do
+          content_tag(:span) do
+            "<script>foo</script>"
+          end
+        end
+      end
+    end
+  end
+
+  let(:instance) { test_cell.new model, options }
+
+  before do
+    allow(controller).to receive(:view_context).and_return(action_view)
+  end
+
+  shared_examples 'uses action_view helpers' do
+    describe '#link' do
+      subject { instance.link }
+
+      it 'uses link_to from rails with escaping' do
+        expect(subject.to_s).to eq %(<a href="/foo/bar">&lt;strong&gt;HTML&lt;/strong&gt;</a>)
+      end
+    end
+
+    describe '#foo' do
+      subject { instance.foo }
+
+      it 'escapes the property' do
+        expect(subject.to_s).to eq "&lt;strong&gt;Some HTML here!&lt;/strong&gt;"
+      end
+    end
+
+    describe '#content' do
+      subject { instance.content }
+
+      it 'uses content_tag from rails with escaping', :aggregate_failures do
+        expect(action_view).to receive(:content_tag).twice.and_call_original
+        expect(subject.to_s).to eq "<div><span>&lt;script&gt;foo&lt;/script&gt;</span></div>"
+      end
+    end
+  end
+
+  describe 'delegate to action_view' do
+    context 'when action_view set' do
+      let(:context) do
+        { controller: controller, action_view: action_view }
+      end
+
+      it_behaves_like 'uses action_view helpers'
+    end
+
+    context 'when not set' do
+      it_behaves_like 'uses action_view helpers'
+    end
+  end
+end


### PR DESCRIPTION
* Properly escapes the name. The cells gem does not escape strings unlike rails
* Fixes the case statement for links and includes the link for placeholder users

By that it turns:

![image](https://user-images.githubusercontent.com/617519/109934761-296bc280-7ccd-11eb-8be9-00bc02137875.png)

into:

![image](https://user-images.githubusercontent.com/617519/109934670-12c56b80-7ccd-11eb-8b57-fdec5fea54bb.png)
