### PR TITLE
limit reminder times to full hours

### DIFF
--- a/app/contracts/user_preferences/base_contract.rb
+++ b/app/contracts/user_preferences/base_contract.rb
@@ -45,6 +45,9 @@ module UserPreferences
     validate :time_zone_correctness,
              if: -> { model.time_zone.present? }
 
+    validate :full_hour_reminder_time,
+             if: -> { model.daily_reminders.present? }
+
     protected
 
     def time_zone_correctness
@@ -57,6 +60,12 @@ module UserPreferences
     def user_allowed_to_access
       unless user.allowed_to_globally?(:manage_user) || (user.logged? && user.active? && user.id == model.user_id)
         errors.add :base, :error_unauthorized
+      end
+    end
+
+    def full_hour_reminder_time
+      unless model.daily_reminders[:times].all? { |time| time.match?(/00:00\+00:00\z/) }
+        errors.add :daily_reminders, :full_hour
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -760,6 +760,10 @@ en:
           attributes:
             hours:
               day_limit: "is too high as a maximum of 24 hours can be logged per date."
+        user_preference:
+          attributes:
+            daily_reminders:
+              full_hour: "can only be configured to be delivered at a full hour."
         wiki_page:
           attributes:
             slug:

--- a/spec/contracts/user_preferences/update_contract_spec.rb
+++ b/spec/contracts/user_preferences/update_contract_spec.rb
@@ -1,4 +1,5 @@
 #-- encoding: UTF-8
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -173,7 +174,20 @@ describe UserPreferences::UpdateContract do
       }
     end
 
-    it_behaves_like 'contract is invalid', daily_reminders: :format_nested
+    it_behaves_like 'contract is invalid', daily_reminders: %i[format_nested full_hour]
+  end
+
+  context 'with a sub hour time for the daily_reminders' do
+    let(:settings) do
+      {
+        daily_reminders: {
+          enabled: true,
+          times: %w[12:30:00+00:00]
+        }
+      }
+    end
+
+    it_behaves_like 'contract is invalid', daily_reminders: :full_hour
   end
 
   context 'with an invalid order for comments_sorting' do

--- a/spec/requests/api/v3/user_preferences/user_preferences_resource_spec.rb
+++ b/spec/requests/api/v3/user_preferences/user_preferences_resource_spec.rb
@@ -130,11 +130,19 @@ describe 'API v3 UserPreferences resource', type: :request, content_type: :json 
 
         expect(subject.body)
           .to be_json_eql("Daily reminders does not match the expected format 'time' at path 'times/0'.".to_json)
-                .at_path('message')
+                .at_path('_embedded/errors/0/message')
 
         expect(subject.body)
           .to be_json_eql("dailyReminders".to_json)
-                .at_path('_embedded/details/attribute')
+                .at_path('_embedded/errors/0/_embedded/details/attribute')
+
+        expect(subject.body)
+          .to be_json_eql("Daily reminders can only be configured to be delivered at a full hour.".to_json)
+                .at_path('_embedded/errors/1/message')
+
+        expect(subject.body)
+          .to be_json_eql("dailyReminders".to_json)
+                .at_path('_embedded/errors/1/_embedded/details/attribute')
       end
 
       it 'keeps the previous values' do


### PR DESCRIPTION
The UI already limits the times a daily reminder can be configured to be delivered to be a full hour but a different client could specify a different value which the job delivering the reminders will not support