### PR TITLE
Also reload activities in the work package split view on update, not just the notification count

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-base.controller.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-base.controller.ts
@@ -32,6 +32,9 @@ import {
   OnInit,
 } from '@angular/core';
 import { UIRouterGlobals } from '@uirouter/core';
+import { Observable } from 'rxjs';
+import { map, distinctUntilChanged } from 'rxjs/operators';
+import { take } from 'rxjs/internal/operators/take';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { ActivityEntryInfo } from 'core-app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-entry-info';
@@ -39,10 +42,7 @@ import { WorkPackagesActivityService } from 'core-app/features/work-packages/com
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { APIV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-view-base/state/wp-single-view.service';
-import { take } from 'rxjs/internal/operators/take';
 
 @Directive()
 export class ActivityPanelBaseController extends UntilDestroyedMixin implements OnInit {
@@ -71,6 +71,8 @@ export class ActivityPanelBaseController extends UntilDestroyedMixin implements 
 
   private additionalScrollMargin = 200;
 
+  private initialized = false;
+
   constructor(
     readonly apiV3Service:APIV3Service,
     readonly I18n:I18nService,
@@ -78,6 +80,7 @@ export class ActivityPanelBaseController extends UntilDestroyedMixin implements 
     readonly uiRouterGlobals:UIRouterGlobals,
     readonly wpActivity:WorkPackagesActivityService,
     readonly storeService:WpSingleViewService,
+    private wpSingleViewService:WpSingleViewService,
   ) {
     super();
 
@@ -86,8 +89,7 @@ export class ActivityPanelBaseController extends UntilDestroyedMixin implements 
   }
 
   ngOnInit():void {
-    let initialized = false;
-
+    this.initialized = false;
     this
       .apiV3Service
       .work_packages
@@ -96,15 +98,17 @@ export class ActivityPanelBaseController extends UntilDestroyedMixin implements 
       .pipe(this.untilDestroyed())
       .subscribe((wp) => {
         this.workPackage = wp;
-        void this.wpActivity.require(this.workPackage).then((activities:HalResource[]) => {
-          this.updateActivities(activities);
-          this.cdRef.detectChanges();
+        this.reloadActivities();
+      });
 
-          if (!initialized) {
-            initialized = true;
-            this.scrollIfNotificationPresent();
-          }
-        });
+    this.wpSingleViewService.query
+      .selectNotificationsCount$
+      .pipe(
+        this.untilDestroyed(),
+        distinctUntilChanged(),
+      )
+      .subscribe(() => {
+        this.reloadActivities();
       });
   }
 
@@ -116,6 +120,18 @@ export class ActivityPanelBaseController extends UntilDestroyedMixin implements 
           this.scrollToUnreadNotification();
         }
       });
+  }
+
+  private reloadActivities() {
+    void this.wpActivity.require(this.workPackage, true).then((activities:HalResource[]) => {
+      this.updateActivities(activities);
+      this.cdRef.detectChanges();
+
+      if (!this.initialized) {
+        this.initialized = true;
+        this.scrollIfNotificationPresent();
+      }
+    });
   }
 
   protected updateActivities(activities:HalResource[]):void {

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
@@ -47,7 +47,7 @@ import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-
 @Component({
   templateUrl: './wp-split-view.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  selector: 'wp-split-view',
+  selector: 'op-wp-split-view',
   providers: [
     WpSingleViewService,
     { provide: HalResourceNotificationService, useClass: WorkPackageNotificationService },

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
@@ -47,7 +47,7 @@ import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-
 @Component({
   templateUrl: './wp-split-view.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  selector: 'wp-split-view-entry',
+  selector: 'wp-split-view',
   providers: [
     WpSingleViewService,
     { provide: HalResourceNotificationService, useClass: WorkPackageNotificationService },


### PR DESCRIPTION
When there are new notifications in the center, the user can force an update to the list. We also updated the number of
notifications inside the work package, but did not load the new activity tab entries. This is fixed in this PR.

Relevant comment:

https://community.openproject.org/work_packages/39466/activity#activity-6

While we're here, also change the wp-split-view selector to align with the filename