### PR TITLE
[35095] Use iso week formatting of moment to get week numbers

### DIFF
--- a/frontend/src/app/core/i18n/i18n.service.ts
+++ b/frontend/src/app/core/i18n/i18n.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
  * General components
  */
 export interface GlobalI18n {
-  t(translateId:string, parameters?:any):string;
+  t<T=string>(translateId:string, parameters?:unknown):T;
 
   lookup(translateId:string):boolean|undefined;
 

--- a/frontend/src/app/core/setup/globals/global-listeners/augmented-date-picker.ts
+++ b/frontend/src/app/core/setup/globals/global-listeners/augmented-date-picker.ts
@@ -16,7 +16,7 @@ export function augmentedDatePicker(evt:JQuery.TriggeredEvent, target:JQuery) {
       .then((context) => {
         const datePicker = new DatePicker(
           '.-augmented-datepicker',
-          target.val(),
+          target.val() as string,
           {
             weekNumbers: true,
             allowInput: true,

--- a/frontend/src/app/core/setup/init-locale.ts
+++ b/frontend/src/app/core/setup/init-locale.ts
@@ -35,9 +35,9 @@ export function initializeLocale() {
   const firstWeekOfYear = parseInt(meta.dataset.firstWeekOfYear || '', 10);
 
   I18n.locale = locale;
-  I18n.firstDayOfWeek = firstDayOfWeek;
 
   if (!Number.isNaN(firstDayOfWeek) && !Number.isNaN(firstWeekOfYear)) {
+    I18n.firstDayOfWeek = firstDayOfWeek;
     moment.updateLocale(locale, {
       week: {
         dow: firstDayOfWeek,

--- a/frontend/src/app/features/boards/board/board-actions/status/status-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/status/status-action.service.ts
@@ -41,7 +41,7 @@ export class BoardStatusActionService extends CachedBoardActionService {
         .then(() => board));
   }
 
-  public warningTextWhenNoOptionsAvailable() {
+  public warningTextWhenNoOptionsAvailable():Promise<string> {
     return Promise.resolve(this.I18n.t('js.boards.add_list_modal.warning.status'));
   }
 

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
@@ -52,6 +52,7 @@ import { ConfigurationService } from 'core-app/core/config/configuration.service
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { DayElement } from "flatpickr/dist/types/instance";
+import flatpickr from 'flatpickr';
 
 export type DateKeys = 'date'|'start'|'end';
 
@@ -285,11 +286,11 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
         onYearChange: () => {
           this.datepickerHelper.setRangeClasses(this.dates);
         },
-        onDayCreate: (dObj:Date[], dStr:string, fp:DatePicker, dayElem:DayElement) => {
+        onDayCreate: (dObj:Date[], dStr:string, fp:flatpickr.Instance, dayElem:DayElement) => {
           dayElem.setAttribute('data-iso-date', dayElem.dateObj.toISOString());
         },
       },
-      undefined,
+      null,
       this.configurationService,
     );
   }

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/date-input/components/date-picker-adapter/date-picker-adapter.component.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/date-input/components/date-picker-adapter/date-picker-adapter.component.ts
@@ -5,6 +5,7 @@ import { OpSingleDatePickerComponent } from 'core-app/shared/components/op-date-
 import * as moment from 'moment';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 @Component({
   selector: 'op-date-picker-adapter',
@@ -24,10 +25,11 @@ export class DatePickerAdapterComponent extends OpSingleDatePickerComponent impl
 
   constructor(
     timezoneService:TimezoneService,
+    configurationService:ConfigurationService,
     private ngZone:NgZone,
     private changeDetectorRef:ChangeDetectorRef,
   ) {
-    super(timezoneService);
+    super(timezoneService, configurationService);
   }
 
   writeValue(date:string):void {

--- a/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/date-input/components/date-picker-control/date-picker-control.component.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/components/dynamic-inputs/date-input/components/date-picker-control/date-picker-control.component.ts
@@ -5,6 +5,7 @@ import * as moment from 'moment';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { OpSingleDatePickerComponent } from 'core-app/shared/components/op-date-picker/op-single-date-picker/op-single-date-picker.component';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 @Component({
   selector: 'op-date-picker-control',
@@ -27,10 +28,11 @@ export class DatePickerControlComponent extends OpSingleDatePickerComponent impl
 
   constructor(
     timezoneService:TimezoneService,
+    configurationService:ConfigurationService,
     private ngZone:NgZone,
     private changeDetectorRef:ChangeDetectorRef,
   ) {
-    super(timezoneService);
+    super(timezoneService, configurationService);
   }
 
   writeValue(date:string):void {

--- a/frontend/src/app/shared/components/op-date-picker/date-picker.directive.ts
+++ b/frontend/src/app/shared/components/op-date-picker/date-picker.directive.ts
@@ -39,6 +39,7 @@ import {
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { DatePicker } from 'core-app/shared/components/op-date-picker/datepicker';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 @Directive()
 export abstract class AbstractDatePickerDirective extends UntilDestroyedMixin implements OnDestroy, AfterViewInit {
@@ -62,7 +63,10 @@ export abstract class AbstractDatePickerDirective extends UntilDestroyedMixin im
 
   protected datePickerInstance:DatePicker;
 
-  public constructor(protected timezoneService:TimezoneService) {
+  public constructor(
+    protected timezoneService:TimezoneService,
+    protected configurationService:ConfigurationService,
+  ) {
     super();
 
     if (!this.id) {

--- a/frontend/src/app/shared/components/op-date-picker/datepicker.ts
+++ b/frontend/src/app/shared/components/op-date-picker/datepicker.ts
@@ -37,28 +37,28 @@ import DateOption = flatpickr.Options.DateOption;
 export class DatePicker {
   private datepickerFormat = 'Y-m-d';
 
-  private datepickerCont:HTMLElement = document.querySelector(this.datepickerElemIdentifier)! ;
+  private datepickerCont:HTMLElement = document.querySelector(this.datepickerElemIdentifier)!;
 
   public datepickerInstance:Instance;
 
   private reshowTimeout:any;
 
   constructor(private datepickerElemIdentifier:string,
-    private date:any,
-    private options:any,
-    private datepickerTarget?:HTMLElement,
-    private configurationService?:ConfigurationService) {
+    private date:Date|Date[]|string[]|string,
+    private options:flatpickr.Options.Options,
+    private datepickerTarget:HTMLElement|null,
+    private configurationService:ConfigurationService) {
     this.initialize(options);
   }
 
-  private initialize(options:any) {
+  private initialize(options:flatpickr.Options.Options) {
     const I18n = new I18nService();
-    const firstDayOfWeek = this.configurationService?.startOfWeekPresent() ? this.configurationService.startOfWeek() : 1;
+    const firstDayOfWeek = this.configurationService.startOfWeek() as number;
 
     const mergedOptions = _.extend({}, options, {
       weekNumbers: true,
       getWeek(dateObj:Date) {
-        return moment(dateObj).week();
+        return moment(dateObj).format('W');
       },
       dateFormat: this.datepickerFormat,
       defaultDate: this.date,
@@ -68,8 +68,8 @@ export class DatePicker {
           longhand: I18n.t('date.day_names'),
         },
         months: {
-          shorthand: (I18n.t('date.abbr_month_names') as any).slice(1),
-          longhand: (I18n.t('date.month_names') as any).slice(1),
+          shorthand: I18n.t<string[]>('date.abbr_month_names').slice(1),
+          longhand: I18n.t<string[]>('date.month_names').slice(1),
         },
         firstDayOfWeek,
         weekAbbreviation: I18n.t('date.abbr_week'),

--- a/frontend/src/app/shared/components/op-date-picker/op-range-date-picker/op-range-date-picker.component.ts
+++ b/frontend/src/app/shared/components/op-date-picker/op-range-date-picker/op-range-date-picker.component.ts
@@ -1,6 +1,8 @@
 import {
+  ChangeDetectionStrategy,
   Component,
-  ChangeDetectionStrategy, Input, Output,
+  Input,
+  Output,
 } from '@angular/core';
 import { Instance } from 'flatpickr/dist/types/instance';
 import { KeyCodes } from 'core-app/shared/helpers/keyCodes.enum';
@@ -8,7 +10,6 @@ import { DatePicker } from 'core-app/shared/components/op-date-picker/datepicker
 import { AbstractDatePickerDirective } from 'core-app/shared/components/op-date-picker/date-picker.directive';
 import { DebouncedEventEmitter } from 'core-app/shared/helpers/rxjs/debounced-event-emitter';
 import { componentDestroyed } from '@w11k/ngx-componentdestroyed';
-import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 
 export const rangeSeparator = '-';
 
@@ -24,10 +25,6 @@ export class OpRangeDatePickerComponent extends AbstractDatePickerDirective {
 
   initialValue = '';
 
-  constructor(protected timezoneService:TimezoneService) {
-    super(timezoneService);
-  }
-
   protected initializeDatepicker():void {
     this.initialDates = this.initialDates || [];
     this.initialValue = this.resolveDateArrayToString(this.initialDates);
@@ -35,7 +32,7 @@ export class OpRangeDatePickerComponent extends AbstractDatePickerDirective {
     const options = {
       allowInput: true,
       appendTo: this.appendTo,
-      mode: 'range',
+      mode: 'range' as const,
       onChange: (selectedDates:Date[], dateStr:string) => {
         if (this.isEmpty()) {
           return;
@@ -64,6 +61,8 @@ export class OpRangeDatePickerComponent extends AbstractDatePickerDirective {
       `#${this.id}`,
       initialValue,
       options,
+      null,
+      this.configurationService,
     );
   }
 

--- a/frontend/src/app/shared/components/op-date-picker/op-single-date-picker/op-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/op-date-picker/op-single-date-picker/op-single-date-picker.component.ts
@@ -87,6 +87,8 @@ export class OpSingleDatePickerComponent extends AbstractDatePickerDirective {
       `#${this.id}`,
       initialValue,
       options,
+      null,
+      this.configurationService,
     );
   }
 }

--- a/frontend/src/test/i18n-shim.ts
+++ b/frontend/src/test/i18n-shim.ts
@@ -13,23 +13,28 @@ export class I18nShim implements GlobalI18n {
 
   public pluralization = {};
 
-  t(key:string) {
-    return `[missing "${key}" translation]`;
+  t<T=string>(key:string):T {
+    return `[missing "${key}" translation]` as unknown as T;
   }
 
-  lookup(translateId:string):boolean {
+  lookup():boolean {
     return false;
   }
 
   // Return the input for these helpers
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
   public toNumber = _.identity;
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
   public toPercentage = _.identity;
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
   public toCurrency = _.identity;
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
   public strftime = _.identity;
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
   public toHumanSize = _.identity;
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment


### PR DESCRIPTION
Use `moment(date).format('W')` for ISO week numbers so that they are correct in flatpickr

Compare https://savvytime.com/week-number/united-states/2021 for US locale and https://www.aktuelle-kalenderwoche.org/ for DE locale

[OP#35095](https://community.openproject.org/wp/35095)