### PR TITLE
Feature/user invite from members for non admins

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -220,7 +220,7 @@ class MembersController < ApplicationController
   end
 
   def user_ids_for_new_members(member_params)
-    invite_new_users possibly_seperated_ids_for_entity(member_params, :user)
+    invite_new_users possibly_separated_ids_for_entity(member_params, :user)
   end
 
   def invite_new_users(user_ids)
@@ -233,7 +233,7 @@ class MembersController < ApplicationController
           user = UserInvitation.invite_new_user(email: id) ||
                  User.find_by_mail(id)
 
-          user.id if user
+          user&.id
         end
       else
         id
@@ -245,7 +245,7 @@ class MembersController < ApplicationController
     !OpenProject::Enterprise.user_limit_reached? || !OpenProject::Enterprise.fail_fast?
   end
 
-  def each_comma_seperated(array, &block)
+  def each_comma_separated(array, &block)
     array.map do |e|
       if e.to_s.match /\d(,\d)*/
         block.call(e)
@@ -255,17 +255,17 @@ class MembersController < ApplicationController
     end.flatten
   end
 
-  def transform_array_of_comma_seperated_ids(array)
-    return array unless array.present?
+  def transform_array_of_comma_separated_ids(array)
+    return array if array.blank?
 
-    each_comma_seperated(array) do |elem|
+    each_comma_separated(array) do |elem|
       elem.to_s.split(',')
     end
   end
 
-  def possibly_seperated_ids_for_entity(array, entity = :user)
+  def possibly_separated_ids_for_entity(array, entity = :user)
     if !array[:"#{entity}_ids"].nil?
-      transform_array_of_comma_seperated_ids(array[:"#{entity}_ids"])
+      transform_array_of_comma_separated_ids(array[:"#{entity}_ids"])
     elsif !array[:"#{entity}_id"].nil? && (id = array[:"#{entity}_id"]).present?
       [id]
     else

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -151,7 +151,7 @@ class MembersController < ApplicationController
   end
 
   def suggest_invite_via_email?(user, query, principals)
-    user.admin? && # only admins may add new users via email
+    user.allowed_to_globally?(:manage_user) &&
       query =~ mail_regex &&
       principals.none? { |p| p.mail == query || p.login == query } &&
       query # finally return email
@@ -226,8 +226,8 @@ class MembersController < ApplicationController
   def invite_new_users(user_ids)
     user_ids.map do |id|
       if id.to_i == 0 && id.present? # we've got an email - invite that user
-        # only admins can invite new users
-        if current_user.admin? && enterprise_allow_new_users?
+        # Only users with the manage_member permission can add users.
+        if current_user.allowed_to_globally?(:manage_user) && enterprise_allow_new_users?
           # The invitation can pretty much only fail due to the user already
           # having been invited. So look them up if it does.
           user = UserInvitation.invite_new_user(email: id) ||

--- a/spec/features/members/invitation_spec.rb
+++ b/spec/features/members/invitation_spec.rb
@@ -29,15 +29,17 @@
 require 'spec_helper'
 
 feature 'invite user via email', type: :feature, js: true do
-  shared_let(:admin) { FactoryBot.create :admin }
   let!(:project) { FactoryBot.create :project, name: 'Project 1', identifier: 'project1', members: project_members }
   let!(:developer) { FactoryBot.create :role, name: 'Developer' }
   let(:project_members) { {} }
 
   let(:members_page) { Pages::Members.new project.identifier }
 
-  before do
-    allow(User).to receive(:current).and_return admin
+  current_user do
+    FactoryBot.create(:user,
+                      global_permissions: [:manage_user],
+                      member_in_project: project,
+                      member_with_permissions: %i[view_members manage_members])
   end
 
   context 'with a new user' do


### PR DESCRIPTION
A user having the `manage_user` permission can now invite users on the project members administration screen same as admins could.

https://community.openproject.org/wp/37126