### PR TITLE
[38700] add temporary op-form--section-header for margins

### DIFF
--- a/frontend/src/app/features/user-preferences/reminder-settings/email-alerts/email-alerts-settings.component.html
+++ b/frontend/src/app/features/user-preferences/reminder-settings/email-alerts/email-alerts-settings.component.html
@@ -1,6 +1,8 @@
 <ng-container [formGroup]="form">
-  <h5 [textContent]="text.title"></h5>
-  <p [textContent]="text.explanation"></p>
+  <div class="op-form--section-header">
+    <h5 [textContent]="text.title"></h5>
+    <p [textContent]="text.explanation"></p>
+  </div>
 
   <op-checkbox-field
     [control]="form.get(setting)"

--- a/frontend/src/app/features/user-preferences/reminder-settings/immediate-reminders/immediate-reminder-settings.component.html
+++ b/frontend/src/app/features/user-preferences/reminder-settings/immediate-reminders/immediate-reminder-settings.component.html
@@ -1,5 +1,7 @@
 <ng-container [formGroup]="form">
-  <h5 [textContent]="text.title"></h5>
+  <div class="op-form--section-header">
+    <h5 [textContent]="text.title"></h5>
+  </div>
 
   <op-checkbox-field
     [control]="form.get('mentioned')"

--- a/frontend/src/app/features/user-preferences/reminder-settings/reminder-time/reminder-settings-daily-time.component.html
+++ b/frontend/src/app/features/user-preferences/reminder-settings/reminder-time/reminder-settings-daily-time.component.html
@@ -2,8 +2,10 @@
   *ngIf="(selectedTimes$ | async) as selectedTimes"
   [formGroup]="form"
 >
-  <h5 [textContent]="text.title"></h5>
-  <p [textContent]="text.explanation"></p>
+  <div class="op-form--section-header">
+      <h5 [textContent]="text.title"></h5>
+      <p [textContent]="text.explanation"></p>
+  </div>
 
   <op-checkbox-field [control]="form.get('enabled')">
     <input

--- a/frontend/src/app/features/user-preferences/reminder-settings/workdays/workdays-settings.component.html
+++ b/frontend/src/app/features/user-preferences/reminder-settings/workdays/workdays-settings.component.html
@@ -1,5 +1,7 @@
 <ng-container [formGroup]="formGroup.control">
-  <h5 [textContent]="text.title"></h5>
+  <div class="op-form--section-header">
+    <h5 [textContent]="text.title"></h5>
+  </div>
 
   <op-checkbox-field
     *ngFor="let workday of localeWorkdays; let i = index"

--- a/frontend/src/app/shared/components/forms/form.sass
+++ b/frontend/src/app/shared/components/forms/form.sass
@@ -14,6 +14,7 @@
       max-width: 100%
       width: 50rem
 
+    &--section-header,
     > .op-form--fieldset,
     > .op-form--field,
     > .op-form-field,


### PR DESCRIPTION
The email reminders have a special kind of margin with a h5~like header and sometimes a description paragraph below it.

The figma design specifies margins after the description, but in some cases there is none. So I added a header to wrap h5 + description

I personally find the margins to be a bit much, but they appear that way in figma (https://www.figma.com/file/Zi5ZwMqJZY1kQ6Kq2nd4cZ/Notification-Settings?node-id=0%3A1)

https://community.openproject.org/wp/38700