### PR TITLE
Use ActiveSupport::Logger to support .silenced

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,4 +83,4 @@ OpenProject::Application.configure do
   config.action_mailer.delivery_method = :letter_opener
 end
 
-ActiveRecord::Base.logger = Logger.new(STDOUT) unless String(ENV["SILENCE_SQL_LOGS"]).to_bool
+ActiveRecord::Base.logger = ActiveSupport::Logger.new(STDOUT) unless String(ENV["SILENCE_SQL_LOGS"]).to_bool

--- a/lib/open_project/logging/tee_logger.rb
+++ b/lib/open_project/logging/tee_logger.rb
@@ -9,8 +9,8 @@ module OpenProject
       # Initialize a stdout/stderr and file logger
       # with the file logger within <rails root>/log/<filename>
       def initialize(log_name, max_level = ::Logger::DEBUG)
-        @stdout = ::Logger.new STDOUT
-        @file = ::Logger.new Rails.root.join('log', "#{File.basename(log_name, '.log')}.log")
+        @stdout = ::ActiveSupport::Logger.new STDOUT
+        @file = ::ActiveSupport::Logger.new Rails.root.join('log', "#{File.basename(log_name, '.log')}.log")
 
         stdout.level = max_level
         file.level = max_level

--- a/lib/open_project/text_formatting/formats/markdown/pandoc_wrapper.rb
+++ b/lib/open_project/text_formatting/formats/markdown/pandoc_wrapper.rb
@@ -35,7 +35,7 @@ module OpenProject::TextFormatting::Formats
     class PandocWrapper
       attr_reader :logger
 
-      def initialize(logger = ::Logger.new(STDOUT))
+      def initialize(logger = ::ActiveSupport::Logger.new(STDOUT))
         @logger = logger
       end
 


### PR DESCRIPTION
The activerecord session store uses `logger.silenced` on the AR logger, but in development we pass a Ruby logger, which doesn't offer the silencing.

In previous versions, they used the LoggerSilencer extension of Rails but that is no longer the case. If you have session storage enabled locally, this will result in exceptions now