### PR TITLE
[38812] Unclear error message when deleting work package type

### DIFF
--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -121,7 +121,18 @@ class TypesController < ApplicationController
       flash[:error] = if @type.is_standard?
                         t(:error_can_not_delete_standard_type)
                       else
-                        t(:error_can_not_delete_type)
+                        error_message = [
+                          t(:'error_can_not_delete_type.explanation',
+                            { url: belonging_wps_url(@type.id)}).html_safe
+                        ]
+
+                        archived_projects = @type.projects.filter(&:archived?)
+                        error_message.push(
+                          t(:'error_can_not_delete_type.archived_projects',
+                            { archived_projects: archived_projects.map(&:name).join(', ')}).html_safe
+                        ) if archived_projects.length > 0
+
+                        error_message
                       end
     end
     redirect_to action: 'index'
@@ -164,5 +175,9 @@ class TypesController < ApplicationController
 
   def show_local_breadcrumb
     true
+  end
+
+  def belonging_wps_url(type_id)
+    work_packages_path query_props: '{"f":[{"n":"type","o":"=","v":[' + type_id.to_s + ']}]}'
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -934,7 +934,7 @@ en:
     user: "User"
     version: "Version"
     work_package: "Work package"
-  
+
   backup:
     label_backup_token: "Backup token"
     label_create_token: "Create backup token"
@@ -1237,7 +1237,9 @@ en:
   error_can_not_archive_project: "This project cannot be archived: %{errors}"
   error_can_not_delete_entry: "Unable to delete entry"
   error_can_not_delete_custom_field: "Unable to delete custom field"
-  error_can_not_delete_type: "This type contains work packages and cannot be deleted."
+  error_can_not_delete_type:
+    explanation: 'This type contains work packages and cannot be deleted. You can see all affected work packages in <a target="_blank" href="%{url}">this view</a>.'
+    archived_projects: 'There are also work packages in archived projects. You need to reactivate the following projects first, before you can change the type of the respective work packages: %{archived_projects}'
   error_can_not_delete_standard_type: "Standard types cannot be deleted."
   error_can_not_invite_user: "Failed to send invitation to user."
   error_can_not_remove_role: "This role is in use and cannot be deleted."
@@ -3125,5 +3127,5 @@ en:
     authorization_error: "An authorization error has occurred."
     revoke_my_application_confirmation: "Do you really want to remove this application? This will revoke %{token_count} active for it."
     my_registered_applications: "Registered OAuth applications"
-  
+
   you: you

--- a/spec/controllers/types_controller_spec.rb
+++ b/spec/controllers/types_controller_spec.rb
@@ -309,7 +309,7 @@ describe TypesController, type: :controller do
       let(:type2) { FactoryBot.create(:type, name: 'My type 2', projects: [project]) }
       let(:type3) { FactoryBot.create(:type, name: 'My type 3', is_standard: true) }
 
-      describe 'successful detroy' do
+      describe 'successful destroy' do
         let(:params) { { 'id' => type.id } }
 
         before do
@@ -326,9 +326,10 @@ describe TypesController, type: :controller do
         end
       end
 
-      describe 'detroy type in use should fail' do
+      describe 'destroy type in use should fail' do
         let(:project2) do
           FactoryBot.create(:project,
+                            active: false,
                             work_package_custom_fields: [custom_field_2],
                             types: [type2])
         end
@@ -347,8 +348,13 @@ describe TypesController, type: :controller do
         it { expect(response).to be_redirect }
         it { expect(response).to redirect_to(types_path) }
         it 'should show an error message' do
-          expect(flash[:error]).to eq(I18n.t(:error_can_not_delete_type))
+          error_message = [I18n.t(:'error_can_not_delete_type.explanation')]
+          error_message.push(I18n.t(:'error_can_not_delete_type.archived_projects',
+                                    { archived_projects: project2.name }))
+
+          expect(sanitize_string(flash[:error])).to eq(sanitize_string(error_message))
         end
+
         it 'should be present in the database' do
           expect(::Type.find_by(name: 'My type 2').id).to eq(type2.id)
         end


### PR DESCRIPTION
This aims to improve the error handling when trying to delete a Work package type that is still used.

- [x] Provide an url which links to a WP query that filters for all WPs with that type
- [x] When there are archived projects that use this type, list them in the error message as wel
- [x] Write tests for the new behaviour
<img width="575" alt="Bildschirmfoto 2021-10-22 um 14 32 10" src="https://user-images.githubusercontent.com/7457313/138454146-8f06f7d2-0a98-489a-be26-57c0d1a8cb4c.png">

[OP#38812](https://community.openproject.org/projects/openproject/work_packages/38812/activity)


