### PR TITLE
Fix board creation modal layout

### DIFF
--- a/frontend/src/app/modules/boards/new-board-modal/new-board-modal.html
+++ b/frontend/src/app/modules/boards/new-board-modal/new-board-modal.html
@@ -1,5 +1,5 @@
 <div
-  class="op-modal confirm-form-submit--modal loading-indicator--location" 
+  class="op-modal op-modal_wide confirm-form-submit--modal loading-indicator--location" 
   data-indicator-name="modal"
 >
   <op-modal-header (close)="closeMe($event)">{{text.board_type}}</op-modal-header>


### PR DESCRIPTION
This got broken when refactoring all the modals to `op-modal` styling. All this commit does is increase the width

Closes https://community.openproject.org/projects/openproject/work_packages/37258/activity