### PR TITLE
[38633] Unnecessary horizontal scrollbar in activity tab when commenting

### DIFF
--- a/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
@@ -69,7 +69,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
   private resizer:HTMLElement;
 
   // Min-width this element is allowed to have
-  private elementMinWidth = 530;
+  private elementMinWidth = 645;
 
   public moving = false;
 

--- a/frontend/src/global_styles/layout/work_packages/_details_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_details_view.sass
@@ -49,8 +49,8 @@ body.router--work-packages-partitioned-split-view-new
   height: 100%
   position: relative
   width: 100%
-  // Min-width is actually 530px but the border already needs 2px
-  min-width: 528px
+  // Min-width is actually 645px but the border already needs 2px
+  min-width: 643px
 
   @media only screen and (max-width: 1280px)
     @at-root

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -96,7 +96,7 @@
           line-height: calc(var(--work-package-details--tab-height) - 10px)
 
 .work-packages-full-view--split-right
-  min-width: 500px
+  min-width: 645px
   overflow-y: scroll
   overflow-x: auto
   position: relative


### PR DESCRIPTION
The base min-width of the resizer changed to be compatible with the size of ckeditor, because the ckeditor at first overflows (when we saw the scrollbar) then shrinks to be as wide as other elements in the split view.

https://community.openproject.org/projects/openproject/work_packages/38633/activity