### PR TITLE
[36596] Fix group assignee returned non-active users

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -684,12 +684,12 @@ class WorkPackage < ApplicationRecord
   def attribute_users
     related = [author]
 
-    [responsible, assigned_to].each do |user|
-      case user
+    [responsible, assigned_to].each do |principal|
+      case principal
       when Group
-        related += user.users
+        related += principal.users.active
       when User
-        related << user
+        related << principal
       end
     end
 

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -684,7 +684,7 @@ describe WorkPackage, type: :model do
         let(:assignee) do
           group = FactoryBot.build_stubbed(:group)
           allow(group)
-            .to receive(:users)
+            .to receive_message_chain(:users, :active)
             .and_return([user1, user2, user3])
           group
         end
@@ -700,7 +700,7 @@ describe WorkPackage, type: :model do
         let(:responsible) do
           group = FactoryBot.build_stubbed(:group)
           allow(group)
-            .to receive(:users)
+            .to receive_message_chain(:users, :active)
             .and_return([user1, user2, user3])
           group
         end


### PR DESCRIPTION
https://community.openproject.org/work_packages/36596

We talked about refactoring this part and move it to the journal service, so this fix is really only a band-aid. I extracted ticket https://community.openproject.org/work_packages/36690 into 11.3(tbd) to move this correctly.