### PR TITLE
Add ability to log hours in HH:MM format

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+	"name": "Existing Docker Compose (Extend)",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"../docker-compose.yml",
+		"docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "frontend",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/workspace",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": []
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.7'
+services:
+  # Update this to the name of the service you want to work with in your docker-compose.yml file
+  frontend:
+    # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
+    # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks, 
+    # debugging) to execute as the user. Uncomment the next line if you want the entire 
+    # container to run as this user instead. Note that, on Linux, you may need to 
+    # ensure the UID and GID of the container user you create matches your local user. 
+    # See https://aka.ms/vscode-remote/containers/non-root for details.
+    #
+    # user: vscode
+
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
+    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+    # array). The sample below assumes your primary file is in the root of your project.
+    #
+    # build:
+    #   context: .
+    #   dockerfile: .devcontainer/Dockerfile
+    
+    volumes:
+      # Update this to wherever you want VS Code to mount the folder of your project
+      - .:/workspace:cached
+
+      # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
+      # - /var/run/docker.sock:/var/run/docker.sock 
+
+    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+    # cap_add:
+    #   - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done"
+ 

--- a/docs/development/development-environment-ubuntu/README.md
+++ b/docs/development/development-environment-ubuntu/README.md
@@ -161,7 +161,7 @@ bundler --version
 Bundler version 2.1.4
 
 node --version
-v14.16.1
+v14.17.0
 
 npm --version
 7.15.1

--- a/frontend/src/app/shared/components/time_entries/form/form.component.ts
+++ b/frontend/src/app/shared/components/time_entries/form/form.component.ts
@@ -36,12 +36,20 @@ export class TimeEntryFormComponent extends UntilDestroyedMixin implements OnIni
     attributes: {
       comment: this.i18n.t('js.time_entry.comment'),
       hours: this.i18n.t('js.time_entry.hours'),
+      time: 'Time',
       activity: this.i18n.t('js.time_entry.activity'),
       workPackage: this.i18n.t('js.time_entry.work_package'),
       spentOn: this.i18n.t('js.time_entry.spent_on'),
     },
     wpRequired: this.i18n.t('js.time_entry.work_package_required')
   };
+
+  public time = {
+    name: 'time',
+    value: '1:2',
+  };
+
+  public test_that = 0.0;
 
   public workPackageSelected = false;
   public customFields:{ key:string, label:string }[] = [];
@@ -64,6 +72,7 @@ export class TimeEntryFormComponent extends UntilDestroyedMixin implements OnIni
           this.workPackageSelected = true;
           this.cdRef.markForCheck();
         }
+        // if(changeset && changeset.workPackage)
       });
 
     this.setCustomFields();
@@ -98,6 +107,19 @@ export class TimeEntryFormComponent extends UntilDestroyedMixin implements OnIni
     }
   }
 
+  private padNum = n => (n | 0).toString().padStart(2, '0');
+
+  public hoursToTime = (value:string):string => `${padNum(value)}:${padNum(Math.round(parseFloat(value) * 60 % 60))}`;
+
+  public timeToHours(value:string):number {
+    const [ hours, minutes ] = value.split(':');
+    return parseFloat((parseInt(hours) + parseInt(minutes) / 60).toFixed(2));
+  }
+
+  public handleTimeChange(value:string) {
+    this.time.value = this.timeToHours(value);
+  }
+
   private setCustomFields() {
     Object.entries(this.schema).forEach(([key, keySchema]) => {
       if (key.match(/customField\d+/)) {
@@ -109,4 +131,5 @@ export class TimeEntryFormComponent extends UntilDestroyedMixin implements OnIni
   private get schema() {
     return this.changeset.schema;
   }
+
 }


### PR DESCRIPTION
Hello. When I log time with Open Project there is always a problem to `convert` in mind `HH:MM` format to the hours in floating point format. I suggest to change the interface and allow users to use additional field `Time in HH:MM` at the "Log time" popup.
At the `database` it will be `still stored as hours` in `float number format` and for any kind of calculation used the same format as well.

What do you think about such improvement? Should I continue to implement that and have a change to be merged next? It's only the UI change, hours will be still in float values at the database.

Have a look at screenshots with prototype:

<img width="637" alt="Screenshot 2021-07-10 at 16 17 10" src="https://user-images.githubusercontent.com/1463086/125164873-1dbd6a80-e19d-11eb-8cd1-c016b7d22d0e.png">
<img width="638" alt="Screenshot 2021-07-10 at 16 39 46" src="https://user-images.githubusercontent.com/1463086/125164938-77be3000-e19d-11eb-9797-e696d0d45186.png">
