### PR TITLE
[#37583] Error "Identifier is invalid"

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -118,6 +118,10 @@ class Project < ApplicationRecord
               only_when_blank: true, # Only generate when identifier not set
               limit: IDENTIFIER_MAX_LENGTH,
               blacklist: RESERVED_IDENTIFIERS,
+              custom_rule: -> {
+                # remove leading numbers and hypens as they would clash with the identifier's validations later on.
+                base_url.sub(/^[-\d]*|-*$/, '')
+              },
               adapter: OpenProject::ActsAsUrl::Adapter::OpActiveRecord # use a custom adapter able to handle edge cases
 
   validates :identifier,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -118,8 +118,8 @@ class Project < ApplicationRecord
               only_when_blank: true, # Only generate when identifier not set
               limit: IDENTIFIER_MAX_LENGTH,
               blacklist: RESERVED_IDENTIFIERS,
-              custom_rule: -> {
-                # remove leading numbers and hypens as they would clash with the identifier's validations later on.
+              custom_rule: ->(base_url) {
+                # remove leading numbers and hyphens as they would clash with the identifier's validations later on.
                 base_url.sub(/^[-\d]*|-*$/, '')
               },
               adapter: OpenProject::ActsAsUrl::Adapter::OpActiveRecord # use a custom adapter able to handle edge cases

--- a/lib/open_project/acts_as_url/adapter/op_active_record.rb
+++ b/lib/open_project/acts_as_url/adapter/op_active_record.rb
@@ -60,8 +60,8 @@ module OpenProject
         def modify_base_url
           super
 
-          if settings.respond_to?(:custom_rule)
-            self.base_url = instance_exec(&settings.custom_rule)
+          if !base_url.empty? && settings.respond_to?(:custom_rule)
+            self.base_url = settings.custom_rule.call(base_url)
           end
 
           modify_base_url_custom_rules if base_url.empty?

--- a/lib/open_project/acts_as_url/adapter/op_active_record.rb
+++ b/lib/open_project/acts_as_url/adapter/op_active_record.rb
@@ -31,7 +31,10 @@
 # Improves handling of some edge cases when to_url is called. The method is provided by
 # stringex but some edge cases have not been handled properly by that gem.
 #
-# Currently, this is limited to the string '.' which would lead to an empty string otherwise.
+# This includes
+#   * the strings '.' and '!' which would lead to an empty string otherwise
+#   * the ability to add a custom_rule lambda that is able to postprocess the identifier. It will run
+#     after the default transformation was executed.
 
 module OpenProject
   module ActsAsUrl
@@ -56,6 +59,10 @@ module OpenProject
 
         def modify_base_url
           super
+
+          if settings.respond_to?(:custom_rule)
+            self.base_url = instance_exec(&settings.custom_rule)
+          end
 
           modify_base_url_custom_rules if base_url.empty?
         end

--- a/spec/services/projects/set_attributes_service_integration_spec.rb
+++ b/spec/services/projects/set_attributes_service_integration_spec.rb
@@ -35,12 +35,23 @@ describe Projects::SetAttributesService, 'integration', type: :model do
   let(:contract) { Projects::CreateContract }
   let(:instance) { described_class.new(user: user, model: project, contract_class: contract) }
   let(:attributes) { {} }
+  let(:project) { Project.new }
   let(:service_result) do
     instance.call(attributes)
   end
 
+  describe 'with a project name starting with numbers' do
+    let(:attributes) { { name: '100 Project A' } }
+
+    it 'will create an identifier with the numbers stripped' do
+      expect(service_result).to be_success
+      expect(service_result.result.identifier).to eq 'project-a'
+    end
+  end
+
   describe 'with an existing project' do
-    let!(:existing) { FactoryBot.create :project, identifier: 'my-new-project' }
+    let(:existing_identifier) { 'my-new-project' }
+    let!(:existing) { FactoryBot.create :project, identifier: existing_identifier }
 
     context 'and a new project with no identifier set' do
       let(:project) { Project.new name: 'My new project' }
@@ -60,6 +71,15 @@ describe Projects::SetAttributesService, 'integration', type: :model do
 
         errors = service_result.errors.full_messages
         expect(errors).to eq ['Identifier has already been taken.']
+      end
+    end
+
+    context 'with an existing identifier and a project name starting with numbers' do
+      let(:attributes) { { name: '100 My new project' } }
+
+      it 'will auto correct the identifier with the numbers stripped' do
+        expect(service_result).to be_success
+        expect(service_result.result.identifier).to eq 'my-new-project-1'
       end
     end
   end


### PR DESCRIPTION
Happens when creating a project that starts with a digit or a hypen. The
functionality is added by extending acts_as_url to support a custom_rule
lambda.

https://community.openproject.org/work_packages/37583