### PR TITLE
[38081] Never mix in-app facets and unreadcount

### DIFF
--- a/frontend/src/app/features/in-app-notifications/store/in-app-notifications.query.ts
+++ b/frontend/src/app/features/in-app-notifications/store/in-app-notifications.query.ts
@@ -6,7 +6,7 @@ import { InAppNotificationsStore, InAppNotificationsState } from './in-app-notif
 @Injectable({ providedIn: 'root' })
 export class InAppNotificationsQuery extends QueryEntity<InAppNotificationsState> {
   /** Get the number of unread items */
-  unreadCount$ = this.select('count');
+  unreadCount$ = this.select('unreadCount');
 
   /** Do we have any unread items? */
   hasUnread$ = this.unreadCount$.pipe(map((count) => count > 0));

--- a/frontend/src/app/features/in-app-notifications/store/in-app-notifications.store.ts
+++ b/frontend/src/app/features/in-app-notifications/store/in-app-notifications.store.ts
@@ -3,14 +3,15 @@ import { EntityState, EntityStore, StoreConfig } from '@datorama/akita';
 import { InAppNotification } from './in-app-notification.model';
 
 export interface InAppNotificationsState extends EntityState<InAppNotification> {
-  count:number;
+  /** The entities in the store might not all be unread so we keep separate count */
+  unreadCount:number;
   activeFacet:string;
   expanded:boolean;
 }
 
 export function createInitialState():InAppNotificationsState {
   return {
-    count: 0,
+    unreadCount: 0,
     notShowing: 0,
     activeFacet: 'unread',
     expanded: false,


### PR DESCRIPTION
The store variable `count` of the in-app store would suggest it keeps count of all notifications, but in reality it should only count
unread for the bell.

This is separate from the actual count of the entities depending on our
facet filter.

https://community.openproject.org/wp/38081