### PR TITLE
bug/40112 cant upload bcf files as normal attachments to work packages via fog

### DIFF
--- a/modules/bim/lib/open_project/bim/patches/fog_file_uploader_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/fog_file_uploader_patch.rb
@@ -7,9 +7,9 @@ module OpenProject::Bim::Patches::FogFileUploaderPatch
     def fog_attributes
       return super unless path.ends_with?(".bcf")
 
-      {
-        "Content-Type" => "application/octet-stream"
-      }
+      super.merge({
+                    "Content-Type" => "application/octet-stream"
+                  })
     end
   end
 end


### PR DESCRIPTION
The BIM module currently patches the `FogFileUploader` and overwrites all `fog_attributes`. It should not do that but instead simply merge those attributes that it needs to get changed with those are provided by `super`.

https://community.openproject.org/wp/40112