### PR TITLE
fix namespace of actions

### DIFF
--- a/app/models/actions/scopes/default.rb
+++ b/app/models/actions/scopes/default.rb
@@ -64,7 +64,7 @@ module Actions::Scopes
       end
 
       def action_v3_name(name)
-        API::Utilities::PropertyNameConverter.from_ar_name(name.to_s.singularize).pluralize
+        API::Utilities::PropertyNameConverter.from_ar_name(name.to_s.singularize).pluralize.underscore
       end
 
       def quote_string(string)

--- a/frontend/src/app/modules/apiv3/api-v3.service.ts
+++ b/frontend/src/app/modules/apiv3/api-v3.service.ts
@@ -121,7 +121,7 @@ export class APIV3Service {
   // /api/v3/users
   public readonly users = this.apiV3CustomEndpoint(Apiv3UsersPaths);
 
-  // /api/v3/placeholderUsers
+  // /api/v3/placeholder_users
   public readonly placeholder_users = this.apiV3CustomEndpoint(Apiv3PlaceholderUsersPaths);
 
   // /api/v3/groups

--- a/frontend/src/app/modules/invite-user-modal/principal/principal-search.component.ts
+++ b/frontend/src/app/modules/invite-user-modal/principal/principal-search.component.ts
@@ -65,7 +65,7 @@ export class PrincipalSearchComponent extends UntilDestroyedMixin implements OnI
     this.items$,
     this.input$,
     this.currentUserService.capabilities$.pipe(
-      map(capabilities => !!capabilities.find(c => c.action.href.endsWith('/placeholderUsers/create'))),
+      map(capabilities => !!capabilities.find(c => c.action.href.endsWith('/placeholder_users/create'))),
       distinctUntilChanged(),
     ),
   ).pipe(

--- a/frontend/src/app/modules/invite-user-modal/project-selection/project-selection.component.ts
+++ b/frontend/src/app/modules/invite-user-modal/project-selection/project-selection.component.ts
@@ -92,7 +92,7 @@ export class ProjectSelectionComponent implements OnInit {
       });
     } else {
       this.currentUserService.capabilities$.pipe(take(1)).subscribe((capabilities) => {
-        if (!capabilities.find(c => c.action.href.endsWith('/placeholderUsers/read'))) {
+        if (!capabilities.find(c => c.action.href.endsWith('/placeholder_users/read'))) {
           return;
         }
         // We only add the option if the user has placeholder read rights

--- a/spec/models/actions/scopes/default_spec.rb
+++ b/spec/models/actions/scopes/default_spec.rb
@@ -35,7 +35,7 @@ describe Actions::Scopes::Default, type: :model do
     let(:expected) do
       # This complicated and programmatic way is chosen so that the test can deal with additional actions being defined
       item = ->(permission, namespace, action, global, module_name) {
-        ["#{API::Utilities::PropertyNameConverter.from_ar_name(namespace.to_s.singularize).pluralize}/#{action}",
+        ["#{API::Utilities::PropertyNameConverter.from_ar_name(namespace.to_s.singularize).pluralize.underscore}/#{action}",
          permission.to_s,
          global,
          module_name&.to_s]

--- a/spec/models/capabilities/scopes/default_spec.rb
+++ b/spec/models/capabilities/scopes/default_spec.rb
@@ -223,7 +223,7 @@ describe Capabilities::Scopes::Default, type: :model do
         let(:expected) do
           # This complicated and programmatic way is chosen so that the test can deal with additional actions being defined
           item = ->(namespace, action, global) {
-            ["#{API::Utilities::PropertyNameConverter.from_ar_name(namespace.to_s.singularize).pluralize}/#{action}",
+            ["#{API::Utilities::PropertyNameConverter.from_ar_name(namespace.to_s.singularize).pluralize.underscore}/#{action}",
              user.id,
              global ? nil : project.id]
           }
@@ -249,7 +249,7 @@ describe Capabilities::Scopes::Default, type: :model do
           item = ->(namespace, action, global) {
             return if namespace == :work_packages
 
-            ["#{API::Utilities::PropertyNameConverter.from_ar_name(namespace.to_s.singularize).pluralize}/#{action}",
+            ["#{API::Utilities::PropertyNameConverter.from_ar_name(namespace.to_s.singularize).pluralize.underscore}/#{action}",
              user.id,
              global ? nil : project.id]
           }

--- a/spec/requests/api/v3/action_resource_spec.rb
+++ b/spec/requests/api/v3/action_resource_spec.rb
@@ -83,6 +83,25 @@ describe 'API v3 action resource', type: :request, content_type: :json do
         .at_path('id')
     end
 
+    context 'with an action that has an underscore' do
+      let(:path) { api_v3_paths.action("work_packages/read") }
+
+      it 'returns 200 OK' do
+        expect(subject.status)
+          .to eql(200)
+      end
+
+      it 'returns the action' do
+        expect(subject.body)
+          .to be_json_eql('Action'.to_json)
+                .at_path('_type')
+
+        expect(subject.body)
+          .to be_json_eql("work_packages/read".to_json)
+                .at_path('id')
+      end
+    end
+
     context 'if querying a non existing action' do
       let(:path) { api_v3_paths.action("foo/bar") }
 


### PR DESCRIPTION
The actions are now more rubyish again which will reflect in the urls where we also have an underscore based pattern