### PR TITLE
[38905] Links in consent form open in same tab / word missing in error message

### DIFF
--- a/app/controllers/concerns/accounts/user_consent.rb
+++ b/app/controllers/concerns/accounts/user_consent.rb
@@ -61,7 +61,7 @@ module Accounts::UserConsent
   def decline_consent
     message = I18n.t('consent.decline_warning_message') + "\n"
     message <<
-      if Setting.consent_decline_mail
+      if Setting.consent_decline_mail.present?
         I18n.t('consent.contact_this_mail_address', mail_address: Setting.consent_decline_mail)
       else
         I18n.t('consent.contact_your_administrator')

--- a/app/views/account/_user_consent_check.html.erb
+++ b/app/views/account/_user_consent_check.html.erb
@@ -1,6 +1,6 @@
 <section class="form--section">
   <p>
-    <%= format_text user_consent_instructions(consenting_user) %>
+    <%= format_text user_consent_instructions(consenting_user), { target: '_blank' } %>
   </p>
 
   <label class="form--label-with-check-box -required -no-ellipsis">
@@ -8,6 +8,6 @@
       <input type="checkbox" name="consent_check" class="form--check-box" required="required" />
     </div>
 
-    <%= format_text consent_checkbox_label %>
+    <p><%= consent_checkbox_label %></p>
   </label>
 </section>

--- a/lib/open_project/text_formatting/filters/link_attribute_filter.rb
+++ b/lib/open_project/text_formatting/filters/link_attribute_filter.rb
@@ -27,43 +27,21 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-require 'task_list/filter'
 
-module OpenProject::TextFormatting::Formats::Markdown
-  class Formatter < OpenProject::TextFormatting::Formats::BaseFormatter
-    def to_html(text)
-      result = pipeline.call(text, context)
-      output = result[:output].to_s
+module OpenProject::TextFormatting
+  module Filters
+    class LinkAttributeFilter < HTML::Pipeline::Filter
+      def call
+        links.each do |node|
+          node['target'] = context[:target] if context[:target].present?
+        end
 
-      output.html_safe
-    end
+        doc
+      end
 
-    def to_document(text)
-      pipeline.to_document text, context
-    end
-
-    def filters
-      %i[
-        setting_macros
-        markdown
-        sanitization
-        task_list
-        table_of_contents
-        macro
-        mention
-        pattern_matcher
-        syntax_highlight
-        attachment
-        relative_link
-        link_attribute
-        figure_wrapped
-        bem_css
-        autolink
-      ]
-    end
-
-    def self.format
-      :markdown
+      def links
+        doc.xpath(".//a[contains(@href,'/')]")
+      end
     end
   end
 end


### PR DESCRIPTION
Add LinkAttributeFilter to be able to add "target" attribute. Thus the "privacy policy"-link opens automatically in a new tab.



https://community.openproject.org/projects/openproject/work_packages/38905/activity