### PR TITLE
[37463] Pass in work package project to IUM

### DIFF
--- a/frontend/src/app/modules/autocompleter/create-autocompleter/create-autocompleter.component.html
+++ b/frontend/src/app/modules/autocompleter/create-autocompleter/create-autocompleter.component.html
@@ -37,6 +37,9 @@
   </ng-template>
 
   <ng-template ng-footer-tmp *ngIf="showAddNewButton">
-    <op-invite-user-button class="op-select-footer"></op-invite-user-button>
+    <op-invite-user-button
+      [projectId]="resource.project?.id"
+      class="op-select-footer"
+    ></op-invite-user-button>
   </ng-template>
 </ng-select>

--- a/frontend/src/app/modules/autocompleter/create-autocompleter/create-autocompleter.component.ts
+++ b/frontend/src/app/modules/autocompleter/create-autocompleter/create-autocompleter.component.ts
@@ -49,6 +49,7 @@ import { InjectField } from "core-app/helpers/angular/inject-field.decorator";
 import { Subject } from 'rxjs';
 import { PrincipalHelper } from "core-app/modules/principal/principal-helper";
 import { AngularTrackingHelpers } from "core-components/angular/tracking-functions";
+import { filter } from "rxjs/operators";
 
 export interface CreateAutocompleterValueOption {
   name:string;
@@ -58,11 +59,12 @@ export interface CreateAutocompleterValueOption {
 @Component({
   templateUrl: './create-autocompleter.component.html',
   selector: 'create-autocompleter',
-  styleUrls: ['./create-autocompleter.component.sass']
+  styleUrls: ['./create-autocompleter.component.sass'],
 })
 export class CreateAutocompleterComponent extends UntilDestroyedMixin implements AfterViewInit {
   @Input() public availableValues:CreateAutocompleterValueOption[];
   @Input() public appendTo:string;
+  @Input() public resource:HalResource;
   @Input() public model:any;
   @Input() public required = false;
   @Input() public disabled = false;
@@ -104,8 +106,11 @@ export class CreateAutocompleterComponent extends UntilDestroyedMixin implements
     this.onAfterViewInit.emit(this);
     if (this.opInviteUserModalService) {
       this.opInviteUserModalService.close
-        .pipe(this.untilDestroyed())
-        .subscribe((user: HalResource) => {
+        .pipe(
+          this.untilDestroyed(),
+          filter(user => !!user)
+        )
+        .subscribe((user:HalResource) => {
           this.onChange.emit(user);
         });
     }

--- a/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-input/select-input.component.html
+++ b/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-input/select-input.component.html
@@ -21,6 +21,9 @@
   </ng-template>
 
   <ng-template ng-footer-tmp *ngIf="to.showAddNewUserButton">
-    <op-invite-user-button class="op-select-footer"></op-invite-user-button>
+    <op-invite-user-button
+        class="op-select-footer"
+        [projectId]="projectId"
+    ></op-invite-user-button>
   </ng-template>
 </ng-select>

--- a/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-input/select-input.component.ts
+++ b/frontend/src/app/modules/common/dynamic-forms/components/dynamic-inputs/select-input/select-input.component.ts
@@ -1,10 +1,18 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FieldType } from "@ngx-formly/core";
+import { HalResource } from "core-app/modules/hal/resources/hal-resource";
 
 @Component({
   selector: 'op-select-input',
   templateUrl: './select-input.component.html',
   styleUrls: ['./select-input.component.scss']
 })
-export class SelectInputComponent extends FieldType {
+export class SelectInputComponent extends FieldType implements OnInit {
+  projectId:string|undefined;
+
+  public ngOnInit():void {
+    if (this.model?.project) {
+      this.projectId = HalResource.idFromLink(this.model.project?.href)
+    }
+  }
 }

--- a/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/multi-select-edit-field.component.html
@@ -19,7 +19,10 @@
            [dropdownPosition]="'top'"
            [hideSelected]="true">
   <ng-template ng-footer-tmp *ngIf="showAddNewUserButton">
-    <op-invite-user-button (invited)="selectedOption = $event"></op-invite-user-button>
+    <op-invite-user-button
+        [projectId]="resource.project?.id"
+        (invited)="selectedOption = $event"
+    ></op-invite-user-button>
   </ng-template>
 </ng-select>
 

--- a/frontend/src/app/modules/fields/edit/field-types/select-edit-field/select-edit-field.component.html
+++ b/frontend/src/app/modules/fields/edit/field-types/select-edit-field/select-edit-field.component.html
@@ -1,6 +1,7 @@
 <ndc-dynamic [ndcDynamicComponent]="autocompleterComponent()"
              [ndcDynamicInputs]="{ availableValues: valueOptions,
                                    appendTo: appendTo,
+                                   resource: this.resource,
                                    model: selectedOption ? selectedOption : '',
                                    required: required,
                                    disabled: inFlight,

--- a/frontend/src/app/modules/invite-user-modal/button/invite-user-button.component.html
+++ b/frontend/src/app/modules/invite-user-modal/button/invite-user-button.component.html
@@ -2,7 +2,7 @@
   class="op-select-footer--label"
   type="button"
   (click)="onAddNewClick($event)"
-  *ngIf="canInviteUsersToProject"
+  *ngIf="(canInviteUsersToProject$ | async)"
 >
   <span class="icon-context">
     <op-icon icon-classes="icon-user-plus icon-context"></op-icon>

--- a/frontend/src/app/modules/invite-user-modal/button/invite-user-button.component.ts
+++ b/frontend/src/app/modules/invite-user-modal/button/invite-user-button.component.ts
@@ -1,8 +1,11 @@
-import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
 import { NgSelectComponent } from "@ng-select/ng-select";
 import { I18nService } from "core-app/modules/common/i18n/i18n.service";
 import { PermissionsService } from "core-app/core/services/permissions/permissions.service";
 import { OpInviteUserModalService } from "core-app/modules/invite-user-modal/invite-user-modal.service";
+import { Observable } from "rxjs";
+import { CurrentProjectService } from "core-components/projects/current-project.service";
+import { CurrentUserService } from "core-app/modules/current-user/current-user.service";
 
 @Component({
   selector: 'op-invite-user-button',
@@ -10,6 +13,8 @@ import { OpInviteUserModalService } from "core-app/modules/invite-user-modal/inv
   styleUrls: ['./invite-user-button.component.sass']
 })
 export class InviteUserButtonComponent implements OnInit {
+  @Input() projectId:string|null;
+
   /** This component does not provide an output, because both primary usecases were in places where the button was
    * destroyed before the modal closed, causing the data from the modal to never arrive at the parent.
    * If you want to do something with the output from the modal that is opened, use the OpInviteUserModalService
@@ -18,28 +23,29 @@ export class InviteUserButtonComponent implements OnInit {
   text = {
     button: this.I18n.t('js.invite_user_modal.invite'),
   };
-  canInviteUsersToProject:boolean;
+
+  canInviteUsersToProject$:Observable<boolean>;
 
   constructor(
     readonly I18n:I18nService,
     readonly opInviteUserModalService:OpInviteUserModalService,
-    readonly permissionsService:PermissionsService,
+    readonly currentProjectService:CurrentProjectService,
+    readonly currentUserService:CurrentUserService,
     readonly ngSelectComponent:NgSelectComponent,
     readonly changeDetectorRef:ChangeDetectorRef,
   ) {}
 
-  ngOnInit():void {
-    this.permissionsService
-      .canInviteUsersToProject()
-      .subscribe(canInviteUsersToProject => {
-        this.canInviteUsersToProject = canInviteUsersToProject;
-        this.changeDetectorRef.detectChanges();
-      });
+  public ngOnInit():void {
+    this.projectId = this.projectId || this.currentProjectService.id;
+    this.canInviteUsersToProject$ = this.currentUserService.hasCapabilities$(
+      'memberships/create',
+      this.projectId || undefined
+    );
   }
 
-  onAddNewClick($event:Event) {
+  public onAddNewClick($event:Event):void {
     $event.stopPropagation();
-    this.opInviteUserModalService.open();
+    this.opInviteUserModalService.open(this.projectId);
     this.ngSelectComponent.close();
   }
 }

--- a/frontend/src/app/modules/invite-user-modal/invite-user-modal.service.ts
+++ b/frontend/src/app/modules/invite-user-modal/invite-user-modal.service.ts
@@ -39,23 +39,24 @@ import { InviteUserModalComponent } from "./invite-user.component";
  */
 @Injectable()
 export class OpInviteUserModalService {
-  public close = new EventEmitter<HalResource | HalResource[]>();
+  public close = new EventEmitter<HalResource|HalResource[]>();
 
   constructor(
     protected opModalService:OpModalService,
     protected currentProjectService:CurrentProjectService,
-  ) { }
+  ) {
+  }
 
-  public open(projectId: string|null = this.currentProjectService.id) {
+  public open(projectId:string|null = this.currentProjectService.id) {
     const modal = this.opModalService.show(
       InviteUserModalComponent,
       'global',
-      { projectId }
+      { projectId },
     );
 
     modal
       .closingEvent
-      .subscribe((modal: InviteUserModalComponent) => {
+      .subscribe((modal:InviteUserModalComponent) => {
         this.close.emit(modal.data);
       });
   }

--- a/spec/features/users/invite_user_modal/subproject_invite_spec.rb
+++ b/spec/features/users/invite_user_modal/subproject_invite_spec.rb
@@ -1,0 +1,96 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Invite user modal subprojects', type: :feature, js: true do
+  shared_let(:project) { FactoryBot.create :project, name: 'Parent project' }
+  shared_let(:subproject) { FactoryBot.create :project, name: 'Subproject', parent: project }
+  shared_let(:work_package) { FactoryBot.create :work_package, project: subproject }
+  shared_let(:invitable_user) { FactoryBot.create :user, firstname: 'Invitable', lastname: 'User' }
+
+  let(:permissions) { %i[view_work_packages edit_work_packages manage_members] }
+  let(:global_permissions) { %i[] }
+  let(:modal) do
+    ::Components::Users::InviteUserModal.new project: subproject,
+                                             principal: invitable_user,
+                                             role: role
+  end
+  let!(:role) do
+    FactoryBot.create :role,
+                      name: 'Member',
+                      permissions: permissions
+  end
+  let(:wp_page) { Pages::FullWorkPackage.new(work_package, project) }
+  let(:assignee_field) { wp_page.edit_field :assignee }
+
+  current_user do
+    FactoryBot.create :user,
+                      member_in_projects: [project, subproject],
+                      member_through_role: role,
+                      global_permissions: global_permissions
+  end
+
+  context 'with manage permissions in subproject' do
+    it 'uses the subproject as the preselected project' do
+      wp_page.visit!
+
+      assignee_field.activate!
+
+      find('.ng-dropdown-footer button', text: 'Invite', wait: 10).click
+
+      modal.expect_open
+      modal.within_modal do
+        expect(page).to have_selector '.ng-value', text: 'Subproject'
+      end
+
+      modal.run_all_steps
+
+      assignee_field.expect_inactive!
+      assignee_field.expect_display_value invitable_user.name
+
+      new_member = subproject.reload.member_principals.find_by(user_id: invitable_user.id)
+      expect(new_member).to be_present
+      expect(new_member.roles).to eq [role]
+    end
+  end
+
+  context 'without manage permissions in subproject' do
+    let(:permissions) { %i[view_work_packages edit_work_packages] }
+
+    it 'does not show the invite button of the subproject' do
+      wp_page.visit!
+
+      assignee_field.activate!
+
+      expect(page).to have_selector '.ng-dropdown-panel'
+
+      expect(page).to have_no_selector('.ng-dropdown-footer button', text: 'Invite')
+    end
+  end
+end


### PR DESCRIPTION
When showing a work package from a subproject, the invite user modal should be opened for that work package's project, not the current project. Otherwise the user will not be assignable afterwards.

https://community.openproject.org/work_packages/37463