### PR TITLE
Bug/37571 not possible to create or edit projects if relative url root configured

### DIFF
--- a/frontend/src/app/modules/apiv3/endpoints/users/apiv3-users-form.ts
+++ b/frontend/src/app/modules/apiv3/endpoints/users/apiv3-users-form.ts
@@ -1,0 +1,5 @@
+import { APIv3FormResource } from "core-app/modules/apiv3/forms/apiv3-form-resource";
+
+export class APIv3UsersForm extends APIv3FormResource {
+}
+

--- a/frontend/src/app/modules/apiv3/endpoints/users/apiv3-users-paths.ts
+++ b/frontend/src/app/modules/apiv3/endpoints/users/apiv3-users-paths.ts
@@ -31,6 +31,7 @@ import { APIv3UserPaths } from "core-app/modules/apiv3/endpoints/users/apiv3-use
 import { Observable } from "rxjs";
 import { UserResource } from "core-app/modules/hal/resources/user-resource";
 import { APIV3Service } from "core-app/modules/apiv3/api-v3.service";
+import { APIv3UsersForm } from "core-app/modules/apiv3/endpoints/users/apiv3-users-form";
 
 export class Apiv3UsersPaths extends APIv3ResourceCollection<UserResource, APIv3UserPaths> {
   constructor(protected apiRoot:APIV3Service,
@@ -42,6 +43,9 @@ export class Apiv3UsersPaths extends APIv3ResourceCollection<UserResource, APIv3
 
   // /api/v3/users/me
   public readonly me = this.path + '/me';
+
+  // /api/v3/users/form
+  public readonly form:APIv3UsersForm = this.subResource('form', APIv3UsersForm);
 
   /**
    * Create a new UserResource

--- a/frontend/src/app/modules/common/dynamic-forms/components/dynamic-form/dynamic-form.component.ts
+++ b/frontend/src/app/modules/common/dynamic-forms/components/dynamic-form/dynamic-form.component.ts
@@ -295,7 +295,7 @@ export class DynamicFormComponent extends UntilDestroyedMixin implements OnChang
     }
 
     if (resourcePath) {
-      return `${this._pathHelperService.api.v3.apiV3Base}${resourcePath}`;
+      return resourcePath;
     }
 
     return;
@@ -349,7 +349,7 @@ export class DynamicFormComponent extends UntilDestroyedMixin implements OnChang
 
       submit_message = `${title || ''} ${this.text.job_started}`;
     } else {
-      submit_message = this.resourceId ? this.text.successful_update : this.text.successful_create;
+      submit_message = this.formHttpMethod === 'patch' ? this.text.successful_update : this.text.successful_create;
     }
 
     this._notificationsService.addSuccess(submit_message);

--- a/frontend/src/app/modules/current-user/current-user.service.ts
+++ b/frontend/src/app/modules/current-user/current-user.service.ts
@@ -153,7 +153,7 @@ export class CurrentUserService {
     return this.capabilitiesForContext$(contextId).pipe(
       map((capabilities) => actions.reduce(
         (acc, action) => {
-          return acc && !!capabilities.find(cap => cap.action.href === `/api/v3/actions/${action}`);
+          return acc && !!capabilities.find(cap => cap.action.href.endsWith(`/api/v3/actions/${action}`));
         },
         capabilities.length > 0,
       )),
@@ -168,7 +168,7 @@ export class CurrentUserService {
     const actionsToFilter = _.castArray(actions);
     return this.capabilitiesForContext$(contextId).pipe(
       map((capabilities) => capabilities.reduce(
-        (acc, cap) => acc || !!actionsToFilter.find(action => cap.action.href === `/api/v3/actions/${action}`),
+        (acc, cap) => acc || !!actionsToFilter.find(action => cap.action.href.endsWith(`/api/v3/actions/${action}`)),
         false,
       )),
       distinctUntilChanged(),

--- a/frontend/src/app/modules/invite-user-modal/principal/principal.component.html
+++ b/frontend/src/app/modules/invite-user-modal/principal/principal.component.html
@@ -53,7 +53,7 @@
       *ngIf="isNewPrincipal && type === PrincipalType.User && userDynamicFieldConfig.schema"
       [dynamicFormGroup]="dynamicFieldsControl"
       [settings]="userDynamicFieldConfig"
-      [resourcePath]="pathHelper.usersPath()"
+      [formUrl]="apiV3Service.users.form.path"
       [handleSubmit]="false"
     ></op-dynamic-form>
   </div>

--- a/frontend/src/app/modules/projects/components/copy-project/copy-project.component.ts
+++ b/frontend/src/app/modules/projects/components/copy-project/copy-project.component.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit} from '@angular/core';
-import {StateService, UIRouterGlobals} from "@uirouter/core";
+import {StateService} from "@uirouter/core";
 import {UntilDestroyedMixin} from "core-app/helpers/angular/until-destroyed.mixin";
 import {PathHelperService} from "core-app/modules/common/path-helper/path-helper.service";
 import {HalSource} from "core-app/modules/hal/resources/hal-resource";
@@ -12,6 +12,7 @@ import {I18nService} from "core-app/modules/common/i18n/i18n.service";
 import {APIV3Service} from "core-app/modules/apiv3/api-v3.service";
 import {JobStatusModal} from "core-app/modules/job-status/job-status-modal/job-status.modal";
 import {OpModalService} from "core-app/modules/modal/modal.service";
+import { CurrentProjectService } from "core-components/projects/current-project.service";
 
 @Component({
   selector: 'op-copy-project',
@@ -35,7 +36,7 @@ export class CopyProjectComponent extends UntilDestroyedMixin implements OnInit 
 
   constructor(
     private apiV3Service:APIV3Service,
-    private uIRouterGlobals:UIRouterGlobals,
+    private currentProjectService:CurrentProjectService,
     private pathHelperService:PathHelperService,
     private modalService:OpModalService,
     private $state:StateService,
@@ -45,7 +46,7 @@ export class CopyProjectComponent extends UntilDestroyedMixin implements OnInit 
   }
 
   ngOnInit():void {
-    this.formUrl = this.apiV3Service.projects.id(this.uIRouterGlobals.params.projectPath).copy.form.path;
+    this.formUrl = this.apiV3Service.projects.id(this.currentProjectService.id!).copy.form.path;
     this.fieldGroups = [
       {
         name: this.text.advancedSettingsLabel,

--- a/frontend/src/app/modules/projects/components/new-project/new-project.component.ts
+++ b/frontend/src/app/modules/projects/components/new-project/new-project.component.ts
@@ -80,7 +80,7 @@ export class NewProjectComponent extends UntilDestroyedMixin implements OnInit {
   }
 
   ngOnInit():void {
-    this.resourcePath = this.pathHelperService.projectsPath();
+    this.resourcePath = this.apiV3Service.projects.path;
     this.fieldGroups = [{
       name: this.text.advancedSettingsLabel,
       fieldsFilter: (field) => !['name', 'parent'].includes(field.templateOptions?.property!) &&

--- a/frontend/src/app/modules/projects/components/projects/projects.component.html
+++ b/frontend/src/app/modules/projects/components/projects/projects.component.html
@@ -1,6 +1,6 @@
 <op-dynamic-form
-    [resourceId]="resourceId"
     [resourcePath]="projectsPath"
+    [formHttpMethod]="formMethod"
     [fieldsSettingsPipe]="dynamicFieldsSettingsPipe"
     helpTextAttributeScope="Project"
 ></op-dynamic-form>

--- a/frontend/src/app/modules/projects/components/projects/projects.component.ts
+++ b/frontend/src/app/modules/projects/components/projects/projects.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit } from '@angular/core';
-import { StateService, UIRouterGlobals } from "@uirouter/core";
+import { StateService } from "@uirouter/core";
 import { UntilDestroyedMixin } from "core-app/helpers/angular/until-destroyed.mixin";
 import { PathHelperService } from "core-app/modules/common/path-helper/path-helper.service";
-import { HalSource } from "core-app/modules/hal/resources/hal-resource";
 import { IOPFormlyFieldSettings } from "core-app/modules/common/dynamic-forms/typings";
+import { CurrentProjectService } from "core-components/projects/current-project.service";
 
 @Component({
   selector: 'app-projects',
@@ -11,23 +11,22 @@ import { IOPFormlyFieldSettings } from "core-app/modules/common/dynamic-forms/ty
   styleUrls: ['./projects.component.scss']
 })
 export class ProjectsComponent extends UntilDestroyedMixin implements OnInit {
-  resourceId:string;
   projectsPath:string;
+  formMethod = 'patch';
   text:{ [key:string]:string };
   dynamicFieldsSettingsPipe:(dynamicFieldsSettings:IOPFormlyFieldSettings[]) => IOPFormlyFieldSettings[];
   hiddenFields = ['identifier', 'active'];
 
   constructor(
-    private _uIRouterGlobals:UIRouterGlobals,
     private _pathHelperService:PathHelperService,
     private _$state:StateService,
+    private _currentProjectService:CurrentProjectService,
   ) {
     super();
   }
 
   ngOnInit():void {
-    this.projectsPath = this._pathHelperService.projectsPath();
-    this.resourceId = this._uIRouterGlobals.params.projectPath;
+    this.projectsPath = this._currentProjectService.apiv3Path!;
     this.dynamicFieldsSettingsPipe = (dynamicFieldsSettings) => {
       return dynamicFieldsSettings
         .reduce((formattedDynamicFieldsSettings:IOPFormlyFieldSettings[], dynamicFormField) => {
@@ -40,13 +39,6 @@ export class ProjectsComponent extends UntilDestroyedMixin implements OnInit {
 
           return [...formattedDynamicFieldsSettings, dynamicFormField];
         }, []);
-    }
-  }
-
-  onSubmitted(formResource:HalSource) {
-    // TODO: Filter out if this.resourceId === 'new'?
-    if (!this.resourceId) {
-      this._$state.go('.', { ...this._$state.params, projectPath: formResource.identifier });
     }
   }
 


### PR DESCRIPTION
## Fixes

* [#37571] Not possible to create or edit project if relative url root configured https://community.openproject.org/work_packages/37571
* [#37618] Not possible to invite users via modal if relative url root configured https://community.openproject.org/work_packages/37618

Those bugs where caused by not relying on the path helpers to get the path in the first place (not factoring in the relative url root at all (e.g. `/api/v3/users`) and by not relying on them to combine different parts of a path (ending up with e.g. `/op/api/v3/op/projects/form`).

## Notes

Because of the change, the `resourceId` input of the `DynamicFormComponent` is now unused. Only `formUrl`, `formHttpMethod` and `resourcePath` are used and if I am not mistaken, there is no real difference between `formUrl` and `resourcePath`. 

I deemed it too big of a change to start that as part of the bugfix, but either the interface should consist of only `formUrl` and `formHttpMethod` or switch its interface to accept a resource type and optionally an id. In the later case, the path construction could be internalized which might prevent a problem such as the one just fixed.  
