### PR TITLE
[38365] Fix display of broken backend notification settings

### DIFF
--- a/frontend/src/app/features/user-preferences/notifications-settings/row/notification-setting-row.component.html
+++ b/frontend/src/app/features/user-preferences/notifications-settings/row/notification-setting-row.component.html
@@ -1,6 +1,6 @@
 <td
     *ngIf="first"
-    rowspan="3"
+    [attr.rowspan]="count"
 >
   <span
       *ngIf="setting._links.project.href; else defaultTitle"
@@ -53,7 +53,7 @@
 </td>
 <td
     *ngIf="first"
-    rowspan="3"
+    [attr.rowspan]="count"
     class="buttons"
 >
   <button

--- a/frontend/src/app/features/user-preferences/notifications-settings/row/notification-setting-row.component.ts
+++ b/frontend/src/app/features/user-preferences/notifications-settings/row/notification-setting-row.component.ts
@@ -7,12 +7,15 @@ import { NotificationSetting } from 'core-app/features/user-preferences/state/no
 import { UserPreferencesStore } from 'core-app/features/user-preferences/state/user-preferences.store';
 
 @Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
   selector: '[op-notification-setting-row]',
   templateUrl: './notification-setting-row.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NotificationSettingRowComponent implements OnInit {
   @Input() first = false;
+
+  @Input() count:number;
 
   @Input() setting:NotificationSetting;
 

--- a/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.html
+++ b/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.html
@@ -62,6 +62,7 @@
               op-notification-setting-row
               [attr.data-qa-notification-project]="item.key"
               [attr.data-qa-notification-channel]="setting.channel"
+              [count]="item.value.length"
               [first]="first"
               [setting]="setting"
           >


### PR DESCRIPTION
This doesn't assume we always have three rows, even though we should.
The backend should ensure the settings are correct. Still, we can at
least render robustly.

https://community.openproject.org/wp/38365


Before
![image](https://user-images.githubusercontent.com/459462/127976032-1094c16e-8a90-472f-861c-09436dc14b1f.png)

After
![2021-08-03_09-31](https://user-images.githubusercontent.com/459462/127976011-d856fcb2-6e99-4d9f-bc8d-ec90a1205300.png)

Each project should have three channels, but somehow Wieland has projects with only the email channel
