### PR TITLE
improve performance of aggregate journals migration

### DIFF
--- a/db/migrate/20210615150558_aggregate_journals.rb
+++ b/db/migrate/20210615150558_aggregate_journals.rb
@@ -25,7 +25,7 @@ class AggregateJournals < ActiveRecord::Migration[6.1]
   # The change is irreversible (aggregated journals cannot be broken down) but down will not cause database inconsistencies.
 
   def aggregate_journals(klass)
-    klass.in_batches(of: 20) do |instances|
+    klass.in_batches do |instances|
       # Instantiating is faster than calculating the aggregated journals multiple times.
       aggregated_journals = aggregated_journals_of(klass, instances).to_a
 


### PR DESCRIPTION
The purpose of the rather low batch size (the default is 1000) does no longer apply. It was important before the journals where cast to an array in the next line. The ideal batch size will probably vary depending on the system. If this change is not enough, we might want to allow passing in an ENV variable for tweaking.

On my machine, the change (with older data from community) dropped the execution time from 100s to 37s.

https://community.openproject.org/wp/37940