### PR TITLE
Add pageSize=1000 to dynamic form components

### DIFF
--- a/frontend/src/app/shared/components/dynamic-forms/services/dynamic-fields/dynamic-fields.service.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/services/dynamic-fields/dynamic-fields.service.ts
@@ -7,6 +7,7 @@ import { HalLink } from 'core-app/features/hal/hal-link/hal-link';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { FormsService } from 'core-app/core/forms/forms.service';
 import { IDynamicFieldGroupConfig, IOPDynamicInputTypeSettings, IOPFormlyFieldSettings } from '../../typings';
+import { addParamToHref } from 'core-app/shared/helpers/url-helpers';
 
 @Injectable()
 export class DynamicFieldsService {
@@ -256,7 +257,7 @@ export class DynamicFieldsService {
       options = of(optionsValues);
     } else if (allowedValues.href) {
       options = this.httpClient
-        .get(allowedValues.href)
+        .get(addParamToHref(allowedValues.href, { pageSize: '1000' }))
         .pipe(
           map((response:api.v3.Result) => response._embedded.elements),
           map((options) => this.formatAllowedValues(options)),

--- a/frontend/src/app/shared/components/dynamic-forms/services/dynamic-fields/dynamic-fields.service.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/services/dynamic-fields/dynamic-fields.service.ts
@@ -257,7 +257,8 @@ export class DynamicFieldsService {
       options = of(optionsValues);
     } else if (allowedValues.href) {
       options = this.httpClient
-        .get(addParamToHref(allowedValues.href, { pageSize: '1000' }))
+        // The page size value of '-1' is a magic number that will result in the maximum allowed page size.
+        .get(addParamToHref(allowedValues.href, { pageSize: '-1' }))
         .pipe(
           map((response:api.v3.Result) => response._embedded.elements),
           map((options) => this.formatAllowedValues(options)),

--- a/frontend/src/app/shared/helpers/url-helpers.ts
+++ b/frontend/src/app/shared/helpers/url-helpers.ts
@@ -1,0 +1,14 @@
+/**
+ * Capitalize
+ */
+export function addParamToHref(href:string, params:Record<string,string>):string {
+  const url = new URL(href, window.location.origin);
+
+  Object
+    .keys(params)
+    .forEach((key) => {
+      url.searchParams.set(key, params[key])
+    });
+
+  return url.pathname + url.search;
+}

--- a/frontend/src/app/shared/helpers/url-helpers.ts
+++ b/frontend/src/app/shared/helpers/url-helpers.ts
@@ -1,13 +1,13 @@
 /**
  * Capitalize
  */
-export function addParamToHref(href:string, params:Record<string,string>):string {
+export function addParamToHref(href:string, params:Record<string, string>):string {
   const url = new URL(href, window.location.origin);
 
   Object
     .keys(params)
     .forEach((key) => {
-      url.searchParams.set(key, params[key])
+      url.searchParams.set(key, params[key]);
     });
 
   return url.pathname + url.search;

--- a/lib/api/utilities/page_size_helper.rb
+++ b/lib/api/utilities/page_size_helper.rb
@@ -35,14 +35,14 @@ module API
       # with the previous private setting `maximum_page_size`.
       # The actual value is taken from
       # max(Setting.per_page_options)
-      DEFAULT_API_MAX_SIZE ||= 500
+      DEFAULT_API_MAX_SIZE = 500
 
       ##
       # Determine set page_size from string
       def resolve_page_size(string)
         resolved_value = to_i_or_nil(string)
-        # a page size of 0 is a magic number for the maximum page size value
-        if resolved_value == 0 || resolved_value.to_i > maximum_page_size
+        # a page size of -1 is a magic number for the maximum page size value
+        if resolved_value == -1 || resolved_value.to_i > maximum_page_size
           resolved_value = maximum_page_size
         end
         resolved_value

--- a/lib/api/v3/queries/schemas/principal_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/principal_filter_dependency_representer.rb
@@ -37,9 +37,9 @@ module API
           def href_callback
             query = CGI.escape(::JSON.dump(filter_query))
 
-            # pageSize of 0 is the magic number for maximum size and not
+            # pageSize of -1 is the magic number for maximum size and not
             # the default pageSize value.
-            "#{api_v3_paths.principals}?filters=#{query}&pageSize=0"
+            "#{api_v3_paths.principals}?filters=#{query}&pageSize=-1"
           end
 
           def type

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -291,7 +291,7 @@ module API
             # keep the appended filters between requests.
             filters = static_filters + instance_filters.call(represented)
 
-            api_v3_paths.path_for(:principals, filters: filters, page_size: 0)
+            api_v3_paths.path_for(:principals, filters: filters, page_size: -1)
           }
         end
 

--- a/lib/api/v3/utilities/endpoints/index.rb
+++ b/lib/api/v3/utilities/endpoints/index.rb
@@ -102,7 +102,7 @@ module API
           def calculate_resulting_params(query, provided_params)
             calculate_default_params(query).merge(provided_params.slice('offset', 'pageSize').symbolize_keys).tap do |params|
               params[:offset] = to_i_or_nil(params[:offset])
-              params[:pageSize] = to_i_or_nil(params[:pageSize])
+              params[:pageSize] = resolve_page_size(params[:pageSize])
             end
           end
 

--- a/spec/lib/api/v3/queries/schemas/all_principals_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/all_principals_filter_dependency_representer_spec.rb
@@ -50,7 +50,7 @@ describe ::API::V3::Queries::Schemas::AllPrincipalsFilterDependencyRepresenter, 
         let(:path) { 'values' }
         let(:type) { '[]User' }
         let(:href) do
-          "#{api_v3_paths.principals}?filters=#{CGI.escape(JSON.dump(filter_query))}&pageSize=0"
+          "#{api_v3_paths.principals}?filters=#{CGI.escape(JSON.dump(filter_query))}&pageSize=-1"
         end
 
         context "for operator 'Queries::Operators::All'" do

--- a/spec/lib/api/v3/queries/schemas/group_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/group_filter_dependency_representer_spec.rb
@@ -50,7 +50,7 @@ describe ::API::V3::Queries::Schemas::GroupFilterDependencyRepresenter, clear_ca
         let(:path) { 'values' }
         let(:type) { '[]User' }
         let(:href) do
-          "#{api_v3_paths.principals}?filters=#{CGI.escape(JSON.dump(filter_query))}&pageSize=0"
+          "#{api_v3_paths.principals}?filters=#{CGI.escape(JSON.dump(filter_query))}&pageSize=-1"
         end
 
         context "for operator 'Queries::Operators::All'" do

--- a/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
@@ -55,7 +55,7 @@ describe ::API::V3::Queries::Schemas::UserFilterDependencyRepresenter, clear_cac
            { member: { operator: '=', values: [project.id.to_s] } }]
         end
         let(:href) do
-          "#{api_v3_paths.principals}?filters=#{CGI.escape(JSON.dump(filter_query))}&pageSize=0"
+          "#{api_v3_paths.principals}?filters=#{CGI.escape(JSON.dump(filter_query))}&pageSize=-1"
         end
 
         context "for operator 'Queries::Operators::Equals'" do

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -233,7 +233,7 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
 
           query = CGI.escape(::JSON.dump(params))
 
-          "#{api_v3_paths.principals}?filters=#{query}&pageSize=0"
+          "#{api_v3_paths.principals}?filters=#{query}&pageSize=-1"
         end
       end
     end
@@ -263,7 +263,7 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
 
           query = CGI.escape(::JSON.dump(params))
 
-          "#{api_v3_paths.principals}?filters=#{query}&pageSize=0"
+          "#{api_v3_paths.principals}?filters=#{query}&pageSize=-1"
         end
       end
     end


### PR DESCRIPTION
Force the dynamic fields that load allowedValues only once to get more items as before. This is only a workaround, as the response will still be limited. However, https://github.com/opf/openproject/pull/10046 will take more time I fear.