### PR TITLE
Fix frontend docker dev container permissions

### DIFF
--- a/docker/dev/frontend/Dockerfile
+++ b/docker/dev/frontend/Dockerfile
@@ -4,30 +4,23 @@ MAINTAINER operations@openproject.com
 ARG DEV_UID=1000
 ARG DEV_GID=1001
 
-ENV USER=dev
+ENV USER=node
 
 RUN apt-get update && apt-get install -y chromium
 
 RUN npm i -g npm
 
-# `--no-log-init` is required as a workaround to avoid disk exhaustion.
-#
-# Read more at:
-# * https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
-# * https://github.com/golang/go/issues/13548
-RUN useradd --no-log-init -d /home/$USER -m $USER -g node || true
-
-RUN usermod -u $DEV_UID $USER || true
 RUN groupadd $USER || true
 RUN groupmod -g $DEV_GID $USER || true
+RUN usermod -u $DEV_UID -d /home/dev $USER || true
 
 EXPOSE 4200
 
-RUN mkdir -p /home/$USER/openproject/public/assets/frontend
-RUN chown $USER:$USER -R /home/$USER/openproject/public
+RUN mkdir -p /home/dev/openproject/public/assets/frontend
+RUN chown $USER:$USER -R /home/dev
 
-VOLUME ["/home/$USER/openproject", "/home/$USER/openproject/public/assets/frontend"]
+VOLUME ["/home/dev/openproject", "/home/dev/openproject/public/assets/frontend"]
 
-WORKDIR /home/$USER/openproject/frontend
+WORKDIR /home/dev/openproject/frontend
 
 USER $USER


### PR DESCRIPTION
The frontend container already comes with a `node` user. In some instances, the new `dev` and old `node` user would have ID or name collisions. This PR fixes that by only reusing the `node` user.