### PR TITLE
update teaser block to 12.0

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -316,29 +316,31 @@ en:
         new_features:
           text_new_features: "Read about new features and product updates."
           learn_about: "Learn more about the new features"
-          standard:
-            learn_about_link: https://www.openproject.org/openproject-11-3-release
-            current_new_feature_html: >
-              The release contains various new features and improvements: <br>
-              <ul class="%{list_styling_class}">
-                <li>New button in header navigation to create projects, users and work packages.</li>
-                <li>A new invite modal for users, groups and placeholder users allows to easily add or invite new users and assign them to work packages.</li>
-                <li>GitHub integration into OpenProject.</li>
-                <li>API v3 extensions for groups and more, i.e. create, read, update and delete groups and group members through the API.</li>
-                <li>Multi-selection for project custom fields of type list.</li>
-                <li>Creation of backup from the web interface.</li>
-              </ul>
-          bim:
-            learn_about_link: https://www.openproject.org/blog/openproject-11-4-release
-            current_new_feature_html: >
-              The release contains various new features and improvements: <br>
-              <ul class="%{list_styling_class}">
-                <li>Take a look at our <a href="https://github.com/opf/openproject-revit-add-in">Revit Add-in</a> which lets you work on BCF work packages directly in Revit.</li>
-                <li>IFC properties got a dedicated pane. Copying GUIDs has never been easier.</li>
-                <li>Reverse clipping plane direction in BCF viewpoint and become compliant with future BCF 3.0 (Now same direction as Solibri).
-                <li>Fixed viewing IFC models on mobile.</li>
-                <li>Fixed export of work package views with BCF snapshot column.</li>
-              </ul>
+          # Include the version to invalidate outdated translations in other locales.
+          # Otherwise, e.g. chinese might still have the translations for 10.0 in the 12.0 release.
+          '12_0':
+            standard:
+              learn_about_link: https://www.openproject.org/blog/openproject-12-0-release
+              new_features_html: >
+                The release contains various new features and improvements: <br>
+                <ul class="%{list_styling_class}">
+                  <li>With the new <b>in-app notifications</b> you receive all important updates directly in the application and don't get a flood of emails anymore.</li>
+                  <li>The new <b>notification center</b> shows all the changes, including intuitive filter options, e.g. by reason for notification or projects. It even allows editing directly in a split view.</li>
+                  <li>Improved <b>notification settings</b> allow to fine-tune for which actions and in which projects you want to receive a notification.</li>
+                  <li><b>Email reminders</b> can be configured to receive important updates via a daily email summary</li>
+                  <li>The work package auto-completer for relations now also shows additional information (project name, status, ...) to easily identify the respective work package.</li>
+                </ul>
+            bim:
+              learn_about_link: https://www.openproject.org/blog/openproject-12-0-release
+              new_features_html: >
+                The release contains various new features and improvements: <br>
+                <ul class="%{list_styling_class}">
+                  <li>With the new <b>in-app notifications</b> you receive all important updates directly in the application and don't get a flood of emails anymore.</li>
+                  <li>The new <b>notification center</b> shows all the changes, including intuitive filter options, e.g. by reason for notification or projects. It even allows editing directly in a split view.</li>
+                  <li>Improved <b>notification settings</b> allow to fine-tune for which actions and in which projects you want to receive a notification.</li>
+                  <li><b>Email reminders</b> can be configured to receive important updates via a daily email summary</li>
+                  <li>The work package auto-completer for relations now also shows additional information (project name, status, ...) to easily identify the respective work package.</li>
+                </ul>
 
     label_activate: "Activate"
     label_add_column_after: "Add column after"

--- a/frontend/src/app/features/homescreen/blocks/new-features.component.spec.ts
+++ b/frontend/src/app/features/homescreen/blocks/new-features.component.spec.ts
@@ -58,7 +58,7 @@ describe('shows edition-specific content', () => {
     fixture.detectChanges();
 
     // checking for missing translation key as translations are not loaded in specs
-    expect(element.nativeElement.textContent).toContain('.bim.current_new_feature_html');
+    expect(element.nativeElement.textContent).toContain('.bim.new_features_html');
   }));
 
   it('should render standard text for standard edition', fakeAsync(() => {
@@ -67,6 +67,6 @@ describe('shows edition-specific content', () => {
     fixture.detectChanges();
 
     // checking for missing translation key as translations are not loaded in specs
-    expect(element.nativeElement.textContent).toContain('.standard.current_new_feature_html');
+    expect(element.nativeElement.textContent).toContain('.standard.new_features_html');
   }));
 });

--- a/frontend/src/app/features/homescreen/blocks/new-features.component.ts
+++ b/frontend/src/app/features/homescreen/blocks/new-features.component.ts
@@ -33,6 +33,8 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { imagePath } from 'core-app/shared/helpers/images/path-helper';
 
 export const homescreenNewFeaturesBlockSelector = 'homescreen-new-features-block';
+// The key used in the I18n files to distinguish between versions.
+const OpVersionI18n = '12_0';
 
 @Component({
   template: `
@@ -82,16 +84,11 @@ export class HomescreenNewFeaturesBlockComponent {
   }
 
   public get currentNewFeatureHtml():string {
-    return this.translated('current_new_feature_html');
+    return this.translated('new_features_html');
   }
 
   private translated(key:string):string {
-    return this.i18n.t(`${this.i18nBase + this.i18nPrefix}.${key}`, { list_styling_class: 'widget-box--arrow-links', bcf_api_link: BcfRestApi });
-  }
-
-  private i18nBase = 'js.homescreen.blocks.new_features.';
-
-  private get i18nPrefix():string {
-    return this.isStandardEdition ? 'standard' : 'bim';
+    return this.i18n.t(`js.homescreen.blocks.new_features.${OpVersionI18n}.${this.isStandardEdition ? 'standard' : 'bim'}.${key}`,
+      { list_styling_class: 'widget-box--arrow-links', bcf_api_link: BcfRestApi });
   }
 }


### PR DESCRIPTION
The texts for the teaser block highlight the 12.0 features. The image is not yet replaced.

The teaser block texts in other locales should now get invalidated by updating the key to the current OP version.

https://community.openproject.org/wp/37389 