### PR TITLE
treat nil value as non false

### DIFF
--- a/app/models/queries/filters/strategies/boolean_list_strict.rb
+++ b/app/models/queries/filters/strategies/boolean_list_strict.rb
@@ -28,14 +28,13 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::Notifications::Filters::ReadIanFilter < Queries::Notifications::Filters::NotificationFilter
-  include Queries::Filters::Shared::BooleanFilter
+module Queries::Filters::Strategies
+  class BooleanListStrict < BooleanList
+    def operator_map
+      super_value = super.dup
+      super_value['='] = ::Queries::Operators::BooleanEqualsStrict
 
-  def self.key
-    :read_ian
-  end
-
-  def type_strategy
-    @type_strategy ||= ::Queries::Filters::Strategies::BooleanListStrict.new self
+      super_value
+    end
   end
 end

--- a/app/models/queries/operators/boolean_equals_strict.rb
+++ b/app/models/queries/operators/boolean_equals_strict.rb
@@ -28,14 +28,13 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::Notifications::Filters::ReadIanFilter < Queries::Notifications::Filters::NotificationFilter
-  include Queries::Filters::Shared::BooleanFilter
+module Queries::Operators
+  class BooleanEqualsStrict < Base
+    label 'equals'
+    set_symbol '='
 
-  def self.key
-    :read_ian
-  end
-
-  def type_strategy
-    @type_strategy ||= ::Queries::Filters::Strategies::BooleanListStrict.new self
+    def self.sql_for_field(values, db_table, db_field)
+      "#{db_table}.#{db_field} IN (#{values.map { |val| "'#{connection.quote_string(val)}'" }.join(',')})"
+    end
   end
 end

--- a/spec/models/queries/notifications/filters/read_ian_filter_spec.rb
+++ b/spec/models/queries/notifications/filters/read_ian_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -28,14 +26,21 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-class Queries::Notifications::Filters::ReadIanFilter < Queries::Notifications::Filters::NotificationFilter
-  include Queries::Filters::Shared::BooleanFilter
+require 'spec_helper'
 
-  def self.key
-    :read_ian
-  end
+describe Queries::Notifications::Filters::ReadIanFilter, type: :model do
+  it_behaves_like 'basic query filter' do
+    let(:type) { :list }
+    let(:class_key) { :read_ian }
 
-  def type_strategy
-    @type_strategy ||= ::Queries::Filters::Strategies::BooleanListStrict.new self
+    describe '#available_operators' do
+      it 'supports = and !' do
+        expect(instance.available_operators)
+          .to eql [Queries::Operators::BooleanEqualsStrict,
+                   Queries::Operators::BooleanNotEquals]
+      end
+    end
+
+    it_behaves_like 'non ar filter'
   end
 end

--- a/spec/requests/api/v3/support/api_v3_collection_response.rb
+++ b/spec/requests/api/v3/support/api_v3_collection_response.rb
@@ -30,6 +30,10 @@ require 'spec_helper'
 
 shared_examples_for 'API V3 collection response' do |total, count, type|
   subject { last_response.body }
+  # If an array of elements is provided, those elements are expected
+  # to be embedded in the _embedded/elements section in the order provided.
+  # Only the id of the element is checked for.
+  let(:elements) { nil }
 
   # Allow input to pass a proc to avoid counting before the example
   # context
@@ -59,6 +63,10 @@ shared_examples_for 'API V3 collection response' do |total, count, type|
 
       if type && count_number > 0
         expect(subject).to be_json_eql(type.to_json).at_path('_embedded/elements/0/_type')
+      end
+
+      elements&.each_with_index do |element, index|
+        expect(subject).to be_json_eql(element.id.to_json).at_path("_embedded/elements/#{index}/id")
       end
     end
   end


### PR DESCRIPTION
The default BooleanEquals filter treats null same as false. Because of that, notifications that are not meant for ian were displayed. The BooleanEqualsStrict filter only filters for false as expected so that the notifications are not displayed.