### PR TITLE
Implementation/38920 improve performance of loading notifications

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -110,10 +110,14 @@ class Journal < ApplicationRecord
   private
 
   def predecessor
-    @predecessor ||= self.class
-                     .where(journable_type: journable_type, journable_id: journable_id)
-                     .where("#{self.class.table_name}.version < ?", version)
-                     .order("#{self.class.table_name}.version DESC")
-                     .first
+    @predecessor ||= if initial?
+                       nil
+                     else
+                       self.class
+                         .where(journable_type: journable_type, journable_id: journable_id)
+                         .where("#{self.class.table_name}.version < ?", version)
+                         .order(version: :desc)
+                         .first
+                     end
   end
 end

--- a/lib/api/v3/activities/activity_collection_representer.rb
+++ b/lib/api/v3/activities/activity_collection_representer.rb
@@ -32,6 +32,11 @@ module API
   module V3
     module Activities
       class ActivityCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
+        def initialize(models, self_link:, current_user:)
+          super
+
+          @represented = ::API::V3::Activities::ActivityEagerLoadingWrapper.wrap(represented)
+        end
       end
     end
   end

--- a/lib/api/v3/activities/activity_eager_loading_wrapper.rb
+++ b/lib/api/v3/activities/activity_eager_loading_wrapper.rb
@@ -1,0 +1,142 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module Activities
+      class ActivityEagerLoadingWrapper < API::V3::Utilities::EagerLoading::EagerLoadingWrapper
+        class << self
+          def wrap(journals)
+            if journals.any?
+              set_journable(journals)
+              set_predecessor(journals)
+              set_data(journals)
+            end
+
+            super
+          end
+
+          private
+
+          def set_journable(journals)
+            journables = journable_by_type_and_id(journals)
+
+            journals.each do |journal|
+              journal.journable = journables[journal.journable_type][journal.journable_id]
+            end
+          end
+
+          def set_predecessor(journals)
+            predecessors = predecessors_by_type_and_id(journals)
+
+            journals.each do |journal|
+              next unless predecessors[journal.journable_type]
+
+              predecessor = predecessors[journal.journable_type][journal.journable_id]&.find { |j| j.version < journal.version }
+
+              journal.instance_variable_set(:@predecessor, predecessor)
+            end
+          end
+
+          def set_data(journals)
+            data = data_by_type_and_id(journals)
+
+            journals.each do |journal|
+              journal.data = data[journal.data_type][journal.data_id]
+              journal.previous.data = data[journal.data_type][journal.previous.data_id] if journal.previous.present?
+            end
+          end
+
+          def journable_by_type_and_id(journals)
+            journals.map(&:journable_type).uniq.each_with_object(Hash.new([])) do |class_name, hash|
+              hash[class_name] = class_name
+                                   .constantize
+                                   .where(id: journals.map(&:journable_id))
+                                   .includes(:project)
+                                   .group_by(&:id)
+                                   .transform_values(&:first)
+            end
+          end
+
+          def data_by_type_and_id(journals)
+            # Assuming that
+            # * the journable has already been loaded by #set_journable
+            # * previous has already been loaded by #set_predecessor
+            journals
+              .group_by(&:data_type)
+              .each_with_object(Hash.new({})) do |(class_name, class_journals), hash|
+              hash[class_name] = class_name
+                                   .constantize
+                                   .find(data_ids(class_journals))
+                                   .group_by(&:id)
+                                   .transform_values(&:first)
+            end
+          end
+
+          def predecessors_by_type_and_id(journals)
+            predecessor_journals(journals)
+              .group_by(&:journable_type)
+              .transform_values do |v|
+              v
+                .group_by(&:journable_id)
+                .transform_values { |j| j.sort_by(&:version).reverse }
+            end
+          end
+
+          def data_ids(journals)
+            journals.map { |j| [j.data_id, j.previous&.data_id] }.flatten.compact
+          end
+
+          def predecessor_journals(journals)
+            current = journals.map { |j| [j.journable_type, j.journable_id, j.version] }
+
+            Journal
+              .from(
+                <<~SQL.squish
+                  (SELECT DISTINCT ON (predecessors.journable_type, predecessors.journable_id, current.version)
+                  predecessors.*
+                  FROM
+                  #{Journal.arel_table.grouping(Arel::Nodes::ValuesList.new(current)).as('current(journable_type, journable_id, version)').to_sql}
+                  JOIN journals predecessors
+                  ON
+                  current.journable_type = predecessors.journable_type
+                  AND current.journable_id = predecessors.journable_id
+                  AND current.version > predecessors.version
+                  ORDER BY predecessors.journable_type, predecessors.journable_id, current.version, predecessors.version DESC
+                  ) AS journals
+                SQL
+              )
+              .includes(:attachable_journals, :customizable_journals)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/notifications/notification_eager_loading_wrapper.rb
+++ b/lib/api/v3/notifications/notification_eager_loading_wrapper.rb
@@ -31,11 +31,25 @@
 module API
   module V3
     module Notifications
-      class NotificationCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
-        def initialize(models, self_link:, current_user:, query: {}, page: nil, per_page: nil, groups: nil)
-          super
+      class NotificationEagerLoadingWrapper < API::V3::Utilities::EagerLoading::EagerLoadingWrapper
+        class << self
+          def wrap(notifications)
+            API::V3::Activities::ActivityEagerLoadingWrapper.wrap(notifications.map(&:journal))
+            set_resource(notifications)
 
-          @represented = ::API::V3::Notifications::NotificationEagerLoadingWrapper.wrap(represented)
+            super
+          end
+
+          private
+
+          # Copy the resource over from the journal.
+          # Those two should always be the same.
+          # The journable will be loaded within the ActivityEagerLoadingWrapper.
+          def set_resource(notifications)
+            notifications.select { |n| n.journal.present? }.each do |notification|
+              notification.resource = notification.journal.journable
+            end
+          end
         end
       end
     end

--- a/lib/api/v3/projects/project_eager_loading_wrapper.rb
+++ b/lib/api/v3/projects/project_eager_loading_wrapper.rb
@@ -36,7 +36,7 @@ module API
 
         class << self
           def wrap(projects)
-            custom_fields = if projects && !projects.empty?
+            custom_fields = if projects.present?
                               projects.first.available_custom_fields
                             end
 

--- a/lib/api/v3/work_packages/eager_loading/custom_value.rb
+++ b/lib/api/v3/work_packages/eager_loading/custom_value.rb
@@ -118,8 +118,7 @@ module API
 
             scope
               .where(id: ids_of_values)
-              .map { |v| [v.id, v] }
-              .to_h
+              .index_by(&:id)
           end
 
           def custom_values_of(field_format)
@@ -143,8 +142,7 @@ module API
             @loaded_custom_fields_by_id ||= begin
               WorkPackageCustomField
                 .where(id: usages.map { |u| u['custom_field_id'] }.uniq)
-                .map { |cf| [cf.id, cf] }
-                .to_h
+                .index_by(&:id)
             end
 
             @loaded_custom_fields_by_id[id]

--- a/lib/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_formatter/named_association.rb
@@ -69,7 +69,7 @@ module JournalFormatter
     def associated_object(klass, id, options = {})
       cache = options[:cache]
 
-      if cache && cache.is_a?(Acts::Journalized::JournalObjectCache)
+      if cache.is_a?(Acts::Journalized::JournalObjectCache)
         cache.fetch(klass, id) do |k, i|
           k.find_by(id: i)
         end
@@ -85,9 +85,7 @@ module JournalFormatter
     def class_from_field(field)
       association = @journal.journable.class.reflect_on_association(field)
 
-      if association
-        association.class_name.constantize
-      end
+      association&.class_name&.constantize
     end
   end
 end

--- a/spec/features/notifications/navigation_spec.rb
+++ b/spec/features/notifications/navigation_spec.rb
@@ -23,7 +23,7 @@ describe "Notification center navigation", type: :feature, js: true do
                       recipient: recipient,
                       project: project,
                       resource: second_work_package,
-                      journal: work_package.journals.last
+                      journal: second_work_package.journals.last
   end
 
   let(:center) { ::Components::Notifications::Center.new }

--- a/spec/features/notifications/notification_center/split_screen_spec.rb
+++ b/spec/features/notifications/notification_center/split_screen_spec.rb
@@ -23,7 +23,7 @@ describe "Split screen in the notification center", type: :feature, js: true do
                       recipient: recipient,
                       project: project,
                       resource: second_work_package,
-                      journal: work_package.journals.last
+                      journal: second_work_package.journals.last
   end
 
   let(:center) { ::Components::Notifications::Center.new }

--- a/spec/lib/api/v3/notifications/notification_collection_representer_spec.rb
+++ b/spec/lib/api/v3/notifications/notification_collection_representer_spec.rb
@@ -63,6 +63,13 @@ describe ::API::V3::Notifications::NotificationCollectionRepresenter do
 
   include API::V3::Utilities::PathHelper
 
+  before do
+    allow(API::V3::Notifications::NotificationEagerLoadingWrapper)
+      .to receive(:wrap)
+            .with(notifications)
+            .and_return(notifications)
+  end
+
   describe 'generation' do
     subject(:collection) { representer.to_json }
 

--- a/spec/requests/api/v3/notifications/index_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/index_resource_spec.rb
@@ -47,13 +47,15 @@ describe ::API::V3::Notifications::NotificationsAPI,
     FactoryBot.create :notification,
                       recipient: recipient,
                       resource: work_package,
-                      project: work_package.project
+                      project: work_package.project,
+                      journal: work_package.journals.first
   end
   shared_let(:notification2) do
     FactoryBot.create :notification,
                       recipient: recipient,
                       resource: work_package,
-                      project: work_package.project
+                      project: work_package.project,
+                      journal: work_package.journals.first
   end
 
   let(:notifications) { [notification1, notification2] }
@@ -172,14 +174,16 @@ describe ::API::V3::Notifications::NotificationsAPI,
                           reason_ian: :assigned,
                           recipient: recipient,
                           resource: work_package,
-                          project: work_package.project
+                          project: work_package.project,
+                          journal: work_package.journals.first
       end
       let(:notification4) do
         FactoryBot.create :notification,
                           reason_ian: :responsible,
                           recipient: recipient,
                           resource: work_package,
-                          project: work_package.project
+                          project: work_package.project,
+                          journal: work_package.journals.first
       end
       let(:notifications) { [notification1, notification2, notification3, notification4] }
 
@@ -222,7 +226,14 @@ describe ::API::V3::Notifications::NotificationsAPI,
     end
 
     context 'with a reason groupBy' do
-      let(:responsible_notification) { FactoryBot.create :notification, recipient: recipient, reason_ian: :responsible }
+      let(:responsible_notification) do
+        FactoryBot.create :notification,
+                          recipient: recipient,
+                          reason_ian: :responsible,
+                          resource: work_package,
+                          project: work_package.project,
+                          journal: work_package.journals.first
+      end
 
       let(:notifications) { [notification1, notification2, responsible_notification] }
 
@@ -252,7 +263,8 @@ describe ::API::V3::Notifications::NotificationsAPI,
                           resource: work_package2,
                           project: work_package2.project,
                           recipient: recipient,
-                          reason_ian: :responsible
+                          reason_ian: :responsible,
+                          journal: work_package2.journals.first
       end
 
       let(:notifications) { [notification1, notification2, other_project_notification] }


### PR DESCRIPTION
Associations that cannot be loaded via rails` eager loading are eager
loaded by hand:
* The `data` association of journals
* The `predecessor` association of journals
* The `journable` association of journals
* The `resource` association of notifications

Since the notifications and the activities index api have a similar data
structure, notifications can reuse the eager loading of activities.

Does not include any optimization for the rendering of the details as of
now since the structure of the details is still subject to change.

In my test data, the response time is roughly halved.

https://community.openproject.org/projects/openproject/work_packages/38920

