### PR TITLE
Handle API errors that respond without JSON

### DIFF
--- a/frontend/src/app/features/hal/services/hal-error.ts
+++ b/frontend/src/app/features/hal/services/hal-error.ts
@@ -5,16 +5,16 @@ export class HalError extends Error {
   readonly name = 'HALError';
 
   get message():string {
-    return this.resource.message || this.httpError?.message || 'Unknown error';
+    return this.resource?.message || this.httpError?.message || 'Unknown error';
   }
 
   get errorIdentifier():string {
-    return this.resource.errorIdentifier;
+    return this.resource?.errorIdentifier || 'unknown';
   }
 
   constructor(
     readonly httpError:HttpErrorResponse,
-    readonly resource:ErrorResource,
+    readonly resource:ErrorResource|null,
   ) {
     super();
     Object.setPrototypeOf(this, HalError.prototype);

--- a/frontend/src/app/features/hal/services/hal-resource-notification.service.ts
+++ b/frontend/src/app/features/hal/services/hal-resource-notification.service.ts
@@ -79,7 +79,7 @@ export class HalResourceNotificationService {
 
     // Some transformation may already have returned the error as a HAL resource,
     // which we will forward to handleErrorResponse
-    if (response instanceof HalError) {
+    if (response instanceof HalError && resource) {
       return this.handleErrorResponse(response.resource, resource);
     }
 

--- a/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts
@@ -194,7 +194,7 @@ export abstract class EditForm<T extends HalResource = HalResource> {
         .catch((error:ErrorResource|unknown) => {
           this.halNotification.handleRawError(error, this.resource);
 
-          if (error instanceof HalError) {
+          if (error instanceof HalError && error.resource) {
             this.handleSubmissionErrors(error.resource);
             reject();
           }


### PR DESCRIPTION
In case a 429 rate limit response is caused by the Rails middleware, the frontend response expects an `application/json` response but get's a plain text or HTML response depending on the error.

This results in the following sentry error: https://sentry2.openproject.com/organizations/sentry/issues/1072/?project=4&query=is%3Aunresolved

To try this fix, change `lib/api/v3/work_packages/work_packages_api.rb:84` and let it respond something like this:

```ruby
            get do
              str = "<html>
<head><title>429 Too Many Requests</title></head>
<body>
<center><h1>429 Too Many Requests</h1></center>
<hr><center>nginx</center>
</body>
</html>
"

              error! str, 429
            end
``` 