### PR TITLE
[38813] Ensure embedded tables load their own columns

### DIFF
--- a/frontend/src/app/components/states.service.ts
+++ b/frontend/src/app/components/states.service.ts
@@ -1,23 +1,19 @@
-import { ProjectResource } from 'core-app/modules/hal/resources/project-resource';
-import { SchemaResource } from 'core-app/modules/hal/resources/schema-resource';
-import { TypeResource } from 'core-app/modules/hal/resources/type-resource';
-import { RoleResource } from 'core-app/modules/hal/resources/role-resource';
-import { UserResource } from 'core-app/modules/hal/resources/user-resource';
-import { PlaceholderUserResource } from 'core-app/modules/hal/resources/placeholder-user-resource';
-import { WorkPackageResource } from 'core-app/modules/hal/resources/work-package-resource';
-import { input, InputState, multiInput, MultiInputState, StatesGroup } from 'reactivestates';
-import { QueryColumn } from './wp-query/query-column';
-import { PostResource } from 'core-app/modules/hal/resources/post-resource';
-import { HalResource } from 'core-app/modules/hal/resources/hal-resource';
+import { InputState, multiInput, MultiInputState, StatesGroup } from 'reactivestates';
+import { Subject } from 'rxjs';
+import { ProjectResource } from "core-app/modules/hal/resources/project-resource";
+import { WorkPackageResource } from "core-app/modules/hal/resources/work-package-resource";
+import { PostResource } from "core-app/modules/hal/resources/post-resource";
+import { SchemaResource } from "core-app/modules/hal/resources/schema-resource";
+import { TypeResource } from "core-app/modules/hal/resources/type-resource";
 import { StatusResource } from "core-app/modules/hal/resources/status-resource";
-import { QueryFilterInstanceSchemaResource } from "core-app/modules/hal/resources/query-filter-instance-schema-resource";
-import { Subject } from "rxjs";
-import { QuerySortByResource } from "core-app/modules/hal/resources/query-sort-by-resource";
-import { QueryGroupByResource } from "core-app/modules/hal/resources/query-group-by-resource";
-import { VersionResource } from "core-app/modules/hal/resources/version-resource";
-import { WorkPackageDisplayRepresentationValue } from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-display-representation.service";
 import { TimeEntryResource } from "core-app/modules/hal/resources/time-entry-resource";
 import { CapabilityResource } from "core-app/modules/hal/resources/capability-resource";
+import { VersionResource } from "core-app/modules/hal/resources/version-resource";
+import { UserResource } from "core-app/modules/hal/resources/user-resource";
+import { PlaceholderUserResource } from "core-app/modules/hal/resources/placeholder-user-resource";
+import { RoleResource } from "core-app/modules/hal/resources/role-resource";
+import { HalResource } from "core-app/modules/hal/resources/hal-resource";
+
 
 export class States extends StatesGroup {
   name = 'MainStore';
@@ -58,10 +54,6 @@ export class States extends StatesGroup {
   /* /api/v3/roles */
   roles = multiInput<RoleResource>();
 
-
-  // Work Package query states
-  queries = new QueryAvailableDataStates();
-
   // Global events to isolated changes
   changes = new GlobalStateChanges();
 
@@ -75,11 +67,11 @@ export class States extends StatesGroup {
       state = this.additional[stateName] = multiInput<T>();
     }
 
-    return state as any;
+    return state;
   }
 
   forResource<T extends HalResource = HalResource>(resource:T):InputState<T>|undefined {
-    const stateName = _.camelCase(resource._type) + 's';
+    const stateName = `${_.camelCase(resource._type)}s`;
     const state = this.forType<T>(stateName);
 
     return state && state.get(resource.id!);
@@ -93,21 +85,4 @@ export class States extends StatesGroup {
 export class GlobalStateChanges {
   // Global subject on changes to the given query ID
   queries = new Subject();
-}
-
-export class QueryAvailableDataStates {
-  // Available columns
-  columns = input<QueryColumn[]>();
-
-  // Available SortBy Columns
-  sortBy = input<QuerySortByResource[]>();
-
-  // Available GroupBy columns
-  groupBy = input<QueryGroupByResource[]>();
-
-  // Available filter schemas (derived from their schema)
-  filters = input<QueryFilterInstanceSchemaResource[]>();
-
-  // Display of the WP results
-  displayRepresentation = input<WorkPackageDisplayRepresentationValue|null>();
 }

--- a/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/src/app/components/wp-list/wp-states-initialization.service.ts
@@ -91,10 +91,10 @@ export class WorkPackageStatesInitializationService {
     this.wpTableFilters.initializeFilters(query, schema);
     this.querySpace.queryForm.putValue(form);
 
-    this.states.queries.columns.putValue(schema.columns.allowedValues);
-    this.states.queries.sortBy.putValue(schema.sortBy.allowedValues);
-    this.states.queries.groupBy.putValue(schema.groupBy.allowedValues);
-    this.states.queries.displayRepresentation.putValue(schema.displayRepresentation.allowedValues);
+    this.querySpace.available.columns.putValue(schema.columns.allowedValues);
+    this.querySpace.available.sortBy.putValue(schema.sortBy.allowedValues);
+    this.querySpace.available.groupBy.putValue(schema.groupBy.allowedValues);
+    this.querySpace.available.displayRepresentation.putValue(schema.displayRepresentation.allowedValues);
   }
 
   public updateQuerySpace(query:QueryResource, results:WorkPackageCollectionResource) {

--- a/frontend/src/app/components/wp-table/embedded/wp-embedded-table.component.ts
+++ b/frontend/src/app/components/wp-table/embedded/wp-embedded-table.component.ts
@@ -90,11 +90,7 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
   }
 
   protected initializeStates(query:QueryResource) {
-    // If the configuration requests filters, we need to load the query form as well.
-    if (this.configuration.withFilters) {
-      this.loadForm(query);
-    }
-
+    void this.loadForm(query);
     super.initializeStates(query);
 
 

--- a/frontend/src/app/modules/work_packages/query-space/isolated-query-space.ts
+++ b/frontend/src/app/modules/work_packages/query-space/isolated-query-space.ts
@@ -7,14 +7,13 @@ import { GroupObject, WorkPackageCollectionResource } from 'core-app/modules/hal
 import { QueryFormResource } from "core-app/modules/hal/resources/query-form-resource";
 import { QueryColumn } from "core-components/wp-query/query-column";
 import { RenderedWorkPackage } from "core-app/modules/work_packages/render-info/rendered-work-package.type";
+import { QuerySortByResource } from "core-app/modules/hal/resources/query-sort-by-resource";
+import { QueryGroupByResource } from "core-app/modules/hal/resources/query-group-by-resource";
+import { QueryFilterInstanceSchemaResource } from "core-app/modules/hal/resources/query-filter-instance-schema-resource";
+import { WorkPackageDisplayRepresentationValue } from "core-app/modules/work_packages/routing/wp-view-base/view-services/wp-view-display-representation.service";
 
 @Injectable()
 export class IsolatedQuerySpace extends StatesGroup {
-
-  constructor() {
-    super();
-  }
-
   name = 'IsolatedQuerySpace';
 
   // The query that results in this table state
@@ -55,4 +54,22 @@ export class IsolatedQuerySpace extends StatesGroup {
 
   // Input state that emits whenever table services have initialized
   initialized = input<unknown>();
+
+  // Available states
+  available = {
+    // Available columns
+    columns: input<QueryColumn[]>(),
+
+    // Available SortBy Columns
+    sortBy: input<QuerySortByResource[]>(),
+
+    // Available GroupBy columns
+    groupBy: input<QueryGroupByResource[]>(),
+
+    // Available filter schemas (derived from their schema)
+    filters: input<QueryFilterInstanceSchemaResource[]>(),
+
+    // Display of the WP results
+    displayRepresentation: input<WorkPackageDisplayRepresentationValue|null>(),
+  };
 }

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-columns.service.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-columns.service.ts
@@ -246,7 +246,7 @@ export class WorkPackageViewColumnsService extends WorkPackageQueryStateService<
 
   // Get the available state
   protected get availableState() {
-    return this.states.queries.columns;
+    return this.querySpace.available.columns;
   }
 
   /**

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
@@ -92,7 +92,7 @@ export class WorkPackageViewFiltersService extends WorkPackageQueryStateService<
   }
 
   public get availableState():InputState<QueryFilterInstanceSchemaResource[]> {
-    return this.states.queries.filters;
+    return this.querySpace.available.filters;
   }
 
   /** Return whether the filters the user is working on are incomplete */

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-group-by.service.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-group-by.service.ts
@@ -82,7 +82,7 @@ export class WorkPackageViewGroupByService extends WorkPackageQueryStateService<
   }
 
   protected get availableState() {
-    return this.states.queries.groupBy;
+    return this.querySpace.available.groupBy;
   }
 
   public get isEnabled():boolean {

--- a/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-sort-by.service.ts
+++ b/frontend/src/app/modules/work_packages/routing/wp-view-base/view-services/wp-view-sort-by.service.ts
@@ -52,7 +52,7 @@ export class WorkPackageViewSortByService extends WorkPackageQueryStateService<Q
   }
 
   public onReadyWithAvailable():Observable<null> {
-    return combine(this.pristineState, this.states.queries.sortBy)
+    return combine(this.pristineState, this.querySpace.available.sortBy)
       .values$()
       .pipe(
         mapTo(null)
@@ -142,7 +142,7 @@ export class WorkPackageViewSortByService extends WorkPackageQueryStateService<Q
   }
 
   private get availableState() {
-    return this.states.queries.sortBy;
+    return this.querySpace.available.sortBy;
   }
 
   public get available():QuerySortByResource[] {


### PR DESCRIPTION
Previously, if `showFilters` was false, the embedded tables would not load their own query form but piggyback on the globally loaded form.

This however does not work when:

1. Opening a work package in a deep link (global query form never loaded)

2. The embedded table resides in a subproject (different query form necessary)

That's why this PR moves the available states into the isolated query space and ensures the form is always loaded.

https://community.openproject.org/wp/38813