### PR TITLE
introduce resourceId and resourceType filter

### DIFF
--- a/app/models/queries/notifications/filters/resource_id_filter.rb
+++ b/app/models/queries/notifications/filters/resource_id_filter.rb
@@ -2,13 +2,13 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2020 the OpenProject GmbH
+# Copyright (C) 2012-2021 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
 #
 # OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
-# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2006-2013 Jean-Philippe Lang
 # Copyright (C) 2010-2013 the ChiliProject Team
 #
 # This program is free software; you can redistribute it and/or
@@ -28,19 +28,14 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Queries::Notifications
-  [Queries::Notifications::Filters::ReadIanFilter,
-   Queries::Notifications::Filters::IdFilter,
-   Queries::Notifications::Filters::ResourceIdFilter,
-   Queries::Notifications::Filters::ResourceTypeFilter].each do |filter|
-    Queries::Register.filter Queries::Notifications::NotificationQuery,
-                             filter
+class Queries::Notifications::Filters::ResourceIdFilter < Queries::Notifications::Filters::NotificationFilter
+  def allowed_values
+    WorkPackage
+      .visible(User.current)
+      .pluck(:id, :id)
   end
 
-  [Queries::Notifications::Orders::DefaultOrder,
-   Queries::Notifications::Orders::ReasonOrder,
-   Queries::Notifications::Orders::ReadIanOrder].each do |order|
-    Queries::Register.order Queries::Notifications::NotificationQuery,
-                            order
+  def type
+    :list
   end
 end

--- a/app/models/queries/notifications/filters/resource_type_filter.rb
+++ b/app/models/queries/notifications/filters/resource_type_filter.rb
@@ -2,13 +2,13 @@
 
 #-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2012-2020 the OpenProject GmbH
+# Copyright (C) 2012-2021 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
 #
 # OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
-# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2006-2013 Jean-Philippe Lang
 # Copyright (C) 2010-2013 the ChiliProject Team
 #
 # This program is free software; you can redistribute it and/or
@@ -28,19 +28,12 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module Queries::Notifications
-  [Queries::Notifications::Filters::ReadIanFilter,
-   Queries::Notifications::Filters::IdFilter,
-   Queries::Notifications::Filters::ResourceIdFilter,
-   Queries::Notifications::Filters::ResourceTypeFilter].each do |filter|
-    Queries::Register.filter Queries::Notifications::NotificationQuery,
-                             filter
+class Queries::Notifications::Filters::ResourceTypeFilter < Queries::Notifications::Filters::NotificationFilter
+  def allowed_values
+    [[WorkPackage.name, WorkPackage.name]]
   end
 
-  [Queries::Notifications::Orders::DefaultOrder,
-   Queries::Notifications::Orders::ReasonOrder,
-   Queries::Notifications::Orders::ReadIanOrder].each do |order|
-    Queries::Register.order Queries::Notifications::NotificationQuery,
-                            order
+  def type
+    :list
   end
 end

--- a/spec/requests/api/v3/notifications/index_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/index_resource_spec.rb
@@ -37,9 +37,14 @@ describe ::API::V3::Notifications::NotificationsAPI,
 
   include API::V3::Utilities::PathHelper
 
-  shared_let(:recipient) { FactoryBot.create :user }
-  shared_let(:notification1) { FactoryBot.create :notification, recipient: recipient }
-  shared_let(:notification2) { FactoryBot.create :notification, recipient: recipient }
+  shared_let(:work_package) { FactoryBot.create :work_package }
+  shared_let(:recipient) do
+    FactoryBot.create :user,
+                      member_in_project: work_package.project,
+                      member_with_permissions: %i[view_work_packages]
+  end
+  shared_let(:notification1) { FactoryBot.create :notification, recipient: recipient, resource: work_package }
+  shared_let(:notification2) { FactoryBot.create :notification, recipient: recipient, resource: work_package }
 
   let(:notifications) { [notification1, notification2] }
 
@@ -85,6 +90,34 @@ describe ::API::V3::Notifications::NotificationsAPI,
               'operator' => '=',
               'values' => ['f']
 
+            }
+          }
+        ]
+      end
+
+      context 'with the filter being set to false' do
+        it_behaves_like 'API V3 collection response', 2, 2, 'Notification' do
+          let(:elements) { [notification2, notification1] }
+        end
+      end
+    end
+
+    context 'with a resource filter' do
+      let(:notification3) { FactoryBot.create :notification, recipient: recipient }
+      let(:notifications) { [notification1, notification2, notification3] }
+
+      let(:filters) do
+        [
+          {
+            'resourceId' => {
+              'operator' => '=',
+              'values' => [work_package.id.to_s]
+            }
+          },
+          {
+            'resourceType' => {
+              'operator' => '=',
+              'values' => [WorkPackage.name.to_s]
             }
           }
         ]


### PR DESCRIPTION
These filters in combination allow filtering notifications via the
associated resource, e.g. a work package. When only using the id filter,
due to the polymorphic association of the resource, it will not be
guaranteed to only return the desired notifications. A different
resource, e.g. a meeting might have the same id.

But using the resourceType filter by itself also makes sense so that a
client can fetch only notifications associated to a subset of resources,
e.g. work packages.

Required for https://community.openproject.org/wp/38339