### PR TITLE
Add debian 11 to supported distros for bim

### DIFF
--- a/packaging/addons/openproject-edition/bin/configure
+++ b/packaging/addons/openproject-edition/bin/configure
@@ -17,6 +17,9 @@ supported_distribution() {
 				"10")
 					return 0
 					;;
+				"11")
+					return 0
+					;;
 			esac
 			;;
 		"redhat")


### PR DESCRIPTION
https://community.openproject.org/wp/39113