### PR TITLE
seed user permissions to global role

### DIFF
--- a/app/seeders/basic_data/role_seeder.rb
+++ b/app/seeders/basic_data/role_seeder.rb
@@ -187,9 +187,13 @@ module BasicData
 
     def project_creator
       {
-        name: I18n.t(:default_role_project_creator),
+        name: I18n.t(:default_role_project_creator_and_staff_manager),
         position: 6,
-        permissions: [:add_project]
+        permissions: %i[
+          add_project
+          manage_user
+          manage_placeholder_user
+        ]
       }
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1110,7 +1110,7 @@ en:
   default_role_anonymous: "Anonymous"
   default_role_developer: "Developer"
   default_role_project_admin: "Project admin"
-  default_role_project_creator: "Project creator"
+  default_role_project_creator_and_staff_manager: "Staff manager and project creator"
   default_role_non_member: "Non member"
   default_role_reader: "Reader"
   default_role_member: "Member"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1110,7 +1110,7 @@ en:
   default_role_anonymous: "Anonymous"
   default_role_developer: "Developer"
   default_role_project_admin: "Project admin"
-  default_role_project_creator_and_staff_manager: "Staff manager and project creator"
+  default_role_project_creator_and_staff_manager: "Staff and projects manager"
   default_role_non_member: "Non member"
   default_role_reader: "Reader"
   default_role_member: "Member"


### PR DESCRIPTION
The i18n key was altered deliberately to trigger retranslation

The name chosen for the role was altered a bit from what was discussed in 

https://community.openproject.org/wp/35523

Since the name of roles typically address what a user having such a role is turned into e.g. 'Project creator', 'Project admin', 'Developer' the previously discussed and agreed upon 'Staffing and project creation' felt out of line. 