### PR TITLE
[39773] Prevent WP being shown when reading a notification on mobile

### DIFF
--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -51,6 +51,7 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
 import { UIRouterGlobals } from '@uirouter/core';
 import { StateService } from '@uirouter/angular';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
+import { DeviceService } from 'core-app/core/browser/device.service';
 
 @Injectable()
 @EffectHandler
@@ -98,6 +99,7 @@ export class IanCenterService extends UntilDestroyedMixin {
     readonly toastService:ToastService,
     readonly uiRouterGlobals:UIRouterGlobals,
     readonly state:StateService,
+    readonly deviceService:DeviceService,
   ) {
     super();
     this.reload.subscribe();
@@ -212,7 +214,10 @@ export class IanCenterService extends UntilDestroyedMixin {
         ids: activeCollection.ids.filter((activeID) => !action.notifications.includes(activeID)),
       },
     });
-    this.showNextNotification();
+
+    if (!this.deviceService.isMobile) {
+      this.showNextNotification();
+    }
   }
 
   private sideLoadInvolvedWorkPackages(elements:InAppNotification[]):Promise<unknown> {


### PR DESCRIPTION
Automatically opening the next notification in combination with the automatic redirect on mobile lead to the next WP being shown when marking a notification as read on mobile

https://community.openproject.org/projects/openproject/work_packages/39773/activity