### PR TITLE
Hide scrollable table if its empty

### DIFF
--- a/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.html
+++ b/frontend/src/app/features/user-preferences/notifications-settings/table/notification-settings-table.component.html
@@ -1,8 +1,8 @@
-<div class="op-scrollable-table">
-  <table
-    class="op-table"
-    *ngIf="settings.length > 0"
-  >
+<div
+  class="op-scrollable-table"
+  *ngIf="settings.length > 0"
+>
+  <table class="op-table">
     <thead>
       <tr>
         <th class="op-table--cell op-table--cell_heading">

--- a/frontend/src/app/shared/components/table/scrollable-table.sass
+++ b/frontend/src/app/shared/components/table/scrollable-table.sass
@@ -1,9 +1,6 @@
 .op-scrollable-table
   max-width: 100%
   overflow-x: scroll
-
-  &:empty
-    display: none
   
   .op-table
     width: auto

--- a/frontend/src/app/shared/components/table/scrollable-table.sass
+++ b/frontend/src/app/shared/components/table/scrollable-table.sass
@@ -1,6 +1,9 @@
 .op-scrollable-table
   max-width: 100%
   overflow-x: scroll
+
+  &:empty
+    display: none
   
   .op-table
     width: auto


### PR DESCRIPTION
The scrollable table used to show a scrollbar even if empty, because `overflow-x: scroll;` is set explicitly. Completely
hiding the element if it's empty fixes this

Closes https://community.openproject.org/projects/openproject/work_packages/39767/activity