### PR TITLE
Use the pg13 branch of the postgres packager addon

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -39,7 +39,7 @@ installer: https://github.com/pkgr/installer.git
 wizards:
   - https://github.com/pkgr/addon-legacy-installer.git
   - ./packaging/addons/openproject-edition
-  - https://github.com/opf/addon-postgres
+  - https://github.com/opf/addon-postgres#pg13
   - https://github.com/pkgr/addon-apache2.git
   - ./packaging/addons/repositories
   - https://github.com/pkgr/addon-smtp.git


### PR DESCRIPTION
We don't yet merge the `pg13` branch of the addon into `master` since new packages built for current stable versions of OpenProject would then inherit the pg13 default, which we do not (yet) want.