### PR TITLE
manually load attachments' fulltext on search

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -63,10 +63,7 @@ See COPYRIGHT and LICENSE files for more details.
           <%= link_to highlight_tokens(truncate(e.event_title, escape: false, length: 255), @tokens), with_notes_anchor(e, @tokens) %>
         </dt>
         <dd>
-          <span class="description"><%= highlight_first([last_journal(e).try(:notes),
-                                                         attachment_fulltexts(e),
-                                                         attachment_filenames(e),
-                                                         e.event_description], @tokens) %></span>
+          <span class="description"><%= highlight_tokens_in_event(e, @tokens) %></span>
           <span class="author"><%= format_time(e.event_datetime) %></span>
         </dd>
       <% end %>


### PR DESCRIPTION
We avoid loading fulltext and fulltext_tsv by default since those values are not displayed a lot but might add a huge amount of time when loading attachments models.

Therefore, the fulltext column cannot be accessed from the Attachment model. This seems to be the only place where fulltext is displayed so it is probably better to have a special handling here instead of a poor performance at multiple places.

https://community.openproject.org/wp/38719