### PR TITLE
[39148] Styling of notification center toolbar on mobile

### DIFF
--- a/frontend/src/app/features/work-packages/components/back-routing/back-button.component.sass
+++ b/frontend/src/app/features/work-packages/components/back-routing/back-button.component.sass
@@ -11,9 +11,5 @@
 
   &_mobile-full-width
     @media only screen and (max-width: 679px)
-      // Move button in the current reverse order to front
-      position: absolute
-      top: 0
-      left: 0
-      z-index: 1
       width: 100%
+      margin-bottom: 20px

--- a/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.html
+++ b/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.html
@@ -3,7 +3,8 @@
   <div class="toolbar-container -editable">
     <div class="toolbar">
       <op-back-button *ngIf="backButtonCallback"
-                      linkClass="back-button"
+                      class="op-back-button"
+                      linkClass="op-back-button_mobile-full-width"
                       [customBackMethod]="backButtonCallback">
       </op-back-button>
 

--- a/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
+++ b/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
@@ -1,6 +1,7 @@
 @import "src/assets/sass/helpers"
 
 .work-packages-partitioned-query-space--container
+  position: relative
   height: 100%
   overflow: hidden
   display: grid
@@ -40,3 +41,18 @@
       min-width: initial
       max-width: 100vw
       max-height: 100%
+
+    .toolbar
+      display: grid
+      grid-template-columns: 1fr auto
+      grid-template-rows: auto auto
+
+      .op-back-button
+        grid-column: 1 / 3
+        grid-row: 1 / 2
+      .title-container
+        grid-column: 1 / 2
+        grid-row: 2 / 3
+      .toolbar-items
+        grid-column: 2 / 3
+        grid-row: 2 / 3

--- a/frontend/src/global_styles/layout/_boards.sass
+++ b/frontend/src/global_styles/layout/_boards.sass
@@ -1,6 +1,7 @@
 // Let board list span whole screen
 .router--boards-full-view
-  @include extended-content--left
+  @media only screen and (min-width: 680px)
+    @include extended-content--left
 
   #content
     height: 100%

--- a/frontend/src/global_styles/layout/_toolbar_mobile.sass
+++ b/frontend/src/global_styles/layout/_toolbar_mobile.sass
@@ -29,7 +29,7 @@
 @include breakpoint (680px down)
   #content
     .toolbar-container
-      margin-top: 10px
+      margin-top: 5px
 
       .title-container:not(editable-toolbar-title)
         margin-right: 10px

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -163,6 +163,13 @@
     #toolbar-items
       margin-left: 0
 
+    .work-packages-back-button
+      // Move button in the current reverse order to front
+      position: absolute
+      top: 0
+      left: 0
+      z-index: 1
+
 #work-packages-index
   .op-uc-link_permalink
     display: none

--- a/frontend/src/global_styles/layout/work_packages/_mobile.sass
+++ b/frontend/src/global_styles/layout/work_packages/_mobile.sass
@@ -33,7 +33,7 @@
 
       #main
         #content-wrapper
-          padding: 10px 15px
+          padding: 15px
           &.nomenus
             top: 0
             padding: 0


### PR DESCRIPTION
Introduce CSS grid for toolbars on partitioned query space pages for mobile. Thus on every page with that layout, the back button (if it exists), moves above the title and spans the whole width. The special solution for the WP page stays untouched by this. 

<img width="344" alt="Bildschirmfoto 2021-11-08 um 14 16 09" src="https://user-images.githubusercontent.com/7457313/140748487-95b3fded-8931-42e6-be1b-ac8986ff26aa.png">

https://community.openproject.org/projects/openproject/work_packages/39148/activity