### PR TITLE
check migrations in initializer to speed up boot process

### DIFF
--- a/config/initializers/06-pending_migrations_check.rb
+++ b/config/initializers/06-pending_migrations_check.rb
@@ -1,0 +1,40 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+# We want to abort booting when there are missing migrations by default
+# since it can lead to runtime schema cache issues.
+# Refusing to boot will encourage admins to fix missing migrations.
+
+exceptions = %w(db:create db:drop db:migrate db:structure:load db:schema:load)
+is_console = Rails.const_defined? 'Console'
+
+if Rails.env.production? && !is_console && (exceptions & ARGV).empty?
+  ActiveRecord::Migration.check_pending! # will raise an exception and abort boot
+end

--- a/docker/prod/migration_status
+++ b/docker/prod/migration_status
@@ -1,4 +1,0 @@
-#!/bin/bash -e
-
-echo "Checking migration status..."
-bundle exec rails runner 'ActiveRecord::Migration.check_pending!'

--- a/docker/prod/web
+++ b/docker/prod/web
@@ -15,8 +15,6 @@ fi
 if [ "$MIGRATE" = "true" ]; then
 	echo "Migrating database..."
 	bundle exec rake db:migrate
-else
-	$APP_PATH/docker/prod/migration_status # abort if there are pending migrations
 fi
 
 # see `config/puma.rb` for configuration

--- a/docker/prod/worker
+++ b/docker/prod/worker
@@ -5,6 +5,4 @@ if [ "$1" = "--seed" ]; then
 	$APP_PATH/docker/prod/seeder "$@"
 fi
 
-$APP_PATH/docker/prod/migration_status # abort if there are pending migrations
-
 QUIET=true bundle exec rake jobs:work


### PR DESCRIPTION
This is related to WP [#35673](https://community.openproject.org/projects/openproject/work_packages/35673/activity). The original solution starts a new process before starting the actual rails server. This is quite slow (taking up to 30s before the server is even tried to start).

This can lead to some issues with the health check when the processes take too long to boot in the docker setup.
Hence this PR aims to remove the extra time by checking for pending migrations in-process in an initializer to speed things up considerably.