### PR TITLE
allow project identifier to begin with numbers

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -118,10 +118,6 @@ class Project < ApplicationRecord
               only_when_blank: true, # Only generate when identifier not set
               limit: IDENTIFIER_MAX_LENGTH,
               blacklist: RESERVED_IDENTIFIERS,
-              custom_rule: ->(base_url) {
-                # remove leading numbers and hyphens as they would clash with the identifier's validations later on.
-                base_url.sub(/^[-\d]*|-*$/, '')
-              },
               adapter: OpenProject::ActsAsUrl::Adapter::OpActiveRecord # use a custom adapter able to handle edge cases
 
   validates :identifier,
@@ -131,12 +127,12 @@ class Project < ApplicationRecord
             exclusion: RESERVED_IDENTIFIERS,
             if: ->(p) { p.persisted? || p.identifier.present? }
 
-  validates_associated :repository, :wiki
-  # starts with lower-case letter, a-z, 0-9, dashes and underscores afterwards
+  # Contains only a-z, 0-9, dashes and underscores but cannot consist of numbers only as it would clash with the id.
   validates :identifier,
-            format: { with: /\A[a-z][a-z0-9\-_]*\z/ },
+            format: { with: /\A(?!^\d+\z)[a-z0-9\-_]+\z/ },
             if: ->(p) { p.identifier_changed? && p.identifier.present? }
-  # reserved words
+
+  validates_associated :repository, :wiki
 
   friendly_id :identifier, use: :finders
 

--- a/lib/open_project/acts_as_url/adapter/op_active_record.rb
+++ b/lib/open_project/acts_as_url/adapter/op_active_record.rb
@@ -33,8 +33,6 @@
 #
 # This includes
 #   * the strings '.' and '!' which would lead to an empty string otherwise
-#   * the ability to add a custom_rule lambda that is able to postprocess the identifier. It will run
-#     after the default transformation was executed.
 
 module OpenProject
   module ActsAsUrl
@@ -59,10 +57,6 @@ module OpenProject
 
         def modify_base_url
           super
-
-          if !base_url.empty? && settings.respond_to?(:custom_rule)
-            self.base_url = settings.custom_rule.call(base_url)
-          end
 
           modify_base_url_custom_rules if base_url.empty?
         end

--- a/spec/contracts/projects/shared_contract_examples.rb
+++ b/spec/contracts/projects/shared_contract_examples.rb
@@ -150,6 +150,58 @@ shared_examples_for 'project contract' do
     end
   end
 
+  context 'when the identifier consists of only letters' do
+    let(:project_identifier) { 'abc' }
+
+    it_behaves_like 'is valid'
+  end
+
+  context 'when the identifier consists of letters followed by numbers' do
+    let(:project_identifier) { 'abc12' }
+
+    it_behaves_like 'is valid'
+  end
+
+  context 'when the identifier consists of letters followed by numbers with a hyphen in between' do
+    let(:project_identifier) { 'abc-12' }
+
+    it_behaves_like 'is valid'
+  end
+  
+  context 'when the identifier consists of letters followed by numbers with an underscore in between' do
+    let(:project_identifier) { 'abc_12' }
+
+    it_behaves_like 'is valid'
+  end
+
+  context 'when the identifier consists of numbers followed by letters with a hyphen in between' do
+    let(:project_identifier) { '12-abc' }
+
+    it_behaves_like 'is valid'
+  end
+
+  context 'when the identifier consists of numbers followed by letters with an underscore in between' do
+    let(:project_identifier) { '12_abc' }
+
+    it_behaves_like 'is valid'
+  end
+
+  context 'when the identifier consists of only numbers' do
+    let(:project_identifier) { '12' }
+
+    it 'is invalid' do
+      expect_valid(false, identifier: %i(invalid))
+    end
+  end
+
+  context 'when the identifier consists of a reserved word' do
+    let(:project_identifier) { 'new' }
+
+    it 'is invalid' do
+      expect_valid(false, identifier: %i(exclusion))
+    end
+  end
+
   context 'if the user lacks permission' do
     let(:permissions) { [] }
 

--- a/spec/contracts/projects/update_contract_spec.rb
+++ b/spec/contracts/projects/update_contract_spec.rb
@@ -33,13 +33,13 @@ describe Projects::UpdateContract do
   it_behaves_like 'project contract' do
     let(:project) do
       FactoryBot.build_stubbed(:project,
-                               identifier: project_identifier,
                                active: project_active,
                                public: project_public,
                                status: project_status).tap do |p|
         # in order to actually have something changed
         p.name = project_name
         p.parent = project_parent
+        p.identifier = project_identifier
       end
     end
     let(:permissions) { [:edit_project] }

--- a/spec/services/projects/set_attributes_service_integration_spec.rb
+++ b/spec/services/projects/set_attributes_service_integration_spec.rb
@@ -43,9 +43,9 @@ describe Projects::SetAttributesService, 'integration', type: :model do
   describe 'with a project name starting with numbers' do
     let(:attributes) { { name: '100 Project A' } }
 
-    it 'will create an identifier with the numbers stripped' do
+    it 'will create an identifier including the numbers' do
       expect(service_result).to be_success
-      expect(service_result.result.identifier).to eq 'project-a'
+      expect(service_result.result.identifier).to eq '100-project-a'
     end
   end
 
@@ -71,15 +71,6 @@ describe Projects::SetAttributesService, 'integration', type: :model do
 
         errors = service_result.errors.full_messages
         expect(errors).to eq ['Identifier has already been taken.']
-      end
-    end
-
-    context 'with an existing identifier and a project name starting with numbers' do
-      let(:attributes) { { name: '100 My new project' } }
-
-      it 'will auto correct the identifier with the numbers stripped' do
-        expect(service_result).to be_success
-        expect(service_result.result.identifier).to eq 'my-new-project-1'
       end
     end
   end

--- a/spec_legacy/unit/project_spec.rb
+++ b/spec_legacy/unit/project_spec.rb
@@ -76,22 +76,6 @@ describe Project, type: :model do
     assert_equal 'eCook', @ecookbook.name
   end
 
-  it 'should validate identifier' do
-    to_test = { 'abc' => true,
-                'ab12' => true,
-                'ab-12' => true,
-                'ab_12' => true,
-                '12' => false,
-                'new' => false }
-
-    to_test.each do |identifier, valid|
-      p = Project.new
-      p.identifier = identifier
-      p.valid?
-      assert_equal valid, p.errors['identifier'].empty?
-    end
-  end
-
   it 'should members should be active users' do
     Project.all.each do |project|
       assert_nil project.members.detect { |m| !(m.principal.is_a?(User) && m.principal.active?) }


### PR DESCRIPTION
Allows project identifiers to begin with numbers/hyphens/underscores. The only restriction left in place is for the identifier to not consist of numbers only as that would clash with the id when used within a url.

**/cc** @machisuji 