### PR TITLE
Render backtrace for debug log level through LogDelegator

### DIFF
--- a/lib/open_project/logging/log_delegator.rb
+++ b/lib/open_project/logging/log_delegator.rb
@@ -48,7 +48,7 @@ module OpenProject
         def clean_backtrace(exception)
           return nil unless exception&.backtrace
 
-          Rails.backtrace_cleaner.clean exception.backtrace, :full
+          Rails.backtrace_cleaner.clean exception.backtrace
         end
 
         ##
@@ -84,10 +84,17 @@ module OpenProject
         # A lambda handler for logging the error
         # to rails.
         def rails_logger_handler(message, context = {})
-          Rails.logger.public_send(
-            context[:level],
+          Rails.logger.public_send(context[:level]) do
             "#{context_string(context)} #{message}"
-          )
+          end
+
+          if context.key?(:exception)
+            Rails.logger.debug do
+              exception = context[:exception]
+              trace = context[:backtrace]&.join('; ')
+              "[#{exception.class}] #{exception.message}: #{trace}"
+            end
+          end
         end
 
         ##


### PR DESCRIPTION
This PR renders the cleaned backtrace of an exception for `log_level == :debug`. Also removes the now unsupported `:full` cleaner call and returns to the default, which is cleaning and filtering for library traces

[OP#37960](https://community.openproject.org/wp/37960)