### PR TITLE
[#39084] avoid sending member update notifications/mails upon copying a project

### DIFF
--- a/app/services/members/create_service.rb
+++ b/app/services/members/create_service.rb
@@ -47,7 +47,8 @@ class Members::CreateService < ::BaseServices::Create
   def send_notification(member)
     OpenProject::Notifications.send(OpenProject::Events::MEMBER_CREATED,
                                     member: member,
-                                    message: params[:notification_message])
+                                    message: params[:notification_message],
+                                    send_notifications: params.fetch(:send_notifications, true))
   end
 
   def add_group_memberships(member)
@@ -59,6 +60,6 @@ class Members::CreateService < ::BaseServices::Create
   end
 
   def set_attributes_params(params)
-    super.except(:notification_message)
+    super.except(:notification_message, :send_notifications)
   end
 end

--- a/app/services/projects/copy/members_dependent_service.rb
+++ b/app/services/projects/copy/members_dependent_service.rb
@@ -57,7 +57,11 @@ module Projects::Copy
 
       attributes = member
                      .attributes.dup.except('id', 'project_id', 'created_at', 'updated_at')
-                     .merge(role_ids: role_ids, project: target)
+                     .merge(role_ids: role_ids,
+                            project: target,
+                            # This is magic for now. The settings has been set before in the Projects::CopyService
+                            # It would be better if this was not sneaked in but rather passed in as a parameter.
+                            send_notifications: ActionMailer::Base.perform_deliveries)
 
       Members::CreateService
         .new(user: User.current, contract_class: EmptyContract)

--- a/app/workers/mails/member_job.rb
+++ b/app/workers/mails/member_job.rb
@@ -54,7 +54,7 @@ class Mails::MemberJob < ApplicationJob
   end
 
   def send_updated_global(current_user, member, member_message)
-    return if sending_disabled?(:updated, member.user_id, member_message)
+    return if sending_disabled?(:updated, current_user, member.user_id, member_message)
 
     MemberMailer
       .updated_global(current_user, member, member_message)
@@ -62,7 +62,7 @@ class Mails::MemberJob < ApplicationJob
   end
 
   def send_added_project(current_user, member, member_message)
-    return if sending_disabled?(:added, member.user_id, member_message)
+    return if sending_disabled?(:added, current_user, member.user_id, member_message)
 
     MemberMailer
       .added_project(current_user, member, member_message)
@@ -70,7 +70,7 @@ class Mails::MemberJob < ApplicationJob
   end
 
   def send_updated_project(current_user, member, member_message)
-    return if sending_disabled?(:updated, member.user_id, member_message)
+    return if sending_disabled?(:updated, current_user, member.user_id, member_message)
 
     MemberMailer
       .updated_project(current_user, member, member_message)
@@ -85,7 +85,9 @@ class Mails::MemberJob < ApplicationJob
       .each(&block)
   end
 
-  def sending_disabled?(setting, user_id, message)
+  def sending_disabled?(setting, current_user, user_id, message)
+    # Never self notify
+    return true if current_user.id == user_id
     # In case we have an invitation message, always send a mail
     return false if message.present?
 

--- a/config/initializers/subscribe_listeners.rb
+++ b/config/initializers/subscribe_listeners.rb
@@ -57,6 +57,8 @@ OpenProject::Notifications.subscribe(OpenProject::Events::WATCHER_REMOVED) do |p
 end
 
 OpenProject::Notifications.subscribe(OpenProject::Events::MEMBER_CREATED) do |payload|
+  next unless payload[:send_notifications]
+
   Mails::MemberCreatedJob
     .perform_later(current_user: User.current,
                    member: payload[:member],

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -28,28 +28,23 @@
 
 require 'spec_helper'
 
+# rubocop:disable RSpec:MultipleMemoizedHelpers
 describe 'Projects copy',
          type: :feature,
          js: true do
   describe 'with a full copy example' do
     let!(:project) do
-      project = FactoryBot.create(:project,
-                                  parent: parent_project,
-                                  types: active_types,
-                                  custom_field_values: { project_custom_field.id => 'some text cf' })
+      FactoryBot.create(:project,
+                        parent: parent_project,
+                        types: active_types,
+                        members: { user => role },
+                        custom_field_values: { project_custom_field.id => 'some text cf' }).tap do |p|
+        p.work_package_custom_fields << wp_custom_field
+        p.types.first.custom_fields << wp_custom_field
 
-      FactoryBot.create(:member,
-                        project: project,
-                        user: user,
-                        roles: [role])
-
-      project.work_package_custom_fields << wp_custom_field
-      project.types.first.custom_fields << wp_custom_field
-
-      # Enable wiki
-      project.enabled_module_names += ['wiki']
-
-      project
+        # Enable wiki
+        p.enabled_module_names += ['wiki']
+      end
     end
 
     let!(:parent_project) do
@@ -151,12 +146,16 @@ describe 'Projects copy',
 
       expect(page).to have_text 'The job has been queued and will be processed shortly.'
 
-      perform_enqueued_jobs
+      # ensure all jobs are run especially emails which might be sent later on
+      while perform_enqueued_jobs > 0 do end
 
       copied_project = Project.find_by(name: 'Copied project')
 
       expect(copied_project)
         .to be_present
+
+      # Will redirect to the new project automatically once the copy process is done
+      expect(page).to have_current_path("#{project_path(copied_project)}/")
 
       copied_settings_page = Pages::Projects::Settings.new(copied_project)
       copied_settings_page.visit!
@@ -300,3 +299,4 @@ describe 'Projects copy',
     end
   end
 end
+# rubocop:enable RSpec:MultipleMemoizedHelpers

--- a/spec/features/projects/copy_spec.rb
+++ b/spec/features/projects/copy_spec.rb
@@ -142,6 +142,10 @@ describe 'Projects copy',
       editor = ::Components::WysiwygEditor.new "[data-qa-field-name='customField#{project_custom_field.id}']"
       editor.expect_value 'some text cf'
 
+      # Deactivate sending of mails during copying
+      click_on 'Copy options'
+      uncheck 'Send email notifications during the project copy'
+
       click_button 'Save'
 
       expect(page).to have_text 'The job has been queued and will be processed shortly.'
@@ -155,7 +159,7 @@ describe 'Projects copy',
         .to be_present
 
       # Will redirect to the new project automatically once the copy process is done
-      expect(page).to have_current_path("#{project_path(copied_project)}/")
+      expect(page).to have_current_path(Regexp.new("#{project_path(copied_project)}/?"))
 
       copied_settings_page = Pages::Projects::Settings.new(copied_project)
       copied_settings_page.visit!

--- a/spec/requests/api/v3/groups/group_resource_spec.rb
+++ b/spec/requests/api/v3/groups/group_resource_spec.rb
@@ -263,14 +263,13 @@ describe 'API v3 Group resource', type: :request, content_type: :json do
 
       it 'sends a mail notifying of the added project memberships to the added user' do
         expect(ActionMailer::Base.deliveries.size)
-          .to eql 2
+          .to eql 1
 
         expect(ActionMailer::Base.deliveries.map(&:to).flatten.uniq)
           .to match_array another_user.mail
 
         expect(ActionMailer::Base.deliveries.map(&:subject).flatten)
-          .to match_array [I18n.t(:'mail_member_added_project.subject', project: other_project.name),
-                           I18n.t(:'mail_member_updated_project.subject', project: project.name)]
+          .to match_array [I18n.t(:'mail_member_updated_project.subject', project: project.name)]
       end
     end
 

--- a/spec/services/members/create_service_spec.rb
+++ b/spec/services/members/create_service_spec.rb
@@ -34,7 +34,13 @@ require 'services/base_services/behaves_like_create_service'
 describe Members::CreateService, type: :model do
   it_behaves_like 'BaseServices create service' do
     let(:call_attributes) do
-      { project_id: "1", user_id: "2", role_ids: ["2"], notification_message: "Wish you where **here**." }
+      {
+        project_id: "1",
+        user_id: "2",
+        role_ids: ["2"],
+        notification_message: "Wish you where **here**.",
+        send_notifications: true
+      }
     end
 
     let!(:allow_notification_call) do
@@ -48,7 +54,8 @@ describe Members::CreateService, type: :model do
           .to receive(:send)
           .with(OpenProject::Events::MEMBER_CREATED,
                 member: model_instance,
-                message: call_attributes[:notification_message])
+                message: call_attributes[:notification_message],
+                send_notifications: true)
 
         subject
       end

--- a/spec/workers/mails/shared/member_job.rb
+++ b/spec/workers/mails/shared/member_job.rb
@@ -149,6 +149,12 @@ shared_examples 'member job' do
         it_behaves_like 'sends no mail'
       end
     end
+
+    context 'with the current user being the membership user' do
+      let(:user) { current_user }
+
+      it_behaves_like 'sends no mail'
+    end
   end
 
   context 'with a user membership' do
@@ -160,6 +166,12 @@ shared_examples 'member job' do
           .to have_received(user_project_mail_method)
                 .with(current_user, member, message)
       end
+    end
+
+    context 'with the current user being the member user' do
+      let(:user) { current_user }
+
+      it_behaves_like 'sends no mail'
     end
   end
 end


### PR DESCRIPTION
When unchecking notification sending upon copying a project

![image](https://user-images.githubusercontent.com/617519/136055531-f075e379-3046-4674-80a5-0a441b1bca71.png)

membership updates are also no longer sent. This allows to copy projects without informing all the members that are only members because they need access to a project for copying purposes.

https://community.openproject.org/wp/39084
https://community.openproject.org/wp/38026

It also fixes being self notified upon member manipulation (e.g. when creating a project where the current user gets assigned a default role but also when being part of a group)