### PR TITLE
Fix/40191 git view differences results in 500 error in repository module

### DIFF
--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -85,6 +85,10 @@ class UserPreference < ApplicationRecord
     comments_sorting == 'desc'
   end
 
+  def diff_type
+    settings.fetch(:diff_type, 'inline')
+  end
+
   def hide_mail
     settings.fetch(:hide_mail, true)
   end

--- a/config/schemas/user_preferences.schema.json
+++ b/config/schemas/user_preferences.schema.json
@@ -22,6 +22,10 @@
                 "auto_hide_popups": {
                     "type": "boolean"
                 },
+                "diff_type": {
+                  "type": "string",
+                  "enum": ["inline", "sbs"]
+                },
                 "workdays": {
                   "type": "array",
                   "items": {

--- a/spec/models/user_preference_spec.rb
+++ b/spec/models/user_preference_spec.rb
@@ -140,6 +140,27 @@ describe UserPreference do
     end
   end
 
+  describe '#diff_type' do
+    it 'can be set and written' do
+      expect(subject.diff_type)
+        .to eql 'inline'
+
+      subject.diff_type = 'sbs'
+
+      expect(subject.diff_type)
+        .to eql 'sbs'
+    end
+
+    context 'with a new pref instance' do
+      subject { described_class.new }
+
+      it 'defaults to `inline`' do
+        expect(subject.diff_type)
+          .to eql 'inline'
+      end
+    end
+  end
+
   describe '#daily_reminders' do
     context 'without reminders being stored' do
       it 'uses the defaults' do


### PR DESCRIPTION
Readds the diff_type to the user preferences. We cannot recreate the values that got lost when migrating to an OpenProject >12.0.0 & < 12.0.4 but the loss should be acceptable.

https://community.openproject.org/wp/40191

Additionally removes a ruby 1.8 specific code branch.