### PR TITLE
[Proposal] Speed up `bin/compose setup` significantly

### DIFF
--- a/bin/compose
+++ b/bin/compose
@@ -2,6 +2,9 @@
 
 set -e
 
+export COMPOSE_DOCKER_CLI_BUILD=1
+export DOCKER_BUILDKIT=1
+
 if [ -f .env ]; then
   export `grep -v '^#' .env | xargs`
 else

--- a/docker/dev/backend/Dockerfile
+++ b/docker/dev/backend/Dockerfile
@@ -9,7 +9,13 @@ ENV RAILS_ENV=development
 
 ENV BUNDLER_VERSION "2.0.2"
 
-RUN useradd -d /home/$USER -m $USER
+# `--no-log-init` is required as a workaround to avoid disk exhaustion.
+#
+# Read more at:
+# * https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+# * https://github.com/golang/go/issues/13548
+RUN useradd --no-log-init -d /home/$USER -m $USER
+
 RUN usermod -u $DEV_UID $USER
 RUN groupmod -g $DEV_GID $USER || true
 

--- a/docker/dev/backend/scripts/setup
+++ b/docker/dev/backend/scripts/setup
@@ -2,7 +2,9 @@
 
 set -e
 
-bundle install
+export MAKE="make --jobs $(nproc)"
+
+bundle install --jobs $(nproc)
 bundle exec rake db:create db:migrate
 bundle exec rake db:seed
 bundle exec rake openproject:plugins:register_frontend

--- a/docker/dev/frontend/Dockerfile
+++ b/docker/dev/frontend/Dockerfile
@@ -8,7 +8,13 @@ ENV USER=dev
 
 RUN npm i -g npm
 
-RUN usermod -l $USER -d /home/$USER -m node
+# `--no-log-init` is required as a workaround to avoid disk exhaustion.
+#
+# Read more at:
+# * https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+# * https://github.com/golang/go/issues/13548
+RUN useradd --no-log-init -d /home/$USER -m $USER -g node
+
 RUN usermod -u $DEV_UID $USER
 RUN groupadd $USER
 RUN groupmod -g $DEV_GID $USER || true


### PR DESCRIPTION
With the proposed changes the time required to run `./bin/compose setup` is being reduced from ~18 minutes down to ~7 minutes on my machine. In addition, a workaround is applied to reduce the size of the images.

## Changes

### Speed-Up `bundle install`

The time spent withing `bundle install` takes a significant amount of time during the `./bin/compose setup`.
We could make use of two improvements, which both allows us to utilize multiple CPU cores:

* Make use of the bundle `--jobs` argument
* Make use of the lesser-known/used `MAKE` environment variable

A significant amount of time spent during `bundle install` is actually compiling C-extensions, that's why the usage of the `MAKE` variable will drastically improve performance.

### `useradd --no-log-init`

Unfortunately, there is a nasty bug when running `useradd` for a huge `uid`, which could result in excessive image sizes. See attached links for more information.

#### Image size on my machine:

```shell
$ id -u
103187885

docker build --build-arg DEV_UID=$(id -u) -t open-project-backend --target develop --file docker/dev/backend/Dockerfile .
```

<img width="1021" alt="op-backend-image-size" src="https://user-images.githubusercontent.com/385500/122802161-51575400-d2c5-11eb-843a-f71c6a889bec.png">

* It's similar for `docker/dev/frontend/Dockerfile`

### BuildKit

BuildKit is the default builder toolkit for Docker on Windows and DockerDesktop on Macs. Using BuildKit will greatly improve performance when building docker images.

## Links

### Speed-Up `bundle install`

* [One Weird Trick That Will Speed Up Your Bundle Install](https://build.betterup.com/one-weird-trick-that-will-speed-up-your-bundle-install/)

### BuildKit

* [Build images with BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/)
* [Faster builds in Docker Compose 1.25.1 thanks to BuildKit Support](https://www.docker.com/blog/faster-builds-in-compose-thanks-to-buildkit-support/)

### `useradd --no-log-init`

* Best practices for writing Dockerfiles: [User](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user)
* golang/co: [archive/tar: add support for writing tar containing sparse files](https://github.com/golang/go/issues/13548)