### PR TITLE
[40142] Textausrichtung von Langtextfeldern in Projektübersicht

### DIFF
--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -164,7 +164,7 @@ table.generic-table
       line-height: 1.6
       padding-top: 0.5rem
       padding-bottom: 0.5rem
-      vertical-align: middle
+      vertical-align: top
 
       // Center input fields and select boxes vertically in tables
       .form--field
@@ -213,9 +213,8 @@ table.generic-table
       &.-no-highlighting
         background-color: $body-background
 
-    p
-      padding: 0 8px
-      margin: 0
+    .op-uc-p
+      @include text-shortener
 
 
 // Enable sticky headers

--- a/frontend/src/global_styles/content/work_packages/_table_content.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_content.sass
@@ -69,6 +69,7 @@
   padding-left: 0
   padding-top: 0
   padding-bottom: 0
+  vertical-align: middle
   // To display the input field border correctly (input height is 24px)
   line-height: 24px
 
@@ -137,7 +138,7 @@ html:not(.-browser-mobile)
   display: inline-block
   vertical-align: middle
   width: 100%
-  
+
   @media print
     white-space: normal
 
@@ -177,4 +178,3 @@ body.-browser-edge
 .wp-table--cell-td img.thumbnail
   height: 40px
   outline: none
-


### PR DESCRIPTION
Align text content in tables at the top to avoid having to scroll to see content because one cell blows up the whole row

https://community.openproject.org/projects/openproject/work_packages/40142/activity