### PR TITLE
[38337] Onboarding tour does not start when closing the language section modal 

### DIFF
--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour_trigger.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour_trigger.ts
@@ -4,6 +4,7 @@ import {
   demoProjectsLinks,
   OnboardingTourNames,
   onboardingTourStorageKey,
+  waitForElement,
 } from 'core-app/core/setup/globals/onboarding/helpers';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 
@@ -31,10 +32,12 @@ export function detectOnboardingTour():void {
       currentTourPart = '';
       sessionStorage.setItem(onboardingTourStorageKey, 'readyToStart');
 
-      // Start automatically when the language selection is closed
-      jQuery('.op-modal--close-button').click(() => {
-        tourCancelled = true;
-        void triggerTour('homescreen');
+      waitForElement('.onboarding-modal .op-modal--close-button', 'body', () => {
+        // Start automatically when the language selection is closed
+        jQuery('.op-modal--close-button').click(() => {
+          tourCancelled = true;
+          void triggerTour('homescreen');
+        });
       });
 
       // Start automatically when the escape button is pressed


### PR DESCRIPTION
Wait for close icon to appear before registering the click handler

[OP#38337](https://community.openproject.org/projects/openproject/work_packages/38337/activity)