### PR TITLE
Fix/nil parent rendering

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2787,9 +2787,6 @@ en:
 
   total_progress: "Total progress"
 
-  undisclosed:
-    parent: Undisclosed - The selected parent is invisible because of lacking permissions.
-
   user:
     all: "all"
     active: "active"
@@ -2933,6 +2930,9 @@ en:
 
     resources:
       schema: 'Schema'
+
+    undisclosed:
+      parent: Undisclosed - The selected parent is invisible because of lacking permissions.
 
   doorkeeper:
     pre_authorization:

--- a/lib/api/decorators/linked_resource.rb
+++ b/lib/api/decorators/linked_resource.rb
@@ -186,7 +186,7 @@ module API
             if undisclosed && instance_exec(&skip_link)
               {
                 href: API::V3::URN_UNDISCLOSED,
-                title: I18n.t(:"undisclosed.#{name}")
+                title: I18n.t(:"api_v3.undisclosed.#{name}")
               }
             elsif !instance_exec(&skip_link)
               ::API::Decorators::LinkObject

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -158,7 +158,7 @@ module API
                             representer: ::API::V3::Projects::ProjectRepresenter,
                             uncacheable_link: true,
                             undisclosed: true,
-                            skip_render: ->(*) { !represented.parent&.visible? }
+                            skip_render: ->(*) { represented.parent && !represented.parent.visible? }
 
         property :id
         property :identifier,

--- a/spec/features/projects/edit_settings_spec.rb
+++ b/spec/features/projects/edit_settings_spec.rb
@@ -192,7 +192,7 @@ describe 'Projects', 'editing settings', type: :feature, js: true do
 
       fill_in 'Name', with: 'New project name'
 
-      parent_field.expect_selected I18n.t(:'undisclosed.parent')
+      parent_field.expect_selected I18n.t(:'api_v3.undisclosed.parent')
 
       click_on 'Save'
 

--- a/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
@@ -218,6 +218,15 @@ describe ::API::V3::Projects::ProjectRepresenter, 'rendering' do
           let(:title) { I18n.t(:'api_v3.undisclosed.parent') }
         end
       end
+
+      context 'without a parent' do
+        let(:parent_project) { nil }
+
+        it_behaves_like 'has an untitled link' do
+          let(:link) { 'parent' }
+          let(:href) { nil }
+        end
+      end
     end
 
     context 'status' do

--- a/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
@@ -215,7 +215,7 @@ describe ::API::V3::Projects::ProjectRepresenter, 'rendering' do
         it_behaves_like 'has a titled link' do
           let(:link) { 'parent' }
           let(:href) { API::V3::URN_UNDISCLOSED }
-          let(:title) { I18n.t(:'undisclosed.parent') }
+          let(:title) { I18n.t(:'api_v3.undisclosed.parent') }
         end
       end
     end


### PR DESCRIPTION
Fixes displaying the "undisclosed" option in case a project has no parent which is always the case for new projects (belongs to #9336).