### PR TITLE
[36521] Saving changes to user profile after handling error message leads to user profile instead of edit user page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -159,7 +159,7 @@ class UsersController < ApplicationController
       respond_to do |format|
         format.html do
           flash[:notice] = I18n.t(:notice_successful_update)
-          redirect_back(fallback_location: edit_user_path(@user))
+          render action: :edit
         end
       end
     else


### PR DESCRIPTION
After handling an error while updating a user data, instead of redirecting to the user profile page, stay on its edit page.

https://community.openproject.org/projects/openproject/work_packages/36521/activity