### PR TITLE
enforces dependent project modules being active

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -112,11 +112,18 @@ class ProjectsController < ApplicationController
   end
 
   def modules
-    @project.enabled_module_names = permitted_params.project[:enabled_module_names]
-    # Ensure the project is touched to update its cache key
-    @project.touch
-    flash[:notice] = I18n.t(:notice_successful_update)
-    redirect_to settings_modules_project_path(@project)
+    call = Projects::EnabledModulesService
+           .new(model: @project, user: current_user)
+           .call(enabled_modules: permitted_params.project[:enabled_module_names])
+
+    if call.success?
+      flash[:notice] = I18n.t(:notice_successful_update)
+
+      redirect_to settings_modules_project_path(@project)
+    else
+      @errors = call.errors
+      render 'project_settings/modules'
+    end
   end
 
   def custom_fields

--- a/app/services/shared/service_context.rb
+++ b/app/services/shared/service_context.rb
@@ -41,27 +41,33 @@ module Shared
     end
 
     def in_mutex_context(model, send_notifications = true, &block)
-      OpenProject::Mutex.with_advisory_lock_transaction(model) do
-        in_user_context(send_notifications, &block)
-      end
-    end
-
-    def in_user_context(send_notifications = true)
       result = nil
 
-      ActiveRecord::Base.transaction do
-        User.execute_as user do
-          Journal::NotificationConfiguration.with(send_notifications) do
-            result = yield
+      OpenProject::Mutex.with_advisory_lock_transaction(model) do
+        result = without_context_transaction(send_notifications, &block)
 
-            if result.failure?
-              raise ActiveRecord::Rollback
-            end
-          end
-        end
+        raise ActiveRecord::Rollback if result.failure?
       end
 
       result
+    end
+
+    def in_user_context(send_notifications = true, &block)
+      result = nil
+
+      ActiveRecord::Base.transaction do
+        result = without_context_transaction(send_notifications, &block)
+
+        raise ActiveRecord::Rollback if result.failure?
+      end
+
+      result
+    end
+
+    def without_context_transaction(send_notifications, &block)
+      User.execute_as user do
+        Journal::NotificationConfiguration.with(send_notifications, &block)
+      end
     end
   end
 end

--- a/app/views/project_settings/modules.html.erb
+++ b/app/views/project_settings/modules.html.erb
@@ -31,6 +31,8 @@ See docs/COPYRIGHT.rdoc for more details.
   <%= render partial: 'projects/form/toolbar', locals: { form_name: "edit_project_#{@project.id}" } %>
 <% end %>
 
+<%= error_messages_for_contract(@project, @errors) %>
+
 <%= labelled_tabular_form_for @project,
                               url: modules_project_path(@project),
                               method: :put do |form| %>

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -92,7 +92,8 @@ OpenProject::AccessControl.map do |map|
 
     map.permission :select_project_modules,
                    { projects: :modules },
-                   require: :member
+                   require: :member,
+                   dependencies: :edit_project
 
     map.permission :manage_members,
                    { members: %i[index new create update destroy autocomplete_for_member] },
@@ -338,7 +339,7 @@ OpenProject::AccessControl.map do |map|
                      require: :loggedin
   end
 
-  map.project_module :calendar do |cal|
+  map.project_module :calendar, dependencies: :work_package_tracking do |cal|
     cal.permission :view_calendar,
                    'work_packages/calendars': [:index]
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -661,6 +661,9 @@ en:
           attributes:
             types:
               in_use_by_work_packages: "still in use by work packages: %{types}"
+            enabled_modules:
+              dependency_missing: "The module '%{dependency}' needs to be enabled as well since the module '%{module}' depends on it."
+              format: "%{message}"
         query:
           attributes:
             project:

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -69,7 +69,7 @@ module OpenProject::Backlogs
         edit.controller_actions << 'rb_impediments/update'
       end
 
-      project_module :backlogs do
+      project_module :backlogs, dependencies: :work_package_tracking do
         # SYNTAX: permission :name_of_permission, { :controller_name => [:action1, :action2] }
 
         # Master backlog permissions

--- a/modules/boards/lib/open_project/boards/engine.rb
+++ b/modules/boards/lib/open_project/boards/engine.rb
@@ -27,7 +27,7 @@ module OpenProject::Boards
              bundled: true,
              settings: {},
              name: 'OpenProject Boards' do
-      project_module :board_view, order: 80 do
+      project_module :board_view, dependencies: :work_package_tracking, order: 80 do
         permission :show_board_views, 'boards/boards': %i[index], dependencies: :view_work_packages
         permission :manage_board_views, 'boards/boards': %i[index], dependencies: :manage_public_queries
       end

--- a/modules/github_integration/lib/open_project/github_integration/engine.rb
+++ b/modules/github_integration/lib/open_project/github_integration/engine.rb
@@ -60,7 +60,7 @@ module OpenProject::GithubIntegration
 
     initializer 'github.permissions' do
       OpenProject::AccessControl.map do |ac_map|
-        ac_map.project_module(:github, {}) do |pm_map|
+        ac_map.project_module(:github, dependencies: :work_package_tracking) do |pm_map|
           pm_map.permission(:show_github_content, {}, {})
         end
       end

--- a/spec/contracts/projects/enabled_modules_contract_spec.rb
+++ b/spec/contracts/projects/enabled_modules_contract_spec.rb
@@ -1,0 +1,72 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'contracts/shared/model_contract_shared_context'
+
+describe Projects::EnabledModulesContract do
+  include_context 'ModelContract shared context'
+
+  let(:project) { FactoryBot.build_stubbed(:project, enabled_module_names: enabled_modules) }
+  let(:contract) { described_class.new(project, current_user) }
+  let(:ac_modules) { [{ name: :a_module, dependencies: %i[b_module] }] }
+  let(:current_user) do
+    FactoryBot.build_stubbed(:user).tap do |user|
+      allow(user)
+        .to receive(:allowed_to?) do |requested_permission, requested_project|
+        permissions.include?(requested_permission) && requested_project == project
+      end
+    end
+  end
+  let(:enabled_modules) { %i[a_module b_module] }
+  let(:permissions) { %i[select_project_modules] }
+
+  before do
+    allow(OpenProject::AccessControl)
+      .to receive(:modules)
+      .and_return(ac_modules)
+  end
+
+  describe '#valid?' do
+    it_behaves_like 'contract is valid'
+
+    context 'when the dependencies are not met' do
+      let(:enabled_modules) { %i[a_module] }
+
+      it_behaves_like 'contract is invalid', enabled_modules: :dependency_missing
+    end
+
+    context 'when the user lacks the select_project_modules permission' do
+      let(:permissions) { %i[] }
+
+      it_behaves_like 'contract is invalid', base: :error_unauthorized
+    end
+  end
+end

--- a/spec/features/projects/modules_spec.rb
+++ b/spec/features/projects/modules_spec.rb
@@ -1,0 +1,104 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Projects module administration',
+         type: :feature do
+
+  let!(:project) do
+    FactoryBot.create(:project,
+                      enabled_module_names: [])
+  end
+
+  let(:role) do
+    FactoryBot.create(:role,
+                      permissions: permissions)
+  end
+  let(:permissions) { %i(edit_project select_project_modules) }
+  let(:settings_page) { Pages::Projects::Settings.new(project) }
+
+  current_user do
+    FactoryBot.create(:user,
+                      member_in_project: project,
+                      member_with_permissions: permissions)
+  end
+
+  it 'allows adding and removing modules' do
+    settings_page.visit_tab!('modules')
+
+    expect(page)
+      .to have_unchecked_field 'Activity'
+
+    expect(page)
+      .to have_unchecked_field 'Calendar'
+
+    expect(page)
+      .to have_unchecked_field 'Time and costs'
+
+    check 'Activity'
+
+    click_button 'Save'
+
+    settings_page.expect_notification message: I18n.t(:notice_successful_update)
+
+    expect(page)
+      .to have_checked_field 'Activity'
+
+    expect(page)
+      .to have_unchecked_field 'Calendar'
+
+    expect(page)
+      .to have_unchecked_field 'Time and costs'
+
+    check 'Calendar'
+
+    click_button 'Save'
+
+    expect(page)
+      .to have_selector '.notification-box.-error',
+                        text: I18n.t(:'activerecord.errors.models.project.attributes.enabled_modules.dependency_missing',
+                                     dependency: 'Work package tracking',
+                                     module: 'Calendar')
+
+    check 'Work package tracking'
+
+    click_button 'Save'
+
+    settings_page.expect_notification message: I18n.t(:notice_successful_update)
+
+    expect(page)
+      .to have_checked_field 'Activity'
+
+    expect(page)
+      .to have_checked_field 'Calendar'
+
+    expect(page)
+      .to have_checked_field 'Work package tracking'
+  end
+end

--- a/spec/lib/open_project/access_control_spec.rb
+++ b/spec/lib/open_project/access_control_spec.rb
@@ -58,6 +58,10 @@ describe OpenProject::AccessControl do
         mod.permission :proj3, { dont: :care }
         mod.permission :global2, { dont: :care }, global: true, contract_actions: { baz: %i[destroy] }
       end
+
+      map.project_module :dependent_module, dependencies: :project_module do |mod|
+        mod.permission :proj4, { dont: :care }
+      end
     end
   end
 
@@ -177,6 +181,23 @@ describe OpenProject::AccessControl do
     end
   end
 
+  describe '.modules' do
+    before do
+      stash_access_control_permissions
+
+      setup_global_permissions
+    end
+
+    after do
+      restore_access_control_permissions
+    end
+
+    it 'can store dependencies' do
+      expect(OpenProject::AccessControl.modules.detect { |m| m[:name] == :dependent_module }[:dependencies])
+        .to match_array(%i[project_module])
+    end
+  end
+
   describe '#global_permissions' do
     before do
       stash_access_control_permissions
@@ -194,7 +215,7 @@ describe OpenProject::AccessControl do
     it { expect(OpenProject::AccessControl.global_permissions.collect(&:name)).to include(:global2) }
   end
 
-  describe '#available_project_modules' do
+  describe '.available_project_modules' do
     before do
       stash_access_control_permissions
 

--- a/spec/services/shared/service_context_integration_spec.rb
+++ b/spec/services/shared/service_context_integration_spec.rb
@@ -1,0 +1,107 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe Shared::ServiceContext, 'integration', type: :model do
+  let(:user) { FactoryBot.build_stubbed(:user) }
+
+  let(:instance) do
+    Class.new do
+      include Shared::ServiceContext
+
+      attr_accessor :user
+
+      def initialize(user)
+        self.user = user
+      end
+
+      def test_method_failure(model)
+        in_context model, true do
+          Setting.connection.execute <<~SQL
+            INSERT INTO settings (name, value)
+            VALUES ('test_setting', 'abc')
+          SQL
+
+          ServiceResult.new success: false
+        end
+      end
+
+      def test_method_success(model)
+        in_context model, true do
+          Setting.connection.execute <<~SQL
+            INSERT INTO settings (name, value)
+            VALUES ('test_setting', 'abc')
+          SQL
+
+          ServiceResult.new success: true
+        end
+      end
+    end.new(user)
+  end
+
+  describe '#in_context' do
+    context 'with a model' do
+      let(:model) { User.new } # model implementation is irrelevant
+
+      context 'with a failure result' do
+        it 'reverts all database changes' do
+          expect { instance.test_method_failure(model) }
+            .not_to change { Setting.count }
+        end
+      end
+
+      context 'with a success result' do
+        it 'keeps database changes' do
+          expect { instance.test_method_success(model) }
+            .to change { Setting.count }
+        end
+      end
+    end
+
+    context 'without a model' do
+      let(:model) { nil }
+
+      context 'with a failure result' do
+        it 'reverts all database changes' do
+          expect { instance.test_method_failure(model) }
+            .not_to change { Setting.count }
+        end
+      end
+
+      context 'with a success result' do
+        it 'keeps database changes' do
+          expect { instance.test_method_success(model) }
+            .to change { Setting.count }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Project modules, e.g. calendar can define dependencies, e.g. work packages. An error message is now displayed if a user enables a project module without the dependency being active in the project as well.

Also fixes a serious bug in the Shared::ServiceContext module. Whenever a failing service result is returned, every change to the database is to be rolled back. This was not true when a model was provided since there was an outer transaction that still committed for the transactional lock.

https://community.openproject.org/wp/34794