### PR TITLE
Fix: RHEL packages depenencies

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -21,12 +21,11 @@ targets:
     <<: *debian9
   centos-7: &centos7
     dependencies:
+      - epel-release
+      - ImageMagick
       - unzip
       - poppler-utils
-      - unrtf
       - tesseract
-      - catdoc
-      - ImageMagick
   centos-8:
     <<: *centos7
   sles-12:


### PR DESCRIPTION
We accidentally broke the RHEL packages with 11.2.1 which caused the following error when trying to install the openproject packager package:

```
Error:
 Problem: cannot install the best candidate for the job
  - nothing provides catdoc needed by openproject-11.2.1-1616487457.a0ea141c.centos8.x86_64
  - nothing provides unrtf needed by openproject-11.2.1-1616487457.a0ea141c.centos8.x86_64
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

This PR adds the mising epel dependency again and removes the unavailable dependencies seen above.