### PR TITLE
Add missing margins in create WP form, add a bottom margin for wp details header

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_details_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_details_view.sass
@@ -80,6 +80,9 @@ body.router--work-packages-partitioned-split-view-new
   width:           100%
   overflow:        hidden
 
+  &.-create-mode
+    padding: 0 5px 10px 20px
+
 // Fix height of subject row
 .work-packages--subject-element,
 .work-packages--details--subject .inline-edit--field
@@ -111,6 +114,7 @@ body.router--work-packages-partitioned-split-view-new
   display: flex
   padding: 0 5px 10px 20px
   border-bottom: 1px solid #ddd
+  margin-bottom: 10px
 
 .work-packages--details-header-left
   display: flex


### PR DESCRIPTION
Closes https://community.openproject.org/projects/openproject/work_packages/39829/activity