### PR TITLE
Fix/39959/duplicate query space initialization

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
@@ -337,16 +337,6 @@ export class WorkPackagesListService {
     }
   }
 
-  private updateStatesFromQueryOnPromise(promise:Promise<QueryResource>):Promise<QueryResource> {
-    void promise
-      .then((query) => {
-        this.wpStatesInitialization.initialize(query, query.results);
-        return query;
-      });
-
-    return promise;
-  }
-
   public get currentQuery() {
     return this.querySpace.query.value!;
   }

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.service.ts
@@ -205,7 +205,7 @@ export class WorkPackageRelationsService extends StateCacheService<RelationsStat
   }
 
   /**
-   * Given a set of complete relations for this work packge,
+   * Given a set of complete relations for this work package,
    * returns the RelationsStateValue
    *
    * @param wpId The wpId the relations belong to

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-additional-elements.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-additional-elements.service.ts
@@ -52,7 +52,7 @@ export class WorkPackageViewAdditionalElementsService {
     readonly wpRelations:WorkPackageRelationsService) {
   }
 
-  public initialize(query:QueryResource, results:WorkPackageCollectionResource) {
+  public initialize(query:QueryResource, results:WorkPackageCollectionResource):void {
     const rows = results.elements;
 
     // Add relations to the stack


### PR DESCRIPTION
Both the `PartitionedQuerySpacePageComponent` as well as the
`WorkPackagesListService` initialize the work package states via the
`WorkPackageStatesInitializationService`.

The `PartitionedQuerySpacePageComponent` initializes the
`WorkPackagesListService` so the former is indirectly for calling both.

Ideally, only the `WorkPackagesListService` would initialize the
`WorkPackageStatesInitializationService` to avoid confusion but this
could not be implemented at this time because of hard to control side
effects.

With this change, the `PartitionedQuerySpacePageComponent` on the first
call to the `WorkPackagesListService` no longer initializes the wp
states trusting in the list service to do it.

This change results in reduced initialization time and avoids duplicated
requests to the server e.g. for relations and the work packages they
point to.

https://community.openproject.org/wp/39959