### PR TITLE
[40319] Show all statuses by default in team planner

### DIFF
--- a/frontend/src/app/features/calendar/op-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-calendar.service.ts
@@ -1,7 +1,6 @@
 import {
   ElementRef,
   Injectable,
-  SecurityContext,
 } from '@angular/core';
 import {
   CalendarOptions,
@@ -39,9 +38,7 @@ import { UIRouterGlobals } from '@uirouter/core';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { WorkPackagesListChecksumService } from 'core-app/features/work-packages/components/wp-list/wp-list-checksum.service';
 import { EventResizeDoneArg } from '@fullcalendar/interaction';
-import { HalResourceEditFieldHandler } from 'core-app/shared/components/fields/edit/field-handler/hal-resource-edit-field-handler';
 import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
-import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
 import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/resource-changeset';
 import * as moment from 'moment';
 
@@ -284,7 +281,7 @@ export class OpCalendarService extends UntilDestroyedMixin {
       t:
         'id:asc',
       f: [
-        { n: 'status', o: 'o', v: [] },
+        { n: 'status', o: '*', v: [] },
         this.dateFilter(startDate, endDate),
       ],
       pp: OpCalendarService.MAX_DISPLAYED,

--- a/modules/team_planner/spec/features/team_planner_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_spec.rb
@@ -70,6 +70,7 @@ describe 'Team planner', type: :feature, js: true do
     let!(:user_outside_project) { FactoryBot.create :user, firstname: 'Not', lastname: 'In Project' }
     let(:type_task) { FactoryBot.create :type_task }
     let(:type_bug) { FactoryBot.create :type_bug }
+    let(:closed_status) { FactoryBot.create :status, is_closed: true }
 
     let!(:other_task) do
       FactoryBot.create :work_package,
@@ -85,6 +86,7 @@ describe 'Team planner', type: :feature, js: true do
                         project: project,
                         type: type_bug,
                         assigned_to: other_user,
+                        status: closed_status,
                         start_date: Time.zone.today - 1.day,
                         due_date: Time.zone.today + 1.day,
                         subject: 'Another task for the other user'


### PR DESCRIPTION
https://community.openproject.org/wp/40319