### PR TITLE
[38361] Sort wiki menu items by title

### DIFF
--- a/app/models/menu_items/wiki_menu_item.rb
+++ b/app/models/menu_items/wiki_menu_item.rb
@@ -34,7 +34,7 @@ class MenuItems::WikiMenuItem < MenuItem
   scope :main_items, ->(wiki_id) {
     where(navigatable_id: wiki_id, parent_id: nil)
       .includes(:children)
-      .order(Arel.sql('id ASC'))
+      .order(Arel.sql('title ASC'))
   }
 
   def slug

--- a/lib/redmine/menu_manager/wiki_menu_helper.rb
+++ b/lib/redmine/menu_manager/wiki_menu_helper.rb
@@ -50,7 +50,6 @@ module Redmine::MenuManager::WikiMenuHelper
               { controller: '/wiki', action: 'show', id: main_item.slug },
               param: :project_id,
               caption: main_item.title,
-              after: :repository,
               icon: 'icon2 icon-wiki',
               html: { class: 'wiki-menu--main-item' }
 


### PR DESCRIPTION
By forcing them to appear after repository, the ordering of the pages is lost. Instead, actively sort them by their title and remove the menu ordering. This means they will appear a bit later in the menu tree, but correctly sorted.

https://community.openproject.org/wp/38361