### PR TITLE
[40859] Today column is not highlighted in the team planner

### DIFF
--- a/frontend/src/global_styles/vendor/_full_calendar.sass
+++ b/frontend/src/global_styles/vendor/_full_calendar.sass
@@ -19,6 +19,9 @@
       border: none
       cursor: unset
 
+    .fc-day-today
+      background: rgb(255 255 120 / 20%)
+
     // ------------------------ END: Calendar cells ------------------------
     // -------
     // ------------------------ BEGIN: Calendar events ------------------------


### PR DESCRIPTION
Highlight today column in team planner

https://community.openproject.org/projects/openproject/work_packages/40859/activity