### PR TITLE
[40154] Dropdown menu empty when adding new element to parent child board

### DIFF
--- a/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.component.ts
+++ b/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.component.ts
@@ -128,7 +128,7 @@ export class AddListModalComponent extends OpModalComponent implements OnInit {
     this.board = this.locals.board;
     this.active = new Set(this.locals.active as string[]);
     this.actionService = this.boardActions.get(this.board.actionAttribute!);
-    this.autocompleterOptions.resource = this.actionService.localizedName.toLowerCase();
+    this.autocompleterOptions.resource = this.actionService.resourceName.toLowerCase();
   }
 
   onModelChange(element:HalResource) {

--- a/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.html
+++ b/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.html
@@ -51,7 +51,7 @@
       [attr.title]="text.button_cancel"
     ></button>
     <button
-      class="button -highlight"
+      class="confirm-form-submit--submit button -highlight"
       (click)="create()"
       [disabled]="!this.selectedAttribute || inFlight"
       [textContent]="text.button_add"

--- a/frontend/src/app/features/boards/board/board-actions/assignee/assignee-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/assignee/assignee-action.service.ts
@@ -15,6 +15,8 @@ import { ProjectResource } from 'core-app/features/hal/resources/project-resourc
 export class BoardAssigneeActionService extends CachedBoardActionService {
   filterName = 'assignee';
 
+  resourceName = 'assignee';
+
   text = this.I18n.t('js.boards.board_type.board_type_title.assignee');
 
   description = this.I18n.t('js.boards.board_type.action_text_assignee');

--- a/frontend/src/app/features/boards/board/board-actions/board-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/board-action.service.ts
@@ -46,6 +46,11 @@ export abstract class BoardActionService {
   filterName:string;
 
   /**
+   * The action resource name for the autocompleter
+   */
+  resourceName:string;
+
+  /**
    * The icon used in tile
    */
   icon:string;

--- a/frontend/src/app/features/boards/board/board-actions/status/status-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/status/status-action.service.ts
@@ -9,6 +9,8 @@ import { imagePath } from 'core-app/shared/helpers/images/path-helper';
 export class BoardStatusActionService extends CachedBoardActionService {
   filterName = 'status';
 
+  resourceName = 'status';
+
   text = this.I18n.t('js.boards.board_type.board_type_title.status');
 
   description = this.I18n.t('js.boards.board_type.action_text_status');

--- a/frontend/src/app/features/boards/board/board-actions/subproject/subproject-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/subproject/subproject-action.service.ts
@@ -14,6 +14,8 @@ import { CollectionResource } from 'core-app/features/hal/resources/collection-r
 export class BoardSubprojectActionService extends CachedBoardActionService {
   filterName = 'onlySubproject';
 
+  resourceName = 'subproject';
+
   text = this.I18n.t('js.boards.board_type.board_type_title.subproject');
 
   description = this.I18n.t('js.boards.board_type.action_text_subprojects');

--- a/frontend/src/app/features/boards/board/board-actions/subtasks/board-subtasks-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/subtasks/board-subtasks-action.service.ts
@@ -14,6 +14,8 @@ import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 export class BoardSubtasksActionService extends BoardActionService {
   filterName = 'parent';
 
+  resourceName = 'parent-child';
+
   text = this.I18n.t('js.boards.board_type.board_type_title.subtasks');
 
   description = this.I18n.t('js.boards.board_type.action_text_subtasks');

--- a/frontend/src/app/features/boards/board/board-actions/version/version-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/version/version-action.service.ts
@@ -22,6 +22,8 @@ export class BoardVersionActionService extends CachedBoardActionService {
 
   filterName = 'version';
 
+  resourceName = 'version';
+
   text = this.I18n.t('js.boards.board_type.board_type_title.version');
 
   description = this.I18n.t('js.boards.board_type.action_text_version');

--- a/modules/boards/spec/features/action_boards/subtasks_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/subtasks_board_spec.rb
@@ -176,4 +176,25 @@ describe 'Subtasks action board', type: :feature, js: true do
       expect(child.parent).to eq parent
     end
   end
+
+  describe 'with German language (regression #40031)' do
+    let!(:german_user) { FactoryBot.create :admin, language: :de }
+    let(:permissions) do
+      %i[show_board_views manage_board_views add_work_packages
+         edit_work_packages view_work_packages manage_public_queries]
+    end
+
+    before do
+      I18n.locale = :de
+      login_as german_user
+    end
+
+    it 'can add lists via the add modal' do
+      board_index.visit!
+      board_page = board_index.create_board action: I18n.t('js.boards.board_type.action_type.subtasks'), expect_empty: true
+      board_page.add_list option: 'Parent WP'
+      board_page.expect_list 'Parent WP'
+      board_page.expect_card 'Parent WP', 'Child'
+    end
+  end
 end

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -192,7 +192,7 @@ module Pages
       else
         open_and_fill_add_list_modal query
         page.find('.ng-option', text: option, wait: 10).click
-        click_on 'Add'
+        page.find('.confirm-form-submit--submit').click
       end
     end
 


### PR DESCRIPTION
Introduce (unlocalised) resource name in the boards action service. This is needed for the autocompleter. By chance this worked for most boards but "parent-child" was translated to "eltern-kind" which is no resource the autocompleter can handle correctly (same applies for "assignee" <-> "Zugewiesen an").

https://community.openproject.org/projects/openproject/work_packages/40154/activity