### PR TITLE
increase robustness of journable_type migration

### DIFF
--- a/modules/costs/db/migrate/20210726065912_rename_cost_object_type.rb
+++ b/modules/costs/db/migrate/20210726065912_rename_cost_object_type.rb
@@ -1,5 +1,24 @@
 class RenameCostObjectType < ActiveRecord::Migration[6.1]
   def up
+    execute <<~SQL.squish
+      UPDATE
+        journals
+      SET
+        version = version + max_journal.max_version
+      FROM
+        (SELECT
+           journable_id, MAX(version) max_version
+         FROM
+           journals
+         WHERE
+           journable_type = 'CostObject'
+         GROUP BY journable_id) max_journal
+      WHERE
+        max_journal.journable_id = journals.journable_id
+      AND
+        journals.journable_type = 'Budget'
+    SQL
+
     Journal
       .where(journable_type: 'CostObject')
       .update_all(journable_type: 'Budget')


### PR DESCRIPTION
In case a journal with a journable_type of `Budget` already exists, that journal will have a version that will later on conflict with the unique index on
```
(journable_id, journable_type, version)
```
when renaming all journable_type columns from `CostObject` to `Budget`. 

To prevent the problem, the version of already existing journals with `Budget` are increased by the highest version of their `CostObject` counterparts.

https://community.openproject.org/wp/38525