### PR TITLE
Fix: Placeholder user avatar rendering

### DIFF
--- a/frontend/src/app/modules/principal/principal-renderer.service.ts
+++ b/frontend/src/app/modules/principal/principal-renderer.service.ts
@@ -92,7 +92,13 @@ export class PrincipalRendererService {
     fallback.classList.add(`op-avatar_${type.replace('_', '-')}`);
     fallback.classList.add('op-avatar--fallback');
     fallback.textContent = userInitials;
-    fallback.style.background = colorCode;
+
+    if (type === "placeholder_user") {
+      fallback.style.color = colorCode;
+      fallback.style.borderColor = colorCode;
+    } else {
+      fallback.style.background = colorCode;
+    }
 
     // Image avatars are only supported for users
     if (type === 'user') {


### PR DESCRIPTION
Currently placeholder users look like the corona virus. We need to set their background transparent and their border color to color that was calculated for the name. 