### PR TITLE
allow suppressing notifications on member create/update

### DIFF
--- a/app/services/groups/concerns/membership_manipulation.rb
+++ b/app/services/groups/concerns/membership_manipulation.rb
@@ -56,7 +56,7 @@ module Groups::Concerns
 
       touch_updated(affected_member_ids)
 
-      send_notifications(affected_member_ids, message) if affected_member_ids.any? && send_notifications
+      send_notifications(affected_member_ids, message, send_notifications) if affected_member_ids.any? && send_notifications
     end
 
     def modify_members_and_roles(_params)
@@ -77,8 +77,8 @@ module Groups::Concerns
         .touch_all
     end
 
-    def send_notifications(member_ids, message)
-      Notifications::GroupMemberAlteredJob.perform_later(member_ids, message)
+    def send_notifications(member_ids, message, send_notifications)
+      Notifications::GroupMemberAlteredJob.perform_later(member_ids, message, send_notifications)
     end
   end
 end

--- a/app/services/groups/update_roles_service.rb
+++ b/app/services/groups/update_roles_service.rb
@@ -54,7 +54,6 @@ module Groups
       execute_query(sql_query)
     end
 
-    # rubocop:disable Metrics/AbcSize
     def update_roles_cte
       <<~SQL
         WITH
@@ -123,6 +122,5 @@ module Groups
         UNION SELECT member_id from members_with_added_roles
       SQL
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/workers/notifications/group_member_altered_job.rb
+++ b/app/workers/notifications/group_member_altered_job.rb
@@ -31,11 +31,12 @@
 class Notifications::GroupMemberAlteredJob < ApplicationJob
   queue_with_priority :notification
 
-  def perform(members_ids, message)
+  def perform(members_ids, message, send_notifications)
     each_member(members_ids) do |member|
       OpenProject::Notifications.send(event_type(member),
                                       member: member,
-                                      message: message)
+                                      message: message,
+                                      send_notifications: send_notifications)
     end
   end
 

--- a/config/initializers/subscribe_listeners.rb
+++ b/config/initializers/subscribe_listeners.rb
@@ -70,6 +70,8 @@ OpenProject::Notifications.subscribe(OpenProject::Events::MEMBER_CREATED) do |pa
 end
 
 OpenProject::Notifications.subscribe(OpenProject::Events::MEMBER_UPDATED) do |payload|
+  next unless payload[:send_notifications]
+
   Mails::MemberUpdatedJob
     .perform_later(current_user: User.current,
                    member: payload[:member],

--- a/docs/api/apiv3/paths/membership.yml
+++ b/docs/api/apiv3/paths/membership.yml
@@ -209,5 +209,7 @@ patch:
 
     By providing a `notificationMessage` within the `_meta` block of the payload, the client can include a customized message to the user
     of the updated membership. In case of a group, the message will be sent to every user belonging to the group.
+
+    By including `{ "sendNotifications": false }` within the `_meta` block of the payload, no notifications is send out at all.
   operationId: Update_membership
   summary: Update membership

--- a/docs/api/apiv3/paths/memberships.yml
+++ b/docs/api/apiv3/paths/memberships.yml
@@ -174,9 +174,11 @@ post:
   description: |-
     Creates a new membership applying the attributes provided in the body.
 
-    You can use the form and schema to be retrieve the valid attribute values and by that be guided towards successful creation.
+    You can use the form and schema to retrieve the valid attribute values and by that be guided towards successful creation.
 
     By providing a `notificationMessage` within the `_meta` block of the payload, the client can include a customized message to the user
     of the newly created membership. In case of a group, the message will be sent to every user belonging to the group.
+
+    By including `{ "sendNotifications": false }` within the `_meta` block of the payload, no notifications is send out at all.
   operationId: Create_membership
   summary: Create membership

--- a/lib/api/v3/memberships/membership_meta_representer.rb
+++ b/lib/api/v3/memberships/membership_meta_representer.rb
@@ -36,6 +36,8 @@ module API
 
         formattable_property :notification_message
 
+        property :send_notifications
+
         def model_required?
           false
         end

--- a/spec/lib/api/v3/memberships/membership_payload_representer_spec.rb
+++ b/spec/lib/api/v3/memberships/membership_payload_representer_spec.rb
@@ -49,6 +49,19 @@ describe ::API::V3::Memberships::MembershipPayloadRepresenter do
           let(:value) { meta.notification_message }
         end
       end
+
+      describe 'sendNotifications' do
+        let(:meta) { OpenStruct.new send_notifications: true }
+        let(:representer) do
+          described_class.create(membership,
+                                 meta: meta,
+                                 current_user: current_user)
+        end
+
+        it_behaves_like 'property', :'_meta/sendNotifications' do
+          let(:value) { true }
+        end
+      end
     end
   end
 
@@ -68,7 +81,8 @@ describe ::API::V3::Memberships::MembershipPayloadRepresenter do
             '_meta' => {
               'notificationMessage' => {
                 "raw" => 'Come to the dark side'
-              }
+              },
+              'sendNotifications' => true
             }
           }
         end
@@ -76,6 +90,11 @@ describe ::API::V3::Memberships::MembershipPayloadRepresenter do
         it 'sets the parsed message' do
           expect(parsed.meta.notification_message)
             .to eql 'Come to the dark side'
+        end
+
+        it 'sets the notification sending configuration' do
+          expect(parsed.meta.send_notifications)
+            .to be_truthy
         end
       end
     end

--- a/spec/requests/api/v3/groups/group_resource_spec.rb
+++ b/spec/requests/api/v3/groups/group_resource_spec.rb
@@ -186,7 +186,7 @@ describe 'API v3 Group resource', type: :request, content_type: :json do
     let(:body) do
       {
         _links: {
-          "members": [
+          members: [
             {
               href: api_v3_paths.user(members.last.id)
             },
@@ -258,15 +258,18 @@ describe 'API v3 Group resource', type: :request, content_type: :json do
           .to match_array [members.last, another_user]
       end
 
-      it 'sends a mail notifying of the added project memberships to the added user' do
+      it 'sends mails notifying of the added and updated project memberships to the added user' do
         expect(ActionMailer::Base.deliveries.size)
-          .to eql 1
+          .to eq 2
 
         expect(ActionMailer::Base.deliveries.map(&:to).flatten.uniq)
           .to match_array another_user.mail
 
         expect(ActionMailer::Base.deliveries.map(&:subject).flatten)
-          .to match_array [I18n.t(:'mail_member_updated_project.subject', project: project.name)]
+          .to match_array [
+            I18n.t(:'mail_member_updated_project.subject', project: project.name),
+            I18n.t(:'mail_member_added_project.subject', project: other_project.name)
+          ]
       end
     end
 
@@ -276,7 +279,7 @@ describe 'API v3 Group resource', type: :request, content_type: :json do
       let(:body) do
         {
           _links: {
-            "members": [
+            members: [
               {
                 href: api_v3_paths.user(members.last.id)
               },

--- a/spec/services/groups/add_users_service_integration_spec.rb
+++ b/spec/services/groups/add_users_service_integration_spec.rb
@@ -77,7 +77,8 @@ describe Groups::AddUsersService, 'integration', type: :model do
       expect(Notifications::GroupMemberAlteredJob)
         .to have_received(:perform_later)
         .with(a_collection_containing_exactly(*ids),
-              message)
+              message,
+              true)
     end
   end
 

--- a/spec/services/groups/cleanup_inherited_roles_service_integration_spec.rb
+++ b/spec/services/groups/cleanup_inherited_roles_service_integration_spec.rb
@@ -139,7 +139,8 @@ describe Groups::CleanupInheritedRolesService, 'integration', type: :model do
       expect(Notifications::GroupMemberAlteredJob)
         .to have_received(:perform_later)
         .with([first_user_member.id],
-              message)
+              message,
+              true)
     end
   end
 
@@ -179,7 +180,8 @@ describe Groups::CleanupInheritedRolesService, 'integration', type: :model do
       expect(Notifications::GroupMemberAlteredJob)
         .to have_received(:perform_later)
         .with([first_user_member.id],
-              message)
+              message,
+              true)
     end
   end
 

--- a/spec/services/groups/update_roles_service_integration_spec.rb
+++ b/spec/services/groups/update_roles_service_integration_spec.rb
@@ -83,7 +83,8 @@ describe Groups::UpdateRolesService, 'integration', type: :model do
       expect(Notifications::GroupMemberAlteredJob)
         .to have_received(:perform_later)
         .with(a_collection_containing_exactly(*Member.where(principal: user).pluck(:id)),
-              message)
+              message,
+              true)
     end
   end
 

--- a/spec/services/members/update_service_spec.rb
+++ b/spec/services/members/update_service_spec.rb
@@ -34,7 +34,11 @@ require 'services/base_services/behaves_like_update_service'
 describe Members::UpdateService, type: :model do
   it_behaves_like 'BaseServices update service' do
     let(:call_attributes) do
-      { role_ids: ["2"], notification_message: "Wish you where **here**." }
+      {
+        role_ids: ["2"],
+        notification_message: "Wish you where **here**.",
+        send_notifications: false
+      }
     end
 
     let!(:allow_notification_call) do
@@ -48,7 +52,8 @@ describe Members::UpdateService, type: :model do
           .to receive(:send)
           .with(OpenProject::Events::MEMBER_UPDATED,
                 member: model_instance,
-                message: call_attributes[:notification_message])
+                message: call_attributes[:notification_message],
+                send_notifications: call_attributes[:send_notifications])
 
         subject
       end

--- a/spec/workers/notifications/group_member_altered_job_spec.rb
+++ b/spec/workers/notifications/group_member_altered_job_spec.rb
@@ -32,8 +32,9 @@ require 'spec_helper'
 
 describe Notifications::GroupMemberAlteredJob, type: :model do
   subject(:service_call) do
-    described_class.new.perform(members_ids, message)
+    described_class.new.perform(members_ids, message, send_notification)
   end
+
   let(:time) { Time.now }
   let(:member1) do
     FactoryBot.build_stubbed(:member, updated_at: time, created_at: time)
@@ -44,6 +45,7 @@ describe Notifications::GroupMemberAlteredJob, type: :model do
   let(:members) { [member1, member2] }
   let(:members_ids) { members.map(&:id) }
   let(:message) { "Some message" }
+  let(:send_notification) { false }
 
   before do
     allow(OpenProject::Notifications)
@@ -60,7 +62,7 @@ describe Notifications::GroupMemberAlteredJob, type: :model do
 
     expect(OpenProject::Notifications)
       .to have_received(:send)
-      .with(OpenProject::Events::MEMBER_CREATED, member: member1, message: message)
+      .with(OpenProject::Events::MEMBER_CREATED, member: member1, message: message, send_notifications: send_notification)
   end
 
   it 'sends an updated notification for the membership with the mismatching timestamps' do
@@ -68,6 +70,6 @@ describe Notifications::GroupMemberAlteredJob, type: :model do
 
     expect(OpenProject::Notifications)
       .to have_received(:send)
-      .with(OpenProject::Events::MEMBER_UPDATED, member: member2, message: message)
+      .with(OpenProject::Events::MEMBER_UPDATED, member: member2, message: message, send_notifications: send_notification)
   end
 end


### PR DESCRIPTION
Allows including
```
{
  "sendNotifications": false
}
```

within the `meta` block of membership create and update requests to suppress sending any notification.

https://community.openproject.org/wp/40316