### PR TITLE
[#40282] wrong position of xeokit context menu

### DIFF
--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/styles/context_menu.sass
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/styles/context_menu.sass
@@ -6,6 +6,7 @@
   visibility: visible
   border: none !important
   box-shadow: none !important
+  width: 200px
 
   &> ul
     @extend .dropdown-menu


### PR DESCRIPTION
Backporting of PR #9995 which made it into `dev` instead of `release/12.0`.
====

- https://community.openproject.org/work_packages/40282
- added fix xeokit context menu width to fit the offset math of xeokit
