### PR TITLE
[#38960] Viewpoint files must end with .bcfv

### DIFF
--- a/modules/bim/lib/open_project/bim/bcf_xml/exporter.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/exporter.rb
@@ -123,7 +123,7 @@ module OpenProject::Bim::BcfXml
     def viewpoints_for(issue_dir, issue)
       [].tap do |files|
         issue.viewpoints.find_each do |vp|
-          vp_file = File.join(issue_dir, "#{vp.uuid}.xml")
+          vp_file = File.join(issue_dir, "#{vp.uuid}.bcfv")
           snapshot_file = File.join(issue_dir, "#{vp.uuid}#{vp.snapshot.extension}")
 
           # Copy the files

--- a/modules/bim/lib/open_project/bim/bcf_xml/issue_writer.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/issue_writer.rb
@@ -222,7 +222,7 @@ module OpenProject::Bim::BcfXml
     def viewpoints(xml)
       issue.viewpoints.find_each do |vp|
         xml.Viewpoints "Guid" => vp.uuid do
-          xml.Viewpoint "#{vp.uuid}.xml"
+          xml.Viewpoint "#{vp.uuid}.bcfv"
           xml.Snapshot "#{vp.uuid}#{vp.snapshot.extension}"
         end
       end

--- a/modules/bim/spec/bcf/bcf_xml/issue_writer_spec.rb
+++ b/modules/bim/spec/bcf/bcf_xml/issue_writer_spec.rb
@@ -182,7 +182,7 @@ describe ::OpenProject::Bim::BcfXml::IssueWriter do
     it 'replaces the BCF viewpoints names to use its uuid only' do
       uuid = bcf_issue.viewpoints.first.uuid
       viewpoint_node = subject.at("/Markup/Viewpoints[@Guid='#{uuid}']")
-      expect(viewpoint_node.at('Viewpoint').content).to eql("#{uuid}.xml")
+      expect(viewpoint_node.at('Viewpoint').content).to eql("#{uuid}.bcfv")
       expect(viewpoint_node.at('Snapshot').content).to eql("#{uuid}.png")
     end
   end


### PR DESCRIPTION
- https://community.openproject.org/work_packages/38960
- changed file extension from xml to bcfv

The change is according to BCF XML specifications.