### PR TITLE
[34309] Link from list "None" in Assingee board leads to invalid user profile page

### DIFF
--- a/frontend/src/app/features/boards/board/board-actions/assignee/assignee-board-header.html
+++ b/frontend/src/app/features/boards/board/board-actions/assignee/assignee-board-header.html
@@ -8,9 +8,13 @@
   <h2 class="editable-toolbar-title--fixed">
     <small [textContent]="text.assignee"></small>
     <br/>
-    <a [href]="pathHelper.userPath(user.id)"
+    <a *ngIf="user.id"
+       [href]="pathHelper.userPath(user.id)"
        [textContent]="user.name"
        target="_blank">
     </a>
+    <span *ngIf="!user.id"
+      [textContent]="user.name">
+    </span>
   </h2>
 </div>


### PR DESCRIPTION
Show span instead of link for "None" list in assignee board

https://community.openproject.org/projects/openproject/work_packages/34309/activity?query_id=2865