### PR TITLE
Add contract_actions to team_planner

### DIFF
--- a/modules/team_planner/lib/open_project/team_planner/engine.rb
+++ b/modules/team_planner/lib/open_project/team_planner/engine.rb
@@ -30,10 +30,13 @@ module OpenProject::TeamPlanner
       project_module :team_planner_view, dependencies: :work_package_tracking do
         permission :view_team_planner,
                    { 'team_planner/team_planner': %i[index] },
-                   dependencies: %i[view_work_packages]
+                   dependencies: %i[view_work_packages],
+                   contract_actions: { team_planner: %i[read] }
+
         permission :manage_team_planner,
                    { 'team_planner/team_planner': %i[index] },
-                   dependencies: %i[view_team_planner add_work_packages edit_work_packages save_queries manage_public_queries]
+                   dependencies: %i[view_team_planner add_work_packages edit_work_packages save_queries manage_public_queries],
+                   contract_actions: { team_planner: %i[create update destroy] }
       end
 
       menu :project_menu,


### PR DESCRIPTION
There are new permissions added to the team planner which are not yet available in the capabilities API due to their contract_actions missing. As we don't have specific contracts in team planner yet, there's nothing we can test for these actions. But as they depend on the work packages actions, having them in the frontend ensures we know we can save/edit/etc.