### PR TITLE
[38064] Auto-completion window in search bar is short

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.sass
@@ -99,7 +99,7 @@ $search-input-height: 30px
       input
         color: var(--header-search-field-font-color)
 
-    .scroll-host
+    .ng-dropdown-panel-items.scroll-host
       @include styled-scroll-bar
       max-height: 80vh
       height: auto


### PR DESCRIPTION
Specify selector to overwrite ngselect default style

https://community.openproject.org/projects/openproject/work_packages/38064/activity?query_id=2881