### PR TITLE
Ensure that IfcModel's conversion status is reset on update

### DIFF
--- a/modules/bim/app/services/bim/ifc_models/update_service.rb
+++ b/modules/bim/app/services/bim/ifc_models/update_service.rb
@@ -43,6 +43,10 @@ module Bim
           # attachments ourselves
           model.attachments.select(&:marked_for_destruction?).each(&:destroy)
 
+          model.conversion_status = ::Bim::IfcModels::IfcModel.conversion_statuses[:pending]
+          model.conversion_error_message = nil
+          model.save
+
           if @ifc_attachment_updated
             IfcConversionJob.perform_later(service_result.result)
           end

--- a/modules/bim/spec/services/ifc_models/update_service_spec.rb
+++ b/modules/bim/spec/services/ifc_models/update_service_spec.rb
@@ -134,6 +134,11 @@ describe Bim::IfcModels::UpdateService do
 
         subject
       end
+
+      it "sets the model's converstion_status to pending" do
+        expect(model).to be_pending
+        expect(model.conversion_error_message).to be_nil
+      end
     end
 
     context 'if the SetAttributeService is unsuccessful' do


### PR DESCRIPTION
When updating an IfcModel the current conversion_status might be "error" with an error message. This PR ensures that the status is reset to pending and delete potential error messages.
