### PR TITLE
Fix loading indicator on team planner

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/page/team-planner-page.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/page/team-planner-page.component.ts
@@ -77,10 +77,6 @@ export class TeamPlannerPageComponent extends PartitionedQuerySpacePageComponent
     );
   }
 
-  protected set loadingIndicator(promise:Promise<unknown>) {
-    this.loadingIndicatorService.indicator('calendar-entry').promise = promise;
-  }
-
   /**
    * We need to set the current partition to the grid to ensure
    * either side gets expanded to full width if we're not in '-split' mode.

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
@@ -1,17 +1,14 @@
-<div class="op-team-planner loading-indicator--location"
-     [attr.data-indicator-name]="'table'">
-  <ng-container
-    *ngIf="(calendarOptions$ | async) as calendarOptions"
-  >
-    <full-calendar
-      #ucCalendar
-      *ngIf="calendarOptions"
-      [options]="calendarOptions"
-    ></full-calendar>
-  </ng-container>
-  <ng-template #resourceContent let-resource="resource">
-    <op-principal
-      [principal]="resource.extendedProps.user"
-    ></op-principal>
-  </ng-template>
-</div>
+<ng-container
+  *ngIf="(calendarOptions$ | async) as calendarOptions"
+>
+  <full-calendar
+    #ucCalendar
+    *ngIf="calendarOptions"
+    [options]="calendarOptions"
+  ></full-calendar>
+</ng-container>
+<ng-template #resourceContent let-resource="resource">
+  <op-principal
+    [principal]="resource.extendedProps.user"
+  ></op-principal>
+</ng-template>


### PR DESCRIPTION
The loading indicator was not shown on the partitioned query space component, as the loading indicator name was overridden