### PR TITLE
Fix multiselect list custom field

### DIFF
--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -94,7 +94,7 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
    */
   public buildSelectedOption() {
     const value:HalResource[] = this.resource[this.name];
-    return value ? value.map(val => this.findValueOption(val)) : [];
+    return value ? _.castArray(value).map(val => this.findValueOption(val)) : [];
   }
 
   public get selectedOption() {


### PR DESCRIPTION
In the custom field type, both array and non-array value types were being handled the same, causing array types to be
unwrapped once too often.

Closes https://community.openproject.org/wp/36607