### PR TITLE
[37859] Use the currency separator to fix languages where they differ

### DIFF
--- a/modules/costs/app/helpers/costs/number_helper.rb
+++ b/modules/costs/app/helpers/costs/number_helper.rb
@@ -36,7 +36,12 @@ module Costs::NumberHelper
 
     # All locales seem to have their delimiters set to "".
     # We thus remove all typical delimiters that are not the separator.
-    separator = I18n.t(:'number.format.separator')
+    separator =
+      if I18n.exists?(:'number.currency.format.separator')
+        I18n.t(:'number.currency.format.separator')
+      else
+        I18n.t(:'number.format.separator', default: '.')
+      end
 
     if separator
       delimiters = Regexp.new('[ .,’˙]'.gsub(separator, ''))

--- a/modules/costs/spec/helpers/costs/number_helper_spec.rb
+++ b/modules/costs/spec/helpers/costs/number_helper_spec.rb
@@ -30,7 +30,7 @@ require File.dirname(__FILE__) + '/../../spec_helper'
 
 describe Costs::NumberHelper, type: :helper do
   describe '#parse_number_string' do
-    context 'for a german local' do
+    context 'with a german local' do
       it 'parses a string with delimiter and separator correctly' do
         I18n.with_locale(:de) do
           expect(helper.parse_number_string("123.456,78"))
@@ -81,7 +81,7 @@ describe Costs::NumberHelper, type: :helper do
       end
     end
 
-    context 'for an english local' do
+    context 'with an english local' do
       it 'parses a string with delimiter and separator correctly' do
         I18n.with_locale(:en) do
           expect(helper.parse_number_string("123,456.78"))
@@ -136,6 +136,57 @@ describe Costs::NumberHelper, type: :helper do
       it 'is nil' do
         expect(helper.parse_number_string(nil))
           .to be_nil
+      end
+    end
+
+    context 'with a russian locale (Regression #37859)' do
+      it 'parses a string with delimiter and separator correctly' do
+        I18n.with_locale(:ru) do
+          expect(helper.parse_number_string("123.456,78"))
+            .to eql "123456.78"
+        end
+      end
+
+      it 'parses a string with space delimiter and separator correctly' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("123 456,78"))
+            .to eql "123456.78"
+        end
+      end
+
+      it 'parses a string without delimiter and separator correctly' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("12345678"))
+            .to eql "12345678"
+        end
+      end
+
+      it 'parses a string without delimiter and with separator correctly' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("123456,78"))
+            .to eql "123456.78"
+        end
+      end
+
+      it 'parses a string with delimiter and without separator correctly' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("12.345.678"))
+            .to eql "12345678"
+        end
+      end
+
+      it 'parses a string with space delimiter and without separator correctly' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("12 345 678"))
+            .to eql "12345678"
+        end
+      end
+
+      it 'returns alphabetical values instead of a delimiter unchanged' do
+        I18n.with_locale(:de) do
+          expect(helper.parse_number_string("123456a78"))
+            .to eql "123456a78"
+        end
       end
     end
   end


### PR DESCRIPTION
In russian, the currency format separator `,` is not identical to the
number separator `.`. We however used the number formatter to parse the
rate in budgets.

https://community.openproject.org/wp/37859