### PR TITLE
Remove the COMMENT ON EXTENSION in the structure.sql

### DIFF
--- a/docker/prod/setup/postinstall-common.sh
+++ b/docker/prod/setup/postinstall-common.sh
@@ -23,6 +23,9 @@ sleep 5
 # dump schema
 DATABASE_URL=postgres://assets:p4ssw0rd@127.0.0.1/assets RAILS_ENV=production bundle exec rake db:migrate db:schema:dump db:schema:cache:dump
 
+# this line requires superuser rights, which is not always available and doesn't matter anyway
+sed -i '/^COMMENT ON EXTENSION/d' db/structure.sql
+
 # precompile assets
 DATABASE_URL=postgres://assets:p4ssw0rd@127.0.0.1/assets RAILS_ENV=production bundle exec rake assets:precompile
 


### PR DESCRIPTION
Commenting on an extension requires superuser privileges, while superuser should not be required to setup the OpenProject database.

For instance, this makes the seeder fail on Scaleway managed databases, which do not allow to create superuser users. Removing the comment makes the install work.