### PR TITLE
Add a format to display lastname and firstname without space

### DIFF
--- a/app/models/principals/scopes/ordered_by_name.rb
+++ b/app/models/principals/scopes/ordered_by_name.rb
@@ -59,7 +59,7 @@ module Principals::Scopes
           "concat_ws(' ', users.firstname, users.lastname)"
         when :firstname
           'users.firstname'
-        when :lastname_firstname, :lastname_coma_firstname
+        when :lastname_firstname, :lastname_coma_firstname, :lastname_n_firstname
           "concat_ws(' ', users.lastname, users.firstname)"
         when :username
           "users.login"

--- a/app/models/queries/filters/shared/user_name_filter.rb
+++ b/app/models/queries/filters/shared/user_name_filter.rb
@@ -75,6 +75,8 @@ module Queries::Filters::Shared::UserNameFilter
         'LOWER(users.firstname)'
       when :lastname_firstname
         "LOWER(CONCAT(users.lastname, CONCAT(' ', users.firstname)))"
+      when :lastname_n_firstname
+        "LOWER(CONCAT(users.lastname, users.firstname))"
       when :username
         "LOWER(users.login)"
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < Principal
     firstname_lastname: %i[firstname lastname],
     firstname: [:firstname],
     lastname_firstname: %i[lastname firstname],
+    lastname_n_firstname: %i[lastname firstname],
     lastname_coma_firstname: %i[lastname firstname],
     username: [:login]
   }.freeze
@@ -268,6 +269,7 @@ class User < Principal
 
     when :firstname_lastname      then "#{firstname} #{lastname}"
     when :lastname_firstname      then "#{lastname} #{firstname}"
+    when :lastname_n_firstname    then "#{lastname}#{firstname}"
     when :lastname_coma_firstname then "#{lastname}, #{firstname}"
     when :firstname               then firstname
     when :username                then login

--- a/spec/models/principals/scopes/ordered_by_name_spec.rb
+++ b/spec/models/principals/scopes/ordered_by_name_spec.rb
@@ -68,6 +68,12 @@ describe Principals::Scopes::OrderedByName, type: :model do
       end
     end
 
+    context 'with lastname_n_firstname user sort', with_settings: { user_format: :lastname_n_firstname } do
+      it_behaves_like 'sorted results' do
+        let(:order) { [eve.id, group.id, placeholder_user.id, alice.id] }
+      end
+    end
+
     context 'with lastname_coma_firstname user sort', with_settings: { user_format: :lastname_coma_firstname } do
       it_behaves_like 'sorted results' do
         let(:order) { [eve.id, group.id, placeholder_user.id, alice.id] }


### PR DESCRIPTION
Add a format to display Chinese username without space between lastname and firstname

So the end user can easy to `@` and search other people.