### PR TITLE
remove wrongfully added attribute

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.html
@@ -1,7 +1,6 @@
 <div
   class="op-wp-single-card"
   data-qa-selector="op-wp-single-card"
-  [attr.data-qa-draggable]="draggable"
   [ngClass]="cardClasses()"
 >
 

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -151,8 +151,8 @@ module Pages
 
     def expect_movable(list_name, card_title, movable: true)
       within_list(list_name) do
-        expect(page).to have_selector('[data-qa-selector="op-wp-single-card"]', text: card_title)
-        expect(page).to have_conditional_selector(movable, '[data-qa-selector="op-wp-single-card"][data-qa-draggable]', text: card_title)
+        expect(page).to have_selector('.op-wp-single-card', text: card_title)
+        expect(page).to have_conditional_selector(movable, '.op-wp-single-card_draggable', text: card_title)
       end
     end
 


### PR DESCRIPTION
Fixes the 

`rspec ./modules/boards/spec/features/action_boards/subproject_board_spec.rb:82`

I only remove this one data attribute but as I don't understand the purpose of them, I did not remove all of them. I currently see no benefit in using them as there are also classes that can be used instead. @bsatarnejad can you shed some light no the purpose, please?