### PR TITLE
Proper check for allowed work package context menu actions

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -104,7 +104,7 @@ export class WorkPackageContextMenuHelperService {
   public getIntersectOfPermittedActions(workPackages:any) {
     const bulkPermittedActions:any = [];
 
-    const permittedActions = _.filter(this.BULK_ACTIONS, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.getAllowedActions(workPackage, [action]).length >= 1));
+    const permittedActions = _.filter(this.BULK_ACTIONS, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.isActionAllowed(workPackage, action)));
 
     _.each(permittedActions, (permittedAction:any) => {
       bulkPermittedActions.push({
@@ -128,6 +128,10 @@ export class WorkPackageContextMenuHelperService {
     const queryParts = linkAndQueryString.concat(new Array(serializedIdParams));
 
     return `${link}?${queryParts.join('&')}`;
+  }
+
+  private isActionAllowed(workPackage:WorkPackageResource, action:WorkPackageAction):boolean {
+    return _.filter(this.getAllowedActions(workPackage, [action]), (a) => a === action).length >= 1;
   }
 
   private getAllowedActions(workPackage:WorkPackageResource, actions:WorkPackageAction[]):WorkPackageAction[] {


### PR DESCRIPTION
While working on a plugin extension for the multi-selected work packages context menu, we discovered that our added context menu was always shown.
We suspect the permitted actions step of the `getIntersectOfPermittedActions` method
accidentally allowed too many actions;  when there are plugin registered
actions. Eg. `logCosts`. - That happens because it only counts for the existence of actions, while plugins can add actions freely.
We fixed it by introducing a new method `isActionAllowed`, which filters the actions correctly. 