### PR TITLE
[38082] On mobile (iOS) icon to close IAN not shown

### DIFF
--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.sass
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.sass
@@ -19,3 +19,9 @@
     margin-bottom: 0
     text-align: center
     font-style: italic
+
+:host
+  .-browser-safari &
+    // Because of Safari's viewport bug, the address bar overlaps content with height: 100vh
+    // Check #38082 before changing it
+    height: 100%


### PR DESCRIPTION
Add special rule for Safari to avoid that the address bar overlaps the close icon of the IAN


https://community.openproject.org/projects/openproject/work_packages/38082/activity