### PR TITLE
Fix/project in user invite validation

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1071,6 +1071,8 @@ en:
       project:
         label: 'Project'
         required: 'Please select a project'
+        lacking_permission: 'Please select a different projects since you lack permissions to assign users to the currently selected.'
+        lacking_permission_info: 'You lack the permission to assign users to the project you are currently in. You need to select a different one.'
         next_button: 'Next'
         no_results: 'No projects were found'
         no_invite_rights: 'You are not allowed to invite members to this project'

--- a/frontend/src/app/modules/invite-user-modal/project-selection/project-allowed.validator.ts
+++ b/frontend/src/app/modules/invite-user-modal/project-selection/project-allowed.validator.ts
@@ -1,0 +1,14 @@
+import { AbstractControl } from "@angular/forms";
+import { CurrentUserService } from "core-app/modules/current-user/current-user.service";
+import { of } from "rxjs";
+import { catchError, map, take } from "rxjs/operators";
+
+export const ProjectAllowedValidator = (currentUserService:CurrentUserService) => {
+  return (control: AbstractControl) => {
+    return currentUserService.hasCapabilities$('memberships/update', control.value.idFromLink).pipe(
+      take(1),
+      map(isAllowed => isAllowed ? null : { lackingPermission: true }),
+      catchError(() => of(null))
+    )
+  }
+}

--- a/frontend/src/app/modules/invite-user-modal/project-selection/project-search.component.ts
+++ b/frontend/src/app/modules/invite-user-modal/project-selection/project-search.component.ts
@@ -4,9 +4,9 @@ import {
   OnInit,
   ElementRef,
 } from '@angular/core';
-import { FormControl, NgControl } from "@angular/forms";
-import { Observable, BehaviorSubject, combineLatest } from "rxjs";
-import { debounceTime, distinctUntilChanged, filter, map, switchMap, tap } from "rxjs/operators";
+import { FormControl } from "@angular/forms";
+import { BehaviorSubject, combineLatest } from "rxjs";
+import { debounceTime, map, switchMap } from "rxjs/operators";
 import { APIV3Service } from "core-app/modules/apiv3/api-v3.service";
 import { ApiV3FilterBuilder } from "core-components/api/api-v3/api-v3-filter-builder";
 import { I18nService } from "core-app/modules/common/i18n/i18n.service";
@@ -17,7 +17,7 @@ import { CurrentUserService } from 'core-app/modules/current-user/current-user.s
 interface NgSelectProjectOption {
   project: ProjectResource,
   disabled: boolean;
-};
+}
 
 @Component({
   selector: 'op-ium-project-search',

--- a/frontend/src/app/modules/invite-user-modal/project-selection/project-selection.component.html
+++ b/frontend/src/app/modules/invite-user-modal/project-selection/project-selection.component.html
@@ -13,13 +13,28 @@
         [opFormBinding]="projectControl"
         slot="input"
       ></op-ium-project-search>
-      
+
+      <div
+        slot="help-text"
+        *ngIf="projectControl!.errors?.lackingPermission"
+      >
+        {{ text.project.lackingPermissionInfo }}
+      </div>
+
       <div
         slot="errors"
         class="op-form-field--error"
-        *ngIf="projectControl?.touched && projectControl?.invalid"
+        *ngIf="projectControl!.errors?.required"
       >
         {{ text.project.required }}
+      </div>
+
+      <div
+        slot="errors"
+        class="op-form-field--error"
+        *ngIf="projectControl!.errors?.lackingPermission"
+      >
+        {{ text.project.lackingPermission }}
       </div>
     </op-form-field>
 

--- a/frontend/src/app/modules/invite-user-modal/project-selection/project-selection.component.ts
+++ b/frontend/src/app/modules/invite-user-modal/project-selection/project-selection.component.ts
@@ -11,13 +11,13 @@ import {
   FormGroup,
   Validators,
 } from '@angular/forms';
-import { take } from "rxjs/operators";
 import { I18nService } from "core-app/modules/common/i18n/i18n.service";
 import { BannersService } from "core-app/modules/common/enterprise/banners.service";
 import { CurrentUserService } from 'core-app/modules/current-user/current-user.service';
 import { IOpOptionListOption } from "core-app/modules/common/option-list/option-list.component";
 import { ProjectResource } from "core-app/modules/hal/resources/project-resource";
 import { PrincipalType } from '../invite-user.component';
+import { ProjectAllowedValidator } from './project-allowed.validator';
 
 @Component({
   selector: 'op-ium-project-selection',
@@ -35,6 +35,8 @@ export class ProjectSelectionComponent implements OnInit {
     title: this.I18n.t('js.invite_user_modal.title.invite'),
     project: {
       required: this.I18n.t('js.invite_user_modal.project.required'),
+      lackingPermission: this.I18n.t('js.invite_user_modal.project.lacking_permission'),
+      lackingPermissionInfo: this.I18n.t('js.invite_user_modal.project.lacking_permission_info'),
     },
     type: {
       required: this.I18n.t('js.invite_user_modal.type.required'),
@@ -57,7 +59,7 @@ export class ProjectSelectionComponent implements OnInit {
 
   projectAndTypeForm = new FormGroup({
     type: new FormControl(PrincipalType.User, [ Validators.required ]),
-    project: new FormControl(null, [ Validators.required ]),
+    project: new FormControl(null, [ Validators.required ], ProjectAllowedValidator(this.currentUserService))
   });
 
   get typeControl() { return this.projectAndTypeForm.get('type'); }

--- a/frontend/src/app/modules/invite-user-modal/project-selection/project-selection.component.ts
+++ b/frontend/src/app/modules/invite-user-modal/project-selection/project-selection.component.ts
@@ -93,17 +93,11 @@ export class ProjectSelectionComponent implements OnInit {
         disabled: true,
       });
     } else {
-      this.currentUserService.capabilities$.pipe(take(1)).subscribe((capabilities) => {
-        if (!capabilities.find(c => c.action.href.endsWith('/placeholder_users/read'))) {
-          return;
-        }
-        // We only add the option if the user has placeholder read rights
-        this.typeOptions.push({
-          value: PrincipalType.Placeholder,
-          title: this.I18n.t('js.invite_user_modal.type.placeholder.title'),
-          description: this.I18n.t('js.invite_user_modal.type.placeholder.description'),
-          disabled: false,
-        });
+      this.typeOptions.push({
+        value: PrincipalType.Placeholder,
+        title: this.I18n.t('js.invite_user_modal.type.placeholder.title'),
+        description: this.I18n.t('js.invite_user_modal.type.placeholder.description'),
+        disabled: false,
       });
     }
   }

--- a/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
+++ b/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
@@ -190,9 +190,12 @@ describe 'Invite user modal', type: :feature, js: true do
             context 'without permissions to manage placeholders' do
               let(:permissions) { %i[view_work_packages edit_work_packages manage_members] }
               it 'does not allow to invite a new placeholder' do
-                modal.within_modal do
-                  expect(page).to have_selector '.op-option-list--item', count: 2
-                end
+                modal.project_step
+
+                modal.open_select_in_step 'SOME NEW PLACEHOLDER'
+
+                expect(page)
+                  .to have_text I18n.t('js.invite_user_modal.principal.no_results_placeholder')
               end
             end
           end
@@ -200,7 +203,7 @@ describe 'Invite user modal', type: :feature, js: true do
           context 'with an existing placeholder' do
             let(:principal) { FactoryBot.create :placeholder_user, name: 'EXISTING PLACEHOLDER' }
             let(:permissions) { %i[view_work_packages edit_work_packages manage_members] }
-            let(:global_permissions) { %i[manage_placeholder_user] }
+            let(:global_permissions) { %i[] }
 
             it_behaves_like 'invites the principal to the project' do
               let(:added_principal) { principal }

--- a/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
+++ b/spec/features/users/invite_user_modal/invite_user_modal_spec.rb
@@ -1,0 +1,250 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Invite user modal', type: :feature, js: true do
+  shared_let(:project) { FactoryBot.create :project }
+  shared_let(:work_package) { FactoryBot.create :work_package, project: project }
+
+  let(:permissions) { %i[view_work_packages edit_work_packages manage_members] }
+  let(:global_permissions) { %i[] }
+  let(:modal) do
+    ::Components::Users::InviteUserModal.new project: project,
+                                             principal: principal,
+                                             role: role,
+                                             invite_message: invite_message
+  end
+  let!(:role) do
+    FactoryBot.create :role,
+                      name: 'Member',
+                      permissions: permissions
+  end
+  let(:invite_message) { "Welcome to the team. **You'll like it here**."}
+  let(:mail_membership_recipients) { [] }
+  let(:mail_invite_recipients) { [] }
+
+  current_user do
+    FactoryBot.create :user,
+                      member_in_project: project,
+                      member_through_role: role,
+                      global_permissions: global_permissions
+  end
+
+  shared_examples 'invites the principal to the project' do
+    it 'invites that principal to the project' do
+      perform_enqueued_jobs do
+        modal.run_all_steps
+      end
+
+      assignee_field.expect_inactive!
+      assignee_field.expect_display_value added_principal.name
+
+      new_member = project.reload.member_principals.find_by(user_id: added_principal.id)
+      expect(new_member).to be_present
+      expect(new_member.roles).to eq [role]
+
+      # Check that the expected number of emails are sent.
+      # This includes no mails being sent if the recipient list is empty.
+      expect(ActionMailer::Base.deliveries.size)
+        .to eql mail_invite_recipients.size + mail_membership_recipients.size
+
+      mail_invite_recipients.each_with_index do |recipient, index|
+        expect(ActionMailer::Base.deliveries[index].to)
+          .to match_array [recipient.mail]
+
+        expect(ActionMailer::Base.deliveries[index].body.encoded)
+          .to include "Welcome to OpenProject"
+      end
+
+      mail_membership_recipients.each_with_index do |recipient, index|
+        overall_index = index + mail_invite_recipients.length
+
+        expect(ActionMailer::Base.deliveries[overall_index].to)
+          .to match_array [recipient.mail]
+
+        expect(ActionMailer::Base.deliveries[overall_index].body.encoded)
+          .to include OpenProject::TextFormatting::Renderer.format_text(invite_message)
+
+        expect(ActionMailer::Base.deliveries[overall_index].body.encoded)
+          .to include role.name
+      end
+    end
+  end
+
+  describe 'inviting a principal to a project' do
+    describe 'through the assignee field' do
+      let(:wp_page) { Pages::FullWorkPackage.new(work_package, project) }
+      let(:assignee_field) { wp_page.edit_field :assignee }
+
+      before do
+        wp_page.visit!
+
+        assignee_field.activate!
+
+        find('.ng-dropdown-footer button', text: 'Invite', wait: 10).click
+      end
+
+      context 'with an existing user' do
+        let!(:principal) do
+          FactoryBot.create :user,
+                            firstname: 'Nonproject firstname',
+                            lastname: 'nonproject lastname'
+        end
+
+        it_behaves_like 'invites the principal to the project' do
+          let(:added_principal) { principal }
+          let(:mail_membership_recipients) { [principal] }
+        end
+      end
+
+      context 'with a user to be invited' do
+        let(:principal) { FactoryBot.build :invited_user }
+
+        context 'when the current user has permissions to create a user' do
+          let(:permissions) { %i[view_work_packages edit_work_packages manage_members] }
+          let(:global_permissions) { %i[manage_user] }
+
+          it_behaves_like 'invites the principal to the project' do
+            let(:added_principal) { User.find_by!(mail: principal.mail) }
+            let(:mail_invite_recipients) { [added_principal] }
+            let(:mail_membership_recipients) { [added_principal] }
+          end
+        end
+
+        context 'when the current user does not have permissions to invite a user to the instance by email' do
+          let(:permissions) { %i[view_work_packages edit_work_packages manage_members] }
+          it 'does not show the invite user option' do
+            modal.project_step
+            ngselect = modal.open_select_in_step principal.mail
+            expect(ngselect).to have_text "No users were found"
+            expect(ngselect).not_to have_text "Invite: #{principal.mail}"
+          end
+        end
+
+        context 'when the current user does not have permissions to invite a user in this project' do
+          let(:permissions) { %i[view_work_packages edit_work_packages manage_members] }
+          let(:global_permissions) { %i[manage_user] }
+
+          let(:project_no_permissions) { FactoryBot.create :project }
+          let(:role_no_permissions) do
+            FactoryBot.create :role,
+                              permissions: %i[view_work_packages edit_work_packages]
+          end
+
+          let!(:membership_no_permission) do
+            FactoryBot.create :member,
+                              user: current_user,
+                              project: project_no_permissions,
+                              roles: [role_no_permissions]
+          end
+
+          it 'disables projects for which you do not have rights' do
+            ngselect = modal.open_select_in_step
+            expect(ngselect).to have_text "#{project_no_permissions.name}\nYou are not allowed to invite members to this project"
+          end
+        end
+      end
+
+      describe 'inviting placeholders' do
+        let(:principal) { FactoryBot.build :placeholder_user, name: 'MY NEW PLACEHOLDER' }
+
+        context 'an enterprise system', with_ee: %i[placeholder_users] do
+          describe 'create a new placeholder' do
+            context 'with permissions to manage placeholders' do
+              let(:permissions) { %i[view_work_packages edit_work_packages manage_members] }
+              let(:global_permissions) { %i[manage_placeholder_user] }
+
+              it_behaves_like 'invites the principal to the project' do
+                let(:added_principal) { PlaceholderUser.find_by!(name: 'MY NEW PLACEHOLDER') }
+                # Placeholders get no invite mail
+                let(:mail_membership_recipients) { [] }
+              end
+            end
+
+            context 'without permissions to manage placeholders' do
+              let(:permissions) { %i[view_work_packages edit_work_packages manage_members] }
+              it 'does not allow to invite a new placeholder' do
+                modal.within_modal do
+                  expect(page).to have_selector '.op-option-list--item', count: 2
+                end
+              end
+            end
+          end
+
+          context 'with an existing placeholder' do
+            let(:principal) { FactoryBot.create :placeholder_user, name: 'EXISTING PLACEHOLDER' }
+            let(:permissions) { %i[view_work_packages edit_work_packages manage_members] }
+            let(:global_permissions) { %i[manage_placeholder_user] }
+
+            it_behaves_like 'invites the principal to the project' do
+              let(:added_principal) { principal }
+              # Placeholders get no invite mail
+              let(:mail_membership_recipients) { [] }
+            end
+          end
+        end
+
+        context 'non-enterprise system' do
+          it 'shows the modal with placeholder option disabled' do
+            modal.within_modal do
+              expect(page).to have_field 'Placeholder user', disabled: true
+            end
+          end
+        end
+      end
+
+      describe 'inviting groups' do
+        let(:group_user) { FactoryBot.create(:user) }
+        let(:principal) { FactoryBot.create :group, name: 'MY NEW GROUP', members: [group_user] }
+
+        it_behaves_like 'invites the principal to the project' do
+          let(:added_principal) { principal }
+          # Groups get no invite mail themselves but their members do
+          let(:mail_membership_recipients) { [group_user] }
+        end
+      end
+    end
+  end
+
+  context 'when the user has no permission to manage members' do
+    let(:permissions) { %i[view_work_packages edit_work_packages] }
+    let(:wp_page) { Pages::FullWorkPackage.new(work_package, project) }
+    let(:assignee_field) { wp_page.edit_field :assignee }
+
+    before do
+      wp_page.visit!
+    end
+
+    it 'cannot add an existing user to the project' do
+      assignee_field.activate!
+
+      expect(page).to have_no_selector('.ng-dropdown-footer', text: 'Invite')
+    end
+  end
+end

--- a/spec/features/users/invite_user_modal/permission_lacking_current_project_spec.rb
+++ b/spec/features/users/invite_user_modal/permission_lacking_current_project_spec.rb
@@ -1,0 +1,94 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Inviting user in project the current user is lacking permission in', type: :feature, js: true do
+  let(:modal) do
+    ::Components::Users::InviteUserModal.new project: invite_project,
+                                             principal: other_user,
+                                             role: view_role
+  end
+  let(:quick_add) { ::Components::QuickAddMenu.new }
+
+  let(:view_role) do
+    FactoryBot.create :role,
+                      permissions: []
+  end
+  let(:invite_role) do
+    FactoryBot.create :role,
+                      permissions: %i[manage_members]
+  end
+
+  let!(:other_user) { FactoryBot.create(:user) }
+  let!(:view_project) { FactoryBot.create(:project, members: { current_user => view_role }) }
+  let!(:invite_project) { FactoryBot.create(:project, members: { current_user => invite_role }) }
+
+  current_user do
+    FactoryBot.create :user
+  end
+
+  it 'user cannot invite in current project but for different one' do
+    visit project_path(view_project)
+
+    quick_add.expect_visible
+
+    quick_add.toggle
+
+    quick_add.click_link 'Invite user'
+
+    modal.expect_help_displayed I18n.t('js.invite_user_modal.project.lacking_permission_info')
+
+    # Attempting to proceed without having a different project selected
+
+    modal.select_type 'User'
+
+    modal.click_next
+
+    modal.expect_error_displayed I18n.t('js.invite_user_modal.project.lacking_permission')
+
+    # Proceeding with a different project
+    modal.autocomplete(invite_project.name)
+    modal.click_next
+
+    # Remaining steps
+    modal.principal_step
+    modal.role_step
+    modal.invitation_step
+
+    modal.expect_text "Invite #{other_user.name} to #{invite_project.name}"
+    modal.confirmation_step
+
+    modal.click_modal_button 'Send invitation'
+    modal.expect_text "#{other_user.name} was invited!"
+
+    # Expect to be added to project
+    expect(invite_project.users)
+      .to include(other_user)
+  end
+end

--- a/spec/support/components/users/invite_user_modal.rb
+++ b/spec/support/components/users/invite_user_modal.rb
@@ -172,8 +172,23 @@ module Components
           principal.name
         end
       end
+
       def type
         principal.model_name.human
+      end
+
+      def expect_error_displayed(message)
+        within_modal do
+          expect(page)
+            .to have_selector('.op-form-field--error', text: message)
+        end
+      end
+
+      def expect_help_displayed(message)
+        within_modal do
+          expect(page)
+            .to have_selector('.op-form-field--help-text', text: message)
+        end
       end
     end
   end

--- a/spec/support/components/users/invite_user_modal.rb
+++ b/spec/support/components/users/invite_user_modal.rb
@@ -105,6 +105,9 @@ module Components
       end
 
       def principal_step(next_step: true)
+        # Without it, the "Invite/Create new option is sometimes not displayed"
+        sleep(0.1)
+
         if invite_user?
           autocomplete principal_name, select_text: "Invite: #{principal_name}"
         else


### PR DESCRIPTION
Started of as a fix to validate the preselected project within the user invite model. If the user is allowed to manage members in  a project but not in the current one, a notification message is displayed and if the user ignores it, an error message.

https://community.openproject.org/wp/37169

Also recreates the feature specs for the invite modal that seem to have been deleted accidentally.

Additionally, it allows users not having the manage_placeholder permission to add existing placeholders to a project.