### PR TITLE
Precompute moment dates for activities

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-activity/user/user-activity.component.sass
@@ -20,3 +20,4 @@
 
   &--avatar
     flex-shrink: 0
+    margin-right: 0.5rem

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-base.controller.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-base.controller.ts
@@ -138,7 +138,13 @@ export class ActivityPanelBaseController extends UntilDestroyedMixin implements 
     this.unfilteredActivities = activities;
 
     const visible = this.getVisibleActivities();
-    this.visibleActivities = visible.map((el:HalResource, i:number) => this.info(el, i));
+    this.visibleActivities = visible
+      .map((el:HalResource, i:number) => {
+        const elWithInfo = this.info(el, i);
+        elWithInfo.isNextDate = el.date === el.dateOfPrevious;
+        return elWithInfo
+      });
+
     this.showToggler = this.shouldShowToggler();
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-base.controller.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-base.controller.ts
@@ -138,13 +138,7 @@ export class ActivityPanelBaseController extends UntilDestroyedMixin implements 
     this.unfilteredActivities = activities;
 
     const visible = this.getVisibleActivities();
-    this.visibleActivities = visible
-      .map((el:HalResource, i:number) => {
-        const elWithInfo = this.info(el, i);
-        elWithInfo.isNextDate = el.date === el.dateOfPrevious;
-        return elWithInfo
-      });
-
+    this.visibleActivities = visible.map((el:HalResource, i:number) => this.info(el, i));
     this.showToggler = this.shouldShowToggler();
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-entry-info.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-entry-info.ts
@@ -29,6 +29,12 @@
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 
 export class ActivityEntryInfo {
+  public isNextDate = false;
+  
+  public date = this.activityDate(this.activity);
+
+  public dateOfPrevious = this.index > 0 ? this.activityDate(this.activities[this.index - 1]) : undefined;
+
   constructor(public timezoneService:TimezoneService,
     public isReversed:boolean,
     public activities:any[],
@@ -38,16 +44,6 @@ export class ActivityEntryInfo {
 
   public number(forceReverse = false) {
     return this.orderedIndex(this.index, forceReverse);
-  }
-
-  public get date() {
-    return this.activityDate(this.activity);
-  }
-
-  public get dateOfPrevious():any {
-    if (this.index > 0) {
-      return this.activityDate(this.activities[this.index - 1]);
-    }
   }
 
   public get href() {
@@ -60,10 +56,6 @@ export class ActivityEntryInfo {
 
   public get version() {
     return this.activity.version;
-  }
-
-  public get isNextDate() {
-    return this.date !== this.dateOfPrevious;
   }
 
   public isInitial(forceReverse = false) {

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-entry-info.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-entry-info.ts
@@ -29,11 +29,11 @@
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 
 export class ActivityEntryInfo {
-  public isNextDate = false;
-  
   public date = this.activityDate(this.activity);
 
   public dateOfPrevious = this.index > 0 ? this.activityDate(this.activities[this.index - 1]) : undefined;
+
+  public isNextDate = this.date === this.dateOfPrevious;
 
   constructor(public timezoneService:TimezoneService,
     public isReversed:boolean,

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-entry-info.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-entry-info.ts
@@ -33,7 +33,7 @@ export class ActivityEntryInfo {
 
   public dateOfPrevious = this.index > 0 ? this.activityDate(this.activities[this.index - 1]) : undefined;
 
-  public isNextDate = this.date === this.dateOfPrevious;
+  public isNextDate = this.date !== this.dateOfPrevious;
 
   constructor(public timezoneService:TimezoneService,
     public isReversed:boolean,


### PR DESCRIPTION
The current activity info class dynamically constructs moment objects each time the `date` or `dateOfPrevious`
properties are accessed. When rendering the list, this causes the date objects for all activities to be computed at
least twice. A mouseenter or mouseleave generates a rerender in this context. This would normally not be an issue, but
when scrolling inside a long list of activities this causes huge render times and fps drops.

This commit changes the date computation; doing it once when the activities are fetched, so that subsequent renders of
the list will be faster.

This slows down the initial render, but makes the page usable afterwards.

Also includes a small style fix :)

Closes https://community.openproject.org/work_packages/40314/activity