### PR TITLE
[39833] Work package title input shrinks when inputting something in FF

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.sass
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.sass
@@ -5,11 +5,11 @@
   height: initial
 
   &--ellipsed
-    width: 100%
+    max-width: 600px
     @include text-shortener
 
   &--active-parent-select
-    width: 100%
+    width: 500px
 
   @media screen and (max-width: 1248px)
     margin-top: 0

--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.sass
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.sass
@@ -5,11 +5,11 @@
   height: initial
 
   &--ellipsed
-    max-width: 420px
+    width: 100%
     @include text-shortener
 
   &--active-parent-select
-    min-width: 320px
+    width: 100%
 
   @media screen and (max-width: 1248px)
     margin-top: 0
@@ -19,3 +19,4 @@
 
   .ng-placeholder
     @include text-shortener
+

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -334,6 +334,7 @@ export class OpAutocompleterComponent extends UntilDestroyedMixin implements Aft
   }
 
   public keydowned(val:any) {
+    this.repositionDropdown();
     this.keydown.emit(val);
   }
 

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -334,7 +334,6 @@ export class OpAutocompleterComponent extends UntilDestroyedMixin implements Aft
   }
 
   public keydowned(val:any) {
-    this.repositionDropdown();
     this.keydown.emit(val);
   }
 

--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -160,8 +160,7 @@ mark.ui-autocomplete-match
 
       .ng-placeholder
         top: 1px !important
-        overflow: hidden
-        text-overflow: ellipsis
+        @include text-shortener
 
       input
         height: 100%

--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -160,6 +160,8 @@ mark.ui-autocomplete-match
 
       .ng-placeholder
         top: 1px !important
+        overflow: hidden
+        text-overflow: ellipsis
 
       input
         height: 100%


### PR DESCRIPTION
Hide the overflowed text of ng-placeholder and set the breadcrumb width to 100% instead of a value, so after the dropdown is repositioned it won't shrink to its initial size. 

https://community.openproject.org/work_packages/39833/activity