### PR TITLE
[#37440] OpenProject backup fails on etc folder

### DIFF
--- a/packaging/scripts/backup
+++ b/packaging/scripts/backup
@@ -62,7 +62,7 @@ if [ -d "/etc/${APP_NAME}" ]; then
   dst="${TARGET}/conf-${timestamp}.tar.gz"
   touch "$dst" && chmod 0640 "$dst"
   echo -n "* Saving configuration..." >&2
-  if tar czf "$dst" -C /etc/${APP_NAME} . ; then
+  if tar czf "$dst" -C /etc/${APP_NAME} installer.dat conf.d ; then
     echo " done" >&2
     echo "$dst"
   else


### PR DESCRIPTION
The backup script was changed to include the config folder in
https://github.com/opf/openproject/pull/9189

This however results in permission errors depending on how the apache
integration is configured. Files added there are owned by root, not
openproject.

The reason behind the PR was to backup the installer.dat and conf.d
entries however, so we can just explicitly add those, avoiding the
permission errors.

https://community.openproject.org/work_packages/37440