### PR TITLE
[38842] Route back to notifications when error happens

### DIFF
--- a/frontend/src/app/core/routing/openproject.routes.ts
+++ b/frontend/src/app/core/routing/openproject.routes.ts
@@ -27,14 +27,27 @@
 //++
 
 import {
-  StateDeclaration, StateService, Transition, TransitionService, UIRouter,
+  StateDeclaration,
+  StateService,
+  Transition,
+  TransitionService,
+  UIRouter,
 } from '@uirouter/core';
-import { INotification, NotificationsService } from 'core-app/shared/components/notifications/notifications.service';
+import {
+  INotification,
+  NotificationsService,
+} from 'core-app/shared/components/notifications/notifications.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { Injector } from '@angular/core';
 import { FirstRouteService } from 'core-app/core/routing/first-route-service';
-import { Ng2StateDeclaration, StatesModule } from '@uirouter/angular';
-import { appBaseSelector, ApplicationBaseComponent } from 'core-app/core/routing/base/application-base.component';
+import {
+  Ng2StateDeclaration,
+  StatesModule,
+} from '@uirouter/angular';
+import {
+  appBaseSelector,
+  ApplicationBaseComponent,
+} from 'core-app/core/routing/base/application-base.component';
 import { BackRoutingService } from 'core-app/features/work-packages/components/back-routing/back-routing.service';
 import { MY_ACCOUNT_LAZY_ROUTES } from 'core-app/features/user-preferences/user-preferences.lazy-routes';
 import { IAN_LAZY_ROUTES } from 'core-app/features/in-app-notifications/in-app-notifications.lazy-routes';
@@ -48,70 +61,80 @@ export const OPENPROJECT_ROUTES:Ng2StateDeclaration[] = [
   },
   {
     name: 'root',
-    url: '/{projects}/{projectPath}',
+    abstract: true,
+    url: '',
     component: ApplicationBaseComponent,
+    params: {
+      // Allow passing of flash messages after routes load
+      flash_message: { dynamic: true, value: null, inherit: false },
+    },
+  },
+  {
+    name: 'optional_project',
+    parent: 'root',
+    url: '/{projects}/{projectPath}',
     abstract: true,
     params: {
       // value: null makes the parameter optional
       // squash: true avoids duplicate slashes when the parameter is not provided
       projectPath: { type: 'path', value: null, squash: true },
       projects: { type: 'path', value: null, squash: true },
-
-      // Allow passing of flash messages after routes load
-      flash_message: { dynamic: true, value: null, inherit: false },
+    },
+    views: {
+      '!$default': { component: ApplicationBaseComponent },
     },
   },
   {
     name: 'api-docs.**',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/api/docs',
     loadChildren: () => import('../../features/api-docs/openproject-api-docs.module').then((m) => m.OpenprojectApiDocsModule),
   },
   {
     name: 'boards.**',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/boards',
     loadChildren: () => import('../../features/boards/openproject-boards.module').then((m) => m.OpenprojectBoardsModule),
   },
   {
     name: 'bim.**',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/bcf',
     loadChildren: () => import('../../features/bim/ifc_models/openproject-ifc-models.module').then((m) => m.OpenprojectIFCModelsModule),
   },
   {
     name: 'backlogs.**',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/backlogs',
     loadChildren: () => import('../../features/backlogs/openproject-backlogs.module').then((m) => m.OpenprojectBacklogsModule),
   },
   {
     name: 'backlogs_sprint.**',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/sprints',
     loadChildren: () => import('../../features/backlogs/openproject-backlogs.module').then((m) => m.OpenprojectBacklogsModule),
   },
   {
     name: 'reporting.**',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/cost_reports',
     loadChildren: () => import('../../features/reporting/openproject-reporting.module').then((m) => m.OpenprojectReportingModule),
   },
   {
     name: 'job-statuses.**',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/job_statuses',
     loadChildren: () => import('../../features/job-status/openproject-job-status.module').then((m) => m.OpenProjectJobStatusModule),
   },
   {
     name: 'project_settings.**',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/settings/generic',
     loadChildren: () => import('../../features/projects/openproject-projects.module').then((m) => m.OpenprojectProjectsModule),
   },
   {
     name: 'project_copy.**',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/copy',
     loadChildren: () => import('../../features/projects/openproject-projects.module').then((m) => m.OpenprojectProjectsModule),
   },

--- a/frontend/src/app/features/api-docs/openproject-api-docs.routes.ts
+++ b/frontend/src/app/features/api-docs/openproject-api-docs.routes.ts
@@ -32,7 +32,7 @@ import { SwaggerUIComponent } from './swagger-ui/swagger-ui.component';
 export const API_DOCS_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'api-docs',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/api/docs',
     component: SwaggerUIComponent,
   },

--- a/frontend/src/app/features/backlogs/openproject-backlogs.routes.ts
+++ b/frontend/src/app/features/backlogs/openproject-backlogs.routes.ts
@@ -32,19 +32,19 @@ import { BacklogsPageComponent } from 'core-app/features/backlogs/backlogs-page/
 export const BACKLOGS_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'backlogs',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/backlogs',
     component: BacklogsPageComponent,
   },
   {
     name: 'backlogs_sprint',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/sprints/{sprintId:int}/taskboard',
     component: BacklogsPageComponent,
   },
   {
     name: 'backlogs_burndown',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/sprints/{sprintId:int}/burndown_chart',
     component: BacklogsPageComponent,
   },

--- a/frontend/src/app/features/bim/ifc_models/openproject-ifc-models.routes.ts
+++ b/frontend/src/app/features/bim/ifc_models/openproject-ifc-models.routes.ts
@@ -39,7 +39,7 @@ import { WorkPackageNewFullViewComponent } from 'core-app/features/work-packages
 export const IFC_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'bim',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/bcf?query_props&models&viewpoint',
     abstract: true,
     component: WorkPackagesBaseComponent,

--- a/frontend/src/app/features/boards/openproject-boards.routes.ts
+++ b/frontend/src/app/features/boards/openproject-boards.routes.ts
@@ -39,7 +39,7 @@ export const menuItemClass = 'board-view-menu-item';
 export const BOARDS_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'boards',
-    parent: 'root',
+    parent: 'optional_project',
     // The trailing slash is important
     // cf., https://community.openproject.com/wp/29754
     url: '/boards/?query_props',

--- a/frontend/src/app/features/dashboards/openproject-dashboards.module.ts
+++ b/frontend/src/app/features/dashboards/openproject-dashboards.module.ts
@@ -37,7 +37,7 @@ const menuItemClass = 'dashboards-menu-item';
 export const DASHBOARDS_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'dashboards',
-    parent: 'root',
+    parent: 'optional_project',
     // The trailing slash is important
     // cf., https://community.openproject.com/wp/29754
     url: '/dashboards/',

--- a/frontend/src/app/features/in-app-notifications/in-app-notifications.routes.ts
+++ b/frontend/src/app/features/in-app-notifications/in-app-notifications.routes.ts
@@ -42,12 +42,15 @@ export interface INotificationPageQueryParameters {
 export const IAN_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'notifications',
+    parent: 'root',
     url: '/notifications?{filter:string}&{name:string}',
     data: {
       bodyClasses: 'router--work-packages-base',
     },
-    component: WorkPackagesBaseComponent,
     redirectTo: 'notifications.center.show',
+    views: {
+      '!$default': { component: WorkPackagesBaseComponent },
+    },
   },
   {
     name: 'notifications.center',

--- a/frontend/src/app/features/job-status/openproject-job-status.module.ts
+++ b/frontend/src/app/features/job-status/openproject-job-status.module.ts
@@ -37,7 +37,7 @@ export const JOB_STATUS_ROUTE:Ng2StateDeclaration[] = [
   {
     name: 'job-statuses',
     url: '/job_statuses/{jobId:[a-z0-9-]+}',
-    parent: 'root',
+    parent: 'optional_project',
     component: DisplayJobPageComponent,
     data: {
       bodyClasses: 'router--job-statuses',

--- a/frontend/src/app/features/overview/openproject-overview.module.ts
+++ b/frontend/src/app/features/overview/openproject-overview.module.ts
@@ -37,7 +37,7 @@ const menuItemClass = 'overview-menu-item';
 export const OVERVIEW_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'overview',
-    parent: 'root',
+    parent: 'optional_project',
     // The trailing slash is important
     // cf., https://community.openproject.com/wp/29754
     url: '/',

--- a/frontend/src/app/features/projects/projects-routes.ts
+++ b/frontend/src/app/features/projects/projects-routes.ts
@@ -6,13 +6,13 @@ import { CopyProjectComponent } from 'core-app/features/projects/components/copy
 export const PROJECTS_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'project_settings',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/settings/generic/',
     component: ProjectsComponent,
   },
   {
     name: 'project_copy',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/copy',
     component: CopyProjectComponent,
   },

--- a/frontend/src/app/features/reporting/openproject-reporting.routes.ts
+++ b/frontend/src/app/features/reporting/openproject-reporting.routes.ts
@@ -32,7 +32,7 @@ import { ReportingPageComponent } from 'core-app/features/reporting/reporting-pa
 export const REPORTING_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'reporting',
-    parent: 'root',
+    parent: 'optional_project',
     url: '/cost_reports',
     component: ReportingPageComponent,
   },

--- a/frontend/src/app/features/work-packages/routing/work-packages-routes.ts
+++ b/frontend/src/app/features/work-packages/routing/work-packages-routes.ts
@@ -42,10 +42,12 @@ export const menuItemClass = 'work-packages-menu-item';
 export const WORK_PACKAGES_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'work-packages',
-    parent: 'root',
-    component: WorkPackagesBaseComponent,
+    parent: 'optional_project',
     url: '/work_packages?query_id&query_props&start_onboarding_tour',
     redirectTo: 'work-packages.partitioned.list',
+    views: {
+      '!$default': { component: WorkPackagesBaseComponent },
+    },
     data: {
       bodyClasses: 'router--work-packages-base',
       menuItem: menuItemClass,

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
@@ -115,4 +115,14 @@ export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase imp
   backToList():void {
     this.backRouting.goToBaseState();
   }
+
+  protected handleLoadingError(error:unknown):void {
+    const message = this.notificationService.retrieveErrorMessage(error);
+
+    // Go back to the base route, closing this split view
+    void this.$state.go(
+      this.baseRoute,
+      { flash_message: { type: 'error', message } },
+    );
+  }
 }

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
@@ -120,7 +120,9 @@ export class WorkPackageSingleViewBase extends UntilDestroyedMixin {
 
         this.cdRef.detectChanges();
       },
-      (error) => this.notificationService.handleRawError(error));
+      (error) => {
+        this.handleLoadingError(error);
+      });
   }
 
   /**
@@ -168,6 +170,10 @@ export class WorkPackageSingleViewBase extends UntilDestroyedMixin {
       .subscribe((tabs:any) => {
         this.updateFocusAnchorLabel(tabs.active);
       });
+  }
+
+  protected handleLoadingError(error:unknown):void {
+    this.notificationService.handleRawError(error);
   }
 
   /**

--- a/spec/features/notifications/navigation_spec.rb
+++ b/spec/features/notifications/navigation_spec.rb
@@ -27,10 +27,11 @@ describe "Notification center navigation", type: :feature, js: true do
 
   let(:center) { ::Pages::Notifications::Center.new }
   let(:activity_tab) { ::Components::WorkPackages::Activities.new(work_package) }
-  let(:split_screen) { ::Pages::SplitWorkPackage.new work_package }
+  let(:split_screen) { ::Pages::Notifications::SplitScreen.new work_package }
+
+  current_user { recipient }
 
   describe 'the back button brings me back to where I came from' do
-    current_user { recipient }
     let(:navigation_helper) { ::Notifications::NavigationHelper.new(center, notification, work_package) }
 
     it 'when coming from a rails based page' do
@@ -61,8 +62,6 @@ describe "Notification center navigation", type: :feature, js: true do
   end
 
   describe 'the path updates accordingly' do
-    current_user { recipient }
-
     it 'when navigating between the tabs' do
       visit home_path
       center.open
@@ -89,5 +88,13 @@ describe "Notification center navigation", type: :feature, js: true do
       split_screen.close
       expect(page).to have_current_path "/notifications"
     end
+  end
+
+  it 'opening a notification that does not exist returns to the center' do
+    visit '/notifications/details/0'
+
+    expect(page).to have_current_path "/notifications"
+
+    split_screen.expect_empty_state
   end
 end


### PR DESCRIPTION
Instead of showing an empty split view, route back to the base route and set a flash message to be rendered after the route completes. 

For that to happen, we need a common root state that we currently did not have. This PR thus has to change some of the route definitions and uses views to set the parent ui-view instead of creating a new component. This reduces the weird stacking effect of the ui-views currently present.

Solves half of requirements in 
https://community.openproject.org/wp/38842