### PR TITLE
split up notification reason involved

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,14 +1,15 @@
 class Notification < ApplicationRecord
   REASONS = {
     mentioned: 0,
-    involved: 1,
+    assigned: 1,
     watched: 2,
     subscribed: 3,
     commented: 4,
     created: 5,
     processed: 6,
     prioritized: 7,
-    scheduled: 8
+    scheduled: 8,
+    responsible: 9
   }.freeze
 
   enum reason_ian: REASONS, _prefix: :ian

--- a/app/services/notifications/create_from_model_service.rb
+++ b/app/services/notifications/create_from_model_service.rb
@@ -123,12 +123,14 @@ class Notifications::CreateFromModelService
                         :mentioned)
   end
 
-  def settings_of_involved
-    scope = User
-              .where(id: group_or_user_ids(journal.data.assigned_to))
-              .or(User.where(id: group_or_user_ids(journal.data.responsible)))
+  def settings_of_assigned
+    applicable_settings(User.where(id: group_or_user_ids(journal.data.assigned_to)),
+                        project,
+                        :involved)
+  end
 
-    applicable_settings(scope,
+  def settings_of_responsible
+    applicable_settings(User.where(id: group_or_user_ids(journal.data.responsible)),
                         project,
                         :involved)
   end

--- a/app/services/notifications/create_from_model_service/work_package_strategy.rb
+++ b/app/services/notifications/create_from_model_service/work_package_strategy.rb
@@ -30,7 +30,7 @@
 
 module Notifications::CreateFromModelService::WorkPackageStrategy
   def self.reasons
-    %i(mentioned involved watched subscribed commented created processed prioritized scheduled)
+    %i(mentioned assigned responsible watched subscribed commented created processed prioritized scheduled)
   end
 
   def self.permission

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1397,9 +1397,8 @@ en:
         assigned: "You have been assigned to %{work_package}"
         subscribed: "You subscribed to %{work_package}"
         mentioned: "You have been mentioned in %{work_package}"
-        involved: "You either are assigned to or are responsible for %{work_package}"
+        responsible: "You have become accountable for %{work_package}"
         watched: "You are watching %{work_package}"
-
 
   label_accessibility: "Accessibility"
   label_account: "Account"
@@ -1985,7 +1984,8 @@ en:
         more_to_see_plural: 'There are %{number} more work packages with notifications.'
         reason:
           watched: 'Watched'
-          involved: 'Assigned or responsible'
+          assigned: 'Assigned'
+          responsible: 'Accountable'
           mentioned: 'Mentioned'
           subscribed: 'all'
           prefix: 'Received because of the notification setting: %{reason}'

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -570,7 +570,8 @@ en:
       reasons:
         mentioned: 'mentioned'
         watched: 'watched'
-        involved: 'involved'
+        assigned: 'assigned'
+        responsible: 'accountable'
       facets:
         unread: 'Unread'
         all: 'All'

--- a/spec/contracts/notifications/create_contract_spec.rb
+++ b/spec/contracts/notifications/create_contract_spec.rb
@@ -42,7 +42,7 @@ describe Notifications::CreateContract do
   let(:notification_recipient) { FactoryBot.build_stubbed(:user) }
   let(:notification_subject) { 'Some text' }
   let(:notification_reason_ian) { :mentioned }
-  let(:notification_reason_mail) { :involved }
+  let(:notification_reason_mail) { :assigned }
   let(:notification_reason_mail_digest) { :watched }
   let(:notification_read_ian) { false }
   let(:notification_read_mail) { false }

--- a/spec/factories/notification_factory.rb
+++ b/spec/factories/notification_factory.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :notification do
-    subject { "MyText" }
+    subject { "MyText" } # rubocop:disable RSpec/EmptyLineAfterSubject
     read_ian { false }
     read_mail { false }
     read_mail_digest { false }
     reason_ian { :mentioned }
-    reason_mail { :involved }
+    reason_mail { :assigned }
     reason_mail_digest { :watched }
     recipient factory: :user
     project { association :project }

--- a/spec/requests/api/v3/notifications/index_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/index_resource_spec.rb
@@ -141,9 +141,9 @@ describe ::API::V3::Notifications::NotificationsAPI,
     end
 
     context 'with a reason groupBy' do
-      let(:involved_notification) { FactoryBot.create :notification, recipient: recipient, reason_ian: :involved }
+      let(:responsible_notification) { FactoryBot.create :notification, recipient: recipient, reason_ian: :responsible }
 
-      let(:notifications) { [notification1, notification2, involved_notification] }
+      let(:notifications) { [notification1, notification2, responsible_notification] }
 
       let(:send_request) do
         get api_v3_paths.path_for :notifications, group_by: :reason
@@ -158,9 +158,9 @@ describe ::API::V3::Notifications::NotificationsAPI,
         expect(groups.count).to eq 2
 
         keyed = groups.index_by { |el| el['value'] }
-        expect(keyed.keys).to contain_exactly 'mentioned', 'involved'
+        expect(keyed.keys).to contain_exactly 'mentioned', 'responsible'
         expect(keyed['mentioned']['count']).to eq 2
-        expect(keyed['involved']['count']).to eq 1
+        expect(keyed['responsible']['count']).to eq 1
       end
     end
 
@@ -171,7 +171,7 @@ describe ::API::V3::Notifications::NotificationsAPI,
                           resource: work_package2,
                           project: work_package2.project,
                           recipient: recipient,
-                          reason_ian: :involved
+                          reason_ian: :responsible
       end
 
       let(:notifications) { [notification1, notification2, other_project_notification] }

--- a/spec/services/notifications/create_from_model_service_work_package_spec.rb
+++ b/spec/services/notifications/create_from_model_service_work_package_spec.rb
@@ -115,11 +115,11 @@ describe Notifications::CreateFromModelService,
       let(:notification_channel_reasons) do
         {
           read_ian: false,
-          reason_ian: :involved,
+          reason_ian: :assigned,
           read_mail: false,
-          reason_mail: :involved,
+          reason_mail: :assigned,
           read_mail_digest: false,
-          reason_mail_digest: :involved
+          reason_mail_digest: :assigned
         }
       end
     end
@@ -141,7 +141,7 @@ describe Notifications::CreateFromModelService,
             read_mail: false,
             reason_mail: :subscribed,
             read_mail_digest: false,
-            reason_mail_digest: :involved
+            reason_mail_digest: :assigned
           }
         end
       end
@@ -160,7 +160,7 @@ describe Notifications::CreateFromModelService,
         let(:notification_channel_reasons) do
           {
             read_ian: false,
-            reason_ian: :involved,
+            reason_ian: :assigned,
             read_mail: nil,
             reason_mail: nil,
             read_mail_digest: nil,
@@ -197,9 +197,9 @@ describe Notifications::CreateFromModelService,
             read_ian: false,
             reason_ian: :subscribed,
             read_mail: false,
-            reason_mail: :involved,
+            reason_mail: :assigned,
             read_mail_digest: false,
-            reason_mail_digest: :involved
+            reason_mail_digest: :assigned
           }
         end
       end
@@ -245,11 +245,11 @@ describe Notifications::CreateFromModelService,
       let(:notification_channel_reasons) do
         {
           read_ian: false,
-          reason_ian: :involved,
+          reason_ian: :responsible,
           read_mail: false,
-          reason_mail: :involved,
+          reason_mail: :responsible,
           read_mail_digest: false,
-          reason_mail_digest: :involved
+          reason_mail_digest: :responsible
         }
       end
     end
@@ -290,7 +290,7 @@ describe Notifications::CreateFromModelService,
         let(:notification_channel_reasons) do
           {
             read_ian: false,
-            reason_ian: :involved,
+            reason_ian: :responsible,
             read_mail: nil,
             reason_mail: nil,
             read_mail_digest: nil,
@@ -953,11 +953,11 @@ describe Notifications::CreateFromModelService,
       let(:notification_channel_reasons) do
         {
           read_ian: false,
-          reason_ian: :involved,
+          reason_ian: :assigned,
           read_mail: false,
-          reason_mail: :involved,
+          reason_mail: :assigned,
           read_mail_digest: false,
-          reason_mail_digest: :involved
+          reason_mail_digest: :assigned
         }
       end
     end

--- a/spec/services/notifications/set_attributes_service_spec.rb
+++ b/spec/services/notifications/set_attributes_service_spec.rb
@@ -30,6 +30,7 @@
 
 require 'spec_helper'
 
+# rubocop:disable RSpec/MultipleMemoizedHelpers
 describe Notifications::SetAttributesService, type: :model do
   let(:user) { FactoryBot.build_stubbed(:user) }
   let(:contract_class) do
@@ -58,7 +59,7 @@ describe Notifications::SetAttributesService, type: :model do
   let(:call_attributes) { {} }
   let(:project) { FactoryBot.build_stubbed(:project) }
   let(:reason_ian) { :mentioned }
-  let(:reason_mail) { :involved }
+  let(:reason_mail) { :assigned }
   let(:reason_mail_digest) { :watched }
   let(:journal) { FactoryBot.build_stubbed(:journal, journable: journable, data: journal_data) }
   let(:journable) { nil }
@@ -99,7 +100,7 @@ describe Notifications::SetAttributesService, type: :model do
           .to eql({
                     project_id: project.id,
                     reason_ian: 'mentioned',
-                    reason_mail: 'involved',
+                    reason_mail: 'assigned',
                     reason_mail_digest: 'watched',
                     journal_id: journal.id,
                     recipient_id: 1,
@@ -139,7 +140,7 @@ describe Notifications::SetAttributesService, type: :model do
             .to eql({
                       project_id: project.id,
                       reason_ian: 'mentioned',
-                      reason_mail: 'involved',
+                      reason_mail: 'assigned',
                       reason_mail_digest: 'watched',
                       resource_id: journable.id,
                       resource_type: 'WorkPackage',
@@ -161,3 +162,4 @@ describe Notifications::SetAttributesService, type: :model do
     end
   end
 end
+# rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
Differentiate between the receiver being assigned or accountable.

https://community.openproject.org/wp/38824