### PR TITLE
resilient notification selection upon empty time zone setting

### DIFF
--- a/spec/models/users/scopes/having_reminder_mail_to_send_spec.rb
+++ b/spec/models/users/scopes/having_reminder_mail_to_send_spec.rb
@@ -575,6 +575,27 @@ describe User, '.having_reminder_mail_to_send', type: :model do
     end
   end
 
+  context 'for a user without a blank time zone' do
+    let(:paris_user) do
+      FactoryBot.create(
+        :user,
+        firstname: 'Europe/Paris',
+        preferences: {
+          time_zone: '',
+          daily_reminders: {
+            enabled: true,
+            times: [hitting_reminder_slot_for("Etc/UTC", current_time)]
+          }
+        }
+      )
+    end
+
+    it 'is including the user as Etc/UTC is assumed' do
+      expect(scope)
+        .to match_array([paris_user])
+    end
+  end
+
   context 'for a user without a time zone and daily_reminders at 08:00' do
     let(:paris_user) do
       FactoryBot.create(


### PR DESCRIPTION
The PR ensures that blank values are treated as a NULL so that the fallback to the default time zone can take place.

https://community.openproject.org/wp/40512