### PR TITLE
Allow ./bin/rails to work with pending migrations

### DIFF
--- a/config/initializers/06-pending_migrations_check.rb
+++ b/config/initializers/06-pending_migrations_check.rb
@@ -30,7 +30,8 @@
 
 is_console = Rails.const_defined? 'Console'
 no_rake_task = !(Rake.respond_to?(:application) && Rake.application.top_level_tasks.present?)
+no_override = ENV['OPENPROJECT_DISABLE__MIGRATIONS__CHECK'] != 'true'
 
-if Rails.env.production? && !is_console && no_rake_task
+if Rails.env.production? && !is_console && no_rake_task && no_override
   ActiveRecord::Migration.check_pending! # will raise an exception and abort boot
 end

--- a/config/initializers/06-pending_migrations_check.rb
+++ b/config/initializers/06-pending_migrations_check.rb
@@ -28,21 +28,9 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# We want to abort booting when there are missing migrations by default
-# since it can lead to runtime schema cache issues.
-# Refusing to boot will encourage admins to fix missing migrations.
-
-exceptions = %w(
-  db:create db:drop
-  db:migrate db:migrate:down db:migrate:redo db:migrate:up db:migrate:status
-  db:prepare db:reset db:rollback
-  db:structure:load db:schema:load
-  db:environment:set
-  db:version
-  assets:precompile assets:clean
-)
 is_console = Rails.const_defined? 'Console'
+no_rake_task = !(Rake.respond_to?(:application) && Rake.application.top_level_tasks.present?)
 
-if Rails.env.production? && !is_console && (exceptions & ARGV).empty?
+if Rails.env.production? && !is_console && no_rake_task
   ActiveRecord::Migration.check_pending! # will raise an exception and abort boot
 end


### PR DESCRIPTION
The initializer `06-pending_migrations_check` did not work with `rails` (vs `rake`) due to checking the `ARGV`.