### PR TITLE
[40790] Deal with missing menu_identifier

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -346,7 +346,7 @@ class WikiController < ApplicationController
       menu_item.menu_identifier
     elsif page.present?
       menu_item = default_menu_item(page)
-      "no-menu-item-#{menu_item.menu_identifier}".to_sym
+      "no-menu-item-#{menu_item&.menu_identifier || 'unknown'}".to_sym
     end
   end
 


### PR DESCRIPTION
While I couldn't reproduce the situation causing no item to be present like this, the `default_menu_item` might be empty and thus results in an internal error.

https://community.openproject.org/wp/40790