### PR TITLE
[37036] Always return user attributes when sync_users enabled

### DIFF
--- a/app/models/ldap_auth_source.rb
+++ b/app/models/ldap_auth_source.rb
@@ -101,10 +101,13 @@ class LdapAuthSource < AuthSource
     }
   end
 
-  # Return the attributes needed for the LDAP search.  It will only
-  # include the user attributes if on-the-fly registration is enabled
-  def search_attributes
-    if onthefly_register?
+  # Return the attributes needed for the LDAP search.
+  #
+  # @param all_attributes [Boolean] Whether to return all user attributes
+  #
+  # By default, it will only include the user attributes if on-the-fly registration is enabled
+  def search_attributes(all_attributes = onthefly_register?)
+    if all_attributes
       ['dn', attr_login, attr_firstname, attr_lastname, attr_mail, attr_admin].compact
     else
       ['dn', attr_login]

--- a/modules/ldap_groups/app/services/ldap_groups/synchronization_service.rb
+++ b/modules/ldap_groups/app/services/ldap_groups/synchronization_service.rb
@@ -85,9 +85,12 @@ module LdapGroups
       base_dn = ldap.base_dn
 
       users = {}
+      # Override the default search attributes from the ldap
+      # if we have sync_users enabled, to also get user attributes
+      search_attributes = ldap.search_attributes(group.sync_users)
       ldap_con.search(base: base_dn,
                       filter: memberof_filter(group),
-                      attributes: ldap.search_attributes) do |entry|
+                      attributes: search_attributes) do |entry|
         data = ldap.get_user_attributes_from_ldap_entry(entry)
         users[data[:login]] = data.except(:dn)
       end

--- a/modules/ldap_groups/spec/services/synchronization_spec.rb
+++ b/modules/ldap_groups/spec/services/synchronization_spec.rb
@@ -183,6 +183,39 @@ describe LdapGroups::SynchronizationService, with_ee: %i[ldap_groups] do
           expect(group_bar.users).to eq([user_cc414])
         end
 
+        context 'with LDAP on-the-fly disabled' do
+          let(:onthefly_register) { false }
+          let(:user_aa729) { User.find_by login: 'aa729' }
+          let(:user_bb459) { User.find_by login: 'bb459' }
+
+
+          context 'and users sync in the groups enabled' do
+            let(:sync_users) { true }
+
+            it 'creates the remaining users' do
+              subject
+              expect(synced_foo.users.count).to eq(1)
+              expect(synced_bar.users.count).to eq(3)
+
+              expect(group_foo.users).to contain_exactly(user_aa729)
+              expect(group_bar.users).to contain_exactly(user_aa729, user_bb459, user_cc414)
+            end
+          end
+
+          context 'and users sync not enabled' do
+            let(:sync_users) { false }
+
+            it 'does not create the users' do
+              subject
+              expect(synced_foo.users.count).to eq(0)
+              expect(synced_bar.users.count).to eq(1)
+
+              expect(group_foo.users).to be_empty
+              expect(group_bar.users).to contain_exactly(user_cc414)
+            end
+          end
+        end
+
         context 'with LDAP on-the-fly enabled' do
           let(:onthefly_register) { true }
           let(:user_aa729) { User.find_by login: 'aa729' }


### PR DESCRIPTION
When a synchronized group has sync_users enabled, we want to synchronize the user to OpenProject even if the connection doesn't have onthefly_register enabled.

But currently, the user attributes (name, mail, etc.) are only returned if onthefly_register is set so the synchronization will never work without it being set on the connnection

https://community.openproject.org/wp/37036