### PR TITLE
[38113] Delete associated notifications when work package is destroyed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -155,6 +155,12 @@ RSpec/DescribeMethod:
 RSpec/LetSetup:
   Enabled: false
 
+RSpec/LeadingSubject:
+  Enabled: false
+
+RSpec/NamedSubject:
+  Enabled: false
+
 Style/Alias:
   Enabled: false
 

--- a/app/services/work_packages/delete_service.rb
+++ b/app/services/work_packages/delete_service.rb
@@ -44,6 +44,7 @@ class WorkPackages::DeleteService < ::BaseServices::Delete
       end
 
       destroy_descendants(descendants, result)
+      delete_associated(model)
     end
 
     result
@@ -57,5 +58,15 @@ class WorkPackages::DeleteService < ::BaseServices::Delete
     descendants.each do |descendant|
       result.add_dependent!(ServiceResult.new(success: descendant.destroy, result: descendant))
     end
+  end
+
+  def delete_associated(model)
+    delete_notifications_resource(model.id)
+  end
+
+  def delete_notifications_resource(id)
+    Notification
+      .where(resource_type: :WorkPackage, resource_id: id)
+      .delete_all
   end
 end

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -7,7 +7,8 @@
   <button
     type="button"
     class="op-ian-item--row"
-    (click)="toggleDetails()"
+    [class.op-ian-item--row_unexpandable]="unexpandable"
+      (click)="toggleDetails()"
   >
     <div
       *ngIf="project"
@@ -44,8 +45,9 @@
     </ng-container>
     <ng-template #workPackageLoading>
       <span
-        class="op-ian-item--title"
-        [textContent]="text.loading"
+        *ngIf="workPackage$"
+          class="op-ian-item--title"
+          [textContent]="text.loading"
       ></span>
     </ng-template>
     <ng-container *ngIf="!workPackage$">
@@ -94,7 +96,7 @@
     </ng-container>
     <ul
       class="work-package-details-activities-messages"
-      *ngIf="details.length > 1"
+      *ngIf="details.length > 0"
     >
       <ng-container *ngFor="let detail of details">
         <li *ngIf="detail.html && detail.html !== ''">

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -38,6 +38,9 @@ $ian-bg-hover-color: #F1F8FF
       grid-template-rows: auto 1fr
       grid-template-areas: "project actor reason" "title actor date"
 
+    &_unexpandable
+      cursor: default
+
 
   &--indicator
     width: 10px

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
@@ -35,6 +35,9 @@ export class InAppNotificationEntryComponent implements OnInit {
   // custom rendered details, if any
   details:InAppNotificationDetail[];
 
+  // Whether body and details are empty
+  unexpandable = false;
+
   // The actor, if any
   actor?:PrincipalLike;
 
@@ -89,6 +92,7 @@ export class InAppNotificationEntryComponent implements OnInit {
     const details = this.notification.details || [];
     this.body = details.filter((el) => el.format === 'markdown');
     this.details = details.filter((el) => el.format === 'custom');
+    this.unexpandable = this.body.length === 0 && this.details.length === 0;
   }
 
   private buildTime() {
@@ -101,6 +105,10 @@ export class InAppNotificationEntryComponent implements OnInit {
   }
 
   toggleDetails():void {
+    if (this.unexpandable) {
+      return;
+    }
+
     if (!this.notification.readIAN) {
       this.inAppNotificationsService.markReadKeepAndExpanded(this.notification);
     }

--- a/lib/api/decorators/polymorphic_resource.rb
+++ b/lib/api/decorators/polymorphic_resource.rb
@@ -55,6 +55,8 @@ module API
           next unless embed_links
 
           resource = represented.send(name)
+          next if resource.nil?
+
           representer = representer_fn.call(resource)
           representer.create(resource, current_user: current_user)
         end
@@ -80,6 +82,8 @@ module API
           next if instance_exec(&skip_link)
 
           resource = represented.send(name)
+          next if resource.nil?
+
           path_name = path_fn.call(resource)
 
           ::API::Decorators::LinkObject

--- a/spec/services/work_packages/delete_service_integration_spec.rb
+++ b/spec/services/work_packages/delete_service_integration_spec.rb
@@ -92,4 +92,28 @@ describe WorkPackages::DeleteService, 'integration', type: :model do
       expect { work_package.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
+
+  describe 'with a notification' do
+    let!(:work_package) { FactoryBot.create :work_package, project: project }
+    let!(:notification) do
+      FactoryBot.create :notification,
+                        recipient: user,
+                        actor: user,
+                        resource: work_package,
+                        project: project
+    end
+
+    let(:instance) do
+      described_class.new(user: user,
+                          model: work_package)
+    end
+
+    subject { instance.call }
+
+    it 'deletes the notification' do
+      expect(subject).to be_success
+      expect { work_package.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end


### PR DESCRIPTION
Also increases resilience of the API and frontend to handle deleted resources just in case.

[OP#38113](https://community.openproject.org/wp/38113)