### PR TITLE
Make PathHelper routing independent

### DIFF
--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -49,32 +49,29 @@ module API
           private_class_method :index
 
           def self.show(name)
-            define_singleton_method(name) do |id|
-              "#{send(name.to_s.pluralize)}/#{id}"
-            end
+            define_singleton_method(name) { |id| build_path(name, id) }
           end
           private_class_method :show
 
           def self.create_form(name)
-            define_singleton_method(:"create_#{name}_form") do
-              "#{send(name.to_s.pluralize)}/form"
-            end
+            define_singleton_method(:"create_#{name}_form") { build_path(name, "form") }
           end
           private_class_method :create_form
 
           def self.update_form(name)
-            define_singleton_method(:"#{name}_form") do |id|
-              "#{send(name, id)}/form"
-            end
+            define_singleton_method(:"#{name}_form") { |id| build_path(name, id, "form") }
           end
           private_class_method :update_form
 
           def self.schema(name)
-            define_singleton_method(:"#{name}_schema") do
-              "#{send(name.to_s.pluralize)}/schema"
-            end
+            define_singleton_method(:"#{name}_schema") { build_path(name, "schema") }
           end
           private_class_method :schema
+
+          def self.build_path(name, *kwargs)
+            [root, name.to_s.pluralize, *kwargs].compact.join("/")
+          end
+          private_class_method :build_path
 
           def self.resources(name,
                              except: [],


### PR DESCRIPTION
Any route can be declared on its own and should not rely on :index route
to be declared.

Thanks @cedricpim