### PR TITLE
Feature/37872 api v3 notifications api bulk confirming notifications

### DIFF
--- a/app/models/queries/notifications/filters/id_filter.rb
+++ b/app/models/queries/notifications/filters/id_filter.rb
@@ -2,13 +2,13 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2020 the OpenProject GmbH
+# Copyright (C) 2012-2021 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
 #
 # OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
-# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2006-2013 Jean-Philippe Lang
 # Copyright (C) 2010-2013 the ChiliProject Team
 #
 # This program is free software; you can redistribute it and/or
@@ -28,19 +28,18 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Queries::Notifications
-  Queries::Register.filter Queries::Notifications::NotificationQuery,
-                           Queries::Notifications::Filters::ReadIanFilter
+class Queries::Notifications::Filters::IdFilter < Queries::Notifications::Filters::NotificationFilter
+  def allowed_values
+    Notification
+      .recipient(User.current)
+      .pluck(:id, :id)
+  end
 
-  Queries::Register.filter Queries::Notifications::NotificationQuery,
-                           Queries::Notifications::Filters::IdFilter
+  def type
+    :list
+  end
 
-  Queries::Register.order Queries::Notifications::NotificationQuery,
-                          Queries::Notifications::Orders::DefaultOrder
-
-  Queries::Register.order Queries::Notifications::NotificationQuery,
-                          Queries::Notifications::Orders::ReasonOrder
-
-  Queries::Register.order Queries::Notifications::NotificationQuery,
-                          Queries::Notifications::Orders::ReadIanOrder
+  def self.key
+    :id
+  end
 end

--- a/frontend/src/app/core/apiv3/endpoints/notifications/apiv3-notification-paths.ts
+++ b/frontend/src/app/core/apiv3/endpoints/notifications/apiv3-notification-paths.ts
@@ -39,7 +39,7 @@ export class Apiv3NotificationPaths extends APIv3GettableResource<InAppNotificat
     return this
       .http
       .post(
-        this.path + '/readIAN',
+        this.path + '/read_ian',
         {},
         {
           withCredentials: true,
@@ -52,7 +52,7 @@ export class Apiv3NotificationPaths extends APIv3GettableResource<InAppNotificat
     return this
       .http
       .post(
-        this.path + '/unreadIAN',
+        this.path + '/unread_ian',
         {},
         {
           withCredentials: true,

--- a/frontend/src/app/core/apiv3/endpoints/notifications/apiv3-notifications-paths.ts
+++ b/frontend/src/app/core/apiv3/endpoints/notifications/apiv3-notifications-paths.ts
@@ -35,6 +35,7 @@ import { Apiv3NotificationPaths } from "core-app/core/apiv3/endpoints/notificati
 import { InjectField } from "core-app/shared/helpers/angular/inject-field.decorator";
 import { HttpClient } from "@angular/common/http";
 import { IHALCollection } from "core-app/core/apiv3/types/hal-collection.type";
+import { ID } from "@datorama/akita";
 
 export class Apiv3NotificationsPaths
   extends APIv3ResourceCollection<InAppNotification, Apiv3NotificationPaths> {
@@ -73,5 +74,22 @@ export class Apiv3NotificationsPaths
     };
 
     return this.list(params);
+  }
+
+  /**
+   * Mark all notifications as read
+   * @param ids
+   */
+  public markRead(ids:Array<ID>):Observable<unknown> {
+    return this
+      .http
+      .post(
+        this.path + '/read_ian' + listParamsString({ filters: [['id', "=", ids.map(id => id.toString())]] }),
+        {},
+        {
+          withCredentials: true,
+          responseType: 'json'
+        }
+      );
   }
 }

--- a/frontend/src/app/features/in-app-notifications/store/in-app-notifications.service.ts
+++ b/frontend/src/app/features/in-app-notifications/store/in-app-notifications.service.ts
@@ -86,9 +86,7 @@ export class InAppNotificationsService {
       .pipe(
         take(1),
         switchMap(events =>
-          forkJoin(
-            events.map(event => this.apiV3Service.notifications.id(event.id).markRead())
-          )
+          this.apiV3Service.notifications.markRead(events.map(event => event.id))
         )
       )
       .subscribe(() => {

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -221,20 +221,36 @@ module API
           index :notification
           show :notification
 
+          def self.notification_bulk_read_ian
+            "#{notifications}/read_ian"
+          end
+
+          def self.notification_bulk_unread_ian
+            "#{notifications}/unread_ian"
+          end
+
+          def self.notification_bulk_read_email
+            "#{notifications}/read_email"
+          end
+
+          def self.notification_bulk_unread_email
+            "#{notifications}/unread_email"
+          end
+
           def self.notification_read_ian(id)
-            "#{notification(id)}/readIAN"
+            "#{notification(id)}/read_ian"
           end
 
           def self.notification_unread_ian(id)
-            "#{notification(id)}/unreadIAN"
+            "#{notification(id)}/unread_ian"
           end
 
           def self.notification_read_email(id)
-            "#{notification(id)}/readEmail"
+            "#{notification(id)}/read_email"
           end
 
           def self.notification_unread_email(id)
-            "#{notification(id)}/unreadEmail"
+            "#{notification(id)}/unread_email"
           end
 
           index :placeholder_user

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -218,6 +218,59 @@ describe ::API::V3::Utilities::PathHelper do
     it_behaves_like 'show', :news
   end
 
+  describe 'notifications paths' do
+    it_behaves_like 'index', :notifications
+    it_behaves_like 'show', :notification
+
+    describe '#notification_bulk_read_ian' do
+      subject { helper.notification_bulk_read_ian }
+
+      it_behaves_like 'api v3 path', '/notifications/read_ian'
+    end
+
+    describe '#notification_bulk_unread_ian' do
+      subject { helper.notification_bulk_unread_ian }
+
+      it_behaves_like 'api v3 path', '/notifications/unread_ian'
+    end
+
+    describe '#notification_bulk_read_email' do
+      subject { helper.notification_bulk_read_email }
+
+      it_behaves_like 'api v3 path', '/notifications/read_email'
+    end
+
+    describe '#notification_bulk_unread_email' do
+      subject { helper.notification_bulk_unread_email }
+
+      it_behaves_like 'api v3 path', '/notifications/unread_email'
+    end
+
+    describe '#notification_read_ian' do
+      subject { helper.notification_read_ian(42) }
+
+      it_behaves_like 'api v3 path', '/notifications/42/read_ian'
+    end
+
+    describe '#notification_unread_ian' do
+      subject { helper.notification_unread_ian(42) }
+
+      it_behaves_like 'api v3 path', '/notifications/42/unread_ian'
+    end
+
+    describe '#notification_read_email' do
+      subject { helper.notification_read_email(42) }
+
+      it_behaves_like 'api v3 path', '/notifications/42/read_email'
+    end
+
+    describe '#notification_unread_email' do
+      subject { helper.notification_unread_email(42) }
+
+      it_behaves_like 'api v3 path', '/notifications/42/unread_email'
+    end
+  end
+
   describe 'markup paths' do
     describe '#render_markup' do
       subject { helper.render_markup(link: 'link-ish') }

--- a/spec/models/queries/notifications/filters/id_filter_spec.rb
+++ b/spec/models/queries/notifications/filters/id_filter_spec.rb
@@ -2,13 +2,13 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2020 the OpenProject GmbH
+# Copyright (C) 2012-2021 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
 #
 # OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
-# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2006-2013 Jean-Philippe Lang
 # Copyright (C) 2010-2013 the ChiliProject Team
 #
 # This program is free software; you can redistribute it and/or
@@ -28,19 +28,14 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Queries::Notifications
-  Queries::Register.filter Queries::Notifications::NotificationQuery,
-                           Queries::Notifications::Filters::ReadIanFilter
+require 'spec_helper'
 
-  Queries::Register.filter Queries::Notifications::NotificationQuery,
-                           Queries::Notifications::Filters::IdFilter
-
-  Queries::Register.order Queries::Notifications::NotificationQuery,
-                          Queries::Notifications::Orders::DefaultOrder
-
-  Queries::Register.order Queries::Notifications::NotificationQuery,
-                          Queries::Notifications::Orders::ReasonOrder
-
-  Queries::Register.order Queries::Notifications::NotificationQuery,
-                          Queries::Notifications::Orders::ReadIanOrder
+describe Queries::Notifications::Filters::IdFilter, type: :model do
+  it_behaves_like 'basic query filter' do
+    let(:class_key) { :id }
+    let(:type) { :list }
+    let(:model) { Notification }
+    let(:attribute) { :id }
+    let(:values) { ['5'] }
+  end
 end

--- a/spec/requests/api/v3/notifications/bulk_read_email_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/bulk_read_email_resource_spec.rb
@@ -1,0 +1,116 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+
+describe ::API::V3::Notifications::NotificationsAPI,
+         'bulk set read status',
+         type: :request,
+         content_type: :json do
+  include API::V3::Utilities::PathHelper
+
+  shared_let(:recipient) { FactoryBot.create :user }
+  shared_let(:other_recipient) { FactoryBot.create :user }
+  shared_let(:notification1) { FactoryBot.create :notification, recipient: recipient }
+  shared_let(:notification2) { FactoryBot.create :notification, recipient: recipient }
+  shared_let(:notification3) { FactoryBot.create :notification, recipient: recipient }
+  shared_let(:other_user_notification) { FactoryBot.create :notification, recipient: other_recipient }
+
+  let(:filters) { nil }
+
+  let(:read_path) do
+    api_v3_paths.path_for :notification_bulk_read_email, filters: filters
+  end
+
+  let(:parsed_response) { JSON.parse(last_response.body) }
+
+  before do
+    login_as current_user
+
+    post read_path
+  end
+
+  describe 'POST /api/v3/notifications/read_email' do
+    let(:current_user) { recipient }
+
+    it 'returns 204' do
+      expect(last_response.status)
+        .to eql(204)
+    end
+
+    it 'sets all the current users`s notifications to read' do
+      expect(::Notification.where(id: [notification1.id, notification2.id, notification3.id]).pluck(:read_email))
+        .to all(be_truthy)
+
+      expect(::Notification.where(id: [other_user_notification]).pluck(:read_email))
+        .to all(be_falsey)
+    end
+
+    context 'with a filter for id' do
+      let(:filters) do
+        [
+          {
+            'id' => {
+              'operator' => '=',
+              'values' => [notification1.id.to_s, notification2.id.to_s]
+
+            }
+          }
+        ]
+      end
+
+      it 'sets the current users`s notifications matching the filter to read' do
+        expect(::Notification.where(id: [notification1.id, notification2.id]).pluck(:read_email))
+          .to all(be_truthy)
+
+        expect(::Notification.where(id: [other_user_notification, notification3.id]).pluck(:read_email))
+          .to all(be_falsey)
+      end
+    end
+
+    context 'with an invalid filter' do
+      let(:filters) do
+        [
+          {
+            'bogus' => {
+              'operator' => '=',
+              'values' => []
+
+            }
+          }
+        ]
+      end
+
+      it 'returns 400' do
+        expect(last_response.status)
+          .to eql(400)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/notifications/bulk_read_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/bulk_read_ian_resource_spec.rb
@@ -1,0 +1,116 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+
+describe ::API::V3::Notifications::NotificationsAPI,
+         'bulk set read status',
+         type: :request,
+         content_type: :json do
+  include API::V3::Utilities::PathHelper
+
+  shared_let(:recipient) { FactoryBot.create :user }
+  shared_let(:other_recipient) { FactoryBot.create :user }
+  shared_let(:notification1) { FactoryBot.create :notification, recipient: recipient }
+  shared_let(:notification2) { FactoryBot.create :notification, recipient: recipient }
+  shared_let(:notification3) { FactoryBot.create :notification, recipient: recipient }
+  shared_let(:other_user_notification) { FactoryBot.create :notification, recipient: other_recipient }
+
+  let(:filters) { nil }
+
+  let(:read_path) do
+    api_v3_paths.path_for :notification_bulk_read_ian, filters: filters
+  end
+
+  let(:parsed_response) { JSON.parse(last_response.body) }
+
+  before do
+    login_as current_user
+
+    post read_path
+  end
+
+  describe 'POST /api/v3/notifications/read_ian' do
+    let(:current_user) { recipient }
+
+    it 'returns 204' do
+      expect(last_response.status)
+        .to eql(204)
+    end
+
+    it 'sets all the current users`s notifications to read' do
+      expect(::Notification.where(id: [notification1.id, notification2.id, notification3.id]).pluck(:read_ian))
+        .to all(be_truthy)
+
+      expect(::Notification.where(id: [other_user_notification]).pluck(:read_ian))
+        .to all(be_falsey)
+    end
+
+    context 'with a filter for id' do
+      let(:filters) do
+        [
+          {
+            'id' => {
+              'operator' => '=',
+              'values' => [notification1.id.to_s, notification2.id.to_s]
+
+            }
+          }
+        ]
+      end
+
+      it 'sets the current users`s notifications matching the filter to read' do
+        expect(::Notification.where(id: [notification1.id, notification2.id]).pluck(:read_ian))
+          .to all(be_truthy)
+
+        expect(::Notification.where(id: [other_user_notification, notification3.id]).pluck(:read_ian))
+          .to all(be_falsey)
+      end
+    end
+
+    context 'with an invalid filter' do
+      let(:filters) do
+        [
+          {
+            'bogus' => {
+              'operator' => '=',
+              'values' => []
+
+            }
+          }
+        ]
+      end
+
+      it 'returns 400' do
+        expect(last_response.status)
+          .to eql(400)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/notifications/bulk_unread_email_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/bulk_unread_email_resource_spec.rb
@@ -1,0 +1,116 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+
+describe ::API::V3::Notifications::NotificationsAPI,
+         'bulk unset read status',
+         type: :request,
+         content_type: :json do
+  include API::V3::Utilities::PathHelper
+
+  shared_let(:recipient) { FactoryBot.create :user }
+  shared_let(:other_recipient) { FactoryBot.create :user }
+  shared_let(:notification1) { FactoryBot.create :notification, recipient: recipient, read_email: true }
+  shared_let(:notification2) { FactoryBot.create :notification, recipient: recipient, read_email: true }
+  shared_let(:notification3) { FactoryBot.create :notification, recipient: recipient, read_email: true }
+  shared_let(:other_user_notification) { FactoryBot.create :notification, recipient: other_recipient, read_email: true }
+
+  let(:filters) { nil }
+
+  let(:read_path) do
+    api_v3_paths.path_for :notification_bulk_unread_email, filters: filters
+  end
+
+  let(:parsed_response) { JSON.parse(last_response.body) }
+
+  before do
+    login_as current_user
+
+    post read_path
+  end
+
+  describe 'POST /api/v3/notifications/unread_email' do
+    let(:current_user) { recipient }
+
+    it 'returns 204' do
+      expect(last_response.status)
+        .to eql(204)
+    end
+
+    it 'sets all the current users`s notifications to read' do
+      expect(::Notification.where(id: [notification1.id, notification2.id, notification3.id]).pluck(:read_email))
+        .to all(be_falsey)
+
+      expect(::Notification.where(id: [other_user_notification]).pluck(:read_email))
+        .to all(be_truthy)
+    end
+
+    context 'with a filter for id' do
+      let(:filters) do
+        [
+          {
+            'id' => {
+              'operator' => '=',
+              'values' => [notification1.id.to_s, notification2.id.to_s]
+
+            }
+          }
+        ]
+      end
+
+      it 'sets the current users`s notifications matching the filter to read' do
+        expect(::Notification.where(id: [notification1.id, notification2.id]).pluck(:read_email))
+          .to all(be_falsey)
+
+        expect(::Notification.where(id: [other_user_notification, notification3.id]).pluck(:read_email))
+          .to all(be_truthy)
+      end
+    end
+
+    context 'with an invalid filter' do
+      let(:filters) do
+        [
+          {
+            'bogus' => {
+              'operator' => '=',
+              'values' => []
+
+            }
+          }
+        ]
+      end
+
+      it 'returns 400' do
+        expect(last_response.status)
+          .to eql(400)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/notifications/bulk_unread_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/bulk_unread_ian_resource_spec.rb
@@ -1,0 +1,116 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2020 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+
+require 'spec_helper'
+
+describe ::API::V3::Notifications::NotificationsAPI,
+         'bulk unset read status',
+         type: :request,
+         content_type: :json do
+  include API::V3::Utilities::PathHelper
+
+  shared_let(:recipient) { FactoryBot.create :user }
+  shared_let(:other_recipient) { FactoryBot.create :user }
+  shared_let(:notification1) { FactoryBot.create :notification, recipient: recipient, read_ian: true }
+  shared_let(:notification2) { FactoryBot.create :notification, recipient: recipient, read_ian: true }
+  shared_let(:notification3) { FactoryBot.create :notification, recipient: recipient, read_ian: true }
+  shared_let(:other_user_notification) { FactoryBot.create :notification, recipient: other_recipient, read_ian: true }
+
+  let(:filters) { nil }
+
+  let(:read_path) do
+    api_v3_paths.path_for :notification_bulk_unread_ian, filters: filters
+  end
+
+  let(:parsed_response) { JSON.parse(last_response.body) }
+
+  before do
+    login_as current_user
+
+    post read_path
+  end
+
+  describe 'POST /api/v3/notifications/unread_ian' do
+    let(:current_user) { recipient }
+
+    it 'returns 204' do
+      expect(last_response.status)
+        .to eql(204)
+    end
+
+    it 'sets all the current users`s notifications to read' do
+      expect(::Notification.where(id: [notification1.id, notification2.id, notification3.id]).pluck(:read_ian))
+        .to all(be_falsey)
+
+      expect(::Notification.where(id: [other_user_notification]).pluck(:read_ian))
+        .to all(be_truthy)
+    end
+
+    context 'with a filter for id' do
+      let(:filters) do
+        [
+          {
+            'id' => {
+              'operator' => '=',
+              'values' => [notification1.id.to_s, notification2.id.to_s]
+
+            }
+          }
+        ]
+      end
+
+      it 'sets the current users`s notifications matching the filter to read' do
+        expect(::Notification.where(id: [notification1.id, notification2.id]).pluck(:read_ian))
+          .to all(be_falsey)
+
+        expect(::Notification.where(id: [other_user_notification, notification3.id]).pluck(:read_ian))
+          .to all(be_truthy)
+      end
+    end
+
+    context 'with an invalid filter' do
+      let(:filters) do
+        [
+          {
+            'bogus' => {
+              'operator' => '=',
+              'values' => []
+
+            }
+          }
+        ]
+      end
+
+      it 'returns 400' do
+        expect(last_response.status)
+          .to eql(400)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/notifications/read_email_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/read_email_resource_spec.rb
@@ -31,19 +31,18 @@ require 'spec_helper'
 
 describe ::API::V3::Notifications::NotificationsAPI,
          'update email read status',
-         type: :request do
+         type: :request,
+         content_type: :json do
   include API::V3::Utilities::PathHelper
 
   shared_let(:recipient) { FactoryBot.create :user }
   shared_let(:notification) { FactoryBot.create :notification, recipient: recipient }
 
   let(:send_read) do
-    header "Content-Type", "application/json"
     post api_v3_paths.notification_read_email(notification.id)
   end
 
   let(:send_unread) do
-    header "Content-Type", "application/json"
     post api_v3_paths.notification_unread_email(notification.id)
   end
 

--- a/spec/requests/api/v3/notifications/read_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/read_ian_resource_spec.rb
@@ -31,19 +31,18 @@ require 'spec_helper'
 
 describe ::API::V3::Notifications::NotificationsAPI,
          'update read status',
-         type: :request do
+         type: :request,
+         content_type: :json do
   include API::V3::Utilities::PathHelper
 
   shared_let(:recipient) { FactoryBot.create :user }
   shared_let(:notification) { FactoryBot.create :notification, recipient: recipient }
 
   let(:send_read) do
-    header "Content-Type", "application/json"
     post api_v3_paths.notification_read_ian(notification.id)
   end
 
   let(:send_unread) do
-    header "Content-Type", "application/json"
     post api_v3_paths.notification_unread_ian(notification.id)
   end
 


### PR DESCRIPTION
Endpoints

- POST /api/v3/notifications/readIAN
- POST /api/v3/notifications/unreadIAN
- POST /api/v3/notifications/readEmail
- POST /api/v3/notifications/unreadEmail

All the endpoints above accept a filter (for ID at first) that will read/unread the notifications matching

Hooks up frontend to use the bulk end point for marking all notifications as read

OP#37872