### PR TITLE
fix `required` value for properties on project resource

### DIFF
--- a/lib/api/v3/projects/schemas/project_schema_representer.rb
+++ b/lib/api/v3/projects/schemas/project_schema_representer.rb
@@ -56,10 +56,12 @@ module API
                  required: false
 
           schema :public,
-                 type: 'Boolean'
+                 type: 'Boolean',
+                 required: false
 
           schema :active,
-                 type: 'Boolean'
+                 type: 'Boolean',
+                 required: false
 
           schema_with_allowed_collection :status,
                                          type: 'ProjectStatus',

--- a/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
+++ b/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
@@ -162,7 +162,7 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
       it_behaves_like 'has basic schema properties' do
         let(:type) { 'Boolean' }
         let(:name) { I18n.t('attributes.public') }
-        let(:required) { true }
+        let(:required) { false }
         let(:writable) { true }
       end
     end
@@ -173,7 +173,7 @@ describe ::API::V3::Projects::Schemas::ProjectSchemaRepresenter do
       it_behaves_like 'has basic schema properties' do
         let(:type) { 'Boolean' }
         let(:name) { I18n.t('attributes.active') }
-        let(:required) { true }
+        let(:required) { false }
         let(:writable) { true }
       end
     end


### PR DESCRIPTION
[#37502] Option "public" for projects shown as required even though not required

https://community.openproject.org/work_packages/37502
