### PR TITLE
prevent possible infinite loops by making sure not to re-use errors objects

### DIFF
--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -180,14 +180,13 @@ class ServiceResult
   private
 
   def initialize_errors(errors)
-    self.errors =
-      if errors
-        errors
-      elsif result.respond_to?(:errors)
-        ActiveModel::Errors.new(self).tap { |e| e.merge! result }
-      else
-        ActiveModel::Errors.new(self)
-      end
+    self.errors = errors || new_errors_with_result
+  end
+
+  def new_errors_with_result
+    ActiveModel::Errors.new(self).tap do |errors|
+      errors.merge!(result) if result.respond_to?(:errors)
+    end
   end
 
   def get_message_type

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -184,7 +184,7 @@ class ServiceResult
       if errors
         errors
       elsif result.respond_to?(:errors)
-        result.errors
+        ActiveModel::Errors.new(self).tap { |e| e.merge! result }
       else
         ActiveModel::Errors.new(self)
       end

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -185,7 +185,7 @@ class ServiceResult
 
   def new_errors_with_result
     ActiveModel::Errors.new(self).tap do |errors|
-      errors.merge!(result) if result.respond_to?(:errors)
+      errors.merge!(result) if result.try(:errors).present?
     end
   end
 

--- a/spec/lib/journal_formatter/custom_field_spec.rb
+++ b/spec/lib/journal_formatter/custom_field_spec.rb
@@ -70,6 +70,7 @@ describe OpenProject::JournalFormatter::CustomField do
       let(:expected) do
         I18n.t(:text_journal_changed,
                label: "<strong>#{custom_field.name}</strong>",
+               linebreak: '',
                old: "<i title=\"#{old_formatted_value}\">#{old_formatted_value}</i>",
                new: "<i title=\"#{new_formatted_value}\">#{new_formatted_value}</i>")
       end
@@ -111,6 +112,7 @@ describe OpenProject::JournalFormatter::CustomField do
         I18n.t(:text_journal_changed_plain,
                label: custom_field.name,
                old: format_value(values.first, custom_field),
+               linebreak: '',
                new: format_value(values.last, custom_field))
       end
 
@@ -152,6 +154,7 @@ describe OpenProject::JournalFormatter::CustomField do
       let(:expected) do
         I18n.t(:text_journal_changed,
                label: "<strong>#{I18n.t(:label_deleted_custom_field)}</strong>",
+               linebreak: '',
                old: "<i title=\"#{values.first}\">#{values.first}</i>",
                new: "<i title=\"#{values.last}\">#{values.last}</i>")
       end
@@ -229,6 +232,7 @@ describe OpenProject::JournalFormatter::CustomField do
         let(:expected) do
           I18n.t(:text_journal_changed,
                  label: "<strong>#{custom_field.name}</strong>",
+                 linebreak: '',
                  old: "<i title=\"cf 1, cf 2\">cf 1, cf 2</i>",
                  new: "<i title=\"cf 3, cf 4\">cf 3, cf 4</i>")
         end
@@ -243,6 +247,7 @@ describe OpenProject::JournalFormatter::CustomField do
         let(:expected) do
           I18n.t(:text_journal_changed,
                  label: "<strong>#{custom_field.name}</strong>",
+                 linebreak: '',
                  old: "<i title=\"cf 1, cf 2\">cf 1, cf 2</i>",
                  new: "<i title=\"(deleted option), cf 4\">(deleted option), cf 4</i>")
         end

--- a/spec/services/base_services/behaves_like_delete_service.rb
+++ b/spec/services/base_services/behaves_like_delete_service.rb
@@ -60,7 +60,7 @@ shared_examples 'BaseServices delete service' do
 
   let(:model_destroy_result) { true }
   let(:contract_validate_result) { true }
-  let(:contract_errors) { double(ActiveModel::Errors) }
+  let(:contract_errors) { ActiveModel::Errors.new(instance) }
 
   before do
     allow(model_instance).to receive(:destroy).and_return(model_destroy_result)
@@ -99,7 +99,7 @@ shared_examples 'BaseServices delete service' do
 
     context 'when model cannot be destroyed' do
       let(:model_destroy_result) { false }
-      let(:model_errors) { instance_double(ActiveModel::Errors) }
+      let(:model_errors) { ActiveModel::Errors.new(model_instance) }
 
       it 'is unsuccessful' do
         expect(subject)
@@ -107,11 +107,14 @@ shared_examples 'BaseServices delete service' do
       end
 
       it "returns the user's errors" do
+        model_errors.add :base, 'This is some error.'
+
         allow(model_instance)
           .to(receive(:errors))
           .and_return model_errors
 
         expect(subject.errors).to eql model_errors
+        expect(subject.errors[:base]).to include "This is some error."
       end
     end
   end

--- a/spec/services/service_result_spec.rb
+++ b/spec/services/service_result_spec.rb
@@ -82,6 +82,15 @@ describe ServiceResult, type: :model do
     it 'is an empty ActiveModel::Errors by default' do
       expect(instance.errors).to be_a ActiveModel::Errors
     end
+
+    context 'providing errors from user' do
+      let(:result) { FactoryBot.build :work_package }
+
+      it 'creates a new errors instance' do
+        instance = ServiceResult.new result: result
+        expect(instance.errors).not_to eq result.errors
+      end
+    end
   end
 
   describe 'result' do


### PR DESCRIPTION
`app/services/work_packages/update_ancestors_service.rb:51` may introduce an infinite loop otherwise if
one tries to delete a work package which has validation errors, because this will in the end to the code trying to merge
an error object with itself at `app/services/work_packages/delete_service.rb:43`. This then leads to an infinite loop in the `ActiveModel::Errors` code which keeps importing the same errors over and over again. At some point the system's memory will run out.

Technically an existing work package shouldn't have validation errors but it can happen in certain circumstances, apparently.

~TODO: add a spec~