### PR TITLE
[37261] Take grid-gap into length consideration for filters

### DIFF
--- a/frontend/src/global_styles/content/_advanced_filters.sass
+++ b/frontend/src/global_styles/content/_advanced_filters.sass
@@ -65,7 +65,7 @@ $advanced-filters--grid-gap: 10px
     margin-bottom: 10px
 
     &.--without-operator
-      grid-template-columns: $advanced-filters--label-size $advanced-filters--values-and-operator-size $advanced-filters--close-icon-size
+      grid-template-columns: $advanced-filters--label-size calc(#{$advanced-filters--values-and-operator-size} + #{$advanced-filters--grid-gap}) $advanced-filters--close-icon-size
 
   .advanced-filters--filter-name,
   .advanced-filters--add-filter-label
@@ -82,7 +82,7 @@ $advanced-filters--grid-gap: 10px
 
 .advanced-filters--add-filter
   display: grid
-  grid-template-columns: $advanced-filters--label-size $advanced-filters--values-and-operator-size $advanced-filters--close-icon-size
+  grid-template-columns: $advanced-filters--label-size calc(#{$advanced-filters--values-and-operator-size} + #{$advanced-filters--grid-gap}) $advanced-filters--close-icon-size
   grid-gap: $advanced-filters--grid-gap
 
 // The type="text" is required to be more specific


### PR DESCRIPTION
The rows without an operator have one grid-gap fewer than the others, resulting in the ones with operator being 10px wider.

https://community.openproject.org/wp/37261