### PR TITLE
Extend payload also for grape logging

### DIFF
--- a/config/initializers/grape_logging.rb
+++ b/config/initializers/grape_logging.rb
@@ -8,7 +8,8 @@ OpenProject::Application.configure do
         view: time[:view]
       }.merge(payload.except(:time))
 
-      Rails.logger.info OpenProject::Logging.formatter.call(attributes)
+      extended = OpenProject::Logging.extend_payload!(attributes, {})
+      Rails.logger.info OpenProject::Logging.formatter.call(extended)
     end
   end
 end


### PR DESCRIPTION
Also use the log extenders to add context information to lograge logging for the case of grape_logging. This was already happening for the core lograge case, but missing for grape. As a result, no user or tenant information was added