### PR TITLE
[40294] User name not shown in news block

### DIFF
--- a/app/views/homescreen/blocks/_news.html.erb
+++ b/app/views/homescreen/blocks/_news.html.erb
@@ -5,7 +5,7 @@
     <li class="-widget-box--arrow-multiline">
       <div>
         <%= avatar(news.author, class: 'news-author-avatar hidden-for-mobile') %>
-        <div class="news-project">
+        <div class="news--project">
           <%= link_to_project(news.project) + ': ' %>
           <%= link_to h(news.title), news_path(news) %>
         </div>

--- a/frontend/src/app/shared/components/grids/widgets/news/news.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/news/news.component.html
@@ -21,7 +21,7 @@
           [hideName]="true"
           class="news-author-avatar hidden-for-mobile"
         ></op-principal>
-        <div>
+        <div class="news-project">
           <a [href]="newsProjectPath(news)"
              [textContent]="newsProjectName(news)">
           </a>:

--- a/frontend/src/app/shared/components/grids/widgets/news/news.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/news/news.component.html
@@ -14,14 +14,14 @@
   <ul class="widget-box--arrow-links">
     <li class="-widget-box--arrow-multiline" 
         *ngFor="let news of entries">
-      <div class="news-project">
+      <div>
         <op-principal
           *ngIf="news.author"
           [principal]="news.author"
           [hideName]="true"
           class="news-author-avatar hidden-for-mobile"
         ></op-principal>
-        <div class="news-project">
+        <div class="news--project">
           <a [href]="newsProjectPath(news)"
              [textContent]="newsProjectName(news)">
           </a>:

--- a/frontend/src/global_styles/content/_news.sass
+++ b/frontend/src/global_styles/content/_news.sass
@@ -49,7 +49,7 @@
     margin-right: 5px
     float: left
 
-.news-project
+.news--project
   display: inline
 
 @media screen and (max-width: 679px)

--- a/frontend/src/global_styles/content/_news.sass
+++ b/frontend/src/global_styles/content/_news.sass
@@ -49,6 +49,8 @@
     margin-right: 5px
     float: left
 
+.news-project
+  display: inline
 
 @media screen and (max-width: 679px)
   .news-author


### PR DESCRIPTION
Make the div including project title and news title aligned with the avatar.

https://community.openproject.org/work_packages/40294/activity