### PR TITLE
App header fixes

### DIFF
--- a/frontend/src/app/components/main-menu/main-menu-toggle.component.ts
+++ b/frontend/src/app/components/main-menu/main-menu-toggle.component.ts
@@ -40,7 +40,7 @@ export const mainMenuToggleSelector = 'main-menu-toggle';
   selector: mainMenuToggleSelector,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'op-app-menu',
+    class: 'op-app-menu op-main-menu-toggle',
   },
   template: `
     <button

--- a/frontend/src/app/modules/common/header/app-header.sass
+++ b/frontend/src/app/modules/common/header/app-header.sass
@@ -1,6 +1,6 @@
 .op-app-header
   display: grid
-  grid-template-columns: 1fr auto 1fr
+  grid-template-columns: minmax(0, 1fr) auto 1fr
   grid-template-rows: auto
   grid-template-areas: "start center end"
   background-color: var(--header-bg-color)
@@ -44,10 +44,6 @@
     border: 1px solid var(--header-item-font-color)
 
   &_search-open
-    @include breakpoint(850px down)
-      .op-logo
-        display: none
-
     @include breakpoint(680px down)
       display: flex
 
@@ -58,10 +54,13 @@
       .op-app-header--end
         flex-grow: 1
 
+      .op-app-search
+        flex-grow: 1
+
       .top-menu-search
         margin: 0
 
-        .top-menu-search--button
+        &--button
           display: none
           color: var(--header-item-font-color)
 

--- a/frontend/src/app/modules/common/header/app-menu.sass
+++ b/frontend/src/app/modules/common/header/app-menu.sass
@@ -3,16 +3,21 @@
   display: flex
   margin: 0
   height: 100%
+  min-width: 0px
 
   &--item
     display: flex
     position: relative
     height: 100%
+    min-width: 0px
 
   &--item-dropdown-indicator
     display: inline-flex
     justify-content: center
     align-items: center
+
+  &--item-title
+    min-width: 0px
 
   &--item-action
     background: transparent 
@@ -27,9 +32,7 @@
     font-size: var(--header-item-font-size)
     text-decoration: none
     padding: 0 15px
-    text-overflow: ellipsis
-    white-space: nowrap
-
+    min-width: 0px
 
     .op-app-menu--item_dropdown-open &,
     &:hover

--- a/frontend/src/app/modules/common/header/app-search.sass
+++ b/frontend/src/app/modules/common/header/app-search.sass
@@ -1,3 +1,3 @@
 .op-app-search
   @include breakpoint(680px down)
-    flex-grow: 1
+    flex-grow: 0

--- a/frontend/src/app/modules/common/header/index.sass
+++ b/frontend/src/app/modules/common/header/index.sass
@@ -4,3 +4,4 @@
 @import './app-search'
 @import './app-help'
 @import './quick-add-menu'
+@import './main-menu-toggle'

--- a/frontend/src/app/modules/common/header/logo.sass
+++ b/frontend/src/app/modules/common/header/logo.sass
@@ -13,5 +13,6 @@
     background-size: contain
     background-repeat: no-repeat
 
-  @include breakpoint(680px down)
+  @include breakpoint(850px down)
     display: none
+

--- a/frontend/src/app/modules/common/header/main-menu-toggle.sass
+++ b/frontend/src/app/modules/common/header/main-menu-toggle.sass
@@ -1,0 +1,3 @@
+.op-main-menu-toggle
+  @at-root .nosidebar &
+    display: none

--- a/frontend/src/app/modules/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/modules/global_search/input/global-search-input.component.sass
@@ -13,20 +13,37 @@ $search-input-height: 30px
   line-height: var(--header-height)
   margin: 0 15px
 
-  .top-menu-search--back-button
+  @media screen and (max-width: 680px)
+    margin: 0
+
+  &--back-button
     display: none
 
-  .top-menu-search--button
+  &--button
     position: absolute
     right: 2px
     font-size: var(--header-item-font-size)
     color: var(--header-item-font-color)
+
     &:hover
       text-decoration: none
+
+    // TODO: This should be using  @include breakpoint(680px down)
+    // Which is hard to do since we don't have access here and it'll
+    // probably require a larger sass import refactoring
+    @media screen and (max-width: 680px)
+      position: relative
+      padding: 0 8px
+
+      &:hover
+        background: var(--header-item-bg-hover-color)
+        color: var(--header-item-font-hover-color)
+        border-bottom: var(--header-border-bottom-width) solid var(--header-border-bottom-color)
+
     &.-input-focused
       color: var(--header-search-field-font-color)
 
-  .top-menu-search--loading
+  &--loading
     top: var(--header-height) - 11px  // display directly under ng-input field
     height: 46px                // ng-option height + 1px border
     z-index: 1051
@@ -106,73 +123,68 @@ $search-input-height: 30px
         &.ng-option-selected
           background-color: var(--drop-down-selected-bg-color)
 
-.global-search--wp-id
-  color: var(--gray-dark)
-  font-size: 13px
-  white-space: nowrap
+  &--input
+    // Fix position of the spinner
+    .ng-spinner-loader
+      position: relative
+      right: 14px
 
+.global-search
+  &--wp-id
+    color: var(--gray-dark)
+    font-size: 13px
+    white-space: nowrap
 
-.top-menu-search--input
-  // Fix position of the spinner
-  .ng-spinner-loader
-    position: relative
-    right: 14px
+  &--option-wrapper
+    padding: 5px 5px
+    line-height: 15px
+    min-height: 25px  // line-height + padding
+    word-break: break-word
 
-.global-search--option-wrapper
-  padding: 5px 5px
-  line-height: 15px
-  min-height: 25px  // line-height + padding
-  word-break: break-word
+  &--option,
+  &--option:hover
+    color: var(--body-font-color)
+    text-decoration: none
 
-.global-search--option,
-.global-search--option:hover
-  color: var(--body-font-color)
-  text-decoration: none
+  &--project-scope
+    position: absolute
+    right: 7px
+    border: 1px solid var(--button--border-color)
+    font-size: 13px
+    background: var(--button--background-color)
+    border-radius: 2px
+    padding: 0 4px
+    color: var(--body-font-color)
 
-.global-search--project-scope
-  position: absolute
-  right: 7px
-  border: 1px solid var(--button--border-color)
-  font-size: 13px
-  background: var(--button--background-color)
-  border-radius: 2px
-  padding: 0 4px
-  color: var(--body-font-color)
+  &--option-wrapper
+    .op-avatar
+      margin-right: 5px
+      float: left
 
-
-.global-search--option-wrapper
-  .op-avatar
-    margin-right: 5px
-    float: left
-
-
-
-.global-search--wp-content
-  display: grid
-  grid-template-columns: 50% 1fr auto
-  grid-template-areas: "project idlink status"
-  font-size: 0.8rem
-  padding: 5px 0 5px 0px
- 
-
-  .global-search--wp-project
+  &--wp-content
+    display: grid
+    grid-template-columns: 50% 1fr auto
+    grid-template-areas: "project idlink status"
+    font-size: 0.8rem
+    padding: 5px 0 5px 0px
+   
+  &--wp-project
     grid-area: project
 
-  .global-search--wp-id
+  &--wp-id
     grid-area: idlink
     place-self: right 
     font-style: italic
 
-  .global-search--wp-status
+  &--wp-status
     grid-area: status
     overflow: hidden
     font-style: italic
 
-
-.global-search--wp-subject
-  font-weight: bold
-  display: inline-block
-  width: 85%
-  overflow: hidden
-  white-space: nowrap
-  text-overflow: ellipsis
+  &--wp-subject
+    font-weight: bold
+    display: inline-block
+    width: 85%
+    overflow: hidden
+    white-space: nowrap
+    text-overflow: ellipsis

--- a/frontend/src/global_styles/content/menus/_project_autocompletion.sass
+++ b/frontend/src/global_styles/content/menus/_project_autocompletion.sass
@@ -62,7 +62,7 @@
     background: var(--header-drop-down-projects-search-input-bg-color)
 
     @include breakpoint(680px down)
-      margin-left: 0px
+      margin: 0 auto
       width: calc(100% - 35px)
 
   // Lens icon on the right

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -115,11 +115,12 @@ module Redmine::MenuManager::MenuHelper
     options[:title] ||= selected ? t(:description_current_position) + label : label
     options[:aria] = { haspopup: 'true' }
     options[:class] = "op-app-menu--item-action #{options[:class]} #{selected ? 'selected' : ''}"
+    options[:span_class] = "op-app-menu--item-title #{options[:span_class]}"
 
     link_to('#', options) do
       concat(op_icon(options[:icon])) if options[:icon]
       concat(you_are_here_info(selected).html_safe)
-      concat(content_tag(:span, label, class: 'button--dropdown-text'))
+      concat(content_tag(:span, label, class: options[:span_class]))
       concat('<i class="op-app-menu--item-dropdown-indicator button--dropdown-indicator"></i>'.html_safe) unless options.key?(:icon)
     end
   end

--- a/lib/redmine/menu_manager/top_menu/projects_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/projects_menu.rb
@@ -42,7 +42,8 @@ module Redmine::MenuManager::TopMenu::ProjectsMenu
       label: label,
       label_options: {
         id: 'projects-menu',
-        accesskey: OpenProject::AccessKeys.key_for(:project_search)
+        accesskey: OpenProject::AccessKeys.key_for(:project_search),
+        span_class: 'ellipsis'
       },
       items: project_items,
       options: {

--- a/lib/redmine/menu_manager/top_menu_helper.rb
+++ b/lib/redmine/menu_manager/top_menu_helper.rb
@@ -64,7 +64,7 @@ module Redmine::MenuManager::TopMenuHelper
     link = link_to url,
                    class: 'op-app-menu--item-action',
                    title: I18n.t(:label_login) do
-      concat('<span class="button--dropdown-text hidden-for-mobile">'.concat(I18n.t(:label_login)).concat('</span>').html_safe)
+      concat('<span class="op-app-menu--item-title hidden-for-mobile">'.concat(I18n.t(:label_login)).concat('</span>').html_safe)
       concat('<i class="op-app-menu--item-dropdown-indicator button--dropdown-indicator hidden-for-mobile"></i>'.html_safe)
       concat('<i class="icon2 icon-user hidden-for-desktop"></i>'.html_safe)
     end
@@ -78,7 +78,7 @@ module Redmine::MenuManager::TopMenuHelper
     link = link_to signin_path,
                    class: 'op-app-menu--item-action login',
                    title: I18n.t(:label_login) do
-      concat('<span class="button--dropdown-text hidden-for-mobile">'.concat(I18n.t(:label_login)).concat('</span>').html_safe)
+      concat('<span class="op-app-menu--item-title hidden-for-mobile">'.concat(I18n.t(:label_login)).concat('</span>').html_safe)
       concat('<i class="icon2 icon-user hidden-for-desktop"></i>'.html_safe)
     end
 

--- a/modules/reporting/spec/features/menu_spec.rb
+++ b/modules/reporting/spec/features/menu_spec.rb
@@ -69,7 +69,7 @@ describe 'project menu', type: :feature do
         it 'leads to cost reports' do
           click_on 'Time and costs'
 
-          expect(page).to have_selector('.button--dropdown-text', text: 'Ponyo')
+          expect(page).to have_selector('.op-app-menu--item-title', text: 'Ponyo')
         end
       end
 


### PR DESCRIPTION
This fixes several issues the app header was experiencing on mobile and tablet screen sizes;

* The project name was overlapping with the search icon, especially for long names. It will now get dotted out
* The logo was being shown on screens that were really too small for it, causing the header to overflow and more important elements to lack space
* The main menu toggle was being shown on pages that did do not have a main menu
* Some refactoring around the global search input css by making it more bemmy, reducing class specificity
* Improved the design of the search button on mobile, making it more in line with the other buttons
* The project search input field was left aligned instead of centered

https://community.openproject.org/work_packages/37452/activity