### PR TITLE
Fix link to security docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ will keep our community secure. If you happen to come across a security issue we
 you to disclose it to us privately to allow our users and community enough time to
 upgrade. Security issues will always take precedence over anything else in the pipeline.
 
-For more information on how to disclosure a security vulnerability, [please see this page](docs/security/README.md).
+For more information on how to disclose a security vulnerability, [please see this page](docs/development/security/README.md).
 
 ## License
 


### PR DESCRIPTION
[skip ci]

The link to the security README is currently a 404. Fix it.