### PR TITLE
Avoid logging with log delegator in migrations

### DIFF
--- a/config/initializers/log_slow_sql_queries.rb
+++ b/config/initializers/log_slow_sql_queries.rb
@@ -2,6 +2,9 @@ OpenProject::Application.configure do
   config.after_initialize do
     next if Rails.env.test?
 
+    # Avoid running this on migrations or when the database is incomplete
+    next if OpenProject::Database.migrations_pending?
+
     slow_sql_threshold = OpenProject::Configuration.sql_slow_query_threshold.to_i
     next if slow_sql_threshold == 0
 


### PR DESCRIPTION
If the slow log catches during migrations, accessing something like
User.current will fail as not all tables are defined yet.

https://app.hubspot.com/live-messages/5842801/inbox/938923930#comment-editor