### PR TITLE
ensure project status is saved

### DIFF
--- a/app/services/projects/update_service.rb
+++ b/app/services/projects/update_service.rb
@@ -44,12 +44,18 @@ module Projects
       ret
     end
 
+    def persist(service_result)
+      # Needs to take place before awesome_nested_set reloads the model (in case the parent changes)
+      persist_status
+
+      super
+    end
+
     def after_perform(service_call)
       touch_on_custom_values_update
       notify_on_identifier_renamed
       send_update_notification
       update_wp_versions_on_parent_change
-      persist_status
       handle_archiving
 
       service_call


### PR DESCRIPTION
aweseome_nested_set, used for maintaining the project hierarchy, reloads
the project after saving. Any change to an associated model, e.g. the
status, is lost upon reloading.

Thus, saving of the status needs to take place before saving the
project.

This is safe to do since it is carried out in a transaction and all the
validations are run for the status as well.

https://community.openproject.org/work_packages/37464