### PR TITLE
limit any_name_attribute filter operators

### DIFF
--- a/app/models/queries/filters/shared/any_user_name_attribute_filter.rb
+++ b/app/models/queries/filters/shared/any_user_name_attribute_filter.rb
@@ -39,6 +39,11 @@ module Queries::Filters::Shared::AnyUserNameAttributeFilter
       :any_name_attribute
     end
 
+    def available_operators
+      [Queries::Operators::Contains,
+       Queries::Operators::NotContains]
+    end
+
     private
 
     def sql_concat_name

--- a/spec/models/queries/users/filters/any_name_attribute_filter_spec.rb
+++ b/spec/models/queries/users/filters/any_name_attribute_filter_spec.rb
@@ -46,29 +46,16 @@ describe Queries::Users::Filters::AnyNameAttributeFilter, type: :model do
         expect(instance.allowed_values).to be_nil
       end
     end
+
+    describe '#available_operators' do
+      it 'supports = and !' do
+        expect(instance.available_operators)
+          .to eql [Queries::Operators::Contains, Queries::Operators::NotContains]
+      end
+    end
   end
 
   describe '#scope' do
-    context 'for "="' do
-      let(:operator) { '=' }
-
-      it 'is the same as handwriting the query' do
-        expected = model.where("#{filter_str} IN ('#{values.first.downcase}')")
-
-        expect(instance.scope.to_sql).to eql expected.to_sql
-      end
-    end
-
-    context 'for "!"' do
-      let(:operator) { '!' }
-
-      it 'is the same as handwriting the query' do
-        expected = model.where("#{filter_str} NOT IN ('#{values.first.downcase}')")
-
-        expect(instance.scope.to_sql).to eql expected.to_sql
-      end
-    end
-
     context 'for "~"' do
       let(:operator) { '~' }
 


### PR DESCRIPTION
`=` and `!` used to be supported but resulted in comparing the concatenation of first/last-name, login and mail as a whole and not individually. As the filter is mostly used as a fuzzy search, it is ok to only support contains and not contains.