### PR TITLE
[38078] Fix bulk controller not setting send_notifications

### DIFF
--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -173,7 +173,7 @@ module WorkPackagesHelper
                                checked,
                                class: 'form--check-box')
         boxes
-      end) + I18n.t(:label_notify_member_plural)
+      end) + I18n.t('notifications.send_notifications')
     end
   end
 

--- a/app/services/work_packages/bulk/update_service.rb
+++ b/app/services/work_packages/bulk/update_service.rb
@@ -43,7 +43,7 @@ module WorkPackages
 
       def call(params:)
         self.permitted_params = PermittedParams.new(params, user)
-        in_user_context do
+        in_user_context(params[:send_notification] == '1') do
           bulk_update(params)
         end
       end
@@ -69,7 +69,7 @@ module WorkPackages
 
           service_call = WorkPackages::UpdateService
                          .new(user: user, model: work_package)
-                         .call(**attributes.merge(send_notifications: params[:send_notification] == '1').symbolize_keys)
+                         .call(**attributes.symbolize_keys)
 
           if service_call.success?
             saved << work_package.id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1374,6 +1374,7 @@ en:
       indefinite_expiration: "Never"
 
   notifications:
+    send_notifications: "Send notifications for this action"
     work_packages:
       subject:
         assigned: "You have been assigned to %{work_package}"
@@ -1684,7 +1685,6 @@ en:
   label_none_parentheses: "(none)"
   label_not_contains: "doesn't contain"
   label_not_equals: "is not"
-  label_notify_member_plural: "Email updates"
   label_on: "on"
   label_open_menu: "Open menu"
   label_open_work_packages: "open"


### PR DESCRIPTION
With the bulk controller not setting notifications, the default is send_notification = true.

All subsequent calls to disable notification sending is ignored, so the call in the WorkPackages::UpdateService is ignored.

This PR also renames the "Send emails" option to the more appropriate term now.

https://community.openproject.org/work_packages/38078