### PR TITLE
Add migration for flipping clipping planes that were created in OP

### DIFF
--- a/db/migrate/20210713081724_flip_bcf_viewpoint_clipping_direction_selectively.rb
+++ b/db/migrate/20210713081724_flip_bcf_viewpoint_clipping_direction_selectively.rb
@@ -1,0 +1,43 @@
+class FlipBcfViewpointClippingDirectionSelectively < ActiveRecord::Migration[6.1]
+  def up
+    flip_op_clipping_planes
+  end
+
+  def down
+    flip_op_clipping_planes
+  end
+
+  private
+
+  def flip_op_clipping_planes
+    viewpoints = select_viewpoints_created_in_op
+    viewpoints.each do |viewpoint|
+      new_json_viewpoint = flip_clipping_planes(viewpoint.json_viewpoint)
+      viewpoint.update_column(:json_viewpoint, new_json_viewpoint)
+    end
+  end
+
+  def select_viewpoints_created_in_op
+    join_condition = %{
+      bcf_viewpoints.json_viewpoint->>'clipping_planes' IS NOT NULL
+      AND
+      (
+        bcf_issues.markup IS NULL
+        OR
+        XPATH_EXISTS('/comment()[contains(., ''Created by OpenProject'')]', bcf_issues.markup)
+      )
+    }
+    ::Bim::Bcf::Viewpoint.joins(:issue).where(join_condition)
+  end
+
+  def flip_clipping_planes(viewpoint)
+    viewpoint_dup = viewpoint.deep_dup
+    viewpoint_dup["clipping_planes"].each do |plane|
+      plane["direction"]["x"] *= -1
+      plane["direction"]["y"] *= -1
+      plane["direction"]["z"] *= -1
+    end
+
+    viewpoint_dup
+  end
+end

--- a/modules/bim/app/models/bim/bcf/viewpoint.rb
+++ b/modules/bim/app/models/bim/bcf/viewpoint.rb
@@ -35,6 +35,10 @@ module Bim::Bcf
       end
     end
 
+    def clipping_planes?
+      json_viewpoint && json_viewpoint["clipping_planes"]
+    end
+
     def snapshot=(file)
       snapshot&.destroy
       attach_files('first' => { 'file' => file, 'description' => 'snapshot' })


### PR DESCRIPTION
https://community.openproject.org/wp/37894

Until now, clipping planes that were created in OpenProject were hiding the opposite side than what the next BCF 3.0 spec finally specifies. We want to be future proof and comply with the upcoming BCF spec. Also the upcoming Revit add-in will also comply with the specs of BCF 3.0.

This migration tries to identify all BCF viewpoins that were created in OpenProject and flips their clipping planes if they have any.  Viewpoints that were created in other tools stay untouched.

This PR only makes sense to merge when merged at the same time with PR #9422 which also flips the clipping direction in xeokit.