### PR TITLE
[36727] Don't clear the datepicker input resulting in an endless loop

### DIFF
--- a/frontend/src/app/modules/common/op-date-picker/op-date-picker.component.ts
+++ b/frontend/src/app/modules/common/op-date-picker/op-date-picker.component.ts
@@ -83,10 +83,10 @@ export class OpDatePickerComponent extends UntilDestroyedMixin implements OnDest
   }
 
   onInputChange(_event:KeyboardEvent) {
-    if (this.isEmpty()) {
-      this.datePickerInstance.clear();
-    } else if (this.inputIsValidDate()) {
+    if (this.inputIsValidDate()) {
       this.onChange.emit(this.currentValue);
+    } else {
+      this.onChange.emit('');
     }
   }
 

--- a/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
+++ b/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
@@ -225,4 +225,30 @@ describe 'custom field inplace editor', js: true do
       end
     end
   end
+
+  describe 'date type' do
+    let(:custom_field) do
+      FactoryBot.create(:date_wp_custom_field, args.merge(name: 'MyDate'))
+    end
+    let(:args) { {} }
+    let(:initial_custom_values) { {} }
+
+    it 'can set and clear the date (Regression #36727)' do
+      field.expect_state_text '-'
+      field.update '2021-03-30'
+      field.expect_state_text '03/30/2021'
+
+      work_package.reload
+      expect(work_package.custom_value_for(custom_field.id).formatted_value).to eq '03/30/2021'
+
+      field.activate!
+      field.clear
+      field.submit_by_enter
+
+      field.expect_state_text '-'
+
+      work_package.reload
+      expect(work_package.custom_value_for(custom_field.id).value).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Clearing the datepicker when it is not set will result in an endless
loop since flatpickr already unsets it properly.

Instead just emit the empty value


https://community.openproject.org/work_packages/36727