### PR TITLE
[39562] Ensure selected item is set when following

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -244,6 +244,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
   }
 
   public followItem(item:WorkPackageResource|SearchOptionItem) {
+    this.selectedItem = item;
     if (item instanceof HalResource) {
       window.location.href = this.wpPath(item.id!);
     } else {


### PR DESCRIPTION
If the selected item is unset, the keydown event triggered _after_ the change will cause a search to be performed, even though we already followed the item in the change handler.

This likely needs a better fix to avoid these double handlings, but I couldn't find another fast fix.

https://community.openproject.org/wp/39562