### PR TITLE
Disable sendNotifications to new project component

### DIFF
--- a/frontend/src/app/features/projects/components/new-project/new-project.component.ts
+++ b/frontend/src/app/features/projects/components/new-project/new-project.component.ts
@@ -33,7 +33,7 @@ export class NewProjectComponent extends UntilDestroyedMixin implements OnInit {
 
   fieldGroups:IDynamicFieldGroupConfig[];
 
-  initialPayload = {};
+  initialPayload:Record<string, unknown> = {};
 
   text = {
     use_template: this.I18n.t('js.project.use_template'),
@@ -85,7 +85,7 @@ export class NewProjectComponent extends UntilDestroyedMixin implements OnInit {
     this.resourcePath = this.apiV3Service.projects.path;
     this.fieldGroups = [{
       name: this.text.advancedSettingsLabel,
-      fieldsFilter: (field) => !['name', 'parent'].includes(field.templateOptions?.property!)
+      fieldsFilter: (field) => !['name', 'parent', 'sendNotifications'].includes(field.templateOptions?.property as string)
         && !(field.templateOptions?.required
         && !field.templateOptions.hasDefault
         && field.templateOptions.payloadValue == null),
@@ -108,6 +108,10 @@ export class NewProjectComponent extends UntilDestroyedMixin implements OnInit {
     this.initialPayload = {
       ...this.initialPayload,
       name: this.dynamicForm.model.name,
+      _meta: {
+        ...(this.initialPayload?._meta as Record<string, unknown>),
+        sendNotifications: false,
+      },
     };
     this.formUrl = selected?.href ? `${selected.href}/copy` : null;
   }


### PR DESCRIPTION
Disable the new "send notifications" when instantiating by default. Otherwise, the previous bugfix [OP#40348](https://community.openproject.org/wp/40348) makes no sense