### PR TITLE
[38713] Highlighting of ng-select breaks when matching multiple words

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -127,14 +127,16 @@
       ></op-principal>
       <span
         class="op-autocompleter--wp-subject"
-        [ngOptionHighlight]="search"
       >
         <span
           *ngIf="item.type"
           [ngClass]="highlighting('type', item.type.id)"
-          textContent="{{ item.type.name }}:"
+          textContent="{{ item.type.name }} "
           ></span>
-        {{item.subject}}
+        <span
+          [ngOptionHighlight]="search"
+          [textContent]="item.subject">
+        </span>
       </span>
 
       <div class="op-autocompleter--wp-content">


### PR DESCRIPTION
Move type out of the highlighted search string


https://community.openproject.org/projects/openproject/work_packages/38713/activity