### PR TITLE
Add UIsref option for op-sidemenu component and use it in the notification center

### DIFF
--- a/frontend/src/app/features/in-app-notifications/center/menu/menu.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/menu/menu.component.ts
@@ -27,7 +27,8 @@ export class IanMenuComponent implements OnInit {
       key: 'inbox',
       title: this.I18n.t('js.notifications.menu.inbox'),
       icon: 'inbox',
-      href: this.getHrefForFilters({}),
+      uiSref: 'notifications.center.show',
+      uiParams: { filter: '', name: '' },
     },
   ];
 
@@ -36,25 +37,25 @@ export class IanMenuComponent implements OnInit {
       key: 'mentioned',
       title: this.I18n.t('js.notifications.menu.mentioned'),
       icon: 'mention',
-      href: this.getHrefForFilters({ filter: 'reason', name: 'mentioned' }),
+      ...this.getUiLinkForFilters({ filter: 'reason', name: 'mentioned' }),
     },
     {
       key: 'assigned',
       title: this.I18n.t('js.notifications.menu.assigned'),
       icon: 'assigned',
-      href: this.getHrefForFilters({ filter: 'reason', name: 'assigned' }),
+      ...this.getUiLinkForFilters({ filter: 'reason', name: 'assigned' }),
     },
     {
       key: 'responsible',
       title: this.I18n.t('js.notifications.menu.accountable'),
       icon: 'accountable',
-      href: this.getHrefForFilters({ filter: 'reason', name: 'responsible' }),
+      ...this.getUiLinkForFilters({ filter: 'reason', name: 'responsible' }),
     },
     {
       key: 'watched',
       title: this.I18n.t('js.notifications.menu.watching'),
       icon: 'watching',
-      href: this.getHrefForFilters({ filter: 'reason', name: 'watched' }),
+      ...this.getUiLinkForFilters({ filter: 'reason', name: 'watched' }),
     },
   ];
 
@@ -63,7 +64,7 @@ export class IanMenuComponent implements OnInit {
       .map((item) => ({
         ...item,
         title: (item.projectHasParent ? '... ' : '') + item.value,
-        href: this.getHrefForFilters({ filter: 'project', name: idFromLink(item._links.valueLink[0].href) }),
+        ...this.getUiLinkForFilters({ filter: 'project', name: idFromLink(item._links.valueLink[0].href) }),
       }))
       .sort((a, b) => {
         if (b.projectHasParent && !a.projectHasParent) {
@@ -123,7 +124,10 @@ export class IanMenuComponent implements OnInit {
     this.ianMenuService.reload();
   }
 
-  private getHrefForFilters(filters:INotificationPageQueryParameters = {}) {
-    return this.state.href('notifications', filters);
+  private getUiLinkForFilters(filters:INotificationPageQueryParameters = {}) {
+    return {
+      uiSref: 'notifications.center.show',
+      uiParams: filters,
+    };
   }
 }

--- a/frontend/src/app/features/in-app-notifications/center/menu/menu.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/menu/menu.component.ts
@@ -27,8 +27,7 @@ export class IanMenuComponent implements OnInit {
       key: 'inbox',
       title: this.I18n.t('js.notifications.menu.inbox'),
       icon: 'inbox',
-      uiSref: 'notifications.center.show',
-      uiParams: { filter: '', name: '' },
+      ...this.getUiLinkForFilters({ filter: '', name: '' }),
     },
   ];
 

--- a/frontend/src/app/features/in-app-notifications/center/menu/menu.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/menu/menu.component.ts
@@ -14,6 +14,11 @@ import { IanMenuService } from './state/ian-menu.service';
 
 export const ianMenuSelector = 'op-ian-menu';
 
+const getUiLinkForFilters = (filters:INotificationPageQueryParameters = {}) => ({
+  uiSref: 'notifications.center.show',
+  uiParams: filters,
+});
+
 @Component({
   selector: ianMenuSelector,
   templateUrl: './menu.component.html',
@@ -27,7 +32,7 @@ export class IanMenuComponent implements OnInit {
       key: 'inbox',
       title: this.I18n.t('js.notifications.menu.inbox'),
       icon: 'inbox',
-      ...this.getUiLinkForFilters({ filter: '', name: '' }),
+      ...getUiLinkForFilters({ filter: '', name: '' }),
     },
   ];
 
@@ -36,25 +41,25 @@ export class IanMenuComponent implements OnInit {
       key: 'mentioned',
       title: this.I18n.t('js.notifications.menu.mentioned'),
       icon: 'mention',
-      ...this.getUiLinkForFilters({ filter: 'reason', name: 'mentioned' }),
+      ...getUiLinkForFilters({ filter: 'reason', name: 'mentioned' }),
     },
     {
       key: 'assigned',
       title: this.I18n.t('js.notifications.menu.assigned'),
       icon: 'assigned',
-      ...this.getUiLinkForFilters({ filter: 'reason', name: 'assigned' }),
+      ...getUiLinkForFilters({ filter: 'reason', name: 'assigned' }),
     },
     {
       key: 'responsible',
       title: this.I18n.t('js.notifications.menu.accountable'),
       icon: 'accountable',
-      ...this.getUiLinkForFilters({ filter: 'reason', name: 'responsible' }),
+      ...getUiLinkForFilters({ filter: 'reason', name: 'responsible' }),
     },
     {
       key: 'watched',
       title: this.I18n.t('js.notifications.menu.watching'),
       icon: 'watching',
-      ...this.getUiLinkForFilters({ filter: 'reason', name: 'watched' }),
+      ...getUiLinkForFilters({ filter: 'reason', name: 'watched' }),
     },
   ];
 
@@ -63,7 +68,7 @@ export class IanMenuComponent implements OnInit {
       .map((item) => ({
         ...item,
         title: (item.projectHasParent ? '... ' : '') + item.value,
-        ...this.getUiLinkForFilters({ filter: 'project', name: idFromLink(item._links.valueLink[0].href) }),
+        ...getUiLinkForFilters({ filter: 'project', name: idFromLink(item._links.valueLink[0].href) }),
       }))
       .sort((a, b) => {
         if (b.projectHasParent && !a.projectHasParent) {
@@ -121,12 +126,5 @@ export class IanMenuComponent implements OnInit {
 
   ngOnInit():void {
     this.ianMenuService.reload();
-  }
-
-  private getUiLinkForFilters(filters:INotificationPageQueryParameters = {}) {
-    return {
-      uiSref: 'notifications.center.show',
-      uiParams: filters,
-    };
   }
 }

--- a/frontend/src/app/shared/components/sidemenu/sidemenu.component.html
+++ b/frontend/src/app/shared/components/sidemenu/sidemenu.component.html
@@ -29,8 +29,12 @@
   >
     <a
       class="op-sidemenu--item-action"
+      uiSrefActive="op-sidemenu--item-action_active-child"
+      uiSrefActiveEq="op-sidemenu--item-action_active"
       [attr.data-qa-selector]="'op-sidemenu--item-action--' + item.title.split(' ').join('')"
       [href]="item.href"
+      [uiSref]="item.uiSref"
+      [uiParams]="item.uiParams"
       *ngIf="!item.children"
     >
       <span

--- a/frontend/src/app/shared/components/sidemenu/sidemenu.component.sass
+++ b/frontend/src/app/shared/components/sidemenu/sidemenu.component.sass
@@ -34,6 +34,14 @@
       background: var(--main-menu-bg-hover-background)
       color: var(--main-menu-hover-font-color)
 
+    &_active
+      background: var(--main-menu-bg-selected-background)
+      color: var(--main-menu-selected-font-color)
+
+    &_active-child
+      background: var(--main-menu-bg-selected-background)
+      color: var(--main-menu-selected-font-color)
+
   &--item-title
     margin-right: auto
     overflow: hidden

--- a/frontend/src/app/shared/components/sidemenu/sidemenu.component.ts
+++ b/frontend/src/app/shared/components/sidemenu/sidemenu.component.ts
@@ -13,7 +13,7 @@ export interface IOpSidemenuItem {
   count?:number;
   href?:string;
   uiSref?:string;
-  uiParams?:any;
+  uiParams?:unknown;
   children?:IOpSidemenuItem[];
   collapsible?:boolean;
 }
@@ -38,7 +38,8 @@ export class OpSidemenuComponent {
   constructor(
     readonly cdRef:ChangeDetectorRef,
     readonly I18n:I18nService,
-  ) { }
+  ) {
+  }
 
   toggleCollapsed():void {
     this.collapsed = !this.collapsed;

--- a/frontend/src/app/shared/components/sidemenu/sidemenu.component.ts
+++ b/frontend/src/app/shared/components/sidemenu/sidemenu.component.ts
@@ -11,7 +11,9 @@ export interface IOpSidemenuItem {
   title:string;
   icon?:string;
   count?:number;
-  href:string;
+  href?:string;
+  uiSref?:string;
+  uiParams?:any;
   children?:IOpSidemenuItem[];
   collapsible?:boolean;
 }


### PR DESCRIPTION
Currently, both active routes and parents of active routes are displayed as selected. This way, the sidemenu item stays selected even in split views.

However, due to some technicalities around route definitions that I haven't been able to figure out, the main `Inbox` item itself is never active. However, this is probably better than having it _always_ active, which is what would happen if it were active for all the other filter states.

No tests included, since we'd basically be tested ui-router again, but if you'd like I can add them.

Closes https://community.openproject.org/projects/openproject/work_packages/39088/activity