### PR TITLE
Add step for quick add menu to onboarding tour

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -506,6 +506,7 @@ en:
         help_menu: 'In the <b>Help</b> menu you will find a user guide and additional help resources. <br> Enjoy your work with OpenProject!'
         members: 'Invite new <b>Members</b> to join your project.'
         project_selection: 'Please click on one of the projects with useful demo data to get started. <br> The <b>Demo project</b> suits best for classical project management, while the <b>Scrum project</b> is better for Agile project management.'
+        quick_add_button: 'Create a new project or invite coworkers.'
         sidebar_arrow: "With the arrow you can navigate back to the project's <b>Main menu</b>."
         welcome: 'Take a three minutes introduction tour to learn the most <b>important features</b>. <br> We recommend completing the steps until the end. You can restart the tour any time.'
         wiki: 'Within the <b>Wiki</b> you can document and share knowledge together with your team.'

--- a/frontend/src/app/globals/onboarding/tours/menu_tour.ts
+++ b/frontend/src/app/globals/onboarding/tours/menu_tour.ts
@@ -11,6 +11,11 @@ export function menuTourSteps() {
       'nextButton': { text: I18n.t('js.onboarding.buttons.next') },
     },
     {
+      'next .op-quick-add-menu': I18n.t('js.onboarding.steps.quick_add_button'),
+      'showSkip': false,
+      'nextButton': { text: I18n.t('js.onboarding.buttons.next') },
+    },
+    {
       'next .op-app-help': I18n.t('js.onboarding.steps.help_menu'),
       'shape': 'circle',
       'showSkip': false,

--- a/spec/support/onboarding_helper.rb
+++ b/spec/support/onboarding_helper.rb
@@ -61,6 +61,9 @@ module OnboardingHelper
     expect(page).to have_text 'Within the Wiki you can document and share knowledge together with your team.'
 
     next_button.click
+    expect(page).to have_text 'Create a new project or invite coworkers.'
+
+    next_button.click
     expect(page).to have_text 'In the Help menu you will find a user guide and additional help resources.'
 
     next_button.click


### PR DESCRIPTION
Add a step for the quick add menu to the onboarding tour. Added a step between the wiki and the help steps.
 
![image](https://user-images.githubusercontent.com/327272/114723052-9f3a6380-9d3a-11eb-82af-a22d95f45f0d.png)

https://community.openproject.org/wp/36593