### PR TITLE
[38062] Avoid sending notifications with no ian reason

### DIFF
--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
@@ -51,6 +51,7 @@ export class InAppNotificationEntryComponent implements OnInit {
 
   text = {
     loading: this.I18n.t('js.ajax.loading'),
+    placeholder: this.I18n.t('js.placeholders.default'),
   };
 
   constructor(
@@ -124,7 +125,7 @@ export class InAppNotificationEntryComponent implements OnInit {
   private buildTranslatedReason() {
     this.translatedReason = this.I18n.t(
       `js.notifications.reasons.${this.notification.reason}`,
-      { defaultValue: this.notification.reason },
+      { defaultValue: this.notification.reason || this.text.placeholder },
     );
   }
 

--- a/lib/api/v3/notifications/notifications_api.rb
+++ b/lib/api/v3/notifications/notifications_api.rb
@@ -42,6 +42,12 @@ module API
                                       .call(params)
             end
 
+            def notification_scope
+              ::Notification
+                .recipient(current_user)
+                .where.not(reason_ian: nil)
+            end
+
             def bulk_update_status(attributes)
               if notification_query.valid?
                 notification_query.results.update_all({ updated_at: Time.zone.now }.merge(attributes))
@@ -53,7 +59,7 @@ module API
           end
 
           get &::API::V3::Utilities::Endpoints::Index
-            .new(model: Notification, scope: -> { Notification.recipient(current_user) })
+            .new(model: Notification, scope: -> { notification_scope })
             .mount
 
           post :read_ian do
@@ -66,7 +72,7 @@ module API
 
           route_param :id, type: Integer, desc: 'Notification ID' do
             after_validation do
-              @notification = Notification.recipient(current_user).find(params[:id])
+              @notification = notification_scope.find(params[:id])
             end
 
             helpers do

--- a/spec/factories/notification_factory.rb
+++ b/spec/factories/notification_factory.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     read_mail { false }
     read_mail_digest { false }
     reason_ian { :mentioned }
-    reason_mail { :involved}
+    reason_mail { :involved }
     reason_mail_digest { :watched }
     recipient factory: :user
     project { association :project }

--- a/spec/requests/api/v3/notifications/index_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/index_resource_spec.rb
@@ -64,6 +64,15 @@ describe ::API::V3::Notifications::NotificationsAPI,
 
     it_behaves_like 'API V3 collection response', 2, 2, 'Notification'
 
+    context 'with a digest notification' do
+      let(:digest_notification) { FactoryBot.create :notification, recipient: recipient, reason_ian: nil }
+      let(:notifications) { [notification1, notification2, digest_notification] }
+
+      it_behaves_like 'API V3 collection response', 2, 2, 'Notification' do
+        let(:elements) { [notification2, notification1] }
+      end
+    end
+
     context 'with a readIAN filter' do
       let(:nil_notification) { FactoryBot.create :notification, recipient: recipient, read_ian: nil }
 


### PR DESCRIPTION
The notifications API allow sending notifications with no ian reason set. The way the notifications API currently works however is only concerned with notifications related to IAN.

:warning: This prevents the notification API from being used for other reasons (mail, digest). However these are also not communitcated to the frontend, so my argument is that this is what the API should be restricted to anyway.

[OP#38062](https://community.openproject.org/wp/38062)