### PR TITLE
Fix/39542/sort reminder times upon save

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -661,7 +661,8 @@ en:
         daily:
           add_time: 'Add time'
           enable: 'Enable daily email reminders'
-          explanation: 'You will receive these reminders only for unread notifications and only at hours you specify.'
+          explanation: 'You will receive these reminders only for unread notifications and only at hours you specify. %{no_time_zone}'
+          no_time_zone: 'Until you configure a time zone for your account, the times will be interpreted to be in UTC.'
           time_label: 'Time %{counter}:'
           title: 'Send me daily email reminders for unread notifications'
         workdays:

--- a/frontend/src/app/features/user-preferences/reminder-settings/page/reminder-settings-page.component.ts
+++ b/frontend/src/app/features/user-preferences/reminder-settings/page/reminder-settings-page.component.ts
@@ -134,7 +134,7 @@ export class ReminderSettingsPageComponent extends UntilDestroyedMixin implement
 
     const dailyReminderTimes = this.form.get('dailyReminders.times') as FormArray;
     dailyReminderTimes.clear({ emitEvent: false });
-    settings.dailyReminders.times.forEach((time) => {
+    [...settings.dailyReminders.times].sort().forEach((time) => {
       dailyReminderTimes.push(this.fb.control(time), { emitEvent: false });
     });
 

--- a/frontend/src/app/features/user-preferences/reminder-settings/reminder-time/reminder-settings-daily-time.component.ts
+++ b/frontend/src/app/features/user-preferences/reminder-settings/reminder-time/reminder-settings-daily-time.component.ts
@@ -21,6 +21,7 @@ import {
   FormGroup,
   FormGroupDirective,
 } from '@angular/forms';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 @Component({
   selector: 'op-reminder-settings-daily-time',
@@ -65,7 +66,8 @@ export class ReminderSettingsDailyTimeComponent implements OnInit {
 
   text = {
     title: this.I18n.t('js.reminders.settings.daily.title'),
-    explanation: this.I18n.t('js.reminders.settings.daily.explanation'),
+    explanation: this.I18n.t('js.reminders.settings.daily.explanation',
+      { no_time_zone: this.configurationService.isTimezoneSet() ? '' : this.I18n.t('js.reminders.settings.daily.no_time_zone') }),
     timeLabel: (counter:number):string => this.I18n.t('js.reminders.settings.daily.time_label', { counter }),
     addTime: this.I18n.t('js.reminders.settings.daily.add_time'),
     enable: this.I18n.t('js.reminders.settings.daily.enable'),
@@ -75,6 +77,7 @@ export class ReminderSettingsDailyTimeComponent implements OnInit {
     private I18n:I18nService,
     private storeService:UserPreferencesService,
     private rootFormGroup:FormGroupDirective,
+    private configurationService:ConfigurationService,
   ) {
   }
 


### PR DESCRIPTION
Sorts the reminder times after the user clicked on save (https://community.openproject.org/wp/39542). Additionally, it shows an explanation in case the user has not selected a time zone yet.