### PR TITLE
Schedule pullpreview cleanup every night

### DIFF
--- a/.github/workflows/pullpreview.yml
+++ b/.github/workflows/pullpreview.yml
@@ -1,12 +1,15 @@
 name: pullpreview
 
 on:
+  schedule:
+    # this is used to make sure no dangling resources are left
+    - cron: "30 2 * * *"
   pull_request:
     types: [labeled, unlabeled, synchronize, closed, reopened]
 
 jobs:
   deploy:
-    if: github.repository == 'opf/openproject' && ( github.event_name == 'push' || github.event.label.name == 'pullpreview' || contains(github.event.pull_request.labels.*.name, 'pullpreview') )
+    if: github.repository == 'opf/openproject' && ( github.event_name == 'schedule' || github.event_name == 'push' || github.event.label.name == 'pullpreview' || contains(github.event.pull_request.labels.*.name, 'pullpreview') )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Sometimes, when a PR is merged or closed with the `pullpreview` label, it can happen that the corresponding GitHub Action is not triggered, resulting in dangling resources on AWS, and incorrectly labelled PRs.

The newest version of pullpreview allows to run a cleanup job via a scheduled job, which will take care of any dangling resources.