### PR TITLE
[36764] Fix margins of table when sums and/or inline create showing

### DIFF
--- a/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/components/wp-inline-create/wp-inline-create.component.ts
@@ -34,7 +34,8 @@ import {
   HostListener,
   Injector,
   Input,
-  OnInit
+  EventEmitter,
+  OnInit, Output
 } from '@angular/core';
 import {AuthorisationService} from 'core-app/modules/common/model-auth/model-auth.service';
 import {WorkPackageViewFocusService} from 'core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-focus.service';
@@ -67,6 +68,8 @@ export class WorkPackageInlineCreateComponent extends UntilDestroyedMixin implem
 
   @Input('wp-inline-create--table') table:WorkPackageTable;
   @Input('wp-inline-create--project-identifier') projectIdentifier:string;
+
+  @Output('wp-inline-create--showing') showing = new EventEmitter<boolean>();
 
   // inner state
   public canAdd:boolean = false;
@@ -117,12 +120,7 @@ export class WorkPackageInlineCreateComponent extends UntilDestroyedMixin implem
         this.canAdd = this.wpInlineCreate.canAdd;
         this.cdRef.detectChanges();
 
-        if (this.canAdd || this.canReference) {
-          // Add this row's height as a padding to the timeline
-          // so the table and the timeline keep aligned
-          const container = jQuery(this.table.timelineBody);
-          container.addClass('-inline-create-mirror');
-        }
+        this.showing.emit(this.canAdd || this.canReference);
       });
 
     // Register callback on newly created work packages

--- a/frontend/src/app/components/wp-table/wp-table-scroll-sync.ts
+++ b/frontend/src/app/components/wp-table/wp-table-scroll-sync.ts
@@ -74,7 +74,7 @@ function syncWheelEvent(jev: JQuery.TriggeredEvent, elementTable: JQuery, elemen
 
   window.requestAnimationFrame(function () {
     elementTable[0].scrollTop = elementTable[0].scrollTop + deltaY;
-    elementTimeline[0].scrollTop = elementTimeline[0].scrollTop + deltaY;
+    elementTimeline[0].scrollTop = elementTable[0].scrollTop + deltaY;
 
     scrollTarget.scrollLeft = scrollTarget.scrollLeft + deltaX;
   });

--- a/frontend/src/app/components/wp-table/wp-table.component.ts
+++ b/frontend/src/app/components/wp-table/wp-table.component.ts
@@ -60,6 +60,7 @@ import {WorkPackageTimelineTableController} from "core-components/wp-table/timel
 import {WorkPackageTable} from "core-components/wp-fast-table/wp-fast-table";
 import {WorkPackageViewTimelineService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-timeline.service";
 import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
+import {WorkPackageViewSumService} from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-sum.service";
 
 export interface WorkPackageFocusContext {
   /** Work package that was focused */
@@ -122,6 +123,11 @@ export class WorkPackagesTableComponent extends UntilDestroyedMixin implements O
 
   public limitedResults = false;
 
+  // We need to sync certain height difference to the timeline
+  // depending on whether inline create or sums rows are being shown
+  public inlineCreateVisible = false;
+  public sumVisible = false;
+
   constructor(readonly elementRef:ElementRef,
               readonly injector:Injector,
               readonly states:States,
@@ -132,7 +138,9 @@ export class WorkPackagesTableComponent extends UntilDestroyedMixin implements O
               readonly wpTableGroupBy:WorkPackageViewGroupByService,
               readonly wpTableTimeline:WorkPackageViewTimelineService,
               readonly wpTableColumns:WorkPackageViewColumnsService,
-              readonly wpTableSortBy:WorkPackageViewSortByService) {
+              readonly wpTableSortBy:WorkPackageViewSortByService,
+              readonly wpTableSums:WorkPackageViewSumService,
+  ) {
     super();
   }
 
@@ -167,15 +175,17 @@ export class WorkPackagesTableComponent extends UntilDestroyedMixin implements O
       this.wpTableGroupBy.live$(),
       this.wpTableColumns.live$(),
       this.wpTableTimeline.live$(),
-      this.wpTableSortBy.live$()
+      this.wpTableSortBy.live$(),
+      this.wpTableSums.live$()
     ]);
 
     statesCombined.pipe(
       this.untilDestroyed()
-    ).subscribe(([results, groupBy, columns, timelines, sort]) => {
+    ).subscribe(([results, groupBy, columns, timelines, sort, sums]) => {
       this.query = this.querySpace.query.value!;
 
       this.results = results;
+      this.sumVisible = sums;
 
       this.groupBy = groupBy;
       this.columns = columns;

--- a/frontend/src/app/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/components/wp-table/wp-table.directive.html
@@ -67,7 +67,9 @@
       <tbody *ngIf="tableElement && configuration.inlineCreateEnabled"
              wpInlineCreate
              [wp-inline-create--table]="workPackageTable"
-             [wp-inline-create--project-identifier]="projectIdentifier">
+             [wp-inline-create--project-identifier]="projectIdentifier"
+             (wp-inline-create--showing)="inlineCreateVisible = $event"
+      >
       </tbody>
     </table>
   </div>
@@ -79,7 +81,8 @@
                 [localStorageKey]="'openProject-timelineFlexBasis'"></wp-resizer>
   </div>
 
-  <div class="work-packages-tabletimeline--timeline-side">
+  <div class="work-packages-tabletimeline--timeline-side"
+       [ngClass]="{ '-single-margin': (sumVisible || inlineCreateVisible) && !(sumVisible && inlineCreateVisible), '-double-margin': sumVisible && inlineCreateVisible }">
     <wp-timeline-container></wp-timeline-container>
   </div>
 </div>

--- a/frontend/src/global_styles/content/work_packages/timelines/_timelines.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/_timelines.sass
@@ -77,17 +77,19 @@
     display: none
 
 // Add margin (row's height) to the timeline on split view
-// to compensate the 'wpTableSumsRow' row that the work
+// to compensate either of 'wpTableSumsRow' or 'wpInlineCreate' row that the work
 // packages table has. If not, when scrolling down the last
 // rows are misaligned.
-.wp-table-timeline--body
-  margin-bottom: var(--table-timeline--row-height)
+.work-packages-tabletimeline--timeline-side
+  // Only one of the rows visible
+  &.-single-margin
+    .wp-table-timeline--body
+      margin-bottom: var(--table-timeline--row-height)
 
-// Add an extra margin (row's height) to the timeline when the
-// wpInlineCreate row is shown in work packages table. If not, when
-// scrolling down the last rows are misaligned.
-.wp-table-timeline--body.-inline-create-mirror
-  margin-bottom: calc(var(--table-timeline--row-height) * 2)
+  // Both rows visible
+  &.-double-margin
+    .wp-table-timeline--body
+      margin-bottom: calc(var(--table-timeline--row-height) * 2)
 
 .children-duration-bar
   position: absolute


### PR DESCRIPTION
This ways, they cannot get out of sync. They should always have the same height anyway (which they do in my testing) but for some reason the delta gets applied to the timeline which results in it being able to overshoot the height of the table.

https://community.openproject.org/wp/36764