### PR TITLE
Weekdays displayed in local order and saved with weekday offset 1

### DIFF
--- a/frontend/src/app/modules/grids/openproject-grids.module.ts
+++ b/frontend/src/app/modules/grids/openproject-grids.module.ts
@@ -66,7 +66,7 @@ import { WidgetMembersComponent } from "core-app/modules/grids/widgets/members/m
 import { WidgetProjectStatusComponent } from "core-app/modules/grids/widgets/project-status/project-status.component";
 import { OpenprojectTimeEntriesModule } from "core-app/modules/time_entries/openproject-time-entries.module";
 import { WidgetTimeEntriesCurrentUserMenuComponent } from "core-app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-menu.component";
-import { TimeEntriesCurrentUserConfigurationModalComponent } from './widgets/time-entries/current-user/time-entries-current-user-configuration.modal';
+import { TimeEntriesCurrentUserConfigurationModalComponent } from './widgets/time-entries/current-user/time-entries-current-user-configuration-modal/time-entries-current-user-configuration.modal';
 
 @NgModule({
   imports: [

--- a/frontend/src/app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-configuration-modal/services/time-entries-current-user-configuration-modal/time-entries-current-user-configuration-modal.service.spec.ts
+++ b/frontend/src/app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-configuration-modal/services/time-entries-current-user-configuration-modal/time-entries-current-user-configuration-modal.service.spec.ts
@@ -1,0 +1,82 @@
+import { TestBed } from '@angular/core/testing';
+import { TimeEntriesCurrentUserConfigurationModalService } from './time-entries-current-user-configuration-modal.service';
+
+describe('TimeEntriesCurrentUserConfigurationModalService', () => {
+  let service: TimeEntriesCurrentUserConfigurationModalService;
+  let daysCheckedValues:boolean[];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TimeEntriesCurrentUserConfigurationModalService,
+      ]
+    });
+
+    service = TestBed.inject(TimeEntriesCurrentUserConfigurationModalService);
+    daysCheckedValues = [true, true, true, true, true, true, false];
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should work with local offset 0', () => {
+    const localWeekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    const localOffset = 0;
+    const orderedDaysData = service.getOrderedDaysData(daysCheckedValues, localWeekdays, localOffset);
+
+    expect(orderedDaysData[0].weekDay).toBe('Sunday');
+    expect(orderedDaysData[0].checked).toBe(false);
+    expect(orderedDaysData[0].originalIndex).toBe(6);
+    expect(orderedDaysData[6].weekDay).toBe('Saturday');
+    expect(orderedDaysData[6].originalIndex).toBe(5);
+    expect(orderedDaysData.filter(dayData => dayData.checked).length).toBe(6);
+
+    // Change the checked value of Monday to false
+    orderedDaysData[1].checked = false;
+    const getCheckedValuesInOriginalOrder = service.getCheckedValuesInOriginalOrder(orderedDaysData);
+    const expectedResult = [false, true, true, true, true, true, false];
+
+    expect(getCheckedValuesInOriginalOrder).toEqual(expectedResult);
+  });
+
+  it('should work with positive local offset (1)', () => {
+    const localWeekdays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+    const localOffset = 1;
+    const orderedDaysData = service.getOrderedDaysData(daysCheckedValues, localWeekdays, localOffset);
+
+    expect(orderedDaysData[0].weekDay).toBe('Monday');
+    expect(orderedDaysData[0].originalIndex).toBe(0);
+    expect(orderedDaysData[6].weekDay).toBe('Sunday');
+    expect(orderedDaysData[6].originalIndex).toBe(6);
+    expect(orderedDaysData[6].checked).toBe(false);
+    expect(orderedDaysData.filter(dayData => dayData.checked).length).toBe(6);
+
+    // Change the checked value of Monday to false
+    orderedDaysData[0].checked = false;
+    const getCheckedValuesInOriginalOrder = service.getCheckedValuesInOriginalOrder(orderedDaysData);
+    const expectedResult = [false, true, true, true, true, true, false];
+
+    expect(getCheckedValuesInOriginalOrder).toEqual(expectedResult);
+  });
+
+  it('should work with positive local offset (3)', () => {
+    const localWeekdays = ['Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday', 'Monday', 'Tuesday'];
+    const localOffset = 3;
+    const orderedDaysData = service.getOrderedDaysData(daysCheckedValues, localWeekdays, localOffset);
+
+    expect(orderedDaysData[0].weekDay).toBe('Wednesday');
+    expect(orderedDaysData[0].originalIndex).toBe(2);
+    expect(orderedDaysData[4].weekDay).toBe('Sunday');
+    expect(orderedDaysData[4].originalIndex).toBe(6);
+    expect(orderedDaysData[4].checked).toBe(false);
+    expect(orderedDaysData.filter(dayData => dayData.checked).length).toBe(6);
+
+    // Change the checked value of Monday to false
+    orderedDaysData[5].checked = false;
+    const getCheckedValuesInOriginalOrder = service.getCheckedValuesInOriginalOrder(orderedDaysData);
+    const expectedResult = [false, true, true, true, true, true, false];
+
+    expect(getCheckedValuesInOriginalOrder).toEqual(expectedResult);
+  });
+});

--- a/frontend/src/app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-configuration-modal/services/time-entries-current-user-configuration-modal/time-entries-current-user-configuration-modal.service.ts
+++ b/frontend/src/app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-configuration-modal/services/time-entries-current-user-configuration-modal/time-entries-current-user-configuration-modal.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class TimeEntriesCurrentUserConfigurationModalService {
+  /*
+  * Get the data of the days in the locale order
+  * @param daysCheckedValues: Checked value of all days of the week, starting from Monday.
+  *                           Moment's default weekday start is Sunday, so daysCheckedValues have a weekday offset of 1.
+  * @param localeWeekDays: week days ordered by locale
+  * @param localeOffset: locale offset regarding the default week start day (Sunday (0)).
+  */
+
+  getOrderedDaysData(
+    daysCheckedValues:boolean[],
+    localeWeekDays = moment.weekdays(true),
+    localeOffset = moment.localeData().firstDayOfWeek(),
+  ):IDayData[] {
+    // The daysCheckedValues come with offset 1 (the week start day is Monday (1),
+    // so the first element in the array is Monday). We have to subtract 1 to the
+    // locale offset to match localeWeekDays with daysCheckedValues. For example:
+    // localeWeekDays (with offset 0) = [SundayValue, MondayValue, TuesdayValue, WednesdayValue, ThursdayValue, FridayValue, SaturdayValue]
+    // daysCheckedValues (with offset 1) = [MondayValue, TuesdayValue, WednesdayValue, ThursdayValue, FridayValue, SaturdayValue, SundayValue]
+    // offsetToApply = -1, so we need to pass the last daysCheckedValues to the start of the array to match the localeWeekDays order
+    // In order save the result, we will have to reorder it with offset 1 (getCheckedValuesInOriginalOrder)
+    const offsetToApply = localeOffset - 1;
+    const offsetCheckedValues = offsetToApply >= 0 ? daysCheckedValues.splice(0, offsetToApply) : daysCheckedValues.splice(offsetToApply);
+    const orderedDaysCheckedValues = offsetToApply >= 0 ? [...daysCheckedValues, ...offsetCheckedValues] : [...offsetCheckedValues, ...daysCheckedValues];
+    const weekDaysWithCheckedValue = orderedDaysCheckedValues
+      .map(
+        (dayCheckedValue, index) => ({
+          weekDay: localeWeekDays[index],
+          checked: dayCheckedValue,
+          originalIndex: this.getOriginalIndex(offsetToApply, index, orderedDaysCheckedValues.length)
+        })
+      );
+
+    return weekDaysWithCheckedValue;
+  }
+
+  getOriginalIndex(offsetToApply:number, currentIndex:number, arrayLength:number):number {
+    let originalIndex = currentIndex + offsetToApply;
+
+    if (originalIndex < 0 ) {
+      originalIndex = arrayLength - 1;
+    } else if (originalIndex >= arrayLength) {
+      originalIndex = 0;
+    }
+
+    return originalIndex;
+  }
+
+  getCheckedValuesInOriginalOrder(days:IDayData[]) {
+    return days
+      .sort((a, b) => a.originalIndex < b.originalIndex ? -1 : 1)
+      .map(localeDayData => localeDayData.checked);
+  }
+}

--- a/frontend/src/app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-configuration-modal/time-entries-current-user-configuration.modal.html
+++ b/frontend/src/app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-configuration-modal/time-entries-current-user-configuration.modal.html
@@ -2,11 +2,11 @@
   <op-modal-header (close)="closeMe($event)">{{text.displayedDays}}</op-modal-header>
 
   <div class="op-modal--body">
-    <div class="form--field -trailing-label" *ngFor="let day of text.weekdays; let index = index">
-      <label class="form--label" [textContent]="day" [htmlFor]="'day_' + index"></label>
+    <div class="form--field -trailing-label" *ngFor="let day of days; let index = index">
+      <label class="form--label" [textContent]="day.weekDay" [htmlFor]="'day_' + index"></label>
       <span class="form--field-container">
         <span class="form--check-box-container">
-          <input type="checkbox" [id]="'day_' + index" name="days" class="form--check-box" [(ngModel)]="days[index]">
+          <input type="checkbox" [id]="'day_' + index" name="days" class="form--check-box" [(ngModel)]="day.checked">
         </span>
       </span>
     </div>

--- a/frontend/src/app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-configuration-modal/time-entries-current-user-configuration.modal.ts
+++ b/frontend/src/app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-configuration-modal/time-entries-current-user-configuration.modal.ts
@@ -2,35 +2,23 @@ import {
   ApplicationRef,
   ChangeDetectorRef,
   Component,
-  ComponentFactoryResolver,
   ElementRef,
   Inject,
-  InjectionToken,
   Injector,
-  OnDestroy,
   OnInit,
-  Optional,
-  ViewChild
 } from '@angular/core';
 import { OpModalLocalsMap } from 'core-app/modules/modal/modal.types';
 import { OpModalComponent } from 'core-app/modules/modal/modal.component';
 import { OpModalLocalsToken } from "core-app/modules/modal/modal.service";
 import { ConfigurationService } from 'core-app/modules/common/config/configuration.service';
-import {
-  ActiveTabInterface,
-  TabComponent,
-  TabInterface,
-  TabPortalOutlet
-} from 'core-components/wp-table/configuration-modal/tab-portal-outlet';
 import { LoadingIndicatorService } from 'core-app/modules/common/loading-indicator/loading-indicator.service';
 import { I18nService } from "core-app/modules/common/i18n/i18n.service";
-import { ComponentType } from "@angular/cdk/portal";
-import { WpGraphConfigurationService } from "core-app/modules/work-package-graphs/configuration/wp-graph-configuration.service";
-import { WpGraphConfiguration } from "core-app/modules/work-package-graphs/configuration/wp-graph-configuration";
 import { WorkPackageNotificationService } from "core-app/modules/work_packages/notifications/work-package-notification.service";
+import { TimeEntriesCurrentUserConfigurationModalService } from "core-app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-configuration-modal/services/time-entries-current-user-configuration-modal/time-entries-current-user-configuration-modal.service";
 
 @Component({
   templateUrl: './time-entries-current-user-configuration.modal.html',
+  providers: [TimeEntriesCurrentUserConfigurationModalService],
 })
 export class TimeEntriesCurrentUserConfigurationModalComponent extends OpModalComponent implements OnInit  {
 
@@ -45,19 +33,16 @@ export class TimeEntriesCurrentUserConfigurationModalComponent extends OpModalCo
   public text = {
     displayedDays: this.I18n.t('js.grid.widgets.time_entries_current_user.displayed_days'),
     closePopup: this.I18n.t('js.close_popup_title'),
-
     applyButton: this.I18n.t('js.modals.button_apply'),
     cancelButton: this.I18n.t('js.modals.button_cancel'),
-
-    weekdays: moment.weekdays()
   };
 
   public firstDayOfWeek:number;
-  public firstDayOffset = this.configuration.startOfWeek();
 
-  // All days of the week, zero based on Monday.
+  // Checked value of all days of the week, starting from Monday.
   public options:{ days:boolean[] };
-  public days:boolean[];
+  public daysOriginalCheckedValues:boolean[];
+  public days:IDayData[];
 
   constructor(@Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
               readonly I18n:I18nService,
@@ -67,19 +52,20 @@ export class TimeEntriesCurrentUserConfigurationModalComponent extends OpModalCo
               readonly notificationService:WorkPackageNotificationService,
               readonly cdRef:ChangeDetectorRef,
               readonly configuration:ConfigurationService,
-              readonly elementRef:ElementRef) {
+              readonly elementRef:ElementRef,
+              readonly timeEntriesCurrentUserConfigurationModalService:TimeEntriesCurrentUserConfigurationModalService) {
     super(locals, cdRef, elementRef);
   }
 
   ngOnInit() {
-    this.days = this.locals.options.days || Array.from({ length: 7 }, () => true );
-
-    const momentFirstDayOffset = 1 + moment.localeData().firstDayOfWeek() % 7;
-    this.text.weekdays = moment.localeData().weekdays().slice(momentFirstDayOffset).concat(moment.localeData().weekdays().slice(0, momentFirstDayOffset));
+    this.daysOriginalCheckedValues = this.locals.options.days || Array.from({ length: 7 }, () => true );
+    this.days = this.timeEntriesCurrentUserConfigurationModalService.getOrderedDaysData(this.daysOriginalCheckedValues);
   }
 
   public saveChanges():void {
-    this.options = { days: this.days };
+    const checkedValuesInOriginalOrder= this.timeEntriesCurrentUserConfigurationModalService.getCheckedValuesInOriginalOrder(this.days);
+
+    this.options = { days: checkedValuesInOriginalOrder };
     this.service.close();
   }
 }

--- a/frontend/src/app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-menu.component.ts
+++ b/frontend/src/app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-menu.component.ts
@@ -26,16 +26,12 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import { Component, Output, EventEmitter, Injector } from '@angular/core';
-import { WpGraphConfigurationModalComponent } from "core-app/modules/work-package-graphs/configuration-modal/wp-graph-configuration.modal";
-import { WidgetWpSetMenuComponent } from "core-app/modules/grids/widgets/menu/wp-set-menu.component";
-import { OpModalService } from "core-app/modules/modal/modal.service";
-import { OpModalComponent } from "core-app/modules/modal/modal.component";
+import { Component, Output, EventEmitter, Injector } from '@angular/core';import { OpModalService } from "core-app/modules/modal/modal.service";
 import { I18nService } from "core-app/modules/common/i18n/i18n.service";
 import { GridRemoveWidgetService } from "core-app/modules/grids/grid/remove-widget.service";
 import { GridAreaService } from "core-app/modules/grids/grid/area.service";
 import { WidgetAbstractMenuComponent } from "core-app/modules/grids/widgets/menu/widget-abstract-menu.component";
-import { TimeEntriesCurrentUserConfigurationModalComponent } from "core-app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-configuration.modal";
+import { TimeEntriesCurrentUserConfigurationModalComponent } from "core-app/modules/grids/widgets/time-entries/current-user/time-entries-current-user-configuration-modal/time-entries-current-user-configuration.modal";
 
 @Component({
   selector: 'widget-time-entries-current-user-menu',

--- a/frontend/src/app/modules/grids/widgets/time-entries/current-user/typings.d.ts
+++ b/frontend/src/app/modules/grids/widgets/time-entries/current-user/typings.d.ts
@@ -1,0 +1,5 @@
+interface IDayData {
+  weekDay:string;
+  checked:boolean;
+  originalIndex:number;
+}


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/35920

This pull request:

- [x]  Fixes the [issue 35920](https://community.openproject.org/projects/openproject/work_packages/35920) by displaying the weekdays in the locale order and saving them starting from Monday (Moment weekdays offset 1, required by [fullcalendar](https://fullcalendar.io/docs/angular)).