### PR TITLE
Add schema location attribute

### DIFF
--- a/docs/api/apiv3/endpoints/members.apib
+++ b/docs/api/apiv3/endpoints/members.apib
@@ -463,6 +463,7 @@ Returns a collection of memberships. The client can choose to filter the members
                     "required": false,
                     "hasDefault": false,
                     "writable": true,
+                    "location": "_links",
                     "_links": {}
                 },
                 "principal": {
@@ -471,6 +472,7 @@ Returns a collection of memberships. The client can choose to filter the members
                     "required": true,
                     "hasDefault": false,
                     "writable": true,
+                    "location": "_links",
                     "_links": {}
                 },
                 "roles": {
@@ -479,6 +481,7 @@ Returns a collection of memberships. The client can choose to filter the members
                     "required": true,
                     "hasDefault": false,
                     "writable": true,
+                    "location": "_links",
                     "_links": {}
                 },
                 "_links": {
@@ -590,6 +593,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "_links": {
                                 "allowedValues": {
                                     "href": "/api/v3/memberships/available_projects?filters=%5B%7B%22principal%22%3A%7B%22operator%22%3A%22%21%22%2C%22values%22%3A%5B%225%22%5D%7D%7D%5D"
@@ -602,6 +606,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": true,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "_links": {
                                 "allowedValues": {
                                     "href": "/api/v3/principals?filters=%5B%7B%22status%22%3A%7B%22operator%22%3A%22%21%22%2C%22values%22%3A%5B%220%22%2C%223%22%5D%7D%7D%2C%7B%22member%22%3A%7B%22operator%22%3A%22%21%22%2C%22values%22%3A%5B%221%22%5D%7D%7D%5D"
@@ -614,6 +619,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": true,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "_links": {
                                 "allowedValues": {
                                     "href": "/api/v3/roles
@@ -757,6 +763,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": true,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "_links": {
                                 "allowedValues": {
                                     "href": "/api/v3/roles?filters=%5B%7B%22unit%22%3A%7B%22operator%22%3A%22%3D%22%2C%22values%22%3A%5B%22project%22%5D%7D%7D%5D"

--- a/docs/api/apiv3/endpoints/projects.apib
+++ b/docs/api/apiv3/endpoints/projects.apib
@@ -584,6 +584,7 @@ You can use the form and schema to be retrieve the valid attribute values and by
                     "required": false,
                     "hasDefault": false,
                     "writable": true,
+                    "location": "_links",
                     "visibility": "default",
                     "_links": {}
                 },
@@ -615,6 +616,7 @@ You can use the form and schema to be retrieve the valid attribute values and by
                     "required": false,
                     "hasDefault": false,
                     "writable": true,
+                    "location": "_links",
                     "visibility": "default",
                     "_links": {}
                 },
@@ -624,6 +626,7 @@ You can use the form and schema to be retrieve the valid attribute values and by
                     "required": false,
                     "hasDefault": false,
                     "writable": true,
+                    "location": "_links",
                     "visibility": "default",
                     "_links": {}
                 },
@@ -782,6 +785,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "visibility": "default",
                             "_links": {
                                 "allowedValues": {
@@ -809,6 +813,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "visibility": "default",
                             "_links": {
                                 "allowedValues": {
@@ -830,6 +835,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "visibility": "default",
                             "_embedded": {
                                 "allowedValues": [
@@ -1097,6 +1103,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "visibility": "default",
                             "_links": {
                                 "allowedValues": {
@@ -1124,6 +1131,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "visibility": "default",
                             "_links": {
                                 "allowedValues": {
@@ -1145,6 +1153,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "visibility": "default",
                             "_embedded": {
                                 "allowedValues": [

--- a/docs/api/apiv3/endpoints/queries.apib
+++ b/docs/api/apiv3/endpoints/queries.apib
@@ -1469,6 +1469,7 @@ Returns the form resource that was created. See [Forms](/api/forms) section for 
                 "required": false,
                 "hasDefault": false,
                 "writable": true,
+                "location": "_links",
                 "_links": {}
               },
               "public": {
@@ -1518,7 +1519,8 @@ Returns the form resource that was created. See [Forms](/api/forms) section for 
                 "name": "Highlighted attributes",
                 "required": false,
                 "hasDefault": true,
-                "writable": true
+                "writable": true,
+                "location": "_links"
               },
               "showHierarchies": {
                 "type": "Boolean",
@@ -1540,6 +1542,7 @@ Returns the form resource that was created. See [Forms](/api/forms) section for 
                 "required": false,
                 "hasDefault": true,
                 "writable": true,
+                "location": "_links",
                 "_links": {}
               },
               "filters": {
@@ -1548,6 +1551,7 @@ Returns the form resource that was created. See [Forms](/api/forms) section for 
                 "required": false,
                 "writable": true,
                 "hasDefault": true,
+                "location": "_links",
                 "_links": {
                   "allowedValuesSchemas": {
                     "href": "/api/v3/queries/filter_instance_schemas"

--- a/docs/api/apiv3/endpoints/schemas.apib
+++ b/docs/api/apiv3/endpoints/schemas.apib
@@ -141,7 +141,7 @@ If it is `4` the property does not exist.
 The property will not be writable if the value is `3`.
 The values allowed to be set differ between having `1` or `2` selected for the depending property.
 
-Because of the limitation of JSON objects,all keys will be strings, even when the depending value is actually something different (e.g. Integer, Date).
+Because of the limitation of JSON objects, all keys will be strings, even when the depending value is actually something different (e.g. Integer, Date).
 This is also true for resources in which case the url of the resource is used as the key.
 
 ## Example Schema [/api/v3/example/schema]
@@ -217,4 +217,3 @@ This is an example of how a schema might look like. Note that this endpoint does
 + Response 200 (application/hal+json)
 
     [Example Schema][]
-

--- a/docs/api/apiv3/endpoints/schemas.apib
+++ b/docs/api/apiv3/endpoints/schemas.apib
@@ -49,9 +49,16 @@ Only one of the links (`allowedValues`, `allowedValuesSchemas`) will exist for a
 | regularExpression | The value of the property must match the given regular expression (if not null)    | String   | null    |
 | required          | If true this property is not nullable                                              | Boolean  | true    |
 | writable          | If false it is not allowed to **change** the properties value                      | Boolean  | true    |
+| location          | If present, contains a reference to the location of the property in the JSON       | String   |         |
 
 All of the above properties that do not have a default value *must* be present in the schema.
 For properties that have a default value, the client can assume the default value, if the property is missing.
+
+### Location property
+
+The location property gives a hint as to where to find the property if it is not contained in the set of local attributes.
+For example, for linked properties, the location attribute of the schema will contain `_links`. The property will then be found in the resource
+under the path `_links.propertyName`.
 
 Note that regular expressions used in the API follow the rules of [Ruby Regular Expressions](http://www.ruby-doc.org/core-2.2.6/Regexp.html).
 
@@ -91,6 +98,7 @@ The following excerpt examplifies the objects that can be found as a value of th
         "required": true,
         "hasDefault": false,
         "writable": true,
+        "location": "_links",
         "_links": {
           "allowedValues": {
             "href": "/api/v3/some/path/to/users"
@@ -105,6 +113,7 @@ The following excerpt examplifies the objects that can be found as a value of th
         "required": true,
         "hasDefault": false,
         "writable": true,
+        "location": "_links",
         "_links": {
           "allowedValues": {
             "href": "/api/v3/a/totally/different/path/to/other/users"
@@ -118,7 +127,8 @@ The following excerpt examplifies the objects that can be found as a value of th
         "name": "Lorem ipsum",
         "required": true,
         "hasDefault": false,
-        "writable": false
+        "writable": false,
+        "location": "_links",
       }
     },
     "4": {}
@@ -126,9 +136,13 @@ The following excerpt examplifies the objects that can be found as a value of th
 }
 ```
 
-Given the example above, the client has to add the property `loremIpsum` to the schema if the depending property is `1`, `2` or `3`. If it is `4` the property does not exist. The property will not be writable if the value is `3`. The values allowed to be set differ between having `1` or `2` selected for the depending property.
+Given the example above, the client has to add the property `loremIpsum` to the schema if the depending property is `1`, `2` or `3`.
+If it is `4` the property does not exist.
+The property will not be writable if the value is `3`.
+The values allowed to be set differ between having `1` or `2` selected for the depending property.
 
-Because of the limitation of JSON objects, all keys will be strings, even when the depending value is actually something different (e.g. Integer, Date). This is also true for resources in which case the url of the resource is used as the key.
+Because of the limitation of JSON objects,all keys will be strings, even when the depending value is actually something different (e.g. Integer, Date).
+This is also true for resources in which case the url of the resource is used as the key.
 
 ## Example Schema [/api/v3/example/schema]
 
@@ -163,6 +177,7 @@ Because of the limitation of JSON objects, all keys will be strings, even when t
 
                     "name": "Status",
                     "type": "Status",
+                    "location": "_links",
 
                     "_embedded": {
                         "allowedValues": [

--- a/docs/api/apiv3/endpoints/schemas.apib
+++ b/docs/api/apiv3/endpoints/schemas.apib
@@ -54,13 +54,16 @@ Only one of the links (`allowedValues`, `allowedValuesSchemas`) will exist for a
 All of the above properties that do not have a default value *must* be present in the schema.
 For properties that have a default value, the client can assume the default value, if the property is missing.
 
+Note that regular expressions used in the API follow the rules of [Ruby Regular Expressions](http://www.ruby-doc.org/core-2.2.6/Regexp.html).
+
+
 ### Location property
 
 The location property gives a hint as to where to find the property if it is not contained in the set of local attributes.
 For example, for linked properties, the location attribute of the schema will contain `_links`. The property will then be found in the resource
 under the path `_links.propertyName`.
 
-Note that regular expressions used in the API follow the rules of [Ruby Regular Expressions](http://www.ruby-doc.org/core-2.2.6/Regexp.html).
+For the default attributes to be added on the top level of the resource, the location attribute will not be set.
 
 # Schema Dependencies
 

--- a/docs/api/apiv3/endpoints/time_entries.apib
+++ b/docs/api/apiv3/endpoints/time_entries.apib
@@ -576,6 +576,7 @@ Lists time entries. The time entries returned depend on the filters provided and
                     "required": false,
                     "hasDefault": false,
                     "writable": true,
+                    "location": "_links",
                     "_links": {}
                 },
                 "project": {
@@ -584,6 +585,7 @@ Lists time entries. The time entries returned depend on the filters provided and
                     "required": false,
                     "hasDefault": false,
                     "writable": true,
+                    "location": "_links",
                     "_links": {}
                 },
                 "activity": {
@@ -592,6 +594,7 @@ Lists time entries. The time entries returned depend on the filters provided and
                     "required": true,
                     "hasDefault": true,
                     "writable": true,
+                    "location": "_links",
                     "_links": {}
                 },
                 "customField29": {
@@ -758,6 +761,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "_links": {
                                 "allowedValues": {
                                     "href": "/api/v3/work_packages?filters=%5B%7B%22project%22%3A%7B%22operator%22%3A%22%3D%22%2C%22values%22%3A%5B%221%22%5D%7D%7D%5D"
@@ -770,6 +774,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "_links": {
                                 "allowedValues": {
                                     "href": "/api/v3/time_entries/available_projects"
@@ -782,6 +787,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": true,
                             "hasDefault": true,
                             "writable": true,
+                            "location": "_links",
                             "_embedded": {
                                 "allowedValues": [
                                     {
@@ -847,6 +853,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "options": {
                                 "rtl": null
                             }
@@ -1028,6 +1035,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "_links": {
                                 "allowedValues": {
                                     "href": "/api/v3/work_packages?filters=%5B%7B%22project%22%3A%7B%22operator%22%3A%22%3D%22%2C%22values%22%3A%5B%221%22%5D%7D%7D%5D"
@@ -1040,6 +1048,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "_links": {
                                 "allowedValues": {
                                     "href": "/api/v3/time_entries/available_projects"
@@ -1052,6 +1061,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": true,
                             "hasDefault": true,
                             "writable": true,
+                            "location": "_links",
                             "_embedded": {
                                 "allowedValues": [
                                     {

--- a/docs/api/apiv3/endpoints/users.apib
+++ b/docs/api/apiv3/endpoints/users.apib
@@ -700,7 +700,8 @@ Lists users. Only administrators or users with manage_user global permission hav
             "name": "User List cf",
             "required": false,
             "hasDefault": false,
-            "writable": true
+            "writable": true,
+            "location": "_links"
           },
           "_links": {
             "self": {
@@ -882,6 +883,7 @@ For more details and all possible responses see the general specification of [Fo
                 "required": false,
                 "hasDefault": false,
                 "writable": true,
+                "location": "_links",
                 "visibility": "default",
                 "_embedded": {
                   "allowedValues": [{
@@ -1148,6 +1150,7 @@ For more details and all possible responses see the general specification of [Fo
                 "required": false,
                 "hasDefault": false,
                 "writable": true,
+                "location": "_links",
                 "visibility": "default",
                 "_embedded": {
                   "allowedValues": [{

--- a/docs/api/apiv3/endpoints/versions.apib
+++ b/docs/api/apiv3/endpoints/versions.apib
@@ -491,6 +491,7 @@ You can use the form and schema to be retrieve the valid attribute values and by
                     "required": false,
                     "hasDefault": false,
                     "writable": true,
+                    "location": "_links",
                     "visibility": "default",
                     "_links": {}
                 },
@@ -671,6 +672,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": true,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "_embedded": {
                                 "allowedValues": [
                                     {
@@ -709,6 +711,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "visibility": "default",
                             "_embedded": {
                                 "allowedValues": [
@@ -973,6 +976,7 @@ For more details and all possible responses see the general specification of [Fo
                             "required": false,
                             "hasDefault": false,
                             "writable": true,
+                            "location": "_links",
                             "visibility": "default",
                             "_embedded": {
                                 "allowedValues": [

--- a/lib/api/decorators/allowed_values_by_collection_representer.rb
+++ b/lib/api/decorators/allowed_values_by_collection_representer.rb
@@ -43,6 +43,7 @@ module API
                      name:,
                      value_representer:,
                      link_factory:,
+                     location: :link,
                      required: true,
                      has_default: false,
                      writable: true,
@@ -59,6 +60,7 @@ module API
               has_default: has_default,
               writable: writable,
               attribute_group: attribute_group,
+              location: location,
               current_user: current_user)
       end
 

--- a/lib/api/decorators/property_schema_representer.rb
+++ b/lib/api/decorators/property_schema_representer.rb
@@ -35,7 +35,7 @@ module API
   module Decorators
     class PropertySchemaRepresenter < ::API::Decorators::Single
       def initialize(
-        type:, name:, required: true, has_default: false, writable: true,
+        type:, name:, location: nil, required: true, has_default: false, writable: true,
         attribute_group: nil, current_user: nil
       )
         @type = type
@@ -44,6 +44,7 @@ module API
         @has_default = has_default
         @writable = writable
         @attribute_group = attribute_group
+        @location = derive_location(location)
 
         super(nil, current_user: current_user)
       end
@@ -57,7 +58,8 @@ module API
                     :min_length,
                     :max_length,
                     :regular_expression,
-                    :options
+                    :options,
+                    :location
 
       property :type, exec_context: :decorator
       property :name, exec_context: :decorator
@@ -70,11 +72,25 @@ module API
       property :regular_expression, exec_context: :decorator
       property :options, exec_context: :decorator
 
+      property :location, exec_context: :decorator, render_nil: false
+
       private
 
       def model_required?
         # we never pass a model to our superclass
         false
+      end
+
+      ##
+      # Derive the frontend location value to be passed
+      # either nil, _links, or _meta depending on the input
+      def derive_location(location)
+        return if location.nil?
+
+        return :_links if location.to_s == 'link'
+        return :_meta if location.to_s == 'meta'
+
+        raise ArgumentError, "Invalid location attribute #{location}"
       end
     end
   end

--- a/lib/api/decorators/schema_representer.rb
+++ b/lib/api/decorators/schema_representer.rb
@@ -56,6 +56,7 @@ module API
                    type:,
                    name_source: property,
                    as: camelize(property),
+                   location: nil,
                    required: true,
                    has_default: false,
                    writable: default_writable_property(property),
@@ -75,7 +76,8 @@ module API
                                    min_length,
                                    max_length,
                                    regular_expression,
-                                   options)
+                                   options,
+                                   location)
           end
 
           schema_property(property,
@@ -287,11 +289,13 @@ module API
                                  min_length,
                                  max_length,
                                  regular_expression,
-                                 options)
+                                 options,
+                                 location)
         name = call_or_translate(name_source)
         schema = ::API::Decorators::PropertySchemaRepresenter
                  .new(type: call_or_use(type),
                       name: name,
+                      location: location,
                       required: call_or_use(required),
                       has_default: call_or_use(has_default),
                       writable: call_or_use(writable),
@@ -314,6 +318,7 @@ module API
         representer = ::API::Decorators::AllowedValuesByLinkRepresenter
                       .new(type: call_or_use(type),
                            name: call_or_translate(name_source),
+                           location: :link,
                            required: call_or_use(required),
                            has_default: call_or_use(has_default),
                            writable: call_or_use(writable),

--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -77,6 +77,7 @@ module API
 
           schema :user,
                  type: 'User',
+                 location: :link,
                  has_default: true
 
           schema_with_allowed_link :project,

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -180,6 +180,7 @@ module API
 
           schema :author,
                  type: 'User',
+                 location: :link,
                  writable: false
 
           schema_with_allowed_link :project,
@@ -202,6 +203,7 @@ module API
 
           schema :parent,
                  type: 'WorkPackage',
+                 location: :link,
                  required: false,
                  writable: true
 

--- a/modules/costs/lib/api/v3/time_entries/schemas/time_entry_schema_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/schemas/time_entry_schema_representer.rb
@@ -54,7 +54,8 @@ module API
                  type: 'Duration'
 
           schema :user,
-                 type: 'User'
+                 type: 'User',
+                 location: :link
 
           schema :comment,
                  type: 'Formattable',

--- a/modules/costs/spec/lib/api/v3/time_entries/schemas/time_entry_schema_representer_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/schemas/time_entry_schema_representer_spec.rb
@@ -156,6 +156,7 @@ describe ::API::V3::TimeEntries::Schemas::TimeEntrySchemaRepresenter do
         let(:name) { TimeEntry.human_attribute_name('user') }
         let(:required) { true }
         let(:writable) { false }
+        let(:location) { '_links' }
       end
     end
 
@@ -167,6 +168,7 @@ describe ::API::V3::TimeEntries::Schemas::TimeEntrySchemaRepresenter do
         let(:name) { TimeEntry.human_attribute_name('work_package') }
         let(:required) { false }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
 
       context 'if embedding' do
@@ -203,6 +205,7 @@ describe ::API::V3::TimeEntries::Schemas::TimeEntrySchemaRepresenter do
         let(:has_default) { true }
         let(:required) { true }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
 
       context 'if embedding' do
@@ -221,6 +224,7 @@ describe ::API::V3::TimeEntries::Schemas::TimeEntrySchemaRepresenter do
           let(:name) { TimeEntry.human_attribute_name('project') }
           let(:required) { false }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         context 'if embedding' do

--- a/modules/grids/spec/lib/api/v3/grids/schemas/grid_schema_representer_spec.rb
+++ b/modules/grids/spec/lib/api/v3/grids/schemas/grid_schema_representer_spec.rb
@@ -148,6 +148,7 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
         let(:name) { Grids::Grid.human_attribute_name('widgets') }
         let(:required) { true }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
 
       context 'when embedding' do
@@ -181,6 +182,7 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
           let(:name) { Grids::Grid.human_attribute_name('scope') }
           let(:required) { true }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         context 'when embedding' do
@@ -217,6 +219,7 @@ describe ::API::V3::Grids::Schemas::GridSchemaRepresenter do
           let(:name) { Grids::Grid.human_attribute_name('scope') }
           let(:required) { true }
           let(:writable) { false }
+          let(:location) { '_links' }
         end
 
         context 'when embedding' do

--- a/spec/lib/api/v3/memberships/schemas/membership_schema_representer_spec.rb
+++ b/spec/lib/api/v3/memberships/schemas/membership_schema_representer_spec.rb
@@ -129,6 +129,7 @@ describe ::API::V3::Memberships::Schemas::MembershipSchemaRepresenter do
           let(:name) { Member.human_attribute_name('project') }
           let(:required) { false }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         context 'if embedding' do
@@ -170,6 +171,7 @@ describe ::API::V3::Memberships::Schemas::MembershipSchemaRepresenter do
           let(:name) { Version.human_attribute_name('project') }
           let(:required) { false }
           let(:writable) { false }
+          let(:location) { '_links' }
         end
 
         context 'if embedding' do
@@ -189,6 +191,7 @@ describe ::API::V3::Memberships::Schemas::MembershipSchemaRepresenter do
           let(:name) { Version.human_attribute_name('principal') }
           let(:required) { true }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         context 'if embedding' do
@@ -237,6 +240,7 @@ describe ::API::V3::Memberships::Schemas::MembershipSchemaRepresenter do
           let(:name) { Version.human_attribute_name('principal') }
           let(:required) { true }
           let(:writable) { false }
+          let(:location) { '_links' }
         end
 
         context 'if embedding' do
@@ -255,6 +259,7 @@ describe ::API::V3::Memberships::Schemas::MembershipSchemaRepresenter do
         let(:name) { Version.human_attribute_name('role') }
         let(:required) { true }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
 
       context 'if embedding' do

--- a/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
+++ b/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
@@ -243,6 +243,7 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
           let(:name) { Project.human_attribute_name('parent') }
           let(:required) { false }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         context 'if embedding' do
@@ -270,6 +271,7 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
           let(:name) { Project.human_attribute_name('parent') }
           let(:required) { false }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         context 'if embedding' do

--- a/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
@@ -115,6 +115,7 @@ describe ::API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter, clea
           let(:name) { Query.human_attribute_name('filter') }
           let(:required) { true }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         it_behaves_like 'does not link to allowed values'
@@ -144,6 +145,7 @@ describe ::API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter, clea
           let(:name) { Query.human_attribute_name('operator') }
           let(:required) { true }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         it_behaves_like 'does not link to allowed values'

--- a/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_schema_representer_spec.rb
@@ -161,6 +161,7 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:required) { true }
           let(:writable) { false }
           let(:has_default) { true }
+          let(:location) { '_links' }
         end
       end
 
@@ -172,6 +173,7 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:name) { Query.human_attribute_name('project') }
           let(:required) { false }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         it_behaves_like 'does not link to allowed values'
@@ -329,6 +331,7 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:required) { false }
           let(:writable) { true }
           let(:has_default) { true }
+          let(:location) { '_links' }
         end
 
         it_behaves_like 'does not link to allowed values'
@@ -375,6 +378,7 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:required) { false }
           let(:writable) { true }
           let(:has_default) { true }
+          let(:location) { '_links' }
         end
 
         it_behaves_like 'does not link to allowed values'
@@ -441,6 +445,7 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:name) { Query.human_attribute_name('group_by') }
           let(:required) { false }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         it_behaves_like 'does not link to allowed values'
@@ -473,6 +478,7 @@ describe ::API::V3::Queries::Schemas::QuerySchemaRepresenter do
           let(:required) { false }
           let(:writable) { true }
           let(:has_default) { true }
+          let(:location) { '_links' }
         end
 
         it_behaves_like 'does not link to allowed values'

--- a/spec/lib/api/v3/support/api_v3_filter_dependency.rb
+++ b/spec/lib/api/v3/support/api_v3_filter_dependency.rb
@@ -32,6 +32,7 @@ shared_examples_for 'filter dependency' do
     let(:required) { true }
     let(:writable) { true }
     let(:has_default) { false }
+    let(:location) { '_links' }
   end
 
   it_behaves_like 'does not link to allowed values'
@@ -49,6 +50,7 @@ shared_examples_for 'filter dependency with allowed link' do
     let(:required) { true }
     let(:writable) { true }
     let(:has_default) { false }
+    let(:location) { '_links' }
   end
 
   it_behaves_like 'does not link to allowed values'
@@ -66,6 +68,7 @@ shared_examples_for 'filter dependency with allowed value link collection' do
     let(:required) { true }
     let(:writable) { true }
     let(:has_default) { false }
+    let(:location) { '_links' }
   end
 
   it_behaves_like 'does not link to allowed values'

--- a/spec/lib/api/v3/support/schema_examples.rb
+++ b/spec/lib/api/v3/support/schema_examples.rb
@@ -60,6 +60,16 @@ shared_examples_for 'has basic schema properties' do
       .to be_json_eql(expected_has_default.to_json)
       .at_path("#{path}/hasDefault")
   end
+
+  it 'indicates if it has a location' do
+    if defined?(location)
+      is_expected
+        .to be_json_eql(location.to_json)
+              .at_path("#{path}/location")
+    else
+      is_expected.not_to have_json_path("#{path}/location")
+    end
+  end
 end
 
 shared_examples_for 'indicates length requirements' do

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -152,6 +152,7 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
         let(:name) { custom_field.name }
         let(:required) { true }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
 
       it_behaves_like 'links to allowed values directly' do
@@ -192,6 +193,7 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
         let(:name) { custom_field.name }
         let(:required) { true }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
 
       it_behaves_like 'links to and embeds allowed values directly' do
@@ -217,6 +219,7 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
         let(:name) { custom_field.name }
         let(:required) { true }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
 
       it_behaves_like 'links to allowed values via collection link' do

--- a/spec/lib/api/v3/versions/schemas/version_schema_representer_spec.rb
+++ b/spec/lib/api/v3/versions/schemas/version_schema_representer_spec.rb
@@ -191,6 +191,7 @@ describe ::API::V3::Versions::Schemas::VersionSchemaRepresenter do
           let(:name) { Version.human_attribute_name('project') }
           let(:required) { true }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         context 'if embedding' do
@@ -218,6 +219,7 @@ describe ::API::V3::Versions::Schemas::VersionSchemaRepresenter do
           let(:name) { Version.human_attribute_name('project') }
           let(:required) { true }
           let(:writable) { false }
+          let(:location) { '_links' }
         end
 
         context 'if embedding' do
@@ -236,6 +238,7 @@ describe ::API::V3::Versions::Schemas::VersionSchemaRepresenter do
         let(:name) { Version.human_attribute_name('status') }
         let(:required) { true }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
 
       it 'contains no link to the allowed values' do
@@ -260,6 +263,7 @@ describe ::API::V3::Versions::Schemas::VersionSchemaRepresenter do
         let(:name) { Version.human_attribute_name('sharing') }
         let(:required) { true }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
 
       it 'contains no link to the allowed values' do

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -644,6 +644,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:name) { I18n.t('attributes.author') }
         let(:required) { true }
         let(:writable) { false }
+        let(:location) { '_links' }
       end
     end
 
@@ -657,6 +658,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:name) { I18n.t('attributes.project') }
           let(:required) { true }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
       end
 
@@ -669,6 +671,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:name) { I18n.t('attributes.project') }
           let(:required) { true }
           let(:writable) { false }
+          let(:location) { '_links' }
         end
       end
 
@@ -725,6 +728,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:name) { I18n.t('activerecord.attributes.work_package.parent') }
         let(:required) { false }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
     end
 
@@ -735,6 +739,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:name) { I18n.t('activerecord.attributes.work_package.type') }
         let(:required) { true }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
 
       it_behaves_like 'has a collection of allowed values' do
@@ -752,6 +757,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:required) { true }
         let(:writable) { true }
         let(:has_default) { true }
+        let(:location) { '_links' }
       end
 
       it_behaves_like 'has a collection of allowed values' do
@@ -768,6 +774,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:name) { I18n.t('attributes.category') }
         let(:required) { false }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
 
       it_behaves_like 'has a collection of allowed values' do
@@ -787,6 +794,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:name) { I18n.t('activerecord.attributes.work_package.version') }
           let(:required) { false }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         it_behaves_like 'has a collection of allowed values' do
@@ -805,6 +813,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:name) { I18n.t('activerecord.attributes.work_package.version') }
           let(:required) { false }
           let(:writable) { false }
+          let(:location) { '_links' }
         end
       end
     end
@@ -821,6 +830,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:required) { true }
         let(:writable) { true }
         let(:has_default) { true }
+        let(:location) { '_links' }
       end
 
       it_behaves_like 'has a collection of allowed values' do
@@ -841,6 +851,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:required) { true }
           let(:writable) { false }
           let(:has_default) { true }
+          let(:location) { '_links' }
         end
       end
     end
@@ -855,6 +866,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:name) { I18n.t('attributes.assigned_to') }
           let(:required) { false }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         it_behaves_like 'links to allowed values via collection link' do
@@ -888,6 +900,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:name) { I18n.t('attributes.responsible') }
           let(:required) { false }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         it_behaves_like 'links to allowed values via collection link' do
@@ -925,6 +938,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
           let(:name) { I18n.t('attributes.budget') }
           let(:required) { false }
           let(:writable) { true }
+          let(:location) { '_links' }
         end
 
         it_behaves_like 'has a collection of allowed values' do


### PR DESCRIPTION
Extends the `schema` property helper with a `location` flag and automatically derives that for linked/collection schema attributes.

https://community.openproject.org/projects/openproject/work_packages/36791