### PR TITLE
Fix SqlBypass sessions reusing the same connection

### DIFF
--- a/app/models/sessions/sql_bypass.rb
+++ b/app/models/sessions/sql_bypass.rb
@@ -109,7 +109,6 @@ module Sessions
       SQL
     end
 
-
     def update!
       connection.update <<~SQL, 'Update session'
         UPDATE sessions
@@ -126,7 +125,7 @@ module Sessions
       uid = user_id
       return unless uid && OpenProject::Configuration.drop_old_sessions_on_logout?
 
-      ::Sessions::ActiveRecord.for_user(uid).delete_all
+      ::Sessions::UserSession.for_user(uid).delete_all
     end
   end
 end

--- a/app/models/sessions/sql_bypass.rb
+++ b/app/models/sessions/sql_bypass.rb
@@ -57,16 +57,18 @@ module Sessions
         end
       end
 
-      ##
-      # Ensure we're not memoizing the connection
-      def connection
-        ::ActiveRecord::Base.connection
-      end
-
       def connection_pool
         ::ActiveRecord::Base.connection_pool
       end
+
+      def connection
+        ::ActiveRecord::Base.connection
+      end
     end
+
+    # Ensure we use our own class methods for delegation of the connection
+    # otherwise the memoized superclass is being used
+    delegate :connection, :connection_pool, to: :class
 
     ##
     # Save while updating the user_id reference and updated_at column
@@ -106,6 +108,7 @@ module Sessions
         )
       SQL
     end
+
 
     def update!
       connection.update <<~SQL, 'Update session'

--- a/app/models/sessions/user_session.rb
+++ b/app/models/sessions/user_session.rb
@@ -32,7 +32,7 @@
 # An AR helper class to access sessions, but not create them.
 # You can still use AR methods to delete records however.
 module Sessions
-  class ActiveRecord < ::ApplicationRecord
+  class UserSession < ::ApplicationRecord
     self.table_name = 'sessions'
 
     scope :for_user, ->(user) do

--- a/app/services/sessions/drop_other_sessions_service.rb
+++ b/app/services/sessions/drop_other_sessions_service.rb
@@ -38,7 +38,7 @@ module Sessions
       def call(user, session)
         return false unless active_record_sessions?
 
-        ::Sessions::ActiveRecord
+        ::Sessions::UserSession
           .for_user(user)
           .where.not(session_id: session.id.private_id)
           .delete_all

--- a/app/services/sessions/initialize_session_service.rb
+++ b/app/services/sessions/initialize_session_service.rb
@@ -42,7 +42,7 @@ module Sessions
 
         if drop_old_sessions?
           Rails.logger.info { "Deleting all other sessions for #{user}." }
-          ::Sessions::ActiveRecord.for_user(user).delete_all
+          ::Sessions::UserSession.for_user(user).delete_all
         end
 
         ServiceResult.new(success: true, result: session)

--- a/spec/features/security/expire_sessions_spec.rb
+++ b/spec/features/security/expire_sessions_spec.rb
@@ -44,16 +44,16 @@ describe 'Expire old user sessions',
   describe 'logging in again' do
     context 'with drop_old_sessions enabled', with_config: { drop_old_sessions_on_login: true } do
       it 'destroys the old session' do
-        expect(::Sessions::ActiveRecord.count).to eq(1)
+        expect(::Sessions::UserSession.count).to eq(1)
 
-        first_session = ::Sessions::ActiveRecord.first
+        first_session = ::Sessions::UserSession.first
         expect(first_session.user_id).to eq(admin.id)
 
         # Actually login now
         login_with(admin.login, admin_password)
 
-        expect(::Sessions::ActiveRecord.count).to eq(1)
-        second_session = ::Sessions::ActiveRecord.first
+        expect(::Sessions::UserSession.count).to eq(1)
+        second_session = ::Sessions::UserSession.first
 
         expect(second_session.user_id).to eq(admin.id)
         expect(second_session.session_id).not_to eq(first_session.session_id)
@@ -65,7 +65,7 @@ describe 'Expire old user sessions',
         # Actually login now
         login_with(admin.login, admin_password)
 
-        expect(::Sessions::ActiveRecord.for_user(admin).count).to eq(2)
+        expect(::Sessions::UserSession.for_user(admin).count).to eq(2)
       end
     end
   end
@@ -74,23 +74,23 @@ describe 'Expire old user sessions',
     before do
       # Actually login now
       login_with(admin.login, admin_password)
-      expect(::Sessions::ActiveRecord.for_user(admin).count).to eq(2)
+      expect(::Sessions::UserSession.for_user(admin).count).to eq(2)
       visit '/logout'
     end
 
     context 'with drop_old_sessions enabled', with_config: { drop_old_sessions_on_logout: true } do
       it 'destroys the old session' do
         # A fresh session is opened due to reset_session
-        expect(::Sessions::ActiveRecord.for_user(admin).count).to eq(0)
-        expect(::Sessions::ActiveRecord.non_user.count).to eq(1)
+        expect(::Sessions::UserSession.for_user(admin).count).to eq(0)
+        expect(::Sessions::UserSession.non_user.count).to eq(1)
       end
     end
 
     context 'with drop_old_sessions disabled',
             with_config: { drop_old_sessions_on_logout: false } do
       it 'keeps the old session' do
-        expect(::Sessions::ActiveRecord.count).to eq(2)
-        expect(::Sessions::ActiveRecord.for_user(admin).count).to eq(1)
+        expect(::Sessions::UserSession.count).to eq(2)
+        expect(::Sessions::UserSession.for_user(admin).count).to eq(1)
       end
     end
   end

--- a/spec/features/users/my_spec.rb
+++ b/spec/features/users/my_spec.rb
@@ -48,7 +48,7 @@ describe 'my',
     expect(page).to have_content I18n.t(:notice_account_other_session_expired)
 
     # expect session to be removed
-    expect(::Sessions::ActiveRecord.for_user(user).where(session_id: 'other').count).to eq 0
+    expect(::Sessions::UserSession.for_user(user).where(session_id: 'other').count).to eq 0
 
     user.reload
     expect(user.mail).to eq 'foo@mail.com'
@@ -62,7 +62,7 @@ describe 'my',
     session = ::Sessions::SqlBypass.new data: { user_id: user.id }, session_id: 'other'
     session.save
 
-    expect(::Sessions::ActiveRecord.for_user(user).where(session_id: 'other').count).to eq 1
+    expect(::Sessions::UserSession.for_user(user).where(session_id: 'other').count).to eq 1
   end
 
   context 'user' do

--- a/spec/features/users/password_change_spec.rb
+++ b/spec/features/users/password_change_spec.rb
@@ -91,13 +91,13 @@ describe 'random password generation',
       session = ::Sessions::SqlBypass.new data: { user_id: user.id }, session_id: 'other'
       session.save
 
-      expect(::Sessions::ActiveRecord.for_user(user.id).count).to be >= 1
+      expect(::Sessions::UserSession.for_user(user.id).count).to be >= 1
 
       click_on 'Save'
       expect(page).to have_selector('.flash.notice', text: I18n.t(:notice_account_password_updated))
 
       # The old session is removed
-      expect(::Sessions::ActiveRecord.find_by(session_id: 'other')).to be_nil
+      expect(::Sessions::UserSession.find_by(session_id: 'other')).to be_nil
 
       # Logout and sign in with outdated password
       visit signout_path

--- a/spec/models/sessions/active_record_sessions_spec.rb
+++ b/spec/models/sessions/active_record_sessions_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::Sessions::ActiveRecord do
+describe ::Sessions::UserSession do
   subject { described_class.new session_id: 'foo' }
 
   describe '#save' do

--- a/spec/models/sessions/sql_bypass_sessions_spec.rb
+++ b/spec/models/sessions/sql_bypass_sessions_spec.rb
@@ -57,21 +57,21 @@ describe ::Sessions::SqlBypass do
     context 'when config is enabled',
             with_config: { drop_old_sessions_on_logout: true } do
       it 'destroys both sessions' do
-        expect(::Sessions::ActiveRecord.for_user(user).count).to eq(2)
+        expect(::Sessions::UserSession.for_user(user).count).to eq(2)
         sessions.first.destroy
 
-        expect(::Sessions::ActiveRecord.count).to eq(0)
+        expect(::Sessions::UserSession.count).to eq(0)
       end
     end
 
     context 'when config is disabled',
             with_config: { drop_old_sessions_on_logout: false } do
       it 'destroys only the one session' do
-        expect(::Sessions::ActiveRecord.for_user(user).count).to eq(2)
+        expect(::Sessions::UserSession.for_user(user).count).to eq(2)
         sessions.first.destroy
 
-        expect(::Sessions::ActiveRecord.count).to eq(1)
-        expect(::Sessions::ActiveRecord.first.session_id).to eq(sessions[1].session_id)
+        expect(::Sessions::UserSession.count).to eq(1)
+        expect(::Sessions::UserSession.first.session_id).to eq(sessions[1].session_id)
       end
     end
   end


### PR DESCRIPTION
Due to `delegate ... :self`, the superclass memoized method is still used. This PR fixes that and also renames the AR class to UserSession to avoid any confusions with the AR superclass