### PR TITLE
[#40275] Xeokit viewer becomes visible in Revit add-in

### DIFF
--- a/frontend/src/app/features/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.ts
+++ b/frontend/src/app/features/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.ts
@@ -210,7 +210,7 @@ export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements
   }
 
   protected showViewpoint(workPackage:WorkPackageResource, index:number):void {
-    if (this.bcfViewer) {
+    if (this.bcfViewer && this.viewerBridge.shouldShowViewer) {
       // FIXME: This component shouldn't know about the state of the BCF module. bcfViewer is null, when outside of
       //  BCF module. Inside BCF module, we try to avoid hard transition, with sending an update to the bcf view
       //  state before showing a viewpoint.


### PR DESCRIPTION
- https://community.openproject.org/work_packages/40275
- added check for viewer bridge state before changing view states