### PR TITLE
fix pagination on projects api

### DIFF
--- a/lib/api/v3/projects/project_collection_representer.rb
+++ b/lib/api/v3/projects/project_collection_representer.rb
@@ -40,18 +40,14 @@ module API
         self.to_eager_load = ::API::V3::Projects::ProjectRepresenter.to_eager_load
         self.checked_permissions = ::API::V3::Projects::ProjectRepresenter.checked_permissions
 
-        def initialize(represented, self_link:, current_user:, query: {}, page: nil, per_page: nil, groups: nil)
-          super
-
-          @represented = ::API::V3::Projects::ProjectEagerLoadingWrapper.wrap(represented)
-        end
-
         links :representations do
           [
             representation_format_csv,
             representation_format_xls
           ]
         end
+
+        protected
 
         def representation_format(format, mime_type:)
           {
@@ -70,6 +66,10 @@ module API
         def representation_format_csv
           representation_format 'csv',
                                 mime_type: 'text/csv'
+        end
+
+        def paged_models(models)
+          ::API::V3::Projects::ProjectEagerLoadingWrapper.wrap(super)
         end
       end
     end

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -490,12 +490,13 @@ module API
             "#{project(project_id)}/work_packages"
           end
 
-          def self.path_for(path, filters: nil, sort_by: nil, group_by: nil, page_size: nil)
+          def self.path_for(path, filters: nil, sort_by: nil, group_by: nil, page_size: nil, offset: nil)
             query_params = {
               filters: filters&.to_json,
               sortBy: sort_by&.to_json,
               groupBy: group_by,
-              pageSize: page_size
+              pageSize: page_size,
+              offset: offset
             }.reject { |_, v| v.blank? }
 
             if query_params.any?

--- a/spec/requests/api/v3/project_resource_spec.rb
+++ b/spec/requests/api/v3/project_resource_spec.rb
@@ -200,7 +200,27 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
 
     it_behaves_like 'API V3 collection response', 1, 1, 'Project'
 
-    context 'filtering for project by ancestor' do
+    context 'with a pageSize and offset' do
+      let(:projects) { [project, project2, project3] }
+      let(:project2) do
+        FactoryBot.create(:project,
+                          members: { current_user => [role] })
+      end
+      let(:project3) do
+        FactoryBot.create(:project,
+                          members: { current_user => [role] })
+      end
+
+      let(:get_path) do
+        api_v3_paths.path_for :projects, sort_by: { id: :asc }, page_size: 2, offset: 2
+      end
+
+      it_behaves_like 'API V3 collection response', 3, 1, 'Project' do
+        let(:elements) { [project3] }
+      end
+    end
+
+    context 'when filtering for project by ancestor' do
       let(:projects) { [project, other_project, parent_project] }
 
       let(:parent_project) do


### PR DESCRIPTION
Before the fix, the pageSize attribute was ignored when querying the projects api resulting in potentially returning all the projects. 