### PR TITLE
Feature/37398 select input none option

### DIFF
--- a/frontend/src/app/core/services/forms/forms.service.ts
+++ b/frontend/src/app/core/services/forms/forms.service.ts
@@ -79,28 +79,21 @@ export class FormsService {
   private formatModelToSubmit(formModel:IOPFormModel):IOPFormModel {
     const resources = formModel?._links || {};
 
+    console.log('formatModelToSubmit', formModel)
+
     const formattedResources = Object
       .keys(resources)
       .reduce((result, resourceKey) => {
         const resource = resources[resourceKey];
-        let resourceValue;
         // Form.payload resources have a HalLinkSource interface while
         // API resource options have a IAllowedValue interface
-        if (Array.isArray(resource)) {
-          const formattedResourceValue = resource
-            .map(resourceElement => ({href: resourceElement?.href || resourceElement?._links?.self?.href}))
-            .filter(resourceElement => !!resourceElement.href);
-
-          resourceValue = formattedResourceValue.length ? formattedResourceValue : null;
-        } else {
-          const href = resource?.href || resource?._links?.self?.href;
-
-          resourceValue = href ? {href} : null;
-        }
+        const resourceValue = Array.isArray(resource) ?
+          resource.map(resourceElement => ({ href: resourceElement?.href || resourceElement?._links?.self?.href || null })) :
+          { href: resource?.href || resource?._links?.self?.href || null };
 
         return {
           ...result,
-          ...resourceValue && {[resourceKey]: resourceValue},
+          [resourceKey]: resourceValue,
         };
       }, {});
 

--- a/frontend/src/app/core/services/forms/forms.service.ts
+++ b/frontend/src/app/core/services/forms/forms.service.ts
@@ -87,14 +87,9 @@ export class FormsService {
         // Form.payload resources have a HalLinkSource interface while
         // API resource options have a IAllowedValue interface
         if (Array.isArray(resource)) {
-          const formattedResourceValue = resource.reduce((result:any[], resourceElement) => {
-            const href = resourceElement?.href || resourceElement?._links?.self?.href;
-            if (href) {
-              result = [...result, {href}]
-            }
-
-            return result
-          }, []);
+          const formattedResourceValue = resource
+            .map(resourceElement => ({href: resourceElement?.href || resourceElement?._links?.self?.href}))
+            .filter(resourceElement => !!resourceElement.href);
 
           resourceValue = formattedResourceValue.length ? formattedResourceValue : null;
         } else {

--- a/frontend/src/app/core/services/forms/forms.service.ts
+++ b/frontend/src/app/core/services/forms/forms.service.ts
@@ -83,15 +83,29 @@ export class FormsService {
       .keys(resources)
       .reduce((result, resourceKey) => {
         const resource = resources[resourceKey];
+        let resourceValue;
         // Form.payload resources have a HalLinkSource interface while
         // API resource options have a IAllowedValue interface
-        const resourceValue = Array.isArray(resource) ?
-          resource.map(resourceElement => ({ href: resourceElement?.href || resourceElement?._links?.self?.href })) :
-          { href: resource?.href || resource?._links?.self?.href };
+        if (Array.isArray(resource)) {
+          const formattedResourceValue = resource.reduce((result:any[], resourceElement) => {
+            const href = resourceElement?.href || resourceElement?._links?.self?.href;
+            if (href) {
+              result = [...result, {href}]
+            }
+
+            return result
+          }, []);
+
+          resourceValue = formattedResourceValue.length ? formattedResourceValue : null;
+        } else {
+          const href = resource?.href || resource?._links?.self?.href;
+
+          resourceValue = href ? {href} : null;
+        }
 
         return {
           ...result,
-          [resourceKey]: resourceValue,
+          ...resourceValue && {[resourceKey]: resourceValue},
         };
       }, {});
 

--- a/frontend/src/app/core/services/forms/typings.d.ts
+++ b/frontend/src/app/core/services/forms/typings.d.ts
@@ -95,10 +95,10 @@ interface IOPAttributeGroup {
 }
 
 interface IOPAllowedValue {
-  id:string;
+  id?:string;
   name:string;
   [key:string]:unknown;
-  _links:{
+  _links?:{
     self:HalSource | IOPApiOption;
     [key:string]:HalSource;
   };

--- a/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-input/select-input.component.html
+++ b/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-input/select-input.component.html
@@ -9,8 +9,8 @@
            [virtualScroll]="to.virtualScroll"
            [clearable]="to.clearable"
            [typeahead]="to.typeahead"
-           [clearOnBackspace]="false"
-           [clearSearchOnAdd]="false"
+           [clearOnBackspace]="to.clearOnBackspace"
+           [clearSearchOnAdd]="to.clearSearchOnAdd"
            [hideSelected]="to.hideSelected">
   <ng-template ng-tag-tmp let-search="searchTerm">
     <b [textContent]="to.text.add_new_action"></b>: {{search}}

--- a/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component.html
+++ b/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component.html
@@ -1,5 +1,4 @@
 <ng-select [items]="to?.options | async"
-           [(ngModel)]="currentStatus"
            [formControl]="formControl"
            [formlyAttributes]="field"
            bindLabel="name"

--- a/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component.ts
+++ b/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-project-status-input/select-project-status-input.component.ts
@@ -1,42 +1,12 @@
 import { Component } from '@angular/core';
 import { FieldType } from "@ngx-formly/core";
-import { projectStatusCodeCssClass, projectStatusI18n } from "core-app/modules/fields/helpers/project-status-helper";
-import { Observable } from 'rxjs';
-import { I18nService } from "core-app/modules/common/i18n/i18n.service";
+import { projectStatusCodeCssClass } from "core-app/modules/fields/helpers/project-status-helper";
 
 @Component({
   selector: 'op-select-project-status-input',
   templateUrl: './select-project-status-input.component.html'
 })
 export class SelectProjectStatusInputComponent extends FieldType {
-  constructor (
-    private I18n:I18nService
-  ) { super() }
-
-  defaultValue = {
-    id: 'not_set',
-    name: projectStatusI18n('not_set', this.I18n),
-    _links: {
-      self: {
-        href: null
-      }
-    }
-  }
-
-  // This and the ngModel is only necessary so that the
-  // default value can be set if no value has been set on the model before.
-  currentStatus = this.defaultValue;
-
-  ngOnInit() {
-    if (this.model._links.status !== null) {
-      this.currentStatus = this.model._links.status;
-    }
-
-    (this.to.options as Observable<any>).subscribe(values => {
-      values.unshift(this.defaultValue)
-    })
-  }
-
   cssClass(item:any) {
     return projectStatusCodeCssClass(item.id)
   }

--- a/frontend/src/app/modules/common/dynamic-forms/services/dynamic-fields/dynamic-fields.service.ts
+++ b/frontend/src/app/modules/common/dynamic-forms/services/dynamic-fields/dynamic-fields.service.ts
@@ -8,10 +8,12 @@ import { FormlyFieldConfig } from "@ngx-formly/core";
 import { Observable, of } from "rxjs";
 import { map } from "rxjs/operators";
 import { HttpClient } from "@angular/common/http";
+import { I18nService } from "core-app/modules/common/i18n/i18n.service";
 
 
 @Injectable()
 export class DynamicFieldsService {
+  readonly selectDefaultValue = {name:'-'};
   readonly inputsCatalogue:IOPDynamicInputTypeSettings[] = [
     {
       config: {
@@ -36,7 +38,7 @@ export class DynamicFieldsService {
         type: 'integerInput',
         templateOptions: {
           type: 'number',
-          locale: I18n.locale,
+          locale: this.I18n.locale,
         },
       },
       useForFields: ['Integer', 'Float']
@@ -70,10 +72,10 @@ export class DynamicFieldsService {
     {
       config: {
         type: 'selectInput',
-        defaultValue: {name:'-'},
+        defaultValue: this.selectDefaultValue,
         templateOptions: {
           type: 'number',
-          locale: I18n.locale,
+          locale: this.I18n.locale,
           bindLabel: 'name',
           searchable: true,
           virtualScroll: true,
@@ -81,7 +83,7 @@ export class DynamicFieldsService {
           clearSearchOnAdd: false,
           hideSelected: false,
           text: {
-            add_new_action: I18n.t('js.label_create'),
+            add_new_action: this.I18n.t('js.label_create'),
           },
         },
         expressionProperties: {
@@ -96,9 +98,10 @@ export class DynamicFieldsService {
     {
       config: {
         type: 'selectProjectStatusInput',
+        defaultValue: this.selectDefaultValue,
         templateOptions: {
           type: 'number',
-          locale: I18n.locale,
+          locale: this.I18n.locale,
           bindLabel: 'name',
           searchable: true,
         },
@@ -113,7 +116,8 @@ export class DynamicFieldsService {
   ];
 
   constructor(
-    private _httpClient:HttpClient,
+    private httpClient:HttpClient,
+    private I18n:I18nService,
   ) {
   }
 
@@ -293,7 +297,7 @@ export class DynamicFieldsService {
 
       options = of(optionsValues);
     } else if (allowedValues!.href) {
-      options = this._httpClient
+      options = this.httpClient
         .get(allowedValues!.href!)
         .pipe(
           map((response:api.v3.Result) => response._embedded.elements),

--- a/frontend/src/app/modules/common/dynamic-forms/services/dynamic-fields/dynamic-fields.service.ts
+++ b/frontend/src/app/modules/common/dynamic-forms/services/dynamic-fields/dynamic-fields.service.ts
@@ -5,7 +5,7 @@ import {
   IOPFormlyFieldSettings,
 } from "../../typings";
 import { FormlyFieldConfig } from "@ngx-formly/core";
-import { of } from "rxjs";
+import { Observable, of } from "rxjs";
 import { map } from "rxjs/operators";
 import { HttpClient } from "@angular/common/http";
 
@@ -70,6 +70,7 @@ export class DynamicFieldsService {
     {
       config: {
         type: 'selectInput',
+        defaultValue: {name:'-'},
         templateOptions: {
           type: 'number',
           locale: I18n.locale,
@@ -135,7 +136,16 @@ export class DynamicFieldsService {
   }
 
   getFormattedFieldsModel(formModel:IOPFormModel = {}):IOPFormModel {
-    const { _links: resourcesModel, _meta: metaModel, ...otherElementsModel } = formModel;
+    const { _links: resourcesModel, _meta: metaModel, ...otherElements } = formModel;
+    const otherElementsModel = Object.keys(otherElements).reduce((model, key) => {
+      const elementValue = otherElements[key];
+
+      if (this.isValue(elementValue)) {
+        model = {...model, [key]:elementValue}
+      }
+
+      return model;
+    }, {})
 
     const model = {
       ...otherElementsModel,
@@ -194,7 +204,7 @@ export class DynamicFieldsService {
 
       result = {
         ...result,
-        [resourceKey]: resourceModel,
+        ...this.isValue(resourceModel) && {[resourceKey]: resourceModel},
       };
 
       return result;
@@ -251,7 +261,7 @@ export class DynamicFieldsService {
         className: field.name,
         templateOptions: {
           ...inputConfig.templateOptions,
-          ...field.type.startsWith('[]') && {multiple: true},
+          ...this.isMultiSelectField(field) && {multiple: true},
           ...fieldType === 'User' && {showAddNewUserButton: true},
         },
       };
@@ -268,21 +278,22 @@ export class DynamicFieldsService {
     return { ...inputConfig, ...configCustomizations };
   }
 
-  private getFieldOptions(field:IOPFieldSchemaWithKey) {
+  private getFieldOptions(field:IOPFieldSchemaWithKey):Observable<IOPAllowedValue[]>|undefined {
     const allowedValues = field._embedded?.allowedValues || field._links?.allowedValues;
+    let options;
 
     if (!allowedValues) {
       return;
     }
 
     if (Array.isArray(allowedValues)) {
-      const options = allowedValues[0]?._links?.self?.title ?
+      const optionsValues = allowedValues[0]?._links?.self?.title ?
         this.formatAllowedValues(allowedValues) :
         allowedValues;
 
-      return of(options);
+      options = of(optionsValues);
     } else if (allowedValues!.href) {
-      return this._httpClient
+      options = this._httpClient
         .get(allowedValues!.href!)
         .pipe(
           map((response:api.v3.Result) => response._embedded.elements),
@@ -290,12 +301,12 @@ export class DynamicFieldsService {
         );
     }
 
-    return;
+    return options?.pipe(map(options => !field.required && !this.isMultiSelectField(field) ? [{name: '-'}, ...options] : options));
   }
 
   // ng-select needs a 'name' in order to show the label
   // We need to add it in case of the form payload (HalLinkSource)
-  private formatAllowedValues(options:IOPAllowedValue[]) {
+  private formatAllowedValues(options:IOPAllowedValue[]):IOPAllowedValue[] {
     return options.map((option:IOPFieldSchema['options']) => ({ ...option, name: option._links?.self?.title }));
   }
 
@@ -379,6 +390,14 @@ export class DynamicFieldsService {
           field.options?.parentForm?.submitted
         ));
     }
+  }
+
+  private isMultiSelectField(field:IOPFieldSchemaWithKey) {
+    return field?.type?.startsWith('[]');
+  }
+
+  private isValue(value:any) {
+    return ![null, undefined, ''].includes(value);
   }
 }
 


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/37398

This pull request:
- [x] Adds a none ('-') option on select-input and select-project-status when they are not required and not multi-select.
- [x] Removes the Angular warning 'It looks like you're using ngModel on the same form field as formControlName...' by:

> - [x] Implementing default values in the form fields. They are only applied if the form model doesn't contain the property, so all the undefined, null and '' are removed from the form payload.