### PR TITLE
Feature/colorful project settings on project form

### DIFF
--- a/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component.html
+++ b/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component.html
@@ -1,21 +1,14 @@
 <ng-select [items]="to?.options | async"
+           [(ngModel)]="currentStatus"
            [formControl]="formControl"
            [formlyAttributes]="field"
-           [attr.aria-required]="to.required"
-           [attr.required]="to.required"
-           [multiple]="to.multiple"
-           [bindLabel]="to.bindLabel"
-           [searchable]="to.searchable"
-           [virtualScroll]="to.virtualScroll"
-           [clearable]="to.clearable"
-           [typeahead]="to.typeahead"
+           bindLabel="name"
+           [searchable]="true"
+           [virtualScroll]="true"
+           [clearable]="false"
            [clearOnBackspace]="false"
            [clearSearchOnAdd]="false"
-           [hideSelected]="to.hideSelected">
-  <ng-template ng-tag-tmp let-search="searchTerm">
-    <b [textContent]="to.text.add_new_action"></b>: {{search}}
-  </ng-template>
-
+           [hideSelected]="true">
   <ng-template ng-label-tmp let-item="item">
     <span class="project-status--bulb -inline" [ngClass]="cssClass(item)"></span>
     <span class="project-status--name" [ngClass]="cssClass(item)">{{item.name}}</span>

--- a/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component.html
+++ b/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component.html
@@ -1,0 +1,27 @@
+<ng-select [items]="to?.options | async"
+           [formControl]="formControl"
+           [formlyAttributes]="field"
+           [attr.aria-required]="to.required"
+           [attr.required]="to.required"
+           [multiple]="to.multiple"
+           [bindLabel]="to.bindLabel"
+           [searchable]="to.searchable"
+           [virtualScroll]="to.virtualScroll"
+           [clearable]="to.clearable"
+           [typeahead]="to.typeahead"
+           [clearOnBackspace]="false"
+           [clearSearchOnAdd]="false"
+           [hideSelected]="to.hideSelected">
+  <ng-template ng-tag-tmp let-search="searchTerm">
+    <b [textContent]="to.text.add_new_action"></b>: {{search}}
+  </ng-template>
+
+  <ng-template ng-label-tmp let-item="item">
+    <span class="project-status--bulb -inline" [ngClass]="cssClass(item)"></span>
+    <span class="project-status--name" [ngClass]="cssClass(item)">{{item.name}}</span>
+  </ng-template>
+  <ng-template ng-option-tmp let-item="item" let-search="searchTerm">
+    <span class="project-status--bulb -inline" [ngClass]="cssClass(item)"></span>
+    <span class="project-status--name" [ngClass]="cssClass(item)">{{item.name}}</span>
+  </ng-template>
+</ng-select>

--- a/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component.ts
+++ b/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component.ts
@@ -1,12 +1,42 @@
 import { Component } from '@angular/core';
 import { FieldType } from "@ngx-formly/core";
-import { projectStatusCodeCssClass } from "core-app/modules/fields/helpers/project-status-helper";
+import { projectStatusCodeCssClass, projectStatusI18n } from "core-app/modules/fields/helpers/project-status-helper";
+import { Observable } from 'rxjs';
+import { I18nService } from "core-app/modules/common/i18n/i18n.service";
 
 @Component({
   selector: 'op-select-project-status-input',
   templateUrl: './select-project-status-input.component.html'
 })
 export class SelectProjectStatusInputComponent extends FieldType {
+  constructor (
+    private I18n:I18nService
+  ) { super() }
+
+  defaultValue = {
+    id: 'not_set',
+    name: projectStatusI18n('not_set', this.I18n),
+    _links: {
+      self: {
+        href: null
+      }
+    }
+  }
+
+  // This and the ngModel is only necessary so that the
+  // default value can be set if no value has been set on the model before.
+  currentStatus = this.defaultValue;
+
+  ngOnInit() {
+    if (this.model._links.status !== null) {
+      this.currentStatus = this.model._links.status;
+    }
+
+    (this.to.options as Observable<any>).subscribe(values => {
+      values.unshift(this.defaultValue)
+    })
+  }
+
   cssClass(item:any) {
     return projectStatusCodeCssClass(item.id)
   }

--- a/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component.ts
+++ b/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { FieldType } from "@ngx-formly/core";
+import { projectStatusCodeCssClass } from "core-app/modules/fields/helpers/project-status-helper";
+
+@Component({
+  selector: 'op-select-project-status-input',
+  templateUrl: './select-project-status-input.component.html'
+})
+export class SelectProjectStatusInputComponent extends FieldType {
+  cssClass(item:any) {
+    return projectStatusCodeCssClass(item.id)
+  }
+}

--- a/frontend/src/app/modules/common/dynamic-forms/dynamic-forms.module.ts
+++ b/frontend/src/app/modules/common/dynamic-forms/dynamic-forms.module.ts
@@ -10,6 +10,7 @@ import { OpenProjectHeaderInterceptor } from "core-app/modules/hal/http/openproj
 import { TextInputComponent } from './components/dynamic-inputs/text-input/text-input.component';
 import { IntegerInputComponent } from './components/dynamic-inputs/integer-input/integer-input.component';
 import { SelectInputComponent } from './components/dynamic-inputs/select-input/select-input.component';
+import { SelectProjectStatusInputComponent } from "./components/dynamic-inputs/select-project-status-input/select-project-status-input.component";
 import { NgOptionHighlightModule } from "@ng-select/ng-option-highlight";
 import { BooleanInputComponent } from './components/dynamic-inputs/boolean-input/boolean-input.component';
 import { DateInputComponent } from './components/dynamic-inputs/date-input/date-input.component';
@@ -33,6 +34,7 @@ import { DynamicFieldWrapperComponent } from './components/dynamic-field-wrapper
         { name: 'textInput', component: TextInputComponent },
         { name: 'dateInput', component: DateInputComponent },
         { name: 'selectInput', component: SelectInputComponent },
+        { name: 'selectProjectStatusInput', component: SelectProjectStatusInputComponent },
         { name: 'formattableInput', component: FormattableTextareaInputComponent },
       ],
       wrappers: [
@@ -66,6 +68,7 @@ import { DynamicFieldWrapperComponent } from './components/dynamic-field-wrapper
     DateInputComponent,
     DatePickerAdapterComponent,
     SelectInputComponent,
+    SelectProjectStatusInputComponent,
     FormattableTextareaInputComponent,
     FormattableControlComponent,
     DynamicFieldWrapperComponent,

--- a/frontend/src/app/modules/common/dynamic-forms/services/dynamic-fields/dynamic-fields.service.ts
+++ b/frontend/src/app/modules/common/dynamic-forms/services/dynamic-fields/dynamic-fields.service.ts
@@ -94,7 +94,33 @@ export class DynamicFieldsService {
       },
       useForFields: [
         'Priority', 'Status', 'Type', 'User', 'Version', 'TimeEntriesActivity',
-        'Category', 'CustomOption', 'Project', 'ProjectStatus'
+        'Category', 'CustomOption', 'Project'
+      ]
+    },
+    {
+      config: {
+        type: 'selectProjectStatusInput',
+        className: `inline-edit--field`,
+        templateOptions: {
+          type: 'number',
+          locale: I18n.locale,
+          bindLabel: 'name',
+          searchable: true,
+          virtualScroll: true,
+          typeahead: false,
+          clearOnBackspace: false,
+          clearSearchOnAdd: false,
+          hideSelected: false,
+          text: {
+            add_new_action: I18n.t('js.label_create'),
+          },
+        },
+        expressionProperties: {
+          'templateOptions.clearable': (model:any, formState:any, field:FormlyFieldConfig) => !field.templateOptions?.required,
+        },
+      },
+      useForFields: [
+        'ProjectStatus'
       ]
     },
   ];

--- a/frontend/src/app/modules/common/dynamic-forms/services/dynamic-fields/dynamic-fields.service.ts
+++ b/frontend/src/app/modules/common/dynamic-forms/services/dynamic-fields/dynamic-fields.service.ts
@@ -106,14 +106,6 @@ export class DynamicFieldsService {
           locale: I18n.locale,
           bindLabel: 'name',
           searchable: true,
-          virtualScroll: true,
-          typeahead: false,
-          clearOnBackspace: false,
-          clearSearchOnAdd: false,
-          hideSelected: false,
-          text: {
-            add_new_action: I18n.t('js.label_create'),
-          },
         },
         expressionProperties: {
           'templateOptions.clearable': (model:any, formState:any, field:FormlyFieldConfig) => !field.templateOptions?.required,

--- a/frontend/src/app/modules/common/dynamic-forms/spec/helpers.ts
+++ b/frontend/src/app/modules/common/dynamic-forms/spec/helpers.ts
@@ -5,6 +5,7 @@ import { CommonModule } from "@angular/common";
 import { TextInputComponent } from "core-app/modules/common/dynamic-forms/components/dynamic-inputs/text-input/text-input.component";
 import { IntegerInputComponent } from "core-app/modules/common/dynamic-forms/components/dynamic-inputs/integer-input/integer-input.component";
 import { SelectInputComponent } from "core-app/modules/common/dynamic-forms/components/dynamic-inputs/select-input/select-input.component";
+import { SelectProjectStatusInputComponent } from "core-app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component";
 import { BooleanInputComponent } from "core-app/modules/common/dynamic-forms/components/dynamic-inputs/boolean-input/boolean-input.component";
 import { DateInputComponent } from "core-app/modules/common/dynamic-forms/components/dynamic-inputs/date-input/date-input.component";
 import { FormattableTextareaInputComponent } from "core-app/modules/common/dynamic-forms/components/dynamic-inputs/formattable-textarea-input/formattable-textarea-input.component";
@@ -64,6 +65,7 @@ export function createDynamicInputFixture(fields: IOPFormlyFieldSettings[], mode
             { name: 'textInput', component: TextInputComponent },
             { name: 'integerInput', component: IntegerInputComponent },
             { name: 'selectInput', component: SelectInputComponent },
+            { name: 'selectProjectStatusInput', component: SelectProjectStatusInputComponent },
             { name: 'booleanInput', component: BooleanInputComponent },
             { name: 'dateInput', component: DateInputComponent },
             { name: 'formattableInput', component: FormattableTextareaInputComponent },
@@ -82,6 +84,7 @@ export function createDynamicInputFixture(fields: IOPFormlyFieldSettings[], mode
         TextInputComponent,
         IntegerInputComponent,
         SelectInputComponent,
+        SelectProjectStatusInputComponent,
         BooleanInputComponent,
         OpFormFieldComponent,
         DateInputComponent,

--- a/frontend/src/app/modules/common/dynamic-forms/typings.d.ts
+++ b/frontend/src/app/modules/common/dynamic-forms/typings.d.ts
@@ -23,7 +23,7 @@ export interface IOPFormlyTemplateOptions extends FormlyTemplateOptions {
 }
 
 type OPInputType = 'formattableInput'|'selectInput'|'textInput'|'integerInput'|
-  'booleanInput'| 'dateInput' | 'formly-group';
+  'booleanInput'| 'dateInput' | 'formly-group'|'selectProjectStatusInput';
 
 export interface IOPDynamicInputTypeSettings {
   config:IOPFormlyFieldSettings,

--- a/spec/features/projects/project_status_administration_spec.rb
+++ b/spec/features/projects/project_status_administration_spec.rb
@@ -78,7 +78,7 @@ describe 'Projects status administration', type: :feature, js: true do
     status_field.expect_selected 'ON TRACK'
     status_description.expect_value 'Everything is fine at the start'
 
-    status_field.select_option 'OFF TRACK'
+    status_field.select_option 'Off track'
     status_description.set_markdown 'Oh no'
 
     click_button 'Save'

--- a/spec/features/projects/project_status_administration_spec.rb
+++ b/spec/features/projects/project_status_administration_spec.rb
@@ -75,15 +75,15 @@ describe 'Projects status administration', type: :feature, js: true do
     # Check that the status has been set correctly
     visit settings_generic_project_path(id: 'new-project')
 
-    status_field.expect_selected 'On track'
+    status_field.expect_selected 'ON TRACK'
     status_description.expect_value 'Everything is fine at the start'
 
-    status_field.select_option 'Off track'
+    status_field.select_option 'OFF TRACK'
     status_description.set_markdown 'Oh no'
 
     click_button 'Save'
 
-    status_field.expect_selected 'Off track'
+    status_field.expect_selected 'OFF TRACK'
     status_description.expect_value 'Oh no'
   end
 end

--- a/spec/features/projects/template_spec.rb
+++ b/spec/features/projects/template_spec.rb
@@ -96,7 +96,7 @@ describe 'Project templates', type: :feature, js: true do
 
       # Updates the identifier in advanced settings
       page.find('.form--fieldset-legend', text: 'ADVANCED SETTINGS').click
-      status_field.expect_selected 'On track'
+      status_field.expect_selected 'ON TRACK'
 
       # Update status to off track
       status_field.select_option 'Off track'


### PR DESCRIPTION
Reimplements the project status select for the formly based project form with the intend of keeping the functionality unchanged. Changes that where made deliberately are:
* used the `-inline` style to reduce the height of the select options. Using the larger items broke the form IMO.
* removed the small x that clears the input as that is what the `Not set` stands for

For the tiny feature of having a default value, the chosen implementation strikes me as overly complicated. E.g. I had to use ngModel to make it work. Advise on how to simplify the code is hence very much welcomed. 

https://community.openproject.org/wp/37079