### PR TITLE
[34904] Grouping work package list by bool custom field fails

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/grouped/group-header-builder.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/grouped/group-header-builder.ts
@@ -43,7 +43,7 @@ export class GroupHeaderBuilder {
         <div class="expander icon-context ${togglerIconClass}">
           <span class="hidden-for-sighted">${_.escape(text)}</span>
         </div>
-        <div class="group--value">
+        <div class="group--value" data-qa-selector="op-group--value">
           ${_.escape(groupName(group))}
           <span class="count">
             (${group.count})

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/grouped/grouped-render-pass.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/grouped/grouped-render-pass.ts
@@ -85,7 +85,7 @@ export class GroupedRenderPass extends PlainRenderPass {
       // Otherwise, fall back to simple value comparison.
       let value = group.value === '' ? null : group.value;
 
-      if (value) {
+      if (value && typeof value === 'string') {
         // For matching we have to remove the % sign which is shown when grouping after progress
         value = value.replace('%', '');
       }

--- a/spec/features/work_packages/table/group_by/group_by_boolean_spec.rb
+++ b/spec/features/work_packages/table/group_by/group_by_boolean_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'Work Package group by boolean field', js: true do
+  let(:user) { FactoryBot.create :admin }
+
+  let(:project) { FactoryBot.create(:project, types: [type], work_package_custom_fields: [bool_cf]) }
+  let(:bool_cf) { FactoryBot.create :bool_wp_custom_field, name: 'booleanField', types: [type] }
+  let(:type) { FactoryBot.create(:type) }
+
+  let!(:wp1) { FactoryBot.create(:work_package, project: project, type: type) }
+  let!(:wp2) { FactoryBot.create(:work_package, project: project, type: type, custom_field_values: { bool_cf.id => true }) }
+  let!(:wp3) { FactoryBot.create(:work_package, project: project, type: type, custom_field_values: { bool_cf.id => false }) }
+
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  let(:group_by) { ::Components::WorkPackages::GroupBy.new }
+
+  before do
+    login_as(user)
+    wp_table.visit!
+    wp_table.expect_work_package_listed wp1, wp2, wp3
+  end
+
+  it 'shows group headers for groups by bool cf (regression test #34904)' do
+    # Group by category
+    group_by.enable_via_menu 'booleanField'
+    loading_indicator_saveguard
+
+    # Expect table to be grouped
+    group_by.expect_number_of_groups 3
+    group_by.expect_grouped_by_value '-', 1
+    group_by.expect_grouped_by_value 'true', 1
+    group_by.expect_grouped_by_value 'false', 1
+  end
+end

--- a/spec/features/work_packages/table/group_by/group_by_progress_spec.rb
+++ b/spec/features/work_packages/table/group_by/group_by_progress_spec.rb
@@ -33,10 +33,10 @@ describe 'Work Package group by progress', js: true do
     group_by.enable_via_menu 'Progress (%)'
 
     # Expect table to be grouped as WP created above
-    expect(page).to have_selector('.group--value .count', count: 3)
-    expect(page).to have_selector('.group--value', text: '0% (1)')
-    expect(page).to have_selector('.group--value', text: '10% (2)')
-    expect(page).to have_selector('.group--value', text: '50% (1)')
+    group_by.expect_number_of_groups 3
+    group_by.expect_grouped_by_value '0%', 1
+    group_by.expect_grouped_by_value '10%', 2
+    group_by.expect_grouped_by_value '50%', 1
 
     # Update category of wp_none
     cat = wp_table.edit_field(wp_1, :percentageDone)
@@ -45,9 +45,9 @@ describe 'Work Package group by progress', js: true do
     loading_indicator_saveguard
 
     # Expect changed groups
-    expect(page).to have_selector('.group--value .count', count: 2)
-    expect(page).to have_selector('.group--value', text: '10% (2)')
-    expect(page).to have_selector('.group--value', text: '50% (2)')
+    group_by.expect_number_of_groups 2
+    group_by.expect_grouped_by_value '10%', 2
+    group_by.expect_grouped_by_value '50%', 2
   end
 
   context 'with grouped query' do
@@ -62,14 +62,14 @@ describe 'Work Package group by progress', js: true do
 
     it 'keeps the disabled group by when reloading (Regression WP#26778)' do
       # Expect table to be grouped as WP created above
-      expect(page).to have_selector('.group--value .count', count: 3)
+      group_by.expect_number_of_groups 3
 
       group_by.disable_via_menu
-      expect(page).to have_no_selector('.group--value')
+      group_by.expect_no_groups
 
       # Expect disabled group by to be kept after reload
       page.driver.browser.navigate.refresh
-      expect(page).to have_no_selector('.group--value')
+      group_by.expect_no_groups
 
       # But query has not been changed
       query.reload

--- a/spec/features/work_packages/table/group_by/group_headers_spec.rb
+++ b/spec/features/work_packages/table/group_by/group_headers_spec.rb
@@ -36,10 +36,10 @@ describe 'Work Package table group headers', js: true do
     group_by.enable_via_menu 'Category'
 
     # Expect table to be grouped as WP created above
-    expect(page).to have_selector('.group--value .count', count: 3)
-    expect(page).to have_selector('.group--value', text: 'Foo (1)')
-    expect(page).to have_selector('.group--value', text: 'Bar (1)')
-    expect(page).to have_selector('.group--value', text: '- (1)')
+    group_by.expect_number_of_groups 3
+    group_by.expect_grouped_by_value 'Foo', 1
+    group_by.expect_grouped_by_value 'Bar', 1
+    group_by.expect_grouped_by_value '-', 1
 
     # Update category of wp_none
     cat = wp_table.edit_field(wp_none, :category)
@@ -49,8 +49,8 @@ describe 'Work Package table group headers', js: true do
     loading_indicator_saveguard
 
     # Expect changed groups
-    expect(page).to have_selector('.group--value .count', count: 2)
-    expect(page).to have_selector('.group--value', text: 'Foo (2)')
-    expect(page).to have_selector('.group--value', text: 'Bar (1)')
+    group_by.expect_number_of_groups 2
+    group_by.expect_grouped_by_value 'Foo', 2
+    group_by.expect_grouped_by_value 'Bar', 1
   end
 end

--- a/spec/support/components/work_packages/group_by.rb
+++ b/spec/support/components/work_packages/group_by.rb
@@ -54,6 +54,18 @@ module Components
         modal.save
       end
 
+      def expect_number_of_groups(count)
+        expect(page).to have_selector('[data-qa-selector="op-group--value"] .count', count: count)
+      end
+
+      def expect_grouped_by_value(value_name, count)
+        expect(page).to have_selector('[data-qa-selector="op-group--value"]', text: "#{value_name} (#{count})")
+      end
+
+      def expect_no_groups
+        expect(page).to have_no_selector('[data-qa-selector="op-group--value"]')
+      end
+
       def expect_not_grouped_by(name)
         open_table_column_context_menu(name)
 


### PR DESCRIPTION
Avoid that `replace()` is called on a boolean as it causes an error

https://community.openproject.org/projects/openproject/work_packages/34904/activity