### PR TITLE
Ensure the payload sent to notifications is a hash

### DIFF
--- a/lib/open_project/notifications.rb
+++ b/lib/open_project/notifications.rb
@@ -53,8 +53,8 @@ module OpenProject
         end
       end
 
-      sub = ActiveSupport::Notifications.subscribe(name.to_s) do |_, _, _, _, payload|
-        block.call(payload)
+      sub = ActiveSupport::Notifications.subscribe(name.to_s) do |_, _, _, _, data|
+        block.call(data.fetch(:payload, data))
       end
 
       subs = clear_subscriptions ? [] : Array(subscriptions[name])
@@ -78,7 +78,7 @@ module OpenProject
     # delivered (although it is not at the moment), so don't count on object equality
     # for the payload.
     def send(name, payload)
-      ActiveSupport::Notifications.instrument(name.to_s, payload)
+      ActiveSupport::Notifications.instrument(name.to_s, payload: payload)
     end
 
     def subscriptions


### PR DESCRIPTION
This does not change our interface to notifications, but ensures that
the payload is always a hash, as some integrations (e.g., Sentry!) depends on it.