### PR TITLE
add simple eager loading to the notifications api

### DIFF
--- a/lib/api/v3/notifications/notification_representer.rb
+++ b/lib/api/v3/notifications/notification_representer.rb
@@ -100,6 +100,10 @@ module API
           'Notification'
         end
 
+        self.to_eager_load = [:project,
+                              :actor,
+                              { journal: %i[attachable_journals customizable_journals] }]
+
         ##
         # For notifications, we want to skip the initial journal
         # as the information is not that useful

--- a/lib/api/v3/notifications/notifications_api.rb
+++ b/lib/api/v3/notifications/notifications_api.rb
@@ -45,7 +45,9 @@ module API
             def notification_scope
               ::Notification
                 .recipient(current_user)
-                .where.not(reason_ian: nil)
+                .includes(NotificationRepresenter.to_eager_load)
+                .where
+                .not(reason_ian: nil)
             end
 
             def bulk_update_status(attributes)


### PR DESCRIPTION
Unfortunatly, the `data` association cannot be eager loaded since it is a polymorphic association and the successor journal (including it's `data`, `customizable_journal` and `attachable_journal`) cannot be eager loaded since there is no association for it at all. Some eager loading wrapper similar to what has been implemented for work packages would help here. It could then also be applied to the activities of an individual work package.

But this change here already helps lowering the response time for notification requests.