### PR TITLE
rebuild positions for tasks

### DIFF
--- a/modules/backlogs/lib/open_project/backlogs/list.rb
+++ b/modules/backlogs/lib/open_project/backlogs/list.rb
@@ -58,7 +58,7 @@ module OpenProject::Backlogs::List
       remove_from_list
       reload
 
-      prev = self.class.find_by_id(prev_id.to_i)
+      prev = self.class.find_by(id: prev_id.to_i)
 
       # If it should be the first story, move it to the 1st position
       if prev.blank?
@@ -146,7 +146,12 @@ module OpenProject::Backlogs::List
     end
 
     def set_default_prev_positions_silently(prev)
-      prev.version.rebuild_positions(prev.project)
+      if prev.is_task?
+        prev.version.rebuild_task_positions(prev)
+      else
+        prev.version.rebuild_story_positions(prev.project)
+      end
+
       prev.reload.position
     end
   end

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
@@ -113,15 +113,16 @@ module OpenProject::Backlogs::Patches::WorkPackagePatch
 
     def story
       if is_story?
-        return Story.find(id)
+        Story.find(id)
       elsif is_task?
-        # Make sure to get the closest ancestor that is a Story, i.e. the one with the highest lft
-        # otherwise, the highest parent that is a Story is returned
-        story_work_package = ancestors.find_by(type_id: Story.types).order(Arel.sql('lft DESC'))
-        return Story.find(story_work_package.id) if story_work_package
+        # Make sure to get the closest ancestor that is a Story
+        ancestors_relations
+          .includes(:from)
+          .where(from: { type_id: Story.types })
+          .order(hierarchy: :asc)
+          .first
+          .from
       end
-
-      nil
     end
 
     def blocks

--- a/modules/backlogs/spec/models/version_spec.rb
+++ b/modules/backlogs/spec/models/version_spec.rb
@@ -127,7 +127,7 @@ describe Version, type: :model do
       expect(work_package1.version_id).to eq(version.id)
     end
 
-    it 'rebuilds postions' do
+    it 'rebuilds positions' do
       e1 = create_work_package(type_id: epic_type.id)
       s2 = create_work_package(type_id: story_type.id)
       s3 = create_work_package(type_id: story_type.id)
@@ -145,7 +145,7 @@ describe Version, type: :model do
       t3.update_column(:position, 3)
       o9.update_column(:position, 9)
 
-      version.rebuild_positions(project)
+      version.rebuild_story_positions(project)
 
       work_packages = version
                       .work_packages


### PR DESCRIPTION
Applies the behaviour of building positions in case they are lacking from stories to tasks. For tasks, only those that are children of the same story need to be rebuild.

https://community.openproject.org/wp/38716