### PR TITLE
[39849] Notification center is too small in Safari on mobile

### DIFF
--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -54,7 +54,7 @@
       margin-top: 0
 
   #content-wrapper
-    height: initial
+    height: 100%
     // Take care that the wrapper has the available screen height at the least
     // Check for example notification center on mobile before changing that
     min-height: calc(100vh - var(--header-height))


### PR DESCRIPTION
Special fix for Safari (mobile) to ensure that the content really spans the full available height. I can't promise that this doesn't break something else, but I at least tested the WP view and the automated header scrolling.

https://community.openproject.org/projects/openproject/work_packages/39849/activity

#### Before
<img width="250" alt="Bildschirmfoto 2021-11-19 um 13 49 15" src="https://user-images.githubusercontent.com/7457313/142625474-b42c95bc-1114-42f3-975c-4f5e51e545ca.png">
