### PR TITLE
[37197] Use setting names in error messages

### DIFF
--- a/app/controllers/admin/settings/display_settings_controller.rb
+++ b/app/controllers/admin/settings/display_settings_controller.rb
@@ -52,7 +52,11 @@ module Admin::Settings
       start_of_year = params[:settings][:first_week_of_year]
 
       if start_of_week.present? ^ start_of_year.present?
-        flash[:error] = I18n.t('settings.display.first_date_of_week_and_year_present')
+        flash[:error] = I18n.t(
+          'settings.display.first_date_of_week_and_year_set',
+          first_week_setting_name: I18n.t(:setting_first_week_of_year),
+          day_of_week_setting_name: I18n.t(:setting_start_of_week)
+        )
         redirect_to action: :show
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2436,8 +2436,8 @@ en:
     session: "Session"
     brute_force_prevention: "Automated user blocking"
     display:
-      first_date_of_week_and_year_present: >
-        If either options "First date of week" or "First week of year contains" are set,
+      first_date_of_week_and_year_set: >
+        If either options "%{day_of_week_setting_name}" or "%{first_week_setting_name}" are set,
         the other has to be set as well to avoid inconsistencies in the frontend.
       first_week_of_year_text: >
         Select the date of January that is contained in the first week of the year.


### PR DESCRIPTION
This avoids wrongly translated content

https://community.openproject.org/work_packages/37197