### PR TITLE
exclude full text columns from attachment model

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -44,6 +44,19 @@ class Attachment < ApplicationRecord
            if: -> { !internal_container? }
   validate :container_changed_more_than_once
 
+  # Those columns are currently not displayed in the application and are rarely used
+  # at all.
+  # Their purpose currently is limited to full text search where the results are not highlighted.
+  # As the columns can contain a lot of text (with the exception of file_tsv) and having them included
+  # leads to them being loaded when attachments are fetched, including the columns leads to a heavily
+  # increased loading time
+  # From a production database:
+  # SELECT "attachments"."id", "attachments"."fulltext" ...
+  # => 2650 ms
+  # SELECT "attachments"."id" ...
+  # => 1 ms
+  self.ignored_columns = %w(fulltext fulltext_tsv file_tsv)
+
   acts_as_journalized
   acts_as_event title: -> { file.name },
                 url: (Proc.new do |o|

--- a/spec/workers/extract_fulltext_job_spec.rb
+++ b/spec/workers/extract_fulltext_job_spec.rb
@@ -31,23 +31,35 @@
 require 'spec_helper'
 
 describe ExtractFulltextJob, type: :job do
+  subject(:extracted_attributes) do
+    perform_enqueued_jobs
+
+    attachment.reload
+
+    Attachment.connection.select_one <<~SQL.squish
+      SELECT
+        fulltext,
+        fulltext_tsv,
+        file_tsv
+      FROM
+        attachments
+      WHERE
+        id = #{attachment.id}
+    SQL
+  end
+
   let(:text) { 'lorem ipsum' }
   let(:attachment) do
     FactoryBot.create(:attachment).tap do |attachment|
       expect(ExtractFulltextJob)
         .to have_been_enqueued
         .with(attachment.id)
+
+      allow(Attachment)
+        .to receive(:find_by)
+              .with(id: attachment.id)
+              .and_return(attachment)
     end
-  end
-
-  let(:subject) do
-    perform_enqueued_jobs
-
-    attachment.reload
-  end
-
-  before do
-    allow(Attachment).to receive(:find_by).with(id: attachment.id).and_return(attachment)
   end
 
   context "with successful text extraction" do
@@ -58,26 +70,22 @@ describe ExtractFulltextJob, type: :job do
     context 'attachment is readable' do
       before do
         allow(attachment).to receive(:readable?).and_return(true)
-        subject
       end
 
       it 'updates the attachment\'s DB record with fulltext, fulltext_tsv, and file_tsv' do
-        expect(attachment.fulltext).to eq text
-        expect(attachment.fulltext_tsv.size).to be > 0
-        expect(attachment.file_tsv.size).to be > 0
+        expect(extracted_attributes['fulltext']).to eq text
+        expect(extracted_attributes['fulltext_tsv'].size).to be > 0
+        expect(extracted_attributes['file_tsv'].size).to be > 0
       end
 
-      # shared_examples 'no fulltext but file name saved as TSV' do
-      # end
-
-      context 'No content was extracted' do
+      context 'without text extracted' do
         let(:text) { nil }
 
         # include_examples 'no fulltext but file name saved as TSV'
         it 'updates the attachment\'s DB record with file_tsv' do
-          expect(attachment.fulltext).to be_blank
-          expect(attachment.fulltext_tsv).to be_blank
-          expect(attachment.file_tsv.size).to be > 0
+          expect(extracted_attributes['fulltext']).to be_blank
+          expect(extracted_attributes['fulltext_tsv']).to be_blank
+          expect(extracted_attributes['file_tsv'].size).to be > 0
         end
       end
     end
@@ -85,16 +93,15 @@ describe ExtractFulltextJob, type: :job do
 
   shared_examples 'only file name indexed' do
     it 'updates the attachment\'s DB record with file_tsv' do
-      expect(attachment.fulltext).to be_blank
-      expect(attachment.fulltext_tsv).to be_blank
-      expect(attachment.file_tsv.size).to be > 0
+      expect(extracted_attributes['fulltext']).to be_blank
+      expect(extracted_attributes['fulltext_tsv']).to be_blank
+      expect(extracted_attributes['file_tsv'].size).to be > 0
     end
   end
 
-  context 'file not readable' do
+  context 'with the file not readable' do
     before do
       allow(attachment).to receive(:readable?).and_return(false)
-      subject
     end
 
     include_examples 'only file name indexed'
@@ -107,13 +114,14 @@ describe ExtractFulltextJob, type: :job do
     before do
       allow_any_instance_of(Plaintext::Resolver).to receive(:text).and_raise(exception_message)
 
-      # This line is actually part of the test. `expect` call needs to go so far up here, as we want to verify that a message gets logged.
-      expect(logger).to receive(:error).with(/boom-internal-error/)
+      allow(logger).to receive(:error)
 
       allow(attachment).to receive(:readable?).and_return(true)
-      subject
     end
 
-    include_examples 'only file name indexed'
+    it 'logs the error' do
+      extracted_attributes
+      expect(logger).to have_received(:error).with(/boom-internal-error/)
+    end
   end
 end


### PR DESCRIPTION
Currently, the fulltext columns `fulltext`, `fulltext_tsv` and
`file_tsv` are never displayed in the application.  As such they are
currently purely used internally when they are involved in the fulltext
search. Having them included in the AR model Attachment will lead to a
lot of data being loaded. Such a column can contain megabytes of data.
This is costly twice: when fetching the data from the database and when
instantiating the model in ruby.  As the data is never displayed, they
can be ignored for now using `ignored_columns`. This changes the SQL for
fetching from

`SELECT "attachments"."*" ...`

to

`SELECT "attachments"."id", "attachments"."file" ...` (without the excluded columns)

The alternative would have been to create a new table for the fulltext
information and this might still be an option once the requirements on
the columns increase. For now, this change is simpler.

https://community.openproject.org/wp/38080