### PR TITLE
[38518] Back button is misplaced on mobile

### DIFF
--- a/frontend/src/app/features/work-packages/components/back-routing/back-button.component.sass
+++ b/frontend/src/app/features/work-packages/components/back-routing/back-button.component.sass
@@ -9,10 +9,11 @@
     font-size: 1rem
     line-height: 22px
 
-  @media only screen and (max-width: 679px)
-    // Move button in the current reverse order to front
-    position: absolute
-    top: 0
-    left: 0
-    z-index: 1
-    width: 100%
+  &_mobile-full-width
+    @media only screen and (max-width: 679px)
+      // Move button in the current reverse order to front
+      position: absolute
+      top: 0
+      left: 0
+      z-index: 1
+      width: 100%

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -9,7 +9,10 @@
       <div id="toolbar">
         <div class="wp-show--header-container">
 
-          <op-back-button linkClass="work-packages-back-button"></op-back-button>
+          <op-back-button
+            linkClass="work-packages-back-button op-back-button_mobile-full-width"
+          >
+          </op-back-button>
 
           <div class="subject-header">
             <wp-subject></wp-subject>


### PR DESCRIPTION
Apply special styles for mobile back button only on WP page as it is the only page that can handle these special rules. All others break with that styling

https://community.openproject.org/projects/openproject/work_packages/38518/activity