### PR TITLE
Timing issue solved with retry_block

### DIFF
--- a/modules/bim/spec/features/viewer/show_viewpoint_spec.rb
+++ b/modules/bim/spec/features/viewer/show_viewpoint_spec.rb
@@ -62,10 +62,10 @@ describe 'Show viewpoint in model viewer',
       model_tree.expand_tree
       model_tree.expect_checked 'minimal'
       model_tree.all_checkboxes.each do |label, checkbox|
-        if label.text == 'minimal' || label.text == 'LUB_Segment_new:S_WHG_Ess:7243035'
-          expect(checkbox).to be_checked
-        else
-          expect(checkbox).to_not be_checked
+        retry_block do
+          if (label.text == 'minimal' || label.text == 'LUB_Segment_new:S_WHG_Ess:7243035') != checkbox.checked?
+            raise 'Checkbox checked status is wrong'
+          end
         end
       end
     end


### PR DESCRIPTION
This pull request:

- [x] Fixes a flickering test in the [pull request 9080](https://github.com/opf/openproject/pull/9080/checks?check_run_id=2075073101) with a retry_block