### PR TITLE
[39810] Different images sizes on application start page on large displays

### DIFF
--- a/frontend/src/app/features/homescreen/blocks/new-features.component.ts
+++ b/frontend/src/app/features/homescreen/blocks/new-features.component.ts
@@ -44,8 +44,9 @@ const OpVersionI18n = '12_0';
       </p>
       <div class="widget-box--description">
         <p [innerHtml]="currentNewFeatureHtml"></p>
-        <img [src]="new_features_image"/>
-        <a class="widget-box--teaser-image op-new-features--teaser-image"></a>
+        <img
+          class="widget-box--teaser-image op-new-features--teaser-image"
+          [src]="new_features_image"/>
       </div>
 
       <a [href]="teaserWebsiteUrl" target="_blank">{{ text.learnAbout }}</a>

--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -79,6 +79,8 @@ $widget-box--enumeration-width: 20px
       padding: 0
       border: 0
 
+    &--teaser-image
+      width: 200px
 
     .widget-box--enumeration
       margin-left: 1.5rem


### PR DESCRIPTION
Unify widths for images in widget boxes

https://community.openproject.org/projects/openproject/work_packages/39810/activity

⚠️ Needs to be merged together with https://github.com/opf/saas-openproject/pull/106