### PR TITLE
[38549] Re-name ordering settings in activity tab to "Oldest first/Newest first"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1472,7 +1472,7 @@ en:
   label_check_uncheck_all_in_column: "Check/Uncheck all in column"
   label_check_uncheck_all_in_row: "Check/Uncheck all in row"
   label_child_element: "Child element"
-  label_chronological_order: "In chronological order"
+  label_chronological_order: "Oldest first"
   label_close_versions: "Close completed versions"
   label_closed_work_packages: "closed"
   label_collapse: "Collapse"
@@ -1776,7 +1776,7 @@ en:
   label_required: 'required'
   label_requires: 'requires'
   label_result_plural: "Results"
-  label_reverse_chronological_order: "In reverse chronological order"
+  label_reverse_chronological_order: "Newest first"
   label_revision: "Revision"
   label_revision_id: "Revision %{value}"
   label_revision_plural: "Revisions"

--- a/docs/getting-started/my-account/README.md
+++ b/docs/getting-started/my-account/README.md
@@ -86,9 +86,9 @@ Pressing the blue **Save** button will save your changes.
 
 ### Change the order to display comments
 
-You can select the order of the comments (for example of the comments for a work package which appear in the Activity tab). You can select the **chronological** or **reverse chronological order** to display the comments.
+You can select the order of the comments (for example of the comments for a work package which appear in the Activity tab). You can select the **oldest first** or **newest first** to display the comments.
 
-If you choose reverse chronological order the latest comment will appear on top in the Activity list.
+If you choose newest first the latest comment will appear on top in the Activity list.
 
 ![display comments](1572883259523.png)
 

--- a/docs/user-guide/activity/README.md
+++ b/docs/user-guide/activity/README.md
@@ -15,7 +15,7 @@ In OpenProject you can display the activities in a project to gain a quick overv
 **Activity** is defined as a module that displays the actions performed in a project over a certain period of time.
 </div>
 
-The changes are listed in reverse chronological order, with the latest changes appearing on top. Apply a filter (located below the project navigation on the left), to select which attributes are included in the activity.
+The changes are listed in newest first order, with the latest changes appearing on top. Apply a filter (located below the project navigation on the left), to select which attributes are included in the activity.
 
 The activity includes changes to work packages, repository changes, new, wiki entries or forum messages.
 

--- a/docs/user-guide/news/README.md
+++ b/docs/user-guide/news/README.md
@@ -31,7 +31,7 @@ In the News module in the project menu on the left, you will see all news from a
 
 ![news](1567425159667.png)
 
-In the news details, click the **Add a comment** link to comment on the news. Type in your comment and click the blue **Add** button. Your comment, along with all other comments, is then displayed below the news entry description, in reverse chronological order.
+In the news details, click the **Add a comment** link to comment on the news. Type in your comment and click the blue **Add** button. Your comment, along with all other comments, is then displayed below the news entry description, newest first.
 
  ![comment-news](comment-news.png)
 


### PR DESCRIPTION
Renaming the options of its dropdown and the documentations.

https://community.openproject.org/projects/openproject/work_packages/38549/activity