### PR TITLE
Remove ignoring bundle paths from eager load

### DIFF
--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -71,7 +71,6 @@ end
 Rails.autoloaders.main.ignore(Rails.root.join('lib/plugins'))
 Rails.autoloaders.main.ignore(Rails.root.join('lib/open_project/patches'))
 Rails.autoloaders.main.ignore(Rails.root.join('lib/generators'))
-Rails.autoloaders.main.ignore(Bundler.bundle_path.join('**/*.rb'))
 
 # Comment in to enable zeitwerk logging.
 # Rails.autoloaders.main.log!

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,3 @@
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>


### PR DESCRIPTION
This fixes eager loading engines such as OP plugins when they originate from a bundler path. In my tests, this failed because activestorage looks for a config file if loaded: https://github.com/rails/rails/blob/main/activestorage/lib/active_storage/engine.rb#L126-L143 and needs a default storage.yml to be added, as we do load activestorage in some places of the core even if we don't use the storage functionality.

**Steps to reproduce**

- Add a Gemfile.plugins with this content:

```
group :opf_plugins do
  gem 'openproject-proto_plugin', git: 'https://github.com/opf/openproject-proto_plugin/blob/dev/app/models/kitten.rb', branch: :dev
end
```

Then run a console in production `RAILS_ENV=production bundle exec rails console` and try to access `Kitten.first`