### PR TITLE
Add Refresh button for Revit Add-in from dev into 11.4

### DIFF
--- a/frontend/src/app/modules/bim/bcf/openproject-bcf.module.ts
+++ b/frontend/src/app/modules/bim/bcf/openproject-bcf.module.ts
@@ -38,6 +38,7 @@ import { BcfPathHelperService } from "core-app/modules/bim/bcf/helper/bcf-path-h
 import { ViewpointsService } from "core-app/modules/bim/bcf/helper/viewpoints.service";
 import { BcfImportButtonComponent } from "core-app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component";
 import { BcfExportButtonComponent } from "core-app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component";
+import { RefreshButtonComponent } from "core-app/modules/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts";
 import { IFCViewerService } from "core-app/modules/bim/ifc_models/ifc-viewer/ifc-viewer.service";
 import { ViewerBridgeService } from "core-app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service";
 import { HookService } from "core-app/modules/plugins/hook-service";
@@ -81,10 +82,12 @@ export const viewerBridgeServiceFactory = (injector:Injector) => {
     BcfNewWpAttributeGroupComponent,
     BcfImportButtonComponent,
     BcfExportButtonComponent,
+    RefreshButtonComponent,
   ],
   exports: [
     BcfImportButtonComponent,
     BcfExportButtonComponent,
+    RefreshButtonComponent,
   ]
 })
 export class OpenprojectBcfModule {

--- a/frontend/src/app/modules/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
@@ -21,6 +21,7 @@ import { StateService, TransitionService } from "@uirouter/core";
 import { BehaviorSubject } from "rxjs";
 import { BcfImportButtonComponent } from "core-app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component";
 import { BcfExportButtonComponent } from "core-app/modules/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component";
+import { RefreshButtonComponent } from "core-app/modules/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts";
 import { componentDestroyed } from "@w11k/ngx-componentdestroyed";
 import { ViewerBridgeService } from "core-app/modules/bim/bcf/bcf-viewer-bridge/viewer-bridge.service";
 
@@ -55,6 +56,10 @@ export class IFCViewerPageComponent extends PartitionedQuerySpacePageComponent {
         stateName$: this.newRoute$,
         allowed: ['work_packages.createWorkPackage', 'work_package.copy']
       }
+    },
+    {
+      component: RefreshButtonComponent,
+      show: ():boolean => !this.viewerBridgeService.shouldShowViewer,
     },
     {
       component: BcfImportButtonComponent,

--- a/frontend/src/app/modules/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
+++ b/frontend/src/app/modules/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
@@ -1,0 +1,58 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2021 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See docs/COPYRIGHT.rdoc for more details.
+//++
+
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { StateService } from '@uirouter/core';
+import { I18nService } from 'core-app/modules/common/i18n/i18n.service';
+
+@Component({
+  template: `
+    <a [title]="text.refresh_hover"
+       class="button refresh-button"
+       (click)="refresh()">
+      <op-icon icon-classes="button--icon icon-workflow"></op-icon>
+    </a>
+  `,
+  selector: 'op-refresh-button',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+
+export class RefreshButtonComponent {
+  public text = {
+    refresh: this.I18n.t('js.bcf.refresh'),
+    refresh_hover: this.I18n.t('js.bcf.refresh_work_package'),
+  };
+
+  constructor(readonly I18n:I18nService,
+    readonly state:StateService) {
+  }
+
+  refresh() {
+    void this.state.go('.', {}, { reload: true });
+  }
+}

--- a/modules/bim/config/locales/js-en.yml
+++ b/modules/bim/config/locales/js-en.yml
@@ -12,6 +12,8 @@ en:
       show_viewpoint: 'Show viewpoint'
       delete_viewpoint: 'Delete viewpoint'
       management: 'BCF management'
+      refresh: 'Refresh'
+      refresh_work_package: 'Refresh work package'
     ifc_models:
       empty_warning: "This project does not yet have any IFC models."
       use_this_link_to_manage: "Use this link to upload and manage your IFC models"

--- a/modules/bim/spec/features/revit_add_in/bim_revit_add_in_navigation_spec.rb
+++ b/modules/bim/spec/features/revit_add_in/bim_revit_add_in_navigation_spec.rb
@@ -26,7 +26,7 @@
 # See docs/COPYRIGHT.rdoc for more details.
 #++
 
-require_relative '../spec_helper'
+require_relative '../../spec_helper'
 
 describe 'BIM Revit Add-in navigation spec',
          type: :feature,
@@ -54,25 +54,21 @@ describe 'BIM Revit Add-in navigation spec',
     before do
       login_as(user)
       model_page.visit!
+
+      # Guard to ensure toolbar is completely loaded and doesn't rerender again.
+      # At first there is no badge. It gets set later and only then the toolbar's
+      # switches are ready to test.
+      model_page.find('#work-packages-filter-toggle-button .badge', text: '1')
     end
 
-    it 'shows "Cards" view by default' do
+    it 'show the right elements on the page' do
+      # shows "Cards" view by default
       model_page.expect_view_toggle_at 'Cards'
-    end
-
-    it 'shows no viewer' do
+      # shows no viewer
       model_page.model_viewer_visible false
-    end
-
-    it 'shows a toolbar' do
+      # shows a toolbar' do
       model_page.page_has_a_toolbar
-    end
-
-    it 'shows no viewer' do
-      model_page.model_viewer_visible false
-    end
-
-    it 'menu has no viewer options' do
+      # menu has no viewer options
       model_page.has_no_menu_item_with_text? 'Viewer'
     end
 
@@ -99,10 +95,7 @@ describe 'BIM Revit Add-in navigation spec',
     end
 
     it 'shows work package details page in full view on Cards display mode' do
-      card_element = page.find('.wp-card')
-
-      card_element.hover
-      card_element.find('.wp-card--details-button').click
+      model_page.click_info_icon(work_package)
 
       expect(page).to have_selector('.work-packages-partitioned-page--content-left', text: work_package.subject)
       expect(page).to have_selector('.work-packages-partitioned-page--content-right', visible: false)

--- a/modules/bim/spec/features/revit_add_in/bim_revit_add_in_refresh_button_spec.rb
+++ b/modules/bim/spec/features/revit_add_in/bim_revit_add_in_refresh_button_spec.rb
@@ -1,0 +1,70 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require_relative '../../spec_helper'
+
+describe 'BIM Revit Add-in navigation spec',
+         type: :feature,
+         with_config: { edition: 'bim' },
+         js: true,
+         driver: :chrome_revit_add_in do
+  let(:project) { FactoryBot.create :project, enabled_module_names: %i[bim work_package_tracking] }
+  let!(:work_package) { FactoryBot.create(:work_package, project: project) }
+  let(:role) do
+    FactoryBot.create(:role,
+                      permissions: %i[view_ifc_models manage_ifc_models add_work_packages edit_work_packages view_work_packages])
+  end
+  let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
+
+  let(:user) do
+    FactoryBot.create :user,
+                      member_in_project: project,
+                      member_through_role: role
+  end
+
+  let(:model_page) { ::Pages::IfcModels::ShowDefault.new(project) }
+
+  before do
+    login_as(user)
+    model_page.visit!
+  end
+
+  it 'click on refresh button reloads information' do
+    # Context BCF cards view
+    model_page.page_shows_a_filter_button(true)
+    work_package.update_attribute(:subject, 'Refreshed while in cards view')
+    model_page.click_refresh_button
+    expect(page).to have_text('Refreshed while in cards view')
+
+    # Context BCF full view
+    model_page.click_info_icon(work_package)
+    work_package.update_attribute(:subject, 'Refreshed while in full view')
+    model_page.click_refresh_button
+    expect(page).to have_text('Refreshed while in full view')
+  end
+end

--- a/modules/bim/spec/support/pages/ifc_models/show_default.rb
+++ b/modules/bim/spec/support/pages/ifc_models/show_default.rb
@@ -85,6 +85,14 @@ module Pages
         expect(page).to have_conditional_selector(visible, '.toolbar-item', text: 'Filter')
       end
 
+      def page_shows_a_refresh_button(visible)
+        expect(page).to have_conditional_selector(visible, '.toolbar-item a.refresh-button')
+      end
+
+      def click_refresh_button
+        page.find('.toolbar-item a.refresh-button').click
+      end
+
       def switch_view(value)
         page.find('#bim-view-toggle-button').click
         page.find('.menu-item', text: value, exact_text: true).click

--- a/spec/support/pages/work_packages/work_package_cards.rb
+++ b/spec/support/pages/work_packages/work_package_cards.rb
@@ -84,6 +84,12 @@ module Pages
       card(work_package).click
     end
 
+    def click_info_icon(work_package)
+      card_element = card(work_package)
+      card_element.hover
+      card_element.find('.wp-card--details-button').click
+    end
+
     def deselect_work_package(work_package)
       element = find("wp-single-card[data-work-package-id='#{work_package.id}']")
 


### PR DESCRIPTION
Originally implemented in PR 9461.

- A feature spec was added here on top.
- The navigation spec for the revit add-in got more
  stable.

https://community.openproject.org/wp/38028