### PR TITLE
Fix/attachment journalizing

### DIFF
--- a/app/services/attachments/touch_container.rb
+++ b/app/services/attachments/touch_container.rb
@@ -1,3 +1,5 @@
+#-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -26,20 +28,22 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Attachments::DeleteService < ::BaseServices::Delete
-  include Attachments::TouchContainer
+module Attachments
+  module TouchContainer
+    extend ActiveSupport::Concern
 
-  def call(params = nil)
-    in_context(model.container || model) do
-      perform(params)
-    end
-  end
+    included do
+      private
 
-  private
-
-  def destroy(attachment)
-    super.tap do
-      touch(attachment.container) if attachment.container
+      def touch(container)
+        # We allow invalid containers to be saved as
+        # adding the attachments does not change the validity of the container
+        # but without that leeway, the user needs to fix the container before
+        # the attachment can be added.
+        # However we want the container to be updated when uploading an attachment. This is important,
+        # e.g. for invalidating caches and also for journalizing
+        container.update_attribute(:updated_at, Time.current)
+      end
     end
   end
 end

--- a/app/services/attachments/touch_container.rb
+++ b/app/services/attachments/touch_container.rb
@@ -42,7 +42,8 @@ module Attachments
         # the attachment can be added.
         # However we want the container to be updated when uploading an attachment. This is important,
         # e.g. for invalidating caches and also for journalizing
-        container.update_attribute(:updated_at, Time.current)
+        container.update_column(:updated_at, Time.current)
+        container.save_journals if container.respond_to?(:save_journals)
       end
     end
   end

--- a/spec/services/attachments/create_service_integration_spec.rb
+++ b/spec/services/attachments/create_service_integration_spec.rb
@@ -29,7 +29,7 @@
 
 require 'spec_helper'
 
-describe Attachments::CreateService do
+describe Attachments::CreateService, 'integration' do
   let(:user) { FactoryBot.create(:user) }
   let(:description) { 'a fancy description' }
 

--- a/spec/services/attachments/delete_service_integration_spec.rb
+++ b/spec/services/attachments/delete_service_integration_spec.rb
@@ -1,0 +1,185 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+
+describe Attachments::DeleteService, 'integration' do
+  subject(:call) { described_class.new(model: attachment, user: user).call }
+
+  let(:user) do
+    FactoryBot.create(:user,
+                      member_in_project: project,
+                      member_with_permissions: permissions)
+  end
+  let(:project) { FactoryBot.create(:project) }
+  let(:attachment) { FactoryBot.create(:attachment, container: container, author: author) }
+  let(:author) { user }
+
+  describe '#call' do
+    context 'when container is journalized' do
+      let(:container) { FactoryBot.create(:work_package, project: project) }
+      let(:permissions) { %i[edit_work_packages] }
+
+      shared_examples 'successful deletion' do
+        it 'is successful' do
+          expect(call)
+            .to be_success
+        end
+
+        it 'removes the attachment' do
+          expect(Attachment.where(id: attachment.id))
+            .not_to exist
+        end
+
+        it 'adds a journal entry to the container' do
+          expect(container.journals.reload.count).to eq 3 # 1 for WP creation + 1 for adding the attachment + 1 for deletion
+        end
+
+        it 'updates the timestamp on the container' do
+          expect(container.reload.updated_at)
+            .not_to eql timestamp_before
+        end
+      end
+
+      context 'with a valid container' do
+        let!(:timestamp_before) { container.updated_at }
+
+        before do
+          # Force to have a journal for the attachment
+          attachment
+          container.add_journal(user)
+          container.save!
+
+          call
+        end
+
+        it_behaves_like 'successful deletion'
+      end
+
+      context "with an invalid container" do
+        let!(:timestamp_before) { container.updated_at }
+
+        before do
+          # Force to have a journal for the attachment
+          attachment
+          container.add_journal(user, 'Some notes')
+          container.save!
+
+          # have an invalid work package
+          container.update_column(:subject, '')
+
+          call
+        end
+
+        it_behaves_like 'successful deletion'
+      end
+    end
+
+    context 'when not journalized' do
+      let(:container) { FactoryBot.create(:message, forum: forum) }
+      let(:forum) { FactoryBot.create(:forum, project: project)}
+      let(:permissions) { %i[delete_messages edit_messages] }
+
+      shared_examples 'successful deletion' do
+        it 'is successful' do
+          expect(call)
+            .to be_success
+        end
+
+        it 'removes the attachment' do
+          expect(Attachment.where(id: attachment.id))
+            .not_to exist
+        end
+
+        it 'updates the timestamp on the container' do
+          expect(container.reload.updated_at)
+            .not_to eql timestamp_before
+        end
+      end
+
+      context 'with a valid container' do
+        let!(:timestamp_before) { container.updated_at }
+
+        before do
+          call
+        end
+
+        it_behaves_like 'successful deletion'
+      end
+
+      context "with an invalid container" do
+        let!(:timestamp_before) { container.updated_at }
+
+        before do
+          # have an invalid container
+          container.update_column(:subject, '')
+
+          call
+        end
+
+        it_behaves_like 'successful deletion'
+      end
+    end
+
+    context "when uncontainered" do
+      let(:container) { nil }
+      let(:permissions) { [] }
+
+      before do
+        call
+      end
+
+      context 'when the user is the attachment author' do
+        it 'is successful' do
+          expect(call)
+            .to be_success
+        end
+
+        it 'removes the attachment' do
+          expect(Attachment.where(id: attachment.id))
+            .not_to exist
+        end
+      end
+
+      context 'with the user not being the attachment author' do
+        let(:author) { FactoryBot.create(:user) }
+
+        it 'fails' do
+          expect(call)
+            .to be_failure
+        end
+
+        it 'keeps the attachment' do
+          expect(Attachment.find(attachment.id))
+            .to eql attachment
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes journalizing attachment containers (e.g. work packages) when:
* creating attachments
* deleting attachments

In both cases, the timestamp where not updated. Because of that, attachment activity was attributed always to the last time the container was updated.

https://community.openproject.org/wp/35636