### PR TITLE
[37509] Avoid position: relative on modal overlay

### DIFF
--- a/frontend/src/app/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.sass
+++ b/frontend/src/app/components/modals/preview-modal/wp-preview-modal/wp-preview.modal.sass
@@ -6,3 +6,4 @@
   min-width: 350px
   padding: 0px
   box-shadow: 0px 0px 5px 2px rgba(0, 0, 0, 0.25)
+  pointer-events: all

--- a/frontend/src/app/globals/global-listeners/preview-trigger.service.ts
+++ b/frontend/src/app/globals/global-listeners/preview-trigger.service.ts
@@ -27,7 +27,7 @@
 //++
 
 
-import { Injectable, Injector } from "@angular/core";
+import { Injectable, Injector, NgZone } from "@angular/core";
 import { OpModalService } from "core-app/modules/modal/modal.service";
 import { WpPreviewModal } from "core-components/modals/preview-modal/wp-preview-modal/wp-preview.modal";
 
@@ -35,13 +35,15 @@ import { WpPreviewModal } from "core-components/modals/preview-modal/wp-preview-
 export class PreviewTriggerService {
   private previewModal:WpPreviewModal;
   private modalElement:HTMLElement;
+  private mouseInModal = false;
 
   constructor(readonly opModalService:OpModalService,
+              readonly ngZone:NgZone,
               readonly injector:Injector) {
   }
 
   setupListener() {
-    jQuery(document.body).on('mouseenter', '.preview-trigger', (e) => {
+    jQuery(document.body).on('mouseover', '.preview-trigger', (e) => {
       e.preventDefault();
       e.stopPropagation();
       const el = jQuery(e.target);
@@ -61,17 +63,27 @@ export class PreviewTriggerService {
       this.previewModal.reposition(jQuery(this.modalElement), el);
     });
 
-    jQuery(document.body).on('mouseleave', '.preview-trigger', (e:JQuery.MouseLeaveEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
+    jQuery(document.body).on('mouseleave', '.preview-trigger', () => {
+      this.closeAfterTimeout();
+    });
 
-      if (this.isMouseOverPreview(e)) {
-        jQuery(this.modalElement).on('mouseleave',  () => {
+    jQuery(document.body).on('mouseleave', '.preview-modal--container', () => {
+      this.mouseInModal = false;
+      this.closeAfterTimeout();
+    });
+
+    jQuery(document.body).on('mouseenter', '.preview-modal--container', () => {
+      this.mouseInModal = true;
+    });
+  }
+
+  private closeAfterTimeout() {
+    this.ngZone.runOutsideAngular(() => {
+      setTimeout(() => {
+        if (!this.mouseInModal) {
           this.opModalService.close();
-        });
-      } else {
-        this.opModalService.close();
-      }
+        }
+      }, 100);
     });
   }
 

--- a/frontend/src/app/modules/modal/modal-overlay.sass
+++ b/frontend/src/app/modules/modal/modal-overlay.sass
@@ -9,10 +9,10 @@
   justify-content: center
   align-items: center
   display: none
+  pointer-events: none
 
   &_active
     display: flex
 
   &_not-full-screen
     background: transparent
-    position: relative

--- a/frontend/src/app/modules/modal/modal-overlay.sass
+++ b/frontend/src/app/modules/modal/modal-overlay.sass
@@ -11,6 +11,9 @@
   display: none
   pointer-events: none
 
+  > *
+    pointer-events: all
+
   &_active
     display: flex
 

--- a/frontend/src/app/modules/modal/modal.sass
+++ b/frontend/src/app/modules/modal/modal.sass
@@ -7,6 +7,7 @@
   flex-direction: column
   align-items: stretch
   background: white
+  pointer-events: all
 
   width: 40rem
   min-height: 500px


### PR DESCRIPTION
the preview trigger / modal was flickering all over the place because the mouse was entering the modal before entering the preview container.

To avoid this, `pointer-events` will be disabled on the overlay. This ensures the mouse can be correctly followed on hovering the trigger and container.

This PR also adds a tiny delay to closing the popup to feel more natural. I originally wanted to refactor the service away from jQuery, but this resulted in different height calculations of the container. So for 11.3 I decided to leave it mostly as is.

[OP#37509](https://community.openproject.org/wp/37509)