### PR TITLE
[38324] Results in quick-search overlap

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search.component.sass
@@ -1,3 +1,5 @@
+@import "src/assets/sass/helpers"
+
 .global-search
   flex-grow: 1
 
@@ -18,6 +20,7 @@
     display: flex
     flex-direction: column
     flex-grow: 1
+    overflow: hidden
 
   &--search-term
     flex-grow: 1
@@ -46,6 +49,7 @@
 
   &--wp-project
     grid-area: project
+    @include text-shortener
 
   &--wp-id
     grid-area: idlink
@@ -63,7 +67,6 @@
   &--wp-subject
     font-weight: bold
     display: inline-block
-    width: 85%
     overflow: hidden
     white-space: nowrap
     text-overflow: ellipsis


### PR DESCRIPTION
Shorten too long results on the global search and give subjects the whole available width.

[OP#38324](https://community.openproject.org/projects/openproject/work_packages/38324/activity)
