### PR TITLE
Remove Travis build badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # OpenProject
-[<img src="https://travis-ci.org/opf/openproject.svg?branch=dev" alt="Build Status" />](https://travis-ci.org/opf/openproject)
 [![Code Climate](https://codeclimate.com/github/opf/openproject/badges/gpa.svg)](https://codeclimate.com/github/opf/openproject)
 
 OpenProject is a web-based project management software. Its key features are:


### PR DESCRIPTION
If I am not mistaken, the badge displayed a build from 2 months ago.