### PR TITLE
Assume all files under lib/openproject-* are OpenProject constants

### DIFF
--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -45,8 +45,7 @@ end
 # As it is complicated to return all the paths where such an initialization file might exist,
 # we simply return the general OpenProject namespace for such files.
 OpenProject::Inflector.rule do |_basename, abspath|
-  if abspath =~ /openproject-\w+\/lib\/openproject-\w+.rb\z/ ||
-     abspath =~ /modules\/\w+\/lib\/openproject-\w+.rb\z/
+  if abspath =~ /\/lib\/openproject-\w+.rb\z/
     'OpenProject'
   end
 end


### PR DESCRIPTION
When you install an OpenProject plugin via git, the bundled gem folder becomes something like `.git-(hash)/`, so the initialization files for the plugin are at e.g., `.git-a1234fd/lib/openproject-plugin.rb` and are no longer being picked up by zeitwerk.

