### PR TITLE
[40294] User name not shown in news block

### DIFF
--- a/frontend/src/app/shared/components/grids/widgets/news/news.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/news/news.component.html
@@ -18,7 +18,7 @@
         <op-principal
           *ngIf="news.author"
           [principal]="news.author"
-          [hide-name]="true"
+          [hide-name]="false"
           class="news-author-avatar hidden-for-mobile"
         ></op-principal>
         <div>


### PR DESCRIPTION
Showing the name of avatar in principal component in news widget component.

https://community.openproject.org/projects/openproject/work_packages/40294/activity