### PR TITLE
[40066] Links in notification documentation lead to "page not found"

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -75,9 +75,9 @@ Our minimum plan for the Enterprise cloud edition and Enterprise on-premises edi
 
 ### OpenProject is Open Source. Which kind of license does it come with? What am I allowed to do? What can I change?
 
-OpenProject comes with the GNU General Public License v3 (GPLv3). You can find out more about the copyright [here](https://github.com/opf/openproject/blob/dev/COPYRIGHT and LICENSE files).
+OpenProject comes with the GNU General Public License v3 (GPLv3). You can find out more about the copyright [here](https://github.com/opf/openproject/blob/dev/COPYRIGHT).
 In accordance with the terms set by the GPLv3 license, users can make modifications, create copies and redistribute the work. 
-Terms and conditions regarding GPLv3 are available at http://www.gnu.org/licenses/gpl-3.0.en.html.
+Terms and conditions regarding GPLv3 are available at http://www.gnu.org/licenses/gpl-3.0.en.html or in [our repository](https://github.com/opf/openproject/blob/dev/LICENSE).
 
 ### Is OpenProject free of charge?
 

--- a/docs/system-admin-guide/README.md
+++ b/docs/system-admin-guide/README.md
@@ -30,7 +30,8 @@ Click on one of the categories in order to proceed with the configuration.
 | [Attribute help texts](./attribute-help-texts)         | Add help texts to explain attributes (including custom fields) in projects and work packages. |
 | [Enumerations](./enumerations)                         | Set enumerations, e.g. work package priorities, time tracking activities, document categories, and more. |
 | [System settings](./system-settings)                   | Configure your system settings, e.g. a welcome text block on the landing page, display settings, repositories, and more. |
-| [Email](./email)                                       | Configure email settings in OpenProject. How to configure email notifications and your email provider? How to set up incoming email? |
+| [Incoming emails](./../installation-and-operations/configuration/incoming-emails) | Configure email settings in OpenProject. How to set up incoming email? |
+| [Outbound emails](./../installation-and-operations/configuration/outbound-emails) | Configure email settings in OpenProject. How to configure email notifications and your email provider? |
 | [Authentication](./authentication)                     | Configure authentication methods in OpenProject, e.g. OAuth, OpenID, Two-factor-authentication, LDAP, and more. |
 | [Announcement](./announcement)                         | How to create a system announcement?                         |
 | [Design](./design)                                     | Create your own design and make it compliant to your company's Corporate Identity, upload logo and customize colors. |

--- a/docs/system-admin-guide/authentication/ldap-authentication/README.md
+++ b/docs/system-admin-guide/authentication/ldap-authentication/README.md
@@ -100,7 +100,7 @@ Next you can define what sections OpenProject will look for in the LDAP and also
 
 
 - **Base DN**: Enter the Base DN to search within for users and groups in the LDAP tree
-- **Filter string**: Enter an optional [LDAP RFC4515 filter string](https://tools.ietf.org/search/rfc4515) to further reduce the returned set of users. This allows you to restrict access to OpenProject with a very flexible filter. For group synchronization, only users matching this filter will be added as well.
+- **Filter string**: Enter an optional [LDAP RFC4515 filter string](https://datatracker.ietf.org/doc/html/rfc4515) to further reduce the returned set of users. This allows you to restrict access to OpenProject with a very flexible filter. For group synchronization, only users matching this filter will be added as well.
 - **Automatic user creation:** Check to automatically  create users in OpenProject when they first login in OpenProject. It  will use the LDAP attribute mapping below to fill out required  attributes. The user will be forwarded to a registration screen to  complete required attributes if they are missing in the LDAP.
 
 ##### Filter Examples

--- a/docs/user-guide/notifications/README.md
+++ b/docs/user-guide/notifications/README.md
@@ -47,11 +47,8 @@ You can filter or group the notifications using the two areas in the left menu b
 
    ![mark-as-read](mark-as-read.png)
 
-4. The [**Notification settings**](/notification-settings) button will bring you to your personal notification settings to configure your notification preferences.
+4. The [**Notification settings**](notification-settings) button will bring you to your personal notification settings to configure your notification preferences.
 
 5. When selecting any of the notifications, you can also view more **details in the split screen**, for example comments members made regarding a specific work package. Unread messages are indicated by a blue bubble. You can even edit directly in this view.
 
-In addition to the in-app notifications, you will also get a once-a-day summary of all notifications by email. To fine-tune Email Reminders, [click here](notification_settings/).
-
-
-
+In addition to the in-app notifications, you will also get a once-a-day summary of all notifications by email. To fine-tune Email Reminders, [click here](../../getting-started/my-account/#email-reminders).

--- a/docs/user-guide/notifications/notification-settings/README.md
+++ b/docs/user-guide/notifications/notification-settings/README.md
@@ -8,7 +8,7 @@ keywords: notifications settings
 ---
 ## Notification settings
 
-To access the in-app notification settings. Please left-click the **Notification settings** button in the upper right side of the [notification center](../notifications) or navigate via **My account > Notification settings**.
+To access the in-app notification settings. Please left-click the **Notification settings** button in the upper right side of the [notification center](../) or navigate via **My account > Notification settings**.
 
 ![notification-settings](notification-settings.PNG)
 
@@ -24,7 +24,7 @@ In the **Notification settings** you can fine-tune what you are notified about:
   - All priority changes
   - All new comments
 
-When someone [mentions](../../user-guide/work-packages/edit-work-package/#-notification-mention) you (@xxx) in e.g. a work package description or comment you will receive an in-app notification.
+When someone [mentions](../../work-packages/edit-work-package/#-notification-mention) you (@xxx) in e.g. a work package description or comment you will receive an in-app notification.
 
 Additionally, you can also add **project specific notification settings** by clicking on the link **Add settings for project**.
 
@@ -33,6 +33,3 @@ Additionally, you can also add **project specific notification settings** by cli
 By default you do not receive any notifications about your own changes. In addition to the in-app notifications, you will also get a once-a-day summary of all notifications as **[Email reminders](../../../getting-started/my-account#email-reminders)**. 
 
 ___
-
-
-


### PR DESCRIPTION
Fix broken links in documentation

https://community.openproject.org/projects/openproject/work_packages/40066/activity