### PR TITLE
[38887] Allow bright colours for WP types again

### DIFF
--- a/app/controllers/colors_controller.rb
+++ b/app/controllers/colors_controller.rb
@@ -36,7 +36,7 @@ class ColorsController < ApplicationController
   menu_item :colors
 
   def index
-    @colors = Color.all
+    @colors = Color.all.sort_by(&:name)
     respond_to do |format|
       format.html
     end

--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -29,11 +29,9 @@
 #++
 
 module ColorsHelper
-  def options_for_colors(colored_thing, allow_bright_colors)
+  def options_for_colors(colored_thing)
     colors = []
     Color.find_each do |c|
-      next if !allow_bright_colors && c.super_bright?
-
       options = {}
       options[:name] = c.name
       options[:value] = c.id

--- a/app/views/colors/_color_autocomplete_field.html.erb
+++ b/app/views/colors/_color_autocomplete_field.html.erb
@@ -10,7 +10,7 @@
     <%= content_tag('colors-autocompleter',
                     '',
                     class: "colors-autocomplete form--select-container " + "#{container_class.present? ? container_class : '-middle'}",
-                    data: { colors: options_for_colors(object, allow_bright_colors),
+                    data: { colors: options_for_colors(object),
                             selected_color: selected_color(object),
                             highlight_text_inline: highlight_text_inline,
                             update_input: type + '[color_id]'}) %>

--- a/app/views/enumerations/_form.html.erb
+++ b/app/views/enumerations/_form.html.erb
@@ -45,7 +45,6 @@ See COPYRIGHT and LICENSE files for more details.
                    form: f,
                    object: @enumeration,
                    type: 'enumeration',
-                   allow_bright_colors: true,
                    label: @enumeration.color_label
                }  %>
   <% end %>

--- a/app/views/statuses/_form.html.erb
+++ b/app/views/statuses/_form.html.erb
@@ -58,7 +58,6 @@ See COPYRIGHT and LICENSE files for more details.
                form: f,
                object: @status,
                type: 'status',
-               allow_bright_colors: true,
                label: t('statuses.edit.status_color_text')
             } %>
 

--- a/app/views/types/form/_settings.html.erb
+++ b/app/views/types/form/_settings.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
                    form: f,
                    object: @type,
                    type: 'type',
-                   allow_bright_colors: false,
+                   allow_bright_colors: true,
                    highlight_text_inline: true,
                    label: t('types.edit.type_color_text'),
                    form_field_class: '-wide-label',

--- a/app/views/types/form/_settings.html.erb
+++ b/app/views/types/form/_settings.html.erb
@@ -37,7 +37,6 @@ See COPYRIGHT and LICENSE files for more details.
                    form: f,
                    object: @type,
                    type: 'type',
-                   allow_bright_colors: true,
                    highlight_text_inline: true,
                    label: t('types.edit.type_color_text'),
                    form_field_class: '-wide-label',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -341,8 +341,8 @@ en:
       query_group_placeholder: "Give the table a name"
       reset: "Reset to defaults"
       type_color_text: |
-        Click to assign or change the color of this type. The selected color distinguishes work packages
-        in Gantt charts. It is therefore recommended to use a strong color.
+        The selected color distinguishes different types
+        in Gantt charts or work packages tables. It is therefore recommended to use a strong color.
 
   versions:
     overview:
@@ -934,7 +934,7 @@ en:
     user: "User"
     version: "Version"
     work_package: "Work package"
-  
+
   backup:
     label_backup_token: "Backup token"
     label_create_token: "Create backup token"
@@ -3125,5 +3125,5 @@ en:
     authorization_error: "An authorization error has occurred."
     revoke_my_application_confirmation: "Do you really want to remove this application? This will revoke %{token_count} active for it."
     my_registered_applications: "Registered OAuth applications"
-  
+
   you: you


### PR DESCRIPTION
In order to prevent users being confused why they can't select a certain color as WP type color, we allow bright colours again.
We thus lay more power back to the users hands. I shortened the instructional text below the select box to emphasise the importance of a strong colour.

[OP#38887](https://community.openproject.org/projects/openproject/work_packages/38887/activity)