### PR TITLE
Remove duplicate not_locked scope

### DIFF
--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -32,12 +32,13 @@ class Principal < ApplicationRecord
   include ::Scopes::Scoped
 
   # Account statuses
+  # Disables enum scopes to include not_builtin (cf. Principals::Scopes::Status)
   enum status: {
     active: 1,
     registered: 2,
     locked: 3,
     invited: 4
-  }.freeze
+  }.freeze, _scopes: false
 
   self.table_name = "#{table_name_prefix}users#{table_name_suffix}"
 
@@ -63,11 +64,8 @@ class Principal < ApplicationRecord
          :possible_assignee,
          :possible_member,
          :user,
-         :ordered_by_name
-
-  scope :not_locked, -> {
-    not_builtin.where.not(status: statuses[:locked])
-  }
+         :ordered_by_name,
+         :status
 
   scope :in_project, ->(project) {
     where(id: Member.of(project).select(:user_id))

--- a/app/models/principals/scopes/status.rb
+++ b/app/models/principals/scopes/status.rb
@@ -1,0 +1,52 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+# Creates scopes for the :status enums but ensuring that not_builtin is used at the same time
+# Excludes
+#   * DeletedUser
+#   * SystemUser
+#   * AnonymousUser
+module Principals::Scopes
+  module Status
+    extend ActiveSupport::Concern
+
+    included do
+      statuses.each do |key, val|
+        define_singleton_method(key) do
+          not_builtin.where(status: val)
+        end
+
+        define_singleton_method("not_#{key}") do
+          not_builtin.where.not(status: val)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/open_project/enterprise_spec.rb
+++ b/spec/lib/open_project/enterprise_spec.rb
@@ -32,7 +32,6 @@ require 'open_project/passwords'
 describe OpenProject::Enterprise do
   describe "#user_limit_reached?" do
     let(:user_limit) { 2 }
-    let(:builtin_user_count) { 2 }
     # create 3 built-in users, only 2 of which are active
     # Also create a placeholder user which will not count against the limit
     let!(:system_user) { User.system }
@@ -50,7 +49,7 @@ describe OpenProject::Enterprise do
       before do
         FactoryBot.create :user
 
-        expect(User.active.count).to eq 1 + builtin_user_count # created user + built-in ones
+        expect(User.active.count).to eq 1 # created user
       end
 
       it "is false" do
@@ -65,7 +64,7 @@ describe OpenProject::Enterprise do
         before do
           FactoryBot.create_list :user, num_active_users
 
-          expect(User.active.count).to eq num_active_users + builtin_user_count
+          expect(User.active.count).to eq num_active_users
         end
 
         it "is true" do


### PR DESCRIPTION
The enum has negative scopes since Rails 6, so not_locked gets

added in https://github.com/opf/openproject/blob/dev/app/models/principal.rb#L35-L40  due to the enum already.