### PR TITLE
Prevent self-assignment of work package parent

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -117,6 +117,7 @@ module WorkPackages
     validate :validate_parent_exists
     validate :validate_parent_in_same_project
     validate :validate_parent_not_subtask
+    validate :validate_parent_not_self
 
     validate :validate_status_exists
     validate :validate_status_transition
@@ -228,6 +229,13 @@ module WorkPackages
       if model.parent.is_a?(WorkPackage::InexistentWorkPackage)
 
         errors.add :parent, :does_not_exist
+      end
+    end
+
+    def validate_parent_not_self
+      if model.parent == model
+
+        errors.add :parent, :cannot_be_self_assigned
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -761,6 +761,7 @@ en:
               not_start_date: "is not on start date, although this is required for milestones."
             parent:
               cannot_be_milestone: "cannot be a milestone."
+              cannot_be_self_assigned: "cannot be assigned to itself."
               cannot_be_in_another_project: "cannot be in another project."
               not_a_valid_parent: "is invalid."
             start_date:

--- a/modules/backlogs/spec/contracts/work_packages/base_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/work_packages/base_contract_spec.rb
@@ -430,7 +430,7 @@ describe WorkPackages::BaseContract, type: :model do
       let(:work_package) { story }
 
       describe 'WITH a story as its parent' do
-        let(:parent) { story }
+        let(:parent) { story2 }
 
         it_behaves_like 'project id unrestricted by parent'
       end

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -579,6 +579,15 @@ describe WorkPackages::BaseContract do
       contract.errors.symbols_for(:base)
     end
 
+    context 'when self assigning' do
+      let(:parent) { work_package }
+
+      it 'returns an error for the aparent' do
+        expect(contract.validate).to eq false
+        expect(contract.errors.symbols_for(:parent)).to eq [:cannot_be_self_assigned]
+      end
+    end
+
     context 'a relation exists between the parent and its ancestors and the work package and its descendants' do
       let(:parent) { child }
 


### PR DESCRIPTION
The backend doesn't prevent parent self assignment of a work package. I triggered this by accident through an API call and this resulted in an endless loop.