### PR TITLE
Codeclimate: Revert rubocop channel back to 1-9-1 

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -27,7 +27,7 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-1-11-0
+    channel: rubocop-1-9-1
   # Codeclimate uses brakeman 4.3.1 which does not support rails 6
   # Check https://docs.codeclimate.com/docs/brakeman for updates.
   brakeman:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -42,7 +42,7 @@ plugins:
       config: frontend/.eslintrc.js
   csslint:
     enabled: true
-  scsslint:
+  scss-lint:
     enabled: true
   fixme:
     enabled: true

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   parserOptions: {
     project: "./src/tsconfig.app.json",
+    tsconfigRootDir: __dirname,
     sourceType: "module",
     createDefaultProgram: true,
   },


### PR DESCRIPTION
Newer versions are not supported yet: https://codeclimate.com/github/opf/openproject/builds/19192

```

Channel rubocop-1-11-0 not found for rubocop, available channels: ["stable", "cache-support", "rubocop-0-42", "rubocop-0-46", "rubocop-0-48", "rubocop-0-49", "rubocop-0-50", "rubocop-0-51", "rubocop-0-52", "rubocop-0-54", "rubocop-0-55", "rubocop-0-56", "rubocop-0-57", "rubocop-0-58", "rubocop-0-59", "rubocop-0-60", "rubocop-0-61", "rubocop-0-62", "rubocop-0-63", "rubocop-0-64", "rubocop-0-66", "rubocop-0-65", "rubocop-0-67", "rubocop-0-68", "rubocop-0-69", "rubocop-0-70", "rubocop-0-71", "rubocop-0-72", "rubocop-0-73", "rubocop-0-74", "rubocop-0-75", "rubocop-0-76", "rubocop-0-76-airbnb", "rubocop-0-77", "rubocop-0-78", "rubocop-0-79", "rubocop-0-80", "rubocop-0-81", "rubocop-0-82", "rubocop-0-83", "rubocop-0-84", "rubocop-0-85", "rubocop-0-86", "rubocop-0-87", "rubocop-0-88", "rubocop-0-89", "rubocop-0-90", "rubocop-0-92", "rubocop-1-70", "rubocop-1-7-0", "rubocop-1-8-1", "rubocop-1-9-1"]
--
```