### PR TITLE
Allow plugins to link into the WP bulk context menu

### DIFF
--- a/frontend/src/app/features/plugins/plugin-context.ts
+++ b/frontend/src/app/features/plugins/plugin-context.ts
@@ -32,6 +32,7 @@ import { DomAutoscrollService } from 'core-app/shared/helpers/drag-and-drop/dom-
  */
 export class OpenProjectPluginContext {
   private _knownHookNames = [
+    'workPackageBulkContextMenu',
     'workPackageTableContextMenu',
     'workPackageSingleContextMenu',
     'workPackageNewInitialization',

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -103,13 +103,14 @@ export class WorkPackageContextMenuHelperService {
 
   public getIntersectOfPermittedActions(workPackages:any) {
     const bulkPermittedActions:any = [];
-
-    const permittedActions = _.filter(this.BULK_ACTIONS, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.isActionAllowed(workPackage, action)));
+    const possibleActions = this.BULK_ACTIONS.concat(this.HookService.call('workPackageBulkContextMenu'));
+    const permittedActions = _.filter(possibleActions, (action:any) => _.every(workPackages, (workPackage:WorkPackageResource) => this.isActionAllowed(workPackage, action)));
 
     _.each(permittedActions, (permittedAction:any) => {
       bulkPermittedActions.push({
         key: permittedAction.key,
         text: permittedAction.text,
+        icon: permittedAction.icon,
         link: this.getBulkActionLink(permittedAction, workPackages),
       });
     });


### PR DESCRIPTION
Currently, plugins cannot add context menu entries on work packages, when more than one work package is selected.

This PR adds a plugin hook so that plugins can register for these bulk actions.

From a plugin, this hook can be used as outlined here 👉  https://github.com/bitcrowd/openproject-proto_plugin/pull/6