### PR TITLE
[38103] Make onboarding tour more stable

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -540,7 +540,8 @@ en:
         welcome: 'Take a three minutes introduction tour to learn the most <b>important features</b>. <br> We recommend completing the steps until the end. You can restart the tour any time.'
         wiki: 'Within the <b>wiki</b> you can document and share knowledge together with your team.'
         backlogs:
-          overview: "Manage your work in the <b>backlogs</b> view. <br> On the right you have the product backlog or a bug backlog, on the left you will have the respective sprints. Here you can create <b>epics, user stories, and bugs</b>, prioritize via drag and drop and add them to a sprint."
+          overview: "Manage your work in the <b>backlogs</b> view."
+          sprints: "On the right you have the product backlog or a bug backlog, on the left you will have the respective sprints. Here you can create <b>epics, user stories, and bugs</b>, prioritize via drag and drop and add them to a sprint."
           task_board_arrow: 'To see your <b>task board</b>, open the sprint drop-down...'
           task_board_select: '...and select the <b>task board</b> entry.'
           task_board: "The task board visualizes the <b>progress for this sprint</b>. Click on the plus (+) icon next to a user story to add new tasks or impediments. <br> The status can be updated by drag and drop."

--- a/frontend/src/app/core/setup/globals/onboarding/helpers.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/helpers.ts
@@ -1,7 +1,7 @@
 export const demoProjectName = 'Demo project';
 export const scrumDemoProjectName = 'Scrum project';
 export const onboardingTourStorageKey = 'openProject-onboardingTour';
-export type OnboardingTourNames = 'backlogs'|'taskboard'|'homescreen'|'main';
+export type OnboardingTourNames = 'prepareBacklogs'|'backlogs'|'taskboard'|'homescreen'|'main';
 
 export function waitForElement(element:string, container:string, execFunction:Function) {
   // Wait for the element to be ready

--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
@@ -48,8 +48,6 @@ function initializeTour(storageValue:string, disabledElements?:string, projectSe
 }
 
 function startTour(steps:any[]) {
-  steps = steps.filter((step) => step.condition ? step.condition() : true );
-
   window.onboardingTourInstance.set(steps);
   window.onboardingTourInstance.run();
 }

--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
@@ -10,6 +10,7 @@ import { boardTourSteps } from 'core-app/core/setup/globals/onboarding/tours/boa
 import { menuTourSteps } from 'core-app/core/setup/globals/onboarding/tours/menu_tour';
 import { homescreenOnboardingTourSteps } from 'core-app/core/setup/globals/onboarding/tours/homescreen_tour';
 import {
+  prepareScrumBacklogsTourSteps,
   scrumBacklogsTourSteps,
   scrumTaskBoardTourSteps,
 } from 'core-app/core/setup/globals/onboarding/tours/backlogs_tour';
@@ -22,28 +23,7 @@ declare global {
   }
 }
 
-export function start(name:OnboardingTourNames) {
-  console.log('star tour', name);
-  switch (name) {
-    case 'backlogs':
-      initializeTour('startTaskBoardTour');
-      startTour(scrumBacklogsTourSteps());
-      break;
-    case 'taskboard':
-      initializeTour('startMainTourFromBacklogs');
-      startTour(scrumTaskBoardTourSteps());
-      break;
-    case 'homescreen':
-      initializeTour('startProjectTour', '.widget-box--blocks--buttons a', true);
-      startTour(homescreenOnboardingTourSteps());
-      break;
-    case 'main':
-      mainTour();
-      break;
-  }
-}
-
-function initializeTour(storageValue:any, disabledElements?:any, projectSelection?:any) {
+function initializeTour(storageValue:string, disabledElements?:string, projectSelection?:boolean) {
   window.onboardingTourInstance = new window.EnjoyHint({
     onStart() {
       jQuery('#content-wrapper, #menu-sidebar').addClass('-hidden-overflow');
@@ -67,8 +47,9 @@ function initializeTour(storageValue:any, disabledElements?:any, projectSelectio
   });
 }
 
-function startTour(steps:any) {
-  console.log('startTour', steps);
+function startTour(steps:any[]) {
+  steps = steps.filter((step) => step.condition ? step.condition() : true );
+
   window.onboardingTourInstance.set(steps);
   window.onboardingTourInstance.run();
 }
@@ -92,4 +73,30 @@ function mainTour() {
 
     startTour(steps);
   });
+}
+
+export function start(name:OnboardingTourNames) {
+  switch (name) {
+    case 'prepareBacklogs':
+      initializeTour('prepareTaskBoardTour');
+      startTour(prepareScrumBacklogsTourSteps());
+      break;
+    case 'backlogs':
+      initializeTour('startTaskBoardTour');
+      startTour(scrumBacklogsTourSteps());
+      break;
+    case 'taskboard':
+      initializeTour('startMainTourFromBacklogs');
+      startTour(scrumTaskBoardTourSteps());
+      break;
+    case 'homescreen':
+      initializeTour('startProjectTour', '.widget-box--blocks--buttons a', true);
+      startTour(homescreenOnboardingTourSteps());
+      break;
+    case 'main':
+      mainTour();
+      break;
+    default:
+      break;
+  }
 }

--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
@@ -23,6 +23,22 @@ declare global {
   }
 }
 
+export type OnboardingStep = {
+  [key:string]:string|unknown,
+  event?:string,
+  description?:string,
+  selector?:string,
+  showSkip?:boolean,
+  skipButton?:{ className:string, text:string },
+  nextButton?:{ text:string },
+  containerClass?:string,
+  clickable?:boolean,
+  timeout?:() => Promise<void>,
+  condition?:() => boolean,
+  onNext?:() => void,
+  onBeforeStart?:() => void,
+};
+
 function initializeTour(storageValue:string, disabledElements?:string, projectSelection?:boolean) {
   window.onboardingTourInstance = new window.EnjoyHint({
     onStart() {
@@ -47,7 +63,7 @@ function initializeTour(storageValue:string, disabledElements?:string, projectSe
   });
 }
 
-function startTour(steps:any[]) {
+function startTour(steps:OnboardingStep[]) {
   window.onboardingTourInstance.set(steps);
   window.onboardingTourInstance.run();
 }
@@ -59,7 +75,7 @@ function mainTour() {
   const eeTokenAvailable = !jQuery('body').hasClass('ee-banners-visible');
 
   waitForElement('.work-package--results-tbody', '#content', () => {
-    let steps:any[];
+    let steps:OnboardingStep[];
 
     // Check for EE edition, and available seed data of boards.
     // Then add boards to the tour, otherwise skip it.
@@ -73,7 +89,7 @@ function mainTour() {
   });
 }
 
-export function start(name:OnboardingTourNames) {
+export function start(name:OnboardingTourNames):void {
   switch (name) {
     case 'prepareBacklogs':
       initializeTour('prepareTaskBoardTour');

--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour_trigger.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour_trigger.ts
@@ -7,14 +7,14 @@ import {
 } from 'core-app/core/setup/globals/onboarding/helpers';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 
-
-async function triggerTour(name:OnboardingTourNames) {
+async function triggerTour(name:OnboardingTourNames):Promise<void> {
   debugLog(`Loading and triggering onboarding tour ${name}`);
-  const tour = await import(/* webpackChunkName: "onboarding-tour" */ './onboarding_tour');
-  tour.start(name);
+  await import(/* webpackChunkName: "onboarding-tour" */ './onboarding_tour').then((tour) => {
+    tour.start(name);
+  });
 }
 
-export function detectOnboardingTour() {
+export function detectOnboardingTour():void {
   // ------------------------------- Global -------------------------------
   const url = new URL(window.location.href);
   const isMobile = document.body.classList.contains('-browser-mobile');
@@ -34,44 +34,45 @@ export function detectOnboardingTour() {
       // Start automatically when the language selection is closed
       jQuery('.op-modal--close-button').click(() => {
         tourCancelled = true;
-        triggerTour('homescreen');
+        void triggerTour('homescreen');
       });
 
       // Start automatically when the escape button is pressed
       document.addEventListener('keydown', (event) => {
         if (event.key === 'Escape' && !tourCancelled) {
           tourCancelled = true;
-          triggerTour('homescreen');
+          void triggerTour('homescreen');
         }
       }, { once: true });
     }
 
     // ------------------------------- Tutorial Homescreen page -------------------------------
     if (currentTourPart === 'readyToStart') {
-      triggerTour('homescreen');
+      void triggerTour('homescreen');
     }
 
     // ------------------------------- Tutorial WP page -------------------------------
     if (currentTourPart === 'startMainTourFromBacklogs' || url.searchParams.get('start_onboarding_tour')) {
-      triggerTour('main');
+      void triggerTour('main');
     }
+
     // ------------------------------- Prepare Backlogs page -------------------------------
     if (url.searchParams.get('start_scrum_onboarding_tour')) {
       if (jQuery('.backlogs-menu-item').length > 0) {
-        triggerTour('prepareBacklogs');
+        void triggerTour('prepareBacklogs');
       } else {
-        triggerTour('taskboard');
+        void triggerTour('taskboard');
       }
     }
 
     // ------------------------------- Tutorial Backlogs page -------------------------------
     if (currentTourPart === 'prepareTaskBoardTour') {
-      triggerTour('backlogs');
+      void triggerTour('backlogs');
     }
-    
+
     // ------------------------------- Tutorial Task Board page -------------------------------
     if (currentTourPart === 'startTaskBoardTour') {
-      triggerTour('taskboard');
+      void triggerTour('taskboard');
     }
   }
 }

--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour_trigger.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour_trigger.ts
@@ -7,6 +7,13 @@ import {
 } from 'core-app/core/setup/globals/onboarding/helpers';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 
+
+async function triggerTour(name:OnboardingTourNames) {
+  debugLog(`Loading and triggering onboarding tour ${name}`);
+  const tour = await import(/* webpackChunkName: "onboarding-tour" */ './onboarding_tour');
+  tour.start(name);
+}
+
 export function detectOnboardingTour() {
   // ------------------------------- Global -------------------------------
   const url = new URL(window.location.href);
@@ -48,23 +55,23 @@ export function detectOnboardingTour() {
     if (currentTourPart === 'startMainTourFromBacklogs' || url.searchParams.get('start_onboarding_tour')) {
       triggerTour('main');
     }
-
-    // ------------------------------- Tutorial Backlogs page -------------------------------
+    // ------------------------------- Prepare Backlogs page -------------------------------
     if (url.searchParams.get('start_scrum_onboarding_tour')) {
       if (jQuery('.backlogs-menu-item').length > 0) {
-        triggerTour('backlogs');
+        triggerTour('prepareBacklogs');
+      } else {
+        triggerTour('taskboard');
       }
     }
 
+    // ------------------------------- Tutorial Backlogs page -------------------------------
+    if (currentTourPart === 'prepareTaskBoardTour') {
+      triggerTour('backlogs');
+    }
+    
     // ------------------------------- Tutorial Task Board page -------------------------------
     if (currentTourPart === 'startTaskBoardTour') {
       triggerTour('taskboard');
     }
   }
-}
-
-async function triggerTour(name:OnboardingTourNames) {
-  debugLog(`Loading and triggering onboarding tour ${name}`);
-  const tour = await import(/* webpackChunkName: "onboarding-tour" */ './onboarding_tour');
-  tour.start(name);
 }

--- a/frontend/src/app/core/setup/globals/onboarding/tours/backlogs_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/backlogs_tour.ts
@@ -1,4 +1,6 @@
-export function prepareScrumBacklogsTourSteps() {
+import { OnboardingStep } from 'core-app/core/setup/globals/onboarding/onboarding_tour';
+
+export function prepareScrumBacklogsTourSteps():OnboardingStep[] {
   return [
     {
       'next .backlogs-menu-item': I18n.t('js.onboarding.steps.backlogs.overview'),
@@ -8,11 +10,11 @@ export function prepareScrumBacklogsTourSteps() {
       onNext() {
         jQuery('.backlogs-menu-item')[0].click();
       },
-    }
+    },
   ];
 }
 
-export function scrumBacklogsTourSteps() {
+export function scrumBacklogsTourSteps():OnboardingStep[] {
   return [
     {
       'next #content-wrapper': I18n.t('js.onboarding.steps.backlogs.sprints'),
@@ -44,16 +46,14 @@ export function scrumBacklogsTourSteps() {
   ];
 }
 
-export function scrumTaskBoardTourSteps() {
+export function scrumTaskBoardTourSteps():OnboardingStep[] {
   return [
     {
       'next #content-wrapper': I18n.t('js.onboarding.steps.backlogs.task_board'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       containerClass: '-dark -hidden-arrow',
-      condition: () => {
-        return document.getElementsByClassName('backlogs-menu-item').length !== 0;
-      },
+      condition: () => document.getElementsByClassName('backlogs-menu-item').length !== 0,
     },
     {
       'next #main-menu-work-packages-wrapper': I18n.t('js.onboarding.steps.wp.toggler'),
@@ -65,4 +65,3 @@ export function scrumTaskBoardTourSteps() {
     },
   ];
 }
-

--- a/frontend/src/app/core/setup/globals/onboarding/tours/backlogs_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/backlogs_tour.ts
@@ -1,7 +1,21 @@
+export function prepareScrumBacklogsTourSteps() {
+  return [
+    {
+      'next .backlogs-menu-item': I18n.t('js.onboarding.steps.backlogs.overview'),
+      showSkip: false,
+      nextButton: { text: I18n.t('js.onboarding.buttons.next') },
+      containerClass: '-dark -hidden-arrow',
+      onNext() {
+        jQuery('.backlogs-menu-item')[0].click();
+      },
+    }
+  ];
+}
+
 export function scrumBacklogsTourSteps() {
   return [
     {
-      'next #content-wrapper': I18n.t('js.onboarding.steps.backlogs.overview'),
+      'next #content-wrapper': I18n.t('js.onboarding.steps.backlogs.sprints'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       containerClass: '-dark -hidden-arrow',
@@ -37,6 +51,9 @@ export function scrumTaskBoardTourSteps() {
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       containerClass: '-dark -hidden-arrow',
+      condition: () => {
+        return document.getElementsByClassName('backlogs-menu-item').length !== 0;
+      },
     },
     {
       'next #main-menu-work-packages-wrapper': I18n.t('js.onboarding.steps.wp.toggler'),
@@ -48,3 +65,4 @@ export function scrumTaskBoardTourSteps() {
     },
   ];
 }
+

--- a/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
@@ -1,6 +1,7 @@
 import { waitForElement } from 'core-app/core/setup/globals/onboarding/helpers';
+import { OnboardingStep } from 'core-app/core/setup/globals/onboarding/onboarding_tour';
 
-export function boardTourSteps() {
+export function boardTourSteps():OnboardingStep[] {
   return [
     {
       'next .board-view-menu-item': I18n.t('js.onboarding.steps.boards.overview'),
@@ -15,24 +16,20 @@ export function boardTourSteps() {
     },
     {
       'next .board-list--container': I18n.t('js.onboarding.steps.boards.lists'),
-      'showSkip': false,
-      'nextButton': { text: I18n.t('js.onboarding.buttons.next') },
-      'containerClass': '-dark -hidden-arrow',
-      'timeout': function () {
-        return new Promise(function (resolve) {
-          waitForElement('.op-wp-single-card', '#content', function () {
-            resolve(undefined);
-          });
+      showSkip: false,
+      nextButton: { text: I18n.t('js.onboarding.buttons.next') },
+      containerClass: '-dark -hidden-arrow',
+      timeout: () => new Promise((resolve) => {
+        waitForElement('.op-wp-single-card', '#content', () => {
+          resolve(undefined);
         });
-      },
+      }),
     },
     {
       'next .board-list--add-button': I18n.t('js.onboarding.steps.boards.add'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
-      condition: () => {
-        return document.getElementsByClassName('board-list--add-button').length !== 0;
-      },
+      condition: () => document.getElementsByClassName('board-list--add-button').length !== 0,
     },
     {
       'next .boards-list--container': I18n.t('js.onboarding.steps.boards.drag'),

--- a/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
@@ -31,7 +31,7 @@ export function boardTourSteps() {
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       condition: () => {
-        document.getElementsByClassName('board-list--add-button').length !== 0
+        return document.getElementsByClassName('board-list--add-button').length !== 0;
       },
     },
     {

--- a/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
@@ -30,6 +30,9 @@ export function boardTourSteps() {
       'next .board-list--add-button': I18n.t('js.onboarding.steps.boards.add'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
+      condition: () => {
+        document.getElementsByClassName('board-list--add-button').length !== 0
+      },
     },
     {
       'next .boards-list--container': I18n.t('js.onboarding.steps.boards.drag'),

--- a/frontend/src/app/core/setup/globals/onboarding/tours/homescreen_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/homescreen_tour.ts
@@ -3,8 +3,9 @@ import {
   preventClickHandler,
   scrumDemoProjectName,
 } from 'core-app/core/setup/globals/onboarding/helpers';
+import { OnboardingStep } from 'core-app/core/setup/globals/onboarding/onboarding_tour';
 
-export function homescreenOnboardingTourSteps() {
+export function homescreenOnboardingTourSteps():OnboardingStep[] {
   return [
     {
       'next .op-app-header': I18n.t('js.onboarding.steps.welcome'),

--- a/frontend/src/app/core/setup/globals/onboarding/tours/homescreen_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/homescreen_tour.ts
@@ -25,7 +25,7 @@ export function homescreenOnboardingTourSteps() {
         // This will be removed once the project selection is implemented
         jQuery(`.widget-box.welcome a:contains(${scrumDemoProjectName})`).click(function (this:HTMLAnchorElement) {
           window.onboardingTourInstance.trigger('next');
-          window.location.href = `${this.href}/backlogs/?start_scrum_onboarding_tour=true`;
+          window.location.href = `${this.href}/?start_scrum_onboarding_tour=true`;
         });
         jQuery(`.widget-box.welcome a:contains(${demoProjectName})`).click(function (this:HTMLAnchorElement) {
           window.onboardingTourInstance.trigger('next');

--- a/frontend/src/app/core/setup/globals/onboarding/tours/menu_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/menu_tour.ts
@@ -1,28 +1,24 @@
-export function menuTourSteps() {
+import { OnboardingStep } from 'core-app/core/setup/globals/onboarding/onboarding_tour';
+
+export function menuTourSteps():OnboardingStep[] {
   return [
     {
       'next .members-menu-item': I18n.t('js.onboarding.steps.members'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
-      condition: () => {
-        return document.getElementsByClassName('members-menu-item').length !== 0;
-      },
+      condition: () => document.getElementsByClassName('members-menu-item').length !== 0,
     },
     {
       'next .wiki-menu--main-item': I18n.t('js.onboarding.steps.wiki'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
-      condition: () => {
-        return document.getElementsByClassName('wiki-menu--main-item').length !== 0;
-      },
+      condition: () => document.getElementsByClassName('wiki-menu--main-item').length !== 0,
     },
     {
       'next .op-quick-add-menu': I18n.t('js.onboarding.steps.quick_add_button'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
-      condition: () => {
-        return document.getElementsByClassName('op-quick-add-menu--icon').length !== 0;
-      },
+      condition: () => document.getElementsByClassName('op-quick-add-menu--icon').length !== 0,
     },
     {
       'next .op-app-help': I18n.t('js.onboarding.steps.help_menu'),

--- a/frontend/src/app/core/setup/globals/onboarding/tours/menu_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/menu_tour.ts
@@ -4,16 +4,25 @@ export function menuTourSteps() {
       'next .members-menu-item': I18n.t('js.onboarding.steps.members'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
+      condition: () => {
+        return document.getElementsByClassName('members-menu-item').length !== 0;
+      },
     },
     {
       'next .wiki-menu--main-item': I18n.t('js.onboarding.steps.wiki'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
+      condition: () => {
+        return document.getElementsByClassName('wiki-menu--main-item').length !== 0;
+      },
     },
     {
       'next .op-quick-add-menu': I18n.t('js.onboarding.steps.quick_add_button'),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
+      condition: () => {
+        return document.getElementsByClassName('op-quick-add-menu--icon').length !== 0;
+      },
     },
     {
       'next .op-app-help': I18n.t('js.onboarding.steps.help_menu'),

--- a/frontend/src/app/core/setup/globals/onboarding/tours/work_package_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/work_package_tour.ts
@@ -1,6 +1,7 @@
 import { waitForElement } from 'core-app/core/setup/globals/onboarding/helpers';
+import { OnboardingStep } from 'core-app/core/setup/globals/onboarding/onboarding_tour';
 
-export function wpOnboardingTourSteps():any[] {
+export function wpOnboardingTourSteps():OnboardingStep[] {
   return [
     {
       'next .wp-table--row': I18n.t('js.onboarding.steps.wp.list'),
@@ -29,16 +30,14 @@ export function wpOnboardingTourSteps():any[] {
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       shape: 'circle',
-      timeout() {
-        return new Promise((resolve) => {
-          // We are waiting here for the badge to appear,
-          // because its the last that appears and it shifts the WP create button to the left.
-          // Thus it is important that the tour rendering starts after the badge is visible
-          waitForElement('#work-packages-filter-toggle-button .badge', '#content', () => {
-            resolve(undefined);
-          });
+      timeout: () => new Promise((resolve) => {
+        // We are waiting here for the badge to appear,
+        // because its the last that appears and it shifts the WP create button to the left.
+        // Thus it is important that the tour rendering starts after the badge is visible
+        waitForElement('#work-packages-filter-toggle-button .badge', '#content', () => {
+          resolve(undefined);
         });
-      },
+      }),
       onNext() {
         jQuery('#wp-view-toggle-button').click();
       },

--- a/frontend/src/vendor/enjoyhint.js
+++ b/frontend/src/vendor/enjoyhint.js
@@ -101,6 +101,13 @@
             var $enjoyhint = $('.enjoyhint');
             var step_data = data[current_step];
 
+            // If the condition for the step is not fullfilled, skip it
+            if (step_data.condition && !step_data.condition()) {
+              current_step++;
+              stepAction();
+              return;
+            }
+
             // Remove all classes
             $enjoyhint.removeClass();
             $enjoyhint.addClass("enjoyhint enjoyhint-step-" + (current_step + 1));

--- a/modules/backlogs/spec/features/onboarding/backlogs_onboarding_tour_spec.rb
+++ b/modules/backlogs/spec/features/onboarding/backlogs_onboarding_tour_spec.rb
@@ -88,7 +88,7 @@ describe 'backlogs onboarding tour', js: true do
     page.execute_script("window.sessionStorage.clear();")
   end
 
-  context 'as a new user who is allowed to see the backlogs plugin' do
+  context 'with a new user who is allowed to see the backlogs plugin' do
     before do
       login_as user
     end
@@ -122,12 +122,13 @@ describe 'backlogs onboarding tour', js: true do
     end
   end
 
-  context 'as a new user who is not allowed to see the backlogs plugin' do
+  context 'with a new user who is not allowed to see the backlogs plugin' do
     # necessary to be able to see public projects
-    let!(:non_member_role) { FactoryBot.create :non_member, permissions: [:view_work_packages] }
+    let(:non_member_role) { FactoryBot.create :non_member, permissions: [:view_work_packages] }
     let(:non_member_user) { FactoryBot.create :user }
 
     before do
+      non_member_role
       login_as non_member_user
     end
 

--- a/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
+++ b/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
@@ -91,7 +91,7 @@ describe 'boards onboarding tour', js: true do
 
       step_through_onboarding_board_tour
 
-      step_through_onboarding_main_menu_tour
+      step_through_onboarding_main_menu_tour has_full_capabilities: true
     end
 
     it "I see the board onboarding tour in the scrum project" do
@@ -105,7 +105,7 @@ describe 'boards onboarding tour', js: true do
 
       step_through_onboarding_board_tour
 
-      step_through_onboarding_main_menu_tour
+      step_through_onboarding_main_menu_tour has_full_capabilities: true
     end
   end
 end

--- a/modules/boards/spec/features/support/onboarding_steps.rb
+++ b/modules/boards/spec/features/support/onboarding_steps.rb
@@ -29,18 +29,18 @@
 module OnboardingSteps
   def step_through_onboarding_board_tour
     next_button.click
-    expect(page).to have_text 'Select boards to shift the view and manage your project using the agile boards view.'
+    expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.boards.overview')), normalize_ws: true
 
     next_button.click
     expect(page)
-      .to have_text 'Here you can create multiple lists (columns) within your board.'
+      .to have_text sanitize_string(I18n.t('js.onboarding.steps.boards.lists')), normalize_ws: true
 
     next_button.click
-    expect(page).to have_text 'Click on the plus (+) icon to create a new card'
+    expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.boards.add')), normalize_ws: true
 
     next_button.click
     expect(page)
-      .to have_text 'Drag and drop your cards within a given list to reorder them, or to move them to another list.'
+      .to have_text sanitize_string(I18n.t('js.onboarding.steps.boards.drag')), normalize_ws: true
   end
 end
 

--- a/spec/features/onboarding/onboarding_tour_spec.rb
+++ b/spec/features/onboarding/onboarding_tour_spec.rb
@@ -41,7 +41,7 @@ describe 'onboarding tour for new users', js: true do
   let!(:wp_1) { FactoryBot.create(:work_package, project: project) }
   let(:next_button) { find('.enjoyhint_next_btn') }
 
-  context 'as a new user' do
+  context 'with a new user' do
     before do
       login_as user
       allow(Setting).to receive(:demo_projects_available).and_return(true)
@@ -127,13 +127,14 @@ describe 'onboarding tour for new users', js: true do
     end
   end
 
-  context 'as a new user who is not allowed to see the parts of the tour' do
+  context 'with a new user who is not allowed to see the parts of the tour' do
     # necessary to be able to see public projects
-    let!(:non_member_role) { FactoryBot.create :non_member, permissions: [:view_work_packages] }
+    let(:non_member_role) { FactoryBot.create :non_member, permissions: [:view_work_packages] }
     let(:non_member_user) { FactoryBot.create :user }
 
     before do
       allow(Setting).to receive(:demo_projects_available).and_return(true)
+      non_member_role
       login_as non_member_user
     end
 

--- a/spec/support/onboarding_helper.rb
+++ b/spec/support/onboarding_helper.rb
@@ -31,43 +31,49 @@ require 'spec_helper'
 module OnboardingHelper
   def step_through_onboarding_wp_tour(project, wp)
     expect(page).not_to have_selector('.loading-indicator')
-    expect(page).to have_text 'This work package overview provides a list of all the work in your project'
+    expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wp.list')), normalize_ws: true
 
     next_button.click
     expect(page).to have_current_path project_work_package_path(project, wp.id, 'activity')
-    expect(page).to have_text 'The work package details view provides all the relevant information'
+    expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wp.full_view')), normalize_ws: true
 
     next_button.click
-    expect(page).to have_text 'Use the return arrow in the top left corner to exit and return to the work package list'
+    expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wp.back_button')), normalize_ws: true
 
     next_button.click
-    expect(page).to have_text 'The + Create button will add a new work package to your project'
+    expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wp.create_button')), normalize_ws: true
 
     next_button.click
-    expect(page).to have_text 'You can activate the Gantt chart view to create a timeline for your project.'
+    expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wp.timeline_button')), normalize_ws: true
 
     next_button.click
-    expect(page).to have_text 'Here you can edit your project plan'
+    expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wp.timeline')), normalize_ws: true
 
     next_button.click
-    expect(page).to have_text 'Use the return arrow in the top left corner to return to the project’s main menu'
+    expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.sidebar_arrow')), normalize_ws: true
   end
 
-  def step_through_onboarding_main_menu_tour
-    next_button.click
-    expect(page).to have_text 'Invite new members to join your project.'
+  def step_through_onboarding_main_menu_tour(has_full_capabilities:)
+    if has_full_capabilities
+      next_button.click
+      expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.members')), normalize_ws: true
+
+      next_button.click
+      expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.wiki')), normalize_ws: true
+
+      next_button.click
+      expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.quick_add_button')), normalize_ws: true
+    end
 
     next_button.click
-    expect(page).to have_text 'Within the wiki you can document and share knowledge together with your team.'
-
-    next_button.click
-    expect(page).to have_text 'Click on the plus (+) icon in the header navigation to create a new project or to invite coworkers.'
-
-    next_button.click
-    expect(page).to have_text 'The Help (?) menu provides additional help resources.'
+    expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.help_menu')), normalize_ws: true
 
     next_button.click
     expect(page).not_to have_selector '.enjoy_hint_label'
+  end
+
+  def sanitize_string(string)
+    Sanitize.clean(string).squish
   end
 end
 


### PR DESCRIPTION
When the user lacks the permission to see certain modules, there is
* either a strange behaviour where you have to click twice without anything being highlighted (best case)
* or an error (worst case, e.g. when the user is not allowed to see backlogs in the scrum project)

This PR make onboarding tour more stable when permissions to see certain modules  are missing. Therefore a `condition` on the `step` object is introduced. This allows us to skip certain steps, if the condition is not fulfilled. 
Further an additional step for the backlogs tour is introduced. The users now start on the overview page of the project and then go either to backlogs or WP module. 

### Todo
- [x] Adapt & extend tests
- [x] Handle conditions which are not known on load (e.g. "Add" button of board list)

https://community.openproject.org/projects/openproject/work_packages/38103/activity