### PR TITLE
[38717] Undesired horizontal scroll bars in relations tab

### DIFF
--- a/frontend/src/global_styles/content/work_packages/_table_relations.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_relations.sass
@@ -42,7 +42,9 @@ body
 
 .relation-row--type
   @include unset-button-styles
+  @include text-shortener
   cursor: default
+  width: 100%
 
 // Reduce padding of relations icon in relation columns
 .relations-header--icon:before


### PR DESCRIPTION
Shortening the text of wp type when the sidebar is not wide enough to show the whole text, and set width of it to 100% of its parent size.

https://community.openproject.org/projects/openproject/work_packages/38717/activity