### PR TITLE
Use the CORE_VERSION for the version's revision

### DIFF
--- a/frontend/src/app/core/errors/sentry/sentry-reporter.ts
+++ b/frontend/src/app/core/errors/sentry/sentry-reporter.ts
@@ -93,7 +93,7 @@ export class SentryReporter implements ErrorReporter {
       sentry.init({
         dsn,
         debug: !environment.production,
-        release: `op-frontend@${version}`,
+        release: version,
         environment: environment.production ? 'production' : 'development',
 
         // Integrations

--- a/lib/open_project/version.rb
+++ b/lib/open_project/version.rb
@@ -54,12 +54,7 @@ module OpenProject
       end
 
       def revision
-        cached_or_block(:@revision) do
-          revision, = Open3.capture3('git', 'rev-parse', 'HEAD')
-          if revision.present?
-            revision.strip[0..8]
-          end
-        end
+        revision_from_core_version || revision_from_git
       end
 
       def product_version
@@ -112,6 +107,21 @@ module OpenProject
         cached_or_block(:@release_date_from_git) do
           date, = Open3.capture3('git', 'log', '-1', '--format=%cd', '--date=short')
           Date.parse(date) if date
+        end
+      end
+
+      def revision_from_core_version
+        return unless core_version.is_a?(String)
+
+        core_version.split.first
+      end
+
+      def revision_from_git
+        cached_or_block(:@revision) do
+          revision, = Open3.capture3('git', 'rev-parse', 'HEAD')
+          if revision.present?
+            revision.strip[0..8]
+          end
         end
       end
 


### PR DESCRIPTION
We output `major.minor.patch.revision` on a OpenProject::Version.to_s call, but revision will almost always be empty on production. If there is a core version file present, it has the core's commit as a first entry, and we can use this to pin a release for Sentry.

Also removes the special prefix of the frontend reporter, as we can differentiate the frontend by a tag now.