### PR TITLE
prevent author watcher on work package copy

### DIFF
--- a/app/services/work_packages/copy_service.rb
+++ b/app/services/work_packages/copy_service.rb
@@ -56,6 +56,7 @@ class WorkPackages::CopyService
     copied = create(attributes, send_notifications)
 
     if copied.success?
+      remove_author_watcher(copied.result)
       copy_watchers(copied.result)
     end
 
@@ -82,6 +83,10 @@ class WorkPackages::CopyService
 
   def writable_work_package_attributes(wp)
     instantiate_contract(wp, user).writable_attributes
+  end
+
+  def remove_author_watcher(copied)
+    copied.remove_watcher(copied.author)
   end
 
   def copy_watchers(copied)

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -482,10 +482,10 @@ describe Projects::CopyService, 'integration', type: :model do
             source.work_packages << wp
           end
 
-          it 'does copy active watchers' do
+          it 'does copy active watchers but does not add the copying user as a watcher' do
             expect(subject).to be_success
             expect(project_copy.work_packages[0].watcher_users)
-              .to match_array([current_user, watcher])
+              .to match_array([watcher])
           end
         end
 
@@ -501,9 +501,9 @@ describe Projects::CopyService, 'integration', type: :model do
             source.work_packages << wp
           end
 
-          it 'does not copy locked watchers but adds the copying user as a watcher' do
+          it 'does not copy locked watchers and does not add the copying user as a watcher' do
             expect(subject).to be_success
-            expect(project_copy.work_packages[0].watcher_users).to eq([current_user])
+            expect(project_copy.work_packages[0].watcher_users).to be_empty
           end
         end
 

--- a/spec/services/work_packages/copy_service_integration_spec.rb
+++ b/spec/services/work_packages/copy_service_integration_spec.rb
@@ -84,13 +84,30 @@ describe WorkPackages::CopyService, 'integration', type: :model do
       it { is_expected.not_to eq(work_package.id) }
     end
 
-    describe 'to the same project' do
+    context 'with the same project' do
       it_behaves_like 'copied work package'
 
-      context 'project' do
+      describe '#project' do
         subject { copy.project }
 
         it { is_expected.to eq(source_project) }
+      end
+
+      describe 'copied watchers' do
+        let(:watcher_user) do
+          FactoryBot.create(:user,
+                            member_in_project: source_project,
+                            member_with_permissions: %i(view_work_packages))
+        end
+
+        before do
+          work_package.add_watcher(watcher_user)
+        end
+
+        it 'copies the watcher and does not add the copying user as a watcher' do
+          expect(copy.watcher_users)
+            .to match_array([watcher_user])
+        end
       end
     end
 


### PR DESCRIPTION
Newly created work packages get their author assigned as a watcher. When copying, this would mean that the copying user is now watcher in all of the copied work packages. This PR changes the behaviour to only include the user as a watcher if that user was also watching the source work package.

https://community.openproject.org/wp/37799