### PR TITLE
Fix/add subproject only flow

### DIFF
--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -45,7 +45,7 @@ end
 OpenProject::AccessControl.map do |map|
   map.project_module nil, order: 100 do
     map.permission :add_project,
-                   { projects: %i[new create] },
+                   { projects: %i[new] },
                    require: :loggedin,
                    global: true,
                    contract_actions: { projects: %i[create] }
@@ -116,7 +116,7 @@ OpenProject::AccessControl.map do |map|
                    require: :member
 
     map.permission :add_subprojects,
-                   { projects: %i[new create] },
+                   { projects: %i[new] },
                    require: :member
 
     map.permission :copy_projects,

--- a/lib/api/v3/projects/available_parents_api.rb
+++ b/lib/api/v3/projects/available_parents_api.rb
@@ -34,7 +34,7 @@ module API
       class AvailableParentsAPI < ::API::OpenProjectAPI
         resource :available_parent_projects do
           after_validation do
-            authorize_any(%i[add_project edit_project], global: true)
+            authorize_any(%i[add_project add_subprojects edit_project], global: true)
           end
 
           get &::API::V3::Utilities::Endpoints::Index.new(model: Project,

--- a/lib/api/v3/projects/create_form_api.rb
+++ b/lib/api/v3/projects/create_form_api.rb
@@ -32,7 +32,7 @@ module API
       class CreateFormAPI < ::API::OpenProjectAPI
         resource :form do
           after_validation do
-            authorize :add_project, global: true
+            authorize_any %i[add_project add_subprojects], global: true
           end
 
           post &::API::V3::Utilities::Endpoints::CreateForm.new(model: Project)

--- a/lib/api/v3/projects/schemas/project_schema_representer.rb
+++ b/lib/api/v3/projects/schemas/project_schema_representer.rb
@@ -85,7 +85,12 @@ module API
 
           schema_with_allowed_link :parent,
                                    type: 'Project',
-                                   required: false,
+                                   required: ->(*) {
+                                     # Users only having the add_subprojects permission need to provide
+                                     # a parent when creating a new project.
+                                     represented.model.new_record? &&
+                                       !current_user.allowed_to_globally?(:add_project)
+                                   },
                                    href_callback: ->(*) {
                                      query_props = if represented.model.new_record?
                                                      ''

--- a/spec/features/projects/projects_spec.rb
+++ b/spec/features/projects/projects_spec.rb
@@ -54,25 +54,6 @@ describe 'Projects', type: :feature, js: true do
       expect(page).to have_current_path /\/projects\/foo-bar\/?/
     end
 
-    it 'can create a subproject' do
-      click_on project.name
-      SeleniumHubWaiter.wait
-      click_on 'Project settings'
-      SeleniumHubWaiter.wait
-      click_on 'New subproject'
-
-      name_field.set_value 'Foo child'
-      parent_field.expect_selected project.name
-
-      click_button 'Save'
-
-      expect(page).to have_current_path /\/projects\/foo-child\/?/
-
-      child = Project.last
-      expect(child.identifier).to eq 'foo-child'
-      expect(child.parent).to eq project
-    end
-
     it 'does not create a project with an already existing identifier' do
       click_on 'New project'
 

--- a/spec/features/projects/subproject_creation_spec.rb
+++ b/spec/features/projects/subproject_creation_spec.rb
@@ -1,0 +1,73 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Subproject creation', type: :feature, js: true do
+  let(:name_field) { ::FormFields::InputFormField.new :name }
+  let(:parent_field) { ::FormFields::SelectFormField.new :parent }
+  let(:add_subproject_role) { FactoryBot.create(:role, permissions: %i[edit_project add_subprojects]) }
+  let(:view_project_role) { FactoryBot.create(:role, permissions: %i[edit_project]) }
+  let!(:parent_project) do
+    FactoryBot.create(:project,
+                      name: 'Foo project',
+                      members: { current_user => add_subproject_role })
+  end
+  let!(:other_project) do
+    FactoryBot.create(:project,
+                      name: 'Other project',
+                      members: { current_user => view_project_role })
+  end
+
+  current_user do
+    FactoryBot.create(:user)
+  end
+
+  before do
+    visit settings_project_path(parent_project)
+  end
+
+  it 'can create a subproject' do
+    click_link 'Subproject'
+
+    name_field.set_value 'Foo child'
+    parent_field.expect_required
+    # The other project is not a valid parent since the user is lacking
+    # the add_subproject permission therein.
+    parent_field.expect_no_option(other_project.name)
+    parent_field.expect_selected parent_project.name
+
+    click_button 'Save'
+
+    expect(page).to have_current_path /\/projects\/foo-child\/?/
+
+    child = Project.last
+    expect(child.identifier).to eq 'foo-child'
+    expect(child.parent).to eq parent_project
+  end
+end

--- a/spec/support/form_fields/form_field.rb
+++ b/spec/support/form_fields/form_field.rb
@@ -14,6 +14,11 @@ module FormFields
       raise NotImplementedError
     end
 
+    def expect_required
+      expect(field_container)
+        .to have_selector '.op-form-field--label-indicator', text: '*'
+    end
+
     def field_container
       page.find(selector)
     end

--- a/spec/support/form_fields/select_form_field.rb
+++ b/spec/support/form_fields/select_form_field.rb
@@ -8,6 +8,13 @@ module FormFields
       end
     end
 
+    def expect_no_option(option)
+      field_container.find('.ng-select-container').click
+
+      expect(page)
+        .not_to have_selector('.ng-option', text: option, visible: :all)
+    end
+
     def expect_visible
       expect(field_container).to have_selector('ng-select')
     end


### PR DESCRIPTION
Allows user not having the `add_projects` but the `add_subproject` permission to create users.

Due to the way the contracts are build currently, the first request needs to send a parent reference href. This might not be desired in the long run but should work for our UI currently.

https://community.openproject.org/wp/37195 