### PR TITLE
Allow to use puma for packager again

### DIFF
--- a/packaging/scripts/web
+++ b/packaging/scripts/web
@@ -6,16 +6,8 @@ RAILS_ENV="${RAILS_ENV:="development"}"
 
 USE_PUMA="${USE_PUMA:="false"}"
 
-if [ "$RAILS_ENV" = "production" ] && [ "$USE_PUMA" = "true" ]; then
-	# @TODO Add apache config to serve the assets. Until then we have Puma serve
-	#       them which is slower. This is ok if an asset host is used (SaaS).
-	#       But for self-hosted installations we may want to fix that.
-	#       Passenger does include a config to have nginx serve the assets.
-	export OPENPROJECT_ENABLE__INTERNAL__ASSETS__SERVER=true
-fi
-
 if [ "$USE_PUMA" = "true" ]; then
-  bundle exec rails server puma -b $HOST -p $PORT
+  bundle exec rails server -u puma -b $HOST -p $PORT
 else
   bundle exec unicorn --config-file config/unicorn.rb --host $HOST --port $PORT --env $RAILS_ENV
 fi


### PR DESCRIPTION
This got broken through some rails update probably, as it now requires `-u` to pass the server to be used.

The section about internal asset server can be removed for packaged installation. Using puma or not has no effect that apache will handle the assets anyway. This was probably wrongly copied over from docker.

This PR does NOT set puma as the default web server, even though it seems to work fine. We might want to talk about when to enable it. Maybe in 12.0 ?