### PR TITLE
allow translations in folders

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -117,7 +117,7 @@ module OpenProject
     # config.time_zone = 'Central Time (US & Canada)'
 
     # Add locales from crowdin translations to i18n
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', 'crowdin', '*.{rb,yml}').to_s]
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :en
 
     # Fall back to default locale


### PR DESCRIPTION
so users could add their own

With this change users could add a folder `/opt/openproject/config/locales/extra/` where they could then add their own translations to override the core's translations. For instance `/opt/openproject/config/locales/extra/de.yml` to provide custom German translations.