### PR TITLE
remove reply from message journaling

### DIFF
--- a/db/migrate/20210519141244_remove_reply_from_message_journalizing.rb
+++ b/db/migrate/20210519141244_remove_reply_from_message_journalizing.rb
@@ -1,0 +1,6 @@
+class RemoveReplyFromMessageJournalizing < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :message_journals, :last_reply_id, :integer
+    remove_column :message_journals, :replies_count, :integer, default: 0, null: false
+  end
+end


### PR DESCRIPTION
The columns:
* last_reply_id
* replies_count

are columns that exist for performance reasons only. They do not contain information about the message itself.

If they are journaled, adding a message to a forum updates the last_reply_id of the parent message. The user replying will then be shown to have updated the replied to message:

![image](https://user-images.githubusercontent.com/617519/118830855-94d23300-b8bf-11eb-967a-12d026e2df5d.png)
