### PR TITLE
Bug/37576 404 for docs release notes 11 3 link to upgrade guide broken

### DIFF
--- a/docs/release-notes/11-3-0/README.md
+++ b/docs/release-notes/11-3-0/README.md
@@ -207,7 +207,7 @@ Want to upgrade from a Community version to try out the Enterprise premium featu
 
 ## Migrating to OpenProject 11.3
 
-Follow the [upgrade guide for the packaged installation or Docker installation](../installation-and-operations/operation/upgrading/) to update your OpenProject installation to OpenProject 11.3.
+Follow the [upgrade guide for the packaged installation or Docker installation](https://docs.openproject.org/installation-and-operations/operation/upgrading/) to update your OpenProject installation to OpenProject 11.3.
 
 We update hosted OpenProject environments (Enterprise cloud) automatically.
 


### PR DESCRIPTION
[#37576] 404 For docs release notes 11.3 - link…

…to upgrade guide broken


https://community.openproject.org/work_packages/37576
