### PR TITLE
Convert attribute help text to datset inputs

### DIFF
--- a/app/views/attribute_help_texts/_tab.html.erb
+++ b/app/views/attribute_help_texts/_tab.html.erb
@@ -42,12 +42,14 @@
                           edit_attribute_help_text_path(attribute_help_text) %>
             </td>
             <td>
-              <attribute-help-text
-                data-help-text-id="<%= attribute_help_text.id %>"
-                data-attribute="<%= attribute_help_text.attribute_name %>"
-                data-attribute-scope="'<%= attribute_help_text.attribute_scope %>'"
-                data-additional-label="<%= t(:'attribute_help_texts.show_preview') %>">
-              </attribute-help-text>
+              <%= angular_component_tag 'attribute-help-text',
+                                        inputs: {
+                                          helpTextId: attribute_help_text.id,
+                                          attribute: attribute_help_text.attribute_name,
+                                          attributeScope: attribute_help_text.attribute_scope,
+                                          additionalLabel: t(:'attribute_help_texts.show_preview')
+                                        }
+              %>
             </td>
             <td class="buttons">
               <%= link_to(

--- a/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.component.ts
+++ b/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.component.ts
@@ -39,9 +39,11 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { AttributeHelpTextsService } from './attribute-help-text.service';
 import { AttributeHelpTextModalComponent } from './attribute-help-text.modal';
+import { DatasetInputs } from 'core-app/shared/components/dataset-inputs.decorator';
 
 export const attributeHelpTextSelector = 'attribute-help-text';
 
+@DatasetInputs
 @Component({
   selector: attributeHelpTextSelector,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -57,7 +59,7 @@ export class AttributeHelpTextComponent implements OnInit {
   @Input() public attributeScope:string;
 
   // Load single id entry if given
-  @Input() public helpTextId?:string;
+  @Input() public helpTextId?:string|number;
 
   public exists = false;
 
@@ -67,22 +69,17 @@ export class AttributeHelpTextComponent implements OnInit {
     close: this.I18n.t('js.button_close'),
   };
 
-  constructor(protected elementRef:ElementRef,
+  constructor(
+    readonly elementRef:ElementRef,
     protected attributeHelpTexts:AttributeHelpTextsService,
     protected opModalService:OpModalService,
     protected cdRef:ChangeDetectorRef,
     protected injector:Injector,
-    protected I18n:I18nService) {
+    protected I18n:I18nService,
+  ) {
   }
 
   ngOnInit() {
-    const element:HTMLElement = this.elementRef.nativeElement;
-    // Fall back to values provided by data
-    this.helpTextId = this.helpTextId || element.dataset.helpTextId!;
-    this.attribute = this.attribute || element.dataset.attribute!;
-    this.attributeScope = this.attributeScope || element.dataset.attributeScope!;
-    this.additionalLabel = this.additionalLabel || element.dataset.additionalLabel!;
-
     if (this.helpTextId) {
       this.exists = true;
     } else {

--- a/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.service.ts
+++ b/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.service.ts
@@ -60,7 +60,7 @@ export class AttributeHelpTextsService {
    * Search for a given attribute help text
    *
    */
-  public requireById(id:string):Promise<HelpTextResource|undefined> {
+  public requireById(id:string|number):Promise<HelpTextResource|undefined> {
     this.load();
 
     return this
@@ -72,7 +72,7 @@ export class AttributeHelpTextsService {
       .toPromise()
       .then(() => {
         const value = this.helpTexts.getValueOr([]);
-        return _.find(value, (element) => element.id?.toString() === id);
+        return _.find(value, (element) => element.id?.toString() === id.toString());
       });
   }
 

--- a/spec/helpers/angular_helper_spec.rb
+++ b/spec/helpers/angular_helper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -28,20 +26,50 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module AngularHelper
-  ##
-  # Create a component element tag with the given attributes
-  #
-  # Allow setting dynamic inputs for components with the @DatasetInputs decorator
-  # by using inputs: { inputName: value }
-  def angular_component_tag(component, options = {})
-    inputs = (options.delete(:inputs) || {})
-               .transform_keys { |k| k.to_s.underscore.dasherize }
-               .transform_values(&:to_json)
+require 'spec_helper'
 
-    options[:data] = options.fetch(:data, {}).merge(inputs)
-    options[:class] ||= "#{options.fetch(:class, '')} op-angular-component"
+describe AngularHelper, type: :helper do
+  let(:tag_name) { 'op-test' }
+  let(:options) do
+    {
+      class: 'op-classname',
+      inputs: inputs,
+      data: data
+    }
+  end
+  let(:data) do
+    {
+      'qa-selector': 'foo'
+    }
+  end
 
-    content_tag(component, '', options)
+  subject { helper.angular_component_tag tag_name, options }
+
+  describe 'inputs transformations' do
+    let(:inputs) do
+      {
+        key: 'value',
+        number: 1,
+        anArray: [1, 2, 3],
+        someRandomObject: { complex: true, foo: 'bar' }
+      }
+    end
+
+    let(:expected) do
+      <<~HTML.squish
+        <op-test
+          class="op-classname"
+          data-key="&quot;value&quot;"
+          data-number="1"
+          data-an-array="[1,2,3]"
+          data-some-random-object="{&quot;complex&quot;:true,&quot;foo&quot;:&quot;bar&quot;}"
+          data-qa-selector="foo"
+        /></op-test>
+      HTML
+    end
+
+    it 'converts the inputs' do
+      expect(subject).to be_html_eql(expected)
+    end
   end
 end


### PR DESCRIPTION
Improves the angular helper to allow passing and converting inputs
[OP#40035](https://community.openproject.org/wp/40035)

Use the helper like that:

```
<%= angular_component_tag(
  'op-foo',
  inputs: { myInput: { anything: 'bla' } }
) %>
```

Example usage for attribute-help-text
https://github.com/opf/openproject/pull/9890/files#diff-967538eeb7e41836af20e7aa7695e17991be3c1a943cb22faf595370b14d1babR46-R53