### PR TITLE
Fix several app-header search styling issues on mobile

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -13,7 +13,7 @@ $search-input-height: 30px
   line-height: var(--header-height)
   margin: 0 15px
 
-  @media screen and (max-width: 680px)
+  @media screen and (max-width: 679px)
     margin: 0
 
   &--back-button
@@ -32,7 +32,7 @@ $search-input-height: 30px
     // TODO: This should be using  @include breakpoint(680px down)
     // Which is hard to do since we don't have access here and it'll
     // probably require a larger sass import refactoring
-    @media screen and (max-width: 680px)
+    @media screen and (max-width: 679px)
       position: relative
       padding: 0 8px
 
@@ -73,7 +73,11 @@ $search-input-height: 30px
       text-align: center
 
     .ng-input
-      top: 0
+      @media screen and (max-width: 679px)
+        // TODO: We need to do this because the default ng-select theme uses a specificity of 5(!) classes
+        // We should probably remove the default theme altogether at some point
+        top: 0 !important
+
       input
         color: var(--header-item-font-color)
         height: $search-input-height

--- a/frontend/src/app/core/global_search/input/global-search.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search.component.sass
@@ -1,6 +1,9 @@
 .global-search
   flex-grow: 1
 
+  @media screen and (max-width: 679px)
+    display: none
+
   &--option,
   &--option:hover
     padding: 5px 5px

--- a/frontend/src/global_styles/common/header/app-header.sass
+++ b/frontend/src/global_styles/common/header/app-header.sass
@@ -13,7 +13,7 @@
   border-bottom-color: var(--header-border-bottom-color)
   width: 100vw
 
-  @include breakpoint(680px down)
+  @media screen and (max-width: 679px)
     position: fixed
     top: 0
     left: 0
@@ -44,7 +44,7 @@
     border: 1px solid var(--header-item-font-color)
 
   &_search-open
-    @include breakpoint(680px down)
+    @media screen and (max-width: 679px)
       display: flex
 
       .op-app-header--start,
@@ -57,6 +57,9 @@
       .op-app-search
         flex-grow: 1
 
+      .global-search
+        display: block
+
       .top-menu-search
         margin: 0
 
@@ -64,7 +67,7 @@
           display: none
           color: var(--header-item-font-color)
 
-    @include breakpoint(480px down)
+    @media screen and (max-width: 379px)
       .op-app-menu
         display: none
 

--- a/frontend/src/global_styles/common/header/app-menu.sass
+++ b/frontend/src/global_styles/common/header/app-menu.sass
@@ -18,6 +18,7 @@
 
   &--item-title
     min-width: 0px
+    white-space: nowrap
 
   &--item-action
     background: transparent 

--- a/frontend/src/global_styles/common/header/app-search.sass
+++ b/frontend/src/global_styles/common/header/app-search.sass
@@ -1,3 +1,3 @@
 .op-app-search
-  @include breakpoint(680px down)
+  @media screen and (max-width: 679px)
     flex-grow: 0


### PR DESCRIPTION
After introduction of the new op-autocompleter component for the app-search component, there were a couple of styling
issues related to the ng-select default styles.

* Correctly set max-width to 679px, so that the tablet breakpoint starts at 680px exactly. There were some issues with
  overlapping queries or queries that ignored the exact 680px point
* Disable line wrapping in menu items. The "sign in" button was getting line wrapped on certain screen sizes
* Fix text vertical alignment in the search input

Some of these fixes can probably be reverted after we take a closer look at the ng-select and op-autocompleter styles