### PR TITLE
[38663] Type and subject not aligned when the user is not logged in

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_details_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_details_view.sass
@@ -95,7 +95,6 @@ body.router--work-packages-partitioned-split-view-new
     font-weight: bold
 
   .work-packages--details--subject
-    line-height: 24px
     overflow: hidden
 
     .inline-edit--field

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -190,6 +190,7 @@
 .work-packages--subject-type-row
   display: flex
   position: relative
+  line-height: 24px
 
 .work-packages--type-selector:not(.wp-new-top-row--element)
   .inline-edit--display-field


### PR DESCRIPTION
Setting line-height to the row including subject and type, instead of only subject element when it is not in editable mode.

https://community.openproject.org/projects/openproject/work_packages/38663/activity