### PR TITLE
use ifc model title as filename for ifc downloads

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -69,7 +69,7 @@ class Attachment < ApplicationRecord
   # Returns an URL if the attachment is stored in an external (fog) attachment storage
   # or nil otherwise.
   def external_url(expires_in: nil)
-    url = URI.parse file.download_url(external_url_options) # returns a path if local
+    url = URI.parse file.download_url(external_url_options(expires_in: expires_in)) # returns a path if local
 
     url if url.host
   rescue URI::InvalidURIError

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -94,12 +94,12 @@ class Attachment < ApplicationRecord
   end
 
   def content_disposition(include_filename: true)
-    return "inline" if inlineable?
+    disposition = inlineable? ? 'inline' : 'attachment'
 
     if include_filename
-      "attachment; filename=#{attachment.filename}"
+      "#{disposition}; filename=#{filename}"
     else
-      "attachment"
+      disposition
     end
   end
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -76,6 +76,10 @@ class Attachment < ApplicationRecord
     nil
   end
 
+  ##
+  # Do not include the filename in the content disposition as this may break for Unicode file names
+  # specifically when using S3 for attachments. In the case of S3 the file name for the downloaded
+  # file will still be correct as it's part of the URL before the query.
   def external_url_options(expires_in: nil)
     { content_disposition: content_disposition(include_filename: false), expires_in: expires_in }
   end

--- a/lib/api/helpers/attachment_renderer.rb
+++ b/lib/api/helpers/attachment_renderer.rb
@@ -76,7 +76,7 @@ module API
 
       def send_attachment(attachment)
         content_type attachment.content_type
-        header['Content-Disposition'] = "#{attachment.content_disposition}; filename=#{attachment.filename}"
+        header['Content-Disposition'] = attachment.content_disposition
         env['api.format'] = :binary
         sendfile attachment.diskfile.path
       end

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -97,7 +97,7 @@ module OpenProject::Bim
 
     assets %w(bim/logo_openproject_bim_big.png)
 
-    patches %i[WorkPackage Type Journal RootSeeder Project FogFileUploader]
+    patches %i[Attachment WorkPackage Type Journal RootSeeder Project FogFileUploader]
 
     patch_with_namespace :OpenProject, :CustomStyles, :ColorThemes
     patch_with_namespace :API, :V3, :Activities, :ActivityRepresenter

--- a/modules/bim/lib/open_project/bim/patches/attachment_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/attachment_patch.rb
@@ -33,7 +33,7 @@ module OpenProject::Bim::Patches::AttachmentPatch
 
   module InstanceMethods
     def external_url_options(expires_in: nil)
-      return super unless ifc_model?
+      return super unless ifc_file?
 
       super.merge content_disposition: ifc_content_disposition
     end
@@ -44,8 +44,8 @@ module OpenProject::Bim::Patches::AttachmentPatch
       ifc_content_disposition
     end
 
-    def ifc_model?
-      container_type == Bim::IfcModels::IfcModel.name && container.present?
+    def ifc_file?
+      container_type == Bim::IfcModels::IfcModel.name && extension == ".ifc" && container.present?
     end
 
     def ifc_content_disposition

--- a/modules/bim/lib/open_project/bim/patches/attachment_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/attachment_patch.rb
@@ -55,7 +55,7 @@ module OpenProject::Bim::Patches::AttachmentPatch
     def ifc_file_name
       title = container.title.sub /\.ifc\Z/, ''
 
-      title.to_localized_slug(:en) + ".ifc"
+      title.to_localized_slug(locale: :en) + ".ifc"
     end
   end
 end

--- a/modules/bim/lib/open_project/bim/patches/attachment_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/attachment_patch.rb
@@ -39,13 +39,13 @@ module OpenProject::Bim::Patches::AttachmentPatch
     end
 
     def content_disposition(include_filename: true)
-      return super unless ifc_model? && include_filename
+      return super unless ifc_file? && include_filename
       
       ifc_content_disposition
     end
 
     def ifc_file?
-      container_type == Bim::IfcModels::IfcModel.name && extension == ".ifc" && container.present?
+      container_type == Bim::IfcModels::IfcModel.name && description == "ifc" && container.present?
     end
 
     def ifc_content_disposition

--- a/modules/bim/lib/open_project/bim/patches/attachment_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/attachment_patch.rb
@@ -1,0 +1,61 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject::Bim::Patches::AttachmentPatch
+  def self.included(base) # :nodoc:
+    base.prepend InstanceMethods
+  end
+
+  module InstanceMethods
+    def external_url_options(expires_in: nil)
+      return super unless ifc_model?
+
+      super.merge content_disposition: ifc_content_disposition
+    end
+
+    def content_disposition(include_filename: true)
+      return super unless ifc_model? && include_filename
+      
+      ifc_content_disposition
+    end
+
+    def ifc_model?
+      container_type == Bim::IfcModels::IfcModel.name && container.present?
+    end
+
+    def ifc_content_disposition
+      "attachment; filename=#{ifc_file_name}"
+    end
+
+    def ifc_file_name
+      title = container.title.sub /\.ifc\Z/, ''
+
+      title.to_localized_slug(:en) + ".ifc"
+    end
+  end
+end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -244,12 +244,27 @@ describe Attachment, type: :model do
       end
     end
 
+    shared_examples "it uses content disposition inline" do
+      let(:attachment) { raise "define me!" }
+
+      describe 'the external url (for remote attachments)' do
+        it 'contains inline content disposition without the filename' do
+          expect(attachment.external_url.to_s).to include "response-content-disposition=inline&"
+        end
+      end
+
+      describe 'content disposition (for local attachments)' do
+        it 'is inline, including the filename' do
+          expect(attachment.content_disposition).to eq "inline; filename=#{attachment.filename}"
+        end
+      end
+    end
+
     describe "for an image file" do
       before { image_attachment.save! }
 
-      it "should make S3 use content_disposition inline" do
-        expect(image_attachment.content_disposition).to eq "inline; filename=image.png"
-        expect(image_attachment.external_url.to_s).to include "response-content-disposition=inline"
+      it_behaves_like "it uses content disposition inline" do
+        let(:attachment) { image_attachment }
       end
 
       # this is independent from the type of file uploaded so we just test this for the first one
@@ -261,9 +276,8 @@ describe Attachment, type: :model do
     describe "for a text file" do
       before { text_attachment.save! }
 
-      it "should make S3 use content_disposition inline" do
-        expect(text_attachment.content_disposition).to eq "inline; filename=testfile.txt"
-        expect(text_attachment.external_url.to_s).to include "response-content-disposition=inline"
+      it_behaves_like "it uses content disposition inline" do
+        let(:attachment) { text_attachment }
       end
     end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -248,7 +248,7 @@ describe Attachment, type: :model do
       before { image_attachment.save! }
 
       it "should make S3 use content_disposition inline" do
-        expect(image_attachment.content_disposition).to eq "inline"
+        expect(image_attachment.content_disposition).to eq "inline; filename=image.png"
         expect(image_attachment.external_url.to_s).to include "response-content-disposition=inline"
       end
 
@@ -262,7 +262,7 @@ describe Attachment, type: :model do
       before { text_attachment.save! }
 
       it "should make S3 use content_disposition inline" do
-        expect(text_attachment.content_disposition).to eq "inline"
+        expect(text_attachment.content_disposition).to eq "inline; filename=testfile.txt"
         expect(text_attachment.external_url.to_s).to include "response-content-disposition=inline"
       end
     end
@@ -282,7 +282,7 @@ describe Attachment, type: :model do
       before { binary_attachment.save! }
 
       it "should make S3 use content_disposition 'attachment; filename=...'" do
-        expect(binary_attachment.content_disposition).to eq "attachment"
+        expect(binary_attachment.content_disposition).to eq "attachment; filename=textfile.txt.gz"
         expect(binary_attachment.external_url.to_s).to include "response-content-disposition=attachment"
       end
     end


### PR DESCRIPTION
Changes nothing in the content disposition behaviour in the core/default case, but changes it to the IFC model title for IFC file downloads. This way not all models will be named `model.ifc` when downloaded.