### PR TITLE
[38121] Fix logic when datepicker today link is shown

### DIFF
--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.html
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.html
@@ -38,7 +38,9 @@
       </ng-container>
 
       <ng-container *ngIf="!singleDate">
-        <div class="form--field">
+        <div class="form--field"
+             data-qa-selector="datepicker-start-date"
+        >
           <label class="form--label"
                  [textContent]="text.startDate">
           </label>
@@ -67,7 +69,9 @@
             </a>
           </div>
         </div>
-        <div class="form--field">
+        <div class="form--field"
+             data-qa-selector="datepicker-end-date"
+        >
           <label class="form--label"
                  [textContent]="text.endDate">
           </label>
@@ -139,7 +143,7 @@
       data-qa-selector="op-datepicker-modal--action"
       [textContent]="text.cancel"
     ></button>
-    <button 
+    <button
       [attr.disabled]="!this.isSavable || undefined"
       class="op-datepicker-modal--action button -highlight"
       data-qa-selector="op-datepicker-modal--action"

--- a/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
+++ b/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
@@ -245,6 +245,7 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
     }
 
     // Return whatever is on the base.
+    // TODO this needs to be typed
     return this.pristineResource[key];
   }
 

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -70,13 +70,32 @@ describe 'date inplace editor',
 
     start_date.click_today
 
-    start_date.datepicker.expect_year Date.today.year
-    start_date.datepicker.expect_month Date.today.strftime("%B"), true
-    start_date.datepicker.expect_day Date.today.day
+    start_date.datepicker.expect_year Time.zone.today.year
+    start_date.datepicker.expect_month Time.zone.today.strftime("%B"), true
+    start_date.datepicker.expect_day Time.zone.today.day
 
     start_date.save!
     start_date.expect_inactive!
-    start_date.expect_state_text '2016-01-01 - ' + Date.today.strftime('%Y-%m-%d')
+    start_date.expect_state_text "#{Time.zone.today.strftime('%Y-%m-%d')} - no finish date"
+  end
+
+  context 'with the start date empty' do
+    let(:work_package) { FactoryBot.create :work_package, project: project, start_date: nil }
+
+    it 'can set "today" as a date via the provided link' do
+      start_date.activate!
+      start_date.expect_active!
+
+      start_date.click_today
+
+      start_date.datepicker.expect_year Time.zone.today.year
+      start_date.datepicker.expect_month Time.zone.today.strftime("%B"), true
+      start_date.datepicker.expect_day Time.zone.today.day
+
+      start_date.save!
+      start_date.expect_inactive!
+      start_date.expect_state_text "#{Time.zone.today.strftime('%Y-%m-%d')} - no finish date"
+    end
   end
 
   it 'can set start and due date to the same day' do
@@ -84,14 +103,14 @@ describe 'date inplace editor',
     start_date.expect_active!
 
     # Set the due date
-    start_date.datepicker.set_date Date.today, true
+    start_date.datepicker.set_date Time.zone.today, true
     # As the to be selected date is automatically toggled,
     # we can directly set the start date afterwards to the same day
-    start_date.datepicker.set_date Date.today, true
+    start_date.datepicker.set_date Time.zone.today, true
 
     start_date.save!
     start_date.expect_inactive!
-    start_date.expect_state_text Date.today.strftime('%Y-%m-%d') + ' - ' + Date.today.strftime('%Y-%m-%d')
+    start_date.expect_state_text "#{Time.zone.today.strftime('%Y-%m-%d')} - #{Time.zone.today.strftime('%Y-%m-%d')}"
   end
 
   it 'saves the date when clearing and then confirming' do
@@ -165,14 +184,14 @@ describe 'date inplace editor',
 
       # Open date picker
       cf_field.input_element.click
-      datepicker.set_date Date.today
+      datepicker.set_date Time.zone.today
 
       create_page.edit_field(:subject).set_value 'My subject!'
       create_page.save!
       create_page.expect_and_dismiss_notification message: 'Successful creation'
 
       wp = WorkPackage.last
-      expect(wp.custom_value_for(date_cf.id).value).to eq Date.today.iso8601
+      expect(wp.custom_value_for(date_cf.id).value).to eq Time.zone.today.iso8601
     end
   end
 end

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -107,9 +107,9 @@ class DateEditField < EditField
     end
   end
 
-  def click_today
+  def click_today(which: :start)
     within_modal do
-      find('.form--field-extra-actions a', text: 'Today').click
+      find("[data-qa-selector='datepicker-#{which}-date'] .form--field-extra-actions a", text: 'Today').click
     end
   end
 


### PR DESCRIPTION
When the end date is empty, always show the start date today button and vice versa.

[OP#38121](https://community.openproject.org/wp/38121)