### PR TITLE
[39502] Try to remove all email notification parts from the footer

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -298,10 +298,7 @@ repository_log_display_limit:
   default: 100
 emails_footer:
   serialized: true
-  default:
-    en: |-
-      You have received this notification because you have either subscribed to it, or are involved in it.
-      To change your notification preferences, please click here: {{opSetting:base_url}}/my/notifications
+  default: {}
 start_of_week:
   default: ''
 first_week_of_year:

--- a/db/migrate/20211103120946_clean_emails_footer.rb
+++ b/db/migrate/20211103120946_clean_emails_footer.rb
@@ -1,0 +1,34 @@
+class CleanEmailsFooter < ActiveRecord::Migration[6.1]
+  def up
+    Setting.reset_column_information
+    filtered_footer = Setting
+      .emails_footer
+      .reject do |locale, text|
+      if assumed_notification_text?(text)
+        warn "Removing emails footer for #{locale} as it matches the default notification syntax."
+        true
+      end
+    end
+
+    if filtered_footer.length < Setting.emails_footer.length
+      Setting.emails_footer = filtered_footer
+    end
+  end
+
+  def down
+    # Nothing to migrate
+  end
+
+  private
+
+  def assumed_notification_text?(text)
+    [
+      'You have received this notification because of your notification settings',
+      'You have received this notification because you have either subscribed to it, or are involved in it.',
+      'Sie erhalten diese E-Mail aufgrund Ihrer Benachrichtungseinstellungen',
+      '/my/account',
+      '/my/notifications',
+      '/my/mail\_notifications'
+    ].any? { |val| text.include?(val) }
+  end
+end

--- a/spec/support/pages/reminders/settings.rb
+++ b/spec/support/pages/reminders/settings.rb
@@ -110,9 +110,9 @@ module Pages
 
       def expect_paused(paused, first: nil, last: nil)
         if paused
-          expect(page).to have_field 'Temporarily pause daily email reminders'
+          expect(page).to have_checked_field 'Temporarily pause daily email reminders'
         else
-          expect(page).to have_no_field 'Temporarily pause daily email reminders'
+          expect(page).to have_no_checked_field 'Temporarily pause daily email reminders'
         end
 
         if first && last


### PR DESCRIPTION
https://community.openproject.org/wp/39502

I tried this on all footers from vips1, and this removes all default messages from over the years but leaves some with imprints in it. That should be a good enough effort.