### PR TITLE
Update Selenium Grid for docker development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,7 @@ services:
 
   # https://vitobotta.com/2019/09/04/rails-parallel-system-tests-selenium-docker/
   selenium-hub:
-    image: selenium/hub:latest
+    image: selenium/hub:4.0
     container_name: selenium-hub
     hostname: selenium-hub
     environment:
@@ -182,10 +182,10 @@ services:
     networks:
       - testing
     ports:
-      - "4444:4444"
+      - "4442-4444:4442-4444"
 
   chrome:
-    image: selenium/node-chrome-debug:latest
+    image: selenium/node-chrome:4.0
     volumes:
       - /dev/shm:/dev/shm
       - "downloads-test:/home/seluser/Downloads"
@@ -193,9 +193,11 @@ services:
       - testing
     ports:
       - "5900-5915:5900"
+    shm_size: 2g
     environment:
-      HUB_HOST: selenium-hub
-      HUB_PORT: 4444
+      SE_EVENT_BUS_HOST: selenium-hub
+      SE_EVENT_BUS_PUBLISH_PORT: 4442
+      SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
       SCREEN_WIDTH: 1920
       SCREEN_HEIGHT: 1080
       # in case we want multiple sessions per container
@@ -203,7 +205,7 @@ services:
       NODE_MAX_SESSION: "${CI_JOBS:-4}"
 
   firefox:
-    image: selenium/node-firefox-debug:latest
+    image: selenium/node-firefox:4.0
     volumes:
       - /dev/shm:/dev/shm
       - "downloads-test:/home/seluser/Downloads"
@@ -211,9 +213,11 @@ services:
       - testing
     ports:
       - "5916-5931:5900"
+    shm_size: 2g
     environment:
-      HUB_HOST: selenium-hub
-      HUB_PORT: 4444
+      SE_EVENT_BUS_HOST: selenium-hub
+      SE_EVENT_BUS_PUBLISH_PORT: 4442
+      SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
       SCREEN_WIDTH: 1920
       SCREEN_HEIGHT: 1080
       # in case we want multiple sessions per container
@@ -221,7 +225,7 @@ services:
       NODE_MAX_SESSION: "${CI_JOBS:-4}"
 
   opera:
-    image: selenium/node-opera-debug:latest
+    image: selenium/node-opera:4.0
     volumes:
       - /dev/shm:/dev/shm
       - "downloads-test:/home/seluser/Downloads"
@@ -230,8 +234,9 @@ services:
     ports:
       - "5932-5957:5900"
     environment:
-      HUB_HOST: selenium-hub
-      HUB_PORT: 4444
+      SE_EVENT_BUS_HOST: selenium-hub
+      SE_EVENT_BUS_PUBLISH_PORT: 4442
+      SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
       SCREEN_WIDTH: 1920
       SCREEN_HEIGHT: 1080
       # in case we want multiple sessions per container


### PR DESCRIPTION
Commit e37b29b8fc9 updated the selenium driver and webdriver from v3 to v4, but failed to address local docker
development. This commit updates the docker selenium setup, and pins the docker images to a specific version, something
which wasn't done before.