### PR TITLE
Sort team planner menu items alphabetically

### DIFF
--- a/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
@@ -187,17 +187,21 @@ export class ViewSelectComponent extends UntilDestroyedMixin implements OnInit {
       .fetchViews(params)
       .pipe(this.untilDestroyed())
       .subscribe((queryCollection) => {
-        queryCollection._embedded.elements.forEach((view) => {
-          let cat = 'private';
-          if (view.public) {
-            cat = 'public';
-          }
-          if (view.starred) {
-            cat = 'starred';
-          }
+        queryCollection
+          ._embedded
+          .elements
+          .sort((a, b) => a._links.query.title.localeCompare(b._links.query.title))
+          .forEach((view) => {
+            let cat = 'private';
+            if (view.public) {
+              cat = 'public';
+            }
+            if (view.starred) {
+              cat = 'starred';
+            }
 
-          categories[cat].push(this.toOpSideMenuItem(view));
-        });
+            categories[cat].push(this.toOpSideMenuItem(view));
+          });
 
         const staticQueries = this.opStaticQueries.getStaticQueriesForView(this.viewType);
         const newQueryLink = this.opStaticQueries.getCreateNewQueryForView(this.viewType);


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/40014/activity

This is done globally in the op-view-select component, which I think is probably preferred (so that if it's used for e.g. work packages we'll have the same behaviour). I could test this but I'm unsure how useful that'd be.