### PR TITLE
Prevent dates from being persisted in team planner query

### DIFF
--- a/frontend/src/app/core/apiv3/endpoints/queries/apiv3-queries-paths.ts
+++ b/frontend/src/app/core/apiv3/endpoints/queries/apiv3-queries-paths.ts
@@ -74,7 +74,7 @@ export class ApiV3QueriesPaths extends ApiV3ResourceCollection<QueryResource, Ap
    * @param queryId
    * @param projectIdentifier
    */
-  public find(queryData:Object, queryId?:string, projectIdentifier?:string|null|undefined):Observable<QueryResource> {
+  public find(queryData:Object, queryId?:string|null, projectIdentifier?:string|null|undefined):Observable<QueryResource> {
     let path:string;
 
     if (queryId) {

--- a/frontend/src/app/core/apiv3/endpoints/queries/apiv3-query-form.ts
+++ b/frontend/src/app/core/apiv3/endpoints/queries/apiv3-query-form.ts
@@ -75,7 +75,7 @@ export class ApiV3QueryForm extends ApiV3FormResource<QueryFormResource> {
    * @param projectIdentifier
    * @param payload
    */
-  public loadWithParams(params:{ [key:string]:unknown }, queryId:string|undefined, projectIdentifier:string|undefined|null, payload:any = {}):Observable<[QueryFormResource, QueryResource]> {
+  public loadWithParams(params:{ [key:string]:unknown }, queryId:string|null|undefined, projectIdentifier:string|undefined|null, payload:any = {}):Observable<[QueryFormResource, QueryResource]> {
     // We need a valid payload so that we
     // can check whether form saving is possible.
     // The query needs a name to be valid.

--- a/frontend/src/app/features/team-planner/team-planner/page/team-planner-page.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/page/team-planner-page.component.ts
@@ -108,9 +108,6 @@ export class TeamPlannerPageComponent extends PartitionedQuerySpacePageComponent
    * @protected
    */
   protected loadInitialQuery():void {
-    const queryId = this.uiRouterGlobals.params.queryId as string|null;
-    if (queryId) {
-      super.loadInitialQuery();
-    }
+    // We never load the initial query as the calendar service does all that.
   }
 }

--- a/frontend/src/app/features/team-planner/team-planner/team-planner.routes.ts
+++ b/frontend/src/app/features/team-planner/team-planner/team-planner.routes.ts
@@ -37,13 +37,14 @@ export const TEAM_PLANNER_ROUTES:Ng2StateDeclaration[] = [
   {
     name: 'team_planner',
     parent: 'optional_project',
-    url: '/team_planner?query_id&query_props',
+    url: '/team_planner?query_id&query_props&cdate',
     redirectTo: 'team_planner.page',
     views: {
       '!$default': { component: WorkPackagesBaseComponent },
     },
     params: {
       query_id: { type: 'query', dynamic: true },
+      cdate: { type: 'string', dynamic: true },
       // Use custom encoder/decoder that ensures validity of URL string
       query_props: { type: 'opQueryString' },
     },

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-list-checksum.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-list-checksum.service.ts
@@ -96,7 +96,7 @@ export class WorkPackagesListChecksumService {
     }
   }
 
-  private set(id:string|null, checksum:string|null) {
+  public set(id:string|null, checksum:string|null) {
     this.id = id;
     this.checksum = checksum;
   }
@@ -145,8 +145,8 @@ export class WorkPackagesListChecksumService {
     return this.UrlParamsHelper.encodeQueryJsonParams(
       query,
       {
-        pa: pagination.page,
         pp: pagination.perPage,
+        pa: pagination.page,
       },
     );
   }

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-list-checksum.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-list-checksum.service.ts
@@ -142,7 +142,13 @@ export class WorkPackagesListChecksumService {
   }
 
   private getNewChecksum(query:QueryResource, pagination:WorkPackageViewPagination) {
-    return this.UrlParamsHelper.encodeQueryJsonParams(query, _.pick(pagination, ['page', 'perPage']));
+    return this.UrlParamsHelper.encodeQueryJsonParams(
+      query,
+      {
+        pa: pagination.page,
+        pp: pagination.perPage,
+      },
+    );
   }
 
   private maintainUrlQueryState(id:string|null, checksum:string|null):TransitionPromise {

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
@@ -64,7 +64,7 @@ import { WorkPackagesListInvalidQueryService } from './wp-list-invalid-query.ser
 import { WorkPackagesQueryViewService } from 'core-app/features/work-packages/components/wp-list/wp-query-view.service';
 
 export interface QueryDefinition {
-  queryParams:{ query_id?:string, query_props?:string };
+  queryParams:{ query_id?:string|null, query_props?:string|null };
   projectIdentifier?:string;
 }
 
@@ -118,7 +118,7 @@ export class WorkPackagesListService {
    * @param queryParams
    * @param projectIdentifier
    */
-  private streamQueryRequest(queryParams:{ query_id?:string, query_props?:string }, projectIdentifier?:string):Observable<QueryResource> {
+  private streamQueryRequest(queryParams:{ query_id?:string|null, query_props?:string|null }, projectIdentifier?:string):Observable<QueryResource> {
     const decodedProps = this.getCurrentQueryProps(queryParams);
     const queryData = this.UrlParamsHelper.buildV3GetQueryFromJsonParams(decodedProps);
     const stream = this
@@ -139,7 +139,7 @@ export class WorkPackagesListService {
    * Load a query.
    * The query is either a persisted query, identified by the query_id parameter, or the default query. Both will be modified by the parameters in the query_props parameter.
    */
-  public fromQueryParams(queryParams:{ query_id?:string, query_props?:string }, projectIdentifier?:string):Observable<QueryResource> {
+  public fromQueryParams(queryParams:{ query_id?:string|null, query_props?:string }, projectIdentifier?:string):Observable<QueryResource> {
     this.queryRequests.clear();
     this.queryRequests.putValue({ queryParams, projectIdentifier });
 
@@ -153,7 +153,7 @@ export class WorkPackagesListService {
   /**
    * Get the current decoded query props, if any
    */
-  public getCurrentQueryProps(params:{ query_props?:string }):string|null {
+  public getCurrentQueryProps(params:{ query_props?:string|null }):string|null {
     if (params.query_props) {
       return decodeURIComponent(params.query_props);
     }
@@ -366,7 +366,7 @@ export class WorkPackagesListService {
     return this.querySpace.query.value!;
   }
 
-  private handleQueryLoadingError(error:ErrorResource, queryProps:any, queryId?:string, projectIdentifier?:string|null):Promise<QueryResource> {
+  private handleQueryLoadingError(error:ErrorResource, queryProps:any, queryId?:string|null, projectIdentifier?:string|null):Promise<QueryResource> {
     this.toastService.addError(this.I18n.t('js.work_packages.faulty_query.description'), error.message);
 
     return new Promise((resolve, reject) => {

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
@@ -35,10 +35,19 @@ import { Injectable } from '@angular/core';
 import { UrlParamsHelperService } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { from, Observable, of } from 'rxjs';
+import {
+  from,
+  Observable,
+  of,
+} from 'rxjs';
 import { input } from 'reactivestates';
 import {
-  catchError, mapTo, mergeMap, share, switchMap, take,
+  catchError,
+  mapTo,
+  mergeMap,
+  share,
+  switchMap,
+  take,
 } from 'rxjs/operators';
 import {
   WorkPackageViewPaginationService,
@@ -163,8 +172,7 @@ export class WorkPackagesListService {
    * Reloads the current query and set the pagination to the first page.
    */
   public reloadQuery(query:QueryResource, projectIdentifier?:string):Observable<QueryResource> {
-    const pagination = { ...this.wpTablePagination.current, page: 1 };
-    const queryParams = this.UrlParamsHelper.encodeQueryJsonParams(query, pagination);
+    const queryParams = this.extractParamsFromQuery(query, { pa: 1 });
 
     this.queryRequests.clear();
     this.queryRequests.putValue({
@@ -177,6 +185,25 @@ export class WorkPackagesListService {
       .pipe(
         take(1),
       );
+  }
+
+  /**
+   * Extract a set of query params from the current query resource
+   * @param query The query to derive props from
+   * @param additional Additional props to append
+   */
+  public extractParamsFromQuery(
+    query:QueryResource,
+    additional:Record<string, unknown> = {},
+  ):string {
+    return this.UrlParamsHelper.encodeQueryJsonParams(
+      query,
+      {
+        pa: this.wpTablePagination.current.page,
+        pp: this.wpTablePagination.current.perPage,
+        ...additional,
+      },
+    );
   }
 
   /**

--- a/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.spec.ts
@@ -105,14 +105,14 @@ describe('UrlParamsHelper', () => {
       };
 
       additional = {
-        page: 10,
-        perPage: 100,
+        pa: 10,
+        pp: 100,
       };
     });
 
     it('should encode query to params JSON', () => {
       const encodedJSON = UrlParamsHelper.encodeQueryJsonParams(query, additional);
-      const expectedJSON = '{"c":["type","status","soße"],"s":true,"tv":true,"tzl":"days","hl":"disabled","hi":true,"g":"status","t":"type:desc","f":[{"n":"soße","o":"=","v":["knoblauch"]},{"n":"created_at","o":"<t-","v":["5"]}],"pa":10,"pp":100}';
+      const expectedJSON = '{"c":["type","status","soße"],"hi":true,"g":"status","s":true,"tv":true,"tzl":"days","hl":"disabled","t":"type:desc","f":[{"n":"soße","o":"=","v":["knoblauch"]},{"n":"created_at","o":"<t-","v":["5"]}],"pa":10,"pp":100}'
 
       expect(encodedJSON).toEqual(expectedJSON);
     });

--- a/frontend/src/app/shared/components/calendar/op-calendar.service.ts
+++ b/frontend/src/app/shared/components/calendar/op-calendar.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular/core';
 import {
   CalendarOptions,
+  DatesSetArg,
   EventApi,
 } from '@fullcalendar/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -31,6 +32,8 @@ import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/que
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { UrlParamsHelperService } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import { UIRouterGlobals } from '@uirouter/core';
+import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 
 export interface CalendarViewEvent {
   el:HTMLElement;
@@ -68,6 +71,8 @@ export class OpCalendarService extends UntilDestroyedMixin {
     readonly querySpace:IsolatedQuerySpace,
     readonly apiV3Service:ApiV3Service,
     readonly halResourceService:HalResourceService,
+    readonly uiRouterGlobals:UIRouterGlobals,
+    readonly timezoneService:TimezoneService,
   ) {
     super();
   }
@@ -218,6 +223,8 @@ export class OpCalendarService extends UntilDestroyedMixin {
         center: 'title',
         right: '',
       },
+      initialDate: this.initialDate,
+      datesSet: (dates) => this.updateDateParam(dates),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       eventClick: this.openSplitView.bind(this),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -331,5 +338,21 @@ export class OpCalendarService extends UntilDestroyedMixin {
 
   private get areFiltersEmpty() {
     return this.wpTableFilters.isEmpty;
+  }
+
+  private get initialDate():string|undefined {
+    const date = this.uiRouterGlobals.params.cdate as string|undefined;
+    if (date) {
+      return this.timezoneService.formattedISODate(date);
+    }
+
+    return undefined;
+  }
+
+  private updateDateParam(dates:DatesSetArg) {
+    void this.$state.go(
+      '.',
+      { cdate: this.timezoneService.formattedISODate(dates.start) },
+    );
   }
 }

--- a/frontend/src/app/shared/components/calendar/op-calendar.service.ts
+++ b/frontend/src/app/shared/components/calendar/op-calendar.service.ts
@@ -158,6 +158,11 @@ export class OpCalendarService extends UntilDestroyedMixin {
     fetchInfo:{ start:Date, end:Date, timeZone:string },
     projectIdentifier:string|undefined,
   ):Promise<unknown> {
+    if (this.areFiltersEmpty && this.querySpace.query.value) {
+      // nothing to do
+      return Promise.resolve();
+    }
+
     const startDate = moment(fetchInfo.start).format('YYYY-MM-DD');
     const endDate = moment(fetchInfo.end).format('YYYY-MM-DD');
 
@@ -198,16 +203,14 @@ export class OpCalendarService extends UntilDestroyedMixin {
     } else {
       queryProps = this.urlParamsHelper.encodeQueryJsonParams(
         this.querySpace.query.value as QueryResource,
-        (props) => {
-          return {
-            ...props,
-            pa: OpCalendarService.MAX_DISPLAYED,
-            f: [
-              ...props.f.filter((filter) => filter.n !== 'datesInterval'),
-              OpCalendarService.dateFilter(startDate, endDate),
-            ],
-          };
-        },
+        (props) => ({
+          ...props,
+          pa: OpCalendarService.MAX_DISPLAYED,
+          f: [
+            ...props.f.filter((filter) => filter.n !== 'datesInterval'),
+            OpCalendarService.dateFilter(startDate, endDate),
+          ],
+        }),
       );
     }
 

--- a/frontend/src/app/shared/components/calendar/op-calendar.service.ts
+++ b/frontend/src/app/shared/components/calendar/op-calendar.service.ts
@@ -310,6 +310,7 @@ export class OpCalendarService extends UntilDestroyedMixin {
         this.dateFilter(startDate, endDate),
       ],
       pp: OpCalendarService.MAX_DISPLAYED,
+      pa: 1,
     };
 
     return JSON.stringify(props);

--- a/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
@@ -217,6 +217,7 @@ export class ViewSelectComponent extends UntilDestroyedMixin implements OnInit {
       title: query.title,
       uiSref: this.baseRoute,
       uiParams: { query_id: idFromLink(query.href), query_props: '' },
+      uiOptions: { reload: true },
     };
   }
 

--- a/frontend/src/app/shared/components/sidemenu/sidemenu.component.html
+++ b/frontend/src/app/shared/components/sidemenu/sidemenu.component.html
@@ -43,6 +43,7 @@
       [attr.data-qa-selector]="'op-sidemenu--item-action--' + item.title.split(' ').join('')"
       [uiSref]="item.uiSref"
       [uiParams]="item.uiParams"
+      [uiOptions]="item.uiOptions"
     >
       <ng-container *ngTemplateOutlet="itemTemplate; context: { item }"></ng-container>
     </a>

--- a/frontend/src/app/shared/components/sidemenu/sidemenu.component.ts
+++ b/frontend/src/app/shared/components/sidemenu/sidemenu.component.ts
@@ -15,6 +15,7 @@ export interface IOpSidemenuItem {
   href?:string;
   uiSref?:string;
   uiParams?:unknown;
+  uiOptions?:unknown;
   children?:IOpSidemenuItem[];
   collapsible?:boolean;
 }


### PR DESCRIPTION
**TODOS**
 - [x] In case a `query_id` prop is present, 3 requests are fired in order to get the query. It should be possible to reduce that to 2. The first one should ideally be suppressed.
 - [x] In case a `query_id` prop is present, the query_props get updated visibly in the url 
 - [x] Using next/previous week button triggers the query save icon to appear next to the title. The date range should not be stored at all.  
  - [x] The query should not persist the time interval chosen when saving as it will be overwritten anyway