### PR TITLE
Better database connection check

### DIFF
--- a/packaging/scripts/check
+++ b/packaging/scripts/check
@@ -11,10 +11,10 @@ log_ko() {
 }
 
 # try to get a setting to make sure database connection works
-if rake setting:get[protocol] &>/dev/null; then
-  log_ok "MySQL configuration is working"
+if rake openproject:db:check_connection 2>/dev/null; then
+  log_ok "PostgreSQL configuration is working"
 else
-  log_ko "MySQL connection is NOT working"
+  log_ko "PostgreSQL connection is NOT working"
 fi
 
 if ps -u "$SERVER_USER" &>/dev/null ; then


### PR DESCRIPTION
Fixes the MySQL output and adds a rake task to properly check the connection

This will e.g., output something like this

```
Database connection failed with error: FATAL:  Datenbank »bla« existiert nicht
```


Caused by the reference to MySQL resulting in confusion in
https://community.openproject.org/topics/13398?r=13443