### PR TITLE
[40016] Wiki Link List in content formatting issue

### DIFF
--- a/frontend/src/global_styles/layout/_tree_menu.sass
+++ b/frontend/src/global_styles/layout/_tree_menu.sass
@@ -19,9 +19,6 @@ div.wiki ul.pages-hierarchy,
     line-height: $tree-menu-item-height
     text-decoration: none !important
 
-  .op-uc-link
-    display: inline
-
   .tree-menu--hierarchy-span
     display: inline-block
     line-height: $tree-menu-item-height
@@ -85,6 +82,7 @@ div.wiki ul.pages-hierarchy,
     line-height: $tree-menu-item-height
     padding: 0 10px
     overflow-x: hidden
+    white-space: nowrap
     &.-selected
       background: var(--main-menu-bg-hover-background)
       .tree-menu--title

--- a/frontend/src/global_styles/layout/_tree_menu.sass
+++ b/frontend/src/global_styles/layout/_tree_menu.sass
@@ -19,6 +19,9 @@ div.wiki ul.pages-hierarchy,
     line-height: $tree-menu-item-height
     text-decoration: none !important
 
+  .op-uc-link
+    display: inline
+
   .tree-menu--hierarchy-span
     display: inline-block
     line-height: $tree-menu-item-height


### PR DESCRIPTION
Set the display of title to 'inline' instead of 'inline-block' to make it beside the bullet.

https://community.openproject.org/projects/openproject/work_packages/40016/activity