### PR TITLE
[40281] User Avatar misaligned in top menu

### DIFF
--- a/frontend/src/global_styles/common/header/app-menu.sass
+++ b/frontend/src/global_styles/common/header/app-menu.sass
@@ -17,11 +17,12 @@
     align-items: center
 
   &--item-title
-    min-width: 0px
+    min-width: 0
+    line-height: 1
     white-space: nowrap
 
   &--item-action
-    background: transparent 
+    background: transparent
     border: 0
     display: flex
     justify-content: center

--- a/frontend/src/global_styles/content/_avatar.sass
+++ b/frontend/src/global_styles/content/_avatar.sass
@@ -4,7 +4,6 @@
   // min-width was added because the avatar was getting squished as a flex-child
   min-width: var(--user-avatar-width)
   height: var(--user-avatar-height)
-  margin-right: 10px
   color: white
   display: inline-block
   text-align: center

--- a/frontend/src/global_styles/content/_principal.sass
+++ b/frontend/src/global_styles/content/_principal.sass
@@ -7,10 +7,11 @@
     flex-shrink: 0
 
   &--name
-    @include text-shortener 
+    @include text-shortener
     flex-grow: 1
     flex-shrink: 1
     min-width: 0 // See: https://css-tricks.com/flexbox-truncated-text/
+    margin-left: 10px
 
   &--multi-line
     display: block


### PR DESCRIPTION
Add margin to avatar only when there is a name next to it and align in top menu correctly

https://community.openproject.org/projects/openproject/work_packages/40281/activity