### PR TITLE
Fix comment user-content styles

### DIFF
--- a/frontend/src/app/components/wp-activity/user/user-activity.component.html
+++ b/frontend/src/app/components/wp-activity/user/user-activity.component.html
@@ -49,10 +49,11 @@
         </edit-form-portal>
       </div>
     </div>
-    <op-dynamic-bootstrap *ngIf="!active && (isComment || isBcfComment)"
-                          [HTML]="postedComment"
-                          class="message wiki op-uc-container">
-    </op-dynamic-bootstrap>
+    <op-dynamic-bootstrap
+      *ngIf="!active && (isComment || isBcfComment)"
+      [HTML]="postedComment"
+      class="message"
+    ></op-dynamic-bootstrap>
     <ul class="work-package-details-activities-messages" *ngIf="!isInitial">
       <li *ngFor="let detail of details">
         <span class="message" [innerHtml]="detail"></span>

--- a/frontend/src/app/modules/common/dynamic-bootstrap/component/dynamic-bootstrap/dynamic-bootstrap.component.html
+++ b/frontend/src/app/modules/common/dynamic-bootstrap/component/dynamic-bootstrap/dynamic-bootstrap.component.html
@@ -1,1 +1,4 @@
-<div [innerHtml]="innerHtml"></div>
+<div
+  [innerHtml]="innerHtml"
+  class="op-uc-container"
+></div>


### PR DESCRIPTION
Move the `op-uc-container` class to the direct parent of the user generated content, thus fixing the styles for user
comments left in the work package activities.

Closes https://community.openproject.org/projects/openproject/work_packages/details/36989/overview