### PR TITLE
Bump translations plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GIT
 
 GIT
   remote: https://github.com/opf/openproject-translations.git
-  revision: b28dbe0bc4f347e79f34cd5b42cff2f03f2f7404
+  revision: 6ce2c62dbfe751aee9fa212fb1768784c42dea81
   branch: dev
   specs:
     openproject-translations (7.4.0)


### PR DESCRIPTION
Translations plugin had wrong URLs that were fixed in 

https://github.com/opf/openproject-translations/commit/e5ab38402c0da3f61c1a68f691ccea05b0a15961 &
https://github.com/opf/openproject-translations/commit/6ce2c62dbfe751aee9fa212fb1768784c42dea81