### PR TITLE
[37010] Add user job to provide system user with privileges

### DIFF
--- a/app/services/projects/schedule_deletion_service.rb
+++ b/app/services/projects/schedule_deletion_service.rb
@@ -48,7 +48,7 @@ module Projects
     end
 
     def persist(call)
-      DeleteProjectJob.perform_later(user_id: user.id, project_id: model.id)
+      DeleteProjectJob.perform_later(user: user, project: model)
       call
     end
   end

--- a/spec/services/projects/schedule_deletion_service_spec.rb
+++ b/spec/services/projects/schedule_deletion_service_spec.rb
@@ -91,7 +91,7 @@ describe ::Projects::ScheduleDeletionService, type: :model do
 
       expect(::Projects::DeleteProjectJob)
         .to receive(:perform_later)
-        .with(user_id: user.id, project_id: project.id)
+        .with(user: user, project: project)
 
       expect(subject).to be_success
     end


### PR DESCRIPTION
Simply passing in the user will fail if, for example, using the global user auth with the system user. It gets temporary admin privileges during the request here (https://github.com/opf/openproject/blob/dev/lib/open_project/authentication/strategies/warden/global_basic_auth.rb#L84), but loses that obviously if the record is found again in the delayed job.

https://community.openproject.org/work_packages/37010