### PR TITLE
Fix/39073 store time zone preferences as tzinfo

### DIFF
--- a/app/cells/settings/time_zone_setting_cell.rb
+++ b/app/cells/settings/time_zone_setting_cell.rb
@@ -63,7 +63,7 @@ module Settings
     end
 
     # If there are multiple AS::TimeZones for a single TZInfo::Timezone, we
-    # one return the one that is the namesake.
+    # only return the one that is the namesake.
     def namesake_time_zone(time_zones)
       if time_zones.length == 1
         time_zones.first

--- a/app/cells/settings/time_zone_setting_cell.rb
+++ b/app/cells/settings/time_zone_setting_cell.rb
@@ -43,17 +43,11 @@ module Settings
     end
 
     def time_zone_entries
-      contract
+      UserPreferences::UpdateContract
         .assignable_time_zones
         .map do |tz|
         [tz.to_s, tz.tzinfo.canonical_identifier]
       end
-    end
-
-    private
-
-    def contract
-      @contract ||= UserPreferences::UpdateContract.new(form.object, User.current)
     end
   end
 end

--- a/app/cells/settings/time_zone_setting_cell.rb
+++ b/app/cells/settings/time_zone_setting_cell.rb
@@ -42,34 +42,18 @@ module Settings
       )
     end
 
-    def time_zones
-      ActiveSupport::TimeZone.all
-    end
-
-    ##
-    # Returns time zone (label, value) tuples to be used for a select field.
-    # As we only store tzinfo compatible data we only provide options, for which the
-    # values can later on be retrieved unambiguously. This is not always the case
-    # for values in ActiveSupport::TimeZone since multiple AS zones map to single tzinfo zones.
     def time_zone_entries
-      time_zones
-        .group_by { |tz| tz.tzinfo.name }
-        .values
-        .map do |zones|
-        tz = namesake_time_zone(zones)
-
+      contract
+        .assignable_time_zones
+        .map do |tz|
         [tz.to_s, tz.tzinfo.canonical_identifier]
       end
     end
 
-    # If there are multiple AS::TimeZones for a single TZInfo::Timezone, we
-    # only return the one that is the namesake.
-    def namesake_time_zone(time_zones)
-      if time_zones.length == 1
-        time_zones.first
-      else
-        time_zones.detect { |tz| tz.tzinfo.name.include?(tz.name.gsub(' ', '_')) }
-      end
+    private
+
+    def contract
+      @contract ||= UserPreferences::UpdateContract.new(form.object, User.current)
     end
   end
 end

--- a/app/contracts/user_preferences/base_contract.rb
+++ b/app/contracts/user_preferences/base_contract.rb
@@ -54,7 +54,10 @@ module UserPreferences
     protected
 
     def time_zone_correctness
-      errors.add(:time_zone, :inclusion) if model.time_zone.present? && model.canonical_time_zone.nil?
+      if model.time_zone.present? &&
+         ActiveSupport::TimeZone[model.time_zone]&.tzinfo&.canonical_identifier != model.time_zone
+        errors.add(:time_zone, :inclusion)
+      end
     end
 
     ##

--- a/app/contracts/user_preferences/base_contract.rb
+++ b/app/contracts/user_preferences/base_contract.rb
@@ -51,24 +51,42 @@ module UserPreferences
     validate :no_duplicate_workdays,
              if: -> { model.workdays.present? }
 
-    ##
-    # Returns time zones supported by OpenProject. Those include only the subset of all the
-    # TZInfo timezones also handled by ActiveSupport::TimeZone.
-    # The reason for this is currently:
-    #   * the reminder mail implementation which could be amended
-    #   * the select in the form which only displays ActiveSupport::TimeZone as they are more
-    #     user friendly.
-    # As we only store tzinfo compatible data we only provide options, for which the
-    # values can later on be retrieved unambiguously. This is not always the case
-    # for values in ActiveSupport::TimeZone since multiple AS zones map to single tzinfo zones.
-    def assignable_time_zones
-      ActiveSupport::TimeZone
-        .all
-        .group_by { |tz| tz.tzinfo.name }
-        .values
-        .map do |zones|
-        namesake_time_zone(zones)
+    class << self
+      ##
+      # Returns time zones supported by OpenProject. Those include only the subset of all the
+      # TZInfo timezones also handled by ActiveSupport::TimeZone.
+      # The reason for this is currently:
+      #   * the reminder mail implementation which could be amended
+      #   * the select in the form which only displays ActiveSupport::TimeZone as they are more
+      #     user friendly.
+      # As we only store tzinfo compatible data we only provide options, for which the
+      # values can later on be retrieved unambiguously. This is not always the case
+      # for values in ActiveSupport::TimeZone since multiple AS zones map to single tzinfo zones.
+      def assignable_time_zones
+        ActiveSupport::TimeZone
+          .all
+          .group_by { |tz| tz.tzinfo.name }
+          .values
+          .map do |zones|
+          namesake_time_zone(zones)
+        end
       end
+
+      private
+
+      # If there are multiple AS::TimeZones for a single TZInfo::Timezone, we
+      # only return the one that is the namesake.
+      def namesake_time_zone(time_zones)
+        if time_zones.length == 1
+          time_zones.first
+        else
+          time_zones.detect { |tz| tz.tzinfo.name.include?(tz.name.gsub(' ', '_')) }
+        end
+      end
+    end
+
+    def assignable_time_zones
+      self.class.assignable_time_zones
     end
 
     protected
@@ -98,16 +116,6 @@ module UserPreferences
     def no_duplicate_workdays
       unless model.workdays.uniq.length == model.workdays.length
         errors.add :workdays, :no_duplicates
-      end
-    end
-
-    # If there are multiple AS::TimeZones for a single TZInfo::Timezone, we
-    # only return the one that is the namesake.
-    def namesake_time_zone(time_zones)
-      if time_zones.length == 1
-        time_zones.first
-      else
-        time_zones.detect { |tz| tz.tzinfo.name.include?(tz.name.gsub(' ', '_')) }
       end
     end
   end

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -130,13 +130,6 @@ class UserPreference < ApplicationRecord
     super.presence || [1, 2, 3, 4, 5]
   end
 
-  def canonical_time_zone
-    return if time_zone.nil?
-
-    zone = ActiveSupport::TimeZone.new(time_zone)
-    zone&.tzinfo&.canonical_identifier
-  end
-
   private
 
   def to_boolean(value)

--- a/app/models/users/scopes/having_reminder_mail_to_send.rb
+++ b/app/models/users/scopes/having_reminder_mail_to_send.rb
@@ -68,14 +68,16 @@ module Users::Scopes
         # Joins the times local to the user preferences and then checks whether:
         # * reminders are enabled
         # * any of the configured reminder time is the local time
+        # * the local workday is enabled to receive a reminder on
         # If no time zone is present, utc is assumed.
         # If no reminder settings are present, sending a reminder at 08:00 local time is assumed.
+        # If no workdays are specified, 1 - 5 is assumed which is represents Monday to Friday.
         times_sql = arel_table
                       .grouping(Arel::Nodes::ValuesList.new(local_times))
                       .as('t(time, zone, workday)')
         <<~SQL.squish
           JOIN (SELECT * FROM #{times_sql.to_sql}) AS local_times
-          ON COALESCE(user_preferences.settings->>'time_zone', 'UTC') = local_times.zone
+          ON COALESCE(user_preferences.settings->>'time_zone', 'Etc/UTC') = local_times.zone
           AND (
             user_preferences.settings->'workdays' @> to_jsonb(local_times.workday)
             OR (
@@ -104,23 +106,23 @@ module Users::Scopes
       end
 
       def times_for_zones(times)
-        ActiveSupport::TimeZone
-          .all
+        UserPreferences::UpdateContract
+          .assignable_time_zones
           .map do |z|
-          times.map do |time|
-            local_time = time.in_time_zone(z)
+            times.map do |time|
+              local_time = time.in_time_zone(z)
 
-            # Get the iso weekday of the current time to check
-            # which users have it enabled as a workday
-            workday = local_time.to_date.cwday
+              # Get the iso weekday of the current time to check
+              # which users have it enabled as a workday
+              workday = local_time.to_date.cwday
 
-            # Since only full hours can be configured, we can disregard any local time that is not
-            # a full hour.
-            next if local_time.min != 0
+              # Since only full hours can be configured, we can disregard any local time that is not
+              # a full hour.
+              next if local_time.min != 0
 
-            [local_time.strftime('%H:00:00+00:00'), z.name.gsub("'", "''"), workday]
+              [local_time.strftime('%H:00:00+00:00'), z.tzinfo.canonical_zone.name, workday]
+            end
           end
-        end
           .flatten(1)
           .compact
       end

--- a/db/migrate/20211005080304_tzinfo_time_zones.rb
+++ b/db/migrate/20211005080304_tzinfo_time_zones.rb
@@ -41,7 +41,8 @@ class TzinfoTimeZones < ActiveRecord::Migration[6.1]
                     end
                     .flatten(1)
 
-    migrate_time_zone(zone_mappings)
+    migrate_user_time_zone(zone_mappings)
+    migrate_default_time_zone(zone_mappings)
   end
 
   def down
@@ -51,18 +52,19 @@ class TzinfoTimeZones < ActiveRecord::Migration[6.1]
                         [tz.tzinfo.canonical_zone.name, tz.name]
                       end
 
-    migrate_time_zone(zone_mappings)
+    migrate_user_time_zone(zone_mappings)
+    migrate_default_time_zone(zone_mappings)
   end
 
   protected
 
-  def migrate_time_zone(mappings)
+  def migrate_user_time_zone(mappings)
     execute <<~SQL.squish
       WITH source AS (
         SELECT id, settings || jsonb_build_object('time_zone', to_zone) settings
-      FROM user_preferences
-      LEFT JOIN (SELECT * FROM (#{Arel::Nodes::ValuesList.new(mappings).to_sql}) as t(from_zone, to_zone)) zones
-        ON zones.from_zone = user_preferences.settings->>'time_zone'
+        FROM user_preferences
+        LEFT JOIN (SELECT * FROM (#{Arel::Nodes::ValuesList.new(mappings).to_sql}) as t(from_zone, to_zone)) zones
+          ON zones.from_zone = user_preferences.settings->>'time_zone'
       )
 
       UPDATE user_preferences sink
@@ -70,6 +72,20 @@ class TzinfoTimeZones < ActiveRecord::Migration[6.1]
       FROM source
       WHERE source.id = sink.id
       AND sink.settings->'time_zone' IS NOT NULL
+    SQL
+  end
+
+  def migrate_default_time_zone(mappings)
+    execute <<~SQL.squish
+      WITH zones AS (
+        SELECT * FROM (#{Arel::Nodes::ValuesList.new(mappings).to_sql}) as t(from_zone, to_zone)
+      )
+
+      UPDATE settings
+      SET value = zones.to_zone
+      FROM zones
+      WHERE settings.name = 'user_default_timezone'
+      AND settings.value = zones.from_zone
     SQL
   end
 end

--- a/db/migrate/20211005080304_tzinfo_time_zones.rb
+++ b/db/migrate/20211005080304_tzinfo_time_zones.rb
@@ -1,0 +1,75 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class TzinfoTimeZones < ActiveRecord::Migration[6.1]
+  def up
+    zone_mappings = ActiveSupport::TimeZone
+                    .all
+                    .map do |tz|
+                      [
+                        [tz.name, tz.tzinfo.canonical_zone.name],
+                        # Some entries seem to already be in that format so we leave them unchanged
+                        [tz.tzinfo.canonical_zone.name, tz.tzinfo.canonical_zone.name]
+                      ]
+                    end
+                    .flatten(1)
+
+    migrate_time_zone(zone_mappings)
+  end
+
+  def down
+    zone_mappings = ActiveSupport::TimeZone
+                      .all
+                      .map do |tz|
+                        [tz.tzinfo.canonical_zone.name, tz.name]
+                      end
+
+    migrate_time_zone(zone_mappings)
+  end
+
+  protected
+
+  def migrate_time_zone(mappings)
+    execute <<~SQL.squish
+      WITH source AS (
+        SELECT id, settings || jsonb_build_object('time_zone', to_zone) settings
+      FROM user_preferences
+      LEFT JOIN (SELECT * FROM (#{Arel::Nodes::ValuesList.new(mappings).to_sql}) as t(from_zone, to_zone)) zones
+        ON zones.from_zone = user_preferences.settings->>'time_zone'
+      )
+
+      UPDATE user_preferences sink
+      SET settings = source.settings
+      FROM source
+      WHERE source.id = sink.id
+      AND sink.settings->'time_zone' IS NOT NULL
+    SQL
+  end
+end

--- a/lib/api/v3/user_preferences/user_preference_representer.rb
+++ b/lib/api/v3/user_preferences/user_preference_representer.rb
@@ -57,7 +57,6 @@ module API
 
         property :hide_mail
         property :time_zone,
-                 getter: ->(*) { canonical_time_zone },
                  render_nil: true
 
         property :warn_on_leaving_unsaved

--- a/spec/contracts/user_preferences/update_contract_spec.rb
+++ b/spec/contracts/user_preferences/update_contract_spec.rb
@@ -57,215 +57,242 @@ describe UserPreferences::UpdateContract do
   end
   let(:contract) { described_class.new(user_preference, current_user) }
 
-  context 'when current_user is admin' do
-    let(:current_user) { FactoryBot.build_stubbed(:admin) }
-    let(:preference_user) { FactoryBot.build_stubbed(:user) }
+  describe 'validation' do
+    context 'when current_user is admin' do
+      let(:current_user) { FactoryBot.build_stubbed(:admin) }
+      let(:preference_user) { FactoryBot.build_stubbed(:user) }
 
-    it_behaves_like 'contract is valid'
-  end
-
-  context 'when current_user has manage_user permission' do
-    let(:preference_user) { FactoryBot.build_stubbed(:user) }
-
-    before do
-      allow(current_user).to receive(:allowed_to_globally?).with(:manage_user).and_return true
+      it_behaves_like 'contract is valid'
     end
 
-    it_behaves_like 'contract is valid'
-  end
+    context 'when current_user has manage_user permission' do
+      let(:preference_user) { FactoryBot.build_stubbed(:user) }
 
-  context 'when current_user is the own user' do
-    it_behaves_like 'contract is valid'
-  end
+      before do
+        allow(current_user).to receive(:allowed_to_globally?).with(:manage_user).and_return true
+      end
 
-  context 'when current_user is the own user but not active' do
-    before do
-      allow(current_user).to receive(:active?).and_return false
+      it_behaves_like 'contract is valid'
     end
 
-    it_behaves_like 'contract user is unauthorized'
-  end
-
-  context 'when current_user is anonymous' do
-    let(:current_user) { User.anonymous }
-
-    it_behaves_like 'contract user is unauthorized'
-  end
-
-  context 'when current_user is a regular user' do
-    let(:preference_user) { FactoryBot.build_stubbed(:user) }
-
-    it_behaves_like 'contract user is unauthorized'
-  end
-
-  context 'with empty settings' do
-    let(:settings) do
-      {}
+    context 'when current_user is the own user' do
+      it_behaves_like 'contract is valid'
     end
 
-    it_behaves_like 'contract is valid'
-  end
+    context 'when current_user is the own user but not active' do
+      before do
+        allow(current_user).to receive(:active?).and_return false
+      end
 
-  context 'with a string for hide_mail' do
-    let(:settings) do
-      {
-        hide_mail: 'yes please'
-      }
+      it_behaves_like 'contract user is unauthorized'
     end
 
-    it_behaves_like 'contract is invalid', hide_mail: :type_mismatch
-  end
+    context 'when current_user is anonymous' do
+      let(:current_user) { User.anonymous }
 
-  context 'with a field within the daily_reminders having the wrong type' do
-    let(:settings) do
-      {
-        daily_reminders: {
-          enabled: 'sure',
-          times: %w[08:00:00+00:00 12:00:00+00:00]
+      it_behaves_like 'contract user is unauthorized'
+    end
+
+    context 'when current_user is a regular user' do
+      let(:preference_user) { FactoryBot.build_stubbed(:user) }
+
+      it_behaves_like 'contract user is unauthorized'
+    end
+
+    context 'with empty settings' do
+      let(:settings) do
+        {}
+      end
+
+      it_behaves_like 'contract is valid'
+    end
+
+    context 'with a string for hide_mail' do
+      let(:settings) do
+        {
+          hide_mail: 'yes please'
         }
-      }
+      end
+
+      it_behaves_like 'contract is invalid', hide_mail: :type_mismatch
     end
 
-    it_behaves_like 'contract is invalid', daily_reminders: :type_mismatch_nested
-  end
-
-  context 'with a field within the daily_reminders missing' do
-    let(:settings) do
-      {
-        daily_reminders: {
-          times: %w[08:00:00+00:00 12:00:00+00:00]
+    context 'with a field within the daily_reminders having the wrong type' do
+      let(:settings) do
+        {
+          daily_reminders: {
+            enabled: 'sure',
+            times: %w[08:00:00+00:00 12:00:00+00:00]
+          }
         }
-      }
+      end
+
+      it_behaves_like 'contract is invalid', daily_reminders: :type_mismatch_nested
     end
 
-    it_behaves_like 'contract is invalid', daily_reminders: :blank_nested
-  end
+    context 'with a field within the daily_reminders missing' do
+      let(:settings) do
+        {
+          daily_reminders: {
+            times: %w[08:00:00+00:00 12:00:00+00:00]
+          }
+        }
+      end
 
-  context 'with an extra property' do
-    let(:settings) do
-      {
-        foo: true
-      }
+      it_behaves_like 'contract is invalid', daily_reminders: :blank_nested
     end
 
-    it_behaves_like 'contract is invalid', foo: :unknown_property
-  end
-
-  context 'with an extra property within the daily_reminders' do
-    let(:settings) do
-      {
-        daily_reminders: {
-          enabled: true,
-          times: %w[08:00:00+00:00 12:00:00+00:00],
+    context 'with an extra property' do
+      let(:settings) do
+        {
           foo: true
         }
-      }
+      end
+
+      it_behaves_like 'contract is invalid', foo: :unknown_property
     end
 
-    it_behaves_like 'contract is invalid', daily_reminders: :unknown_property_nested
-  end
-
-  context 'with an invalid time for the daily_reminders' do
-    let(:settings) do
-      {
-        daily_reminders: {
-          enabled: true,
-          times: %w[abc 12:00:00+00:00]
+    context 'with an extra property within the daily_reminders' do
+      let(:settings) do
+        {
+          daily_reminders: {
+            enabled: true,
+            times: %w[08:00:00+00:00 12:00:00+00:00],
+            foo: true
+          }
         }
-      }
+      end
+
+      it_behaves_like 'contract is invalid', daily_reminders: :unknown_property_nested
     end
 
-    it_behaves_like 'contract is invalid', daily_reminders: %i[format_nested full_hour]
-  end
-
-  context 'with a sub hour time for the daily_reminders' do
-    let(:settings) do
-      {
-        daily_reminders: {
-          enabled: true,
-          times: %w[12:30:00+00:00]
+    context 'with an invalid time for the daily_reminders' do
+      let(:settings) do
+        {
+          daily_reminders: {
+            enabled: true,
+            times: %w[abc 12:00:00+00:00]
+          }
         }
-      }
+      end
+
+      it_behaves_like 'contract is invalid', daily_reminders: %i[format_nested full_hour]
     end
 
-    it_behaves_like 'contract is invalid', daily_reminders: :full_hour
+    context 'with a sub hour time for the daily_reminders' do
+      let(:settings) do
+        {
+          daily_reminders: {
+            enabled: true,
+            times: %w[12:30:00+00:00]
+          }
+        }
+      end
+
+      it_behaves_like 'contract is invalid', daily_reminders: :full_hour
+    end
+
+    context 'with an invalid order for comments_sorting' do
+      let(:settings) do
+        {
+          comments_sorting: 'up'
+        }
+      end
+
+      it_behaves_like 'contract is invalid', comments_sorting: :inclusion
+    end
+
+    context 'without a time_zone' do
+      let(:settings) do
+        {
+          hide_mail: true,
+          auto_hide_popups: true,
+          comments_sorting: 'desc',
+          daily_reminders: {
+            enabled: true,
+            times: %w[08:00:00+00:00 12:00:00+00:00]
+          },
+          warn_on_leaving_unsaved: true
+        }
+      end
+
+      it_behaves_like 'contract is valid'
+    end
+
+    context 'with a full time_zone' do
+      let(:settings) do
+        {
+          time_zone: 'Europe/Paris'
+        }
+      end
+
+      it_behaves_like 'contract is valid'
+    end
+
+    context 'with a non ActiveSupport::Timezone timezone' do
+      let(:settings) do
+        {
+          time_zone: 'America/Adak'
+        }
+      end
+
+      it_behaves_like 'contract is invalid', time_zone: :inclusion
+    end
+
+    context 'with a malformed time_zone' do
+      let(:settings) do
+        {
+          time_zone: '123Brasilia'
+        }
+      end
+
+      it_behaves_like 'contract is invalid', time_zone: :inclusion
+    end
+
+    context 'with a non tzinfo time_zone' do
+      let(:settings) do
+        {
+          time_zone: 'Brasilia'
+        }
+      end
+
+      it_behaves_like 'contract is invalid', time_zone: :inclusion
+    end
+
+    context 'with duplicate workday entries' do
+      let(:settings) do
+        {
+          workdays: [1, 1]
+        }
+      end
+
+      it_behaves_like 'contract is invalid', workdays: :no_duplicates
+    end
+
+    context 'with non-iso workday entries' do
+      let(:settings) do
+        {
+          workdays: [nil, 'foo', :bar, 21345, 2.0]
+        }
+      end
+
+      it_behaves_like 'contract is invalid', workdays: %i[invalid type_mismatch_nested
+                                                          type_mismatch_nested type_mismatch_nested]
+    end
   end
 
-  context 'with an invalid order for comments_sorting' do
-    let(:settings) do
-      {
-        comments_sorting: 'up'
-      }
+  describe '#assignable_time_zones' do
+    subject(:time_zones) { contract.assignable_time_zones }
+
+    it 'returns a list of AS::TimeZones' do
+      expect(time_zones)
+        .to(be_all { |tz| tz.is_a?(ActiveSupport::TimeZone) })
     end
 
-    it_behaves_like 'contract is invalid', comments_sorting: :inclusion
-  end
-
-  context 'without a time_zone' do
-    let(:settings) do
-      {
-        hide_mail: true,
-        auto_hide_popups: true,
-        comments_sorting: 'desc',
-        daily_reminders: {
-          enabled: true,
-          times: %w[08:00:00+00:00 12:00:00+00:00]
-        },
-        warn_on_leaving_unsaved: true
-      }
+    it 'includes only the namesake zone if multiple AS::Timezone map to the same TZInfo' do
+      # In this case 'Edinburgh' and 'Bern' are not included
+      expect(time_zones.select { |tz| %w[Europe/London Europe/Zurich].include? tz.tzinfo.canonical_zone.name })
+        .to match_array([ActiveSupport::TimeZone['London'], ActiveSupport::TimeZone['Zurich']])
     end
-
-    it_behaves_like 'contract is valid'
-  end
-
-  context 'with a full time_zone' do
-    let(:settings) do
-      {
-        time_zone: 'Europe/Paris'
-      }
-    end
-
-    it_behaves_like 'contract is valid'
-  end
-
-  context 'with a malformed time_zone' do
-    let(:settings) do
-      {
-        time_zone: '123Brasilia'
-      }
-    end
-
-    it_behaves_like 'contract is invalid', time_zone: :inclusion
-  end
-
-  context 'with a non tzinfo time_zone' do
-    let(:settings) do
-      {
-        time_zone: 'Brasilia'
-      }
-    end
-
-    it_behaves_like 'contract is invalid', time_zone: :inclusion
-  end
-
-  context 'with duplicate workday entries' do
-    let(:settings) do
-      {
-        workdays: [1, 1]
-      }
-    end
-
-    it_behaves_like 'contract is invalid', workdays: :no_duplicates
-  end
-
-  context 'with non-iso workday entries' do
-    let(:settings) do
-      {
-        workdays: [nil, 'foo', :bar, 21345, 2.0]
-      }
-    end
-
-    it_behaves_like 'contract is invalid', workdays: %i[invalid type_mismatch_nested
-                                                        type_mismatch_nested type_mismatch_nested]
   end
 end

--- a/spec/contracts/user_preferences/update_contract_spec.rb
+++ b/spec/contracts/user_preferences/update_contract_spec.rb
@@ -50,8 +50,9 @@ describe UserPreferences::UpdateContract do
         enabled: true,
         times: %w[08:00:00+00:00 12:00:00+00:00]
       },
-      time_zone: 'Brasilia',
-      warn_on_leaving_unsaved: true
+      time_zone: 'America/Sao_Paulo',
+      warn_on_leaving_unsaved: true,
+      workdays: [1, 2, 4, 6]
     }
   end
   let(:contract) { described_class.new(user_preference, current_user) }
@@ -237,36 +238,34 @@ describe UserPreferences::UpdateContract do
     it_behaves_like 'contract is invalid', time_zone: :inclusion
   end
 
-  describe 'workdays' do
-    context 'with valid entries' do
-      let(:settings) do
-        {
-          workdays: [1, 2, 4, 6]
-        }
-      end
-
-      it_behaves_like 'contract is valid'
+  context 'with a non tzinfo time_zone' do
+    let(:settings) do
+      {
+        time_zone: 'Brasilia'
+      }
     end
 
-    context 'with duplicate entries' do
-      let(:settings) do
-        {
-          workdays: [1, 1]
-        }
-      end
+    it_behaves_like 'contract is invalid', time_zone: :inclusion
+  end
 
-      it_behaves_like 'contract is invalid', workdays: :no_duplicates
+  context 'with duplicate workday entries' do
+    let(:settings) do
+      {
+        workdays: [1, 1]
+      }
     end
 
-    context 'with non-iso entries' do
-      let(:settings) do
-        {
-          workdays: [nil, 'foo', :bar, 21345, 2.0]
-        }
-      end
+    it_behaves_like 'contract is invalid', workdays: :no_duplicates
+  end
 
-      it_behaves_like 'contract is invalid', workdays: %i[invalid type_mismatch_nested
-                                                          type_mismatch_nested type_mismatch_nested]
+  context 'with non-iso workday entries' do
+    let(:settings) do
+      {
+        workdays: [nil, 'foo', :bar, 21345, 2.0]
+      }
     end
+
+    it_behaves_like 'contract is invalid', workdays: %i[invalid type_mismatch_nested
+                                                        type_mismatch_nested type_mismatch_nested]
   end
 end

--- a/spec/features/notifications/reminder_mail_spec.rb
+++ b/spec/features/notifications/reminder_mail_spec.rb
@@ -14,17 +14,17 @@ describe "Reminder email sending", type: :feature, js: true do
   # time zone. For the time zone Hawaii (UTC-10) this means between 8:00:00 and 8:14:59 UTC.
   # The job is scheduled to run every 15 min so the run_at will in production always move between the quarters of an hour.
   # The current time can be way behind that.
-  let(:current_utc_time) { ActiveSupport::TimeZone['Hawaii'].parse("08:34:10").utc }
-  let(:job_run_at) { ActiveSupport::TimeZone['Hawaii'].parse("08:00").utc }
+  let(:current_utc_time) { ActiveSupport::TimeZone['Pacific/Honolulu'].parse("08:34:10").utc }
+  let(:job_run_at) { ActiveSupport::TimeZone['Pacific/Honolulu'].parse("08:00").utc }
 
   current_user do
     FactoryBot.create(
       :user,
       preferences: {
-        time_zone: "Hawaii",
+        time_zone: 'Pacific/Honolulu',
         daily_reminders: {
           enabled: true,
-          times: [hitting_reminder_slot_for("Hawaii", current_utc_time)]
+          times: [hitting_reminder_slot_for('Pacific/Honolulu', current_utc_time)]
         }
       },
       notification_settings: [

--- a/spec/lib/api/v3/user_preferences/user_preference_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/user_preferences/user_preference_representer_rendering_spec.rb
@@ -59,7 +59,7 @@ describe ::API::V3::UserPreferences::UserPreferenceRepresenter,
   it { expect(subject).to have_json_path('autoHidePopups') }
 
   describe 'timeZone' do
-    context 'no time zone set' do
+    context 'without a timezone set' do
       let(:preference) { FactoryBot.build(:user_preference, time_zone: '') }
 
       it 'shows the timeZone as nil' do
@@ -67,15 +67,7 @@ describe ::API::V3::UserPreferences::UserPreferenceRepresenter,
       end
     end
 
-    context 'short timezone set' do
-      let(:preference) { FactoryBot.build(:user_preference, time_zone: 'Berlin') }
-
-      it 'shows the canonical time zone' do
-        expect(subject).to be_json_eql('Europe/Berlin'.to_json).at_path('timeZone')
-      end
-    end
-
-    context 'canonical timezone set' do
+    context 'with a timezone set' do
       let(:preference) { FactoryBot.build(:user_preference, time_zone: 'Europe/Paris') }
 
       it 'shows the canonical time zone' do

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -165,20 +165,6 @@ describe UserPreference do
     end
   end
 
-  describe 'time_zone' do
-    it 'allows to save short time zones' do
-      subject.time_zone = 'Berlin'
-      expect(subject.time_zone).to eq('Berlin')
-      expect(subject.canonical_time_zone).to eq('Europe/Berlin')
-    end
-
-    it 'allows to set full time zones' do
-      subject.time_zone = 'Europe/Paris'
-      expect(subject.time_zone).to eq('Europe/Paris')
-      expect(subject.canonical_time_zone).to eq('Europe/Paris')
-    end
-  end
-
   describe '[]=' do
     let(:user) { FactoryBot.create(:user) }
 

--- a/spec/models/users/default_timezone_spec.rb
+++ b/spec/models/users/default_timezone_spec.rb
@@ -37,9 +37,9 @@ describe User, "default time zone" do
     end
   end
 
-  context "with a system default set", with_settings: { user_default_timezone: "Edinburgh" } do
+  context "with a system default set", with_settings: { user_default_timezone: "Europe/London" } do
     it "is set to the default" do
-      expect(user.pref.time_zone).to eq "Edinburgh"
+      expect(user.pref.time_zone).to eq "Europe/London"
     end
   end
 end

--- a/spec/models/users/scopes/having_reminder_mail_to_send_spec.rb
+++ b/spec/models/users/scopes/having_reminder_mail_to_send_spec.rb
@@ -521,6 +521,31 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     end
   end
 
+  context 'for a user without a time zone and a default time zone configured',
+          with_settings: { user_default_timezone: 'Europe/Moscow' } do
+    let(:moscow_user) do
+      FactoryBot.create(
+        :user,
+        firstname: 'Europe/Moscow',
+        preferences: {
+          daily_reminders: {
+            enabled: true,
+            times: [hitting_reminder_slot_for("Europe/Moscow", current_time)]
+          }
+        }
+      )
+    end
+    let(:notifications) do
+      FactoryBot.create(:notification, recipient: moscow_user, created_at: 5.minutes.ago)
+    end
+    let(:users) { [moscow_user] }
+
+    it 'is including the configured default timezone is assumed' do
+      expect(scope)
+        .to match_array([moscow_user])
+    end
+  end
+
   context 'when the provided scope_time is after the current time' do
     let(:scope_time) { Time.current + 1.minute }
 

--- a/spec/models/users/scopes/having_reminder_mail_to_send_spec.rb
+++ b/spec/models/users/scopes/having_reminder_mail_to_send_spec.rb
@@ -50,9 +50,9 @@ describe User, '.having_reminder_mail_to_send', type: :model do
   let(:paris_user) do
     FactoryBot.create(
       :user,
-      firstname: 'Paris',
+      firstname: 'Europe/Paris',
       preferences: {
-        time_zone: "Paris",
+        time_zone: "Europe/Paris",
         workdays: paris_user_workdays,
         daily_reminders: paris_user_daily_reminders
       }
@@ -62,7 +62,7 @@ describe User, '.having_reminder_mail_to_send', type: :model do
   let(:paris_user_daily_reminders) do
     {
       enabled: true,
-      times: [hitting_reminder_slot_for("Paris", current_time)]
+      times: [hitting_reminder_slot_for("Europe/Paris", current_time)]
     }
   end
   let(:notifications) { FactoryBot.create(:notification, recipient: paris_user, created_at: 5.minutes.ago) }
@@ -101,17 +101,17 @@ describe User, '.having_reminder_mail_to_send', type: :model do
   end
 
   context 'for a user whose local time is on the previous workday' do
-    # 8:00 thursday UTC = 22:00 wednesday Hawaii
+    # 8:00 thursday Etc/UTC = 22:00 wednesday Pacific/Honolulu
     let(:hawaii_user) do
       FactoryBot.create(
         :user,
-        firstname: 'Hawaii',
+        firstname: 'Pacific/Honolulu',
         preferences: {
-          time_zone: "Hawaii",
+          time_zone: "Pacific/Honolulu",
           workdays: hawaii_user_workdays,
           daily_reminders: {
             enabled: true,
-            times: [hitting_reminder_slot_for("Hawaii", current_time)]
+            times: [hitting_reminder_slot_for("Pacific/Honolulu", current_time)]
           }
         }
       )
@@ -138,20 +138,20 @@ describe User, '.having_reminder_mail_to_send', type: :model do
   end
 
   context 'for a user whose local time is on the next workday' do
-    # 12:00 thursday UTC = 03:00 friday @ Samoa
+    # 12:00 thursday Etc/UTC = 03:00 friday @ Pacific/Apia
     let(:current_time) { "2021-09-30T12:05:59Z".to_datetime }
     let(:scope_time) { "2021-09-30T12:00:00Z".to_datetime }
 
     let(:samoa_user) do
       FactoryBot.create(
         :user,
-        firstname: 'Samoa',
+        firstname: 'Pacific/Apia',
         preferences: {
-          time_zone: "Samoa",
+          time_zone: "Pacific/Apia",
           workdays: samoa_user_workdays,
           daily_reminders: {
             enabled: true,
-            times: [hitting_reminder_slot_for("Samoa", current_time)]
+            times: [hitting_reminder_slot_for("Pacific/Apia", current_time)]
           }
         }
       )
@@ -181,12 +181,12 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     let(:moscow_user) do
       FactoryBot.create(
         :user,
-        firstname: 'Moscow',
+        firstname: 'Europe/Moscow',
         preferences: {
-          time_zone: "Moscow",
+          time_zone: "Europe/Moscow",
           daily_reminders: {
             enabled: true,
-            times: [hitting_reminder_slot_for("Moscow", current_time)]
+            times: [hitting_reminder_slot_for("Europe/Moscow", current_time)]
           }
         }
       )
@@ -207,9 +207,9 @@ describe User, '.having_reminder_mail_to_send', type: :model do
       {
         enabled: true,
         times: [
-          hitting_reminder_slot_for("Paris", current_time - 3.hours),
-          hitting_reminder_slot_for("Paris", current_time),
-          hitting_reminder_slot_for("Paris", current_time + 3.hours)
+          hitting_reminder_slot_for("Europe/Paris", current_time - 3.hours),
+          hitting_reminder_slot_for("Europe/Paris", current_time),
+          hitting_reminder_slot_for("Europe/Paris", current_time + 3.hours)
         ]
       }
     end
@@ -225,12 +225,12 @@ describe User, '.having_reminder_mail_to_send', type: :model do
       {
         enabled: true,
         times: [
-          hitting_reminder_slot_for("Paris", current_time - 2.hours),
-          hitting_reminder_slot_for("Paris", current_time + 3.hours)
+          hitting_reminder_slot_for("Europe/Paris", current_time - 2.hours),
+          hitting_reminder_slot_for("Europe/Paris", current_time + 3.hours)
         ]
       }
     end
-    let(:scope_time) { ActiveSupport::TimeZone['UTC'].parse("06:00") }
+    let(:scope_time) { ActiveSupport::TimeZone['Etc/UTC'].parse("06:00") }
 
     it 'contains the user' do
       expect(scope)
@@ -243,8 +243,8 @@ describe User, '.having_reminder_mail_to_send', type: :model do
       {
         enabled: true,
         times: [
-          hitting_reminder_slot_for("Paris", current_time - 3.hours),
-          hitting_reminder_slot_for("Paris", current_time + 1.hour)
+          hitting_reminder_slot_for("Europe/Paris", current_time - 3.hours),
+          hitting_reminder_slot_for("Europe/Paris", current_time + 1.hour)
         ]
       }
     end
@@ -271,7 +271,7 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     let(:paris_user_daily_reminders) do
       {
         enabled: false,
-        times: [hitting_reminder_slot_for("Paris", current_time)]
+        times: [hitting_reminder_slot_for("Europe/Paris", current_time)]
       }
     end
 
@@ -285,14 +285,14 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     let(:paris_user) do
       FactoryBot.create(
         :user,
-        firstname: 'Paris',
+        firstname: 'Europe/Paris',
         preferences: {
-          time_zone: "Paris"
+          time_zone: "Europe/Paris"
         }
       )
     end
-    let(:current_time) { ActiveSupport::TimeZone['Paris'].parse("2021-09-30T08:09").utc }
-    let(:scope_time) { ActiveSupport::TimeZone['Paris'].parse("2021-09-30T08:00") }
+    let(:current_time) { ActiveSupport::TimeZone['Europe/Paris'].parse("2021-09-30T08:09").utc }
+    let(:scope_time) { ActiveSupport::TimeZone['Europe/Paris'].parse("2021-09-30T08:00") }
 
     it 'contains the user' do
       expect(scope)
@@ -304,14 +304,14 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     let(:paris_user) do
       FactoryBot.create(
         :user,
-        firstname: 'Paris',
+        firstname: 'Europe/Paris',
         preferences: {
-          time_zone: "Paris"
+          time_zone: "Europe/Paris"
         }
       )
     end
-    let(:current_time) { ActiveSupport::TimeZone['Paris'].parse("2021-09-30T10:00").utc }
-    let(:scope_time) { ActiveSupport::TimeZone['Paris'].parse("2021-09-30T10:00") }
+    let(:current_time) { ActiveSupport::TimeZone['Europe/Paris'].parse("2021-09-30T10:00").utc }
+    let(:scope_time) { ActiveSupport::TimeZone['Europe/Paris'].parse("2021-09-30T10:00") }
 
     it 'is empty' do
       expect(scope)
@@ -323,9 +323,9 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     let(:kathmandu_user) do
       FactoryBot.create(
         :user,
-        firstname: 'Kathmandu',
+        firstname: 'Asia/Kathmandu',
         preferences: {
-          time_zone: "Kathmandu",
+          time_zone: "Asia/Kathmandu",
           daily_reminders: {
             enabled: true,
             times: [hitting_reminder_slot_for("Asia/Kathmandu", current_time)]
@@ -351,9 +351,9 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     let(:kathmandu_user) do
       FactoryBot.create(
         :user,
-        firstname: 'Kathmandu',
+        firstname: 'Asia/Kathmandu',
         preferences: {
-          time_zone: "Kathmandu",
+          time_zone: "Asia/Kathmandu",
           daily_reminders: {
             enabled: true,
             times: [hitting_reminder_slot_for("Asia/Kathmandu", current_time)]
@@ -379,9 +379,9 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     let(:kathmandu_user) do
       FactoryBot.create(
         :user,
-        firstname: 'Kathmandu',
+        firstname: 'Asia/Kathmandu',
         preferences: {
-          time_zone: "Kathmandu",
+          time_zone: "Asia/Kathmandu",
           daily_reminders: {
             enabled: true,
             times: [hitting_reminder_slot_for("Asia/Kathmandu", current_time)]
@@ -444,7 +444,7 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     let(:paris_user_daily_reminders) do
       {
         enabled: true,
-        times: [hitting_reminder_slot_for("Paris", current_time + 1.hour)]
+        times: [hitting_reminder_slot_for("Europe/Paris", current_time + 1.hour)]
       }
     end
 
@@ -458,7 +458,7 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     let(:paris_user_daily_reminders) do
       {
         enabled: true,
-        times: [hitting_reminder_slot_for("Paris", current_time - 1.hour)]
+        times: [hitting_reminder_slot_for("Europe/Paris", current_time - 1.hour)]
       }
     end
 
@@ -472,17 +472,17 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     let(:paris_user) do
       FactoryBot.create(
         :user,
-        firstname: 'Paris',
+        firstname: 'Europe/Paris',
         preferences: {
           daily_reminders: {
             enabled: true,
-            times: [hitting_reminder_slot_for("UTC", current_time)]
+            times: [hitting_reminder_slot_for("Etc/UTC", current_time)]
           }
         }
       )
     end
 
-    it 'is including the user as UTC is assumed' do
+    it 'is including the user as Etc/UTC is assumed' do
       expect(scope)
         .to match_array([paris_user])
     end
@@ -492,13 +492,13 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     let(:paris_user) do
       FactoryBot.create(
         :user,
-        firstname: 'Paris',
+        firstname: 'Europe/Paris',
         preferences: {}
       )
     end
-    let(:current_time) { ActiveSupport::TimeZone['UTC'].parse("2021-09-30T08:00").utc }
+    let(:current_time) { ActiveSupport::TimeZone['Etc/UTC'].parse("2021-09-30T08:00").utc }
 
-    it 'is including the user as UTC at 08:00 is assumed' do
+    it 'is including the user as Etc/UTC at 08:00 is assumed' do
       expect(scope)
         .to match_array([paris_user])
     end
@@ -508,14 +508,14 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     let(:paris_user) do
       FactoryBot.create(
         :user,
-        firstname: 'Paris',
+        firstname: 'Europe/Paris',
         preferences: {}
       )
     end
-    let(:current_time) { ActiveSupport::TimeZone['UTC'].parse("2021-09-30T10:00").utc }
-    let(:scope_time) { ActiveSupport::TimeZone['UTC'].parse("2021-09-30T10:00").utc }
+    let(:current_time) { ActiveSupport::TimeZone['Etc/UTC'].parse("2021-09-30T10:00").utc }
+    let(:scope_time) { ActiveSupport::TimeZone['Etc/UTC'].parse("2021-09-30T10:00").utc }
 
-    it 'is empty as UTC at 08:00 is assumed' do
+    it 'is empty as Etc/UTC at 08:00 is assumed' do
       expect(scope)
         .to be_empty
     end
@@ -531,28 +531,28 @@ describe User, '.having_reminder_mail_to_send', type: :model do
   end
 
   context 'for a user without preferences at 08:00' do
-    let(:current_time) { ActiveSupport::TimeZone['UTC'].parse("2021-09-30T08:00").utc }
-    let(:scope_time) { ActiveSupport::TimeZone['UTC'].parse("2021-09-30T08:00").utc }
+    let(:current_time) { ActiveSupport::TimeZone['Etc/UTC'].parse("2021-09-30T08:00").utc }
+    let(:scope_time) { ActiveSupport::TimeZone['Etc/UTC'].parse("2021-09-30T08:00").utc }
 
     before do
       paris_user.pref.destroy
     end
 
-    it 'is including the user as UTC at 08:00 is assumed' do
+    it 'is including the user as Etc/UTC at 08:00 is assumed' do
       expect(scope)
         .to match_array([paris_user])
     end
   end
 
   context 'for a user without preferences at 10:00' do
-    let(:current_time) { ActiveSupport::TimeZone['UTC'].parse("2021-09-30T10:00").utc }
-    let(:scope_time) { ActiveSupport::TimeZone['UTC'].parse("2021-09-30T10:00").utc }
+    let(:current_time) { ActiveSupport::TimeZone['Etc/UTC'].parse("2021-09-30T10:00").utc }
+    let(:scope_time) { ActiveSupport::TimeZone['Etc/UTC'].parse("2021-09-30T10:00").utc }
 
     before do
       paris_user.pref.destroy
     end
 
-    it 'is empty as UTC at 08:00 is assumed' do
+    it 'is empty as Etc/UTC at 08:00 is assumed' do
       expect(scope)
         .to be_empty
     end

--- a/spec/requests/api/v3/user_preferences/user_preferences_resource_spec.rb
+++ b/spec/requests/api/v3/user_preferences/user_preferences_resource_spec.rb
@@ -162,7 +162,7 @@ describe 'API v3 UserPreferences resource', type: :request, content_type: :json 
         end
       end
 
-      context 'with full time zone' do
+      context 'with valid time zone' do
         let(:params) do
           { timeZone: 'Europe/Paris' }
         end
@@ -170,18 +170,6 @@ describe 'API v3 UserPreferences resource', type: :request, content_type: :json 
         it 'responds with a UserPreferences representer' do
           expect(subject.body).to be_json_eql('Europe/Paris'.to_json).at_path('timeZone')
           expect(preference.time_zone).to eq('Europe/Paris')
-        end
-      end
-
-      context 'with short time zone' do
-        let(:params) do
-          { timeZone: 'Hawaii' }
-        end
-
-        it 'responds with a UserPreferences representer' do
-          expect(subject.body).to be_json_eql('Pacific/Honolulu'.to_json).at_path('timeZone')
-          expect(preference.time_zone).to eq('Hawaii')
-          expect(preference.canonical_time_zone).to eq('Pacific/Honolulu')
         end
       end
     end


### PR DESCRIPTION
Only accepts a TZInfo::Timezone identifier string for user time zones:
* the individual time zone configured for each user
* the instance wide default time zone

Existing data is migrated.

This reduces the amount of time zones selectable by a user since multiple ActiveSupport::TimeZone entries map to the same TZInfo::Timezone, but every time zone is still covered. 

Implements https://community.openproject.org/wp/39073 and by that should fix https://community.openproject.org/wp/38091