### PR TITLE
[39835] Actually localize the announcement mail

### DIFF
--- a/app/mailers/announcement_mailer.rb
+++ b/app/mailers/announcement_mailer.rb
@@ -37,19 +37,31 @@ class AnnouncementMailer < ApplicationMailer
 
   def announce(user, subject:, body:, body_header: nil, body_subheader: nil)
     with_locale_for(user) do
+      localized_subject = localized(subject)
+
       mail to: user.mail,
-           subject: subject do |format|
+           subject: localized_subject do |format|
         locals = {
-          body: body,
+          body: localized(body),
           user: user,
-          header_summary: subject,
-          body_header: body_header,
-          body_subheader: body_subheader
+          header_summary: localized_subject,
+          body_header: localized(body_header),
+          body_subheader: localized(body_subheader)
         }
 
         format.html { render locals: locals }
         format.text { render locals: locals }
       end
+    end
+  end
+
+  private
+
+  def localized(input)
+    if input.is_a?(Symbol)
+      I18n.t(input)
+    else
+      input
     end
   end
 end

--- a/db/migrate/20211105142202_queue_notification_update_mail.rb
+++ b/db/migrate/20211105142202_queue_notification_update_mail.rb
@@ -1,9 +1,9 @@
 class QueueNotificationUpdateMail < ActiveRecord::Migration[6.1]
   def up
     ::Announcements::SchedulerJob
-      .perform_later subject: I18n.t(:'notifications.update_info_mail.subject'),
-                     body: I18n.t(:'notifications.update_info_mail.body'),
-                     body_header: I18n.t(:'notifications.update_info_mail.body_header'),
-                     body_subheader: I18n.t(:'notifications.update_info_mail.body_subheader')
+      .perform_later subject: :'notifications.update_info_mail.subject',
+                     body: :'notifications.update_info_mail.body',
+                     body_header: :'notifications.update_info_mail.body_header',
+                     body_subheader: :'notifications.update_info_mail.body_subheader'
   end
 end


### PR DESCRIPTION
The announcement mailer is scheduled with the default locale on startup. The mailer uses locale_for(user) but the I18n.t call is already done at that time. As the user's language is never taken into consideration, it will almost always be the Setting.default_language (and by that, basically always english)

https://community.openproject.org/work_packages/39835