### PR TITLE
Always run the synchronization service as the system user

### DIFF
--- a/modules/ldap_groups/app/services/ldap_groups/synchronization_service.rb
+++ b/modules/ldap_groups/app/services/ldap_groups/synchronization_service.rb
@@ -1,7 +1,9 @@
 module LdapGroups
   class SynchronizationService
     def self.synchronize!
-      new.call
+      User.system.run_given do
+        new.call
+      end
     end
 
     def call

--- a/modules/ldap_groups/app/workers/ldap_groups/synchronization_job.rb
+++ b/modules/ldap_groups/app/workers/ldap_groups/synchronization_job.rb
@@ -37,9 +37,7 @@ module LdapGroups
       return unless EnterpriseToken.allows_to?(:ldap_groups)
       return if skipped?
 
-      User.system.run_given do
-        ::LdapGroups::SynchronizationService.synchronize!
-      end
+      ::LdapGroups::SynchronizationService.synchronize!
     end
 
     def skipped?


### PR DESCRIPTION
When running the synchronization rake task manually, the service is called without the system user getting admin permissions

https://community.openproject.org/wp/37275