### PR TITLE
Only store notification reasons for in app

### DIFF
--- a/spec/services/notifications/journal_wp_notification_service_spec.rb
+++ b/spec/services/notifications/journal_wp_notification_service_spec.rb
@@ -140,7 +140,7 @@ describe Notifications::JournalWpNotificationService, with_settings: { journal_a
 
       expect(events_service)
         .to have_received(:call)
-              .with({ recipient: recipient,
+              .with({ recipient_id: recipient.id,
                       reason: event_reason,
                       project: journal.project,
                       actor: journal.user,
@@ -221,13 +221,23 @@ describe Notifications::JournalWpNotificationService, with_settings: { journal_a
         ]
       end
 
-      # Event creation will be prevented by the service
+      it_behaves_like 'creates no notification'
+    end
+
+    context 'assignee has all in app notifications enabled but only involved for mail' do
+      let(:recipient_notification_settings) do
+        [
+          FactoryBot.build(:mail_notification_setting, involved: true),
+          FactoryBot.build(:in_app_notification_setting, involved: false, watched: false, mentioned: false, all: true)
+        ]
+      end
+
       it_behaves_like 'creates notification' do
-        let(:event_reason) { :involved }
+        let(:event_reason) { :subscribed }
         let(:event_channels) do
           {
-            read_ian: nil,
-            read_email: nil
+            read_ian: false,
+            read_email: false
           }
         end
       end
@@ -305,16 +315,7 @@ describe Notifications::JournalWpNotificationService, with_settings: { journal_a
         ]
       end
 
-      # Event creation will be prevented by the service
-      it_behaves_like 'creates notification' do
-        let(:event_reason) { :involved }
-        let(:event_channels) do
-          {
-            read_ian: nil,
-            read_email: nil
-          }
-        end
-      end
+      it_behaves_like 'creates no notification'
     end
 
     context 'when responsible is not allowed to view work packages' do
@@ -389,16 +390,7 @@ describe Notifications::JournalWpNotificationService, with_settings: { journal_a
         ]
       end
 
-      # Event creation will be prevented by the service
-      it_behaves_like 'creates notification' do
-        let(:event_reason) { :watched }
-        let(:event_channels) do
-          {
-            read_ian: nil,
-            read_email: nil
-          }
-        end
-      end
+      it_behaves_like 'creates no notification'
     end
 
     context 'when watcher is not allowed to view work packages' do
@@ -631,15 +623,7 @@ describe Notifications::JournalWpNotificationService, with_settings: { journal_a
             ]
           end
 
-          # Event creation will be prevented by the service
-          it_behaves_like 'creates notification' do
-            let(:event_channels) do
-              {
-                read_ian: nil,
-                read_email: nil
-              }
-            end
-          end
+          it_behaves_like 'creates no notification'
         end
       end
 
@@ -712,15 +696,7 @@ describe Notifications::JournalWpNotificationService, with_settings: { journal_a
               "Hello user:\"#{recipient.login}\", hey user##{recipient.id}"
             end
 
-            # Event creation will be prevented by the service
-            it_behaves_like 'creates notification' do
-              let(:event_channels) do
-                {
-                  read_ian: nil,
-                  read_email: nil
-                }
-              end
-            end
+            it_behaves_like 'creates no notification'
           end
         end
 

--- a/spec_legacy/unit/mail_handler_spec.rb
+++ b/spec_legacy/unit/mail_handler_spec.rb
@@ -274,6 +274,8 @@ describe MailHandler, type: :model do
   it 'should add work package should send email notification' do
     Setting.notified_events = ['work_package_added']
 
+    User.find(2).notification_settings.create(channel: :mail, all: true)
+
     # This email contains: 'Project: onlinestore'
     issue = submit_email('ticket_on_given_project.eml')
     assert issue.is_a?(WorkPackage)
@@ -321,6 +323,9 @@ describe MailHandler, type: :model do
   end
 
   it 'should add work package note should send email notification' do
+    User.find(2).notification_settings.create(channel: :mail, all: true)
+    User.find(3).notification_settings.create(channel: :mail, involved: true)
+
     journal = submit_email('ticket_reply.eml')
     assert journal.is_a?(Journal)
     assert_equal 2, ActionMailer::Base.deliveries.size


### PR DESCRIPTION
We currently display the wrong reason for a notification in the in app notification center. Currently it could be a reason for a e-mail notification that is displayed. Thus we need to focus on in-app notifications only when communicating the reason for a notification.

Before, the first matching reason was taken regardless of the channel. So if for example mail notifications is set to `involved`, and in app to `all`, the reason for an in-app notification displayed was `involved`. That's not correct. It should be `involved`.

Out of scope:

- Once we introduce digests, we should introduce `reason_*` together with `read_*` so that the reason can be tracked per channel.
- We might also track all reasons for each channel.