### PR TITLE
[36236] Unnecessary requests (3 - 4 times too many) on loading the board   

### DIFF
--- a/frontend/src/app/features/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.ts
@@ -399,10 +399,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     let observable = this
       .apiv3Service
       .queries
-      .find(this.columnsQueryProps, this.queryId)
-      .pipe(
-        retry(3),
-      );
+      .find(this.columnsQueryProps, this.queryId);
 
     // Spread arguments on pipe does not work:
     // https://github.com/ReactiveX/rxjs/issues/3989

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.ts
@@ -76,6 +76,9 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
   /** Output fired upon query removal */
   @Output() onRemove = new EventEmitter<void>();
 
+  /* Output fired after it is assured whether a user has the right to see the list */
+  @Output() visibilityChange = new EventEmitter<boolean>();
+
   /** Access to the board resource */
   @Input() public board:Board;
 
@@ -409,8 +412,14 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
     observable
       .subscribe(
-        (query) => this.wpStatesInitialization.updateQuerySpace(query, query.results),
+        (query) => {
+          this.wpStatesInitialization.updateQuerySpace(query, query.results);
+        },
         (error) => {
+          const userIsNotAllowedToSeeSubprojectError = 'urn:openproject-org:api:v3:errors:InvalidQuery';
+          if(error.errorIdentifier === userIsNotAllowedToSeeSubprojectError) {
+            this.visibilityChange.emit(false);
+          }
           this.loadingError = this.halNotification.retrieveErrorMessage(error);
           this.cdRef.detectChanges();
         },

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
@@ -20,7 +20,8 @@
             cdkDragHandle></span>
       <board-list [resource]="boardWidget"
                   [board]="board"
-                  (onRemove)="removeList(board, boardWidget)">
+                  (onRemove)="removeList(board, boardWidget)"
+                  (visibilityChange)="changeVisibilityOfList(board, boardWidget, $event)">
       </board-list>
     </div>
 

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
@@ -24,6 +24,11 @@
                   (visibilityChange)="changeVisibilityOfList(board, boardWidget, $event)">
       </board-list>
     </div>
+    <span *ngIf="showHiddenListWarning"
+          class="boards-list--tooltip tooltip--right"
+          [attr.data-tooltip]="text.hiddenListWarning">
+      <i class="icon icon-attention"></i>
+    </span>
 
     <div class="boards-list--add-item -no-text-select"
          *ngIf="board.editable"

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.sass
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.sass
@@ -1,7 +1,7 @@
 @import 'src/assets/sass/helpers'
 
 $board-list-max-width: 300px
-$board-list-top-offset: 18x
+$board-list-top-offset: 18px
 
 .boards-list--container
   display: flex

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.sass
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.sass
@@ -1,6 +1,7 @@
 @import 'src/assets/sass/helpers'
 
 $board-list-max-width: 300px
+$board-list-top-offset: 18x
 
 .boards-list--container
   display: flex
@@ -17,7 +18,7 @@ $board-list-max-width: 300px
   position: absolute
   font-size: 14px
   left: 0
-  top: 18px
+  top: $board-list-top-offset
   z-index: 100
   opacity: 0
   cursor: grab
@@ -60,3 +61,7 @@ $board-list-max-width: 300px
 
   &.cdk-drag-placeholder
     @include modifying--placeholder
+
+.boards-list--tooltip
+  align-self: start
+  margin-top: $board-list-top-offset

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
@@ -33,7 +33,6 @@ import { WorkPackageStatesInitializationService } from 'core-app/features/work-p
 })
 export class BoardListContainerComponent extends UntilDestroyedMixin implements OnInit {
   text = {
-    button_more: this.I18n.t('js.button_more'),
     delete: this.I18n.t('js.button_delete'),
     areYouSure: this.I18n.t('js.text_are_you_sure'),
     deleteSuccessful: this.I18n.t('js.notice_successful_delete'),
@@ -42,7 +41,8 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
     addList: this.I18n.t('js.boards.add_list'),
     upsaleBoards: this.I18n.t('js.boards.upsale.teaser_text'),
     upsaleCheckOutLink: this.I18n.t('js.work_packages.table_configuration.upsale.check_out_link'),
-    unnamed_list: this.I18n.t('js.boards.label_unnamed_list'),
+    unnamedList: this.I18n.t('js.boards.label_unnamed_list'),
+    hiddenListWarning: this.I18n.t('js.boards.text_hidden_list_warning'),
   };
 
   /** Container reference */
@@ -68,6 +68,8 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
   board$:Observable<Board>;
 
   boardWidgets:GridWidgetResource[] = [];
+
+  showHiddenListWarning:boolean = false;
 
   private currentQueryUpdatedMonitoring:Subscription;
 
@@ -129,7 +131,7 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
   addList(board:Board):any {
     if (board.isFree) {
       return this.BoardList
-        .addFreeQuery(board, { name: this.text.unnamed_list })
+        .addFreeQuery(board, { name: this.text.unnamedList })
         .then((board) => this.Boards.save(board).toPromise())
         .catch((error) => this.showError(error));
     }
@@ -143,6 +145,7 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
 
   changeVisibilityOfList(board:Board, boardWidget:GridWidgetResource, visible:boolean) {
     if (!visible) {
+      this.showHiddenListWarning = true;
       this.boardWidgets = this.boardWidgets.filter(widget => widget.id !== boardWidget.id);
     }
   }

--- a/modules/boards/config/locales/js-en.yml
+++ b/modules/boards/config/locales/js-en.yml
@@ -33,6 +33,7 @@ en:
       error_loading_the_list: "Error loading the list: %{error_message}"
       error_permission_missing: "The permission to create public queries is missing"
       error_cannot_move_into_self: "You can not move a work package into its own column."
+      text_hidden_list_warning: "Not all lists are displayed because you lack the permission. Contact your admin for more information."
       click_to_remove_list: "Click to remove this list"
       board_type:
         text: 'Board type'


### PR DESCRIPTION
Each boardList loads its own query and creates an error event if the user does not have the permission to see the list. The container then hides the according list. 
Thus we prevent that the lists are loaded unnecessarily way too often compared to the previous implementation.

In order to avoid confusion for the user, a little hint shall be shown, that some lists are hidden.

see https://community.openproject.org/projects/openproject/work_packages/36236/activity

