### PR TITLE
[38795] Easier testing of safari in browser stack

### DIFF
--- a/bin/safari_browser_stack
+++ b/bin/safari_browser_stack
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Sets environment variable OPENPROJECT_DISABLE_DEV_ASSET_PROXY and builds assets manifest
+# Useful for testing Safari on browser stack
+
+yell() { echo -e "$0: $*" >&2; }
+die() { yell "$*"; exit 1; }
+try() { eval "$@" || die "\n\nFailed to run '$*', check log/safari_browser_stack.log for more information."; }
+
+
+echo "Building new assets"
+try 'export OPENPROJECT_DISABLE_DEV_ASSET_PROXY="true"'
+try 'bundle exec rake assets:rebuild_manifest >> log/safari_browser_stack.log'
+
+echo "---------------------------------------"
+echo "Done. Now run the following services"
+echo '- Rails server `RAILS_ENV=development OPENPROJECT_DISABLE_DEV_ASSET_PROXY=true ./bin/rails s`'
+echo '- Angular CLI: `cd frontend && npm run build:watch`'
+echo ''
+echo 'Once you are done: keep in mind to remove the public/assets folder or run the setup_dev script.'
+

--- a/bin/setup_dev
+++ b/bin/setup_dev
@@ -11,8 +11,8 @@ printf "Bundling rails dependencies ... "
 try 'bundle install > log/setup_dev.log'
 echo "done."
 
-echo "Removing public frontend assets"
-try 'rm -rf public/assets/frontend >> log/setup_dev.log'
+echo "Removing public assets"
+try 'rm -rf public/assets >> log/setup_dev.log'
 
 echo "Installing node_modules ... "
 try '(cd frontend && npm ci) >> log/setup_dev.log'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -81,6 +81,8 @@ OpenProject::Application.configure do
 
   # Send mails to browser window
   config.action_mailer.delivery_method = :letter_opener
+
+  config.hosts << 'bs-local.com' if ENV['OPENPROJECT_DISABLE_DEV_ASSET_PROXY'].present?
 end
 
 ActiveRecord::Base.logger = ActiveSupport::Logger.new(STDOUT) unless String(ENV["SILENCE_SQL_LOGS"]).to_bool


### PR DESCRIPTION
In order to test Safari on browser stack there are some preparational steps needed. To make it a little bit easier, this PR adds the necessary code changes hidden behind an environment variable. Further a script is added which sets the variable, manually builds the asset manifest and writes down the necessary next steps.

https://community.openproject.org/projects/openproject/work_packages/38795/activity