### PR TITLE
hide quick add menu when login is required and user is anonymous

### DIFF
--- a/lib/redmine/menu_manager/top_menu/quick_add_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/quick_add_menu.rb
@@ -80,12 +80,10 @@ module Redmine::MenuManager::TopMenu::QuickAddMenu
   end
 
   def visible_types
-    @visible_types ||= begin
-                         if user_can_create_work_package?
-                           in_project_context? ? @project.types : Type.all
-                         else
-                           Type.none
-                         end
+    @visible_types ||= if user_can_create_work_package?
+                         in_project_context? ? @project.types : Type.all
+                       else
+                         Type.none
                        end
   end
 

--- a/lib/redmine/menu_manager/top_menu/quick_add_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/quick_add_menu.rb
@@ -108,12 +108,17 @@ module Redmine::MenuManager::TopMenu::QuickAddMenu
   end
 
   def show_quick_add_menu?
-    %i[add_work_packages add_project manage_members].any? do |permission|
-      User.current.allowed_to_globally?(permission)
-    end
+    !anonymous_and_login_required? &&
+      %i[add_work_packages add_project manage_members].any? do |permission|
+        User.current.allowed_to_globally?(permission)
+      end
   end
 
   def in_project_context?
     @project&.persisted?
+  end
+
+  def anonymous_and_login_required?
+    Setting.login_required? && User.current.anonymous?
   end
 end

--- a/spec/features/menu_items/quick_add_menu_spec.rb
+++ b/spec/features/menu_items/quick_add_menu_spec.rb
@@ -140,11 +140,14 @@ feature 'Quick-add menu', js: true, selenium: true do
     end
   end
 
-  context 'as an anonymous user' do
-    current_user { FactoryBot.create :anonymous }
+  context 'as an anonymous user', with_settings: { login_required: true } do
+    current_user do
+      FactoryBot.create(:anonymous_role, permissions: %i[add_work_packages])
+      FactoryBot.create :anonymous
+    end
 
     it 'does not show the quick add menu on the home screen' do
-      visit home_path
+      visit signin_path
       quick_add.expect_invisible
     end
   end


### PR DESCRIPTION
The quick add menu ("+" icon in top bar) should not be displayed if login is required and the current user is anonymous even though anonymous might be allowed to create work packages.

![image](https://user-images.githubusercontent.com/617519/116560366-984a4e00-a901-11eb-9b04-6e4e6e303281.png)
