### PR TITLE
Work around bad hostname detection during postfix package install.

### DIFF
--- a/docker/prod/setup/preinstall-on-prem.sh
+++ b/docker/prod/setup/preinstall-on-prem.sh
@@ -2,6 +2,18 @@
 set -e
 set -o pipefail
 
+# postfix.postinst tries to generate a hostname based on /etc/resolv.conf, which
+# gets copied in to the docker environment from the host system. On systems
+# that are not on a network with a domain, this will result in a failed install.
+#
+# See https://salsa.debian.org/postfix-team/postfix-dev/-/blob/debian/buster-updates/debian/postfix.postinst#L40
+if [ -f /run/.containerenv -o -f /.dockerenv ]; then
+	mv /bin/hostname /bin/x-hostname
+	echo openproject.local > /etc/hostname
+	apt-get install -y postfix
+	mv /bin/x-hostname /bin/hostname
+fi
+
 apt-get install -y  \
 	memcached \
 	postfix \


### PR DESCRIPTION
This pull request addresses a failure that occurs on `docker build -f docker/prod/Dockerfile .` if the docker host system is on a network that does not set a search domain.

## Bug

Trying to `apt-get install postfix` fails in some environments because its postinstall script [tries to detect a value for `myhostname` in my.cnf](https://salsa.debian.org/postfix-team/postfix-dev/-/blob/debian/buster-updates/debian/postfix.postinst#L40) using a very curious algorithm.

1. It reads `hostname --fqdn`, which because this is a docker build is always a randomly-generated container id.
2. It skips reading `/etc/hostname` because `hostname` returned something non-blank.
3. It tries checking `/etc/resolv.conf` for a search domain to append to the hostname it found, because it wants the hostname to have dots in it.

`/etc/resolv.conf` gets copied from the host by docker, which means the result of the dockerfile depends on what your `/etc/resolv.conf` contained when you ran `docker build`, and on systems that aren't on a network that has a search domain, results in an install failure with errors like these:

```
Running newaliases
newaliases: warning: valid_hostname: misplaced delimiter: 416a192f42bf..
newaliases: fatal: file /etc/postfix/main.cf: parameter myhostname: bad parameter value: 416a192f42bf..
dpkg: error processing package postfix (--configure):
 installed postfix package post-installation script subprocess returned error exit status 75
```

This was previously reported as [Ticket 31899](https://community.openproject.org/projects/openproject/work_packages/31899/) which was closed inactive a year ago because the OP disappeared. The last question asked on that ticket was:

> Hello, any reason to rebuild the image instead of pulling it from Docker Hub?

I don't know what the OP's reason was, but mine is because my group has an internal fork of openproject that we rebase and `docker build` whenever there's a new release.

## Fix

Because `postfix.postinst` honors `/etc/hostname` only if it is unable to call `/bin/hostname`, this fix works by temporarily moving `/bin/hostname` so that call fails, and supplying a fixed string as `/etc/hostname`.

## Side Effect

Currently the openproject on the docker hub embeds your CI environment's domain in the postfix configuration:

```
$ docker run --rm -it openproject/community:12 grep ^myhostname /etc/postfix/main.cf
-----> Setting PGVERSION=13 PGBIN=/usr/lib/postgresql/13/bin PGCONF_FILE=/etc/postgresql/13/main/postgresql.conf
myhostname = 0c40db4cd121.aibneqh1mxpuhl3tnnuy2ifbce.bx.internal.cloudapp.net
```

This would change to `myhostname = openproject.local`.