### PR TITLE
[34832] Wrong symbol (prohibition sign) when hovering over "Spent time" in the work packages details view

### DIFF
--- a/frontend/src/app/shared/components/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -55,7 +55,12 @@ export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
     const link = document.createElement('a');
     link.textContent = displayText;
     link.setAttribute('title', this.text.linkTitle);
-    link.setAttribute('class', 'time-logging--value');
+
+    if (displayText === this.placeholder) {
+      link.setAttribute('class', 'time-logging--value time-logging--value_empty');
+    } else {
+      link.setAttribute('class', 'time-logging--value');
+    }
 
     if (this.resource.project) {
       const wpID = this.resource.id.toString();

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -140,7 +140,7 @@
 // Mark focused, non-editable read-values
 // Special handling for spent time field, as the logTime link should not be highlighted
 .inline-edit--display-field:not(.id):not(.spentTime).-read-only,
-.inline-edit--display-field.spentTime.-read-only .time-logging--value
+.inline-edit--display-field.spentTime.-read-only .time-logging--value_empty
   cursor: not-allowed
 
   &:focus, &:hover


### PR DESCRIPTION
Show normal cursor when hovering over spent time display field with a value. Empty fields still have the "not-allowed" cursor to prevent that users click on the link when they want to log time.

[OP#34832](https://community.openproject.org/projects/openproject/work_packages/34832/activity)