### PR TITLE
exclude deleted work packages from digest rendering

### DIFF
--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -58,6 +58,8 @@ class DigestMailer < ApplicationMailer
                                   .group_by(&:project)
                                   .transform_values { |of_project| of_project.group_by(&:resource) }
 
+    return if @notifications_by_project.empty?
+
     mail to: recipient.mail,
          subject: I18n.t('mail.digests.work_packages.subject',
                          date: format_time_as_date(Time.current),
@@ -70,5 +72,6 @@ class DigestMailer < ApplicationMailer
     Notification
       .where(id: notification_ids)
       .includes(:project, :resource, journal: %i[data attachable_journals customizable_journals])
+      .reject { |notification| notification.resource.nil? || notification.project.nil? || notification.journal.nil? }
   end
 end

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -75,6 +75,7 @@ describe DigestMailer, type: :mailer do
 
   describe '#work_packages' do
     subject(:mail) { described_class.work_packages(recipient.id, notifications.map(&:id)) }
+
     let(:mail_body) { mail.body.parts.detect { |part| part['Content-Type'].value == 'text/html' }.body.to_s }
 
     it 'notes the day and the number of notifications in the subject' do
@@ -116,6 +117,18 @@ describe DigestMailer, type: :mailer do
       expect(mail_body)
         .to have_selector('body section section li',
                           text: "Subject changed from old subject to new subject")
+    end
+
+    context 'with only a deleted work package for the digest' do
+      let(:work_package) { nil }
+
+      it `is a NullMail which isn't sent` do
+        expect(mail.body)
+          .to eql ''
+
+        expect(mail.header)
+          .to eql({})
+      end
     end
   end
 end


### PR DESCRIPTION
Work packages can be deleted after the notification has been created. This fix attempts to ignore such notifications when rendering the daily summary mail.

https://sentry2.openproject.com/organizations/sentry/issues/487

A different approach might be to remove notifications that have become invalid as there is no way to render them any more. In any case, the PRs code will increase resilience.