### PR TITLE
use jsonb column for dj handler

### DIFF
--- a/app/workers/cron/cron_job.rb
+++ b/app/workers/cron/cron_job.rb
@@ -70,7 +70,7 @@ module Cron
 
       def delayed_job
         Delayed::Job
-          .where('handler LIKE ?', "%job_class: #{name}%")
+          .where("delayed_jobs.handler -> 'job_class' ? :name", name: name)
           .first
       end
     end

--- a/db/migrate/20211029144812_delayed_job_json_handler.rb
+++ b/db/migrate/20211029144812_delayed_job_json_handler.rb
@@ -1,0 +1,32 @@
+class DelayedJobJsonHandler < ActiveRecord::Migration[6.1]
+  def up
+    rename_column :delayed_jobs, :handler, :yaml_handler
+    add_column :delayed_jobs, :handler, :jsonb
+
+    Delayed::Job.find_each do |job|
+      job.handler = YAML
+                      .safe_load(job.yaml_handler,
+                                 permitted_classes: [ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper])
+                      .job_data
+      job.save
+    end
+
+    add_index :delayed_jobs,
+              "((delayed_jobs.handler->>'job_class'))",
+              name: :index_delayed_jobs_job_class
+
+    remove_column :delayed_jobs, :yaml_handler
+  end
+
+  def down
+    rename_column :delayed_jobs, :handler, :json_handler
+    add_column :delayed_jobs, :handler, :text
+
+    Delayed::Job.find_each do |job|
+      job.handler = YAML.dump(ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new(job.json_handler))
+      job.save
+    end
+
+    remove_column :delayed_jobs, :json_handler
+  end
+end

--- a/lib/open_project/patches/delayed_job_json_handler.rb
+++ b/lib/open_project/patches/delayed_job_json_handler.rb
@@ -1,0 +1,22 @@
+require 'open_project/patches'
+
+module OpenProject::Patches::DelayedJobJsonHandler
+  extend ActiveSupport::Concern
+
+  included do
+    # Overwriting the methods for (de)serializing the handler.
+    # That way, the handler is stored as json which is queryable performantly.
+    def payload_object=(object)
+      @payload_object = object
+      self.handler = object.job_data
+    end
+
+    def payload_object
+      @payload_object ||= ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new(handler)
+    end
+  end
+end
+
+OpenProject::Patches.patch_gem_version 'delayed_job_active_record', '4.1.6' do
+  Delayed::Backend::ActiveRecord::Job.include OpenProject::Patches::DelayedJobJsonHandler
+end

--- a/spec/workers/notifications/schedule_reminder_mails_job_spec.rb
+++ b/spec/workers/notifications/schedule_reminder_mails_job_spec.rb
@@ -68,16 +68,14 @@ describe Notifications::ScheduleReminderMailsJob, type: :job do
           .to change(Delayed::Job, :count)
                 .by(2)
 
-        jobs = Delayed::Job.all.map do |job|
-          YAML.safe_load(job.handler, permitted_classes: [ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper])
-        end
+        jobs = Delayed::Job.all.map(&:handler)
 
-        reminder_jobs = jobs.select { |job| job.job_data['job_class'] == "Mails::ReminderJob" }
+        reminder_jobs = jobs.select { |job| job['job_class'] == "Mails::ReminderJob" }
 
-        expect(reminder_jobs[0].job_data['arguments'])
+        expect(reminder_jobs[0]['arguments'])
           .to match_array([23])
 
-        expect(reminder_jobs[1].job_data['arguments'])
+        expect(reminder_jobs[1]['arguments'])
           .to match_array([42])
       end
 


### PR DESCRIPTION
End of the week attempt to store the handler information of delayed job as jsonb instead of yaml as jsonb can be indexed.

I haven't performed extensive tests yet. Especially the serialization of the arguments might prove troublesome.