### PR TITLE
[39543] Work package create and add forms have only one column even though there is enough space

### DIFF
--- a/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
@@ -163,11 +163,8 @@ export class MainMenuToggleService {
     this.htmlNode.style.setProperty('--main-menu-width', `${this.elementWidth}px`);
 
     // Send change event when size of menu is changing (menu toggled or resized)
-    // Event should only be fired, when transition is finished
     const changeEvent = jQuery.Event('change');
-    jQuery('#content-wrapper').on('transitionend webkitTransitionEnd oTransitionEnd otransitionend MSTransitionEnd', () => {
-      this.changeData.next(changeEvent);
-    });
+    this.changeData.next(changeEvent);
   }
 
   public get showNavigation():boolean {

--- a/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.ts
@@ -267,13 +267,6 @@ export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implemen
     return this.I18n.t('js.project.work_package_belongs_to', { projectname: project });
   }
 
-  /*
-   * Show two column layout for new WP per default, but disable in MS Edge (#29941)
-   */
-  public get enableTwoColumnLayout() {
-    return this.workPackage.isNew && !this.browserDetector.isEdge;
-  }
-
   private rebuildGroupedFields(change:WorkPackageChangeset, attributeGroups:any) {
     if (!attributeGroups) {
       return [];

--- a/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.html
@@ -1,6 +1,6 @@
 <div *ngIf="workPackage"
-     class="work-package--single-view"
-     [ngClass]="{'-can-have-columns' : enableTwoColumnLayout }">
+     class="work-package--single-view work-package--single-view_with-columns"
+     data-selector="wp-single-view">
   <div class="wp-new--subject-wrapper"
        *ngIf="isNewResource(workPackage)">
     <editable-attribute-field [resource]="workPackage"

--- a/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
@@ -109,9 +109,10 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
       .pipe(
         distinctUntilChanged(),
         this.untilDestroyed(),
+        debounceTime(100),
       )
-      .subscribe((changeData) => {
-        this.toggleFullscreenColumns();
+      .subscribe(() => {
+        this.applyColumnLayout();
       });
 
     // Listen to event
@@ -120,14 +121,14 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
         this.untilDestroyed(),
         debounceTime(250),
       )
-      .subscribe(() => this.toggleFullscreenColumns());
+      .subscribe(() => this.applyColumnLayout());
   }
 
   ngAfterViewInit():void {
     // Get the reziser
     this.resizer = <HTMLElement> this.elementRef.nativeElement.getElementsByClassName(this.resizerClass)[0];
 
-    this.applyColumnLayout(this.resizingElement, this.elementWidth);
+    this.applyColumnLayout();
   }
 
   ngOnDestroy() {
@@ -180,7 +181,7 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
     window.OpenProject.guardedLocalStorage(this.localStorageKey, `${newValue}`);
 
     // Apply two column layout
-    this.applyColumnLayout(this.resizingElement, newValue);
+    this.applyColumnLayout();
 
     // Set new width
     this.resizingElement.style[this.resizeStyle] = `${newValue}px`;
@@ -196,28 +197,11 @@ export class WpResizerDirective extends UntilDestroyedMixin implements OnInit, A
 
     return undefined;
   }
-
-  private applyColumnLayout(element:HTMLElement, newWidth:number) {
-    // Apply two column layout in fullscreen view of a workpackage
-    if (element === jQuery('.work-packages-full-view--split-right')[0]) {
-      this.toggleFullscreenColumns();
+  private applyColumnLayout(checkWidth = 750) {
+    const singleView = document.querySelectorAll("[data-selector='wp-single-view']")[0] as HTMLElement;
+    if (singleView) {
+      jQuery(singleView).toggleClass('work-package--single-view_with-columns', singleView.offsetWidth > checkWidth);
     }
-    // Apply two column layout when details view of wp is open
-    else {
-      this.toggleColumns(element, 700);
-    }
-  }
-
-  private toggleColumns(element:HTMLElement, checkWidth = 750) {
-    // Disable two column layout for MS Edge (#29941)
-    if (element && !this.browserDetector.isEdge) {
-      jQuery(element).toggleClass('-can-have-columns', element.offsetWidth > checkWidth);
-    }
-  }
-
-  private toggleFullscreenColumns() {
-    const fullScreenLeftView = jQuery('.work-packages-full-view--split-left')[0];
-    this.toggleColumns(fullScreenLeftView);
   }
 
   private manageErrorClass(shouldBePresent:boolean) {

--- a/frontend/src/global_styles/content/work_packages/single_view/_single_view.sass
+++ b/frontend/src/global_styles/content/work_packages/single_view/_single_view.sass
@@ -79,6 +79,21 @@
     textarea
       resize: vertical
 
+
+  // Implement two column layout for WP full screen view
+  &_with-columns
+    @media screen and (min-width: 92rem), print
+      .-columns-2
+        @include two-column-layout
+
+      @supports (column-span: all)
+        // Remove the outline on focus since that breaks the column in chrome
+        // Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=565116
+        body
+          .attributes-key-value--value-container
+            *:focus
+              outline: 1px solid $gray
+
 .detail-panel-description
   margin: 0
   line-height: 18px
@@ -129,22 +144,6 @@ i
     flex: 1 0 55%
     max-width: 55%
 
-// Implement two column layout for WP full screen view
-@media screen and (min-width: 92rem), print
-  .router--work-packages-full-view .-can-have-columns,
-  .router--work-packages-full-create .-can-have-columns
-
-    .-columns-2
-      @include two-column-layout
-
-  @supports (column-span: all)
-    // Remove the outline on focus since that breaks the column in chrome
-    // Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=565116
-    body
-      .attributes-key-value--value-container
-        *:focus
-          outline: 1px solid $gray
-
 // -------------------- Info row --------------------
 .work-packages--info-row
   font-size: 12px
@@ -170,7 +169,7 @@ i
   wp-status-button
     // Should not be longer than mobile screen width (margin of 15px left and right)
     max-width: calc(100vw - 30px)
-    
+
   attribute-help-text,
   wp-status-button,
   .work-packages--info-row

--- a/frontend/src/global_styles/layout/work_packages/_details_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_details_view.sass
@@ -41,10 +41,6 @@ body.router--work-packages-partitioned-split-view-new
     // Will eventually be overridden by the resizer
     flex-basis: 580px
 
-    &.-can-have-columns
-      .-columns-2
-        @include two-column-layout
-
 .work-packages--details
   height: 100%
   position: relative


### PR DESCRIPTION
Simplify code for two column layout for WP view by moving it all to one modifier class on the `wp-single-view`

https://community.openproject.org/projects/openproject/work_packages/39543/activity