### PR TITLE
[38606] Ensure we always use the english slug

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -40,6 +40,7 @@ class WikiPage < ApplicationRecord
               url_attribute: :slug,
               scope: :wiki_id, # Unique slugs per WIKI
               sync_url: true, # Keep slug updated on #rename
+              locale: :en,
               adapter: OpenProject::ActsAsUrl::Adapter::OpActiveRecord # use a custom adapter able to handle edge cases
 
   acts_as_watchable

--- a/lib/open_project/acts_as_url/adapter/op_active_record.rb
+++ b/lib/open_project/acts_as_url/adapter/op_active_record.rb
@@ -56,7 +56,9 @@ module OpenProject
         private
 
         def modify_base_url
-          super
+          root = instance.send(settings.attribute_to_urlify).to_s
+          locale = configuration.settings.locale || :en
+          self.base_url = root.to_localized_slug(locale: locale, **configuration.string_extensions_settings)
 
           modify_base_url_custom_rules if base_url.empty?
         end

--- a/spec/models/wiki_page_spec.rb
+++ b/spec/models/wiki_page_spec.rb
@@ -85,6 +85,25 @@ describe WikiPage, type: :model do
           .to raise_error(ActiveRecord::RecordInvalid)
       end
     end
+
+    context 'with another default language', with_settings: { default_language: 'de' } do
+      let(:wiki_page) { FactoryBot.build(:wiki_page, wiki: wiki, title: 'Übersicht') }
+
+      it 'will still use english slug methods' do
+        expect(wiki_page.save).to eq true
+        expect(wiki_page.slug).to eq 'ubersicht'
+      end
+    end
+
+    context 'with another I18n.locale set', with_settings: { default_language: 'de' } do
+      let(:wiki_page) { FactoryBot.build(:wiki_page, wiki: wiki, title: 'Übersicht') }
+
+      it 'will still use english slug methods' do
+        I18n.locale = :de
+        expect(wiki_page.save).to eq true
+        expect(wiki_page.slug).to eq 'ubersicht'
+      end
+    end
   end
 
   describe '#nearest_main_item' do

--- a/spec/models/wiki_spec.rb
+++ b/spec/models/wiki_spec.rb
@@ -50,5 +50,28 @@ describe Wiki, type: :model do
         expect(wiki.wiki_menu_items.first.title).to eq(start_page)
       end
     end
+
+    describe '#find_page' do
+      let(:wiki) { project.create_wiki start_page: start_page }
+      let(:wiki_page) { FactoryBot.build(:wiki_page, wiki: wiki, title: 'Übersicht') }
+
+      subject { wiki.find_page('Übersicht') }
+
+      it 'will find the page using the title' do
+        wiki_page.save!
+        expect(wiki_page.slug).to eq 'ubersicht'
+        expect(subject).to eq wiki_page
+      end
+
+      context 'with german default_language', with_settings: { default_language: 'de' } do
+        it 'will find the page with the default_language slug title (Regression #38606)' do
+          wiki_page.save!
+          wiki_page.update_column(:slug, 'uebersicht')
+
+          expect(wiki_page.reload.slug).to eq 'uebersicht'
+          expect(subject).to eq wiki_page
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When creating wiki pages, `to_url` uses the I18n.locale used on startup, which is set to the default_language setting.

We don't want that, and instead always want to create english slugs for consistency.

To still find pages created with the default_language flag, `find_page` is extended to fall back to the later one.

https://community.openproject.org/wp/38606