### PR TITLE
[37453] Fix user custom fields on new projects not being selectable

### DIFF
--- a/frontend/src/app/core/services/permissions/permissions.service.ts
+++ b/frontend/src/app/core/services/permissions/permissions.service.ts
@@ -4,6 +4,7 @@ import { Observable, of } from 'rxjs';
 import { CurrentProjectService } from 'core-components/projects/current-project.service';
 import { map, catchError } from 'rxjs/operators';
 import { FilterOperator } from 'core-components/api/api-v3/api-v3-filter-builder';
+import { ApiV3ListFilter } from "core-app/modules/apiv3/paths/apiv3-list-resource.interface";
 
 @Injectable({
   providedIn: 'root',
@@ -14,9 +15,12 @@ export class PermissionsService {
     private currentProjectService:CurrentProjectService,
   ) { }
 
-  canInviteUsersToProject(projectId = this.currentProjectService.id!):Observable<boolean> {
-    // TODO: Remove/Fix this typing issue
-    const filters:[string, FilterOperator, string[]][] = [['id', '=', [projectId]]];
+  canInviteUsersToProject(projectId = this.currentProjectService.id):Observable<boolean> {
+    if (!projectId) {
+      return of(false);
+    }
+
+    const filters:ApiV3ListFilter[] = [['id', '=' as FilterOperator, [projectId]]];
 
     return this.apiV3Service
       .memberships

--- a/frontend/src/app/modules/apiv3/paths/apiv3-list-resource.interface.ts
+++ b/frontend/src/app/modules/apiv3/paths/apiv3-list-resource.interface.ts
@@ -30,8 +30,10 @@ import { CollectionResource } from "core-app/modules/hal/resources/collection-re
 import { ApiV3FilterBuilder, FilterOperator } from "core-components/api/api-v3/api-v3-filter-builder";
 import { Observable } from "rxjs";
 
+export type ApiV3ListFilter = [string, FilterOperator, string[]];
+
 export interface Apiv3ListParameters {
-  filters?:[string, FilterOperator, string[]][];
+  filters?:ApiV3ListFilter[];
   sortBy?:[string, string][];
   pageSize?:number;
   offset?:number;

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -358,10 +358,10 @@ module API
               represented.project_id.to_s
             end
 
-          if project_id_value.nil?
-            [{ member: { operator: '*', values: [] } }]
-          else
+          if project_id_value.present?
             [{ member: { operator: '=', values: [project_id_value.to_s] } }]
+          else
+            [{ member: { operator: '*', values: [] } }]
           end
         end
 

--- a/spec/features/projects/projects_custom_fields_spec.rb
+++ b/spec/features/projects/projects_custom_fields_spec.rb
@@ -208,4 +208,45 @@ describe 'Projects custom fields', type: :feature, js: true do
       expect(field).to be_checked
     end
   end
+
+  describe 'with user CF' do
+    let!(:custom_field) do
+      FactoryBot.create(:user_project_custom_field)
+    end
+
+    # Create a second project for visible options
+    let!(:existing_project) { FactoryBot.create :project }
+
+    # Assume one user is visible
+    let!(:invisible_user) { FactoryBot.create :user, firstname: 'Invisible', lastname: 'User'  }
+    let!(:visible_user) { FactoryBot.create :user, firstname: 'Visible', lastname: 'User', member_in_project: existing_project }
+    current_user do
+      FactoryBot.create :user,
+                        firstname: 'Itsa me',
+                        lastname: 'Mario',
+                        member_in_project: existing_project,
+                        global_permissions: %i[add_project]
+    end
+
+    let(:cf_field) { ::FormFields::SelectFormField.new custom_field }
+
+    scenario 'allows setting a visible user CF (regression #26313)' do
+      visit new_project_path
+
+      name_field.set_value 'My project name'
+
+      find('.form--fieldset-legend a', text: 'ADVANCED SETTINGS').click
+
+      cf_field.expect_visible
+      cf_field.expect_no_option invisible_user
+      cf_field.select_option visible_user
+
+      click_on 'Save'
+
+      expect(page).to have_current_path /\/projects\/my-project-name\/?/
+      project = Project.find_by(name: 'My project name')
+      cv = project.custom_values.find_by(custom_field_id: custom_field.id).typed_value
+      expect(cv).to eq visible_user
+    end
+  end
 end

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -237,6 +237,36 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
         end
       end
     end
+
+    describe 'user custom field on new project' do
+      let(:schema) do
+        double('ProjectSchema',
+               id: nil,
+               model: Project.new,
+               defines_assignable_values?: true,
+               available_custom_fields: [custom_field])
+      end
+      let(:custom_field) do
+        FactoryBot.build(:custom_field,
+                         field_format: 'user',
+                         is_required: true)
+      end
+
+      it_behaves_like 'links to allowed values via collection link' do
+        let(:path) { cf_path }
+        let(:href) do
+          params = [
+            { status: { operator: '!', values: [Principal.statuses[:locked].to_s] } },
+            { type: { operator: '=', values: %w[User Group PlaceholderUser] } },
+            { member: { operator: '*', values: [] } }
+          ]
+
+          query = CGI.escape(::JSON.dump(params))
+
+          "#{api_v3_paths.principals}?filters=#{query}&pageSize=0"
+        end
+      end
+    end
   end
 
   describe '#inject_value' do


### PR DESCRIPTION
This restores the functionality to select any visible existing user throug the API.

Also fixes an unrelated bug in the permissions service that tries to determine visibility of the invite user button and fails due to an empty project id.

https://community.openproject.org/wp/37453