### PR TITLE
Use our own GPL fork of mimemagic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,10 @@ gem 'activerecord-session_store', '~> 1.1.0'
 gem 'rails', '~> 6.1.0'
 gem 'responders', '~> 3.0'
 
+# Keep mimemagic at older version until rails provides its own
+# solution without adding a system dependency. We are GPL ourselves so this is fine.
+gem 'mimemagic', git: 'https://github.com/opf/mimemagic', ref: 'bf8d7c2'
+
 gem 'rdoc', '>= 2.4.2'
 
 # Maintain our own omniauth due to relative URL root issues

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/opf/mimemagic
+  revision: bf8d7c2b32d9c5aadb46013402af55f23eb71c90
+  ref: bf8d7c2
+  specs:
+    mimemagic (0.3.6)
+
+GIT
   remote: https://github.com/opf/omniauth
   revision: fe862f986b2e846e291784d2caa3d90a658c67f0
   ref: fe862f986b2e846e291784d2caa3d90a658c67f0
@@ -575,7 +582,6 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.6)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
@@ -991,6 +997,7 @@ DEPENDENCIES
   livingstyleguide (~> 2.1.0)
   lograge (~> 0.11.0)
   meta-tags (~> 2.14.0)
+  mimemagic!
   mini_magick (~> 4.11.0)
   multi_json (~> 1.15.0)
   my_page!


### PR DESCRIPTION
The upstream mimemagic now is MIT again, but requires
a system dependency on shared-mime-info which we don't care about
as we are GPL ourselves.

https://github.com/opf/openproject/pull/9124