### PR TITLE
Feature/37824 remove option to get notified about changes that i make myself

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -74,7 +74,7 @@ class ApplicationMailer < ActionMailer::Base
     end
 
     def remove_self_notifications(message, author)
-      if author.pref && author.pref[:no_self_notified] && message.to.present?
+      if author.pref && message.to.present?
         message.to = message.to.reject { |address| address == author.mail }
       end
     end

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -59,14 +59,6 @@ class UserPreference < ApplicationRecord
     comments_sorting == 'desc'
   end
 
-  def self_notified?
-    !others[:no_self_notified]
-  end
-
-  def self_notified=(value)
-    others[:no_self_notified] = !value
-  end
-
   def auto_hide_popups=(value)
     others[:auto_hide_popups] = to_boolean(value)
   end
@@ -116,7 +108,7 @@ class UserPreference < ApplicationRecord
   end
 
   def init_other_preferences
-    self.others ||= { no_self_notified: true }
+    self.others ||= {}
   end
 
   def time_zone_correctness

--- a/app/services/notifications/create_from_model_service.rb
+++ b/app/services/notifications/create_from_model_service.rb
@@ -272,7 +272,7 @@ class Notifications::CreateFromModelService
   end
 
   def remove_self_recipient(receivers)
-    receivers.delete(user_with_fallback.id) if !user_with_fallback.pref.self_notified?
+    receivers.delete(user_with_fallback.id)
   end
 
   def receivers_hash

--- a/app/workers/mails/watcher_job.rb
+++ b/app/workers/mails/watcher_job.rb
@@ -54,7 +54,7 @@ class Mails::WatcherJob < Mails::DeliverJob
   end
 
   def notify_about_watcher_changed?
-    return false if notify_about_self_watching?
+    return false if self_watching?
     return false unless UserMailer.perform_deliveries
 
     settings = watcher
@@ -67,8 +67,8 @@ class Mails::WatcherJob < Mails::DeliverJob
     settings.watched || settings.all
   end
 
-  def notify_about_self_watching?
-    watcher.user == sender && !sender.pref.self_notified?
+  def self_watching?
+    watcher.user == sender
   end
 
   def action

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -593,7 +593,6 @@ en:
         already_selected: 'This project is already selected'
         remove_projects: 'Remove notifications for projects'
         title: "Notification settings"
-        self_notify: "I want to be notified of changes that I make myself"
 
     password_confirmation:
       field_description: 'You need to enter your account password to confirm this change.'

--- a/docs/api/apiv3/components/schemas/user_preference_model.yml
+++ b/docs/api/apiv3/components/schemas/user_preference_model.yml
@@ -11,9 +11,6 @@ properties:
   notifications:
     type: NotificationSetting
     description: The settings for the notifications to be received by the user
-  selfNotified:
-    type: boolean
-    description: Whether the user wants to be notfified of changes done by the user her/himself
   timeZone:
     type: string
     description: Current selected time zone

--- a/docs/api/apiv3/tags/userpreferences.yml
+++ b/docs/api/apiv3/tags/userpreferences.yml
@@ -14,7 +14,6 @@ description: |-
   | autoHidePopups         | Whether to hide popups (e.g. success messages) after 5 seconds                  | Boolean             |             | READ / WRITE         |
   | hideMail               | Hide mail address from other users                                              | Boolean             |             | READ / WRITE         |
   | notifications          | The settings for the notifications to be received by the user                   | NotificationSetting |             | READ / WRITE         |
-  | selfNotified           | Whether the user wants to be notfified of changes done by the user her/himself  | Boolean             |             | READ / WRITE         |
   | timeZone               | Current selected time zone                                                      | String              |             | READ / WRITE         |
   | commentSortDescending  | Sort comments in descending order                                               | Boolean             |             | READ / WRITE         |
   | warnOnLeavingUnsaved   | Issue warning when leaving a page with unsaved text                             | Boolean             |             | READ / WRITE         |

--- a/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.html
+++ b/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.html
@@ -4,24 +4,6 @@
     [userId]="userId"
 ></op-notification-settings-table>
 
-<fieldset class="form--fieldset form--section">
-  <legend class="form--fieldset-legend">
-    {{ text.advanced_settings }}
-  </legend>
-  <op-form-field
-      class="op-form-field_checkbox"
-      [noWrapLabel]="false"
-      [label]="text.self_notify"
-  >
-    <input
-        slot="input"
-        type="checkbox"
-        [checked]="(preferences$ | async).selfNotified"
-        (change)="updateNotified($event.target.checked)"
-    />
-  </op-form-field>
-</fieldset>
-
 <div class="generic-table--action-buttons">
   <button
       class="button -highlight"

--- a/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.ts
+++ b/frontend/src/app/features/user-preferences/notifications-settings/page/notifications-settings-page.component.ts
@@ -6,7 +6,6 @@ import { CurrentUserService } from 'core-app/core/current-user/current-user.serv
 import { take } from 'rxjs/internal/operators/take';
 import { UIRouterGlobals } from '@uirouter/core';
 import { UserPreferencesService } from 'core-app/features/user-preferences/state/user-preferences.service';
-import { UserPreferencesStore } from 'core-app/features/user-preferences/state/user-preferences.store';
 import { UserPreferencesQuery } from 'core-app/features/user-preferences/state/user-preferences.query';
 
 export const myNotificationsPageComponentSelector = 'op-notifications-page';
@@ -19,21 +18,16 @@ export const myNotificationsPageComponentSelector = 'op-notifications-page';
 export class NotificationsSettingsPageComponent implements OnInit {
   @Input() userId:string;
 
-  preferences$ = this.query.preferences$;
-
   text = {
     save: this.I18n.t('js.button_save'),
     email: this.I18n.t('js.notifications.email'),
     inApp: this.I18n.t('js.notifications.in_app'),
     default_all_projects: this.I18n.t('js.notifications.settings.default_all_projects'),
-    advanced_settings: this.I18n.t('js.forms.advanced_settings'),
-    self_notify: this.I18n.t('js.notifications.settings.self_notify'),
   };
 
   constructor(
     private I18n:I18nService,
     private stateService:UserPreferencesService,
-    private store:UserPreferencesStore,
     private query:UserPreferencesQuery,
     private currentUserService:CurrentUserService,
     private uiRouterGlobals:UIRouterGlobals,
@@ -55,9 +49,5 @@ export class NotificationsSettingsPageComponent implements OnInit {
   public saveChanges():void {
     const prefs = this.query.getValue();
     this.stateService.update(this.userId, prefs);
-  }
-
-  updateNotified(checked:boolean) {
-    this.store.update({ selfNotified: checked });
   }
 }

--- a/frontend/src/app/features/user-preferences/state/user-preferences.model.ts
+++ b/frontend/src/app/features/user-preferences/state/user-preferences.model.ts
@@ -6,6 +6,5 @@ export interface UserPreferencesModel {
   hideMail:boolean;
   timeZone:string|null;
   warnOnLeavingUnsaved:boolean;
-  selfNotified:boolean;
   notifications:NotificationSetting[];
 }

--- a/frontend/src/app/features/user-preferences/state/user-preferences.store.ts
+++ b/frontend/src/app/features/user-preferences/state/user-preferences.store.ts
@@ -37,7 +37,6 @@ function createInitialState():UserPreferencesModel {
     hideMail: true,
     timeZone: null,
     warnOnLeavingUnsaved: true,
-    selfNotified: false,
     notifications: [],
   };
 }

--- a/lib/api/v3/user_preferences/user_preference_representer.rb
+++ b/lib/api/v3/user_preferences/user_preference_representer.rb
@@ -65,12 +65,6 @@ module API
                  as: :commentSortDescending
         property :auto_hide_popups
 
-        property :self_notified,
-                 getter: ->(*) { self_notified? },
-                 setter: ->(fragment:, represented:, **) do
-                   represented.no_self_notified = !fragment
-                 end
-
         property :notification_settings,
                  as: :notifications,
                  exec_context: :decorator,

--- a/modules/meeting/app/services/meeting_notification_service.rb
+++ b/modules/meeting/app/services/meeting_notification_service.rb
@@ -15,11 +15,10 @@ class MeetingNotificationService
 
   def send_notifications!(content, action, include_author:)
     author_mail = meeting.author.mail
-    do_not_notify_author = meeting.author.pref[:no_self_notified] && !include_author
 
     recipients_with_errors = []
     meeting.participants.includes(:user).each do |recipient|
-      next if recipient.mail == author_mail && do_not_notify_author
+      next if recipient.mail == author_mail && !include_author
 
       MeetingMailer.send(action, content, content_type, recipient.user).deliver_now
     rescue StandardError => e

--- a/modules/meeting/spec/controllers/meeting_contents_controller_spec.rb
+++ b/modules/meeting/spec/controllers/meeting_contents_controller_spec.rb
@@ -66,32 +66,16 @@ describe MeetingContentsController do
     describe 'notify' do
       let(:action) { 'notify' }
 
-      context 'when author no_self_notified property is true' do
-        before do
-          author.pref[:no_self_notified] = true
-          author.save!
-        end
-
-        it_behaves_like 'delivered by mail' do
-          let(:mail_count) { 2 }
-        end
+      before do
+        author.save!
       end
 
-      context 'when author no_self_notified property is false' do
-        before do
-          author.pref[:no_self_notified] = false
-          author.save!
-        end
-
-        it_behaves_like 'delivered by mail' do
-          let(:mail_count) { 3 }
-        end
+      it_behaves_like 'delivered by mail' do
+        let(:mail_count) { 2 }
       end
 
       context 'with an error during deliver' do
         before do
-          author.pref[:no_self_notified] = false
-          author.save!
           allow(MeetingMailer).to receive(:content_for_review).and_raise(Net::SMTPError)
         end
 
@@ -111,31 +95,16 @@ describe MeetingContentsController do
     describe 'icalendar' do
       let(:action) { 'icalendar' }
 
-      context 'when author no_self_notified property is true' do
-        before do
-          author.pref[:no_self_notified] = true
-          author.save!
-        end
-
-        it_behaves_like 'delivered by mail' do
-          let(:mail_count) { 3 }
-        end
+      before do
+        author.save!
       end
 
-      context 'when author no_self_notified property is false' do
-        before do
-          author.pref[:no_self_notified] = false
-          author.save!
-        end
-
-        it_behaves_like 'delivered by mail' do
-          let(:mail_count) { 3 }
-        end
+      it_behaves_like 'delivered by mail' do
+        let(:mail_count) { 3 }
       end
 
       context 'with an error during deliver' do
         before do
-          author.pref[:no_self_notified] = false
           author.save!
           allow(MeetingMailer).to receive(:content_for_review).and_raise(Net::SMTPError)
         end

--- a/modules/meeting/spec/mailers/meeting_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_mailer_spec.rb
@@ -50,8 +50,6 @@ describe MeetingMailer, type: :mailer do
   end
 
   before do
-    author.pref[:no_self_notified] = false
-    author.save!
     meeting.participants.merge([meeting.participants.build(user: watcher1, invited: true, attended: false),
                                 meeting.participants.build(user: watcher2, invited: true, attended: false)])
     meeting.save!

--- a/spec/controllers/my_controller_spec.rb
+++ b/spec/controllers/my_controller_spec.rb
@@ -155,7 +155,7 @@ describe MyController, type: :controller do
     context 'PATCH' do
       before do
         as_logged_in_user user do
-          user.pref.self_notified = false
+          user.pref.comments_sorting = 'desc'
           user.pref.auto_hide_popups = true
 
           patch :update_settings, params: { user: { language: 'en' }, pref: { auto_hide_popups: 0 } }
@@ -164,7 +164,7 @@ describe MyController, type: :controller do
 
       it 'updates the settings appropriately', :aggregate_failures do
         expect(assigns(:user).language).to eq 'en'
-        expect(assigns(:user).pref.self_notified?).to be_falsey
+        expect(assigns(:user).pref.comments_sorting).to eql 'desc'
         expect(assigns(:user).pref.auto_hide_popups?).to be_falsey
 
         expect(request.path).to eq(my_settings_path)

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -34,11 +34,7 @@ describe NewsController, type: :controller do
   include BecomeMember
 
   let(:user) do
-    user = FactoryBot.create(:admin)
-
-    FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
-
-    user
+    FactoryBot.create(:admin)
   end
   let(:project) { FactoryBot.create(:project) }
   let(:news) { FactoryBot.create(:news) }

--- a/spec/lib/api/v3/user_preferences/user_preference_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/user_preferences/user_preference_representer_parsing_spec.rb
@@ -38,30 +38,6 @@ describe ::API::V3::UserPreferences::UserPreferenceRepresenter,
 
   subject { representer.from_hash request_body }
 
-  describe 'selfNotified' do
-    let(:request_body) do
-      {
-        'selfNotified' => self_notified
-      }
-    end
-
-    context 'with setting true' do
-      let(:self_notified) { true }
-
-      it 'sets no_self_notified to false' do
-        expect(subject.no_self_notified).to eq false
-      end
-    end
-
-    context 'with setting false' do
-      let(:self_notified) { false }
-
-      it 'sets no_self_notified to true' do
-        expect(subject.no_self_notified).to eq true
-      end
-    end
-  end
-
   describe 'notification_settings' do
     let(:request_body) do
       {

--- a/spec/lib/api/v3/user_preferences/user_preference_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/user_preferences/user_preference_representer_rendering_spec.rb
@@ -77,26 +77,6 @@ describe ::API::V3::UserPreferences::UserPreferenceRepresenter,
     end
   end
 
-  describe 'selfNotified' do
-    let(:preference) { FactoryBot.build(:user_preference, others: { no_self_notified: no_self_notified }) }
-
-    context 'with setting true' do
-      let(:no_self_notified) { true }
-
-      it 'renders the property as false' do
-        is_expected.to be_json_eql(false.to_json).at_path('selfNotified')
-      end
-    end
-
-    context 'with setting false' do
-      let(:no_self_notified) { false }
-
-      it 'renders the property as true' do
-        is_expected.to be_json_eql(true.to_json).at_path('selfNotified')
-      end
-    end
-  end
-
   describe 'notification_settings' do
     it 'renders them as a nested array' do
       is_expected.to have_json_type(Array).at_path('notifications')

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -91,11 +91,8 @@ describe UserMailer, type: :mailer do
     end
   end
 
-  shared_examples_for 'does only send mails to author if permitted' do
-    let(:user_preference) do
-      FactoryBot.build(:user_preference, others: { no_self_notified: true })
-    end
-    let(:user) { FactoryBot.build_stubbed(:user, preference: user_preference) }
+  shared_examples_for 'does not send mails to author' do
+    let(:user) { FactoryBot.build_stubbed(:user) }
 
     context 'when mail is for another user' do
       it_behaves_like 'mail is sent'
@@ -205,7 +202,7 @@ describe UserMailer, type: :mailer do
       end
     end
 
-    it_behaves_like 'does only send mails to author if permitted'
+    it_behaves_like 'does not send mails to author'
   end
 
   describe '#work_package_updated' do
@@ -251,7 +248,7 @@ describe UserMailer, type: :mailer do
       end
     end
 
-    it_behaves_like 'does only send mails to author if permitted'
+    it_behaves_like 'does not send mails to author'
   end
 
   describe '#work_package_watcher_changed' do
@@ -278,7 +275,7 @@ describe UserMailer, type: :mailer do
 
     it_behaves_like 'mail is sent'
 
-    it_behaves_like 'does only send mails to author if permitted'
+    it_behaves_like 'does not send mails to author'
   end
 
   describe '#wiki_content_updated' do
@@ -294,7 +291,7 @@ describe UserMailer, type: :mailer do
       expect(deliveries.first.body.encoded).to include 'diff/1'
     end
 
-    it_behaves_like 'does only send mails to author if permitted'
+    it_behaves_like 'does not send mails to author'
   end
 
   describe '#message_posted' do
@@ -328,7 +325,7 @@ describe UserMailer, type: :mailer do
       end
     end
 
-    it_behaves_like 'does only send mails to author if permitted'
+    it_behaves_like 'does not send mails to author'
   end
 
   describe '#account_information' do
@@ -360,7 +357,7 @@ describe UserMailer, type: :mailer do
       end
     end
 
-    it_behaves_like 'does only send mails to author if permitted'
+    it_behaves_like 'does not send mails to author'
   end
 
   describe '#news_comment_added' do
@@ -373,7 +370,7 @@ describe UserMailer, type: :mailer do
 
     it_behaves_like 'mail is sent'
 
-    it_behaves_like 'does only send mails to author if permitted'
+    it_behaves_like 'does not send mails to author'
   end
 
   describe '#password_lost' do
@@ -808,7 +805,7 @@ describe UserMailer, type: :mailer do
                                "en" => 'english header'
                              } } do
       let(:recipient) do
-        FactoryBot.build_stubbed(:user, language: 'de', preferences: { no_self_notified: false })
+        FactoryBot.build_stubbed(:user, language: 'de')
       end
 
       before do
@@ -839,7 +836,7 @@ describe UserMailer, type: :mailer do
                                "en" => 'english header'
                              } } do
       let(:recipient) do
-        FactoryBot.build_stubbed(:user, language: '', preferences: { no_self_notified: false })
+        FactoryBot.build_stubbed(:user, language: '')
       end
 
       before do

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -29,16 +29,13 @@
 require 'spec_helper'
 
 describe UserPreference do
-  let(:user) { FactoryBot.build_stubbed(:user) }
   subject { FactoryBot.build(:user_preference, user: user) }
+
+  let(:user) { FactoryBot.build_stubbed(:user) }
 
   describe 'default settings' do
     it 'hides the email address' do
       expect(subject.hide_mail).to eql(true)
-    end
-
-    it 'activates no self notification' do
-      expect(subject.others[:no_self_notified]).to be_truthy
     end
 
     context 'with default setting auto_hide_popups to false', with_settings: { default_auto_hide_popups: false } do
@@ -131,31 +128,23 @@ describe UserPreference do
     end
   end
 
-  describe 'self_notified getter/setter' do
-    it 'has a getter and a setter for self_notified' do
-      subject.self_notified = false
-      expect(subject.self_notified?).to be_falsey
-      expect(subject[:no_self_notified]).to be_truthy
-    end
-  end
-
   describe '[]=' do
     let(:user) { FactoryBot.create(:user) }
 
-    context 'for attributes stored in "others"' do
+    context 'with attributes stored in "others"' do
       it 'will save the values on sending "save"' do
         subject.save
 
-        value_no_self_notified = !subject[:no_self_notified]
+        value_warn_on_leaving_unsaved = !subject[:warn_on_leaving_unsaved]
         value_auto_hide_popups = !subject[:auto_hide_popups]
 
-        subject[:no_self_notified] = value_no_self_notified
+        subject[:warn_on_leaving_unsaved] = value_warn_on_leaving_unsaved
         subject[:auto_hide_popups] = value_auto_hide_popups
 
         subject.save
         subject.reload
 
-        expect(subject[:no_self_notified]).to eql(value_no_self_notified)
+        expect(subject[:warn_on_leaving_unsaved]).to eql(value_warn_on_leaving_unsaved)
         expect(subject[:auto_hide_popups]).to eql(value_auto_hide_popups)
       end
     end

--- a/spec/requests/api/v3/work_packages/delete_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/delete_resource_spec.rb
@@ -48,7 +48,7 @@ describe 'API v3 Work package resource',
   current_user do
     user = FactoryBot.create(:user, member_in_project: project, member_through_role: role)
 
-    FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
+    FactoryBot.create(:user_preference, user: user)
 
     user
   end

--- a/spec/requests/api/v3/work_packages/dependent_errors_spec.rb
+++ b/spec/requests/api/v3/work_packages/dependent_errors_spec.rb
@@ -79,11 +79,7 @@ describe 'API v3 Work package resource', type: :request, content_type: :json do
   let(:permissions) { %i[view_work_packages edit_work_packages create_work_packages] }
 
   let(:current_user) do
-    user = FactoryBot.create(:user, member_in_project: project, member_through_role: role)
-
-    FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
-
-    user
+    FactoryBot.create(:user, member_in_project: project, member_through_role: role)
   end
 
   let(:dependent_error_result) do

--- a/spec/requests/api/v3/work_packages/index_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/index_resource_spec.rb
@@ -46,11 +46,7 @@ describe 'API v3 Work package resource',
   let(:permissions) { %i[view_work_packages edit_work_packages assign_versions] }
 
   current_user do
-    user = FactoryBot.create(:user, member_in_project: project, member_through_role: role)
-
-    FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
-
-    user
+    FactoryBot.create(:user, member_in_project: project, member_through_role: role)
   end
 
   describe 'GET /api/v3/work_packages' do

--- a/spec/requests/api/v3/work_packages/show_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/show_resource_spec.rb
@@ -49,11 +49,7 @@ describe 'API v3 Work package resource',
   let(:role) { FactoryBot.create(:role, permissions: permissions) }
   let(:permissions) { %i[view_work_packages edit_work_packages assign_versions] }
   let(:current_user) do
-    user = FactoryBot.create(:user, member_in_project: project, member_through_role: role)
-
-    FactoryBot.create(:user_preference, user: user, others: { no_self_notified: false })
-
-    user
+    FactoryBot.create(:user, member_in_project: project, member_through_role: role)
   end
   let(:unauthorize_user) { FactoryBot.create(:user) }
   let(:type) { FactoryBot.create(:type) }

--- a/spec/services/notifications/create_from_journal_job_shared.rb
+++ b/spec/services/notifications/create_from_journal_job_shared.rb
@@ -37,13 +37,9 @@ shared_context 'with CreateFromJournalJob context' do
                       notification_settings: recipient_notification_settings,
                       member_in_project: project,
                       member_through_role: FactoryBot.create(:role, permissions: permissions),
-                      login: recipient_login,
-                      preferences: {
-                        no_self_notified: recipient_no_self_notified
-                      })
+                      login: recipient_login)
   end
   let(:recipient_login) { "johndoe" }
-  let(:recipient_no_self_notified) { true }
   let(:other_user) do
     notification_settings = [
       FactoryBot.build(:mail_notification_setting, **notification_settings_all_false),

--- a/spec/services/notifications/create_from_model_service_work_package_spec.rb
+++ b/spec/services/notifications/create_from_model_service_work_package_spec.rb
@@ -217,7 +217,7 @@ describe Notifications::CreateFromModelService,
       it_behaves_like 'creates no notification'
     end
 
-    context 'when assignee has all notifications enabled but made the change himself and has deactivated self notification' do
+    context 'when assignee has all notifications enabled but made the change himself' do
       let(:recipient_notification_settings) do
         [
           FactoryBot.build(:mail_notification_setting, **notification_settings_all_false.merge(involved: true, all: true)),
@@ -228,31 +228,6 @@ describe Notifications::CreateFromModelService,
       let(:author) { recipient }
 
       it_behaves_like 'creates no notification'
-    end
-
-    context 'when assignee has all notifications enabled, made the change himself and has activated self notification' do
-      let(:recipient_notification_settings) do
-        [
-          FactoryBot.build(:mail_notification_setting, **notification_settings_all_false.merge(involved: true, all: true)),
-          FactoryBot.build(:in_app_notification_setting, **notification_settings_all_false.merge(involved: true, all: true)),
-          FactoryBot.build(:mail_digest_notification_setting, **notification_settings_all_false.merge(involved: true, all: true))
-        ]
-      end
-      let(:author) { recipient }
-      let(:recipient_no_self_notified) { false }
-
-      it_behaves_like 'creates notification' do
-        let(:notification_channel_reasons) do
-          {
-            read_ian: false,
-            reason_ian: :involved,
-            read_mail: false,
-            reason_mail: :involved,
-            read_mail_digest: false,
-            reason_mail_digest: :involved
-          }
-        end
-      end
     end
   end
 
@@ -349,7 +324,7 @@ describe Notifications::CreateFromModelService,
       it_behaves_like 'creates no notification'
     end
 
-    context 'when responsible has all notifications enabled but made the change himself and has deactivated self notification' do
+    context 'when responsible has all notifications enabled but made the change himself' do
       let(:recipient_notification_settings) do
         [
           FactoryBot.build(:mail_notification_setting, involved: true, all: true),
@@ -360,31 +335,6 @@ describe Notifications::CreateFromModelService,
       let(:author) { recipient }
 
       it_behaves_like 'creates no notification'
-    end
-
-    context 'when responsible has all notifications enabled, made the change himself and has activated self notification' do
-      let(:recipient_notification_settings) do
-        [
-          FactoryBot.build(:mail_notification_setting, involved: true, all: true),
-          FactoryBot.build(:mail_digest_notification_setting, involved: true, all: true),
-          FactoryBot.build(:in_app_notification_setting, involved: true, all: true)
-        ]
-      end
-      let(:author) { recipient }
-      let(:recipient_no_self_notified) { false }
-
-      it_behaves_like 'creates notification' do
-        let(:notification_channel_reasons) do
-          {
-            read_ian: false,
-            reason_ian: :involved,
-            read_mail: false,
-            reason_mail: :involved,
-            read_mail_digest: false,
-            reason_mail_digest: :involved
-          }
-        end
-      end
     end
   end
 
@@ -475,7 +425,7 @@ describe Notifications::CreateFromModelService,
       it_behaves_like 'creates no notification'
     end
 
-    context 'when watcher has all notifications enabled but made the change himself and has deactivated self notification' do
+    context 'when watcher has all notifications enabled but made the change himself' do
       let(:recipient_notification_settings) do
         [
           FactoryBot.build(:mail_notification_setting, **notification_settings_all_false.merge(watched: true, all: true)),
@@ -486,31 +436,6 @@ describe Notifications::CreateFromModelService,
       let(:author) { recipient }
 
       it_behaves_like 'creates no notification'
-    end
-
-    context 'when watcher has all notifications enabled, made the change himself and has activated self notification' do
-      let(:recipient_notification_settings) do
-        [
-          FactoryBot.build(:mail_notification_setting, **notification_settings_all_false.merge(watched: true, all: true)),
-          FactoryBot.build(:in_app_notification_setting, **notification_settings_all_false.merge(watched: true, all: true)),
-          FactoryBot.build(:mail_digest_notification_setting, **notification_settings_all_false.merge(watched: true, all: true))
-        ]
-      end
-      let(:author) { recipient }
-      let(:recipient_no_self_notified) { false }
-
-      it_behaves_like 'creates notification' do
-        let(:notification_channel_reasons) do
-          {
-            read_ian: false,
-            reason_ian: :watched,
-            read_mail: false,
-            reason_mail: :watched,
-            read_mail_digest: false,
-            reason_mail_digest: :watched
-          }
-        end
-      end
     end
   end
 
@@ -644,7 +569,7 @@ describe Notifications::CreateFromModelService,
       it_behaves_like 'creates no notification'
     end
 
-    context 'when recipient has all notifications enabled but made the change himself and has deactivated self notification' do
+    context 'when recipient has all notifications enabled but made the change himself' do
       let(:recipient_notification_settings) do
         [
           FactoryBot.build(:mail_notification_setting, all: true),
@@ -655,31 +580,6 @@ describe Notifications::CreateFromModelService,
       let(:author) { recipient }
 
       it_behaves_like 'creates no notification'
-    end
-
-    context 'when recipient has all notifications enabled, made the change himself and has activated self notification' do
-      let(:recipient_notification_settings) do
-        [
-          FactoryBot.build(:mail_notification_setting, all: true),
-          FactoryBot.build(:mail_digest_notification_setting, all: true),
-          FactoryBot.build(:in_app_notification_setting, all: true)
-        ]
-      end
-      let(:author) { recipient }
-      let(:recipient_no_self_notified) { false }
-
-      it_behaves_like 'creates notification' do
-        let(:notification_channel_reasons) do
-          {
-            read_ian: false,
-            reason_ian: :subscribed,
-            read_mail: false,
-            reason_mail: :subscribed,
-            read_mail_digest: false,
-            reason_mail_digest: :subscribed
-          }
-        end
-      end
     end
   end
 
@@ -1248,34 +1148,13 @@ describe Notifications::CreateFromModelService,
           it_behaves_like 'creates no notification'
         end
 
-        context 'when the mentioned user made the change himself and has deactivated self notification' do
+        context 'when the mentioned user made the change himself' do
           let(:note) do
             "Hello user:#{recipient.login}, hey user##{recipient.id}"
           end
           let(:author) { recipient }
 
           it_behaves_like 'creates no notification'
-        end
-
-        context 'when the mentioned user made the change himself, but has activated self notification' do
-          let(:note) do
-            "Hello user:#{recipient.login}, hey user##{recipient.id}"
-          end
-          let(:author) { recipient }
-          let(:recipient_no_self_notified) { false }
-
-          it_behaves_like 'creates notification' do
-            let(:notification_channel_reasons) do
-              {
-                read_ian: false,
-                reason_ian: :mentioned,
-                read_mail: false,
-                reason_mail: :mentioned,
-                read_mail_digest: false,
-                reason_mail_digest: :mentioned
-              }
-            end
-          end
         end
       end
 

--- a/spec/services/users/set_attributes_service_spec.rb
+++ b/spec/services/users/set_attributes_service_spec.rb
@@ -114,14 +114,14 @@ describe Users::SetAttributesService, type: :model do
       let(:params) do
         {
           pref: {
-            self_notified: true
+            auto_hide_popups: true
           }
         }
       end
 
       it 'initializes the user`s preferences with those attributes' do
         expect(call.result.pref)
-          .to be_self_notified
+          .to be_auto_hide_popups
       end
     end
   end

--- a/spec/workers/mails/shared/watcher_job.rb
+++ b/spec/workers/mails/shared/watcher_job.rb
@@ -42,21 +42,15 @@ shared_examples "watcher job" do |action|
   let(:watcher) do
     FactoryBot.build_stubbed(:watcher, watchable: work_package, user: watching_user)
   end
-  let(:self_notified) { true }
   let(:user_pref) do
-    pref = FactoryBot.build_stubbed(:user_preference)
-
-    allow(pref).to receive(:self_notified?).and_return(self_notified)
-
-    pref
+    FactoryBot.build_stubbed(:user_preference)
   end
   let(:notification_settings) do
     [FactoryBot.build_stubbed(:mail_notification_setting, all: true)]
   end
   let(:watching_user) do
     FactoryBot.build_stubbed(:user,
-                             notification_settings: notification_settings,
-                             preference: user_pref).tap do |user|
+                             notification_settings: notification_settings).tap do |user|
       allow(user)
         .to receive(:notification_settings)
               .and_return(notification_settings)
@@ -113,34 +107,14 @@ shared_examples "watcher job" do |action|
   end
 
   shared_examples_for 'notifies the watcher' do
-    context 'when added by a different user
-               and has self_notified activated' do
-      let(:self_notified) { true }
-
+    context 'when added by a different user' do
       it_behaves_like 'sends a mail'
     end
 
-    context 'when added by a different user
-               and has self_notified deactivated' do
-      let(:self_notified) { false }
-
-      it_behaves_like 'sends a mail'
-    end
-
-    context 'but when watcher is added by theirself
-               and has self_notified deactivated' do
+    context 'when watcher is added by theirself' do
       let(:watcher_changer) { watching_user }
-      let(:self_notified) { false }
 
       it_behaves_like 'sends no mail'
-    end
-
-    context 'but when watcher is added by theirself
-               and has self_notified activated' do
-      let(:watcher_changer) { watching_user }
-      let(:self_notified) { true }
-
-      it_behaves_like 'sends a mail'
     end
   end
 
@@ -151,7 +125,6 @@ shared_examples "watcher job" do |action|
 
     context 'when watcher is added by theirself' do
       let(:watcher_changer) { watching_user }
-      let(:self_notified) { false }
 
       it_behaves_like 'sends no mail'
     end

--- a/spec_legacy/fixtures/user_preferences.yml
+++ b/spec_legacy/fixtures/user_preferences.yml
@@ -58,7 +58,6 @@ user_preferences_002:
 user_preferences_003:
   others: |
     ---
-    no_self_notified: false
   id: 3
   user_id: 2
   hide_mail: false

--- a/spec_legacy/unit/mail_handler_spec.rb
+++ b/spec_legacy/unit/mail_handler_spec.rb
@@ -271,16 +271,6 @@ describe MailHandler, type: :model do
     end
   end
 
-  it 'should add work package should send email notification' do
-    User.find(2).notification_settings.create(channel: :mail, all: true)
-
-    # This email contains: 'Project: onlinestore'
-    issue = submit_email('ticket_on_given_project.eml')
-    assert issue.is_a?(WorkPackage)
-    # One for the wp creation.
-    assert_equal 1, ActionMailer::Base.deliveries.size
-  end
-
   it 'should add work package note' do
     journal = submit_email('ticket_reply.eml')
     assert journal.is_a?(Journal)
@@ -318,15 +308,6 @@ describe MailHandler, type: :model do
     # keywords should be removed from the email body
     assert !journal.notes.match(/^Status:/i)
     assert !journal.notes.match(/^Start Date:/i)
-  end
-
-  it 'should add work package note should send email notification' do
-    User.find(2).notification_settings.create(channel: :mail, all: true)
-    User.find(3).notification_settings.create(channel: :mail, involved: true)
-
-    journal = submit_email('ticket_reply.eml')
-    assert journal.is_a?(Journal)
-    assert_equal 2, ActionMailer::Base.deliveries.size
   end
 
   it 'should add work package note should not set defaults' do


### PR DESCRIPTION
Removes the "no_self_notified" user preference so users no longer have the option to receive notifications (regardless of the channel) that was carried out by themselves.

There is no migration removing the preferences already stored as having them still present in the `others` column poses no problem.

https://community.openproject.org/wp/37824