### PR TITLE
[38099] Save button in editCostType form is too big

### DIFF
--- a/modules/costs/app/views/cost_types/edit.html.erb
+++ b/modules/costs/app/views/cost_types/edit.html.erb
@@ -114,7 +114,7 @@ See docs/COPYRIGHT.rdoc for more details.
     <a id="add_rate_date" href="#" class="add-row-button wp-inline-create--add-link" title="<%= t(:button_add_rate) %>">
       <%= op_icon('icon icon-add') %>
     </a>
-    <%= styled_button_tag t(:button_save), class: '-with-icon icon-checkmark' %>
   </div>
+  <%= styled_button_tag t(:button_save), class: '-with-icon icon-checkmark' %>
 <% end %>
 </costs-subform>


### PR DESCRIPTION
Move submit button out of "inline-create-button" container because it should not be affected by that styling

https://community.openproject.org/projects/openproject/work_packages/38099/activity