### PR TITLE
[40296] Incorrect label causes screenreader problems

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/editing-portal/edit-form-portal.component.html
+++ b/frontend/src/app/shared/components/fields/edit/editing-portal/edit-form-portal.component.html
@@ -9,7 +9,7 @@
            class="hidden-for-sighted">
       {{handler.fieldLabel}}
 
-      {{handler.errorMessageOnLabel}}
+      {{handler.errorMessageOnLabel()}}
     </label>
     <ng-container *ngComponentOutlet="componentClass; injector: fieldInjector"></ng-container>
   </form>


### PR DESCRIPTION
Call the function in the correct way while using text interpolation, so it won't show the function as a text in label.

https://community.openproject.org/projects/openproject/work_packages/40296/activity