### PR TITLE
[40396] no "Example" for Host name in "Administration->General"

### DIFF
--- a/app/controllers/admin/settings/general_settings_controller.rb
+++ b/app/controllers/admin/settings/general_settings_controller.rb
@@ -32,6 +32,11 @@ module Admin::Settings
   class GeneralSettingsController < ::Admin::SettingsController
     menu_item :settings_general
 
+    def show
+      super
+      @guessed_host = request.host_with_port.dup
+    end
+
     def default_breadcrumb
       t(:label_general)
     end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -48,7 +48,6 @@ module Admin
     end
 
     def show
-      @guessed_host = request.host_with_port.dup
       respond_to :html
     end
 

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -48,6 +48,7 @@ module Admin
     end
 
     def show
+      @guessed_host = request.host_with_port.dup
       respond_to :html
     end
 


### PR DESCRIPTION
To make it looks like in earlier versions, we should set the correct value to guessed_host variable when we are in show state in its controller.

https://community.openproject.org/projects/openproject/work_packages/40396/activity