### PR TITLE
proper representer initialization to ensure cf inclusion

### DIFF
--- a/lib/api/v3/attachments/attachment_representer.rb
+++ b/lib/api/v3/attachments/attachment_representer.rb
@@ -53,7 +53,7 @@ module API
             next unless embed_links && container_representer
 
             container_representer
-              .new(represented.container, current_user: current_user)
+              .create(represented.container, current_user: current_user)
           end
         end
 


### PR DESCRIPTION
Representers including the CustomFieldInjector need to use the create method to ensure proper handling of the cf properties. If that representer is cached, as is the case with WorkPackages, not using the .create method will affect every subsequent rendering of the representer as well since most of the information is cached.

https://community.openproject.org/wp/40826