### PR TITLE
change rounding scale from 2 to 4 digits

### DIFF
--- a/modules/costs/app/views/hourly_rates/_rate.html.erb
+++ b/modules/costs/app/views/hourly_rates/_rate.html.erb
@@ -53,7 +53,7 @@ See docs/COPYRIGHT.rdoc for more details.
         <label class="hidden-for-sighted" for="<%= "#{id_prefix}_rate" %>"><%= Rate.model_name.human %></label>
         <%= rate_form.text_field :rate,
                                  index: id_or_index,
-                                 value: rate.rate ? rate.rate.round(2) : "",
+                                 value: rate.rate ? rate.rate.round(4) : "",
                                  required: true %>
         <span class="form-label">
           <%= Setting.plugin_costs['costs_currency'] %>


### PR DESCRIPTION
A rate will be saved with a scale of 4 in the database.
Without this patch the form is prefill with a rounded rate with a scale of 2 when you open the update form even when a scale of 4 is defined in the database.
You won't see the real value of the database. Even worst is when you click on save you will save this new rounded value.
Example:
You define a rate of 0.125 and save it. In the database the 0.125 is saved.
When you reopen the rates form you will see an 0.13.
When you open the update view of the rate, you will see a prefilled form with 0.13.
When you now click on save the untouched value will be saved to the database.
In the database the rate of 0.13 saved.

This patch change the update view so that the prefilled form shows the rate with a scale of 4 like it is saved in the database.