### PR TITLE
Fix: Maintain reverse order of work packages

### DIFF
--- a/frontend/src/app/modules/bim/revit_add_in/revit-bridge.service.ts
+++ b/frontend/src/app/modules/bim/revit_add_in/revit-bridge.service.ts
@@ -69,7 +69,13 @@ export class RevitBridgeService extends ViewerBridgeService {
   public showViewpoint(workPackage:WorkPackageResource, index:number) {
     this.viewpointsService
       .getViewPoint$(workPackage, index)
-      .subscribe((viewpoint:BcfViewpointInterface) =>  this.sendMessageToRevit('ShowViewpoint', this.newTrackingId(), JSON.stringify(viewpoint)));
+      .subscribe((viewpoint:BcfViewpointInterface) =>
+        this.sendMessageToRevit(
+          'ShowViewpoint',
+          this.newTrackingId(),
+          JSON.stringify(viewpoint)
+        )
+      );
   }
 
   sendMessageToRevit(messageType:string, trackingId:string, messagePayload?:any) {

--- a/frontend/src/app/modules/common/path-helper/path-helper.service.ts
+++ b/frontend/src/app/modules/common/path-helper/path-helper.service.ts
@@ -128,7 +128,7 @@ export class PathHelperService {
     let path = `${this.projectPath(projectIdentifier)}/bcf/split/details/${workPackageId}`;
 
     if (viewpoint !== null) {
-      path += `?viewpoint=${viewpoint}`;
+      path += `?query_props=%7B"t"%3A"id%3Adesc"%7D&viewpoint=${viewpoint}`;
     }
 
     return path;


### PR DESCRIPTION
When openening a BCF work package in full view
on click on a viewpoint icon
it shall load the page with a viewer and
a query with reverse order. The last bit was
missing and got fixed in this commit.
