### PR TITLE
[34322] Row break in status selector on cards after spaces

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-status-button/wp-status-button.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-status-button/wp-status-button.component.sass
@@ -12,6 +12,6 @@
 
   &--text
     @include text-shortener
-    
+
   &--button
     display: flex

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-status-button/wp-status-button.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-status-button/wp-status-button.component.sass
@@ -11,4 +11,8 @@
     max-width: 100%
 
   &--text
-    margin: 0 5px
+    @include text-shortener
+    width: 80px
+    
+  &--button
+    display: flex

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-status-button/wp-status-button.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-status-button/wp-status-button.component.sass
@@ -9,9 +9,7 @@
     border: none
     color: white
     max-width: 100%
+    display: flex
 
   &--text
     @include text-shortener
-
-  &--button
-    display: flex

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-status-button/wp-status-button.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-status-button/wp-status-button.component.sass
@@ -12,7 +12,6 @@
 
   &--text
     @include text-shortener
-    width: 80px
     
   &--button
     display: flex

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -64,7 +64,6 @@
       place-self: center right
     &-status
       grid-area: attributeTag
-      max-width: 120px
       margin-right: 5px
       overflow: hidden
     &-cover-image


### PR DESCRIPTION
Shorten the status selector text and set an exact width to it, so it is the same for all status names without considering their width, if they are wider than its width, they will be shortened. Also removing max-width of status selector as it has an exact width and the text won't overflow its parent now.