### PR TITLE
[34288] Buttons on form configuration displayed on left instead of right side

### DIFF
--- a/frontend/src/app/features/admin/types/type-form-configuration.html
+++ b/frontend/src/app/features/admin/types/type-form-configuration.html
@@ -1,5 +1,5 @@
 <div class="toolbar-container -with-dropdown">
-  <div class="toolbar">
+  <div class="toolbar toolbar_empty-title">
     <ul class="toolbar-items">
       <li class="toolbar-item">
         <button type="button -alt-highlight"

--- a/frontend/src/global_styles/layout/_toolbar.sass
+++ b/frontend/src/global_styles/layout/_toolbar.sass
@@ -73,6 +73,9 @@ $nm-color-success-background: #d8fdd1
   flex-wrap: wrap
   align-items: flex-start
 
+  &_empty-title
+    justify-content: flex-end
+
 // automatically clear the toolbar
 .toolbar:after
   clear: both


### PR DESCRIPTION
Show toolbar buttons always on the right, even if the title is empty

[OP#34288](https://community.openproject.org/projects/openproject/work_packages/34288/activity)