### PR TITLE
Fix some broken links in docs/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,21 +18,21 @@ ToDo: check all links.
 
 Get started with installing and upgrading OpenProject using [our Installation Guide starting point](https://www.openproject.org/docs/installation-and-operations/).
 
-The guides for [manual](./installation/manual/README.md), [packaged](./installation/packaged/) and [Docker-based](./installation/docker/README.md) installations are provided.
+The guides for [manual](./installation-and-operations/installation/manual), [packaged](./installation-and-operations/installation/packaged) and [Docker-based](./installation-and-operations/installation/docker) installations are provided.
 
 ## Upgrading
 
 The detailed upgrade instructions for our packaged installer are located on the [official website](https://www.openproject.org/download/upgrade-guides/).
 
-The guides for [manual](./operations/upgrading/manual/upgrading.md), [packaged](./operations/upgrading/packaged/upgrading.md) and [Docker-based](./operations/upgrading/docker/upgrading.md) upgrading are provided.
+The guides for [upgrading](./installation-and-operations/operation/upgrading) are provided.
 
 ## Operation
 
-* Backup guides for [manual](./operations/backup/manual/backup.md), [packaged](./operations/backup/packaged/backup.md) and [Docker-based](./operations/backup/docker/backup.md) installations
-* [Alter configuration of OpenProject](./configuration/configuration.md)
-* [Manual repository integration for Git and Subversion](./repositories/README.md)
-* [Configure incoming mails](./configuration/incoming-emails.md)
-* [Install custom plugins](./plugins/plugins.md)
+* [Backing up you installation](./installation-and-operations/operation/backing-up)
+* [Alter configuration of OpenProject](./installation-and-operations/configuration)
+* [Manual repository integration for Git and Subversion](./installation-and-operations/configuration/repositories)
+* [Configure incoming mails](./installation-and-operations/configuration/incoming-emails)
+* [Install custom plugins](./installation-and-operations/configuration/plugins)
 
 
 ## User Guides
@@ -42,13 +42,12 @@ Please see our [User Guide pages](https://www.openproject.org/docs/user-guide/) 
 
 ## Development
 
-* [Quick Start for developers](./development/quick-start.md)
-* [Full development environment for developers on Ubuntu](./development/development-environment-ubuntu.md) and [Mac OS X](./development/development-environment-osx.md)
-* [Developing plugins](./development/create-openproject-plugin.md)
-* [Developing OmniAuth Plugins](./development/create-omniauth-plugin.md)
-* [Running tests](./development/running-tests.md)
-* [Code review guidelines](./development/code-review-guidelines.md)
-* [API documentation](./api/README.md)
+* [Full development environment for developers on Ubuntu](./development/development-environment-ubuntu) and [Mac OS X](./development/development-environment-osx)
+* [Developing plugins](./development/create-openproject-plugin)
+* [Developing OmniAuth Plugins](./development/create-omniauth-plugin)
+* [Running tests](./development/running-tests)
+* [Code review guidelines](./development/code-review-guidelines)
+* [API documentation](./api)
 
 
 ## APIv3 documentation sources

--- a/docs/development/development-environment-osx/README.md
+++ b/docs/development/development-environment-osx/README.md
@@ -238,7 +238,7 @@ You can then access the application either through `localhost:3000` (Rails serve
 ## Start Coding
 
 Please have a look at [our development guidelines](../code-review-guidelines) for tips and guides on how to start coding. We have advice on how to get your changes back into the OpenProject core as smooth as possible.
-Also, take a look at the `doc` directory in our sources, especially the [how to run tests](https://github.com/opf/openproject/blob/dev/docs/development/running-tests.md) documentation (we like to have automated tests for every new developed feature).
+Also, take a look at the `doc` directory in our sources, especially the [how to run tests](https://github.com/opf/openproject/blob/dev/docs/development/running-tests) documentation (we like to have automated tests for every new developed feature).
 
 ## Troubleshooting
 

--- a/docs/development/development-environment-ubuntu/README.md
+++ b/docs/development/development-environment-ubuntu/README.md
@@ -282,7 +282,7 @@ You can then access the application either through `localhost:3000` (Rails serve
 ## Start Coding
 
 Please have a look at [our development guidelines](../code-review-guidelines/) for tips and guides on how to start coding. We have advice on how to get your changes back into the OpenProject core as smooth as possible.
-Also, take a look at the `doc` directory in our sources, especially the [how to run tests](https://github.com/opf/openproject/blob/dev/docs/development/running-tests/README.md) documentation (we like to have automated tests for every new developed feature).
+Also, take a look at the `doc` directory in our sources, especially the [how to run tests](https://github.com/opf/openproject/tree/dev/docs/development/running-tests) documentation (we like to have automated tests for every new developed feature).
 
 ## Troubleshooting
 


### PR DESCRIPTION
Initially I wanted to fix the broken link "how to run tests" from https://www.openproject.org/docs/development/development-environment-osx/. Then I saw the same broken link existed in `docs/README.md` and some other links were broken too, so I tried to check and fix them all.

The guides for manual, packaged, and docker-based upgrading from docs/README.md are and the guides for manual, packaged, and docker-based backing up do not exist anymore since e1c642f46e. I linked to the unique available resource instead. Maybe that's wrong.

Also I did not link to the README.md files. I linked to the parent directory like it is done in the [`docs/development/README.md`](https://github.com/opf/openproject/blob/10f6de26841c383d59e36788a95ca34d21b25a1c/docs/development/README.md#additional-resources) file. That's why I updated the link in `docs/development/development-environment-ubuntu/README.md` too 