### PR TITLE
Feature/project action filter

### DIFF
--- a/app/models/queries/register.rb
+++ b/app/models/queries/register.rb
@@ -54,6 +54,10 @@ module Queries::Register
       @columns[query] << column
     end
 
+    def register(&block)
+      instance_exec(&block)
+    end
+
     attr_accessor :filters,
                   :orders,
                   :columns

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -117,7 +117,8 @@ OpenProject::AccessControl.map do |map|
                    {
                      copy_projects: %i[copy copy_project]
                    },
-                   require: :member
+                   require: :member,
+                   contract_actions: { projects: %i[copy] }
   end
 
   map.project_module :work_package_tracking, order: 90 do |wpt|

--- a/docs/api/apiv3/endpoints/projects.apib
+++ b/docs/api/apiv3/endpoints/projects.apib
@@ -513,6 +513,7 @@ Returns a collection of projects. The collection can be filtered via query param
       + parent_id: filters projects by their parent.
       + principal: based on members of the project.
       + type_id: based on the types active in a project.
+      + user_action: based on the actions (see [Actions](#actions)) the current user has in the project.
       + id: based on projects' id.
     There might also be additional filters based on the custom fields that have been configured.
     + sortBy (optional, string, `[["id", "asc"]]`) ... JSON specifying sort criteria.

--- a/spec/models/queries/projects/filters/user_action_filter_spec.rb
+++ b/spec/models/queries/projects/filters/user_action_filter_spec.rb
@@ -28,32 +28,14 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Queries::Projects
-  filters = ::Queries::Projects::Filters
-  orders = ::Queries::Projects::Orders
-  query = ::Queries::Projects::ProjectQuery
+require 'spec_helper'
 
-  ::Queries::Register.register do
-    filter query, filters::AncestorFilter
-    filter query, filters::TypeFilter
-    filter query, filters::ActiveFilter
-    filter query, filters::TemplatedFilter
-    filter query, filters::PublicFilter
-    filter query, filters::NameAndIdentifierFilter
-    filter query, filters::CustomFieldFilter
-    filter query, filters::CreatedAtFilter
-    filter query, filters::LatestActivityAtFilter
-    filter query, filters::PrincipalFilter
-    filter query, filters::ParentFilter
-    filter query, filters::IdFilter
-    filter query, filters::ProjectStatusFilter
-    filter query, filters::UserActionFilter
-
-    order query, orders::DefaultOrder
-    order query, orders::LatestActivityAtOrder
-    order query, orders::RequiredDiskSpaceOrder
-    order query, orders::CustomFieldOrder
-    order query, orders::ProjectStatusOrder
-    order query, orders::NameOrder
+describe Queries::Projects::Filters::UserActionFilter, type: :model do
+  it_behaves_like 'basic query filter' do
+    let(:class_key) { :user_action }
+    let(:type) { :list }
+    let(:model) { Project }
+    let(:attribute) { :user_action }
+    let(:values) { ['projects/view'] }
   end
 end

--- a/spec/requests/api/v3/project_resource_spec.rb
+++ b/spec/requests/api/v3/project_resource_spec.rb
@@ -234,6 +234,26 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
       end
     end
 
+    context 'with filtering by capability action' do
+      let(:other_project) do
+        FactoryBot.create(:project, members: [current_user])
+      end
+      let(:projects) { [project, other_project] }
+      let(:role) { FactoryBot.create(:role, permissions: [:copy_projects]) }
+
+      let(:get_path) do
+        api_v3_paths.path_for :projects, filters: [{ "user_action": { "operator": "=", "values": ["projects/copy"] } }]
+      end
+
+      it_behaves_like 'API V3 collection response', 1, 1, 'Project'
+
+      it 'returns the project the current user has the capability in' do
+        expect(response.body)
+          .to be_json_eql(api_v3_paths.project(project.id).to_json)
+                .at_path('_embedded/elements/0/_links/self/href')
+      end
+    end
+
     context 'filtering for principals (members)' do
       let(:other_project) do
         Role.non_member


### PR DESCRIPTION
Introduces the filter allowing to reduce the set of all visible projects to the ones where the current user can carry out an action. Also introduces the `projects/copy` action which a user receives by having the copy_projects permission assigned.

A client can use the filter like this:

```
/api/v3/projects?filters=[{"user_action": {"operator": "=", "values": ["projects/copy"]}}]
```

or together with e.g. the templated filter

```
/api/v3/projects?filters=[{"user_action": {"operator": "=", "values": ["projects/copy"]}}, {"templated": {"operator": "=", "values": ["t"]}}]
```