### PR TITLE
[38325] Using existing gem for email validations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ gem 'semantic', '~> 1.6.1'
 gem 'svg-graph', '~> 2.2.0'
 
 gem 'date_validator', '~> 0.11.0'
+gem 'email_validator', '~> 2.2.3'
 gem 'ruby-duration', '~> 3.2.0'
 
 # provide compatible filesystem information for available storage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -438,6 +438,8 @@ GEM
       eventmachine (>= 1.0.0.beta.4)
     em-synchrony (1.0.6)
       eventmachine (>= 1.0.0.beta.1)
+    email_validator (2.2.3)
+      activemodel
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erbse (0.1.4)
@@ -992,6 +994,7 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.1.5)
   disposable (~> 0.4.7)
   doorkeeper (~> 5.5.0)
+  email_validator (~> 2.2.3)
   equivalent-xml (~> 0.6)
   escape_utils (~> 1.0)
   factory_bot (~> 6.2.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,7 +99,7 @@ class User < Principal
                         :firstname,
                         :lastname,
                         :mail,
-                        unless: Proc.new { |user| user.is_a?(AnonymousUser) || user.is_a?(DeletedUser) || user.is_a?(SystemUser) }
+                        unless: Proc.new { |user| user.builtin? }
 
   validates_uniqueness_of :login, if: Proc.new { |user| !user.login.blank? }, case_sensitive: false
   validates_uniqueness_of :mail, allow_blank: true, case_sensitive: false
@@ -107,7 +107,7 @@ class User < Principal
   validates_format_of :login, with: /\A[a-z0-9_\-@.+ ]*\z/i
   validates_length_of :login, maximum: 256
   validates_length_of :firstname, :lastname, maximum: 256
-  validates_format_of :mail, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, allow_blank: true
+  validates :mail, email: true, unless: Proc.new { |user| user.mail.blank? }
   validates_length_of :mail, maximum: 256, allow_nil: true
   validates_confirmation_of :password, allow_nil: true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -600,6 +600,7 @@ en:
         error_enterprise_only: "is only available in the OpenProject Enterprise Edition"
         error_unauthorized: "may not be accessed."
         error_readonly: "was attempted to be written but is not writable."
+        email: "is not a valid email address."
         empty: "can't be empty."
         even: "must be even."
         exclusion: "is reserved."

--- a/spec/controllers/my_controller_spec.rb
+++ b/spec/controllers/my_controller_spec.rb
@@ -179,7 +179,7 @@ describe MyController, type: :controller do
         end
 
         it 'shows a flash error' do
-          expect(flash[:error]).to include 'Email is invalid.'
+          expect(flash[:error]).to include 'Email is not a valid email address.'
           expect(request.path).to eq(my_settings_path)
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -114,6 +114,17 @@ describe User, type: :model do
       expect(user.mail)
         .to eql 'foo@bar.com'
     end
+
+    it 'validates for local mails' do
+      user.mail = 'foobar@abc.def.some-internet'
+      expect(user).to be_valid
+    end
+
+    it 'invalidates wrong mails' do
+      user.mail = 'foobar+abc.def.some-internet'
+      expect(user).not_to be_valid
+      expect(user.errors[:mail]).to include 'is not a valid email address.'
+    end
   end
 
   describe '#login' do

--- a/spec/services/users/update_service_spec.rb
+++ b/spec/services/users/update_service_spec.rb
@@ -53,7 +53,7 @@ describe Users::UpdateService do
         update_user.reload
         expect(update_user.mail).to eq('correct@example.org')
 
-        expect(subject.errors.symbols_for(:mail)).to match_array(%i[invalid])
+        expect(subject.errors.symbols_for(:mail)).to match_array(%i[email])
       end
     end
 


### PR DESCRIPTION
Our email validation is too strict for RFC compliant emails.
Instead of trying to do it ourselves (email validation regexps are hard!),
let's just use a gem to do that for us.

Note: The gem also has a strict mode that could be optionally enabled. This however results in some emails on community to become invalid. I left it on the default mode for now.

https://community.openproject.org/work_packages/38325