### PR TITLE
Feature/40330 wp project filter within project

### DIFF
--- a/app/models/queries/work_packages/filter/project_filter.rb
+++ b/app/models/queries/work_packages/filter/project_filter.rb
@@ -42,7 +42,7 @@ class Queries::WorkPackages::Filter::ProjectFilter < Queries::WorkPackages::Filt
   end
 
   def available?
-    !project && visible_projects.exists?
+    visible_projects.exists?
   end
 
   def type

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -365,7 +365,7 @@ class Query < ApplicationRecord
   end
 
   def project_limiting_filter
-    return if subproject_filters_involved?
+    return if project_filter_set?
 
     subproject_filter = Queries::WorkPackages::Filter::SubprojectFilter.create!
     subproject_filter.context = self
@@ -382,10 +382,14 @@ class Query < ApplicationRecord
 
   ##
   # Determine whether there are explicit filters
-  # on whether work packages from subprojects are used
-  def subproject_filters_involved?
+  # on whether work packages from
+  # * subprojects
+  # * other projects
+  # are used.
+  def project_filter_set?
     filters.any? do |filter|
-      filter.is_a?(::Queries::WorkPackages::Filter::SubprojectFilter)
+      filter.is_a?(::Queries::WorkPackages::Filter::SubprojectFilter) ||
+        filter.is_a?(::Queries::WorkPackages::Filter::ProjectFilter)
     end
   end
 

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -43,8 +43,9 @@ class Query < ApplicationRecord
   serialize :column_names, Array
   serialize :sort_criteria, Array
 
-  validates :name, presence: true
-  validates_length_of :name, maximum: 255
+  validates :name,
+            presence: true,
+            length: { maximum: 255 }
 
   validate :validate_work_package_filters
   validate :validate_columns
@@ -93,7 +94,7 @@ class Query < ApplicationRecord
   end
 
   def add_default_filter
-    return unless filters.blank?
+    return if filters.present?
 
     add_filter('status_id', 'o', [''])
   end
@@ -251,7 +252,7 @@ class Query < ApplicationRecord
 
   def column_names=(names)
     col_names = Array(names)
-                .reject(&:blank?)
+                .compact_blank
                 .map(&:to_sym)
 
     # Set column_names to blank/nil if it is equal to the default columns
@@ -335,7 +336,7 @@ class Query < ApplicationRecord
 
     statement_filters
       .map { |filter| "(#{filter.where})" }
-      .reject(&:empty?)
+      .compact_blank
       .join(' AND ')
   end
 

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -62,17 +62,6 @@ class ::Query::Results
       .order(sort_criteria_array)
   end
 
-  def versions
-    scope = Version
-            .visible
-
-    if query.project && (limiting_filter = query.project_limiting_filter)
-      scope.where(limiting_filter.where)
-    end
-
-    scope
-  end
-
   def order_option
     order_option = [group_by_sort].compact_blank.join(', ')
 

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -74,7 +74,7 @@ class ::Query::Results
   end
 
   def order_option
-    order_option = [group_by_sort].reject(&:blank?).join(', ')
+    order_option = [group_by_sort].compact_blank.join(', ')
 
     if order_option.blank?
       nil

--- a/spec/models/queries/work_packages/filter/project_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/project_filter_spec.rb
@@ -32,48 +32,60 @@ describe Queries::WorkPackages::Filter::ProjectFilter, type: :model do
   it_behaves_like 'basic query filter' do
     let(:type) { :list }
     let(:class_key) { :project_id }
+    let(:visible_projects) { build_stubbed_list(:project, 2) }
+
+    before do
+      scope = class_double(Project)
+
+      allow(Project)
+        .to receive(:visible)
+              .and_return(scope)
+
+      allow(scope)
+        .to receive(:active)
+              .and_return(visible_projects)
+
+      allow(visible_projects)
+        .to receive(:exists?)
+              .and_return(visible_projects.any?)
+    end
 
     describe '#available?' do
-      context 'within a project' do
-        it 'is false' do
-          expect(instance).to_not be_available
+      shared_examples_for 'filter availability' do
+        context 'when able to see projects' do
+          it 'is true' do
+            expect(instance).to be_available
+          end
+        end
+
+        context 'when not able to see projects' do
+          let(:visible_projects) { [] }
+
+          it 'is true' do
+            expect(instance).not_to be_available
+          end
         end
       end
 
-      context 'outside of a project' do
+      context 'when inside a project' do
+        # Used to be always false hence still checking.
+        it_behaves_like 'filter availability'
+      end
+
+      context 'when outside of a project' do
         let(:project) { nil }
 
-        it 'is true if the user can see project' do
-          allow(Project)
-            .to receive_message_chain(:visible, :active, :exists?)
-            .and_return(true)
-
-          expect(instance).to be_available
-        end
-
-        it 'is true if the user can not see project' do
-          allow(Project)
-            .to receive_message_chain(:visible, :active, :exists?)
-            .and_return(false)
-
-          expect(instance).to_not be_available
-        end
+        it_behaves_like 'filter availability'
       end
     end
 
     describe '#allowed_values' do
       let(:project) { nil }
+      let(:parent) { build_stubbed(:project, id: 1) }
+      let(:child) { build_stubbed(:project, parent: parent, id: 2) }
+      let(:visible_projects) { [parent, child] }
 
       it 'is an array of group values' do
-        parent = build_stubbed(:project, id: 1)
-        child = build_stubbed(:project, parent: parent, id: 2)
-
-        visible_projects = [parent, child]
-
-        allow(Project)
-          .to receive_message_chain(:visible, :active)
-          .and_return(visible_projects)
-
         allow(Project)
           .to receive(:project_tree)
           .with(visible_projects)
@@ -94,20 +106,13 @@ describe Queries::WorkPackages::Filter::ProjectFilter, type: :model do
     end
 
     describe '#value_objects' do
-      let(:project) { build_stubbed(:project) }
-      let(:project2) { build_stubbed(:project) }
-
       before do
-        allow(Project)
-          .to receive_message_chain(:visible, :active)
-          .and_return([project, project2])
-
-        instance.values = [project.id.to_s]
+        instance.values = [visible_projects.first.id.to_s]
       end
 
       it 'returns an array of projects' do
         expect(instance.value_objects)
-          .to match_array([project])
+          .to match_array([visible_projects.first])
       end
     end
   end

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -48,14 +48,14 @@ describe Query, type: :model do
 
   describe '.new_default' do
     it 'set the default sortation' do
-      query = Query.new_default
+      query = described_class.new_default
 
       expect(query.sort_criteria)
         .to match_array([['id', 'asc']])
     end
 
     it 'does not use the default sortation if an order is provided' do
-      query = Query.new_default(sort_criteria: [['id', 'asc']])
+      query = described_class.new_default(sort_criteria: [['id', 'asc']])
 
       expect(query.sort_criteria)
         .to match_array([['id', 'asc']])
@@ -175,14 +175,14 @@ describe Query, type: :model do
 
   describe 'hierarchies' do
     it 'is enabled in default queries' do
-      query = Query.new_default
+      query = described_class.new_default
       expect(query.show_hierarchies).to be_truthy
       query.show_hierarchies = false
       expect(query.show_hierarchies).to be_falsey
     end
 
     it 'is mutually exclusive with group_by' do
-      query = Query.new_default
+      query = described_class.new_default
       expect(query.show_hierarchies).to be_truthy
       query.group_by = :assignee
 
@@ -195,7 +195,7 @@ describe Query, type: :model do
 
   describe '#available_columns' do
     context 'with work_package_done_ratio NOT disabled' do
-      it 'should include the done_ratio column' do
+      it 'includes the done_ratio column' do
         expect(query.available_columns.map(&:name)).to include :done_ratio
       end
     end
@@ -205,7 +205,7 @@ describe Query, type: :model do
         allow(WorkPackage).to receive(:done_ratio_disabled?).and_return(true)
       end
 
-      it 'should NOT include the done_ratio column' do
+      it 'does not include the done_ratio column' do
         expect(query.available_columns.map(&:name)).not_to include :done_ratio
       end
     end
@@ -281,7 +281,7 @@ describe Query, type: :model do
         type_not_in_project
       end
 
-      context 'in project' do
+      context 'when in project' do
         before do
           query.project = project
         end
@@ -303,7 +303,7 @@ describe Query, type: :model do
         end
       end
 
-      context 'global' do
+      context 'when global' do
         before do
           query.project = nil
         end
@@ -324,7 +324,7 @@ describe Query, type: :model do
       end
     end
 
-    context 'relation_of_type columns' do
+    context 'with relation_of_type columns' do
       before do
         stub_const('Relation::TYPES',
                    relation1: { name: :label_relates_to, sym_name: :label_relates_to, order: 1, sym: :relation1 },
@@ -368,7 +368,7 @@ describe Query, type: :model do
                            [:"relations_to_type_#{type.id}"] +
                            %i(relations_of_type_relation1 relations_of_type_relation2)
 
-        expect(Query.available_columns.map(&:name)).to include *expected_columns
+        expect(described_class.available_columns.map(&:name)).to include *expected_columns
       end
     end
 
@@ -386,14 +386,14 @@ describe Query, type: :model do
         unexpected_columns = [:"relations_to_type_#{type.id}"] +
                              %i(relations_of_type_relation1 relations_of_type_relation2)
 
-        expect(Query.available_columns.map(&:name)).to include *expected_columns
-        expect(Query.available_columns.map(&:name)).not_to include *unexpected_columns
+        expect(described_class.available_columns.map(&:name)).to include *expected_columns
+        expect(described_class.available_columns.map(&:name)).not_to include *unexpected_columns
       end
     end
   end
 
   describe '#valid?' do
-    it 'should not be valid without a name' do
+    it 'is not valid without a name' do
       query.name = ''
       expect(query.save).to be_falsey
       expect(query.errors[:name].first).to include(I18n.t('activerecord.errors.messages.blank'))
@@ -415,7 +415,8 @@ describe Query, type: :model do
       let(:query) { build(:query).tap { |q| q.filters = [] } }
 
       it 'is valid' do
-        expect(query.valid?).to be_truthy
+        expect(query)
+          .to be_valid
       end
     end
 
@@ -428,8 +429,8 @@ describe Query, type: :model do
         query.add_filter('cf_' + custom_field.id.to_s, '=', [''])
       end
 
-      it 'should have the name of the custom field in the error message' do
-        expect(query).to_not be_valid
+      it 'has the name of the custom field in the error message' do
+        expect(query).not_to be_valid
         expect(query.errors.messages[:base].to_s).to include(custom_field.name)
       end
     end
@@ -661,7 +662,7 @@ describe Query, type: :model do
     end
   end
 
-  describe 'project limiting filter' do
+  describe '#statement_filters (private method)' do
     def subproject_filter?(filter)
       filter.is_a?(Queries::WorkPackages::Filter::SubprojectFilter)
     end

--- a/spec/requests/api/v3/work_packages/by_project_index_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/by_project_index_resource_spec.rb
@@ -37,7 +37,9 @@ describe API::V3::WorkPackages::WorkPackagesByProjectAPI, type: :request, conten
   let(:role) { create(:role, permissions: permissions) }
   let(:permissions) { [:view_work_packages] }
   let(:project) { create(:project_with_types, public: false) }
-  let(:path) { api_v3_paths.work_packages_by_project project.id }
+  let(:base_path) { api_v3_paths.work_packages_by_project project.id }
+  let(:query) { {} }
+  let(:path) { "#{base_path}?#{query.to_query}" }
   let(:work_packages) { [] }
 
   current_user do
@@ -71,217 +73,151 @@ describe API::V3::WorkPackages::WorkPackagesByProjectAPI, type: :request, conten
     end
   end
 
-  describe 'advanced query options' do
-    let(:base_path) { api_v3_paths.work_packages_by_project project.id }
-    let(:query) { {} }
-    let(:path) { "#{base_path}?#{query.to_query}" }
+  describe 'sorting' do
+    let(:query) { { sortBy: '[["id", "desc"]]' } }
+    let(:work_packages) { create_list(:work_package, 2, project: project) }
 
-    describe 'sorting' do
-      let(:query) { { sortBy: '[["id", "desc"]]' } }
-      let(:work_packages) { create_list(:work_package, 2, project: project) }
-
-      it 'returns both elements' do
-        expect(subject.body).to be_json_eql(2).at_path('count')
-        expect(subject.body).to be_json_eql(2).at_path('total')
-      end
-
-      it 'returns work packages in the expected order' do
-        first_wp = work_packages.first
-        last_wp = work_packages.last
-
-        expect(subject.body).to be_json_eql(last_wp.id).at_path('_embedded/elements/0/id')
-        expect(subject.body).to be_json_eql(first_wp.id).at_path('_embedded/elements/1/id')
-      end
+    it_behaves_like 'API V3 collection response', 2, 2, 'WorkPackage', 'WorkPackageCollection' do
+      let(:elements) { work_packages.reverse }
     end
+  end
 
-    describe 'filtering' do
-      let(:query) do
-        {
-          filters: [
-            {
-              priority: {
-                operator: '=',
-                values: [priority1.id.to_s]
-              }
-            }
-          ].to_json
-        }
-      end
-      let(:priority1) { create(:priority, name: 'Prio A') }
-      let(:priority2) { create(:priority, name: 'Prio B') }
-      let(:work_packages) do
-        [
-          create(:work_package, project: project, priority: priority1),
-          create(:work_package, project: project, priority: priority2)
-        ]
-      end
-
-      it 'returns only one element' do
-        expect(subject.body).to be_json_eql(1).at_path('count')
-        expect(subject.body).to be_json_eql(1).at_path('total')
-      end
-
-      it 'returns the matching element' do
-        expected_id = work_packages.first.id
-        expect(subject.body).to be_json_eql(expected_id).at_path('_embedded/elements/0/id')
-      end
-    end
-
-    describe 'grouping' do
-      let(:query) { { groupBy: 'priority' } }
-      let(:priority1) { build(:priority, name: 'Prio A', position: 2) }
-      let(:priority2) { build(:priority, name: 'Prio B', position: 1) }
-      let(:work_packages) do
-        [
-          create(:work_package,
-                 project: project,
-                 priority: priority1,
-                 estimated_hours: 1),
-          create(:work_package,
-                 project: project,
-                 priority: priority2,
-                 estimated_hours: 2),
-          create(:work_package,
-                 project: project,
-                 priority: priority1,
-                 estimated_hours: 3)
-        ]
-      end
-      let(:expected_group1) do
-        {
-          _links: {
-            valueLink: [{
-              href: api_v3_paths.priority(priority1.id)
-            }],
-            groupBy: {
-              href: api_v3_paths.query_group_by('priority'),
-              title: 'Priority'
-            }
-          },
-          value: priority1.name,
-          count: 2
-        }
-      end
-      let(:expected_group2) do
-        {
-          _links: {
-            valueLink: [{
-              href: api_v3_paths.priority(priority2.id)
-            }],
-            groupBy: {
-              href: api_v3_paths.query_group_by('priority'),
-              title: 'Priority'
-            }
-          },
-          value: priority2.name,
-          count: 1
-        }
-      end
-
-      it 'returns all elements' do
-        expect(subject.body).to be_json_eql(3).at_path('count')
-        expect(subject.body).to be_json_eql(3).at_path('total')
-      end
-
-      it 'returns work packages ordered by priority' do
-        prio1_path = api_v3_paths.priority(priority1.id)
-        prio2_path = api_v3_paths.priority(priority2.id)
-
-        expect(subject.body).to(be_json_eql(prio2_path.to_json)
-                                  .at_path('_embedded/elements/0/_links/priority/href'))
-        expect(subject.body).to(be_json_eql(prio1_path.to_json)
-                                  .at_path('_embedded/elements/1/_links/priority/href'))
-        expect(subject.body).to(be_json_eql(prio1_path.to_json)
-                                  .at_path('_embedded/elements/2/_links/priority/href'))
-      end
-
-      it 'contains group elements' do
-        expect(subject.body).to include_json(expected_group1.to_json).at_path('groups')
-        expect(subject.body).to include_json(expected_group2.to_json).at_path('groups')
-      end
-
-      context 'when displaying sums' do
-        let(:query) { { groupBy: 'priority', showSums: 'true' } }
-        let(:expected_group1) do
+  describe 'filtering by priority' do
+    let(:query) do
+      {
+        filters: [
           {
-            _links: {
-              valueLink: [{
-                href: api_v3_paths.priority(priority1.id)
-              }],
-              groupBy: {
-                href: api_v3_paths.query_group_by('priority'),
-                title: 'Priority'
-              }
-            },
-            value: priority1.name,
-            count: 2,
-            sums: {
-              estimatedTime: 'PT4H',
-              laborCosts: "0.00 EUR",
-              materialCosts: "0.00 EUR",
-              overallCosts: "0.00 EUR",
-              remainingTime: nil,
-              storyPoints: nil
+            priority: {
+              operator: '=',
+              values: [priority1.id.to_s]
             }
           }
-        end
-        let(:expected_group2) do
-          {
-            _links: {
-              valueLink: [{
-                href: api_v3_paths.priority(priority2.id)
-              }],
-              groupBy: {
-                href: api_v3_paths.query_group_by('priority'),
-                title: 'Priority'
-              }
-            },
-            value: priority2.name,
-            count: 1,
-            sums: {
-              estimatedTime: 'PT2H',
-              laborCosts: "0.00 EUR",
-              materialCosts: "0.00 EUR",
-              overallCosts: "0.00 EUR",
-              remainingTime: nil,
-              storyPoints: nil
-            }
-          }
-        end
-
-        it 'contains extended group elements' do
-          expect(subject.body).to include_json(expected_group1.to_json).at_path('groups')
-          expect(subject.body).to include_json(expected_group2.to_json).at_path('groups')
-        end
-      end
+        ].to_json
+      }
+    end
+    let(:priority1) { create(:priority, name: 'Prio A') }
+    let(:priority2) { create(:priority, name: 'Prio B') }
+    let(:work_packages) do
+      [
+        create(:work_package, project: project, priority: priority1),
+        create(:work_package, project: project, priority: priority2)
+      ]
     end
 
-    describe 'displaying sums' do
-      let(:query) { { showSums: 'true' } }
-      let(:work_packages) do
-        [
-          create(:work_package, project: project, estimated_hours: 1),
-          create(:work_package, project: project, estimated_hours: 2)
-        ]
-      end
+    it_behaves_like 'API V3 collection response', 1, 1, 'WorkPackage', 'WorkPackageCollection' do
+      let(:elements) { [work_packages.first] }
+    end
+  end
 
-      it 'returns both elements' do
-        expect(subject.body).to be_json_eql(2).at_path('count')
-        expect(subject.body).to be_json_eql(2).at_path('total')
-      end
+  describe 'filtering by project (one different from the project of the path)' do
+    let(:query) do
+      {
+        filters: [
+          {
+            project: {
+              operator: '=',
+              values: [other_project.id.to_s]
+            }
+          }
+        ].to_json
+      }
+    end
+    let(:other_project) { create(:project, members: { current_user => role }) }
+    let(:work_packages) { [other_project_work_package, project_work_package] }
+    let(:project_work_package) { create(:work_package, project: project) }
+    let(:other_project_work_package) { create(:work_package, project: other_project) }
 
-      it 'contains the sum element' do
-        expected = {
-          estimatedTime: 'PT3H',
-          laborCosts: "0.00 EUR",
-          materialCosts: "0.00 EUR",
-          overallCosts: "0.00 EUR",
-          remainingTime: nil,
-          storyPoints: nil
-        }
+    it_behaves_like 'API V3 collection response', 1, 1, 'WorkPackage', 'WorkPackageCollection' do
+      let(:elements) { [other_project_work_package] }
+    end
+  end
 
-        expect(subject.body).to be_json_eql(expected.to_json).at_path('totalSums')
-      end
+  describe 'grouping' do
+    let(:query) { { groupBy: 'priority' } }
+    let(:priority1) { build(:priority, name: 'Prio A', position: 2) }
+    let(:priority2) { build(:priority, name: 'Prio B', position: 1) }
+    let(:work_packages) do
+      [
+        create(:work_package,
+               project: project,
+               priority: priority1,
+               estimated_hours: 1),
+        create(:work_package,
+               project: project,
+               priority: priority2,
+               estimated_hours: 2),
+        create(:work_package,
+               project: project,
+               priority: priority1,
+               estimated_hours: 3)
+      ]
+    end
+    let(:expected_group1) do
+      {
+        _links: {
+          valueLink: [{
+            href: api_v3_paths.priority(priority1.id)
+          }],
+          groupBy: {
+            href: api_v3_paths.query_group_by('priority'),
+            title: 'Priority'
+          }
+        },
+        value: priority1.name,
+        count: 2
+      }
+    end
+    let(:expected_group2) do
+      {
+        _links: {
+          valueLink: [{
+            href: api_v3_paths.priority(priority2.id)
+          }],
+          groupBy: {
+            href: api_v3_paths.query_group_by('priority'),
+            title: 'Priority'
+          }
+        },
+        value: priority2.name,
+        count: 1
+      }
+    end
+
+    it_behaves_like 'API V3 collection response', 3, 3, 'WorkPackage', 'WorkPackageCollection' do
+      let(:elements) { [work_packages.second, work_packages.first, work_packages.third] }
+    end
+
+    it 'contains group elements' do
+      expect(subject.body).to include_json(expected_group1.to_json).at_path('groups')
+      expect(subject.body).to include_json(expected_group2.to_json).at_path('groups')
+    end
+  end
+
+
+  describe 'displaying sums' do
+    let(:query) { { showSums: 'true' } }
+    let(:work_packages) do
+      [
+        create(:work_package, project: project, estimated_hours: 1),
+        create(:work_package, project: project, estimated_hours: 2)
+      ]
+    end
+
+    it_behaves_like 'API V3 collection response', 2, 2, 'WorkPackage', 'WorkPackageCollection' do
+      let(:elements) { work_packages }
+    end
+
+    it 'contains the sum element' do
+      expected = {
+        estimatedTime: 'PT3H',
+        laborCosts: "0.00 EUR",
+        materialCosts: "0.00 EUR",
+        overallCosts: "0.00 EUR",
+        remainingTime: nil,
+        storyPoints: nil
+      }
+
+      expect(subject.body).to be_json_eql(expected.to_json).at_path('totalSums')
     end
   end
 end


### PR DESCRIPTION
Allows the `project_id` filter to be used inside a project. If the project filter is added, no subproject filter limits the results to the subprojects of the project the query is situated in (context).

As of now, the PR does not deal with the consequences of this change. Other filters are not adapted so the filter values and the availability of the filters is governed by the hosting project still and not by the value(s) of the project filter.

## TODO

* [x] Check whether filters need to adapt to value in project filter. -> They do not have to be adapted for now. Long term, they will probably have to.
* ~Check whether `#allowed_values` in filters can be simplified to now only contain the value instead of the pair of [title, value]~ out of scope. Will be done in separate PR