### PR TITLE
enable reloading in test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,7 +38,7 @@ OpenProject::Application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = ENV['CI'].present?
 
   # Use eager load to mirror the production environment
   # on travis


### PR DESCRIPTION
Spring requires to have the classes reloaded as of version 3.0. On the CI we don't need that to happen.