### PR TITLE
Add tests for team planner drag and drop behavior

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -320,11 +320,15 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
         }
 
         const assignee = this.wpAssignee(workPackage);
+        const durationEditable = this.eventDurationEditable(workPackage);
+        const resourceEditable = this.eventResourceEditable(workPackage);
+
         return {
           id: `${workPackage.href as string}-${assignee}`,
           resourceId: assignee,
-          durationEditable: this.eventDurationEditable(workPackage),
-          resourceEditable: this.eventResourceEditable(workPackage),
+          editable: durationEditable || resourceEditable,
+          durationEditable,
+          resourceEditable,
           constraint: this.eventConstaints(workPackage),
           title: workPackage.subject,
           start: this.wpStartDate(workPackage),

--- a/modules/backlogs/spec/features/stories_in_backlog_spec.rb
+++ b/modules/backlogs/spec/features/stories_in_backlog_spec.rb
@@ -253,6 +253,8 @@ describe 'Stories in backlog',
     backlogs_page
       .drag_in_sprint(backlog_story1, sprint_story2, before: false)
 
+    sleep(0.5)
+
     backlogs_page
       .expect_stories_in_order(sprint, new_story, sprint_story2, backlog_story1, sprint_story1)
 

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -150,21 +150,7 @@ module Pages
       moved_element = find(story_selector(moved))
       target_element = find(story_selector(target))
 
-      page
-        .driver
-        .browser
-        .action
-        .move_to(moved_element.native)
-        .click_and_hold(moved_element.native)
-        .perform
-
-      page
-        .driver
-        .browser
-        .action
-        .move_to(target_element.native, 0, before ? +10 : +20)
-        .release
-        .perform
+      drag_n_drop_element from: moved_element, to: target_element, offset_x: 0, offset_y: before ? +10 : +20
     end
 
     def fold_backlog(backlog)

--- a/modules/backlogs/spec/support/pages/taskboard.rb
+++ b/modules/backlogs/spec/support/pages/taskboard.rb
@@ -88,21 +88,10 @@ module Pages
       moved_element = find("#work_package_#{dragged_task.id}")
       target_element = find("#work_package_#{target.id}")
 
-      page
-        .driver
-        .browser
-        .action
-        .move_to(moved_element.native)
-        .click_and_hold(moved_element.native)
-        .perform
-
-      page
-        .driver
-        .browser
-        .action
-        .move_to(target_element.native, before_or_after == :before ? 0 : +50, +40)
-        .release
-        .perform
+      drag_n_drop_element from: moved_element,
+                          to: target_element,
+                          offset_x: before_or_after == :before ? 0 : +50,
+                          offset_y: +40
     end
 
     def drag_to_column(dragged_task, story, col_number)

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -160,23 +160,7 @@ module Pages
       source = page.all("#{list_selector(from)} [data-qa-selector='op-wp-single-card']")[index]
       target = page.find list_selector(to)
 
-      scroll_to_element(source)
-      page
-        .driver
-        .browser
-        .action
-        .move_to(source.native)
-        .click_and_hold(source.native)
-        .perform
-
-      scroll_to_element(target)
-      page
-        .driver
-        .browser
-        .action
-        .move_to(target.native)
-        .release
-        .perform
+      drag_n_drop_element(from: source, to: target)
     end
 
     def add_list(option: nil, query: option)

--- a/modules/team_planner/spec/features/team_planner_error_handling_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_error_handling_spec.rb
@@ -1,0 +1,84 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require_relative './shared_context'
+
+describe 'Team planner error handling', type: :feature, js: true do
+  include_context 'with team planner full access'
+
+  let!(:first_wp) do
+    FactoryBot.create :work_package,
+                      project: project,
+                      type: type,
+                      assigned_to: user,
+                      start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
+                      due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
+  end
+
+  let!(:custom_field) do
+    FactoryBot.create(:work_package_custom_field,
+                      default_value: nil,
+                      is_for_all: true,
+                      is_required: false)
+  end
+
+  let(:type) { FactoryBot.create(:type, custom_fields: [custom_field]) }
+
+  context 'with full permissions' do
+    before do
+      project.types << type
+      project.save!
+
+      custom_field.is_required = true
+      custom_field.save!
+
+      team_planner.visit!
+
+      team_planner.add_assignee user
+
+      team_planner.within_lane(user) do
+        team_planner.expect_event first_wp, present: true
+      end
+    end
+
+    it 'cannot change the wp because of required fields not being set' do
+      # Try to move the wp
+      retry_block do
+        team_planner.drag_wp_by_pixel(first_wp, 150, 0)
+      end
+      team_planner.expect_toast(type: :error, message: 'Custom Field Nr. 1 can\'t be blank')
+
+      team_planner.within_lane(user) do
+        team_planner.expect_event first_wp
+      end
+    end
+  end
+end

--- a/modules/team_planner/spec/features/team_planner_user_interaction_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_user_interaction_spec.rb
@@ -126,7 +126,9 @@ describe 'Team planner drag&dop and resizing', type: :feature, js: true do
       end
 
       # Move the third WP to the empty row of the other user
-      team_planner.drag_wp_by_pixel(third_wp, 0, 100)
+      retry_block do
+        team_planner.drag_wp_by_pixel(third_wp, 0, 100)
+      end
       team_planner.expect_and_dismiss_toaster(message: I18n.t('js.notice_successful_update'))
 
       team_planner.within_lane(user) do

--- a/modules/team_planner/spec/features/team_planner_user_interaction_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_user_interaction_spec.rb
@@ -31,7 +31,7 @@
 require 'spec_helper'
 require_relative './shared_context'
 
-describe 'Team planner', type: :feature, js: true do
+describe 'Team planner drag&dop and resizing', type: :feature, js: true do
   include_context 'with team planner full access'
 
   let!(:other_user) do

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -144,7 +144,7 @@ module Pages
         resizer = wp_strip.find('.fc-event-resizer-end')
       end
 
-      drag_by_pixel(element: resizer, by_x: number_of_days * 150, by_y: 0) unless resizer.nil?
+      drag_by_pixel(element: resizer, by_x: number_of_days * 170, by_y: 0) unless resizer.nil?
     end
 
     def drag_wp_by_pixel(work_package, x, y)
@@ -152,6 +152,14 @@ module Pages
                  .find('.fc-event', text: work_package.subject)
 
       drag_by_pixel(element: source, by_x: x, by_y: y)
+    end
+
+    def expect_wp_not_resizable(work_package)
+      expect(page).to have_selector('.fc-event:not(.fc-event-resizable)', text: work_package.subject)
+    end
+
+    def expect_wp_not_draggable(work_package)
+      expect(page).to have_selector('.fc-event:not(.fc-event-draggable)', text: work_package.subject)
     end
   end
 end

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -127,6 +127,26 @@ module Pages
                           query: name,
                           results_selector: 'body'
     end
+
+    def change_wp_date_by_resizing(work_package, number_of_days:, is_start_date:)
+      wp_strip = page.find('.fc-event', text: work_package.subject)
+
+      page
+        .driver
+        .browser
+        .action
+        .move_to(wp_strip.native)
+        .perform
+
+      if is_start_date
+        resizer = wp_strip.find('.fc-event-resizer-start')
+      else
+        resizer = wp_strip.find('.fc-event-resizer-end')
+      end
+
+      drag_by_pixel(element: resizer, by_x: number_of_days * 150, by_y: 0) unless resizer.nil?
+    end
+
     def drag_wp_by_pixel(work_package, x, y)
       source = page
                  .find('.fc-event', text: work_package.subject)

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -51,7 +51,9 @@ module Pages
     end
 
     def expect_empty_state(present: true)
-      expect(page).to have_conditional_selector(present, '.op-team-planner--no-data', text: 'Add assignees to set up your team planner.')
+      expect(page).to have_conditional_selector(present,
+                                                '.op-team-planner--no-data',
+                                                text: 'Add assignees to set up your team planner.')
     end
 
     def expect_assignee(user, present: true)
@@ -138,20 +140,16 @@ module Pages
         .move_to(wp_strip.native)
         .perform
 
-      if is_start_date
-        resizer = wp_strip.find('.fc-event-resizer-start')
-      else
-        resizer = wp_strip.find('.fc-event-resizer-end')
-      end
+      resizer = is_start_date ? wp_strip.find('.fc-event-resizer-start') : wp_strip.find('.fc-event-resizer-end')
 
       drag_by_pixel(element: resizer, by_x: number_of_days * 170, by_y: 0) unless resizer.nil?
     end
 
-    def drag_wp_by_pixel(work_package, x, y)
+    def drag_wp_by_pixel(work_package, by_x, by_y)
       source = page
                  .find('.fc-event', text: work_package.subject)
 
-      drag_by_pixel(element: source, by_x: x, by_y: y)
+      drag_by_pixel(element: source, by_x: by_x, by_y: by_y)
     end
 
     def expect_wp_not_resizable(work_package)

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -105,6 +105,7 @@ module Pages
 
     def add_assignee(name)
       click_add_user
+      page.find('[data-qa-selector="tp-add-assignee"] input')
       search_user_to_add name
       select_user_to_add name
     end
@@ -125,6 +126,12 @@ module Pages
       search_autocomplete page.find('[data-qa-selector="tp-add-assignee"]'),
                           query: name,
                           results_selector: 'body'
+    end
+    def drag_wp_by_pixel(work_package, x, y)
+      source = page
+                 .find('.fc-event', text: work_package.subject)
+
+      drag_by_pixel(element: source, by_x: x, by_y: y)
     end
   end
 end

--- a/spec/features/admin/custom_fields/multi_value_custom_fields_spec.rb
+++ b/spec/features/admin/custom_fields/multi_value_custom_fields_spec.rb
@@ -31,26 +31,6 @@ require 'spec_helper'
 describe 'Multi-value custom fields creation', type: :feature, js: true do
   shared_let(:admin) { FactoryBot.create :admin }
 
-  def drag_and_drop(handle, to)
-    scroll_to_element(handle)
-    page
-      .driver
-      .browser
-      .action
-      .move_to(handle.native)
-      .click_and_hold(handle.native)
-      .perform
-
-    scroll_to_element(to)
-    page
-      .driver
-      .browser
-      .action
-      .move_to(to.native)
-      .release
-      .perform
-  end
-
   before do
     login_as(admin)
     visit custom_fields_path
@@ -103,7 +83,7 @@ describe 'Multi-value custom fields creation', type: :feature, js: true do
 
     rows = page.all('tr.custom-option-row')
     expect(rows.length).to eq(3)
-    drag_and_drop rows[0].find('.dragula-handle'), page.find('.__drag_and_drop_end_of_list')
+    drag_n_drop_element from: rows[0].find('.dragula-handle'), to: page.find('.__drag_and_drop_end_of_list')
 
     sleep 1
 

--- a/spec/support/shared/drag_and_drop_helper_spec.rb
+++ b/spec/support/shared/drag_and_drop_helper_spec.rb
@@ -1,0 +1,46 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+def drag_by_pixel(element:, by_x:, by_y:)
+  scroll_to_element(element)
+  page
+    .driver
+    .browser
+    .action
+    .move_to(element.native)
+    .click_and_hold(element.native)
+    .perform
+
+  page
+    .driver
+    .browser
+    .action
+    .move_by(by_x, by_y)
+    .release
+    .perform
+end

--- a/spec/support/shared/drag_and_drop_helper_spec.rb
+++ b/spec/support/shared/drag_and_drop_helper_spec.rb
@@ -26,8 +26,29 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+def drag_n_drop_element(from:, to:, offset_x: nil, offset_y: nil)
+  scroll_to_element(from)
+  page
+    .driver
+    .browser
+    .action
+    .move_to(from.native)
+    .click_and_hold(from.native)
+    .perform
+
+  scroll_to_element(to)
+  page
+    .driver
+    .browser
+    .action
+    .move_to(to.native, offset_x, offset_y)
+    .release
+    .perform
+end
+
 def drag_by_pixel(element:, by_x:, by_y:)
   scroll_to_element(element)
+
   page
     .driver
     .browser


### PR DESCRIPTION
### ToDo

- [x] Dragging a wp from one resource to the other
- [x] Resizing a wp to change the date
- [x] Without permissions, nothing should be possible
- [x] Error handling: 
  - [x] when required custom fields are missing
  - [x] conflicting modifications