### PR TITLE
Fix NoMethodError: undefined method `patch_gem_version' for OpenProject::Patches:Module

### DIFF
--- a/lib/open_project/patches/declarative_option.rb
+++ b/lib/open_project/patches/declarative_option.rb
@@ -1,3 +1,5 @@
+require 'open_project/patches'
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH


### PR DESCRIPTION
When running `openproject configure`, this error is thrown, I'm wondering how it got released with this bug since it doesn't build correctly?
openproject version 11.2.1-1616511231.6fcf4413.xenial
At least this fixes it.