### PR TITLE
Fix repository breadcrumbs with query string instead of path

### DIFF
--- a/app/views/repositories/_breadcrumbs.html.erb
+++ b/app/views/repositories/_breadcrumbs.html.erb
@@ -44,7 +44,7 @@ dirs.each_with_index do |dir, index|
         <strong><%= h(dir) %></strong>
       <% else %>
         <%= link_to h(dir), action: 'show', project_id: @project,
-                            path: to_path_param(link_path), rev: @rev %>
+                            repo_path: to_path_param(link_path), rev: @rev %>
       <% end %>
 <% end %>
 <%


### PR DESCRIPTION
Missed in 85a1079e25f02b3551d502038fedb60c859648e0

The repository breadcrumbs otherwise contain a useless `path=/repository/path/here` in the query string and just link to the repository root directory.