### PR TITLE
Fix message-id regex in mail_handler

### DIFF
--- a/spec/fixtures/mail_handler/message_reply.eml
+++ b/spec/fixtures/mail_handler/message_reply.eml
@@ -1,0 +1,60 @@
+Date: Tue, 16 Mar 2021 16:24:54 +0100
+To: notifications@openproject.com
+From: user@example.org
+Message-ID: <openproject.message-70917-12559.20200922103727@openproject.com>
+Subject: [OpenProject - General discussion - msg12559] Test
+ fields in user stories
+Mime-Version: 1.0
+Content-Type: multipart/alternative;
+ boundary="--==_mimepart_6050cdc2e4db_2257939a87567a";
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+X-OpenProject-Project: openproject
+X-OpenProject-Wiki-Page-Id: 12559
+X-OpenProject-Type: Forum
+
+
+----==_mimepart_6050cdc2e4db_2257939a87567a
+Content-Type: text/plain;
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+
+
+
+
+http://localhost:3000/topics/12559?r=12559#message-12559
+Test User
+
+Test message
+
+
+--
+You have received this notification because you have either subscribed to it, or are involved in it.
+To change your notification preferences, please click here: https://community.openproject.org/my/mail_notifications
+
+----==_mimepart_6050cdc2e4db_2257939a87567a
+Content-Type: text/html;
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+  <body>
+      <span class="header"></span>
+
+
+<h1>
+  OpenProject - General discussion: <a href="http://localhost:3000/topics/12559?r=12559#message-12559">Ready-If and Done-If fields in user stories</a>
+</h1>
+<em>Test user</em>
+
+<p class="op-uc-p">Test message</p>
+
+
+      <hr />
+      <span class="footer"><p class="op-uc-p">You have received this notification because you have either subscribed to it, or are involved in it.<br>
+To change your notification preferences, please click here: <a href="https://community.openproject.org/my/mail_notifications" class="op-uc-link">https://community.openproject.org/my/mail_notifications</a></p></span>
+  </body>
+</html>
+
+----==_mimepart_6050cdc2e4db_2257939a87567a--

--- a/spec/fixtures/mail_handler/work_package_reply.eml
+++ b/spec/fixtures/mail_handler/work_package_reply.eml
@@ -1,0 +1,108 @@
+Date: Tue, 16 Mar 2021 15:17:04 +0100
+To: notifications@openproject.com
+From: user@example.org
+Message-ID: <openproject.work_package-70917-34540.20210302144105@openproject.com>
+References: <openproject.work_package-70917-34540.20210215121742@openproject.com>
+Subject: test - new Task #34540: asdf
+Mime-Version: 1.0
+Content-Type: multipart/alternative;
+ boundary="--==_mimepart_6050bdd0cb97_2257939a8755e5";
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+X-OpenProject-Project: test
+X-OpenProject-Issue-Id: 34540
+X-OpenProject-Issue-Author: admin
+X-OpenProject-Type: WorkPackage
+X-OpenProject-Issue-Assignee: reader
+
+
+----==_mimepart_6050bdd0cb97_2257939a8755e5
+Content-Type: text/plain;
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+
+
+
+
+Work package #34540 has been updated by admin lastname.
+
+  Assignee set to reader reader
+
+
+----------------------------------------
+
+Task #34540: asdf
+http://localhost:3000/work_packages/34540
+
+Author: admin lastname
+Status: new
+Priority: Medium
+Assignee: reader reader
+Accountable:
+Category:
+Version: test version
+Start date:
+Finish date:
+Estimated time:
+Module:
+Onboarding Activity:
+Ordered by:
+Prio board:
+
+
+
+
+
+--
+You have received this notification because you have either subscribed to it, or are involved in it.
+To change your notification preferences, please click here: https://community.openproject.org/my/mail_notifications
+
+----==_mimepart_6050bdd0cb97_2257939a8755e5
+Content-Type: text/html;
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<html>
+  <body>
+      <span class="header"></span>
+
+      Work package #34540 has been updated by admin lastname.
+<ul>
+    <li><strong>Assignee</strong> set to <i title="reader reader">reader reader</i></li>
+</ul>
+
+<hr />
+
+<h1><a href="http://localhost:3000/work_packages/34540">Task #34540: asdf</a></h1>
+
+<ul>
+  <li>Author: admin lastname</li>
+  <li>Status: new</li>
+  <li>Priority: Medium</li>
+  <li>Assignee: reader reader</li>
+  <li>Accountable: </li>
+  <li>Category: </li>
+  <li>Version: test version</li>
+  <li>Start date: </li>
+  <li>Finish date: </li>
+  <li>Estimated time: </li>
+
+
+    <li>Module: </li>
+    <li>Onboarding Activity: </li>
+    <li>Ordered by: </li>
+    <li>Prio board: </li>
+</ul>
+
+
+
+
+
+      <hr />
+      <span class="footer"><p class="op-uc-p">You have received this notification because you have either subscribed to it, or are involved in it.<br>
+To change your notification preferences, please click here: <a href="https://community.openproject.org/my/mail_notifications" class="op-uc-link">https://community.openproject.org/my/mail_notifications</a></p></span>
+  </body>
+</html>
+
+----==_mimepart_6050bdd0cb97_2257939a8755e5--

--- a/spec/fixtures/mail_handler/wp_update_with_multiple_quoted_reply_above.eml
+++ b/spec/fixtures/mail_handler/wp_update_with_multiple_quoted_reply_above.eml
@@ -3,7 +3,7 @@ Received: from osiris ([127.0.0.1])
 	by OSIRIS
 	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
 Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
-In-Reply-To: <openproject.issue-2.20060719210421@osiris>
+In-Reply-To: <openproject.issue-1-2.20060719210421@osiris>
 From: "John Smith" <JSmith@somenet.foo>
 To: <openproject@somenet.foo>
 Subject: Re: update to issue 2

--- a/spec/fixtures/mail_handler/wp_update_with_quoted_reply_above.eml
+++ b/spec/fixtures/mail_handler/wp_update_with_quoted_reply_above.eml
@@ -3,7 +3,7 @@ Received: from osiris ([127.0.0.1])
 	by OSIRIS
 	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
 Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
-In-Reply-To: <openproject.issue-2.20060719210421@osiris>
+In-Reply-To: <openproject.issue-1-2.20060719210421@osiris>
 From: "John Smith" <JSmith@somenet.foo>
 To: <openproject@somenet.foo>
 Subject: Re: update to issue 2

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -605,13 +605,46 @@ describe MailHandler, type: :model do
     end
   end
 
+  describe '#dispatch_target_from_message_id' do
+    let!(:mail_user) { FactoryBot.create :admin, mail: 'user@example.org' }
+    let(:instance) do
+      mh = MailHandler.new
+      mh.options = {}
+      mh
+    end
+    subject { instance.receive mail }
+
+    context 'receiving reply from work package' do
+      let(:mail) { Mail.new(read_email('work_package_reply.eml')) }
+
+      it 'calls the work package reply' do
+        expect(instance).to receive(:receive_work_package_reply).with(34540)
+
+        subject
+      end
+    end
+
+    context 'receiving reply from message' do
+      let(:mail) { Mail.new(read_email('message_reply.eml')) }
+
+      it 'calls the work package reply' do
+        expect(instance).to receive(:receive_message_reply).with(12559)
+
+        subject
+      end
+    end
+  end
+
   private
 
   FIXTURES_PATH = File.dirname(__FILE__) + '/../fixtures/mail_handler'
 
+  def read_email(filename)
+    IO.read(File.join(FIXTURES_PATH, filename))
+  end
+
   def submit_email(filename, options = {})
-    raw = IO.read(File.join(FIXTURES_PATH, filename))
-    MailHandler.receive(raw, options)
+    MailHandler.receive(read_email(filename), options)
   end
 
   def work_package_created(work_package)

--- a/spec_legacy/fixtures/mail_handler/issue_update_with_multiple_quoted_reply_above.eml
+++ b/spec_legacy/fixtures/mail_handler/issue_update_with_multiple_quoted_reply_above.eml
@@ -3,7 +3,7 @@ Received: from osiris ([127.0.0.1])
 	by OSIRIS
 	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
 Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
-In-Reply-To: <openproject.issue-2.20060719210421@osiris>
+In-Reply-To: <openproject.issue-1-2.20060719210421@osiris>
 From: "John Smith" <JSmith@somenet.foo>
 To: <openproject@somenet.foo>
 Subject: Re: update to issue 2

--- a/spec_legacy/fixtures/mail_handler/issue_update_with_quoted_reply_above.eml
+++ b/spec_legacy/fixtures/mail_handler/issue_update_with_quoted_reply_above.eml
@@ -3,7 +3,7 @@ Received: from osiris ([127.0.0.1])
 	by OSIRIS
 	with hMailServer ; Sun, 22 Jun 2008 12:28:07 +0200
 Message-ID: <000501c8d452$a95cd7e0$0a00a8c0@osiris>
-In-Reply-To: <openproject.issue-2.20060719210421@osiris>
+In-Reply-To: <openproject.issue-1-2.20060719210421@osiris>
 From: "John Smith" <JSmith@somenet.foo>
 To: <openproject@somenet.foo>
 Subject: Re: update to issue 2

--- a/spec_legacy/fixtures/mail_handler/message_reply.eml
+++ b/spec_legacy/fixtures/mail_handler/message_reply.eml
@@ -5,8 +5,8 @@ User-Agent: Thunderbird 2.0.0.19 (Windows/20081209)
 MIME-Version: 1.0
 To: openproject@somenet.foo
 Subject: Reply via email
-References: <openproject.message-2.20070512171800@somenet.foo>
-In-Reply-To: <openproject.message-2.20070512171800@somenet.foo>
+References: <openproject.message-1-2.20070512171800@somenet.foo>
+In-Reply-To: <openproject.message-1-2.20070512171800@somenet.foo>
 Content-Type: text/plain; charset=UTF-8; format=flowed
 Content-Transfer-Encoding: 7bit
 

--- a/spec_legacy/fixtures/mail_handler/ticket_reply.eml
+++ b/spec_legacy/fixtures/mail_handler/ticket_reply.eml
@@ -3,7 +3,7 @@ Received: from osiris ([127.0.0.1])
 	by OSIRIS
 	with hMailServer ; Sat, 21 Jun 2008 18:41:39 +0200
 Message-ID: <006a01c8d3bd$ad9baec0$0a00a8c0@osiris>
-In-Reply-To: <openproject.issue-2.20060719210421@osiris>
+In-Reply-To: <openproject.issue-1-2.20060719210421@osiris>
 From: "John Smith" <jsmith@somenet.foo>
 To: <openproject@somenet.foo>
 References: <485d0ad366c88_d7014663a025f@osiris.tmail>

--- a/spec_legacy/fixtures/mail_handler/ticket_reply_by_message_id.eml
+++ b/spec_legacy/fixtures/mail_handler/ticket_reply_by_message_id.eml
@@ -3,7 +3,7 @@ Received: from osiris ([127.0.0.1])
 	by OSIRIS
 	with hMailServer ; Sat, 21 Jun 2008 18:41:39 +0200
 Message-ID: <006a01c8d3bd$ad9baec0$0a00a8c0@osiris>
-In-Reply-To: <openproject.issue_journal-3.20110617112550@example.net>
+In-Reply-To: <openproject.issue_journal-1-3.20110617112550@example.net>
 From: "John Smith" <jsmith@somenet.foo>
 To: <openproject@somenet.foo>
 References: <485d0ad366c88_d7014663a025f@osiris.tmail>


### PR DESCRIPTION
In https://github.com/opf/openproject/pull/660, (WP #3020), the message-id was extended to include the user. But the mail_handler rspec was never extended to catch replies through that message id.


https://community.openproject.com/work_packages/35834