### PR TITLE
Ensure CostQuery exists after saving by waiting

### DIFF
--- a/modules/reporting/spec/features/me_value_spec.rb
+++ b/modules/reporting/spec/features/me_value_spec.rb
@@ -41,7 +41,12 @@ describe 'Cost report showing my own times', type: :feature, js: true do
 
       expect(page).to have_selector('.report', text: '10.00')
 
-      report = CostQuery.last
+      report = nil
+      retry_block do
+        report = CostQuery.last
+        raise "Expected CostQuery to exist" unless report
+      end
+
       user_filter = report.serialized[:filters].detect { |name, _| name == filter_name }
       expect(user_filter[1][:values]).to eq %w(me)
 


### PR DESCRIPTION
`./modules/reporting/spec/features/me_value_spec.rb` started failing in some PRs due to a timing issue