### PR TITLE
[38842] Allow customized not found message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2989,6 +2989,8 @@ en:
       code_409: "Could not update the resource because of conflicting modifications."
       code_429: "Too many requests. Please try again later."
       code_500: "An internal error has occurred."
+      not_found:
+        work_package: "The work package you are looking for cannot be found or has been deleted."
       expected:
         date: "YYYY-MM-DD (ISO 8601 date only)"
         duration: "ISO 8601 duration"

--- a/lib/api/errors/bad_request.rb
+++ b/lib/api/errors/bad_request.rb
@@ -34,7 +34,7 @@ module API
       identifier 'BadRequest'
       code 400
 
-      def initialize(message)
+      def initialize(message, **)
         super I18n.t('api_v3.errors.code_400', message: message)
       end
     end

--- a/lib/api/errors/error_base.rb
+++ b/lib/api/errors/error_base.rb
@@ -103,9 +103,11 @@ module API
         end
       end
 
-      def initialize(message)
+      def initialize(message, **)
         @message = message
         @errors = []
+
+        super message: message
       end
     end
   end

--- a/lib/api/errors/internal_error.rb
+++ b/lib/api/errors/internal_error.rb
@@ -34,7 +34,7 @@ module API
       identifier 'InternalServerError'
       code 500
 
-      def initialize(error_message = nil)
+      def initialize(error_message = nil, **)
         error = I18n.t('api_v3.errors.code_500')
 
         if error_message

--- a/lib/api/errors/not_found.rb
+++ b/lib/api/errors/not_found.rb
@@ -34,20 +34,22 @@ module API
       identifier 'NotFound'
       code 404
 
-      def initialize(_message = nil, exception: nil)
-        super(better_model_message(exception) || I18n.t('api_v3.errors.code_404'))
+      def initialize(_message = nil, exception: nil, model: nil)
+        # Try to find a localizable error message for
+        # the not found error by checking the "model" property set by rails.
+        model ||= exception&.model&.underscore
+        super not_found_message(model)
       end
 
       private
 
-      ##
-      # Try to find a localizable error message for
-      # the not found error by checking the "model" property set by rails.
-      def better_model_message(exception)
-        return unless exception&.model
 
-        model_name = exception.model.underscore
-        I18n.t("api_v3.errors.not_found.#{model_name}", default: nil)
+      def not_found_message(model)
+        if model.present?
+          I18n.t("api_v3.errors.not_found.#{model}", default: I18n.t('api_v3.errors.code_404'))
+        else
+          I18n.t('api_v3.errors.code_404')
+        end
       end
     end
   end

--- a/lib/api/errors/not_found.rb
+++ b/lib/api/errors/not_found.rb
@@ -34,10 +34,20 @@ module API
       identifier 'NotFound'
       code 404
 
-      def initialize(*args)
-        opts = args.last.is_a?(Hash) ? args.last : {}
+      def initialize(_message = nil, exception: nil)
+        super(better_model_message(exception) || I18n.t('api_v3.errors.code_404'))
+      end
 
-        super opts[:message] || I18n.t('api_v3.errors.code_404')
+      private
+
+      ##
+      # Try to find a localizable error message for
+      # the not found error by checking the "model" property set by rails.
+      def better_model_message(exception)
+        return unless exception&.model
+
+        model_name = exception.model.underscore
+        I18n.t("api_v3.errors.not_found.#{model_name}", default: nil)
       end
     end
   end

--- a/lib/api/errors/not_implemented.rb
+++ b/lib/api/errors/not_implemented.rb
@@ -34,7 +34,7 @@ module API
       identifier 'NotImplemented'.freeze
       code 501
 
-      def initialize(error_message = 'Not yet implemented'.freeze)
+      def initialize(error_message = 'Not yet implemented'.freeze, **)
         super error_message
       end
     end

--- a/lib/api/utilities/grape_helper.rb
+++ b/lib/api/utilities/grape_helper.rb
@@ -56,7 +56,7 @@ module API
           if error.nil?
             error_response_lambda
           else
-            lambda { |e| instance_exec error.new(e.message), &error_response_lambda }
+            lambda { |e| instance_exec error.new(e.message, exception: e), &error_response_lambda }
           end
 
         # We do this lambda business because #rescue_from behaves differently

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -77,7 +77,7 @@ module API
               @work_package = WorkPackage.find(declared_params[:id])
 
               authorize(:view_work_packages, context: @work_package.project) do
-                raise API::Errors::NotFound.new nil, model: :work_package
+                raise API::Errors::NotFound.new model: :work_package
               end
             end
 

--- a/lib/api/v3/work_packages/work_packages_api.rb
+++ b/lib/api/v3/work_packages/work_packages_api.rb
@@ -77,7 +77,7 @@ module API
               @work_package = WorkPackage.find(declared_params[:id])
 
               authorize(:view_work_packages, context: @work_package.project) do
-                raise API::Errors::NotFound.new
+                raise API::Errors::NotFound.new nil, model: :work_package
               end
             end
 

--- a/modules/budgets/spec/requests/api/v3/budgets/budget_resource_spec.rb
+++ b/modules/budgets/spec/requests/api/v3/budgets/budget_resource_spec.rb
@@ -100,7 +100,7 @@ describe 'API v3 Budget resource' do
         get get_path
       end
 
-      it_behaves_like 'not found'
+      it_behaves_like 'not found', 'User'
     end
   end
 end

--- a/modules/budgets/spec/requests/api/v3/budgets/budget_resource_spec.rb
+++ b/modules/budgets/spec/requests/api/v3/budgets/budget_resource_spec.rb
@@ -100,7 +100,7 @@ describe 'API v3 Budget resource' do
         get get_path
       end
 
-      it_behaves_like 'not found', 'User'
+      it_behaves_like 'not found'
     end
   end
 end

--- a/modules/costs/spec/requests/api/cost_types/cost_type_resource_spec.rb
+++ b/modules/costs/spec/requests/api/cost_types/cost_type_resource_spec.rb
@@ -61,9 +61,7 @@ describe 'API v3 Cost Type resource' do
       context 'cost type deleted' do
         let!(:cost_type) { FactoryBot.create(:cost_type, :deleted) }
 
-        it_behaves_like 'not found', 'Cost type' do
-          let(:id) { cost_type.id }
-        end
+        it_behaves_like 'not found'
       end
 
       context 'invalid id' do

--- a/modules/costs/spec/requests/api/cost_types/cost_type_resource_spec.rb
+++ b/modules/costs/spec/requests/api/cost_types/cost_type_resource_spec.rb
@@ -61,7 +61,7 @@ describe 'API v3 Cost Type resource' do
       context 'cost type deleted' do
         let!(:cost_type) { FactoryBot.create(:cost_type, :deleted) }
 
-        it_behaves_like 'not found' do
+        it_behaves_like 'not found', 'Cost type' do
           let(:id) { cost_type.id }
         end
       end

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -150,7 +150,7 @@ RSpec.feature 'Work package navigation', js: true, selenium: true do
     page404.expect_notification type: :error, message: I18n.t(:notice_file_not_found)
 
     visit "/projects/#{project.identifier}/work_packages/999999999"
-    page404.expect_and_dismiss_notification type: :error, message: I18n.t('api_v3.errors.code_404')
+    page404.expect_and_dismiss_notification type: :error, message: I18n.t('api_v3.errors.not_found.work_package')
   end
 
   # Regression #29994

--- a/spec/requests/api/v3/activities_api_spec.rb
+++ b/spec/requests/api/v3/activities_api_spec.rb
@@ -169,10 +169,7 @@ describe API::V3::Activities::ActivitiesAPI, type: :request, content_type: :json
       context 'requesting nonexistent activity' do
         let(:get_path) { api_v3_paths.activity 9999 }
 
-        it_behaves_like 'not found' do
-          let(:id) { 9999 }
-          let(:type) { 'Journal' }
-        end
+        it_behaves_like 'not found'
       end
 
       context 'without sufficient permissions' do

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -216,19 +216,14 @@ shared_examples 'an APIv3 attachment resource', type: :request, content_type: :j
       context 'requesting nonexistent attachment' do
         let(:get_path) { api_v3_paths.attachment 9999 }
 
-        it_behaves_like 'not found' do
-          let(:id) { 9999 }
-          let(:type) { 'Attachment' }
-        end
+        it_behaves_like 'not found'
       end
 
       context 'requesting attachments without sufficient permissions' do
         let(:current_user) { missing_permissions_user }
         let(:permissions) { all_permissions - Array(read_permission) }
 
-        it_behaves_like 'not found' do
-          let(:type) { 'Attachment' }
-        end
+        it_behaves_like 'not found'
       end
     end
   end
@@ -367,10 +362,7 @@ shared_examples 'an APIv3 attachment resource', type: :request, content_type: :j
       context 'for a non-existent attachment' do
         let(:path) { api_v3_paths.attachment 1337 }
 
-        it_behaves_like 'not found' do
-          let(:id) { 1337 }
-          let(:type) { 'Attachment' }
-        end
+        it_behaves_like 'not found'
       end
     end
 

--- a/spec/requests/api/v3/category_resource_spec.rb
+++ b/spec/requests/api/v3/category_resource_spec.rb
@@ -74,10 +74,7 @@ describe 'API v3 Category resource' do
         get get_path
       end
 
-      it_behaves_like 'not found' do
-        let(:id) { private_project.id.to_s }
-        let(:type) { 'Project' }
-      end
+      it_behaves_like 'not found'
     end
   end
 

--- a/spec/requests/api/v3/groups/group_resource_spec.rb
+++ b/spec/requests/api/v3/groups/group_resource_spec.rb
@@ -88,10 +88,7 @@ describe 'API v3 Group resource', type: :request, content_type: :json do
     context 'requesting nonexistent group' do
       let(:get_path) { api_v3_paths.group 9999 }
 
-      it_behaves_like 'not found' do
-        let(:id) { 9999 }
-        let(:type) { 'Group' }
-      end
+      it_behaves_like 'not found'
     end
 
     context 'not having the necessary permission to see any group' do
@@ -380,10 +377,7 @@ describe 'API v3 Group resource', type: :request, content_type: :json do
       context 'for a non-existent group' do
         let(:path) { api_v3_paths.group 11111337 }
 
-        it_behaves_like 'not found' do
-          let(:id) { 11111337 }
-          let(:type) { 'Group' }
-        end
+        it_behaves_like 'not found'
       end
     end
 

--- a/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
+++ b/spec/requests/api/v3/help_texts/help_texts_resource_spec.rb
@@ -103,10 +103,7 @@ describe 'API v3 Help texts resource' do
           # cf not visible to the user
           let(:help_text) { help_texts.last }
 
-          it_behaves_like 'not found' do
-            let(:id) { help_text.id }
-            let(:type) { 'HelpText' }
-          end
+          it_behaves_like 'not found'
         end
       end
     end

--- a/spec/requests/api/v3/membership_resources_spec.rb
+++ b/spec/requests/api/v3/membership_resources_spec.rb
@@ -959,10 +959,7 @@ describe 'API v3 memberships resource', type: :request, content_type: :json do
     context 'if lacking the view permissions' do
       let(:permissions) { [] }
 
-      it_behaves_like 'not found' do
-        let(:id) { member.id }
-        let(:type) { 'Membership' }
-      end
+      it_behaves_like 'not found'
     end
   end
 
@@ -993,10 +990,7 @@ describe 'API v3 memberships resource', type: :request, content_type: :json do
       context 'for a non-existent version' do
         let(:path) { api_v3_paths.membership 1337 }
 
-        it_behaves_like 'not found' do
-          let(:id) { 1337 }
-          let(:type) { 'Membership' }
-        end
+        it_behaves_like 'not found'
       end
     end
 

--- a/spec/requests/api/v3/placeholder_users/delete_resource_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/delete_resource_examples.rb
@@ -43,10 +43,7 @@ shared_examples 'deletion allowed' do
   context 'with a non-existent user' do
     let(:path) { api_v3_paths.placeholder_user 1337 }
 
-    it_behaves_like 'not found' do
-      let(:id) { 1337 }
-      let(:type) { 'PlaceholderUser' }
-    end
+    it_behaves_like 'not found'
   end
 end
 

--- a/spec/requests/api/v3/project_resource_spec.rb
+++ b/spec/requests/api/v3/project_resource_spec.rb
@@ -123,10 +123,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
           response
         end
 
-        it_behaves_like 'not found' do
-          let(:id) { 9999 }
-          let(:type) { 'Project' }
-        end
+        it_behaves_like 'not found'
       end
 
       context 'requesting project without sufficient permissions' do
@@ -136,10 +133,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
           response
         end
 
-        it_behaves_like 'not found' do
-          let(:id) { another_project.id.to_s }
-          let(:type) { 'Project' }
-        end
+        it_behaves_like 'not found'
       end
 
       context 'not being allowed to see the parent project' do
@@ -883,10 +877,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
       context 'for a non-existent project' do
         let(:path) { api_v3_paths.project 0 }
 
-        it_behaves_like 'not found' do
-          let(:id) { 0 }
-          let(:type) { 'Project' }
-        end
+        it_behaves_like 'not found'
       end
 
       context 'for a project which has a version foreign work packages refer to' do

--- a/spec/requests/api/v3/projects/statuses/project_status_resource_spec.rb
+++ b/spec/requests/api/v3/projects/statuses/project_status_resource_spec.rb
@@ -66,10 +66,7 @@ describe 'API v3 Project status resource', type: :request, content_type: :json d
           response
         end
 
-        it_behaves_like 'not found' do
-          let(:id) { 'bogus' }
-          let(:type) { 'ProjectStatus' }
-        end
+        it_behaves_like 'not found'
       end
     end
   end

--- a/spec/requests/api/v3/queries/query_resource_spec.rb
+++ b/spec/requests/api/v3/queries/query_resource_spec.rb
@@ -260,10 +260,7 @@ describe 'API v3 Query resource', type: :request, content_type: :json do
       let(:query_id) { 1337 } # could be anything as long as we do not create an actual query
       let(:path) { api_v3_paths.query query_id }
 
-      it_behaves_like 'not found' do
-        let(:id) { query_id }
-        let(:type) { 'Query' }
-      end
+      it_behaves_like 'not found'
     end
   end
 
@@ -333,10 +330,7 @@ describe 'API v3 Query resource', type: :request, content_type: :json do
         context 'when trying to star nonexistent query' do
           let(:star_path) { api_v3_paths.query_star 999 }
 
-          it_behaves_like 'not found' do
-            let(:id) { 999 }
-            let(:type) { 'Query' }
-          end
+          it_behaves_like 'not found'
         end
       end
 
@@ -423,10 +417,7 @@ describe 'API v3 Query resource', type: :request, content_type: :json do
             patch unstar_path
           end
 
-          it_behaves_like 'not found' do
-            let(:id) { 999 }
-            let(:type) { 'Query' }
-          end
+          it_behaves_like 'not found'
         end
       end
 

--- a/spec/requests/api/v3/relations_resource_spec.rb
+++ b/spec/requests/api/v3/relations_resource_spec.rb
@@ -96,7 +96,8 @@ describe 'API v3 Relation resource', type: :request do
         get path
       end
 
-      it_behaves_like 'not found'
+      it_behaves_like 'not found',
+                      I18n.t('api_v3.errors.not_found.work_package')
     end
   end
 end

--- a/spec/requests/api/v3/support/response_examples.rb
+++ b/spec/requests/api/v3/support/response_examples.rb
@@ -112,12 +112,11 @@ shared_examples_for 'unauthorized access' do
                   I18n.t('api_v3.errors.code_403')
 end
 
-shared_examples_for 'not found' do
+shared_examples_for 'not found' do |message = I18n.t('api_v3.errors.code_404')|
   it_behaves_like 'error response',
                   404,
-                  'NotFound' do
-    let(:message) { I18n.t('api_v3.errors.code_404') }
-  end
+                  'NotFound',
+                  message
 end
 
 shared_examples_for 'param validation error' do

--- a/spec/requests/api/v3/user/user_resource_spec.rb
+++ b/spec/requests/api/v3/user/user_resource_spec.rb
@@ -197,10 +197,7 @@ describe 'API v3 User resource',
       context 'requesting nonexistent user' do
         let(:get_path) { api_v3_paths.user 9999 }
 
-        it_behaves_like 'not found' do
-          let(:id) { 9999 }
-          let(:type) { 'User' }
-        end
+        it_behaves_like 'not found'
       end
 
       context 'requesting current user' do
@@ -259,10 +256,7 @@ describe 'API v3 User resource',
       context 'with a non-existent user' do
         let(:path) { api_v3_paths.user 1337 }
 
-        it_behaves_like 'not found' do
-          let(:id) { 1337 }
-          let(:type) { 'User' }
-        end
+        it_behaves_like 'not found'
       end
     end
 

--- a/spec/requests/api/v3/user/userlock_resource_spec.rb
+++ b/spec/requests/api/v3/user/userlock_resource_spec.rb
@@ -74,10 +74,7 @@ describe 'API v3 UserLock resource', type: :request, content_type: :json do
 
     context 'requesting nonexistent user' do
       let(:lock_path) { api_v3_paths.user_lock 9999 }
-      it_behaves_like 'not found' do
-        let(:id) { 9999 }
-        let(:type) { 'User' }
-      end
+      it_behaves_like 'not found'
     end
 
     context 'non-admin user' do

--- a/spec/requests/api/v3/version_resource_spec.rb
+++ b/spec/requests/api/v3/version_resource_spec.rb
@@ -113,10 +113,7 @@ describe 'API v3 Version resource', content_type: :json do
         get get_path
       end
 
-      it_behaves_like 'not found' do
-        let(:id) { version_in_project.id }
-        let(:type) { 'Version' }
-      end
+      it_behaves_like 'not found'
     end
   end
 
@@ -248,10 +245,7 @@ describe 'API v3 Version resource', content_type: :json do
     context 'if lacking the manage permissions' do
       let(:permissions) { [] }
 
-      it_behaves_like 'not found' do
-        let(:id) { version.id }
-        let(:type) { 'Version' }
-      end
+      it_behaves_like 'not found'
     end
 
     context 'if having the manage permission in a different project' do
@@ -455,10 +449,7 @@ describe 'API v3 Version resource', content_type: :json do
       context 'for a non-existent version' do
         let(:path) { api_v3_paths.version 1337 }
 
-        it_behaves_like 'not found' do
-          let(:id) { 1337 }
-          let(:type) { 'Version' }
-        end
+        it_behaves_like 'not found'
       end
     end
 

--- a/spec/requests/api/v3/watcher_resource_spec.rb
+++ b/spec/requests/api/v3/watcher_resource_spec.rb
@@ -97,7 +97,8 @@ describe 'API v3 Watcher resource', type: :request, content_type: :json do
     context 'user not allowed to see work package' do
       let(:permissions) { [] }
 
-      it_behaves_like 'not found'
+      it_behaves_like 'not found',
+                      I18n.t('api_v3.errors.not_found.work_package')
     end
   end
 

--- a/spec/requests/api/v3/watcher_resource_spec.rb
+++ b/spec/requests/api/v3/watcher_resource_spec.rb
@@ -154,10 +154,8 @@ describe 'API v3 Watcher resource', type: :request, content_type: :json do
     context 'when the work package does not exist' do
       let(:post_path) { api_v3_paths.work_package_watchers 9999 }
 
-      it_behaves_like 'not found' do
-        let(:id) { 9999 }
-        let(:type) { 'WorkPackage' }
-      end
+      it_behaves_like 'not found',
+                      I18n.t('api_v3.errors.not_found.work_package')
     end
 
     context 'when the user does not exist' do
@@ -243,10 +241,8 @@ describe 'API v3 Watcher resource', type: :request, content_type: :json do
       context 'when work package doesn\'t exist' do
         let(:delete_path) { api_v3_paths.watcher watching_user.id, 9999 }
 
-        it_behaves_like 'not found' do
-          let(:id) { 9999 }
-          let(:type) { 'WorkPackage' }
-        end
+        it_behaves_like 'not found',
+                        I18n.t('api_v3.errors.not_found.work_package')
       end
     end
 

--- a/spec/requests/api/v3/work_packages/delete_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/delete_resource_spec.rb
@@ -76,10 +76,8 @@ describe 'API v3 Work package resource',
       context 'for a non-existent work package' do
         let(:path) { api_v3_paths.work_package 1337 }
 
-        it_behaves_like 'not found' do
-          let(:id) { 1337 }
-          let(:type) { 'WorkPackage' }
-        end
+        it_behaves_like 'not found',
+                        I18n.t('api_v3.errors.not_found.work_package')
       end
     end
 

--- a/spec/requests/api/v3/work_packages/delete_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/delete_resource_spec.rb
@@ -84,7 +84,8 @@ describe 'API v3 Work package resource',
     context 'without permission to see work packages' do
       let(:permissions) { [] }
 
-      it_behaves_like 'not found'
+      it_behaves_like 'not found',
+                      I18n.t('api_v3.errors.not_found.work_package')
     end
 
     context 'without permission to delete work packages' do

--- a/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/form/work_package_form_resource_spec.rb
@@ -77,7 +77,8 @@ describe 'API v3 Work package form resource', type: :request, with_mail: false d
         let(:current_user) { unauthorized_user }
       end
 
-      it_behaves_like 'not found'
+      it_behaves_like 'not found',
+                      I18n.t('api_v3.errors.not_found.work_package')
     end
 
     context 'user with all edit permissions' do

--- a/spec/requests/api/v3/work_packages/show_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/show_resource_spec.rb
@@ -181,7 +181,8 @@ describe 'API v3 Work package resource',
       context 'requesting nonexistent work package' do
         let(:get_path) { api_v3_paths.work_package 909090 }
 
-        it_behaves_like 'not found'
+        it_behaves_like 'not found',
+                        I18n.t('api_v3.errors.not_found.work_package')
       end
     end
 
@@ -191,7 +192,8 @@ describe 'API v3 Work package resource',
         get get_path
       end
 
-      it_behaves_like 'not found'
+      it_behaves_like 'not found',
+                      I18n.t('api_v3.errors.not_found.work_package')
     end
 
     context 'when acting as an anonymous user' do
@@ -200,7 +202,8 @@ describe 'API v3 Work package resource',
         get get_path
       end
 
-      it_behaves_like 'not found'
+      it_behaves_like 'not found',
+                      I18n.t('api_v3.errors.not_found.work_package')
     end
   end
 end

--- a/spec/requests/api/v3/work_packages/update_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/update_resource_spec.rb
@@ -77,7 +77,8 @@ describe 'API v3 Work package resource',
 
         include_context 'patch request'
 
-        it_behaves_like 'not found'
+        it_behaves_like 'not found',
+                        I18n.t('api_v3.errors.not_found.work_package')
       end
 
       context 'no permission to edit the work package' do


### PR DESCRIPTION
Pass the exception to the NotFound API error wrapper to get more information about the model that could not be found. This allows us to provide a "better" custom message that includes the correct localization of the resource, such as work package that could not be found.

Solves the message part of:
https://community.openproject.org/wp/38842