### PR TITLE
Fix/reject invalid host headers

### DIFF
--- a/docker/prod/entrypoint.sh
+++ b/docker/prod/entrypoint.sh
@@ -42,6 +42,8 @@ if [ "$(id -u)" = '0' ]; then
 	chown -R $APP_USER:$APP_USER $APP_DATA_PATH
 	if [ -d /etc/apache2/sites-enabled ]; then
 		chown -R $APP_USER:$APP_USER /etc/apache2/sites-enabled
+		echo "OpenProject currently expects to be reached on the following domain: ${SERVER_NAME:=localhost}, which does not seem to be how your installation is configured." > /var/www/html/index.html
+		echo "If you are an administrator, please ensure you have correctly set the SERVER_NAME variable when launching your container." >> /var/www/html/index.html
 	fi
 
 	# Clean up any dangling PID file

--- a/docker/prod/proxy.conf.erb
+++ b/docker/prod/proxy.conf.erb
@@ -1,5 +1,13 @@
+<% server_name = ENV.fetch('SERVER_NAME') { "localhost" } %>
+<% unless server_name == "_default_" %>
 <VirtualHost *:80>
-  ServerName <%= ENV.fetch('SERVER_NAME') { "_default_" } %>
+  ServerName _default_
+  DocumentRoot /var/www/html
+</VirtualHost>
+<% end %>
+
+<VirtualHost *:80>
+  ServerName <%= server_name %>
   DocumentRoot <%= ENV.fetch('APP_PATH') %>/public
 
   ProxyRequests off

--- a/docker/prod/proxy.conf.erb
+++ b/docker/prod/proxy.conf.erb
@@ -1,4 +1,4 @@
-<% server_name = ENV.fetch('SERVER_NAME') { "localhost" } %>
+<% server_name = ENV.fetch('SERVER_NAME') { "_default_" } %>
 <% unless server_name == "_default_" %>
 <VirtualHost *:80>
   ServerName _default_

--- a/docs/installation-and-operations/installation/docker/README.md
+++ b/docs/installation-and-operations/installation/docker/README.md
@@ -119,6 +119,9 @@ docker run -d -p 8080:80 --name openproject \
   openproject/community:11
 ```
 
+Please make sure you set the correct public facing hostname in `SERVER_HOSTNAME`. If you don't have a load-balancing or proxying web server in front of your docker container,
+you will otherwise be vulnerable to [HOST header injections](https://portswigger.net/web-security/host-header), as the internal server has no way of identifying the correct host name.
+
 **Note**: Make sure to replace `secret` with a random string. One way to generate one is to run `head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32 ; echo ''` if you are on Linux.
 
 **Note**: MacOS users might encounter an "Operation not permitted" error on the mounted directories. The fix for this is to create the two directories in a user-owned directory of the host machine.


### PR DESCRIPTION
Forces the admin to set a `SERVER_NAME` instead of accepting any requests. Requests hitting the Apache server with an unrecognised host header will see a message indicating that the OpenProject installation is configured differently.

Previous behaviour can still be enabled by setting `SERVER_NAME=_default_` when starting the container.