### PR TITLE
Allow passing custom host and endpoint and whitelist in CSP

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -39,12 +39,12 @@ module CarrierWave
       # Ensure that the provider AWS is uppercased
       provider = credentials[:provider] || 'AWS'
       if [:aws, 'aws'].include? provider
-        provider = 'AWS'
+        credentials[:provider] = 'AWS'
       end
 
       CarrierWave.configure do |config|
         config.fog_provider    = 'fog/aws'
-        config.fog_credentials = { provider: provider }.merge(credentials)
+        config.fog_credentials = credentials
         config.fog_directory   = directory
         config.fog_public      = public
 

--- a/lib/open_project/configuration/helpers.rb
+++ b/lib/open_project/configuration/helpers.rb
@@ -92,7 +92,11 @@ module OpenProject
       end
 
       def remote_storage_hosts
-        [remote_storage_upload_host, remote_storage_download_host].compact
+        [
+          fog_credentials[:host],
+          remote_storage_upload_host,
+          remote_storage_download_host
+        ].compact
       end
 
       def attachments_storage_path


### PR DESCRIPTION
A user in the forums reported that using a custom S3-compatible endpoint does not work due to our CSP. As this will be relevant for our own S3-replacement testing, this PR should solve that issue.

https://community.openproject.org/topics/6288?r=14017#message-14017

[OP#38900](https://community.openproject.org/wp/38900)