### PR TITLE
Fix localization string for derived_estimated_hours

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -825,7 +825,7 @@ en:
     default_columns: "Default columns"
     description: "Description"
     derived_due_date: "Derived finish date"
-    derived_estimated_time: "Derived estimated time"
+    derived_estimated_hours: "Derived estimated time"
     derived_start_date: "Derived start date"
     display_sums: "Display Sums"
     due_date: "Finish date"


### PR DESCRIPTION
The string is incorrect (time vs hours)

https://community.openproject.org/wp/36712