### PR TITLE
[38797] Custom Field - Button to create custom field is placed at the bottom of page

### DIFF
--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -32,11 +32,15 @@ module TabsHelper
   # Renders tabs and their content
   def render_tabs(tabs, form = nil)
     if tabs.any?
-      selected_tab = tabs.detect { |t| t[:name] == params[:tab] } if params[:tab].present?
-      render partial: 'common/tabs', locals: { f: form, tabs: tabs, selected_tab: selected_tab || tabs.first }
+      selected = selected_tab(tabs)
+      render partial: 'common/tabs', locals: { f: form, tabs: tabs, selected_tab: selected }
     else
       content_tag 'p', I18n.t(:label_no_data), class: 'nodata'
     end
+  end
+
+  def selected_tab(tabs)
+    tabs.detect { |t| t[:name] == params[:tab] } || tabs.first
   end
 
   # Render tabs from the ui/extensible tabs manager

--- a/app/views/attribute_help_texts/_tab.html.erb
+++ b/app/views/attribute_help_texts/_tab.html.erb
@@ -66,13 +66,3 @@
 <% else %>
   <%= no_results_box %>
 <% end %>
-
-<div class="generic-table--action-buttons">
-  <%= link_to new_attribute_help_text_path(name: tab[:name]),
-              { class: 'attribute-help-texts--create-button button -alt-highlight',
-                aria: {label: t(:'attribute_help_texts.add_new')},
-                title: t(:'attribute_help_texts.add_new')} do %>
-    <%= op_icon('button--icon icon-add') %>
-    <span class="button--text"><%= t('activerecord.models.attribute_help_text') %></span>
-  <% end %>
-</div>

--- a/app/views/attribute_help_texts/index.html.erb
+++ b/app/views/attribute_help_texts/index.html.erb
@@ -26,18 +26,33 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<%= render_tabs [
-                  {
-                    name: 'WorkPackage',
-                    partial: 'attribute_help_texts/tab',
-                    path: attribute_help_texts_path(tab: 'WorkPackage'),
-                    label: :label_work_package
-                  },
-                  {
-                    name: 'Project',
-                    partial: 'attribute_help_texts/tab',
-                    path: attribute_help_texts_path(tab: 'Project'),
-                    label: Project.model_name.human
-                  }
-                ]
-%>
+
+<% tabs = [
+  {
+    name: 'WorkPackage',
+    partial: 'attribute_help_texts/tab',
+    path: attribute_help_texts_path(tab: 'WorkPackage'),
+    label: :label_work_package
+  },
+  {
+    name: 'Project',
+    partial: 'attribute_help_texts/tab',
+    path: attribute_help_texts_path(tab: 'Project'),
+    label: Project.model_name.human
+  }
+] %>
+
+
+<%= toolbar title: t(:'attribute_help_texts.label_plural') do %>
+  <li class="toolbar-item">
+    <%= link_to new_attribute_help_text_path(name: selected_tab(tabs)[:name]),
+                { class: 'attribute-help-texts--create-button button -alt-highlight',
+                  aria: {label: t(:'attribute_help_texts.add_new')},
+                  title: t(:'attribute_help_texts.add_new')} do %>
+      <%= op_icon('button--icon icon-add') %>
+      <span class="button--text"><%= t('activerecord.models.attribute_help_text') %></span>
+    <% end %>
+  </li>
+<% end %>
+
+<%= render_tabs tabs %>

--- a/app/views/custom_fields/_tab.html.erb
+++ b/app/views/custom_fields/_tab.html.erb
@@ -164,15 +164,6 @@ See COPYRIGHT and LICENSE files for more details.
       </table>
     </div>
   </div>
-  <div class="generic-table--action-buttons">
-    <%= link_to new_custom_field_path(type: tab[:name]),
-          { class: 'button -alt-highlight',
-            aria: {label: t(:label_custom_field_new)},
-            title: t(:label_custom_field_new)} do %>
-      <%= op_icon('button--icon icon-add') %>
-      <span class="button--text"><%= t('activerecord.models.custom_field') %></span>
-    <% end %>
-  </div>
 <% else %>
   <%= no_results_box(action_url: new_custom_field_path(type: tab[:name]), display_action: true) %>
 <% end %>

--- a/app/views/custom_fields/index.html.erb
+++ b/app/views/custom_fields/index.html.erb
@@ -26,7 +26,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<%= toolbar title: t(:label_custom_field_plural) %>
+<%= toolbar title: t(:label_custom_field_plural) do %>
+  <li class="toolbar-item">
+    <%= link_to new_custom_field_path(type: selected_tab(custom_fields_tabs)[:name]),
+                { class: 'button -alt-highlight',
+                  aria: {label: t(:label_custom_field_new)},
+                  title: t(:label_custom_field_new)} do %>
+      <%= op_icon('button--icon icon-add') %>
+      <span class="button--text"><%= t('activerecord.models.custom_field') %></span>
+    <% end %>
+  </li>
+<% end %>
 
 <%= render_tabs custom_fields_tabs %>
 


### PR DESCRIPTION
Move "Create" button to the toolbar on pages with rendered tabs:
* Admin -> Custom Fields
* Admin -> Attribute Help texts 

Thus the button is shown at the top and easily perceivable.

https://community.openproject.org/projects/openproject/work_packages/38797/activity