### PR TITLE
use service to have notification settings created

### DIFF
--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -208,7 +208,7 @@ class PermittedParams
       additional_params << :force_password_change if change_password_allowed
       additional_params << :admin
     end
-    
+
     additional_params << :login if Users::BaseContract.new(User.new, current_user).writable?(:login)
 
     user additional_params

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -36,6 +36,8 @@ See docs/COPYRIGHT.rdoc for more details.
 
 <%= toolbar title: t(:label_user_new) %>
 
+<%= error_messages_for_contract @user, @errors %>
+
 <%= labelled_tabular_form_for @user,
                               url: { action: "create" },
                               html: { class: nil, autocomplete: 'off' },


### PR DESCRIPTION
The `Users::CreateService` correctly creates the notification settings. It is now used in the users controller.

https://community.openproject.org/wp/37882