### PR TITLE
[39857] Sort wiki before members, keeping title order

### DIFF
--- a/lib/redmine/menu_manager/wiki_menu_helper.rb
+++ b/lib/redmine/menu_manager/wiki_menu_helper.rb
@@ -49,6 +49,7 @@ module Redmine::MenuManager::WikiMenuHelper
     menu.push main_item.menu_identifier,
               { controller: '/wiki', action: 'show', id: main_item.slug },
               caption: main_item.title,
+              before: :members,
               icon: 'icon2 icon-wiki',
               html: { class: 'wiki-menu--main-item' }
 


### PR DESCRIPTION
Using before :members keeps the title order and allows members to be positioned afterwards.

Using `after :repository`, what it was set before, results in invalid sorting

https://community.openproject.org/wp/39857