### PR TITLE
Load patches in initializer, not in individual patches

### DIFF
--- a/config/initializers/10-load_patches.rb
+++ b/config/initializers/10-load_patches.rb
@@ -29,6 +29,7 @@
 #++
 
 # Do not place any patches within this file. Add a file to lib/open_project/patches
+require 'open_project/patches'
 
 # Whatever ruby file is placed in lib/open_project/patches is required
 Dir.glob(File.expand_path('../../lib/open_project/patches/*.rb', __dir__)).each do |path|

--- a/lib/open_project/patches/carrierwave_sanitized_file.rb
+++ b/lib/open_project/patches/carrierwave_sanitized_file.rb
@@ -1,5 +1,4 @@
 require 'carrierwave/storage/fog'
-require 'open_project/patches'
 
 ##
 # Code copied straight from the CarrierWave source.

--- a/lib/open_project/patches/i18n_reject_empty_string.rb
+++ b/lib/open_project/patches/i18n_reject_empty_string.rb
@@ -25,7 +25,6 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
-require 'open_project/patches'
 
 module OpenProject
   module Patches


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/36717

I could not reproduce this on my packaged installation nor in docker, but it appears that the load order is not the same in all systems.