### PR TITLE
[36269] Add "other" to pluralization rules for one

### DIFF
--- a/frontend/src/app/init-locale.ts
+++ b/frontend/src/app/init-locale.ts
@@ -1,0 +1,50 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2021 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+//++
+
+
+export function initializeLocale() {
+  const meta = document.querySelector('meta[name=openproject_initializer]') as HTMLMetaElement;
+  I18n.locale = meta.dataset.locale || 'en';
+  I18n.firstDayOfWeek = parseInt(meta.dataset.firstDayOfWeek!, 10);
+
+  // Override the default pluralization function to allow
+  // "other" to be used as a fallback for "one" in languages where one is not set
+  // (japanese, for example)
+  I18n.pluralization["default"] = function (count:number) {
+    switch (count) {
+      case 0:
+        return ["zero", "other"];
+      case 1:
+        return ["one", "other"];
+      default:
+        return ["other"];
+    }
+  };
+
+  return import(/* webpackChunkName: "locale" */ `../locales/${I18n.locale}.js`);
+}

--- a/frontend/src/app/modules/common/i18n/i18n.service.ts
+++ b/frontend/src/app/modules/common/i18n/i18n.service.ts
@@ -20,7 +20,7 @@ export interface GlobalI18n {
 
   locale:string;
   firstDayOfWeek:number;
-
+  pluralization:any;
 }
 
 interface ToNumberOptions {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -6,6 +6,7 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {SentryReporter} from "core-app/sentry/sentry-reporter";
 import {whenDebugging} from "core-app/helpers/debug_output";
 import {enableReactiveStatesLogging} from "reactivestates";
+import {initializeLocale} from "core-app/init-locale";
 
 (window as any).global = window;
 
@@ -26,10 +27,6 @@ window.ErrorReporter = new SentryReporter();
 require('core-app/init-vendors');
 require('core-app/init-globals');
 
-const meta = jQuery('meta[name=openproject_initializer]');
-I18n.locale = meta.data('locale') || 'en';
-I18n.firstDayOfWeek = parseInt(meta.data('firstDayOfWeek'), 10);
-
 if (environment.production) {
   enableProdMode();
 }
@@ -41,7 +38,7 @@ whenDebugging(() => {
 });
 
 // Import the correct locale early on
-import(/* webpackChunkName: "locale" */ `./locales/${I18n.locale}.js`)
+initializeLocale()
   .then(() => {
     jQuery(function () {
       // Due to the behaviour of the Edge browser we need to wait for 'DOM ready'

--- a/frontend/src/test/i18n-shim.ts
+++ b/frontend/src/test/i18n-shim.ts
@@ -9,6 +9,8 @@ export class I18nShim implements GlobalI18n {
     en: {}
   };
 
+  public pluralization = {};
+
   t(key:string) {
     return '[missing "' + key + '" translation]';
   }

--- a/modules/bim/spec/features/viewer/show_viewpoint_spec.rb
+++ b/modules/bim/spec/features/viewer/show_viewpoint_spec.rb
@@ -60,12 +60,12 @@ describe 'Show viewpoint in model viewer',
     it 'loads the minimal viewpoint in the viewer' do
       model_tree.select_sidebar_tab 'Objects'
       model_tree.expand_tree
-      model_tree.expect_checked 'minimal'
       retry_block do
+        model_tree.expect_checked 'minimal'
         model_tree.all_checkboxes.each do |label, checkbox|
           expect_checked = (label.text == 'minimal' || label.text == 'LUB_Segment_new:S_WHG_Ess:7243035')
           if expect_checked != checkbox.checked?
-            raise "Expected #{label} to be #{expect_checked ? 'checked' : 'unchecked'}, but wasn't."
+            raise "Expected #{label.text} to be #{expect_checked ? 'checked' : 'unchecked'}, but wasn't."
           end
         end
       end
@@ -81,6 +81,10 @@ describe 'Show viewpoint in model viewer',
 
   context 'clicking on the card' do
     before do
+      # We need to wait a bit for xeokit to be initialized
+      # otherwise the viewpoint selection won't go through
+      sleep 2
+
       card_view.select_work_package work_package
       card_view.expect_work_package_selected work_package, true
     end
@@ -92,6 +96,10 @@ describe 'Show viewpoint in model viewer',
     before do
       card_view.open_full_screen_by_details work_package
       bcf_details.expect_viewpoint_count 1
+
+      # We need to wait a bit for xeokit to be initialized
+      # otherwise the viewpoint selection won't go through
+      sleep 2
       bcf_details.show_current_viewpoint
     end
 

--- a/spec/features/support/components/time_logging_modal.rb
+++ b/spec/features/support/components/time_logging_modal.rb
@@ -49,7 +49,7 @@ module Components
       if visible
         within modal_container do
           expect(page)
-            .to have_content(I18n.t('js.button_log_time'))
+            .to have_text(I18n.t('js.button_log_time'))
         end
       else
         expect(page).to have_no_selector '.op-modal--modal-container'


### PR DESCRIPTION
For languages that do not have "one" as a pluralization rule (japanese, for example), the pluralization rule defined by I18n.js does not return a valid string for count: 1.

Since we probably do not want to define custom pluralization rules for all languages, we can fall back to the "other" key if "one" is not defined.

https://community.openproject.org/wp/36269 