### PR TITLE
Re-add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "dev"
+    open-pull-requests-limit: 2
+    versioning-strategy: lockfile-only
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+    target-branch: "dev"
+    open-pull-requests-limit: 2
+    versioning-strategy: lockfile-only
+

--- a/Gemfile
+++ b/Gemfile
@@ -319,7 +319,7 @@ gemfiles = Dir.glob File.expand_path('{Gemfile.plugins,Gemfile.modules,Gemfile.l
                                      __dir__)
 gemfiles << ENV['CUSTOM_PLUGIN_GEMFILE'] unless ENV['CUSTOM_PLUGIN_GEMFILE'].nil?
 gemfiles.each do |file|
-  next unless File.readable?(file)
-
-  eval_gemfile(file)
+  # We use send to allow dependabot to function
+  # don't use eval_gemfile(file) here as it will break dependabot!
+  send(:eval_gemfile, file) if File.readable?(file)
 end


### PR DESCRIPTION
We disabled dependabot a while back as it failed to parse our gemfile with non-string versions of `eval_gemfile`. There appears to be a workaround however that I'm willing to try