### PR TITLE
Ensure the importer executes under the given user

### DIFF
--- a/modules/bim/app/seeders/bim/demo_data/bcf_xml_seeder.rb
+++ b/modules/bim/app/seeders/bim/demo_data/bcf_xml_seeder.rb
@@ -41,7 +41,7 @@ module Bim
         filename = project_data_for(key, 'bcf_xml_file')
         return unless filename.present?
 
-        user = User.admin.first
+        user = User.admin.active.first
 
         print_status '    ↳ Import BCF XML file'
 

--- a/modules/bim/lib/open_project/bim/bcf_xml/importer.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/importer.rb
@@ -39,26 +39,14 @@ module OpenProject::Bim::BcfXml
       end
     end
 
-    def aggregations
-      @aggregations ||= Aggregations.new(extractor_list, @project)
+    def import!(options = {})
+      User.execute_as(current_user) do
+        perform_import(options)
+      end
     end
 
-    def import!(options = {})
-      options = DEFAULT_IMPORT_OPTIONS.merge(options)
-      Zip::File.open(@file) do |zip|
-        create_or_add_missing_members(options)
-
-        # Extract all topics of the zip and save them
-        synchronize_topics(zip, options)
-
-        # TODO: Extract documents
-
-        # TODO: Extract BIM snippets
-      end
-    rescue StandardError => e
-      Rails.logger.error "Failed to import BCF Zip #{file}: #{e} #{e.message}"
-      Rails.logger.debug { e.backtrace.join("\n") }
-      raise
+    def aggregations
+      @aggregations ||= Aggregations.new(extractor_list, @project)
     end
 
     def bcf_version_valid?
@@ -75,6 +63,24 @@ module OpenProject::Bim::BcfXml
     end
 
     private
+
+    def perform_import(options)
+      options = DEFAULT_IMPORT_OPTIONS.merge(options)
+      Zip::File.open(@file) do |zip|
+        create_or_add_missing_members(options)
+
+        # Extract all topics of the zip and save them
+        synchronize_topics(zip, options)
+
+        # TODO: Extract documents
+
+        # TODO: Extract BIM snippets
+      end
+    rescue StandardError => e
+      Rails.logger.error "Failed to import BCF Zip #{file}: #{e} #{e.message}"
+      Rails.logger.debug { e.backtrace.join("\n") }
+      raise
+    end
 
     def create_or_add_missing_members(options)
       treat_invalid_people(options)

--- a/modules/bim/spec/bcf/bcf_xml/importer_spec.rb
+++ b/modules/bim/spec/bcf/bcf_xml/importer_spec.rb
@@ -73,7 +73,6 @@ describe ::OpenProject::Bim::BcfXml::Importer do
     workflow
     priority
     bcf_manager_member
-    login_as(bcf_manager)
   end
 
   describe '#to_listing' do


### PR DESCRIPTION
Since the attachment services now depend on a user for authorization, but the viewpoint snapshot is assigned explictily through snapshot.viewpoint=, there is no way to pass the  current_user explicitly. 

Instead, log in the given user for the course of the import process

[OP#39009](https://community.openproject.org/wp/39009)