### PR TITLE
paginate relations collection

### DIFF
--- a/lib/api/v3/relations/relation_paginated_collection_representer.rb
+++ b/lib/api/v3/relations/relation_paginated_collection_representer.rb
@@ -31,10 +31,10 @@
 module API
   module V3
     module Relations
-      # TODO: Usage of this is to be replaced by its paginated equivalent once the front end
-      # handles paginated responses.
-      class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
+      class RelationPaginatedCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
         self.to_eager_load = ::API::V3::Relations::RelationRepresenter.to_eager_load
+
+        element_decorator RelationRepresenter
       end
     end
   end

--- a/lib/api/v3/relations/relations_api.rb
+++ b/lib/api/v3/relations/relations_api.rb
@@ -26,26 +26,19 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'api/v3/relations/relation_representer'
-require 'api/v3/relations/relation_collection_representer'
-
-require 'relations/create_service'
-require 'relations/update_service'
-
 module API
   module V3
     module Relations
       class RelationsAPI < ::API::OpenProjectAPI
         resources :relations do
-          get do
-            scope = Relation
-                    .non_hierarchy
-                    .includes(::API::V3::Relations::RelationRepresenter.to_eager_load)
-
-            ::API::V3::Utilities::ParamsToQuery.collection_response(scope,
-                                                                    current_user,
-                                                                    params)
-          end
+          get &::API::V3::Utilities::Endpoints::Index.new(model: Relation,
+                                                          scope: -> {
+                                                            Relation
+                                                              .non_hierarchy
+                                                              .includes(::API::V3::Relations::RelationRepresenter.to_eager_load)
+                                                          },
+                                                          render_representer: RelationPaginatedCollectionRepresenter)
+                                                     .mount
 
           route_param :id, type: Integer, desc: 'Relation ID' do
             after_validation do

--- a/spec/lib/api/v3/relations/relation_collection_representer_spec.rb
+++ b/spec/lib/api/v3/relations/relation_collection_representer_spec.rb
@@ -34,11 +34,10 @@ describe ::API::V3::Relations::RelationCollectionRepresenter do
   end
 
   let(:relations) do
-    (1..3).map do
-      FactoryBot.build_stubbed(:relation,
-                               from: work_package,
-                               to: FactoryBot.build_stubbed(:work_package))
-    end
+    FactoryBot.build_stubbed_list(:relation,
+                                  3,
+                                  from: work_package,
+                                  to: FactoryBot.build_stubbed(:work_package))
   end
 
   let(:user) do

--- a/spec/lib/api/v3/relations/relation_paginated_collection_representer_spec.rb
+++ b/spec/lib/api/v3/relations/relation_paginated_collection_representer_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2021 the OpenProject GmbH
@@ -28,14 +26,50 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
-    module Relations
-      # TODO: Usage of this is to be replaced by its paginated equivalent once the front end
-      # handles paginated responses.
-      class RelationCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
-        self.to_eager_load = ::API::V3::Relations::RelationRepresenter.to_eager_load
-      end
+require 'spec_helper'
+
+describe ::API::V3::Relations::RelationPaginatedCollectionRepresenter do
+  let(:work_package) do
+    FactoryBot.build_stubbed(:work_package)
+  end
+
+  let(:relations) do
+    FactoryBot.build_stubbed_list(:relation, total).tap do |relations|
+      allow(relations)
+        .to receive(:per_page)
+              .with(page_size)
+              .and_return(relations)
+
+      allow(relations)
+        .to receive(:page)
+              .with(page)
+              .and_return(relations)
+
+      allow(relations)
+        .to receive(:count)
+              .and_return(relations.length)
     end
   end
+
+  let(:user) do
+    FactoryBot.build_stubbed(:user)
+  end
+
+  let(:representer) do
+    described_class.new(relations,
+                        self_link: self_base_link,
+                        page: page,
+                        per_page: page_size,
+                        current_user: user)
+  end
+  let(:total) { 3 }
+  let(:page) { 1 }
+  let(:page_size) { 20 }
+  let(:actual_count) { total }
+  let(:self_base_link) { 'api/v3/relations' }
+  let(:collection_inner_type) { 'Relation' }
+
+  subject(:collection) { representer.to_json }
+
+  it_behaves_like 'offset-paginated APIv3 collection', 3, 'relations', 'Relation'
 end

--- a/spec/requests/api/v3/relations_resource_spec.rb
+++ b/spec/requests/api/v3/relations_resource_spec.rb
@@ -86,7 +86,9 @@ describe 'API v3 Relation resource', type: :request do
         get path
       end
 
-      it_behaves_like 'API V3 collection response', 1, 1, 'Relation'
+      it_behaves_like 'API V3 collection response', 1, 1, 'Relation' do
+        let(:elements) { [visible_relation] }
+      end
     end
 
     context 'when not having view_work_packages' do


### PR DESCRIPTION
The response to /api/v3/relations is paginated.

The response to /api/v3/work_packages/:id/relations is not yet paginated as:
* The front end currently does not handle pagination
* The expected amount of relations returned is lower as it is limited to the relations from/to the one work package.

https://community.openproject.org/wp/40434