### PR TITLE
Filter open_project and openproject from background silencer

### DIFF
--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -39,5 +39,5 @@
 Rails.backtrace_cleaner.remove_silencers!
 
 # compare this with APP_DIRS_PATTERN in railties/lib/rails/backtrace_cleaner.rb
-fixed_dirs_patterns = /^\/?(app|config|lib|test|modules|\(\w*\))/
+fixed_dirs_patterns = /(^\/?(app|config|lib|test|modules|\(\w*\))|open_?project)/
 Rails.backtrace_cleaner.add_silencer { |line| !fixed_dirs_patterns.match?(line) }


### PR DESCRIPTION
Our current backtrace silencer excludes non-app roots, and by that, all plugins that are not part of the modules path. We can add `open_?project` to that check to catch most of the known plugins we control