### PR TITLE
Feature/project status resource

### DIFF
--- a/app/services/api/parse_resource_params_service.rb
+++ b/app/services/api/parse_resource_params_service.rb
@@ -68,13 +68,26 @@ module API
     end
 
     def parse_attributes(request_body)
-      parsing_representer
-        .from_hash(request_body)
-        .to_h
+      struct = parsing_representer
+               .from_hash(request_body)
+
+      deep_to_h(struct)
     end
 
     def struct
       OpenStruct.new
+    end
+
+    def deep_to_h(value)
+      # Does not yet factor in Arrays. There hasn't been the need to do that, yet.
+      case value
+      when OpenStruct, Hash
+        value.to_h.transform_values do |sub_value|
+          deep_to_h(sub_value)
+        end
+      else
+        value
+      end
     end
   end
 end

--- a/docs/api/apiv3/endpoints/projects.apib
+++ b/docs/api/apiv3/endpoints/projects.apib
@@ -16,15 +16,16 @@ As containers, they also control behaviour of the elements within them. One of t
 
 ## Linked Properties
 
-| Link         | Description                          | Type       | Constraints | Supported operations |Condition                                              |
-| :----------: | -------------                        | ----       | ----------- | -------------------- |-----------------------------------------              |
-| self         | This project                         | Project    | not null    | READ                 |                                                       |
-| categories   | Categories available in this project | Collection | not null    | READ                 |                                                       |
-| types        | Types available in this project      | Collection | not null    | READ                 | **Permission**: view work packages or manage types    |
-| versions     | Versions available in this project   | Collection | not null    | READ                 | **Permission**: view work packages or manage versions |
-| memberships  | Memberships in the  project          | Collection | not null    | READ                 | **Permission**: view members                          |
-| workPackages | Work Packages of this project        | Collection | not null    | READ                 |                                                       |
-| parent       | Parent project of the project        | Project    |             | READ/WRITE           | **Permission** edit project                           |
+| Link         | Description                                                                                           | Type          | Constraints | Supported operations |Condition                                              |
+| :----------: | -------------                                                                                         | ----          | ----------- | -------------------- |-----------------------------------------              |
+| self         | This project                                                                                          | Project       | not null    | READ                 |                                                       |
+| categories   | Categories available in this project                                                                  | Collection    | not null    | READ                 |                                                       |
+| types        | Types available in this project                                                                       | Collection    | not null    | READ                 | **Permission**: view work packages or manage types    |
+| versions     | Versions available in this project                                                                    | Collection    | not null    | READ                 | **Permission**: view work packages or manage versions |
+| memberships  | Memberships in the  project                                                                           | Collection    | not null    | READ                 | **Permission**: view members                          |
+| workPackages | Work Packages of this project                                                                         | Collection    | not null    | READ                 |                                                       |
+| parent       | Parent project of the project                                                                         | Project       |             | READ/WRITE           | **Permission** edit project                           |
+| status       | Denotes the status of the project, so whether the project is on track, at risk or is having trouble.  | ProjectStatus |             | READ/WRITE           | **Permission** edit project                           |
 
 Depending on custom fields defined for projects, additional links might exist.
 
@@ -36,7 +37,6 @@ Depending on custom fields defined for projects, additional links might exist.
 | identifier             |                                                                                                       | String            |                                      | READ/WRITE           |
 | name                   |                                                                                                       | String            |                                      | READ/WRITE           |
 | active                 | Indicates whether the project is currently active or already archived                                 | Boolean           |                                      | READ/WRITE           |
-| status                 | Denotes the status of the project, so whether the project is on track, at risk or is having trouble.  | String            | "on track", "at risk" or "off track" | READ/WRITE           |
 | statusExplanation      | A text detailing and explaining why the project has the reported status                               | Formattable       |                                      | READ/WRITE           |
 | public                 | Indicates whether the project is accessible for everybody                                             | Boolean           |                                      | READ/WRITE           |
 | description            |                                                                                                       | Formattable       |                                      | READ/WRITE           |
@@ -45,7 +45,7 @@ Depending on custom fields defined for projects, additional links might exist.
 
 Depending on custom fields defined for projects, additional properties might exist.
 
-## Project [/api/v3/projects/{id}]
+## View project [/api/v3/projects/{id}]
 
 + Model
     + Body
@@ -86,6 +86,10 @@ Depending on custom fields defined for projects, additional properties might exi
                     },
                     "projects": {
                       "href": "/api/v3/projects/123"
+                    },
+                    "status": {
+                      "href": "/api/v3/project_statuses/on_track",
+                      "title": "On track"
                     }
                 },
                 "id": 1,
@@ -93,7 +97,6 @@ Depending on custom fields defined for projects, additional properties might exi
                 "name": "Project example",
                 "active": true,
                 "public": false,
-                "status": "on track",
                 "statusExplanation": {
                     "format": "markdown",
                     "raw": "Everything **fine**",
@@ -117,7 +120,7 @@ Depending on custom fields defined for projects, additional properties might exi
     
 + Response 200 (application/hal+json)
 
-    [Project][]
+    [View project][]
 
 + Response 404 (application/hal+json)
 
@@ -134,8 +137,93 @@ Depending on custom fields defined for projects, additional properties might exi
             {
                 "_type": "Error",
                 "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
-                "message": "The specified project does not exist."
+                "message": "The requested resource could not be found."
             }
+
+## Create project [/api/v3/projects]
+
+## Create project [POST]
+
+Creates a new project, applying the attributes provided in the body.
+
+You can use the form and schema to be retrieve the valid attribute values and by that be guided towards successful creation.
+
++ Request Create project
+
+    + Body
+
+            {
+              "identifier": "new_project_identifier",
+              "name": "New project name",
+              "customField35": "Text custom field value",
+              "statusExplanation": {
+                  "format": "markdown",
+                  "raw": "Everything **fine**",
+                  "html": "<p>Everything <strong>fine</strong></p>"
+              },
+              "_links": {
+                "customField12": {
+                  "href": "/api/v3/users/5"
+                },
+                "parent": {
+                  "href": "/api/v3/projects/6"
+                },
+                "status": {
+                  "href": "/api/v3/project_statuses/on_track"
+                }
+              }
+            }
+
++ Response 201
+
+    [View project][]
+
++ Response 400 (application/hal+json)
+
+    Occurs when the client did not send a valid JSON object in the request body.
+
+    + Body
+
+            {
+                "_type": "Error",
+                 "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidRequestBody",
+                "message": "The request body was not a single JSON object."
+            }
+
++ Response 403 (application/hal+json)
+
+    Returned if the client does not have sufficient permissions.
+
+    **Required permission:** add project which is a global permission
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
+                "message": "You are not authorized to access this resource."
+            }
+
++ Response 422 (application/hal+json)
+
+    Returned if:
+
+    * a constraint for a property was violated (`PropertyConstraintViolation`)
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:PropertyConstraintViolation",
+                "message": "Name can't be blank.",
+                "_embedded": {
+                    "details": {
+                        "attribute": "name"
+                    }
+                }
+            }
+
+## Update project [/api/v3/projects/{id}]
 
 ## Update Project [PATCH]
 
@@ -151,17 +239,19 @@ Updates the given project by applying the attributes provided in the body.
 
             {
                 "name": "A new project name",
-                "status": "at risk",
                 "_links": {
                     "customField35": {
                         "href": "/api/v3/users/3"
+                    },
+                    "status": {
+                      "href": "/api/v3/project_statuses/at_risk",
                     }
                 }
             }
 
 + Response 200
 
-    [Project][]
+    [View project][]
 
 + Response 400 (application/hal+json)
 
@@ -226,6 +316,8 @@ Updates the given project by applying the attributes provided in the body.
                 }
             }
 
+## Delete project [/api/v3/projects/{id}]
+
 ## Delete Project [DELETE]
 
 Deletes the project permanently. As this is a lengthy process, the actual deletion is carried out asynchronously.
@@ -289,7 +381,7 @@ the project scheduled for deletion, it is archived at once.
                    "_embedded": { "details": { "attribute": "base" } }
             }
 
-## Projects [/api/v3/projects{?filters,sortBy}]
+## List projects [/api/v3/projects{?filters,sortBy}]
 
 + Model
     + Body
@@ -328,13 +420,16 @@ the project scheduled for deletion, it is archived at once.
                       },
                       "projects": {
                         "href": "/api/v3/projects/123"
+                      },
+                      "status": {
+                        "href": "/api/v3/project_statuses/on_track",
+                        "title": "On track"
                       }
                     },
                     "id": 6,
                     "identifier": "a_project",
                     "name": "A project",
                     "active": true,
-                    "status": "on track",
                     "statusExplanation": {
                         "format": "markdown",
                         "raw": "Everything **fine**",
@@ -373,13 +468,16 @@ the project scheduled for deletion, it is archived at once.
                       },
                       "projects": {
                         "href": null
+                      },
+                      "status": {
+                        "href": "/api/v3/project_statuses/off_track",
+                        "title": "Off track"
                       }
                     },
                     "id": 14,
                     "identifier": "another_project",
                     "name": "Another project",
                     "active": false,
-                    "status": "off track",
                     "statusExplanation": {
                         "format": "markdown",
                         "raw": "Uh **oh**",
@@ -430,88 +528,7 @@ Returns a collection of projects. The collection can be filtered via query param
 
 + Response 200 (application/hal+json)
 
-    [Projects][]
-
-## Create project [POST]
-
-Creates a new project, applying the attributes provided in the body.
-
-You can use the form and schema to be retrieve the valid attribute values and by that be guided towards successful creation.
-
-+ Parameters
-
-+ Request Create project
-
-    + Body
-
-            {
-              "identifier": "new_project_identifier",
-              "name": "New project name",
-              "customField35": "Text custom field value",
-              "status": "on track",
-              "statusExplanation": {
-                  "format": "markdown",
-                  "raw": "Everything **fine**",
-                  "html": "<p>Everything <strong>fine</strong></p>"
-              },
-              "_links": {
-                "customField12": {
-                  "href": "/api/v3/users/5"
-                },
-                "parent": {
-                  "href": "/api/v3/projects/6"
-                }
-              }
-            }
-
-+ Response 201
-
-    [Project][]
-
-+ Response 400 (application/hal+json)
-
-    Occurs when the client did not send a valid JSON object in the request body.
-
-    + Body
-
-            {
-                "_type": "Error",
-                 "errorIdentifier": "urn:openproject-org:api:v3:errors:InvalidRequestBody",
-                "message": "The request body was not a single JSON object."
-            }
-
-+ Response 403 (application/hal+json)
-
-    Returned if the client does not have sufficient permissions.
-
-    **Required permission:** add project which is a global permission
-
-    + Body
-
-            {
-                "_type": "Error",
-                "errorIdentifier": "urn:openproject-org:api:v3:errors:MissingPermission",
-                "message": "You are not authorized to access this resource."
-            }
-
-+ Response 422 (application/hal+json)
-
-    Returned if:
-
-    * a constraint for a property was violated (`PropertyConstraintViolation`)
-
-    + Body
-
-            {
-                "_type": "Error",
-                "errorIdentifier": "urn:openproject-org:api:v3:errors:PropertyConstraintViolation",
-                "message": "Name can't be blank.",
-                "_embedded": {
-                    "details": {
-                        "attribute": "name"
-                    }
-                }
-            }
+    [List projects][]
 
 ## Projects schema [/api/v3/projects/schemas]
 
@@ -568,11 +585,27 @@ You can use the form and schema to be retrieve the valid attribute values and by
                     "writable": true
                 },
                 "status": {
-                    "type": "String",
+                    "type": "ProjectStatus",
                     "name": "Status",
-                    "required": true,
+                    "required": false,
                     "hasDefault": true,
-                    "writable": true
+                    "writable": true,
+                    "_links": {
+                      "allowedValues": [
+                        {
+                            "href": "/api/v3/project_statuses/on_track",
+                            "title": "On track"
+                        },
+                        {
+                            "href": "/api/v3/project_statuses/at_risk",
+                            "title": "At risk"
+                        },
+                        {
+                            "href": "/api/v3/project_statuses/off_track",
+                            "title": "Off track"
+                        }
+                      ]
+                    }
                 },
                 "statusExplanation": {
                     "type": "Formattable",
@@ -706,7 +739,6 @@ For more details and all possible responses see the general specification of [Fo
                             "html": ""
                         },
                         "customField42": null,
-                        "status": null,
                         "statusExplanation": {
                             "format": "markdown",
                             "raw": null,
@@ -723,6 +755,9 @@ For more details and all possible responses see the general specification of [Fo
                             },
                             "parent": {
                                 "href": null
+                            },
+                            "status": {
+                              "href": null
                             }
                         }
                     },
@@ -776,11 +811,27 @@ For more details and all possible responses see the general specification of [Fo
                             "writable": true
                         },
                         "status": {
-                            "type": "String",
+                            "type": "ProjectStatus",
                             "name": "Status",
-                            "required": true,
+                            "required": false,
                             "hasDefault": true,
-                            "writable": true
+                            "writable": true,
+                            "_links": {
+                              "allowedValues": [
+                                {
+                                    "href": "/api/v3/project_statuses/on_track",
+                                    "title": "On track"
+                                },
+                                {
+                                    "href": "/api/v3/project_statuses/at_risk",
+                                    "title": "At risk"
+                                },
+                                {
+                                    "href": "/api/v3/project_statuses/off_track",
+                                    "title": "Off track"
+                                }
+                              ]
+                            }
                         },
                         "statusExplanation": {
                             "type": "Formattable",
@@ -995,6 +1046,10 @@ For more details and all possible responses see the general specification of [Fo
 
 ## Project update form [POST]
 
++ Parameters
+
+  + id (required, integer, `1`) ... Project id
+
 + Request Update project form
 
     + Body
@@ -1031,7 +1086,6 @@ For more details and all possible responses see the general specification of [Fo
                             "html": ""
                         },
                         "customField42": null,
-                        "status": "at risk",
                         "statusExplanation": {
                             "format": "markdown",
                             "raw": "There is some risk of failure",
@@ -1048,6 +1102,9 @@ For more details and all possible responses see the general specification of [Fo
                             },
                             "parent": {
                                 "href": "/api/v3/projects/45"
+                            },
+                            "status": {
+                              "href": "/api/v3/project_statuses/at_risk"
                             }
                         }
                     },
@@ -1098,10 +1155,33 @@ For more details and all possible responses see the general specification of [Fo
                             "name": "Active",
                             "required": true,
                             "hasDefault": true,
-                            "writable": true,
+                            "writable": true
                         },
                         "status": {
-                            "type": "String",
+                            "type": "ProjectStatus",
+                            "name": "Status",
+                            "required": false,
+                            "hasDefault": true,
+                            "writable": true,
+                            "_links": {
+                              "allowedValues": [
+                                {
+                                    "href": "/api/v3/project_statuses/on_track",
+                                    "title": "On track"
+                                },
+                                {
+                                    "href": "/api/v3/project_statuses/at_risk",
+                                    "title": "At risk"
+                                },
+                                {
+                                    "href": "/api/v3/project_statuses/off_track",
+                                    "title": "Off track"
+                                }
+                              ]
+                            }
+                        },
+                        "statusExplanation": {
+                            "type": "Formattable",
                             "name": "Status",
                             "required": true,
                             "hasDefault": true,
@@ -1338,6 +1418,10 @@ For more details and all possible responses see the general specification of [Fo
 
 ## Project copy form [POST]
 
++ Parameters
+
+  + id (required, integer, `1`) ... Project id
+
 + Request copy project form
 
   + Body
@@ -1378,7 +1462,6 @@ For more details and all possible responses see the general specification of [Fo
                         "html": ""
                     },
                     "customField42": null,
-                    "status": "at risk",
                     "statusExplanation": {
                         "format": "markdown",
                         "raw": "There is some risk of failure",
@@ -1393,7 +1476,10 @@ For more details and all possible responses see the general specification of [Fo
                             "href": null,
                             "title": null
                         },
-                        "parent": null
+                        "parent": null,
+                        "status": {
+                          "href": "/api/v3/project_statuses/at_risk"
+                        }
                     },
                     "_meta": {
                     	"copyOverview": false,
@@ -1456,10 +1542,33 @@ For more details and all possible responses see the general specification of [Fo
                         "name": "Active",
                         "required": true,
                         "hasDefault": true,
-                        "writable": true,
+                        "writable": true
                     },
                     "status": {
-                        "type": "String",
+                        "type": "ProjectStatus",
+                        "name": "Status",
+                        "required": false,
+                        "hasDefault": true,
+                        "writable": true,
+                        "_links": {
+                          "allowedValues": [
+                            {
+                                "href": "/api/v3/project_statuses/on_track",
+                                "title": "On track"
+                            },
+                            {
+                                "href": "/api/v3/project_statuses/at_risk",
+                                "title": "At risk"
+                            },
+                            {
+                                "href": "/api/v3/project_statuses/off_track",
+                                "title": "Off track"
+                            }
+                          ]
+                        }
+                    },
+                    "statusExplanation": {
+                        "type": "Formattable",
                         "name": "Status",
                         "required": true,
                         "hasDefault": true,
@@ -1763,6 +1872,11 @@ The copy endpoint has a `_meta` property that allows defining which associations
 
 ## Create project copy [POST]
 
++ Parameters
+
+  + id (required, integer, `1`) ... Project id
+
+
 + Request Create copy project 
 
   + Body
@@ -1832,7 +1946,7 @@ The copy endpoint has a `_meta` property that allows defining which associations
 
 
 
-## Available parent project candidates [/api/v3/projects/available_parent_projects{?filters,of,sortBy}]
+## List available parent project candidates [/api/v3/projects/available_parent_projects{?filters,of,sortBy}]
 
 + Model
     + Body
@@ -1868,13 +1982,16 @@ The copy endpoint has a `_meta` property that allows defining which associations
                       },
                       "versions": {
                         "href": "/api/v3/projects/6/versions"
+                      },
+                      "status": {
+                        "href": "/api/v3/project_statuses/on_track",
+                        "title": "On track"
                       }
                     },
                     "id": 6,
                     "identifier": "a_project",
                     "name": "A project",
                     "active": true,
-                    "status": "on track",
                     "statusExplanation": {
                         "format": "markdown",
                         "raw": "Everything **fine**",
@@ -1910,13 +2027,16 @@ The copy endpoint has a `_meta` property that allows defining which associations
                       },
                       "versions": {
                         "href": "/api/v3/projects/14/versions"
+                      },
+                      "status": {
+                        "href": "/api/v3/project_statuses/on_track",
+                        "title": "On track"
                       }
                     },
                     "id": 14,
                     "identifier": "another_project",
                     "name": "Another project",
                     "active": true,
-                    "status": "on track",
                     "statusExplanation": {
                         "format": "markdown",
                         "raw": "Everything super **fine**",
@@ -1962,7 +2082,7 @@ For instance to find all parent candidates with "rollout" in their name:
 
 + Response 200 (application/hal+json)
 
-    [Available parent project candidates][]
+    [List available parent project candidates][]
 
 + Response 403 (application/hal+json)
 
@@ -1978,7 +2098,7 @@ For instance to find all parent candidates with "rollout" in their name:
                 "message": "You are not authorized to access this resource."
             }
 
-## Projects by version [/api/v3/versions/{id}/projects]
+## List projects by version [/api/v3/versions/{id}/projects]
 
 + Model
     + Body
@@ -2005,7 +2125,11 @@ For instance to find all parent candidates with "rollout" in their name:
                                     "title": "Lorem"
                                 },
                                 "categories": { "href": "/api/v3/projects/1/categories" },
-                                "versions": { "href": "/api/v3/projects/1/versions" }
+                                "versions": { "href": "/api/v3/projects/1/versions" },
+                                "status": {
+                                  "href": "/api/v3/project_statuses/on_track",
+                                  "title": "On track"
+                                }
                             },
                             "id": 1,
                             "identifier": "project_identifier",
@@ -2016,7 +2140,6 @@ For instance to find all parent candidates with "rollout" in their name:
                                 "html": "<p>Lorem <strong>ipsum</strong> dolor sit amet</p>"
                             },
                             "active": true,
-                            "status": "on track",
                             "statusExplanation": {
                                 "format": "markdown",
                                 "raw": "Everything **fine**",
@@ -2042,7 +2165,7 @@ but are also limited to the projects that the current user is allowed to see.
     
 + Response 200 (application/hal+json)
 
-    [Projects by version][]
+    [List projects by version][]
 
 + Response 404 (application/hal+json)
 
@@ -2059,6 +2182,48 @@ but are also limited to the projects that the current user is allowed to see.
             {
                 "_type": "Error",
                 "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
-                "message": "The specified version does not exist."
+                "message": "The requested resource could not be found."
             }
 
+## View project status
+
+The project status enumerations are a fixed set set status a project can be in: "On track", "At risk" and "Off track". They can be
+used to communicate a judgement on the project's likeliness to succeed.
+
+## View project status [/api/v3/project_statuses/{id}]
+
++ Model
+    + Body
+
+            {
+                "_type": "ProjectStatus",
+                "id": "on_track",
+                "name": "On track",
+                "_links": {
+                  "self": {
+                    "href": "/api/v3/project_statuses/on_track"
+                  }
+                }
+            }
+
+## View project status [GET]
+
++ Parameters
+
+  + id (required, string, `on_track`) ... Project status id
+
++ Response 200 (application/hal+json)
+
+    [View project status][]
+
++ Response 404 (application/hal+json)
+
+    Returned if the project status does not exist.
+
+    + Body
+
+            {
+                "_type": "Error",
+                "errorIdentifier": "urn:openproject-org:api:v3:errors:NotFound",
+                "message": "The requested resource could not be found."
+            }

--- a/frontend/src/app/modules/fields/display/field-types/project-status-display-field.module.ts
+++ b/frontend/src/app/modules/fields/display/field-types/project-status-display-field.module.ts
@@ -32,7 +32,7 @@ import { projectStatusCodeCssClass, projectStatusI18n } from "core-app/modules/f
 
 export class ProjectStatusDisplayField extends DisplayField {
   public render(element:HTMLElement, displayText:string):void {
-    const code = this.value;
+    const code = this.value && this.value.id;
 
     const bulb = document.createElement('span');
     bulb.classList.add('project-status--bulb', projectStatusCodeCssClass(code));

--- a/frontend/src/app/modules/fields/edit/field-types/project-status-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/project-status-edit-field.component.html
@@ -1,7 +1,7 @@
 <ng-select [items]="availableStatuses"
            [(ngModel)]="currentStatusCode"
            bindLabel="name"
-           bindValue="code"
+           bindValue="href"
            class="project-status"
            (open)="onOpen()"
            (close)="onClose()"

--- a/frontend/src/app/modules/fields/edit/field-types/project-status-edit-field.component.ts
+++ b/frontend/src/app/modules/fields/edit/field-types/project-status-edit-field.component.ts
@@ -32,6 +32,13 @@ import { EditFieldComponent } from "core-app/modules/fields/edit/edit-field.comp
 import { NgSelectComponent } from "@ng-select/ng-select";
 import { projectStatusCodeCssClass, projectStatusI18n } from "core-app/modules/fields/helpers/project-status-helper";
 import { InjectField } from "core-app/helpers/angular/inject-field.decorator";
+import { HalResource } from "core-app/modules/hal/resources/hal-resource";
+
+interface ProjectStatusOption {
+  href:string
+  name:string
+  colorClass:string
+}
 
 @Component({
   templateUrl: './project-status-edit-field.component.html',
@@ -41,33 +48,40 @@ export class ProjectStatusEditFieldComponent extends EditFieldComponent implemen
   @ViewChild(NgSelectComponent, { static: true }) public ngSelectComponent:NgSelectComponent;
   @InjectField() I18n!:I18nService;
 
-  private _availableStatusCodes:string[] = ['not set', 'off track', 'at risk', 'on track'];
-  public currentStatusCode = 'not set';
+  public availableStatuses:ProjectStatusOption[] = [{
+      href: 'not_set',
+      name: projectStatusI18n('not_set', this.I18n),
+      colorClass: projectStatusCodeCssClass('not_set')
+    }];
 
-  public availableStatuses:any[] = this._availableStatusCodes.map((code:string):any => {
-    return {
-      code: code,
-      name: projectStatusI18n(code, this.I18n),
-      colorClass: projectStatusCodeCssClass(code)
-    };
-  });
-
+  public currentStatusCode:string;
   public hiddenOverflowContainer = '#content-wrapper';
   public appendToContainer = 'body';
 
   ngOnInit() {
-    this.currentStatusCode = this.resource['status'] === null ? 'not set' : this.resource['status'];
+    this.currentStatusCode = this.resource['status'] === null ? this.availableStatuses[0].href : this.resource['status'].href;
 
-    // The timeout takes care that the opening is added to the end of the current call stack.
-    // Thus we can be sure that the select box is rendered and ready to be opened.
-    const that = this;
-    window.setTimeout(function () {
-      that.ngSelectComponent.open();
-    }, 0);
+    this.change.getForm().then((form) => {
+      form.schema['status'].allowedValues.forEach((status:HalResource) => {
+        this.availableStatuses = [...this.availableStatuses,
+                                  {
+                                    href: status.href!,
+                                    name: status.name,
+                                    colorClass: projectStatusCodeCssClass(status.id)
+                                  }];
+      });
+
+      // The timeout takes care that the opening is added to the end of the current call stack.
+      // Thus we can be sure that the select box is rendered and ready to be opened.
+      const that = this;
+      window.setTimeout(function () {
+        that.ngSelectComponent.open();
+      }, 0);
+    });
   }
 
   public onChange() {
-    this.resource['status'] = this.currentStatusCode === 'not set' ? null : this.currentStatusCode;
+    this.resource['status'] = this.currentStatusCode === this.availableStatuses[0].href ? null : { href: this.currentStatusCode };
     this.handler.handleUserSubmit();
   }
 

--- a/frontend/src/app/modules/fields/helpers/project-status-helper.ts
+++ b/frontend/src/app/modules/fields/helpers/project-status-helper.ts
@@ -3,15 +3,15 @@ import { I18nService } from "core-app/modules/common/i18n/i18n.service";
 export function projectStatusCodeCssClass(code:string|null|undefined):string {
   code = ensureDefaultCode(code);
 
-  return '-' + code.replace(' ', '-');
+  return '-' + code.replace('_', '-');
 }
 
 export function projectStatusI18n(code:string|null|undefined, I18n:I18nService):string {
   code = ensureDefaultCode(code);
 
-  return I18n.t('js.grid.widgets.project_status.' + code.replace(' ', '_'));
+  return I18n.t('js.grid.widgets.project_status.' + code.replace('-', '_'));
 }
 
 function ensureDefaultCode(code:string|null|undefined):string {
-  return code ? code : 'not set';
+  return code ? code : 'not-set';
 }

--- a/lib/api/v3/projects/copy/parse_copy_params_service.rb
+++ b/lib/api/v3/projects/copy/parse_copy_params_service.rb
@@ -35,13 +35,13 @@ module API
 
           def parse_attributes(request_body)
             attributes = super
-            meta = attributes.delete(:meta) || OpenStruct.new
+            meta = attributes.delete(:meta) || {}
 
             {
               target_project_params: attributes,
               attributes_only: true,
-              only: meta.only,
-              send_notifications: meta.send_notifications != false
+              only: meta[:only],
+              send_notifications: meta[:send_notifications] != false
             }
           end
         end

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -187,24 +187,35 @@ module API
 
         date_time_property :updated_at
 
-        property :status,
-                 name_source: ->(*) { I18n.t('activerecord.attributes.projects/status.code') },
-                 render_nil: true,
+        resource :status,
                  getter: ->(*) {
-                   next unless status&.code
+                   next unless represented.status&.code
 
-                   status.code.to_s.tr('_', ' ')
+                   ::API::V3::Projects::Statuses::StatusRepresenter
+                     .create(represented.status.code, current_user: current_user, embed_links: embed_links)
                  },
-                 reader: ->(doc:, represented:, **) {
-                   next unless doc.key?('status')
+                 link: ->(*) {
+                   if represented.status&.code
+                     {
+                       href: api_v3_paths.project_status(represented.status.code),
+                       title: I18n.t(:"activerecord.attributes.projects/status.codes.#{represented.status.code}")
+                     }
+                   else
+                     {
+                       href: nil
+                     }
+                   end
+                 },
+                 setter: ->(fragment:, represented:, **) {
+                   represented.status_attributes ||= OpenStruct.new
 
-                   represented.status_attributes ||= {}
-                   represented.status_attributes[:code] =
-                     if doc['status'].nil?
-                       nil
-                     else
-                       doc['status'].strip.tr(' ', '_').underscore.to_sym
-                     end
+                   link = ::API::Decorators::LinkObject.new(represented.status_attributes,
+                                                            path: :project_status,
+                                                            property_name: :status,
+                                                            getter: :code,
+                                                            setter: :"code=")
+
+                   link.from_hash(fragment)
                  }
 
         property :status_explanation,
@@ -215,7 +226,7 @@ module API
                                                       plain: false)
                  },
                  setter: ->(fragment:, represented:, **) {
-                   represented.status_attributes ||= {}
+                   represented.status_attributes ||= OpenStruct.new
                    represented.status_attributes[:explanation] = fragment["raw"]
                  }
 

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -198,8 +198,9 @@ module API
                    if represented.status&.code
                      {
                        href: api_v3_paths.project_status(represented.status.code),
-                       title: I18n.t(:"activerecord.attributes.projects/status.codes.#{represented.status.code}")
-                     }
+                       title: I18n.t(:"activerecord.attributes.projects/status.codes.#{represented.status.code}",
+                                     default: nil)
+                     }.compact
                    else
                      {
                        href: nil

--- a/lib/api/v3/projects/schemas/project_schema_representer.rb
+++ b/lib/api/v3/projects/schemas/project_schema_representer.rb
@@ -59,11 +59,21 @@ module API
           schema :active,
                  type: 'Boolean'
 
-          schema :status,
-                 type: 'String',
-                 name_source: ->(*) { I18n.t('activerecord.attributes.projects/status.code') },
-                 required: false,
-                 writable: ->(*) { represented.writable?(:status) }
+          schema_with_allowed_collection :status,
+                                         type: 'ProjectStatus',
+                                         name_source: ->(*) { I18n.t('activerecord.attributes.projects/status.code') },
+                                         required: false,
+                                         writable: ->(*) { represented.writable?(:status) },
+                                         values_callback: ->(*) {
+                                           ::Projects::Status.codes.keys
+                                         },
+                                         value_representer: ::API::V3::Projects::Statuses::StatusRepresenter,
+                                         link_factory: ->(value) {
+                                           {
+                                             href: api_v3_paths.project_status(value),
+                                             title: I18n.t(:"activerecord.attributes.projects/status.codes.#{value}")
+                                           }
+                                         }
 
           schema :status_explanation,
                  type: 'Formattable',

--- a/lib/api/v3/projects/statuses/status_representer.rb
+++ b/lib/api/v3/projects/statuses/status_representer.rb
@@ -1,0 +1,56 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module Projects
+      module Statuses
+        class StatusRepresenter < ::API::Decorators::Single
+          link :self do
+            {
+              href: api_v3_paths.project_status(represented),
+              title: I18n.t(:"activerecord.attributes.projects/status.codes.#{represented}")
+            }
+          end
+
+          property :id,
+                   getter: ->(*) { self }
+
+          property :name,
+                   getter: ->(*) { I18n.t(:"activerecord.attributes.projects/status.codes.#{self}") }
+
+          def _type
+            'ProjectStatus'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/projects/statuses/statuses_api.rb
+++ b/lib/api/v3/projects/statuses/statuses_api.rb
@@ -1,0 +1,59 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module Projects
+      module Statuses
+        class StatusesAPI < ::API::OpenProjectAPI
+          resources :project_statuses do
+            params do
+              requires :id, desc: 'Project status identifier'
+            end
+            route_param :id do
+              helpers do
+                def status_exists?
+                  ::Projects::Status.codes.keys.include?(params[:id])
+                end
+              end
+
+              after_validation do
+                raise API::Errors::NotFound unless status_exists?
+              end
+
+              get do
+                API::V3::Projects::Statuses::StatusRepresenter
+                  .new(params[:id], current_user: current_user, embed_links: true)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -57,6 +57,7 @@ module API
       mount ::API::V3::Principals::PrincipalsAPI
       mount ::API::V3::Priorities::PrioritiesAPI
       mount ::API::V3::Projects::ProjectsAPI
+      mount ::API::V3::Projects::Statuses::StatusesAPI
       mount ::API::V3::Queries::QueriesAPI
       mount ::API::V3::Render::RenderAPI
       mount ::API::V3::Relations::RelationsAPI

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -236,6 +236,8 @@ module API
 
           resources :project
 
+          show :project_status
+
           def self.projects_available_parents
             "#{projects}/available_parent_projects"
           end

--- a/spec/lib/api/v3/projects/project_payload_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/projects/project_payload_representer_parsing_spec.rb
@@ -43,15 +43,19 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
     context 'status' do
       let(:hash) do
         {
-          'status' => 'on track',
-          'statusExplanation' => { 'raw' => 'status code explanation' }
+          'statusExplanation' => { 'raw' => 'status code explanation' },
+          '_links' => {
+            'status' => {
+              'href' => api_v3_paths.project_status('on_track')
+            }
+          }
         }
       end
 
       it 'updates code' do
         project = representer.from_hash(hash)
         expect(project.status[:code])
-          .to eql(:on_track)
+          .to eql('on_track')
 
         expect(project.status[:explanation])
           .to eql('status code explanation')
@@ -80,14 +84,18 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
       context 'with explanation not provided' do
         let(:hash) do
           {
-            'status' => 'off track'
+            '_links' => {
+              'status' => {
+                'href' => api_v3_paths.project_status('off_track')
+              }
+            }
           }
         end
 
         it 'does set code' do
           project = representer.from_hash(hash)
           expect(project.status[:code])
-            .to eql :off_track
+            .to eql 'off_track'
         end
 
         it 'does not set explanation' do
@@ -100,7 +108,11 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
       context 'with null for a scope' do
         let(:hash) do
           {
-            'status' => nil
+            '_links' => {
+              'status' => {
+                'href' => nil
+              }
+            }
           }
         end
 
@@ -111,10 +123,10 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
             .to have_key(:status)
 
           status = project[:status]
-          expect(status)
+          expect(status.to_h)
             .to have_key(:code)
 
-          expect(status)
+          expect(status.to_h)
             .not_to have_key(:explanation)
 
           expect(status[:code])

--- a/spec/lib/api/v3/projects/project_representer_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_spec.rb
@@ -119,29 +119,9 @@ describe ::API::V3::Projects::ProjectRepresenter do
         let(:value) { project.description }
       end
 
-      context 'status' do
+      context 'statusExplanation' do
         it_behaves_like 'formattable property', 'statusExplanation' do
           let(:value) { status.explanation }
-        end
-
-        it 'includes the project status code' do
-          expect(subject)
-            .to be_json_eql(status.code.tr('_', ' ').to_json)
-            .at_path('status')
-        end
-
-        context 'if the status is nil' do
-          let(:status) { nil }
-
-          it_behaves_like 'formattable property', 'statusExplanation' do
-            let(:value) { nil }
-          end
-
-          it 'includes the project status code' do
-            expect(subject)
-              .to be_json_eql(nil.to_json)
-              .at_path('status')
-          end
         end
       end
 
@@ -237,6 +217,23 @@ describe ::API::V3::Projects::ProjectRepresenter do
             let(:link) { 'parent' }
             let(:href) { nil }
             let(:title) { nil }
+          end
+        end
+      end
+
+      context 'status' do
+        it_behaves_like 'has a titled link' do
+          let(:link) { 'status' }
+          let(:href) { api_v3_paths.project_status(project.status.code) }
+          let(:title) { I18n.t(:"activerecord.attributes.projects/status.codes.#{project.status.code}") }
+        end
+
+        context 'if the status is nil' do
+          let(:status) { nil }
+
+          it_behaves_like 'has an untitled link' do
+            let(:link) { 'status' }
+            let(:href) { nil }
           end
         end
       end

--- a/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
+++ b/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
@@ -182,22 +182,15 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
       let(:path) { 'status' }
 
       it_behaves_like 'has basic schema properties' do
-        let(:type) { 'String' }
+        let(:type) { 'ProjectStatus' }
         let(:name) { I18n.t('activerecord.attributes.projects/status.code') }
         let(:required) { false }
         let(:writable) { true }
+        let(:location) { '_links' }
       end
 
-      it 'contains no link to the allowed values' do
-        is_expected
-          .not_to have_json_path("#{path}/_links/allowedValues")
-      end
-
-      it 'embeds no values' do
-        allowed_path = "#{path}/_embedded/allowedValues"
-
-        is_expected
-          .not_to have_json_path(allowed_path)
+      it_behaves_like 'links to allowed values directly' do
+        let(:hrefs) { Projects::Status.codes.keys.map { |code| api_v3_paths.project_status code } }
       end
     end
 

--- a/spec/lib/api/v3/projects/statuses/status_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/statuses/status_representer_rendering_spec.rb
@@ -1,0 +1,66 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Projects::Statuses::StatusRepresenter, 'rendering' do
+  include ::API::V3::Utilities::PathHelper
+
+  subject { representer.to_json }
+
+  let(:status) { Projects::Status.codes.keys.first }
+  let(:representer) do
+    described_class.create(status, current_user: current_user, embed_links: true)
+  end
+
+  current_user { FactoryBot.build_stubbed(:user) }
+
+  describe '_links' do
+    describe 'self' do
+      it_behaves_like 'has a titled link' do
+        let(:link) { 'self' }
+        let(:href) { api_v3_paths.project_status status }
+        let(:title) { I18n.t(:"activerecord.attributes.projects/status.codes.#{status}") }
+      end
+    end
+  end
+
+  describe 'properties' do
+    it_behaves_like 'property', :_type do
+      let(:value) { 'ProjectStatus' }
+    end
+
+    it_behaves_like 'property', :id do
+      let(:value) { status }
+    end
+
+    it_behaves_like 'property', :name do
+      let(:value) { I18n.t(:"activerecord.attributes.projects/status.codes.#{status}") }
+    end
+  end
+end

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -269,6 +269,10 @@ describe ::API::V3::Utilities::PathHelper do
     end
   end
 
+  describe 'project status paths' do
+    it_behaves_like 'show', :project_status
+  end
+
   describe 'query paths' do
     it_behaves_like 'resource', :query
 

--- a/spec/requests/api/v3/project_resource_spec.rb
+++ b/spec/requests/api/v3/project_resource_spec.rb
@@ -112,8 +112,8 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
           .at_path("statusExplanation/raw")
 
         expect(subject.body)
-          .to be_json_eql(project_status.code.tr('_', ' ').to_json)
-          .at_path("status")
+          .to be_json_eql(api_v3_paths.project_status(project_status.code).to_json)
+          .at_path("_links/status/href")
       end
 
       context 'requesting nonexistent project' do
@@ -347,15 +347,19 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
         {
           identifier: 'new_project_identifier',
           name: 'Project name',
-          status: 'off track',
-          statusExplanation: { raw: "Some explanation." }
+          statusExplanation: { raw: "Some explanation." },
+          _links: {
+            status: {
+              href: api_v3_paths.project_status('off_track')
+            }
+          }
         }.to_json
       end
 
       it 'sets the status' do
         expect(last_response.body)
-          .to be_json_eql('off track'.to_json)
-          .at_path('status')
+          .to be_json_eql(api_v3_paths.project_status('off_track').to_json)
+                .at_path('_links/status/href')
 
         expect(last_response.body)
           .to be_json_eql(
@@ -440,8 +444,12 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
         {
           identifier: 'new_project_identifier',
           name: 'Project name',
-          status: 'faulty',
-          statusExplanation: "Some explanation."
+          statusExplanation: "Some explanation.",
+          _links: {
+            status: {
+              href: api_v3_paths.project_status('faulty')
+            }
+          }
         }.to_json
       end
 
@@ -547,9 +555,13 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
     context 'with a nil status' do
       let(:body) do
         {
-          status: nil,
           statusExplanation: {
             raw: "Some explanation."
+          },
+          _links: {
+            status: {
+              href: nil
+            }
           }
         }
       end
@@ -557,7 +569,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
       it 'alters the status' do
         expect(last_response.body)
           .to be_json_eql(nil.to_json)
-          .at_path('status')
+          .at_path('_links/status/href')
 
         status = project.status.reload
         expect(status.code).to be_nil
@@ -578,17 +590,21 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
     context 'with a status' do
       let(:body) do
         {
-          status: 'off track',
           statusExplanation: {
             raw: "Some explanation."
+          },
+          _links: {
+            status: {
+              href: api_v3_paths.project_status('off_track')
+            }
           }
         }
       end
 
       it 'alters the status' do
         expect(last_response.body)
-          .to be_json_eql('off track'.to_json)
-          .at_path('status')
+          .to be_json_eql(api_v3_paths.project_status('off_track').to_json)
+          .at_path('_links/status/href')
 
         expect(last_response.body)
           .to be_json_eql(
@@ -644,7 +660,11 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
     context 'with a faulty status' do
       let(:body) do
         {
-          status: "bogus"
+          _links: {
+            status: {
+              href: api_v3_paths.project_status("bogus")
+            }
+          }
         }
       end
 

--- a/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
@@ -117,11 +117,13 @@ describe ::API::V3::Projects::Copy::CreateFormAPI, content_type: :json do
         "customField#{text_custom_field.id}": {
           "raw": "CF text"
         },
-        status: 'on track',
         statusExplanation: { raw: "A magic dwells in each beginning." },
         "_links": {
           "customField#{list_custom_field.id}": {
             "href": api_v3_paths.custom_option(list_custom_field.custom_options.first.id)
+          },
+          "status": {
+            "href": api_v3_paths.project_status('on_track')
           }
         }
       }
@@ -137,8 +139,8 @@ describe ::API::V3::Projects::Copy::CreateFormAPI, content_type: :json do
               .at_path("_embedded/payload/identifier")
 
       expect(response.body)
-        .to be_json_eql('on track'.to_json)
-              .at_path("_embedded/payload/status")
+        .to be_json_eql(api_v3_paths.project_status('on_track').to_json)
+              .at_path("_embedded/payload/_links/status/href")
 
       expect(response.body)
         .to be_json_eql('A magic dwells in each beginning.'.to_json)

--- a/spec/requests/api/v3/projects/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/create_form_resource_spec.rb
@@ -108,11 +108,13 @@ describe ::API::V3::Projects::CreateFormAPI, content_type: :json do
           "customField#{text_custom_field.id}": {
             "raw": "CF text"
           },
-          status: 'on track',
           statusExplanation: { raw: "A magic dwells in each beginning." },
           "_links": {
             "customField#{list_custom_field.id}": {
               "href": api_v3_paths.custom_option(list_custom_field.custom_options.first.id)
+            },
+            "status": {
+              "href": api_v3_paths.project_status('on_track')
             }
           }
         }
@@ -142,8 +144,8 @@ describe ::API::V3::Projects::CreateFormAPI, content_type: :json do
           .at_path("_embedded/payload/_links/customField#{list_custom_field.id}/href")
 
         expect(body)
-          .to be_json_eql('on track'.to_json)
-          .at_path('_embedded/payload/status')
+          .to be_json_eql(api_v3_paths.project_status('on_track').to_json)
+          .at_path('_embedded/payload/_links/status/href')
 
         expect(body)
           .to be_json_eql(
@@ -167,7 +169,11 @@ describe ::API::V3::Projects::CreateFormAPI, content_type: :json do
         {
           identifier: 'new_project_identifier',
           name: 'Project name',
-          status: "bogus"
+          _links: {
+            status: {
+              href: api_v3_paths.project_status("bogus")
+            }
+          }
         }
       end
 

--- a/spec/requests/api/v3/projects/statuses/project_status_resource_spec.rb
+++ b/spec/requests/api/v3/projects/statuses/project_status_resource_spec.rb
@@ -1,0 +1,76 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 Project status resource', type: :request, content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  current_user { FactoryBot.create(:user) }
+
+  describe '#get /project_statuses/:id' do
+    subject(:response) do
+      get get_path
+
+      last_response
+    end
+
+    let(:status) { Projects::Status.codes.keys.last }
+    let(:get_path) { api_v3_paths.project_status status }
+
+    context 'logged in user' do
+      it 'responds with 200 OK' do
+        expect(subject.status).to eq(200)
+      end
+
+      it 'responds with the correct project' do
+        expect(subject.body)
+          .to be_json_eql('ProjectStatus'.to_json)
+                .at_path('_type')
+        expect(subject.body)
+          .to be_json_eql(status.to_json)
+                .at_path('id')
+      end
+
+      context 'requesting nonexistent status' do
+        let(:status) { 'bogus' }
+
+        before do
+          response
+        end
+
+        it_behaves_like 'not found' do
+          let(:id) { 'bogus' }
+          let(:type) { 'ProjectStatus' }
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/projects/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_form_resource_spec.rb
@@ -167,11 +167,13 @@ describe ::API::V3::Projects::UpdateFormAPI, content_type: :json do
           "customField#{text_custom_field.id}": {
             "raw": "new CF text"
           },
-          status: 'off track',
           statusExplanation: { raw: 'Something goes awry.' },
           "_links": {
             "customField#{list_custom_field.id}": {
               "href": api_v3_paths.custom_option(list_custom_field.custom_options.last.id)
+            },
+            "status": {
+              "href": api_v3_paths.project_status('off_track')
             }
           }
         }
@@ -201,8 +203,8 @@ describe ::API::V3::Projects::UpdateFormAPI, content_type: :json do
           .at_path("_embedded/payload/_links/customField#{list_custom_field.id}/href")
 
         expect(body)
-          .to be_json_eql('off track'.to_json)
-          .at_path("_embedded/payload/status")
+          .to be_json_eql(api_v3_paths.project_status('off_track').to_json)
+          .at_path("_embedded/payload/_links/status/href")
 
         expect(body)
           .to be_json_eql('Something goes awry.'.to_json)
@@ -238,14 +240,16 @@ describe ::API::V3::Projects::UpdateFormAPI, content_type: :json do
     context 'with faulty status parameters' do
       let(:params) do
         {
-          status: "bogus"
+          "status": {
+            "href": api_v3_paths.project_status('bogus')
+          }
         }
       end
 
       it 'displays the faulty status in the payload' do
         expect(subject.body)
-          .to be_json_eql('bogus'.to_json)
-          .at_path('_embedded/payload/status')
+          .to be_json_eql({ href: api_v3_paths.project_status('bogus') }.to_json)
+          .at_path('_embedded/payload/_links/status')
       end
 
       it 'has 1 validation errors' do


### PR DESCRIPTION
- Alter `status` property on the `Project`  resource to link to one of a set of ProjectStatus resource
- The `statusExplanation` property on the `Project` resource remains unchanged
- The three currently defined project status ("On track", "At risk", "Off track") are a resource with an endpoint at `/api/v3/project_statuses/:id`
  - using `/api/v3/projects/statuses/:id` might conflict with the freely choosable project identifier


https://community.openproject.org/projects/openproject/work_packages/37023