### PR TITLE
Deprecation warning for < postgres13 in admin/info

### DIFF
--- a/app/views/admin/info.html.erb
+++ b/app/views/admin/info.html.erb
@@ -54,6 +54,28 @@ See docs/COPYRIGHT.rdoc for more details.
         <span><%= @db_version %></span>
       </div>
     </div>
+    <% if OpenProject::Database.version_deprecated? %>
+      <div class="attributes-key-value--key"></div>
+      <div class="attributes-key-value--value-container">
+        <div class="attributes-key-value--value -text">
+          <strong>
+            <%= op_icon 'icon3 icon-warning' %>
+            Deprecation warning:
+          </strong>
+          <p>
+            The next major release of OpenProject will update the requirements
+            on the required PostgreSQL database version.
+            <br/>
+            Starting with OpenProject 12.0, anticipated end of 2021, PostgreSQL 13 will be required
+            to use OpenProject.
+            <br/>
+            We have prepared <%= static_link_to :postgres_13_upgrade,
+                                                label: 'upgrade guides for all installation methods' %>.
+            You can perform the upgrade ahead of the release at any time by following the guides.
+          </p>
+        </div>
+      </div>
+    <% end %>
     <% if display_security_badge_graphic? %>
       <div class="attributes-key-value--key"></div>
       <div class="attributes-key-value--value-container">
@@ -95,38 +117,38 @@ See docs/COPYRIGHT.rdoc for more details.
   </div>
 </div>
 
-<% @storage_information.each_with_index do  |(_,entries), i| %>
-<%= content_tag :h3, t(:label_storage_group, identifier: i + 1) %>
-<div class="attributes-group">
-  <div class="attributes-key-value">
-    <div class="attributes-key-value--key"><%= t(:label_storage_for) %></div>
-    <div class="attributes-key-value--value-container">
-      <div class="attributes-key-value--value -text">
+<% @storage_information.each_with_index do |(_, entries), i| %>
+  <%= content_tag :h3, t(:label_storage_group, identifier: i + 1) %>
+  <div class="attributes-group">
+    <div class="attributes-key-value">
+      <div class="attributes-key-value--key"><%= t(:label_storage_for) %></div>
+      <div class="attributes-key-value--value-container">
+        <div class="attributes-key-value--value -text">
         <span>
           <% entries[:labels].each do |l| %>
             <%= l %>
             <br/>
           <% end %>
         </span>
+        </div>
       </div>
-    </div>
-    <div class="attributes-key-value--key"><%= t(:label_storage_free_space) %></div>
-    <div class="attributes-key-value--value-container">
-      <div class="attributes-key-value--value -text">
-        <span><%= number_to_human_size(entries[:data][:free], precision: 2) %></span>
+      <div class="attributes-key-value--key"><%= t(:label_storage_free_space) %></div>
+      <div class="attributes-key-value--value-container">
+        <div class="attributes-key-value--value -text">
+          <span><%= number_to_human_size(entries[:data][:free], precision: 2) %></span>
+        </div>
       </div>
-    </div>
-    <div class="attributes-key-value--key"><%= t(:label_storage_used_space) %></div>
-    <div class="attributes-key-value--value-container">
-      <div class="attributes-key-value--value -text">
+      <div class="attributes-key-value--key"><%= t(:label_storage_used_space) %></div>
+      <div class="attributes-key-value--value-container">
+        <div class="attributes-key-value--value -text">
         <span>
           <%= number_to_human_size(entries[:data][:used], precision: 2) %>
           (<%= entries[:data][:percent_used].round(2) %> %)
         </span>
+        </div>
       </div>
     </div>
   </div>
-</div>
 <% end %>
 
 <%= call_hook(:view_admin_info_bottom) %>

--- a/lib/open_project/database.rb
+++ b/lib/open_project/database.rb
@@ -83,6 +83,12 @@ module OpenProject
     end
 
     ##
+    # Determine whether the current version is deprecated
+    def self.version_deprecated?
+      !version_matches?(130000)
+    end
+
+    ##
     # Check the database for
     # * being postgresql
     # * version compatibility
@@ -106,10 +112,11 @@ module OpenProject
                   "but current version is #{current}"
 
         raise InsufficientVersionError.new message
-      elsif !version_matches?(130000)
+      elsif version_deprecated?
         message = "The next major release of OpenProject (v12) will require PostgreSQL 13 or later.\n" \
                   "You can anticipate this upgrade by updating your database installation by following the guide at " \
                   "https://docs.openproject.org/installation-and-operations/misc/migration-to-postgresql13/"
+
         raise DeprecatedVersionWarning.new message
       end
     end

--- a/lib/open_project/static/links.rb
+++ b/lib/open_project/static/links.rb
@@ -110,6 +110,9 @@ module OpenProject
               href: 'https://www.openproject.org/operations/migration-guides/migrating-packaged-openproject-database-postgresql/',
               label: :'homescreen.links.postgres_migration'
             },
+            postgres_13_upgrade: {
+              href: 'https://docs.openproject.org/installation-and-operations/misc/migration-to-postgresql13/'
+            },
             configuration_guide: {
               href: 'https://www.openproject.org/operations/configuration/',
               label: 'links.configuration_guide'


### PR DESCRIPTION
https://community.openproject.org/work_packages/38047

I deliberately added the deprecation warning in english only. I believe it doesn't need to be localized, as the migration guides are in english anyway.