### PR TITLE
Fix #37136: Restrict deletion of placeholder users

### DIFF
--- a/app/cells/placeholder_users/row_cell.rb
+++ b/app/cells/placeholder_users/row_cell.rb
@@ -46,11 +46,20 @@ module PlaceholderUsers
     end
 
     def delete_link
-      return nil unless PlaceholderUsers::DeleteContract.deletion_allowed?(User.current)
+      if PlaceholderUsers::DeleteContract.deletion_allowed?(placeholder_user,
+                                                            User.current,
+                                                            table.user_allowed_service)
 
-      link_to '',
-              deletion_info_placeholder_user_path(placeholder_user),
-              class: 'icon icon-delete'
+        link_to deletion_info_placeholder_user_path(placeholder_user) do
+          "<span class=\"tooltip--left\" data-tooltip=\"#{I18n.t('placeholder_users.delete_tooltip')}\"><i class=\"icon icon-delete\"></i></span>".html_safe
+        end
+      else
+        "<span class=\"tooltip--left\" data-tooltip=\"#{I18n.t('placeholder_users.right_to_manage_members_missing')}\"><i class=\"icon icon-help2\"></i></span>".html_safe
+      end
+    end
+
+    def row_css_class
+      "placeholder_user"
     end
   end
 end

--- a/app/cells/placeholder_users/table_cell.rb
+++ b/app/cells/placeholder_users/table_cell.rb
@@ -54,5 +54,9 @@ module PlaceholderUsers
     def desc_by_default
       [:created_at]
     end
+
+    def user_allowed_service
+      @user_allowed_service ||= Authorization::UserAllowedService.new(options[:current_user])
+    end
   end
 end

--- a/app/contracts/placeholder_users/delete_contract.rb
+++ b/app/contracts/placeholder_users/delete_contract.rb
@@ -31,21 +31,29 @@
 module PlaceholderUsers
   class DeleteContract < ::DeleteContract
     delete_permission -> {
-      self.class.deletion_allowed?(user)
+      self.class.deletion_allowed?(model, user)
     }
 
     ##
-    # Checks if a given user may be deleted by another one.
+    # Checks if a given placeholder user may be deleted by a user.
     #
     # @param actor [User] User who wants to delete the given placeholder user.
-    def self.deletion_allowed?(actor)
-      actor.allowed_to_globally?(:manage_placeholder_user)
+    def self.deletion_allowed?(placeholder_user,
+                               actor,
+                               user_allowed_service = Authorization::UserAllowedService.new(actor))
+      actor.allowed_to_globally?(:manage_placeholder_user) &&
+        affected_projects_managed_by_actor?(placeholder_user, user_allowed_service)
     end
 
     protected
 
+    def self.affected_projects_managed_by_actor?(placeholder_user, user_allowed_service)
+      placeholder_user.projects.active.empty? ||
+        user_allowed_service.call(:manage_members, placeholder_user.projects.active).result
+    end
+
     def deletion_allowed?
-      self.class.deletion_allowed? user
+      self.class.deletion_allowed?(model, user)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -280,10 +280,27 @@ en:
       no_results_title_text: This user is currently not a member of a project.
 
   placeholder_users:
-    upsale:
-      title: 'Placeholder users are an Enterprise Edition feature'
-      description: 'Placeholder users allow you create a work plan for users that must not have access to the system (yet).'
+    right_to_manage_members_missing: >
+      You are not allowed to delete the placeholder user.
+      You do not have the right to manage members for all projects that the placeholder user is a member of.
+    delete_tooltip: "Delete placeholder user"
+    deletion_info:
+      heading: "Delete placeholder user %{name}"
+      data_consequences: >
+        All occurrences of the placeholder user (e.g., as assignee, responsible or other user values)
+        will be reassigned to an account called "Deleted user".
 
+        As the data of every deleted account is reassigned to this account
+        it will not be possible to distinguish the data the user created from
+        the data of another deleted account.
+      irreversible: "This action is irreversible"
+      confirmation: "Enter the placeholder user name %{name} to confirm the deletion."
+    upsale:
+      title: Assign work to people that are not members of the project.
+      description: >
+        There are multiple scenarios where you want to assign work to people that are not member of your project.
+        It could simply be that you still need to hire the correct person for the job. Or you just don't want to give
+        that person access to the project's information but still want track tasks assigned to that person.
   prioritiies:
     edit:
      priority_color_text: |
@@ -2141,22 +2158,6 @@ en:
 
   placeholders:
     default: "-"
-
-  placeholder_users:
-    deletion_info:
-      heading: "Delete placeholder user %{name}"
-      data_consequences: >
-        All occurrences of the placeholder user (e.g., as assignee, responsible or other user values)
-        will be reassigned to an account called "Deleted user".
-
-        As the data of every deleted account is reassigned to this account
-        it will not be possible to distinguish the data the user created from
-        the data of another deleted account.
-      irreversible: "This action is irreversible"
-      confirmation: "Enter the placeholder user name %{name} to confirm the deletion."
-    upsale:
-      title: Assign work to people that are not members of the project.
-      description: There are multiple scenarios where you want to assign work to people that are not member of your project. It could simply be that you still need to hire the correct person for the job. Or you just don't want to give that person access to the project's information but still want track tasks assigned to that person.
 
   project:
     destroy:

--- a/spec/contracts/placeholder_users/delete_contract_spec.rb
+++ b/spec/contracts/placeholder_users/delete_contract_spec.rb
@@ -34,14 +34,31 @@ require 'contracts/shared/model_contract_shared_context'
 describe PlaceholderUsers::DeleteContract do
   include_context 'ModelContract shared context'
 
-  let(:placeholder_user) { FactoryBot.build_stubbed(:placeholder_user) }
+  let(:placeholder_user) { FactoryBot.create(:placeholder_user) }
+  let(:role) { FactoryBot.create :existing_role, permissions: [:manage_members] }
+  let(:shared_project) { FactoryBot.create(:project, members: { placeholder_user => role, current_user => role }) }
+  let(:not_shared_project) { FactoryBot.create(:project, members: { placeholder_user => role }) }
   let(:contract) { described_class.new(placeholder_user, current_user) }
 
   it_behaves_like 'contract is valid for active admins and invalid for regular users'
 
-  context 'when user with global permission' do
+  context 'when user with global permission to manage_placeholders' do
     let(:current_user) { FactoryBot.create(:user, global_permission: %i[manage_placeholder_user]) }
 
-    it_behaves_like 'contract is valid'
+    before do
+      shared_project
+    end
+
+    context 'when user is allowed to manage members in all projects of the placeholder user' do
+      it_behaves_like 'contract is valid'
+    end
+
+    context 'when user is not allowed to manage members in all projects of the placeholder user' do
+      before do
+        not_shared_project
+      end
+
+      it_behaves_like 'contract user is unauthorized'
+    end
   end
 end

--- a/spec/features/placeholder_users/index_spec.rb
+++ b/spec/features/placeholder_users/index_spec.rb
@@ -28,24 +28,26 @@
 
 require 'spec_helper'
 
-describe 'index placeholder users', type: :feature do
+describe 'index placeholder users', type: :feature, js: true do
   let!(:current_user) { FactoryBot.create :admin }
   let!(:anonymous) { FactoryBot.create :anonymous }
   let!(:placeholder_user_1) do
     FactoryBot.create(:placeholder_user,
                       name: 'B',
-                      created_at: 3.minute.ago)
+                      created_at: 3.minutes.ago)
   end
   let!(:placeholder_user_2) do
     FactoryBot.create(:placeholder_user,
                       name: 'A',
-                      created_at: 2.minute.ago)
+                      created_at: 2.minutes.ago)
   end
   let!(:placeholder_user_3) do
     FactoryBot.create(:placeholder_user,
                       name: 'C',
                       created_at: 1.minute.ago)
   end
+  let(:manager_role) { FactoryBot.create :existing_role, permissions: [:manage_members] }
+  let(:member_role) { FactoryBot.create :existing_role, permissions: [:view_work_packages] }
   let(:index_page) { Pages::Admin::PlaceholderUsers::Index.new }
 
   shared_examples 'placeholders index flow' do
@@ -86,6 +88,51 @@ describe 'index placeholder users', type: :feature do
     current_user { FactoryBot.create :user, global_permission: %i[manage_placeholder_user] }
 
     it_behaves_like 'placeholders index flow'
+
+    context 'when all placeholder users are not members of any project' do
+      before do
+        index_page.visit!
+      end
+
+      it 'allows the deletion of all placeholder users' do
+        # Reason: As the placeholder users are not used anywhere it is safe to delete them.
+        index_page.expect_delete_button(placeholder_user_1)
+        index_page.expect_delete_button(placeholder_user_2)
+        index_page.expect_delete_button(placeholder_user_3)
+      end
+    end
+    
+    context 'when user is allowed to manage members only in some projects of the placeholder users' do
+      let(:shared_project) do
+        FactoryBot.create(:project, members: {
+                            placeholder_user_1 => member_role,
+                            placeholder_user_2 => member_role,
+                            current_user => manager_role
+                          })
+      end
+
+      let(:not_shared_project) do
+        FactoryBot.create(:project, members: {
+                           placeholder_user_2 => member_role,
+                           placeholder_user_3 => member_role
+                         })
+      end
+
+      before do
+        shared_project
+        not_shared_project
+
+        index_page.visit!
+      end
+
+      it 'shows the delete buttons where allowed' do
+        # Show the delete buttons only for those placeholder users that are only in projects
+        # where the current user has the permission to manage members.
+        index_page.expect_delete_button(placeholder_user_1)
+        index_page.expect_no_delete_button(placeholder_user_2)
+        index_page.expect_no_delete_button(placeholder_user_3)
+      end
+    end
   end
 
   context 'as user without global permission' do

--- a/spec/support/pages/admin/placeholder_users/index.rb
+++ b/spec/support/pages/admin/placeholder_users/index.rb
@@ -74,8 +74,24 @@ module Pages
           end
         end
 
+        def expect_no_delete_button_for_all_rows
+          expect(page).to have_selector('i.icon-help2')
+        end
+
+        def expect_no_delete_button(placeholder_user)
+          within_placeholder_user_row(placeholder_user) do
+            expect(page).to have_selector('i.icon-help2')
+          end
+        end
+
+        def expect_delete_button(placeholder_user)
+          within_placeholder_user_row(placeholder_user) do
+            expect(page).to have_selector('i.icon-delete')
+          end
+        end
+
         def click_placeholder_user_button(placeholder_user, text)
-          within_user_row(placeholder_user) do
+          within_placeholder_user_row(placeholder_user) do
             click_link text
           end
         end
@@ -83,7 +99,7 @@ module Pages
         private
 
         def within_placeholder_user_row(placeholder_user)
-          row = find('tr.placeholder_user', text: placeholder_user.name)
+          row = find('tr.placeholder_user td.name', text: placeholder_user.name).ancestor('tr')
           within row do
             yield
           end


### PR DESCRIPTION
Users that are not active admins but have the right to manage placeholder users should not be allowed to delete placeholder users when the placeholder users are members of projects of which the user does not have the right to manage its members.

- In placeholder user index page we uses tooltips to communicate why you cannot delete a placeholder user.
- Extends the delete contract
- Optimizes for performance when rendering the delete links in the index page
- Extends the delete contract spec
- Extends the feature spec for the index page
- Removes duplicate placeholder user i18n block in en.yml

https://community.openproject.com/wp/37136