### PR TITLE
Fix: BCF XML export: Don't write comment author's mail unless it exists

### DIFF
--- a/modules/bim/lib/open_project/bim/bcf_xml/issue_writer.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/issue_writer.rb
@@ -212,7 +212,7 @@ module OpenProject::Bim::BcfXml
     def comment_node(xml, uuid, journal)
       xml.Comment "Guid" => uuid do
         xml.Date to_bcf_datetime(journal.created_at)
-        xml.Author journal.user.mail if journal.user_id
+        xml.Author(journal.user.mail) if journal.user_id && journal&.user&.mail.present?
         xml.Comment journal.notes
       end
     end

--- a/modules/bim/spec/features/bcf/export_spec.rb
+++ b/modules/bim/spec/features/bcf/export_spec.rb
@@ -81,8 +81,8 @@ describe 'bcf export',
     page.find('.export-bcf-button').click
 
     # Expect to get a response regarding queuing
-    expect(page).to have_content I18n.t('js.job_status.generic_messages.in_queue'),
-                                 wait: 10
+    expect(page).to have_content(I18n.t('js.job_status.generic_messages.in_queue'),
+                                 wait: 10)
 
     perform_enqueued_jobs
     expect(page).to have_text("completed successfully")
@@ -102,28 +102,28 @@ describe 'bcf export',
 
   it 'can export the open and closed BCF issues (Regression #30953)' do
     model_page.visit!
-    wp_cards.expect_work_package_listed open_work_package
-    wp_cards.expect_work_package_not_listed closed_work_package
-    filters.expect_filter_count 1
+    wp_cards.expect_work_package_listed(open_work_package)
+    wp_cards.expect_work_package_not_listed(closed_work_package)
+    filters.expect_filter_count(1)
 
     # Expect only the open issue
     extractor_list = export_into_bcf_extractor
-    expect(extractor_list.length).to eq 1
-    expect(extractor_list.first[:title]).to eq 'Open WP'
+    expect(extractor_list.length).to eq(1)
+    expect(extractor_list.first[:title]).to eq('Open WP')
 
     model_page.visit!
     # Change the query to show all statuses
     filters.open
-    filters.remove_filter 'status'
-    filters.expect_filter_count 0
+    filters.remove_filter('status')
+    filters.expect_filter_count(0)
 
-    wp_cards.expect_work_package_listed open_work_package, closed_work_package
+    wp_cards.expect_work_package_listed(open_work_package, closed_work_package)
 
     # Download again
     extractor_list = export_into_bcf_extractor
-    expect(extractor_list.length).to eq 2
+    expect(extractor_list.length).to eq(2)
 
     titles = extractor_list.map { |hash| hash[:title] }
-    expect(titles).to contain_exactly 'Open WP', 'Closed WP'
+    expect(titles).to contain_exactly('Open WP', 'Closed WP')
   end
 end


### PR DESCRIPTION
If the BCF comment's `Author` for example is the `SystemUser` then the user has no mail address.