### PR TITLE
[35999] Add DB constraint on project identifiers

### DIFF
--- a/db/migrate/20210512121322_make_project_identifier_unique.rb
+++ b/db/migrate/20210512121322_make_project_identifier_unique.rb
@@ -1,0 +1,11 @@
+class MakeProjectIdentifierUnique < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :projects, :identifier
+
+    begin
+      add_index :projects, :identifier, unique: true
+    rescue => e
+      raise "You have a duplicate project identifier in your database: #{e.message}"
+    end
+  end
+end


### PR DESCRIPTION
There appears to be a race condition that allows users to save a project without the rails' uniqueness check being enforced. I couldn't reproduce it, but still believe a database-level constraint to be the sane option here. For the affected user(s), this migration will however fail by design.

https://community.openproject.org/wp/35999