### PR TITLE
[40248] Remember the back_url when initiating auth_source_sso

### DIFF
--- a/app/controllers/concerns/accounts/authentication_stages.rb
+++ b/app/controllers/concerns/accounts/authentication_stages.rb
@@ -88,7 +88,7 @@ module Accounts::AuthenticationStages
 
     # Remember back_url from params since we're redirecting
     # but don't use the referer
-    session[:back_url] = params[:back_url]
+    session[:back_url] ||= params[:back_url]
 
     # Remember the autologin cookie decision
     session[:autologin_requested] = params[:autologin]

--- a/app/controllers/concerns/auth_source_sso.rb
+++ b/app/controllers/concerns/auth_source_sso.rb
@@ -177,6 +177,8 @@ module AuthSourceSSO
 
   def handle_sso_success(user, just_activated)
     session[:user_from_auth_header] = true
+    # remember the back_url so we can redirect to the original request
+    session[:back_url] = request.fullpath
     successful_authentication(user, reset_stages: true, just_registered: just_activated)
   end
 

--- a/spec/controllers/concerns/auth_source_sso_spec.rb
+++ b/spec/controllers/concerns/auth_source_sso_spec.rb
@@ -49,7 +49,7 @@ describe MyController, type: :controller do
 
   shared_examples 'should log in the user' do
     it "logs in given user" do
-      expect(response).to redirect_to my_page_path
+      expect(response).to redirect_to my_account_path
       expect(user.reload.last_login_on).to be_within(10.seconds).of(Time.current)
       expect(session[:user_id]).to eq user.id
     end
@@ -140,7 +140,7 @@ describe MyController, type: :controller do
       end
 
       it "should log in given user and activate it" do
-        expect(response).to redirect_to my_page_path
+        expect(response).to redirect_to my_account_path
         expect(user.reload).to be_active
         expect(session[:user_id]).to eq user.id
       end
@@ -219,7 +219,7 @@ describe MyController, type: :controller do
       get :account
 
       expect(service).to have_received(:call).with(other_user)
-      expect(response).to redirect_to my_page_path
+      expect(response).to redirect_to my_account_path
       expect(user.reload.last_login_on).to be_within(10.seconds).of(Time.current)
       expect(session[:user_id]).to eq user.id
       expect(session[:updated_at]).to be > session_update_time

--- a/spec/requests/auth/auth_source_sso_spec.rb
+++ b/spec/requests/auth/auth_source_sso_spec.rb
@@ -1,0 +1,56 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe AuthSourceSSO,
+         type: :rails_request do
+  let(:sso_config) do
+    {
+      header: "X-Remote-User",
+      optional: true
+    }
+  end
+
+  let(:auth_source) { FactoryBot.create(:auth_source) }
+  let(:user) { FactoryBot.create(:user, login: 'bob', auth_source: auth_source) }
+
+  before do
+    allow(OpenProject::Configuration)
+      .to receive(:auth_source_sso)
+            .and_return(sso_config)
+
+    get '/projects?foo=bar', headers: { 'X-Remote-User' => user.login }
+  end
+
+  it 'redirects the user to that URL' do
+    expect(response).to redirect_to '/projects?foo=bar'
+  end
+end


### PR DESCRIPTION
When the user creates a new session through auth source sso, they are being logged in through `logged_user=` which calls the login service and redirects back afterwards. But there is no back_url set, resulting in a my page redirect.

https://community.openproject.org/wp/40248