### PR TITLE
[38102] Avoid link as grid-area, instead wrap in element

### DIFF
--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -9,14 +9,18 @@
       class="op-ian-item--row"
       (click)="toggleDetails()"
   >
-    <a
-        *ngIf="project"
-        class="op-ian-item--project"
-        [href]="project.showUrl"
-        [textContent]="project.title"
-        (click)="projectClicked($event)"
-        target="_blank"
-    ></a>
+    <div
+          *ngIf="project"
+          class="op-ian-item--project"
+      >
+      <a
+          class="op-ian-item--project-link"
+          [href]="project.showUrl"
+          [textContent]="project.title"
+          (click)="projectClicked($event)"
+          target="_blank"
+      ></a>
+    </div>
     <ng-container *ngIf="workPackage$ && (workPackage$ | async) as workPackage; else workPackageLoading">
       <span
           class="op-ian-item--title"

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -58,8 +58,13 @@ $ian-bg-hover-color: #F1F8FF
   &--project
     grid-area: project
     font-size: 0.8rem
-    color: var(--gray-dark)
     @include text-shortener
+
+  &--project-link
+    color: var(--gray-dark)
+    // Set line-height to show underline
+    // which is otherwise swallowed by overflow
+    line-height: 1.1
 
   &--reason,
   &--date


### PR DESCRIPTION
If the link is the grid-area, it grows in size and expands the clickable area. Instead, wrap it in an element.

Also fixes the underline missing due to an overflow: hidden

https://community.openproject.org/work_packages/38102