### PR TITLE
Fixed by refreshing wps from states

### DIFF
--- a/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/components/wp-card-view/wp-card-view.component.ts
@@ -140,9 +140,9 @@ export class WorkPackageCardViewComponent extends UntilDestroyedMixin implements
           return !!events.find(event => wpIds.indexOf(event.id) !== -1);
         })
       ).subscribe(() => {
-      this.workPackages = this.wpViewOrder.orderedWorkPackages();
-      this.cdRef.detectChanges();
-    });
+        this.workPackages = this.workPackages.map(wp => this.states.workPackages.get(wp.id!).getValueOr(wp));
+        this.cdRef.detectChanges();
+      });
 
     this.querySpace.results
       .values$()


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/34839

This pull request:

- [x] Fixes the card flickering when dropped into a new project by refreshing the work packages from the states. Because this.halEvents.aggregated$('WorkPackage') emitted before this.querySpace.results.values$() it was rendering the previous results (e.g. 1 work package) before this.querySpace.results.values$() rendered the correct final result (e.g. 2 work packages) causing the flickering.

**Notes**
- I created a code maintenance [work package](https://community.openproject.org/projects/openproject/work_packages/36602/relations) to solve the underlying issue when possible.