### PR TITLE
[#38028] Refresh button for Revit Add-in

### DIFF
--- a/frontend/src/app/features/bim/bcf/openproject-bcf.module.ts
+++ b/frontend/src/app/features/bim/bcf/openproject-bcf.module.ts
@@ -45,6 +45,7 @@ import { BcfNewWpAttributeGroupComponent } from 'core-app/features/bim/bcf/bcf-w
 import { RevitBridgeService } from 'core-app/features/bim/revit_add_in/revit-bridge.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { OpenProjectHeaderInterceptor } from 'core-app/features/hal/http/openproject-header-interceptor';
+import { RefreshButtonComponent } from "core-app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component";
 
 /**
  * Determines based on the current user agent whether
@@ -80,10 +81,12 @@ export const viewerBridgeServiceFactory = (injector:Injector) => {
     BcfNewWpAttributeGroupComponent,
     BcfImportButtonComponent,
     BcfExportButtonComponent,
+    RefreshButtonComponent,
   ],
   exports: [
     BcfImportButtonComponent,
     BcfExportButtonComponent,
+    RefreshButtonComponent,
   ],
 })
 export class OpenprojectBcfModule {

--- a/frontend/src/app/features/bim/bcf/openproject-bcf.module.ts
+++ b/frontend/src/app/features/bim/bcf/openproject-bcf.module.ts
@@ -45,7 +45,7 @@ import { BcfNewWpAttributeGroupComponent } from 'core-app/features/bim/bcf/bcf-w
 import { RevitBridgeService } from 'core-app/features/bim/revit_add_in/revit-bridge.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { OpenProjectHeaderInterceptor } from 'core-app/features/hal/http/openproject-header-interceptor';
-import { RefreshButtonComponent } from "core-app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component";
+import { RefreshButtonComponent } from 'core-app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component';
 
 /**
  * Determines based on the current user agent whether

--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
@@ -61,7 +61,7 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent {
     },
     {
       component: RefreshButtonComponent,
-      show: () => window.navigator.userAgent.search('Revit') > -1,
+      show: () => !this.viewerBridgeService.shouldShowViewer
     },
     {
       component: BcfImportButtonComponent,

--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
@@ -61,7 +61,7 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent {
     },
     {
       component: RefreshButtonComponent,
-      show: () => !this.viewerBridgeService.shouldShowViewer
+      show: ():boolean => !this.viewerBridgeService.shouldShowViewer,
     },
     {
       component: BcfImportButtonComponent,

--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
@@ -23,6 +23,7 @@ import { StateService, TransitionService } from '@uirouter/core';
 import { BehaviorSubject } from 'rxjs';
 import { BcfImportButtonComponent } from 'core-app/features/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component';
 import { BcfExportButtonComponent } from 'core-app/features/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component';
+import { RefreshButtonComponent } from 'core-app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component';
 import { componentDestroyed } from '@w11k/ngx-componentdestroyed';
 import { ViewerBridgeService } from 'core-app/features/bim/bcf/bcf-viewer-bridge/viewer-bridge.service';
 
@@ -57,6 +58,10 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent {
         stateName$: this.newRoute$,
         allowed: ['work_packages.createWorkPackage', 'work_package.copy'],
       },
+    },
+    {
+      component: RefreshButtonComponent,
+      show: () => window.navigator.userAgent.search('Revit') > -1,
     },
     {
       component: BcfImportButtonComponent,

--- a/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
@@ -1,0 +1,63 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2021 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+//++
+
+import {
+  Component, Injector, OnDestroy, OnInit,
+} from '@angular/core';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { StateService } from '@uirouter/core';
+import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
+
+@Component({
+  template: `
+    <a [title]="text.refresh_hover"
+       class="button refresh-button"
+       (click)="refresh()">
+      <op-icon icon-classes="button--icon icon-workflow"></op-icon>
+    </a>
+  `,
+  selector: 'refresh-button',
+})
+export class RefreshButtonComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  public text = {
+    refresh: this.I18n.t('js.bcf.refresh'),
+    refresh_hover: this.I18n.t('js.bcf.refresh_work_package'),
+  };
+
+  constructor(readonly I18n:I18nService,
+    readonly state:StateService) {
+    super();
+  }
+
+  ngOnInit() {
+  }
+
+  refresh() {
+    this.state.go('.', {}, { reload: true });
+  }
+}

--- a/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
@@ -26,9 +26,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import {
-  Component, Injector, OnDestroy, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { StateService } from '@uirouter/core';
 
@@ -41,6 +39,7 @@ import { StateService } from '@uirouter/core';
     </a>
   `,
   selector: 'op-refresh-button',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 
 export class RefreshButtonComponent {
@@ -54,6 +53,6 @@ export class RefreshButtonComponent {
   }
 
   refresh() {
-    this.state.go('.', {}, { reload: true });
+    void this.state.go('.', {}, { reload: true });
   }
 }

--- a/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
@@ -31,7 +31,6 @@ import {
 } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { StateService } from '@uirouter/core';
-import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 
 @Component({
   template: `
@@ -41,9 +40,10 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
       <op-icon icon-classes="button--icon icon-workflow"></op-icon>
     </a>
   `,
-  selector: 'refresh-button',
+  selector: 'op-refresh-button',
 })
-export class RefreshButtonComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+
+export class RefreshButtonComponent {
   public text = {
     refresh: this.I18n.t('js.bcf.refresh'),
     refresh_hover: this.I18n.t('js.bcf.refresh_work_package'),
@@ -51,10 +51,6 @@ export class RefreshButtonComponent extends UntilDestroyedMixin implements OnIni
 
   constructor(readonly I18n:I18nService,
     readonly state:StateService) {
-    super();
-  }
-
-  ngOnInit() {
   }
 
   refresh() {

--- a/modules/bim/config/locales/js-en.yml
+++ b/modules/bim/config/locales/js-en.yml
@@ -12,6 +12,8 @@ en:
       show_viewpoint: 'Show viewpoint'
       delete_viewpoint: 'Delete viewpoint'
       management: 'BCF management'
+      refresh: 'Refresh'
+      refresh_work_package: 'Refresh work package'
     ifc_models:
       empty_warning: "This project does not yet have any IFC models."
       use_this_link_to_manage: "Use this link to upload and manage your IFC models"


### PR DESCRIPTION
https://community.openproject.org/work_packages/38028

- The buttons only shows up when OP is loaded in the Revit Add-in.
- It reloads the whole route to achieve two things:
  - Reload queries when there is a WP list/cards visible
  - Reload a WP when a specific WP is open.