### PR TITLE
Have capybara listen to localhost by default

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -21,7 +21,7 @@ RSpec.configure do |_config|
     Capybara.server_host = ip_address
     Capybara.app_host = "http://#{hostname}"
   else
-    Capybara.server_host = ENV.fetch('CAPYBARA_APP_HOSTNAME', '0.0.0.0')
+    Capybara.server_host = ENV.fetch('CAPYBARA_APP_HOSTNAME', 'localhost')
   end
 end
 


### PR DESCRIPTION
With Capybara listening on 0.0.0.0, and the ng asset host running on localhost, we get private access network errors starting in Chrome 94. This PR tells Capybara to listen on localhost instead to prevent that error.