### PR TITLE
Fix/document mail sending

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -188,7 +188,7 @@ module SettingsHelper
 
   # Renders a notification field for an OpenProject::Notifiable option
   def notification_field(notifiable, options = {})
-    content_tag(:label, class: 'form--label-with-check-box' + (notifiable.parent.present? ? ' parent' : '')) do
+    content_tag(:label, class: 'form--label-with-check-box') do
       styled_check_box_tag('settings[notified_events][]',
                            notifiable.name,
                            Setting.notified_events.include?(notifiable.name),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1562,7 +1562,6 @@ en:
   label_feeds_access_key: "RSS access key"
   label_feeds_access_key_created_on: "RSS access key created %{value} ago"
   label_feeds_access_key_type: "RSS"
-  label_file_added: "File added"
   label_file_plural: "Files"
   label_filter_add: "Add filter"
   label_filter_plural: "Filters"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -238,7 +238,6 @@ notified_events:
   default:
   - news_added
   - news_comment_added
-  - file_added
   - message_posted
   - wiki_content_added
   - wiki_content_updated

--- a/lib/open_project/notifiable.rb
+++ b/lib/open_project/notifiable.rb
@@ -32,7 +32,6 @@ module OpenProject
   NOTIFIABLE = [
     %w(news_added),
     %w(news_comment_added),
-    %w(file_added),
     %w(message_posted),
     %w(wiki_content_added),
     %w(wiki_content_updated),

--- a/modules/documents/lib/open_project/documents/engine.rb
+++ b/modules/documents/lib/open_project/documents/engine.rb
@@ -50,14 +50,13 @@ module OpenProject::Documents
         }, require: :loggedin
       end
 
-      OpenProject::Notifiable.all << OpenProject::Notifiable.new('document_added')
-
       Redmine::Search.register :documents
     end
 
     activity_provider :documents, class_name: 'Activities::DocumentActivityProvider', default: false
 
     patches %i[CustomFieldsHelper Project]
+    patch_with_namespace :OpenProject, :Notifiable
 
     add_api_path :documents do
       "#{root}/documents"

--- a/modules/documents/lib/open_project/documents/patches/notifiable_patch.rb
+++ b/modules/documents/lib/open_project/documents/patches/notifiable_patch.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -28,28 +26,16 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-module OpenProject
-  NOTIFIABLE = [
-    %w(news_added),
-    %w(news_comment_added),
-    %w(file_added),
-    %w(message_posted),
-    %w(wiki_content_added),
-    %w(wiki_content_updated),
-    %w(membership_added),
-    %w(membership_updated)
-  ].freeze
-
-  Notifiable = Struct.new(:name) do
-    def to_s
-      name
+module OpenProject::Documents::Patches::NotifiablePatch
+  def self.included(base)
+    class << base
+      prepend ClassMethods
     end
+  end
 
-    # TODO: Plugin API for adding a new notification?
-    def self.all
-      OpenProject::NOTIFIABLE.map do |event_strings|
-        Notifiable.new(*event_strings)
-      end
+  module ClassMethods
+    def all
+      super + [::OpenProject::Notifiable.new('document_added')]
     end
   end
 end

--- a/modules/documents/spec/lib/open_project/notifiable_spec.rb
+++ b/modules/documents/spec/lib/open_project/notifiable_spec.rb
@@ -27,29 +27,13 @@
 #
 # See docs/COPYRIGHT.rdoc for more details.
 #++
+require 'spec_helper'
 
-module OpenProject
-  NOTIFIABLE = [
-    %w(news_added),
-    %w(news_comment_added),
-    %w(file_added),
-    %w(message_posted),
-    %w(wiki_content_added),
-    %w(wiki_content_updated),
-    %w(membership_added),
-    %w(membership_updated)
-  ].freeze
-
-  Notifiable = Struct.new(:name) do
-    def to_s
-      name
-    end
-
-    # TODO: Plugin API for adding a new notification?
-    def self.all
-      OpenProject::NOTIFIABLE.map do |event_strings|
-        Notifiable.new(*event_strings)
-      end
+describe OpenProject::Notifiable do
+  describe '#all' do
+    it 'includes document_added' do
+      expect(described_class.all.map(&:name))
+        .to include('document_added')
     end
   end
 end

--- a/spec/lib/open_project/notifiable_spec.rb
+++ b/spec/lib/open_project/notifiable_spec.rb
@@ -32,11 +32,11 @@ require 'spec_helper'
 describe OpenProject::Notifiable do
   describe '#all' do
     it 'matches expected list' do
-      expected = %w(news_added news_comment_added file_added message_posted wiki_content_added
-                    wiki_content_updated membership_added membership_updated)
-
-      expect(described_class.all.map(&:name))
-        .to match_array(expected)
+      %w(news_added news_comment_added file_added message_posted wiki_content_added
+         wiki_content_updated membership_added membership_updated).each do |expected|
+        expect(described_class.all.map(&:name))
+          .to include(expected)
+      end
     end
   end
 end

--- a/spec/lib/open_project/notifiable_spec.rb
+++ b/spec/lib/open_project/notifiable_spec.rb
@@ -32,7 +32,7 @@ require 'spec_helper'
 describe OpenProject::Notifiable do
   describe '#all' do
     it 'matches expected list' do
-      %w(news_added news_comment_added file_added message_posted wiki_content_added
+      %w(news_added news_comment_added message_posted wiki_content_added
          wiki_content_updated membership_added membership_updated).each do |expected|
         expect(described_class.all.map(&:name))
           .to include(expected)


### PR DESCRIPTION
Fixes sending of mails after a document has been created. The `document_added` key was never added to the list of notifiable events. Additionally, the `file_added` event is removed since nothing is listening for it.

https://community.openproject.org/wp/38333