### PR TITLE
[40191] Git "View Differences" results in 500 error in Repository module

### DIFF
--- a/app/views/repositories/diff.html.erb
+++ b/app/views/repositories/diff.html.erb
@@ -52,8 +52,8 @@ See COPYRIGHT and LICENSE files for more details.
   <% if !@path.blank? %>
     <% unidiff_link.gsub!('?', '&amp;') %>
   <% end %>
-  <% wrong_url = CGI::escapeHTML(URI.encode(with_leading_slash(@path))).concat('.diff') %>
-  <% good_url = '.diff'.concat('?repo_path=', URI.encode(without_leading_slash(@path)).gsub('&', '%26')) %>
+  <% wrong_url = CGI::escapeHTML(CGI.escape(with_leading_slash(@path))).concat('.diff') %>
+  <% good_url = '.diff'.concat('?repo_path=', CGI.escape(without_leading_slash(@path)).gsub('&', '%26')) %>
   <% unidiff_link.gsub!(wrong_url, good_url) %>
   <%= unidiff_link.html_safe %>
 <% end %>


### PR DESCRIPTION
`URI.encode` is outdated with ruby 3.0 and replaced here.

https://community.openproject.org/projects/openproject/work_packages/40191/activity