### PR TITLE
[39733][39774] Move Mark-as-read button in WP view

### DIFF
--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -30,13 +30,6 @@
                                [showText]="false">
             </wp-watcher-button>
           </li>
-          <li class="toolbar-item" *ngIf="displayNotificationsButton$ | async">
-            <op-work-package-mark-notification-button
-              [workPackage]="workPackage"
-              buttonClasses="toolbar-icon"
-              data-qa-selector="mark-notification-read-button"
-            ></op-work-package-mark-notification-button>
-          </li>
           <li class="toolbar-item hidden-for-mobile">
             <zen-mode-toggle-button>
             </zen-mode-toggle-button>
@@ -63,6 +56,15 @@
         <div class="work-packages--panel-inner">
           <span class="hidden-for-sighted" tabindex="-1" opAutofocus [textContent]="focusAnchorLabel"></span>
           <op-wp-tabs [workPackage]="workPackage" view="full"></op-wp-tabs>
+          <div class="work-packages-full-view--tab-breadcrumb">
+            <op-work-package-mark-notification-button
+                    *ngIf="(displayNotificationsButton$ | async) && keepTab.currentTabIdentifier === 'activity'"
+                    class="work-package--details-button"
+                    [workPackage]="workPackage"
+                    buttonClasses="-round button_no-margin"
+                    data-qa-selector="mark-notification-read-button"
+            ></op-work-package-mark-notification-button>
+          </div>
           <div class="tabcontent"
                data-notification-selector='notification-scroll-container'
                ui-view>

--- a/frontend/src/global_styles/content/_buttons.sass
+++ b/frontend/src/global_styles/content/_buttons.sass
@@ -114,6 +114,9 @@ a.button
     margin-right: 0.25rem
     padding: 0.3128em 0.55555em
 
+  &_no-margin
+    margin: 0
+
 .button--icon
   @include icon-common
 

--- a/frontend/src/global_styles/content/work_packages/tabs/_activities.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_activities.sass
@@ -82,7 +82,7 @@ h4.comment
 
 .work-package-details-activities-list
   list-style-type: none
-  margin: 35px 0 0 0
+  margin: 20px 0 0 0
 
 // Position first date with comment toggler
 .activity-date.-with-toggler

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -62,79 +62,84 @@
     button
       margin-right: 0
 
-.work-packages-full-view--split-container
-  display: flex
-  flex-shrink: 8
-  border-top: 1px solid #ccc
-  overflow: visible
-  height: 100%
-  // Important for Firefox to let 'flex-shrink' work correctly.
-  min-height: 0
+.work-packages-full-view
 
-
-.work-packages-full-view--split-left
-  border-right: 1px solid #ccc
-  overflow-y: auto
-  overflow-x: hidden
-  flex: 2
-  position: relative
-  @include styled-scroll-bar
-
-  .work-packages--panel-inner
-    padding: 0px 5px 20px 0
-    width: 100%
-
-    // These styles were taken over from the details tab styling.
-    // Thus the header and the details tab can be aligned on the same line.
-    .attributes-group:first-of-type
-      margin-top: 0px
-
-      .attributes-group--header-container
-        padding-bottom: 2px
-
-        h3.attributes-group--header-text
-          line-height: calc(var(--work-package-details--tab-height) - 10px)
-
-.work-packages-full-view--split-right
-  min-width: 530px
-  overflow-y: hidden
-  overflow-x: auto
-  position: relative
-  @include styled-scroll-bar
-
-  .work-packages--panel-inner
-    display: grid
-    grid-template-rows: auto 1fr
+  &--split-container
+    display: flex
+    flex-shrink: 8
+    border-top: 1px solid #ccc
+    overflow: visible
     height: 100%
-    padding: 5px 0 10px 15px
+    // Important for Firefox to let 'flex-shrink' work correctly.
+    min-height: 0
 
-  .tabcontent
-    height: 100%
-    overflow: auto
+  &--split-left
+    border-right: 1px solid #ccc
+    overflow-y: auto
+    overflow-x: hidden
+    flex: 2
+    position: relative
     @include styled-scroll-bar
-    padding-right: 5px
 
-  .work-package-details-activities-activity-contents ul.work-package-details-activities-messages
-    padding-left: 0
+    .work-packages--panel-inner
+      padding: 0px 5px 20px 0
+      width: 100%
 
-  .activity-comment
-    margin-top: 15px
+      // These styles were taken over from the details tab styling.
+      // Thus the header and the details tab can be aligned on the same line.
+      .attributes-group:first-of-type
+        margin-top: 0px
 
-  .button.icon-edit.ng-hide
-    display: block !important
-    visibility: hidden
+        .attributes-group--header-container
+          padding-bottom: 2px
 
-.work-packages-full-view--resizer
-  position: sticky
-  top: 50%
-  bottom: 50%
-  width: 18px
-  .work-packages--resizer
-    left: -2px
+          h3.attributes-group--header-text
+            line-height: calc(var(--work-package-details--tab-height) - 10px)
+
+  &--split-right
+    min-width: 530px
+    overflow-y: hidden
+    overflow-x: auto
+    position: relative
+    @include styled-scroll-bar
+
+    .work-packages--panel-inner
+      display: grid
+      grid-template-rows: auto auto 1fr
+      height: 100%
+      padding: 5px 0 10px 15px
+
+    .tabcontent
+      height: 100%
+      overflow: auto
+      @include styled-scroll-bar
+      padding-right: 5px
+
+    .work-package-details-activities-activity-contents ul.work-package-details-activities-messages
+      padding-left: 0
+
+    .activity-comment
+      margin-top: 15px
+
+    .button.icon-edit.ng-hide
+      display: block !important
+      visibility: hidden
+
+  &--resizer
+    position: sticky
+    top: 50%
+    bottom: 50%
     width: 18px
-    &::before
-      left: 0
+    .work-packages--resizer
+      left: -2px
+      width: 18px
+      &::before
+        left: 0
 
+  &--tab-breadcrumb
+    text-align: right
+    padding-right: 1rem
+    margin-bottom: 5px
 
 .nosidebar
   ul.subject-header


### PR DESCRIPTION
Show Mark-as-read button in activity tab (instead of toolbar) for full view

https://community.openproject.org/projects/openproject/work_packages/39733/activity
https://community.openproject.org/projects/openproject/work_packages/39774/activity