### PR TITLE
User invite modal: Smaller UI/UX fixes

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -222,7 +222,6 @@ en:
             label_company: "Company"
             label_first_name: "First name"
             label_last_name: "Last name"
-            label_email: "Email"
             label_domain: "Domain"
             label_subscriber: "Subscriber"
             label_maximum_users: "Maximum active users"
@@ -365,6 +364,7 @@ en:
     label_board_locked: "Locked"
     label_board_plural: "Boards"
     label_board_sticky: "Sticky"
+    label_change: "Change"
     label_create: "Create"
     label_create_work_package: "Create new work package"
     label_created_by: "Created by"
@@ -387,6 +387,7 @@ en:
     label_created_on: "created on"
     label_edit_comment: "Edit this comment"
     label_edit_status: "Edit the status of the work package"
+    label_email: "Email"
     label_equals: "is"
     label_expand: "Expand"
     label_expanded: "expanded"
@@ -1103,21 +1104,13 @@ en:
         label:
           name_or_email: 'Name or email address'
           name: 'Name'
-
         already_member_message: 'Already a member of %{project}'
         no_results_user: 'No users were found'
         invite_user: 'Invite:'
-        change_user_selection: 'Change e-mail-address or select an existing user'
-
         no_results_placeholder: 'No placeholders were found'
-        change_placeholder_selection: 'Change name or select an existing placeholder'
         create_new_placeholder: 'Create new placeholder:'
-
         no_results_group: 'No groups were found'
-        change_group_selection: 'Change name or select an existing group'
-
         next_button: 'Next'
-
         required:
           user: 'Please select a user'
           placeholder: 'Please select a placeholder'

--- a/frontend/src/app/components/enterprise/enterprise-active-trial/ee-active-trial.base.ts
+++ b/frontend/src/app/components/enterprise/enterprise-active-trial/ee-active-trial.base.ts
@@ -31,7 +31,7 @@ import { I18nService } from "app/modules/common/i18n/i18n.service";
 
 export class EEActiveTrialBase extends UntilDestroyedMixin {
   public text = {
-    label_email: this.I18n.t('js.admin.enterprise.trial.form.label_email'),
+    label_email: this.I18n.t('js.label_email'),
     label_expires_at: this.I18n.t('js.admin.enterprise.trial.form.label_expires_at'),
     label_maximum_users: this.I18n.t('js.admin.enterprise.trial.form.label_maximum_users'),
     label_company: this.I18n.t('js.admin.enterprise.trial.form.label_company'),

--- a/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.ts
+++ b/frontend/src/app/components/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.ts
@@ -70,7 +70,7 @@ export class EETrialFormComponent {
     label_company: this.I18n.t('js.admin.enterprise.trial.form.label_company'),
     label_first_name: this.I18n.t('js.admin.enterprise.trial.form.label_first_name'),
     label_last_name: this.I18n.t('js.admin.enterprise.trial.form.label_last_name'),
-    label_email: this.I18n.t('js.admin.enterprise.trial.form.label_email'),
+    label_email: this.I18n.t('js.label_email'),
     label_domain: this.I18n.t('js.admin.enterprise.trial.form.label_domain'),
     privacy_policy: this.I18n.t('js.admin.enterprise.trial.form.privacy_policy'),
     receive_newsletter: this.I18n.t('js.admin.enterprise.trial.form.receive_newsletter', { link: newsletterURL }),

--- a/frontend/src/app/modules/invite-user-modal/principal/principal-search.component.html
+++ b/frontend/src/app/modules/invite-user-modal/principal/principal-search.component.html
@@ -51,7 +51,7 @@
 
     <!--Create a new placeholder by name-->
     <div *ngIf="canCreateNewPlaceholder$ | async">
-      <op-icon icon-classes="icon-mail1 icon-context"></op-icon>
+      <op-icon icon-classes="icon-add icon-context"></op-icon>
       <b>{{ text.createNewPlaceholder }}</b>
       {{ input }}
     </div>

--- a/frontend/src/app/modules/invite-user-modal/principal/principal-search.component.ts
+++ b/frontend/src/app/modules/invite-user-modal/principal/principal-search.component.ts
@@ -44,6 +44,7 @@ export class PrincipalSearchComponent extends UntilDestroyedMixin implements OnI
     switchMap(this.loadPrincipalData.bind(this)),
     share(),
   );
+  private emailRegExp:RegExp = /^\S+@\S+\.\S+$/;
     
   public canInviteByEmail$ = combineLatest(
     this.items$,
@@ -53,7 +54,8 @@ export class PrincipalSearchComponent extends UntilDestroyedMixin implements OnI
     map(([elements, input, canCreateUsers]) => {
       return canCreateUsers
       && this.type === PrincipalType.User
-      && input?.includes('@')
+      && !!input
+      && this.emailRegExp.test(input)
       && !elements.find((el) => (el.principal as UserResource).email === input);
     }),
   );

--- a/frontend/src/app/modules/invite-user-modal/principal/principal.component.html
+++ b/frontend/src/app/modules/invite-user-modal/principal/principal.component.html
@@ -6,7 +6,7 @@
 
   <div class="op-modal--body op-form">
     <op-form-field
-      [label]="text.label[type]"
+      [label]="textLabel"
       required
     >
       <op-ium-principal-search
@@ -26,7 +26,7 @@
         <button
           class="op-link"
           (click)="principalControl?.setValue(null)"
-          >{{ text.changeUserSelection }}</button>
+          >{{ text.change }}</button>
       </p>
 
       <p
@@ -37,7 +37,7 @@
         <button
           class="op-link"
           (click)="principalControl?.setValue(null)"
-        >{{ text.changePlaceholderSelection }}</button>
+        >{{ text.change }}</button>
       </p>
 
       <div

--- a/frontend/src/app/modules/invite-user-modal/principal/principal.component.ts
+++ b/frontend/src/app/modules/invite-user-modal/principal/principal.component.ts
@@ -62,10 +62,9 @@ export class PrincipalComponent implements OnInit {
       User: this.I18n.t('js.invite_user_modal.principal.label.name_or_email'),
       PlaceholderUser: this.I18n.t('js.invite_user_modal.principal.label.name'),
       Group: this.I18n.t('js.invite_user_modal.principal.label.name'),
+      Email: this.I18n.t('js.label_email')
     },
-    changeUserSelection: this.I18n.t('js.invite_user_modal.principal.change_user_selection'),
-    changePlaceholderSelection: this.I18n.t('js.invite_user_modal.principal.change_placeholder_selection'),
-    changeGroupSelection: this.I18n.t('js.invite_user_modal.principal.change_group_selection'),
+    change: this.I18n.t('js.label_change'),
     inviteUser: this.I18n.t('js.invite_user_modal.principal.invite_user'),
     createNewPlaceholder: this.I18n.t('js.invite_user_modal.principal.create_new_placeholder'),
     required: {
@@ -108,6 +107,14 @@ export class PrincipalComponent implements OnInit {
 
   get hasPrincipalSelected() {
     return !!this.principal;
+  }
+
+  get textLabel() {
+    if (this.type === PrincipalType.User && this.isNewPrincipal) {
+      return this.text.label.Email;
+    } else {
+      return this.text.label[this.type];
+    }
   }
 
   get isNewPrincipal() {


### PR DESCRIPTION
- Use stricter regex for detecting email addresses.
- Have shorter "Change" links.
- Don't use envelope icon for creating placeholder users.
- Change the label when inviting a user via email was chosen to only "Email".
