### PR TITLE
[39849] Mobile (iOS): Notification center is cut off and scrolls infinitely

### DIFF
--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.sass
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.sass
@@ -10,6 +10,8 @@
 
   &--viewport
     height: 100%
+    // Avoid infinite horizontal scrolling on mobile iOS (#39849)
+    overflow-x: hidden
     @include styled-scroll-bar
 
   &--max-warning


### PR DESCRIPTION
Avoid unnecessary scrolling on iOS

https://community.openproject.org/projects/openproject/work_packages/39849/activity