### PR TITLE
Feature/40330 ancestors in projects endpoint

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -34,6 +34,7 @@ class Project < ApplicationRecord
 
   include Projects::Storage
   include Projects::Activity
+  include Projects::AncestorsFromRoot
   include ::Scopes::Scoped
 
   # Maximum length for project identifiers

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -501,15 +501,18 @@ class User < Principal
   end
 
   # Returns true if user is arg or belongs to arg
+  # rubocop:disable Naming/PredicateName
   def is_or_belongs_to?(arg)
-    if arg.is_a?(User)
+    case arg
+    when User
       self == arg
-    elsif arg.is_a?(Group)
+    when Group
       arg.users.include?(self)
     else
       false
     end
   end
+  # rubocop:enable Naming/PredicateName
 
   def self.allowed(action, project)
     Authorization.users(action, project)
@@ -531,9 +534,7 @@ class User < Principal
     authorization_service.call(action, nil, options.merge(global: true)).result
   end
 
-  def preload_projects_allowed_to(action)
-    authorization_service.preload_projects_allowed_to(action)
-  end
+  delegate :preload_projects_allowed_to, to: :authorization_service
 
   def reported_work_package_count
     WorkPackage.on_active_project.with_author(self).visible.count

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3068,6 +3068,7 @@ en:
 
     undisclosed:
       parent: Undisclosed - The selected parent is invisible because of lacking permissions.
+      ancestor: Undisclosed - The ancestor is invisible because of lacking permissions.
 
   doorkeeper:
     pre_authorization:

--- a/docs/api/apiv3/components/examples/project.yml
+++ b/docs/api/apiv3/components/examples/project.yml
@@ -24,9 +24,17 @@ value:
       href: /api/v3/memberships?filters=[{"project":{"operator":"=","values":["1"]}}]
     customField456:
       href: "/api/v3/users/315"
-      method: A user
-    projects:
+      title: A user
+    parent:
       href: "/api/v3/projects/123"
+      title: "Parent project"
+    ancestors:
+      - href: "/api/v3/projects/2"
+        title: "Root project"
+      - href: "/api/v3/projects/12"
+        title: "Grandparent project"
+      - href: "/api/v3/projects/123"
+        title: "Parent project"
     status:
       href: "/api/v3/project_statuses/on_track"
       title: On track

--- a/docs/api/apiv3/components/examples/project_body.yml
+++ b/docs/api/apiv3/components/examples/project_body.yml
@@ -8,6 +8,7 @@ value:
     raw: Lorem **ipsum** dolor sit amet
   customField123: 123
   _links:
+    parent:
+      href: "/api/v3/projects/123"
     customField456:
       href: "/api/v3/users/315"
-      method: A user

--- a/docs/api/apiv3/tags/projects.yml
+++ b/docs/api/apiv3/tags/projects.yml
@@ -16,21 +16,22 @@ description: |-
 
   ## Linked Properties
 
-  | Link         | Description                                                                                           | Type          | Constraints | Supported operations |Condition                                              |
-  | :----------: | -------------                                                                                         | ----          | ----------- | -------------------- |-----------------------------------------              |
-  | self         | This project                                                                                          | Project       | not null    | READ                 |                                                       |
-  | categories   | Categories available in this project                                                                  | Collection    | not null    | READ                 |                                                       |
-  | types        | Types available in this project                                                                       | Collection    | not null    | READ                 | **Permission**: view work packages or manage types    |
-  | versions     | Versions available in this project                                                                    | Collection    | not null    | READ                 | **Permission**: view work packages or manage versions |
-  | memberships  | Memberships in the  project                                                                           | Collection    | not null    | READ                 | **Permission**: view members                          |
-  | workPackages | Work Packages of this project                                                                         | Collection    | not null    | READ                 |                                                       |
-  | parent       | Parent project of the project                                                                         | Project       |             | READ/WRITE           | **Permission** edit project                           |
-  | status       | Denotes the status of the project, so whether the project is on track, at risk or is having trouble.  | ProjectStatus |             | READ/WRITE           | **Permission** edit project                           |
+  | Link         | Description                                                                                                         | Type          | Constraints | Supported operations |Condition                                                                                  |
+  | :----------: | -------------                                                                                                       | ----          | ----------- | -------------------- |-----------------------------------------                                                  |
+  | self         | This project                                                                                                        | Project       | not null    | READ                 |                                                                                           |
+  | ancestors    | Array of all ancestors of the project, down from the root node (first element) to the parent (last element).        | Collection    | not null    | READ                 | **Permission** view project on the ancestor project. Non visible projects will be omitted |
+  | categories   | Categories available in this project                                                                                | Collection    | not null    | READ                 |                                                                                           |
+  | types        | Types available in this project                                                                                     | Collection    | not null    | READ                 | **Permission**: view work packages or manage types                                        |
+  | versions     | Versions available in this project                                                                                  | Collection    | not null    | READ                 | **Permission**: view work packages or manage versions                                     |
+  | memberships  | Memberships in the project                                                                                          | Collection    | not null    | READ                 | **Permission**: view members                                                              |
+  | workPackages | Work Packages of this project                                                                                       | Collection    | not null    | READ                 |                                                                                           |
+  | parent       | Parent project of the project                                                                                       | Project       |             | READ/WRITE           | **Permission** edit project                                                               |
+  | status       | Denotes the status of the project, so whether the project is on track, at risk or is having trouble.                | ProjectStatus |             | READ/WRITE           | **Permission** edit project                                                               |
 
   Depending on custom fields defined for projects, additional links might exist.
 
-  Note, that the parent link may contain the "undisclosed uri" `urn:openproject-org:api:v3:undisclosed` in case a
-  parent project is defined but the client lacks permission to see it. See the
+  Note, that the parent and ancestor links may contain the "undisclosed uri" `urn:openproject-org:api:v3:undisclosed` in case an
+  ancestor project is defined but the client lacks permission to see it. See the
   [general introduction into links' properties](https://www.openproject.org/docs/api/basic-objects/#local-properties) for more information.
 
   ## Local Properties

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -153,12 +153,31 @@ module API
           }
         end
 
+        links :ancestors,
+              uncacheable: true do
+          represented.ancestors_from_root.map do |ancestor|
+            # Explicitly check for admin as an archived project
+            # will lead to the admin loosing permissions in the project.
+            if current_user.admin? || ancestor.visible?
+              {
+                href: api_v3_paths.project(ancestor.id),
+                title: ancestor.name
+              }
+            else
+              {
+                href: API::V3::URN_UNDISCLOSED,
+                title: I18n.t(:'api_v3.undisclosed.ancestor')
+              }
+            end
+          end
+        end
+
         associated_resource :parent,
                             v3_path: :project,
                             representer: ::API::V3::Projects::ProjectRepresenter,
                             uncacheable_link: true,
                             undisclosed: true,
-                            skip_render: ->(*) { represented.parent && !represented.parent.visible? }
+                            skip_render: ->(*) { represented.parent && !represented.parent.visible? && !current_user.admin? }
 
         property :id
         property :identifier,

--- a/lib/api/v3/utilities/eager_loading/custom_field_accessor.rb
+++ b/lib/api/v3/utilities/eager_loading/custom_field_accessor.rb
@@ -37,9 +37,9 @@ module API
 
           included do
             # Because of the ruby method lookup,
-            # wrapping the work_package here and define the
+            # wrapping the object here and define the
             # available_custom_fields methods on the wrapper does not suffice.
-            # We thus extend each work package.
+            # We thus extend each object (e.g. work package).
             def initialize(object)
               super
               object.extend(CustomFieldAccessorPatch)

--- a/spec/requests/api/v3/project_resource_spec.rb
+++ b/spec/requests/api/v3/project_resource_spec.rb
@@ -82,7 +82,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
       last_response
     end
 
-    context 'logged in user' do
+    context 'for a logged in user' do
       it 'responds with 200 OK' do
         expect(subject.status).to eq(200)
       end
@@ -92,10 +92,14 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
         expect(subject.body).to be_json_eql(project.identifier.to_json).at_path('identifier')
       end
 
-      it 'links to the parent project' do
+      it 'links to the parent/ancestor project' do
         expect(subject.body)
           .to be_json_eql(api_v3_paths.project(parent_project.id).to_json)
           .at_path('_links/parent/href')
+
+        expect(subject.body)
+          .to be_json_eql(api_v3_paths.project(parent_project.id).to_json)
+          .at_path('_links/ancestors/0/href')
       end
 
       it 'includes custom fields' do
@@ -116,7 +120,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
           .at_path("_links/status/href")
       end
 
-      context 'requesting nonexistent project' do
+      context 'when requesting nonexistent project' do
         let(:get_path) { api_v3_paths.project 9999 }
 
         before do
@@ -126,7 +130,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
         it_behaves_like 'not found'
       end
 
-      context 'requesting project without sufficient permissions' do
+      context 'when requesting project without sufficient permissions' do
         let(:get_path) { api_v3_paths.project other_project.id }
 
         before do
@@ -136,8 +140,9 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
         it_behaves_like 'not found'
       end
 
-      context 'not being allowed to see the parent project' do
+      context 'when not being allowed to see the parent project' do
         let!(:parent_memberships) do
+          # no parent memberships
         end
 
         it 'shows the `undisclosed` uri' do
@@ -171,7 +176,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
       end
     end
 
-    context 'not logged in user' do
+    context 'for a not logged in user' do
       let(:current_user) { FactoryBot.create(:anonymous) }
 
       before do
@@ -236,7 +241,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
       end
 
       let(:get_path) do
-        "#{api_v3_paths.projects}?filters=#{CGI.escape(JSON.dump(filter_query))}"
+        api_v3_paths.path_for :projects, filters: filter_query
       end
 
       it_behaves_like 'API V3 collection response', 1, 1, 'Project'
@@ -256,7 +261,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
       let(:role) { FactoryBot.create(:role, permissions: [:copy_projects]) }
 
       let(:get_path) do
-        api_v3_paths.path_for :projects, filters: [{ "user_action": { "operator": "=", "values": ["projects/copy"] } }]
+        api_v3_paths.path_for :projects, filters: [{ user_action: { operator: "=", values: ["projects/copy"] } }]
       end
 
       it_behaves_like 'API V3 collection response', 1, 1, 'Project'
@@ -268,7 +273,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
       end
     end
 
-    context 'filtering for principals (members)' do
+    context 'when filtering for principals (members)' do
       let(:other_project) do
         Role.non_member
         FactoryBot.create(:public_project)
@@ -281,7 +286,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
         end
 
         let(:get_path) do
-          "#{api_v3_paths.projects}?filters=#{CGI.escape(JSON.dump(filter_query))}"
+          api_v3_paths.path_for :projects, filters: filter_query
         end
 
         it 'returns the filtered for value' do
@@ -297,7 +302,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
         end
 
         let(:get_path) do
-          "#{api_v3_paths.projects}?filters=#{CGI.escape(JSON.dump(filter_query))}"
+          api_v3_paths.path_for :projects, filters: filter_query
         end
 
         it 'returns the projects not matching the value' do
@@ -331,7 +336,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
       end
 
       let(:get_path) do
-        api_v3_paths.path_for :projects, filters: [{ "visible": { "operator": "=", "values": [other_user.id.to_s] } }]
+        api_v3_paths.path_for :projects, filters: [{ visible: { operator: "=", values: [other_user.id.to_s] } }]
       end
 
       current_user { admin }
@@ -439,9 +444,9 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
         expect(last_response.body)
           .to be_json_eql(
             {
-              "format": "markdown",
-              "html": "<p class=\"op-uc-p\">Some explanation.</p>",
-              "raw": "Some explanation."
+              format: "markdown",
+              html: "<p class=\"op-uc-p\">Some explanation.</p>",
+              raw: "Some explanation."
             }.to_json
           )
           .at_path("statusExplanation")
@@ -462,7 +467,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
           identifier: 'new_project_identifier',
           name: 'Project name',
           "customField#{custom_field.id}": {
-            "raw": "CF text"
+            raw: "CF text"
           }
         }.to_json
       end
@@ -597,7 +602,7 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
       let(:body) do
         {
           "customField#{custom_field.id}": {
-            "raw": "CF text"
+            raw: "CF text"
           }
         }
       end
@@ -653,9 +658,9 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
         expect(last_response.body)
           .to be_json_eql(
             {
-              "format": "markdown",
-              "html": "<p class=\"op-uc-p\">Some explanation.</p>",
-              "raw": "Some explanation."
+              format: "markdown",
+              html: "<p class=\"op-uc-p\">Some explanation.</p>",
+              raw: "Some explanation."
             }.to_json
           )
           .at_path("statusExplanation")
@@ -684,9 +689,9 @@ describe 'API v3 Project resource', type: :request, content_type: :json do
         expect(last_response.body)
           .to be_json_eql(
             {
-              "format": "markdown",
-              "html": "<p class=\"op-uc-p\">Some explanation.</p>",
-              "raw": "Some explanation."
+              format: "markdown",
+              html: "<p class=\"op-uc-p\">Some explanation.</p>",
+              raw: "Some explanation."
             }.to_json
           )
           .at_path("statusExplanation")


### PR DESCRIPTION
Adds the ancestor list to the project resource ([from root down the hierarchy to the parent project](https://github.com/opf/openproject/compare/feature/40330-ancestors-in-projects-endpoint?expand=1#diff-c17e144789fa0f3c6d394a0e930459b602ddd3dd88013eccb5e670420e94791dR22)).

In line with the project reference, an ancestor that is not visible will be present as an undisclosed element. The PR also fixes the behaviour for an administrator user so that archived projects are still displayed.

https://community.openproject.org/wp/40330