### PR TITLE
work-packages.show.activity changed to work-packages.show

### DIFF
--- a/frontend/src/app/components/work-packages/wp-breadcrumb/wp-breadcrumb-parent.html
+++ b/frontend/src/app/components/work-packages/wp-breadcrumb/wp-breadcrumb-parent.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="!active">
   <a *ngIf="parent"
     [attr.title]="parent.name"
-    uiSref="work-packages.show.activity"
+    uiSref="work-packages.show"
     [uiParams]="{workPackageId: parent.id}"
     class="wp-breadcrumb-parent breadcrumb-project-title nocut">
     <span [textContent]="parent.name"></span>

--- a/frontend/src/app/components/work-packages/wp-breadcrumb/wp-breadcrumb.html
+++ b/frontend/src/app/components/work-packages/wp-breadcrumb/wp-breadcrumb.html
@@ -12,7 +12,7 @@
             [ngClass]="{ 'icon4 icon-small icon-arrow-right5': !first }">
           <a [attr.title]="ancestor.name"
              [textContent]="ancestor.name"
-             uiSref="work-packages.show.activity"
+             uiSref="work-packages.show"
              [uiParams]="{workPackageId: ancestor.id}"
              class="breadcrumb-project-title nocut"></a>
         </li>

--- a/frontend/src/app/components/wp-activity/activity-link.component.ts
+++ b/frontend/src/app/components/wp-activity/activity-link.component.ts
@@ -6,7 +6,7 @@ import { WorkPackageResource } from "core-app/modules/hal/resources/work-package
   template: `
     <a id ="{{ activityHtmlId }}-link"
        [textContent]="activityLabel"
-       uiSref="work-packages.show.activity"
+       uiSref="work-packages.show"
        [uiParams]="{workPackageId: workPackage.id!, '#': activityHtmlId }">
     </a>
   `


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/37575

This pull request:

- [x] Fixes not working breadcrumb and activity links by removing the 'activity' part of the path.

**Notes**
5956ede0305907ef9945d1e12b61dbc5e82b169a replaced 'work-packages.show.activity', 'work-packages.show.activity.details', 'work-packages.show.relations' and 'work-packages.show.watchers' with the path 'work-packages.show.tabs' that defaults to the 'activity' tab (frontend/src/app/modules/work_packages/routing/work-packages-routes.ts). The other paths replaced doesn't seem to be used in the rest of the project anymore.

