### PR TITLE
Use contracted member services and show only manageable projects in user administration

### DIFF
--- a/app/contracts/members/base_contract.rb
+++ b/app/contracts/members/base_contract.rb
@@ -40,7 +40,7 @@ module Members
     validate :project_set
     validate :project_manageable
 
-    def manageable_projects
+    def assignable_projects
       Project
         .active
         .where(id: Project.allowed_to(user, :manage_members))

--- a/app/contracts/members/base_contract.rb
+++ b/app/contracts/members/base_contract.rb
@@ -40,10 +40,10 @@ module Members
     validate :project_set
     validate :project_manageable
 
-    def self.manageable_projects(current_user)
+    def manageable_projects
       Project
         .active
-        .where(id: Project.allowed_to(current_user, :manage_members))
+        .where(id: Project.allowed_to(user, :manage_members))
     end
 
     private

--- a/app/contracts/members/base_contract.rb
+++ b/app/contracts/members/base_contract.rb
@@ -40,6 +40,12 @@ module Members
     validate :project_set
     validate :project_manageable
 
+    def self.manageable_projects(current_user)
+      Project
+        .active
+        .where(id: Project.allowed_to(current_user, :manage_members))
+    end
+
     private
 
     def user_allowed_to_manage

--- a/app/contracts/members/delete_contract.rb
+++ b/app/contracts/members/delete_contract.rb
@@ -29,5 +29,13 @@
 module Members
   class DeleteContract < ::DeleteContract
     delete_permission :manage_members
+
+    validate :member_is_deletable
+
+    private
+
+    def member_is_deletable
+      errors.add(:base, :not_deletable) unless model.deletable?
+    end
   end
 end

--- a/app/services/members/set_attributes_service.rb
+++ b/app/services/members/set_attributes_service.rb
@@ -33,9 +33,19 @@ module Members
     private
 
     def set_attributes(params)
-      model.assign_roles(params.delete(:role_ids)) if params[:role_ids]
+      assign_roles(params)
 
       super
+    end
+
+    def assign_roles(params)
+      return unless params[:role_ids]
+
+      role_ids = params
+        .delete(:role_ids)
+        .select(&:present?)
+
+      model.assign_roles(role_ids)
     end
   end
 end

--- a/app/views/individual_principals/_memberships.html.erb
+++ b/app/views/individual_principals/_memberships.html.erb
@@ -27,10 +27,7 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% roles = Role.givable %>
-<% projects = Project
-  .active
-  .where(id: Project.allowed_to(current_user, :manage_members))
-  .order(Arel.sql('lft')) %>
+<% projects = ::Members::CreateContract.manageable_projects(current_user).order(Arel.sql('lft')) %>
 <% memberships = @individual_principal.memberships.visible(current_user) %>
 
 <div class="grid-block">

--- a/app/views/individual_principals/_memberships.html.erb
+++ b/app/views/individual_principals/_memberships.html.erb
@@ -28,7 +28,7 @@ See docs/COPYRIGHT.rdoc for more details.
 ++#%>
 <% roles = Role.givable %>
 <% projects = ::Members::CreateContract
-  .new(nil, current_user)
+  .new(@individual_principal.memberships.build, current_user)
   .assignable_projects
   .order(Arel.sql('lft')) %>
 <% memberships = @individual_principal.memberships.visible(current_user) %>

--- a/app/views/individual_principals/_memberships.html.erb
+++ b/app/views/individual_principals/_memberships.html.erb
@@ -114,14 +114,16 @@ See docs/COPYRIGHT.rdoc for more details.
                                                                  roles: roles,
                                                                  projects: projects) %>
                   <td class="buttons">
-                    <%= link_to_function icon_wrapper('icon icon-edit', t(:button_edit)),
-                                         "jQuery('.member-#{membership.id}--edit-toggle-item').toggle();",
-                                         class: "member-#{membership.id}--edit-toggle-item memberships--edit-button",
-                                         title: t(:button_edit) %>
-                    <%= link_to(icon_wrapper('icon icon-remove', t(:button_remove)),
-                                polymorphic_path([@individual_principal, :membership], id: membership),
-                                method: :delete,
-                                title: t(:button_remove)) if membership.deletable? %>
+                    <% if User.current.allowed_to?(:manage_members, membership.project) %>
+                      <%= link_to_function icon_wrapper('icon icon-edit', t(:button_edit)),
+                                           "jQuery('.member-#{membership.id}--edit-toggle-item').toggle();",
+                                           class: "member-#{membership.id}--edit-toggle-item memberships--edit-button",
+                                           title: t(:button_edit) %>
+                      <%= link_to(icon_wrapper('icon icon-remove', t(:button_remove)),
+                                  polymorphic_path([@individual_principal, :membership], id: membership),
+                                  method: :delete,
+                                  title: t(:button_remove)) if membership.deletable? %>
+                    <% end %>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/individual_principals/_memberships.html.erb
+++ b/app/views/individual_principals/_memberships.html.erb
@@ -29,7 +29,7 @@ See docs/COPYRIGHT.rdoc for more details.
 <% roles = Role.givable %>
 <% projects = ::Members::CreateContract
   .new(nil, current_user)
-  .manageable_projects
+  .assignable_projects
   .order(Arel.sql('lft')) %>
 <% memberships = @individual_principal.memberships.visible(current_user) %>
 

--- a/app/views/individual_principals/_memberships.html.erb
+++ b/app/views/individual_principals/_memberships.html.erb
@@ -27,7 +27,10 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% roles = Role.givable %>
-<% projects = ::Members::CreateContract.manageable_projects(current_user).order(Arel.sql('lft')) %>
+<% projects = ::Members::CreateContract
+  .new(nil, current_user)
+  .manageable_projects
+  .order(Arel.sql('lft')) %>
 <% memberships = @individual_principal.memberships.visible(current_user) %>
 
 <div class="grid-block">

--- a/app/views/individual_principals/_memberships.html.erb
+++ b/app/views/individual_principals/_memberships.html.erb
@@ -27,7 +27,10 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <% roles = Role.givable %>
-<% projects = Project.visible.active.order(Arel.sql('lft')) %>
+<% projects = Project
+  .active
+  .where(id: Project.allowed_to(current_user, :manage_members))
+  .order(Arel.sql('lft')) %>
 <% memberships = @individual_principal.memberships.visible(current_user) %>
 
 <div class="grid-block">

--- a/app/views/users/_available_global_roles.html.erb
+++ b/app/views/users/_available_global_roles.html.erb
@@ -38,9 +38,16 @@ See docs/COPYRIGHT.rdoc for more details.
       </span>
     <% else %>
       <span id="additional_principal_roles">
-        <%= form_for(:principal_roles, :url => user_memberships_path(user_id: user), :method => :post) do %>
+        <% args =
+             if global_member
+               { url: user_membership_path(id: global_member.id, user_id: user.id), method: :patch }
+             else
+               { url: user_memberships_path(user_id: user.id), method: :post }
+             end
+         %>
+        <%= form_for(:principal_roles, **args) do %>
           <% if global_member %>
-            <%= hidden_field_tag(:id, global_member.id ) %>
+            <%= hidden_field_tag('membership[id]', global_member.id ) %>
 
             <% global_member.roles.each do |role| %>
               <%= hidden_field_tag('membership[role_ids][]', role.id ) %>

--- a/lib/individual_principals/membership_controller_methods.rb
+++ b/lib/individual_principals/membership_controller_methods.rb
@@ -24,23 +24,19 @@ module IndividualPrincipals
     end
 
     def destroy
-      @membership = @individual_principal.memberships.find(params[:id])
-      tab = redirected_to_tab(@membership)
+      call = ::Members::DeleteService
+        .new(model: @membership, user: current_user)
+        .call
 
-      if @membership.deletable? && request.delete?
-        @membership.destroy
-        @membership = nil
-
-        flash[:notice] = I18n.t(:notice_successful_delete)
-      end
-
-      redirect_to edit_polymorphic_path(@individual_principal, tab: tab)
+      respond_with_service_call call, message: :notice_successful_delete
     end
 
     private
 
     def find_membership
       @membership = Member.visible(current_user).find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      render_404
     end
 
     def respond_with_service_call(call, message:)

--- a/spec/contracts/members/create_contract_spec.rb
+++ b/spec/contracts/members/create_contract_spec.rb
@@ -61,5 +61,29 @@ describe Members::CreateContract do
         it_behaves_like 'contract is invalid', principal: :unassignable
       end
     end
+
+    describe '#manageable_projects' do
+      context 'as a user without permission' do
+        let(:current_user) { FactoryBot.build_stubbed :user }
+
+        it 'is empty' do
+          expect(contract.manageable_projects).to be_empty
+        end
+      end
+
+      context 'as a user with permission in one project' do
+        let!(:project1) { FactoryBot.create :project }
+        let!(:project2) { FactoryBot.create :project }
+        let(:current_user) do
+          FactoryBot.create :user,
+                            member_in_project: project1,
+                            member_with_permissions: %i[manage_members]
+        end
+
+        it 'returns the one project' do
+          expect(contract.manageable_projects.to_a).to eq [project1]
+        end
+      end
+    end
   end
 end

--- a/spec/contracts/members/create_contract_spec.rb
+++ b/spec/contracts/members/create_contract_spec.rb
@@ -62,12 +62,12 @@ describe Members::CreateContract do
       end
     end
 
-    describe '#manageable_projects' do
+    describe '#assignable_projects' do
       context 'as a user without permission' do
         let(:current_user) { FactoryBot.build_stubbed :user }
 
         it 'is empty' do
-          expect(contract.manageable_projects).to be_empty
+          expect(contract.assignable_projects).to be_empty
         end
       end
 
@@ -81,7 +81,7 @@ describe Members::CreateContract do
         end
 
         it 'returns the one project' do
-          expect(contract.manageable_projects.to_a).to eq [project1]
+          expect(contract.assignable_projects.to_a).to eq [project1]
         end
       end
     end

--- a/spec/features/principals/shared_memberships_examples.rb
+++ b/spec/features/principals/shared_memberships_examples.rb
@@ -81,6 +81,25 @@ shared_examples 'global user principal membership management flows' do |permissi
     end
   end
 
+  context 'as user with global and project permissions, but not manage_members' do
+    current_user do
+      FactoryBot.create :user,
+                        global_permission: permission,
+                        member_in_project: project,
+                        member_with_permissions: %i[view_work_packages]
+    end
+
+    it 'does not allow to select that project' do
+      principal_page.visit!
+      principal_page.open_projects_tab!
+
+      expect(page).to have_no_selector('tr.member')
+      expect(page).to have_text 'There is currently nothing to display.'
+      expect(page).to have_no_text project.name
+      expect(page).to have_no_text project2.name
+    end
+  end
+
   context 'as user without global permission' do
     current_user { FactoryBot.create :user }
 

--- a/spec/services/members/set_attributes_service_spec.rb
+++ b/spec/services/members/set_attributes_service_spec.rb
@@ -130,6 +130,18 @@ describe Members::SetAttributesService, type: :model do
         it 'adds the new role' do
           expect(subject.result.roles = [second_role, third_role])
         end
+
+        context 'with role_ids not all being present' do
+          let(:call_attributes) do
+            {
+              role_ids: [nil, '', second_role.id, third_role.id]
+            }
+          end
+
+          it 'ignores the empty values' do
+            expect(subject.result.roles = [second_role, third_role])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Users with global permissions would otherwise be allowed to manage memberships to projects they have no permission to