### PR TITLE
[38097] User who has permission to edit a project but not to select modules, can see modules

### DIFF
--- a/app/helpers/project_settings_helper.rb
+++ b/app/helpers/project_settings_helper.rb
@@ -40,6 +40,7 @@ module ProjectSettingsHelper
       {
         name: 'modules',
         action: { controller: '/project_settings/modules', action: 'show' },
+        if: ->(project) { User.current.allowed_to?(:select_project_modules, project) },
         label: :label_module_plural
       },
       {

--- a/spec/features/projects/modules_spec.rb
+++ b/spec/features/projects/modules_spec.rb
@@ -101,4 +101,22 @@ describe 'Projects module administration',
     expect(page)
       .to have_checked_field 'Work package tracking'
   end
+
+  context 'with a user who does not have the correct permissions (#38097)' do
+    let(:user_without_permission) do
+      FactoryBot.create(:user,
+                        member_in_project: project,
+                        member_with_permissions: %i(edit_project))
+    end
+
+    before do
+      login_as user_without_permission
+      settings_page.visit_tab!('generic')
+    end
+
+    it "I can't see the modules menu item" do
+      expect(page)
+        .not_to have_selector('[data-name="settings_modules"]')
+    end
+  end
 end


### PR DESCRIPTION
Don't allow users without permission  to see the project modules list

[OP#38097](https://community.openproject.org/projects/openproject/work_packages/38097/activity)