### PR TITLE
[39821] Logo breaks notification mail header in Gmail App

### DIFF
--- a/app/views/mailer/_notification_mailer_header.html.erb
+++ b/app/views/mailer/_notification_mailer_header.html.erb
@@ -51,8 +51,8 @@
           <td style="vertical-align: top;">
             <table <%= placeholder_table_styles %>>
               <tr>
-                <td style="width: 96px; height: 96px;">
-                  <%= logo_tag(alt: "#{Setting.app_title} #{I18n.t(:'mail.logo_alt_text')}", style: "width: 96px;max-width: 240px;max-height: 96px;") %>
+                <td style="width: 96px; height: 96px; max-width: 96px;">
+                  <%= logo_tag(alt: "#{Setting.app_title} #{I18n.t(:'mail.logo_alt_text')}", style: "width: 96px;max-width: 96px;max-height: 96px;") %>
                 </td>
               </tr>
             </table>


### PR DESCRIPTION
This is an attempt to limit width of the logo with for gmail accounts. Since I cannot reproduce the original issue, this is more an educated guess than a real solution. I assume that the issue only appears on iOS Gmail App, so it should be tested there.


https://community.openproject.org/projects/openproject/work_packages/39821/activity