### PR TITLE
[40860] An empty team planner has visual anomalies (extra lines, wrong colour)

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
@@ -16,13 +16,14 @@
       *ngIf="calendarOptions"
       [options]="calendarOptions"
       class="op-team-planner--calendar"
+      [ngClass]="{'op-team-planner--calendar_empty': (isEmpty$ | async)}"
     ></full-calendar>
 
     <div
       [textContent]="calendar.tooManyResultsText"
       class="op-wp-calendar--notification"></div>
     <div
-      *ngIf="!(principalIds$ | async)?.length && !(showAddAssignee$ | async)"
+      *ngIf="isEmpty$ | async"
       class="op-team-planner--no-data">
       <span [textContent]="text.noData"></span>
     </div>

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.sass
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.sass
@@ -28,7 +28,7 @@
   &--no-data
     grid-area: noData
     min-height: 250px
-    background-color: lightgray
+    background-color: #F3F3F3
     display: flex
     justify-content: center
     align-items: center

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -83,7 +83,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
 
   showAddExistingPane = new BehaviorSubject<boolean>(false);
 
-  showAddAssignee$ = new Subject<boolean>();
+  showAddAssignee$ = new BehaviorSubject<boolean>(false);
 
   private principalIds$ = this.wpTableFilters
     .live$()
@@ -103,6 +103,13 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
         filters: [['id', '=', ids]],
       }) as ApiV3ListParameters),
     );
+
+  isEmpty$ = combineLatest([
+    this.principalIds$,
+    this.showAddAssignee$,
+  ]).pipe(
+    map(([principals, showAddAssignee]) => !principals.length && !showAddAssignee),
+  );
 
   assignees:HalResource[] = [];
 

--- a/frontend/src/global_styles/content/modules/_team_planner.sass
+++ b/frontend/src/global_styles/content/modules/_team_planner.sass
@@ -3,3 +3,9 @@
 .router--team-planner
   #content
     height: 100%
+
+.op-team-planner
+  &--calendar_empty
+    .fc-scrollgrid-section-body,
+    .fc-scrollgrid-section-footer
+      display: none


### PR DESCRIPTION
Hide table body lines when team planner is empty

https://community.openproject.org/projects/openproject/work_packages/40860/activity