### PR TITLE
Use tagged logger with timestamp formatting as early as possible

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -66,6 +66,19 @@ module OpenProject
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # Sets up logging for STDOUT and configures the default logger formatter
+    # so that all environments receive level and timestamp information
+    #
+    # Use default logging formatter so that PID and timestamp are not suppressed.
+    config.log_formatter = ::Logger::Formatter.new
+
+    # Set up STDOUT logging if requested
+    if ENV["RAILS_LOG_TO_STDOUT"].present?
+      logger           = ActiveSupport::Logger.new(STDOUT)
+      logger.formatter = config.log_formatter
+      config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    end
+
     # Use Rack::Deflater to gzip/deflate all the responses if the
     # HTTP_ACCEPT_ENCODING header is set appropriately. As Rack::ETag as
     # Rack::Deflater adds a timestamp to the content which would result in a

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,15 +119,6 @@ OpenProject::Application.configure do
   # Disable automatic flushing of the log to improve performance.
   config.autoflush_log = false
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
-
   config.active_record.dump_schema_after_migration = false
 
   if OpenProject::Configuration.enable_internal_assets_server?


### PR DESCRIPTION
This ensure identical behavior in all environments and results in loggers receiving timestamps

and levels in development as well.