### PR TITLE
 [40744] Date picker for the wp split view in the calendar module misaligned

### DIFF
--- a/frontend/src/app/shared/components/modal/modal-overlay.sass
+++ b/frontend/src/app/shared/components/modal/modal-overlay.sass
@@ -17,3 +17,4 @@
     background: transparent
     right: unset
     bottom: unset
+    top: initial


### PR DESCRIPTION
We should set the top of modal to its initial value, so it is not set to zero to stick to the top of the page, and will be aligned with the box including dates. Therefore, it will be fixed for everywhere in the project that we are opening a modal and other elements on the page are still active and changeable.

https://community.openproject.org/projects/openproject/work_packages/40744/activity