### PR TITLE
[OP#37444] Make default avatar bg color white

### DIFF
--- a/frontend/src/global_styles/openproject/_variables.scss
+++ b/frontend/src/global_styles/openproject/_variables.scss
@@ -152,7 +152,7 @@
   --user-avatar-mini-border-radius: 50%;
   --user-avatar-mini-width: 20px;
   --user-avatar-mini-height: 20px;
-  --user-avatar-default-bg-color: #090952;
+  --user-avatar-default-bg-color: white;
   --widget-box-block-bg-color: var(--body-background);
   --widget-box-block-border-color: var(--content-default-border-color);
   --homescreen-footer-bg-color: var(--gray-light);


### PR DESCRIPTION
This fixes the github logo with transparency, instead of using a dark blue

The variable existed for some time, but wasn't applied until 11.3

![Screenshot from 2021-05-24 20-41-57](https://user-images.githubusercontent.com/459462/119392893-9a20ea80-bcd0-11eb-8c64-4aaa211f20e5.png)


[OP#37444](https://community.openproject.org/wp/37444)