### PR TITLE
[38104] Notification button misaligned in Safari

### DIFF
--- a/frontend/src/global_styles/content/_forms.sass
+++ b/frontend/src/global_styles/content/_forms.sass
@@ -832,6 +832,8 @@ input[readonly].-clickable
 
 .form--field-inline-buttons-container
   white-space: nowrap
+  display: flex
+
   .form--field-inline-button
     margin-right: 0
     border: 1px solid var(--button--border-color)


### PR DESCRIPTION
Add flexbox for Safari to correctly align the buttons

[OP#38104](https://community.openproject.org/projects/openproject/work_packages/38104/activity)