### PR TITLE
[39171] Help text modal text cut off

### DIFF
--- a/frontend/src/global_styles/content/user-content/_index.sass
+++ b/frontend/src/global_styles/content/user-content/_index.sass
@@ -13,7 +13,9 @@
   --op-uc-heading-base: 1.8rem
   --op-uc-heading-falloff: 0.85
   display: block
-  overflow: hidden
+  overflow-x: hidden
+  overflow-y: auto
+  @include styled-scroll-bar
   font-size: var(--wiki-default-font-size)
   z-index: 0
   padding-bottom: 1rem
@@ -28,4 +30,3 @@
 
   &_no-permalinks *:hover .op-uc-link_permalink
     display: none
-

--- a/modules/documents/app/views/documents/show.html.erb
+++ b/modules/documents/app/views/documents/show.html.erb
@@ -48,9 +48,8 @@ See docs/COPYRIGHT.rdoc for more details.
   <% end %>
 <% end %>
 
-<div class="wiki">
+<div class="wiki op-uc-container">
   <%= format_text @document.description, attachments: @document.attachments %>
 </div>
 
 <%= list_attachments(api_v3_document_resource(@document)) %>
-


### PR DESCRIPTION
Allow scrolling within `op-uc-container` e.g for attribute help text in modals. This did not cause any problems earlier because in other places the page itself scrolled. However the modal cannot scroll, if the overflow has already been cut off.

https://community.openproject.org/projects/openproject/work_packages/39171/activity