### PR TITLE
Fix: Revit Add-in - Correct successState when creating BCF issues

### DIFF
--- a/frontend/src/app/components/wp-new/wp-new-full-view.component.ts
+++ b/frontend/src/app/components/wp-new/wp-new-full-view.component.ts
@@ -36,5 +36,5 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class WorkPackageNewFullViewComponent extends WorkPackageCreateComponent {
-  public successState = 'work-packages.show';
+  public successState = this.$state.current.data.successState as string;
 }

--- a/frontend/src/app/modules/bim/ifc_models/openproject-ifc-models.routes.ts
+++ b/frontend/src/app/modules/bim/ifc_models/openproject-ifc-models.routes.ts
@@ -120,6 +120,7 @@ export const IFC_ROUTES:Ng2StateDeclaration[] = [
       baseRoute: 'bim.partitioned.list',
       allowMovingInEditMode: true,
       partition: '-left-only',
+      successState: 'bim.partitioned.show'
     },
     views: { 'content-left': { component:WorkPackageNewFullViewComponent } }
   },

--- a/frontend/src/app/modules/work_packages/routing/work-packages-routes.ts
+++ b/frontend/src/app/modules/work_packages/routing/work-packages-routes.ts
@@ -70,7 +70,8 @@ export const WORK_PACKAGES_ROUTES:Ng2StateDeclaration[] = [
       baseRoute: 'work-packages',
       allowMovingInEditMode: true,
       bodyClasses: 'router--work-packages-full-create',
-      menuItem: menuItemClass
+      menuItem: menuItemClass,
+      successState: 'work-packages.show',
     },
   },
   {

--- a/modules/bim/spec/features/revit_add_in/bim_revit_add_in_navigation_spec.rb
+++ b/modules/bim/spec/features/revit_add_in/bim_revit_add_in_navigation_spec.rb
@@ -109,6 +109,24 @@ describe 'BIM Revit Add-in navigation spec',
       expect(page).to have_selector('.work-packages-partitioned-page--content-left', text: work_package.subject)
       expect(page).to have_selector('.work-packages-partitioned-page--content-right', visible: false)
     end
+
+    context 'Creating BCFs' do
+      let!(:status) { FactoryBot.create(:default_status) }
+      let!(:priority) { FactoryBot.create :priority, is_default: true }
+
+      it 'redirects correctly' do
+        create_page = model_page.create_wp_by_button(FactoryBot.build(:type_standard))
+        expect(page).to have_current_path /bcf\/new$/, ignore_query: true
+        create_page.subject_field.set('Some subject')
+        create_page.save!
+        last_work_package = WorkPackage.find_by(subject: 'Some subject')
+        # The currently working routes seem weird as they duplicate the work package ID.
+        expect(page).to(
+          have_current_path(/bcf\/show\/#{last_work_package.id}\/details\/#{last_work_package.id}\/overview$/,
+                            ignore_query: true)
+        )
+      end
+    end
   end
 
   context "signed out" do


### PR DESCRIPTION
Currently after creating a BCF issue in Revit Add-in
the redirect goes to the work package module's full
view. Instead it should redirect to 'bim.partitioned.show'.

This fix here has no corresponding bug work package on
community.