### PR TITLE
[36981] Make active_record_store the default

### DIFF
--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -65,7 +65,7 @@ module OpenProject
       # use dalli defaults for memcache
       'cache_memcache_server' => nil,
       # where to store session data
-      'session_store' => :cache_store,
+      'session_store' => :active_record_store,
       'session_cookie_name' => '_open_project_session',
       # Destroy all sessions for current_user on logout
       'drop_old_sessions_on_logout' => true,

--- a/packaging/conf/configuration.yml
+++ b/packaging/conf/configuration.yml
@@ -28,7 +28,7 @@
 
 default:
   rails_cache_store: <%= ENV.fetch('RAILS_CACHE_STORE') { :memcache }.to_sym %>
-  session_store: <%= ENV.fetch('SESSION_STORE') { :cache_store }.to_sym %>
+  session_store: <%= ENV.fetch('SESSION_STORE') { :active_record_store }.to_sym %>
   email_delivery_method: <%= ENV.fetch('EMAIL_DELIVERY_METHOD') { :sendmail } %>
   smtp_address: <%= ENV['SMTP_HOST'] %>
   smtp_port: <%= ENV.fetch('SMTP_PORT') { 25 }.to_i %>


### PR DESCRIPTION
Currently, we're using the cache store for almost all environments by default

For the majority of installations, the performance hit to use SQL sessions is negligible while the advantages are known:

- SQL store enables session features such as the builtin termination of old sessions during logout (on by default) and login (off by default). 
- SQL store do not expire until desired, preventing the cache exhaustion logout problem on e.g., community

https://community.openproject.org/wp/36981