### PR TITLE
[38793] Watchers dropdown is cut off

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_details_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_details_view.sass
@@ -111,11 +111,13 @@ body.router--work-packages-partitioned-split-view-new
   .work-packages--details-form
     display: flex
     flex-direction: column
+    height: 100%
     overflow: hidden
 
   .work-package-details-tab
     overflow-y: auto
     overflow-x: hidden
+    flex-grow: 1
     @include styled-scroll-bar
 
   .work-packages--breadcrumb


### PR DESCRIPTION
Use full available height to avoid drowdowns (e.g watcher autocompleter) being cut off


https://community.openproject.org/projects/openproject/work_packages/38793/activity