### PR TITLE
start puma in single rather than cluster mode by default

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("OPENPROJECT_WEB_WORKERS") { 1 }.to_i
+workers ENV.fetch("OPENPROJECT_WEB_WORKERS") { 0 }.to_i
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
using cluster mode with the previous default of 1 worker is unnecessary memory overhead

Doing this as recommended in puma's warning message we've seen recently.

```
[19513] Puma starting in cluster mode...
[19513] * Puma version: 5.3.1 (ruby 2.7.3-p183) ("Sweetnighter")
[19513] *  Min threads: 4
[19513] *  Max threads: 16
[19513] *  Environment: development
[19513] *   Master PID: 19513
[19513] *      Workers: 1
[19513] *     Restarts: (✔) hot (✔) phased
[19513] * Listening on http://127.0.0.1:3000
[19513] * Listening on http://[::1]:3000
[19513] Use Ctrl-C to stop
[19513] ! WARNING: Detected running cluster mode with 1 worker.
[19513] ! Running Puma in cluster mode with a single worker is often a misconfiguration.
[19513] ! Consider running Puma in single-mode (workers = 0) in order to reduce memory overhead.
[19513] ! Set the `silence_single_worker_warning` option to silence this warning message.
```