### PR TITLE
Fixed: default calendar to appendTo = undefined

### DIFF
--- a/frontend/src/app/modules/common/op-date-picker/op-date-picker.component.ts
+++ b/frontend/src/app/modules/common/op-date-picker/op-date-picker.component.ts
@@ -44,7 +44,7 @@ export class OpDatePickerComponent extends UntilDestroyedMixin implements OnDest
   @Output() public onCancel = new EventEmitter<string>();
 
   @Input() public initialDate = '';
-  @Input() public appendTo?:HTMLElement = document.body;
+  @Input() public appendTo?:HTMLElement;
   @Input() public classes = '';
   @Input() public id = '';
   @Input() public name = '';


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/37273

This pull request:

- [x] Fixes [37273](https://community.openproject.org/projects/openproject/work_packages/37273) so the arrows work dynamic form inputs. Previously the flatpickr was defaulting its ``appenTo`` to the body so it was handling the events in the entire form.