### PR TITLE
[37939] Missing cancel button on project create page prevents me from going back

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -618,6 +618,7 @@ en:
         label: 'Project autocompletion'
 
     text_are_you_sure: "Are you sure?"
+    text_data_lost: "All entered data will be lost."
 
     types:
       attribute_groups:

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.html
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.html
@@ -20,8 +20,9 @@
             [disabled]="inFlight">
       {{text.save}}
     </button>
-    <button class="button"
-            (click)="goBack()">
+    <button type="button"
+            class="button"
+            (click)="handleCancel()">
       {{text.cancel}}
     </button>
   </div>

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.html
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.html
@@ -20,6 +20,10 @@
             [disabled]="inFlight">
       {{text.save}}
     </button>
+    <button class="button"
+            (click)="goBack()">
+      {{text.cancel}}
+    </button>
   </div>
 </form>
 

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.spec.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.spec.ts
@@ -24,6 +24,7 @@ import { DynamicFieldGroupWrapperComponent } from 'core-app/shared/components/dy
 import { OpFormFieldComponent } from 'core-app/shared/components/forms/form-field/form-field.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DynamicFieldWrapperComponent } from 'core-app/shared/components/dynamic-forms/components/dynamic-field-wrapper/dynamic-field-wrapper.component';
+import { ConfirmDialogService } from "core-app/shared/components/modals/confirm-dialog/confirm-dialog.service";
 
 @Component({
   template: `
@@ -274,6 +275,7 @@ describe('DynamicFormComponent', () => {
   beforeEach(async () => {
     const notificationsServiceSpy = jasmine.createSpyObj('NotificationsService', ['addError', 'addSuccess']);
     const dynamicFormServiceSpy = jasmine.createSpyObj('DynamicFormService', ['getSettings', 'getSettingsFromBackend$', 'registerForm', 'submit$']);
+    const confirmDialogServiceSpy = jasmine.createSpyObj('ConfirmDialogService', ['confirm']);
 
     await TestBed
       .configureTestingModule({
@@ -322,6 +324,7 @@ describe('DynamicFormComponent', () => {
           { provide: I18nService, useValue: I18nServiceStub },
           { provide: PathHelperService, useValue: IPathHelperServiceStub },
           { provide: NotificationsService, useValue: notificationsServiceSpy },
+          { provide: ConfirmDialogService, useValue: confirmDialogServiceSpy },
         ],
       })
       // Set component providers
@@ -355,7 +358,7 @@ describe('DynamicFormComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('sould get the form schema from the backend when no @Input settings', fakeAsync(() => {
+  it('should get the form schema from the backend when no @Input settings', fakeAsync(() => {
     // @ts-ignore
     dynamicFormService.getSettingsFromBackend$.and.returnValue(defer(() => Promise.resolve(dynamicFormSettings)));
 

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.ts
@@ -20,6 +20,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { IDynamicFieldGroupConfig, IOPDynamicFormSettings, IOPFormlyFieldSettings } from '../../typings';
 import { DynamicFormService } from '../../services/dynamic-form/dynamic-form.service';
+import { ConfirmDialogService } from "core-app/shared/components/modals/confirm-dialog/confirm-dialog.service";
 
 /**
 * SETTINGS:
@@ -217,6 +218,7 @@ export class DynamicFormComponent extends UntilDestroyedMixin implements OnChang
     private _pathHelperService:PathHelperService,
     private _notificationsService:NotificationsService,
     private _changeDetectorRef:ChangeDetectorRef,
+    private _confirmDialogService:ConfirmDialogService,
   ) {
     super();
   }
@@ -287,7 +289,23 @@ export class DynamicFormComponent extends UntilDestroyedMixin implements OnChang
   }
 
 
-  goBack() {
+  handleCancel() {
+    if (this.form.dirty) {
+      this._confirmDialogService.confirm({
+        text: {
+          title: this._I18n.t('js.text_are_you_sure'),
+          text: this._I18n.t('js.text_data_lost'),
+        },
+      }).then(() => {
+        this.goBack();
+      })
+        .catch(() => {});
+    } else {
+      this.goBack();
+    }
+  }
+
+  private goBack() {
     window.history.back();
   }
 

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-form/dynamic-form.component.ts
@@ -186,6 +186,7 @@ export class DynamicFormComponent extends UntilDestroyedMixin implements OnChang
 
   text = {
     save: this._I18n.t('js.button_save'),
+    cancel: this._I18n.t('js.button_cancel'),
     load_error_message: this._I18n.t('js.forms.load_error_message'),
     successful_update: this._I18n.t('js.notice_successful_update'),
     successful_create: this._I18n.t('js.notice_successful_create'),
@@ -283,6 +284,11 @@ export class DynamicFormComponent extends UntilDestroyedMixin implements OnChang
     }
 
     return this._dynamicFormService.validateForm$(this.form, this.formEndpoint);
+  }
+
+
+  goBack() {
+    window.history.back();
   }
 
   private initializeDynamicForm(


### PR DESCRIPTION
Add cancel button to dynamic form. Since the form can be called globally from anywhere, we cannot use the `backRoutingService` and have to use the normal browser back instead.

https://community.openproject.org/projects/openproject/work_packages/37938/activity