### PR TITLE
Fix dropdown size for ium project and user dropdowns

### DIFF
--- a/frontend/src/app/modules/invite-user-modal/principal/principal-search.component.html
+++ b/frontend/src/app/modules/invite-user-modal/principal/principal-search.component.html
@@ -4,7 +4,6 @@
   [addTag]="showAddTag ? createNewFromInput.bind(this) : false"
   [typeahead]="input$"
   [items]="items$ | async"
-  [virtualScroll]="true"
   [clearable]="true"
   [clearOnBackspace]="false"
   [clearSearchOnAdd]="false"

--- a/frontend/src/app/modules/invite-user-modal/project-selection/project-search.component.html
+++ b/frontend/src/app/modules/invite-user-modal/project-selection/project-search.component.html
@@ -3,7 +3,6 @@
   [formControl]="projectFormControl"
   [typeahead]="input$"
   [items]="items$ | async"
-  [virtualScroll]="true"
   [clearable]="true"
   [clearOnBackspace]="false"
   [clearSearchOnAdd]="false"


### PR DESCRIPTION
The dropdowns are using custom disabled elements, which are taller than the rest. This causes virtualscroll to miscalculate the needed height for the dropdown, resulting in a scrollbar. The easy fix is to disable virtualscroll. This makes rendering of large lists a tad slower, but this can be mitigated by e.g. only searching after the second character has been typed should it be necessary.

Closes https://community.openproject.org/projects/openproject/work_packages/37578/activity