### PR TITLE
[40234] Team planner overflows split screen

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.sass
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.sass
@@ -1,0 +1,8 @@
+@import "helpers"
+
+\:host
+  display: block
+  height: 100%
+  overflow: auto
+  // Avoid empty space on the right since the styled scrollbar would only be visible on hover.
+  @include no-visible-scroll-bar


### PR DESCRIPTION
Take care that team planner scrolls independently from the split screen. Thereby the scroll bar is hidden to avoid an ugly white space between the two elements that results because the scroll bar would be only visible on hover. I admit that this is not perfect but currently the only solution I came up with.


https://community.openproject.org/projects/openproject/work_packages/40234/activity