### PR TITLE
Use captureException for sentry

### DIFF
--- a/lib/open_project/logging/sentry_logger.rb
+++ b/lib/open_project/logging/sentry_logger.rb
@@ -7,7 +7,12 @@ module OpenProject
         def log(message, log_context = {})
           Sentry.configure_scope do |sentry_scope|
             build_sentry_context(sentry_scope, log_context.to_h)
-            Sentry.capture_message(message, level: sentry_level(log_context[:level]))
+
+            if log_context[:exception]
+              Sentry.capture_exception(log_context[:exception])
+            else
+              Sentry.capture_message(message, level: sentry_level(log_context[:level]))
+            end
           end
         end
 


### PR DESCRIPTION
We already get an exception and backtrace, but there's no
well-documented way to add this to an event, so I suggest to use
captureException instead.

https://community.openproject.org/wp/39012

Exception rendering with this PR:
https://sentry2.openproject.com/organizations/sentry/issues/1149/?project=3&query=is%3Aunresolved