### PR TITLE
[39828] Notification center empty state showing during loading

### DIFF
--- a/frontend/src/app/features/in-app-notifications/center/empty-state/empty-state.component.html
+++ b/frontend/src/app/features/in-app-notifications/center/empty-state/empty-state.component.html
@@ -3,8 +3,8 @@
         data-qa-selector="op-empty-state"
 >
     <div class="work-packages-tab-view--overflow op-empty-state--content">
-      <ng-container *ngIf="(dataChanged$ | async ) as currentNotificationData; else loading">
-        <ng-container *ngIf="currentNotificationData[0]; else noNotification">
+      <ng-container *ngIf="(loading$ | async) === false; else loading">
+        <ng-container *ngIf="(hasNotifications$ | async) as hasNotifications; else noNotification">
           <img [src]="image.no_selection" class="op-empty-state--content-image"/>
           <p class="op-empty-state--content-text">
             <span>{{ text.no_selection }}</span>
@@ -13,7 +13,7 @@
         <ng-template #noNotification>
           <img [src]="image.no_notification" class="op-empty-state--content-image"/>
           <p class="op-empty-state--content-text">
-            <span [textContent]="noNotificationText(currentNotificationData[0], currentNotificationData[1])"></span>
+            <span [textContent]="noNotificationText(hasNotifications, (totalCount$ | async))"></span>
           </p>
         </ng-template>
 

--- a/frontend/src/app/features/in-app-notifications/center/empty-state/empty-state.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/empty-state/empty-state.component.ts
@@ -59,18 +59,11 @@ export class EmptyStateComponent {
     no_selection: this.I18n.t('js.notifications.center.empty_state.no_selection'),
   };
 
-  private hasNotifications$ = this.storeService.query.hasNotifications$;
+  hasNotifications$ = this.storeService.query.hasNotifications$;
 
-  private totalCount$ = this.bellService.unread$;
+  totalCount$ = this.bellService.unread$;
 
-  dataChanged$ = combineLatest([
-    this.hasNotifications$,
-    this.totalCount$,
-  ])
-    .pipe(
-      distinctUntilChanged(),
-      debounceTime(350),
-    );
+  loading$ = this.storeService.query.selectLoading();
 
   constructor(
     readonly I18n:I18nService,

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.html
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.html
@@ -1,11 +1,6 @@
 <div class="op-ian-center">
-  <div class="op-ian-center--loading-indicator" *ngIf="loading$ | async">
-    <op-content-loader>
-      <svg:rect x="0" y="0" width="100%" height="100%" rx="1" />
-    </op-content-loader>
-  </div>
   <div class="op-ian-center--content">
-    <ng-container *ngIf="(hasNotifications$ | async); else noResults">
+    <ng-container *ngIf="dataLoaded || (hasNotifications$ | async); else noResults">
       <cdk-virtual-scroll-viewport
           itemSize="100"
           class="op-ian-center--viewport"
@@ -24,7 +19,7 @@
         ></op-in-app-notification-entry>
       </cdk-virtual-scroll-viewport>
     </ng-container>
-    <ng-template #noResults>
+    <ng-template #noResults> 
       <no-results *ngIf="(loading$ | async) === false"
                   [title]="noResultText$ | async"
                   [description]="text.change_notification_settings"

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.html
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.html
@@ -1,6 +1,6 @@
 <div class="op-ian-center">
   <div class="op-ian-center--content">
-    <ng-container *ngIf="dataLoaded || (hasNotifications$ | async); else noResults">
+    <ng-container *ngIf="(hasNotifications$ | async); else noResults">
       <cdk-virtual-scroll-viewport
           itemSize="100"
           class="op-ian-center--viewport"

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.html
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.html
@@ -19,7 +19,7 @@
         ></op-in-app-notification-entry>
       </cdk-virtual-scroll-viewport>
     </ng-container>
-    <ng-template #noResults> 
+    <ng-template #noResults>
       <no-results *ngIf="(loading$ | async) === false"
                   [title]="noResultText$ | async"
                   [description]="text.change_notification_settings"

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
@@ -36,6 +36,8 @@ export class InAppNotificationCenterComponent implements OnInit {
 
   notifications$ = this.storeService.query.notifications$;
 
+  dataLoaded = true;
+
   loading$ = this.storeService.query.selectLoading();
 
   private totalCount$ = this.bellService.unread$;
@@ -93,6 +95,7 @@ export class InAppNotificationCenterComponent implements OnInit {
   }
 
   ngOnInit():void {
+    this.loading$.subscribe(isLoading => { this.dataLoaded = isLoading; });
     this.storeService.setFacet('unread');
     this.storeService.setFilters({
       filter: this.uiRouterGlobals.params.filter, // eslint-disable-line @typescript-eslint/no-unsafe-assignment

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
@@ -36,8 +36,6 @@ export class InAppNotificationCenterComponent implements OnInit {
 
   notifications$ = this.storeService.query.notifications$;
 
-  dataLoaded = true;
-
   loading$ = this.storeService.query.selectLoading();
 
   private totalCount$ = this.bellService.unread$;
@@ -95,7 +93,6 @@ export class InAppNotificationCenterComponent implements OnInit {
   }
 
   ngOnInit():void {
-    this.loading$.subscribe((isLoading) => { this.dataLoaded = isLoading; });
     this.storeService.setFacet('unread');
     this.storeService.setFilters({
       filter: this.uiRouterGlobals.params.filter, // eslint-disable-line @typescript-eslint/no-unsafe-assignment

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
@@ -95,7 +95,7 @@ export class InAppNotificationCenterComponent implements OnInit {
   }
 
   ngOnInit():void {
-    this.loading$.subscribe(isLoading => { this.dataLoaded = isLoading; });
+    this.loading$.subscribe((isLoading) => { this.dataLoaded = isLoading; });
     this.storeService.setFacet('unread');
     this.storeService.setFilters({
       filter: this.uiRouterGlobals.params.filter, // eslint-disable-line @typescript-eslint/no-unsafe-assignment

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -76,7 +76,6 @@ export class IanCenterService extends UntilDestroyedMixin {
     switchMap(() => this.resourceService
       .fetchNotifications(this.query.params)
       .pipe(
-        // We don't want to set loading if the request is sent in the background
         switchMap(
           (results) => from(this.sideLoadInvolvedWorkPackages(results._embedded.elements))
             .pipe(

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -11,6 +11,7 @@ import {
   shareReplay,
   switchMap,
   take,
+  tap,
 } from 'rxjs/operators';
 import {
   from,
@@ -67,11 +68,15 @@ export class IanCenterService extends UntilDestroyedMixin {
 
   private onReload = this.reload.pipe(
     debounceTime(0),
-    switchMap((setToLoading) => this.resourceService
+    tap((setToLoading) => {
+      if (setToLoading) {
+        this.store.setLoading(true);
+      }
+    }),
+    switchMap(() => this.resourceService
       .fetchNotifications(this.query.params)
       .pipe(
         // We don't want to set loading if the request is sent in the background
-        setToLoading ? setLoading(this.store) : map((res) => res),
         switchMap(
           (results) => from(this.sideLoadInvolvedWorkPackages(results._embedded.elements))
             .pipe(
@@ -79,6 +84,14 @@ export class IanCenterService extends UntilDestroyedMixin {
             ),
         ),
       )),
+
+    // We need to be slower than the onReload subscribers set below.
+    // Because they're subscribers they're called next in the callback queue.
+    // We need our loading state to be set to false only after all data is in the store,
+    // but we cannot guarantee that here, since the data is set _after_ this piece of code
+    // gets run. The solution is to queue this piece of code back, allowing the store contents
+    // update before the loading state gets reset.
+    tap(() => setTimeout(() => this.store.setLoading(false))),
   );
 
   public selectedNotificationIndex = 0;


### PR DESCRIPTION
Here the content loader is not necessary since we have a content loader for each entry and the gray rectangle won't be shown if we remove it. When the data is completely loaded we should show the entries.

https://community.openproject.org/projects/openproject/work_packages/39828/activity