### PR TITLE
ensure using .create for cf representer initialization

### DIFF
--- a/app/services/api/parse_resource_params_service.rb
+++ b/app/services/api/parse_resource_params_service.rb
@@ -72,16 +72,17 @@ module API
                .from_hash(request_body)
 
       deep_to_h(struct)
+        .deep_symbolize_keys
     end
 
     def struct
-      OpenStruct.new
+      Hashie::Mash.new
     end
 
     def deep_to_h(value)
       # Does not yet factor in Arrays. There hasn't been the need to do that, yet.
       case value
-      when OpenStruct, Hash
+      when Hashie::Mash, Hash
         value.to_h.transform_values do |sub_value|
           deep_to_h(sub_value)
         end

--- a/app/services/api/v3/parse_resource_params_service.rb
+++ b/app/services/api/v3/parse_resource_params_service.rb
@@ -46,10 +46,10 @@ module API
       end
 
       def struct
-        if model&.respond_to?(:available_custom_fields)
-          OpenStruct.new available_custom_fields: model.available_custom_fields(model.new)
-        else
-          super
+        super.tap do |instance|
+          if model.respond_to?(:available_custom_fields)
+            instance.available_custom_fields = model.available_custom_fields(model.new)
+          end
         end
       end
     end

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -125,7 +125,7 @@ module API
       end
 
       def format_query_sums(sums)
-        OpenStruct.new(format_column_keys(sums).merge(available_custom_fields: WorkPackageCustomField.summable.to_a))
+        Hashie::Mash.new(format_column_keys(sums).merge(available_custom_fields: WorkPackageCustomField.summable.to_a))
       end
 
       def format_column_keys(hash_by_column)

--- a/lib/api/decorators/allowed_values_by_collection_representer.rb
+++ b/lib/api/decorators/allowed_values_by_collection_representer.rb
@@ -95,7 +95,7 @@ module API
                           value_representer
                         end
 
-          representer.new(value, current_user: current_user)
+          representer.create(value, current_user: current_user)
         end
       end
     end

--- a/lib/api/decorators/linked_resource.rb
+++ b/lib/api/decorators/linked_resource.rb
@@ -228,7 +228,7 @@ module API
 
           ->(*) do
             represented.send(name)&.map do |associated|
-              representer.new(associated, current_user: current_user)
+              representer.create(associated, current_user: current_user)
             end
           end
         end

--- a/lib/api/utilities/meta_property.rb
+++ b/lib/api/utilities/meta_property.rb
@@ -58,7 +58,7 @@ module API
       protected
 
       def meta_representer
-        meta_representer_class.create(meta || OpenStruct.new, current_user: current_user)
+        meta_representer_class.create(meta || Hashie::Mash.new, current_user: current_user)
       end
 
       def meta_representer_class

--- a/lib/api/v3/attachments/attachment_upload_representer.rb
+++ b/lib/api/v3/attachments/attachment_upload_representer.rb
@@ -50,7 +50,7 @@ module API
             next unless embed_links && container_representer
 
             container_representer
-              .new(represented.container, current_user: current_user)
+              .create(represented.container, current_user: current_user)
           end
         end
 

--- a/lib/api/v3/principals/not_builtin_elements.rb
+++ b/lib/api/v3/principals/not_builtin_elements.rb
@@ -49,7 +49,7 @@ module API
                                                raise "unsupported type"
                                              end
 
-                         representer_class.new(model, current_user: current_user)
+                         representer_class.create(model, current_user: current_user)
                        end
                      },
                      exec_context: :decorator,

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -58,11 +58,11 @@ module API
             struct.status = struct.status_attributes
 
             # Remove temporary attributes workaround
-            struct.delete_field(:status_attributes)
+            struct.delete(:status_attributes)
 
             # Remove nil status_explanation when passed as nil
             if struct.respond_to?(:status_explanation)
-              struct.delete_field(:status_explanation)
+              struct.delete(:status_explanation)
             end
           end
         end
@@ -216,7 +216,7 @@ module API
                    end
                  },
                  setter: ->(fragment:, represented:, **) {
-                   represented.status_attributes ||= OpenStruct.new
+                   represented.status_attributes ||= Hashie::Mash.new
 
                    link = ::API::Decorators::LinkObject.new(represented.status_attributes,
                                                             path: :project_status,
@@ -235,7 +235,7 @@ module API
                                                       plain: false)
                  },
                  setter: ->(fragment:, represented:, **) {
-                   represented.status_attributes ||= OpenStruct.new
+                   represented.status_attributes ||= Hashie::Mash.new
                    represented.status_attributes[:explanation] = fragment["raw"]
                  }
 

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -42,7 +42,7 @@ module API
 
               # Show updated user
               status 200
-              UserRepresenter.new(@user, current_user: current_user)
+              UserRepresenter.create(@user, current_user: current_user)
             else
               fail ::API::Errors::InvalidUserStatusTransition
             end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -366,6 +366,14 @@ module API
         end
 
         module RepresenterClass
+          def self.extended(base)
+            class << base
+              # In order to ensure the custom fields to be loaded correctly, consumers need to call the
+              # .create method.
+              protected :new
+            end
+          end
+
           def custom_field_injector(config)
             @custom_field_injector_config = config.reverse_merge custom_field_injector_config
           end

--- a/lib/api/v3/watchers/watcher_representer.rb
+++ b/lib/api/v3/watchers/watcher_representer.rb
@@ -28,33 +28,13 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'roar/decorator'
-require 'roar/json/hal'
-
 module API
   module V3
     module Watchers
       class WatcherRepresenter < ::API::Decorators::Single
-        def initialize(user)
-          super(user, current_user: nil)
-        end
+        include API::Decorators::LinkedResource
 
-        property :user,
-                 exec_context: :decorator,
-                 getter: ->(*) {
-                   create_link_representer
-                 },
-                 setter: ->(fragment:, **) {
-                   link = create_link_representer
-                   link.from_hash(fragment)
-                 }
-
-        private
-
-        def create_link_representer
-          ::API::Decorators::LinkObject.new(represented,
-                                            property_name: :user)
-        end
+        associated_resource :user
       end
     end
   end

--- a/lib/api/v3/work_packages/form_representer.rb
+++ b/lib/api/v3/work_packages/form_representer.rb
@@ -34,8 +34,7 @@ module API
       class FormRepresenter < ::API::Decorators::Form
         def payload_representer
           WorkPackagePayloadRepresenter
-            .create_class(represented, current_user)
-            .new(represented, current_user: current_user)
+            .create(represented, current_user: current_user)
         end
 
         def schema_representer

--- a/lib/api/v3/work_packages/parse_params_service.rb
+++ b/lib/api/v3/work_packages/parse_params_service.rb
@@ -39,8 +39,7 @@ module API
 
         def parse_attributes(request_body)
           ::API::V3::WorkPackages::WorkPackagePayloadRepresenter
-            .create_class(struct, current_user)
-            .new(struct, current_user: current_user)
+            .create(struct, current_user: current_user)
             .from_hash(Hash(request_body))
             .to_h
             .reverse_merge(lock_version: nil)

--- a/lib/api/v3/work_packages/watchers_api.rb
+++ b/lib/api/v3/work_packages/watchers_api.rb
@@ -76,7 +76,7 @@ module API
               fail ::API::Errors::InvalidRequestBody.new(I18n.t('api_v3.errors.missing_request_body'))
             end
 
-            representer = ::API::V3::Watchers::WatcherRepresenter.new(::Hashie::Mash.new)
+            representer = ::API::V3::Watchers::WatcherRepresenter.create(::Hashie::Mash.new, current_user: current_user)
             representer.from_hash(request_body)
             user_id = representer.represented.user_id.to_i
 
@@ -95,7 +95,7 @@ module API
               }
             )
 
-            ::API::V3::Users::UserRepresenter.new(user, current_user: current_user)
+            ::API::V3::Users::UserRepresenter.create(user, current_user: current_user)
           end
 
           namespace ':user_id' do

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -133,7 +133,7 @@ module API
                      rep_class = element_decorator.custom_field_class(all_fields)
 
                      represented.map do |model|
-                       rep_class.new(model, current_user: current_user)
+                       rep_class.send(:new, model, current_user: current_user)
                      end
                    },
                    exec_context: :decorator,

--- a/modules/avatars/spec/lib/api/v3/users/user_representer_spec.rb
+++ b/modules/avatars/spec/lib/api/v3/users/user_representer_spec.rb
@@ -31,7 +31,7 @@ require 'spec_helper'
 describe ::API::V3::Users::UserRepresenter do
   let(:user) { build_stubbed(:user, status: 1) }
   let(:current_user) { build_stubbed(:user) }
-  let(:representer) { described_class.new(user, current_user: current_user) }
+  let(:representer) { described_class.create(user, current_user: current_user) }
 
   context 'generation' do
     subject(:generated) { representer.to_json }

--- a/modules/bim/spec/api/v3/work_packages/work_package_representer_spec.rb
+++ b/modules/bim/spec/api/v3/work_packages/work_package_representer_spec.rb
@@ -33,23 +33,23 @@ require_relative '../../../support/bcf_topic_with_stubbed_comment'
 describe ::API::V3::WorkPackages::WorkPackageRepresenter do
   include API::V3::Utilities::PathHelper
   include API::Bim::Utilities::PathHelper
+  include_context 'user with stubbed permissions'
+  include_context 'bcf_topic with stubbed comment'
 
   let(:project) do
     work_package.project
   end
-  include_context 'user with stubbed permissions'
-  include_context 'bcf_topic with stubbed comment'
   let(:permissions) { %i[view_linked_issues view_work_packages manage_bcf] }
   let(:work_package) do
     build_stubbed(:stubbed_work_package, bcf_issue: bcf_topic)
   end
   let(:representer) do
-    described_class.new(work_package,
-                        current_user: user,
-                        embed_links: true)
+    described_class.create(work_package,
+                           current_user: user,
+                           embed_links: true)
   end
 
-  before(:each) do
+  before do
     login_as user
   end
 

--- a/modules/costs/lib/api/v3/time_entries/time_entries_activity_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entries_activity_representer.rb
@@ -56,7 +56,7 @@ module API
                              },
                              getter: ->(*) {
                                active_projects.map do |project|
-                                 Projects::ProjectRepresenter.new(project, current_user: current_user)
+                                 Projects::ProjectRepresenter.create(project, current_user: current_user)
                                end
                              }
 

--- a/modules/costs/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/modules/costs/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -33,47 +33,48 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
 
   let(:project) { create(:project) }
   let(:role) do
-    create(:role, permissions: %i[view_time_entries
-                                             view_cost_entries
-                                             view_cost_rates
-                                             view_work_packages])
+    create(:role,
+           permissions: %i[view_time_entries
+                           view_cost_entries
+                           view_cost_rates
+                           view_work_packages])
   end
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
 
   let(:cost_entry_1) do
     create(:cost_entry,
-                      work_package: work_package,
-                      project: project,
-                      units: 3,
-                      spent_on: Date.today,
-                      user: user,
-                      comments: 'Entry 1')
+           work_package: work_package,
+           project: project,
+           units: 3,
+           spent_on: Time.zone.today,
+           user: user,
+           comments: 'Entry 1')
   end
   let(:cost_entry_2) do
     create(:cost_entry,
-                      work_package: work_package,
-                      project: project,
-                      units: 3,
-                      spent_on: Date.today,
-                      user: user,
-                      comments: 'Entry 2')
+           work_package: work_package,
+           project: project,
+           units: 3,
+           spent_on: Time.zone.today,
+           user: user,
+           comments: 'Entry 2')
   end
 
   let(:work_package) do
     create(:work_package,
-                      project_id: project.id)
+           project_id: project.id)
   end
   let(:representer) do
-    described_class.new(work_package,
-                        current_user: user,
-                        embed_links: true)
+    described_class.create(work_package,
+                           current_user: user,
+                           embed_links: true)
   end
 
-  before(:each) do
+  before do
     allow(User).to receive(:current).and_return user
   end
 
@@ -106,9 +107,9 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         context 'time entry with single hour' do
           let(:time_entry) do
             create(:time_entry,
-                              project: work_package.project,
-                              work_package: work_package,
-                              hours: 1.0)
+                   project: work_package.project,
+                   work_package: work_package,
+                   hours: 1.0)
           end
 
           before { time_entry }
@@ -119,9 +120,9 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
         context 'time entry with multiple hours' do
           let(:time_entry) do
             create(:time_entry,
-                              project: work_package.project,
-                              work_package: work_package,
-                              hours: 42.5)
+                   project: work_package.project,
+                   work_package: work_package,
+                   hours: 42.5)
           end
 
           before { time_entry }
@@ -145,24 +146,24 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
 
           let(:user2) do
             create(:user,
-                              member_in_project: project,
-                              member_through_role: own_time_entries_role)
+                   member_in_project: project,
+                   member_through_role: own_time_entries_role)
           end
 
           let!(:own_time_entry) do
             create(:time_entry,
-                              project: work_package.project,
-                              work_package: work_package,
-                              hours: 2,
-                              user: user2)
+                   project: work_package.project,
+                   work_package: work_package,
+                   hours: 2,
+                   user: user2)
           end
 
           let!(:other_time_entry) do
             create(:time_entry,
-                              project: work_package.project,
-                              work_package: work_package,
-                              hours: 1,
-                              user: user)
+                   project: work_package.project,
+                   work_package: work_package,
+                   hours: 1,
+                   user: user)
           end
 
           before do

--- a/spec/lib/api/v3/projects/project_payload_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/projects/project_payload_representer_parsing_spec.rb
@@ -32,7 +32,7 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
   include ::API::V3::Utilities::PathHelper
 
   let(:object) do
-    OpenStruct.new available_custom_fields: []
+    Hashie::Mash.new available_custom_fields: []
   end
   let(:user) { build_stubbed(:user) }
   let(:representer) do
@@ -117,16 +117,16 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
         end
 
         it 'does set status to nil' do
-          project = representer.from_hash(hash).to_h
+          project = representer.from_hash(hash)
 
           expect(project)
             .to have_key(:status)
 
           status = project[:status]
-          expect(status.to_h)
+          expect(status)
             .to have_key(:code)
 
-          expect(status.to_h)
+          expect(status)
             .not_to have_key(:explanation)
 
           expect(status[:code])
@@ -150,7 +150,7 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
         end
 
         it 'sets the parent_id to the value' do
-          project = representer.from_hash(hash).to_h
+          project = representer.from_hash(hash)
 
           expect(project[:parent_id])
             .to eq "5"
@@ -169,7 +169,7 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
         end
 
         it 'sets the parent_id to nil' do
-          project = representer.from_hash(hash).to_h
+          project = representer.from_hash(hash)
 
           expect(project)
             .to have_key(:parent_id)
@@ -191,7 +191,7 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
         end
 
         it 'omits the parent information' do
-          project = representer.from_hash(hash).to_h
+          project = representer.from_hash(hash)
 
           expect(project)
             .not_to have_key(:parent_id)

--- a/spec/lib/api/v3/users/user_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_representer_spec.rb
@@ -32,7 +32,7 @@ describe ::API::V3::Users::UserRepresenter do
   let(:status) { Principal.statuses[:active] }
   let(:user) { build_stubbed(:user, status: status) }
   let(:current_user) { build_stubbed(:user) }
-  let(:representer) { described_class.new(user, current_user: current_user) }
+  let(:representer) { described_class.create(user, current_user: current_user) }
 
   include API::V3::Utilities::PathHelper
 

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -35,9 +35,9 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
   let(:field_format) { 'bool' }
   let(:custom_field) do
     build(:custom_field,
-                     id: 1,
-                     field_format: field_format,
-                     is_required: true)
+          id: 1,
+          field_format: field_format,
+          is_required: true)
   end
 
   describe 'TYPE_MAP' do
@@ -74,10 +74,10 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
       context 'with default set' do
         let(:custom_field) do
           build(:custom_field,
-                           id: 1,
-                           field_format: 'string',
-                           default_value: 'foo',
-                           is_required: true)
+                id: 1,
+                field_format: 'string',
+                default_value: 'foo',
+                is_required: true)
         end
 
         it_behaves_like 'has basic schema properties' do
@@ -132,7 +132,7 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
     describe 'version custom field' do
       let(:custom_field) do
         build(:version_wp_custom_field,
-                         is_required: true)
+              is_required: true)
       end
 
       let(:assignable_versions) { build_list(:version, 3) }
@@ -143,7 +143,7 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
           .with(custom_field)
           .and_return(assignable_versions)
 
-        allow(::API::V3::Versions::VersionRepresenter).to receive(:new).and_return(double)
+        allow(::API::V3::Versions::VersionRepresenter).to receive(:create).and_return(double)
       end
 
       it_behaves_like 'has basic schema properties' do
@@ -209,8 +209,8 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
     describe 'user custom field' do
       let(:custom_field) do
         build(:custom_field,
-                         field_format: 'user',
-                         is_required: true)
+              field_format: 'user',
+              is_required: true)
       end
 
       it_behaves_like 'has basic schema properties' do
@@ -248,8 +248,8 @@ describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
       end
       let(:custom_field) do
         build(:custom_field,
-                         field_format: 'user',
-                         is_required: true)
+              field_format: 'user',
+              is_required: true)
       end
 
       it_behaves_like 'links to allowed values via collection link' do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -28,6 +28,7 @@
 
 require 'spec_helper'
 
+# rubocop:disable RSpec:MultipleMemoizedHelpers
 describe ::API::V3::WorkPackages::WorkPackageRepresenter do
   include ::API::V3::Utilities::PathHelper
 
@@ -53,20 +54,20 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
   let(:budget) { build_stubbed(:budget, project: project) }
   let(:work_package) do
     build_stubbed(:stubbed_work_package,
-                             schedule_manually: schedule_manually,
-                             start_date: start_date,
-                             due_date: due_date,
-                             done_ratio: 50,
-                             parent: parent,
-                             type: type,
-                             project: project,
-                             priority: priority,
-                             assigned_to: assignee,
-                             responsible: responsible,
-                             estimated_hours: estimated_hours,
-                             derived_estimated_hours: derived_estimated_hours,
-                             budget: budget,
-                             status: status) do |wp|
+                  schedule_manually: schedule_manually,
+                  start_date: start_date,
+                  due_date: due_date,
+                  done_ratio: 50,
+                  parent: parent,
+                  type: type,
+                  project: project,
+                  priority: priority,
+                  assigned_to: assignee,
+                  responsible: responsible,
+                  estimated_hours: estimated_hours,
+                  derived_estimated_hours: derived_estimated_hours,
+                  budget: budget,
+                  status: status) do |wp|
       allow(wp)
         .to receive(:available_custom_fields)
         .and_return(available_custom_fields)
@@ -117,6 +118,13 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
     allow(current_user)
       .to receive(:allowed_to?) do |permission, _context|
       permissions.include?(permission)
+    end
+  end
+
+  describe '.new' do
+    it 'is prevented as .create is to be used' do
+      expect { described_class.new(work_package, current_user: current_user, embed_links: embed_links) }
+        .to raise_error NoMethodError
     end
   end
 
@@ -1232,3 +1240,4 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
     end
   end
 end
+# rubocop:enable RSpec:MultipleMemoizedHelpers

--- a/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
@@ -29,7 +29,13 @@
 require 'spec_helper'
 
 describe ::API::V3::WorkPackages::WorkPackageSumsRepresenter do
-  let(:custom_field) { build_stubbed(:int_wp_custom_field, id: 1) }
+  let(:custom_field) do
+    build_stubbed(:int_wp_custom_field, id: 1).tap do |cf|
+      allow(WorkPackageCustomField)
+        .to receive(:summable)
+              .and_return([cf])
+    end
+  end
   let(:sums) do
     double('sums',
            story_points: 5,
@@ -41,10 +47,9 @@ describe ::API::V3::WorkPackages::WorkPackageSumsRepresenter do
            custom_field_1: 5,
            available_custom_fields: [custom_field])
   end
-  let(:schema) { double 'schema', available_custom_fields: [custom_field] }
   let(:current_user) { build_stubbed(:user) }
   let(:representer) do
-    described_class.create_class(schema, current_user).new(sums)
+    described_class.create(sums, current_user)
   end
 
   subject { representer.to_json }

--- a/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
+++ b/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
@@ -250,7 +250,7 @@ describe ::API::V3::WorkPackageCollectionFromQueryService,
               .to receive(:summable)
               .and_return(custom_fields)
 
-            expected = OpenStruct.new(estimated_hours: 0.0, available_custom_fields: custom_fields)
+            expected = Hashie::Mash.new(estimated_hours: 0.0, available_custom_fields: custom_fields)
 
             expect(subject.total_sums)
               .to eq(expected)


### PR DESCRIPTION
Follow up of #10100 which showed that not using the `.create` method can lead to not having custom field properties included in the resources.

The change turns `.new` on representers which are custom field powered, into a protected method. This will probably mean that `.create` needs to be used in more places. Finding those places and ensuring that there isn't a regression is the intend of this PR.