### PR TITLE
Fix how we gather and derive sampling traces for sentry

### DIFF
--- a/app/helpers/sentry_helper.rb
+++ b/app/helpers/sentry_helper.rb
@@ -14,7 +14,7 @@ module SentryHelper
         data: {
           dsn: OpenProject::Configuration.sentry_frontend_dsn,
           version: OpenProject::VERSION.to_s,
-          tracing_rate: OpenProject::Configuration.sentry_traces_sample_rate
+          tracing_factor: OpenProject::Configuration.sentry_frontend_trace_factor
         }
   end
 

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -182,8 +182,13 @@ module OpenProject
       # Allow separate error reporting for frontend errors
       'sentry_frontend_dsn' => nil,
       'sentry_host' => nil,
-      # Sample rate for performance monitoring
-      'sentry_traces_sample_rate' => 0.1,
+      # Allow sentry to collect tracing samples
+      # set to 1 to enable default tracing samples (see sentry initializer)
+      # set to n >= 1 to enable n times the default tracing
+      'sentry_trace_factor' => 0,
+      # Allow sentry to collect tracing samples on frontend
+      # set to n >= 1 to enable n times the default tracing
+      'sentry_frontend_trace_factor' => 0,
 
       # Allow connection to Augur
       'enterprise_trial_creation_host' => 'https://augur.openproject.com',


### PR DESCRIPTION
We previously defined a fixed tracing rate AND a sampling tracer in the backend,
which result in everything to be traced regardless of the actual rate.

We now define a base rate for certain requests, so that we can exclude health checks and other things.
The configuration is now a factor (0 = off, default) (1 = use suggested rates), any other value x (x multiplied by suggested rates)