### PR TITLE
show "new project" option on add_subprojects permission

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -76,7 +76,10 @@ Redmine::MenuManager.map :quick_add_menu do |menu|
               aria: { label: I18n.t(:label_project_new) },
               title: I18n.t(:label_project_new)
             },
-            if: Proc.new { User.current.allowed_to_globally?(:add_project) }
+            if: ->(project) {
+              User.current.allowed_to_globally?(:add_project) ||
+                User.current.allowed_to?(:add_subprojects, project)
+            }
 
   menu.push :invite_user,
             nil,

--- a/lib/redmine/menu_manager/top_menu/quick_add_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/quick_add_menu.rb
@@ -45,7 +45,7 @@ module Redmine::MenuManager::TopMenu::QuickAddMenu
         icon: 'icon-add',
         class: 'op-quick-add-menu--button'
       },
-      items: first_level_menu_items_for(:quick_add_menu),
+      items: first_level_menu_items_for(:quick_add_menu, @project),
       options: {
         drop_down_id: 'quick-add-menu',
         menu_item_class: 'op-quick-add-menu'
@@ -107,9 +107,7 @@ module Redmine::MenuManager::TopMenu::QuickAddMenu
 
   def show_quick_add_menu?
     !anonymous_and_login_required? &&
-      %i[add_work_packages add_project manage_members].any? do |permission|
-        User.current.allowed_to_globally?(permission)
-      end
+      (global_add_permissions? || add_subproject_permission?)
   end
 
   def in_project_context?
@@ -118,5 +116,16 @@ module Redmine::MenuManager::TopMenu::QuickAddMenu
 
   def anonymous_and_login_required?
     Setting.login_required? && User.current.anonymous?
+  end
+
+  def global_add_permissions?
+    %i[add_work_packages add_project manage_members].any? do |permission|
+      User.current.allowed_to_globally?(permission)
+    end
+  end
+
+  def add_subproject_permission?
+    in_project_context? &&
+      User.current.allowed_to?(:add_subprojects, @project)
   end
 end

--- a/spec/features/menu_items/quick_add_menu_spec.rb
+++ b/spec/features/menu_items/quick_add_menu_spec.rb
@@ -52,7 +52,7 @@ feature 'Quick-add menu', js: true, selenium: true do
       current_user do
         FactoryBot.create :user,
                           member_in_project: project,
-                          member_with_permissions: %i[add_project view_project add_subprojects]
+                          member_with_permissions: %i[add_subprojects]
       end
 
       let(:field) { ::FormFields::SelectFormField.new :parent }


### PR DESCRIPTION
The "new project" option will only be displayed when the user is in a context, a project, where the add_subprojects permission is granted.

https://community.openproject.org/wp/35527