### PR TITLE
choose wp type by position only

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -201,7 +201,7 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
 
     return if available_types.include?(work_package.type) && work_package.type
 
-    work_package.type = available_types.detect(&:is_default) || available_types.first
+    work_package.type = available_types.first
 
     reassign_status assignable_statuses
   end

--- a/modules/bim/spec/requests/api/bcf/v2_1/topics_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/topics_api_spec.rb
@@ -596,7 +596,7 @@ describe 'BCF 2.1 topics resource', type: :request, content_type: :json, with_ma
 
       {
         guid: issue&.uuid,
-        topic_type: (base && base.type.name) || standard_type.name,
+        topic_type: (base && base.type.name) || type.name,
         topic_status: (base && base.status.name) || default_status.name,
         priority: (base && base.priority.name) || default_priority.name,
         title: title,

--- a/spec/services/work_packages/create_service_integration_spec.rb
+++ b/spec/services/work_packages/create_service_integration_spec.rb
@@ -111,9 +111,9 @@ describe WorkPackages::CreateService, 'integration', type: :model do
       expect(new_work_package.status)
         .to eql(default_status)
 
-      # assign the default type
+      # assign the first type in the project (not related to is_default)
       expect(new_work_package.type)
-        .to eql(default_type)
+        .to eql(type)
 
       # assign the default priority
       expect(new_work_package.priority)

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -776,25 +776,25 @@ describe WorkPackages::SetAttributesService, type: :model do
           context 'a default type exists in new project' do
             let(:new_types) { [other_type, default_type] }
 
-            it 'uses the default type' do
+            it 'uses the first type (by position)' do
               subject
 
               expect(work_package.type)
-                .to eql default_type
+                .to eql other_type
             end
 
             it 'adds change to system changes' do
               subject
 
               expect(work_package.changed_by_system['type_id'])
-                .to eql [initial_type.id, default_type.id]
+                .to eql [initial_type.id, other_type.id]
             end
           end
 
           context 'no default type exists in new project' do
             let(:new_types) { [other_type, yet_another_type] }
 
-            it 'uses the first type' do
+            it 'uses the first type (by position)' do
               subject
 
               expect(work_package.type)


### PR DESCRIPTION
There was a misconception in the code related to the `is_default` field. The `is_default` field only governs whether a type is enabled by default in a new project or not.

https://community.openproject.org/wp/36350