### PR TITLE
Resort projects when creating or updating their name

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -34,6 +34,7 @@ class Project < ApplicationRecord
 
   include Projects::Storage
   include Projects::Activity
+  include Projects::Hierarchy
   include Projects::AncestorsFromRoot
   include ::Scopes::Scoped
 
@@ -88,8 +89,6 @@ class Project < ApplicationRecord
   has_one :status, class_name: 'Projects::Status', dependent: :destroy
   has_many :budgets, dependent: :destroy
   has_many :notification_settings, dependent: :destroy
-
-  acts_as_nested_set order_column: :name, dependent: :destroy
 
   acts_as_customizable
   acts_as_searchable columns: %W(#{table_name}.name #{table_name}.identifier #{table_name}.description),

--- a/app/models/projects/hierarchy.rb
+++ b/app/models/projects/hierarchy.rb
@@ -1,0 +1,61 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::Hierarchy
+  extend ActiveSupport::Concern
+
+  included do
+    acts_as_nested_set order_column: :name, dependent: :destroy
+
+    # Keep the siblings sorted after naming changes to ensure lft sort includes name sorting
+    before_save :remember_reorder
+    after_save :reorder_by_name, if: -> { @reorder_nested_set }
+
+    def reorder_by_name
+      @reorder_nested_set = nil
+      return unless siblings.any?
+
+      left_neighbor = find_left_neighbor(parent, :name, true)
+
+      if left_neighbor
+        move_to_right_of(left_neighbor)
+      elsif self != parent.children.first
+        move_to_left_of(parent.children[0])
+      end
+    end
+
+    # We need to remember if we want to reorder as nested_set
+    # will perform another save directly in +after_save+ if a parent was set
+    # and that clear new_record? as well as previous_new_record?
+    def remember_reorder
+      @reorder_nested_set = parent_id.present? && (new_record? || name_changed?)
+    end
+  end
+end

--- a/app/models/queries/projects/orders/typeahead_order.rb
+++ b/app/models/queries/projects/orders/typeahead_order.rb
@@ -28,34 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Queries::Projects
-  filters = ::Queries::Projects::Filters
-  orders = ::Queries::Projects::Orders
-  query = ::Queries::Projects::ProjectQuery
+class Queries::Projects::Orders::TypeaheadOrder < Queries::Projects::Orders::DefaultOrder
+  self.model = Project
 
-  ::Queries::Register.register do
-    filter query, filters::AncestorFilter
-    filter query, filters::TypeFilter
-    filter query, filters::ActiveFilter
-    filter query, filters::TemplatedFilter
-    filter query, filters::PublicFilter
-    filter query, filters::NameAndIdentifierFilter
-    filter query, filters::CustomFieldFilter
-    filter query, filters::CreatedAtFilter
-    filter query, filters::LatestActivityAtFilter
-    filter query, filters::PrincipalFilter
-    filter query, filters::ParentFilter
-    filter query, filters::IdFilter
-    filter query, filters::ProjectStatusFilter
-    filter query, filters::UserActionFilter
-    filter query, filters::VisibleFilter
+  def self.key
+    :typeahead
+  end
 
-    order query, orders::DefaultOrder
-    order query, orders::LatestActivityAtOrder
-    order query, orders::RequiredDiskSpaceOrder
-    order query, orders::CustomFieldOrder
-    order query, orders::ProjectStatusOrder
-    order query, orders::NameOrder
-    order query, orders::TypeaheadOrder
+  def order
+    model.order(lft: :asc, name: :asc)
   end
 end

--- a/app/workers/projects/reorder_children_job.rb
+++ b/app/workers/projects/reorder_children_job.rb
@@ -1,0 +1,71 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects
+  class ReorderChildrenJob < ApplicationJob
+    def perform
+      Rails.logger.info { "Resorting siblings by name in the project's nested set." }
+      Project.transaction { reorder! }
+    end
+
+    private
+
+    def reorder!
+      Project
+        .where(id: unique_parent_ids)
+        .find_each(&method(:reorder_children))
+    end
+
+    def unique_parent_ids
+      Project
+        .where.not(parent_id: nil)
+        .select(:parent_id)
+        .distinct
+    end
+
+    def reorder_children(parent)
+      return unless parent.children.many?
+
+      # Resort children manually
+      sorted = parent.children.sort_by(&:name)
+
+      # Get the current first child
+      first = parent.children.first
+
+      sorted.each_with_index do |child, i|
+        if i == 0
+          child.move_to_left_of(first) unless child == first
+        else
+          child.move_to_right_of(sorted[i - 1])
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20220202140507_reorder_project_children.rb
+++ b/db/migrate/20220202140507_reorder_project_children.rb
@@ -1,0 +1,5 @@
+class ReorderProjectChildren < ActiveRecord::Migration[6.1]
+  def up
+    ::Projects::ReorderChildrenJob.perform_later
+  end
+end

--- a/spec/models/projects/reorder_nested_set_spec.rb
+++ b/spec/models/projects/reorder_nested_set_spec.rb
@@ -1,0 +1,56 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe Project, 'reordering of nested set', type: :model do
+  shared_let(:parent_project) { create :project, name: 'Parent' }
+
+  # Create some children in non-alphabetical order
+  shared_let(:child_a) { create :project, name: 'A', parent: parent_project }
+  shared_let(:child_f) { create :project, name: 'F', parent: parent_project }
+  shared_let(:child_b) { create :project, name: 'B', parent: parent_project }
+
+  subject { parent_project.children.reorder(:lft) }
+
+  it 'has the correct sort' do
+    expect(subject.reload.pluck(:name)).to eq %w[A B F]
+  end
+
+  context 'when renaming a child' do
+    before do
+      child_a.update! name: 'Z'
+    end
+
+    it 'updates that order' do
+      expect(subject.reload.pluck(:name)).to eq %w[B F Z]
+    end
+  end
+end

--- a/spec/models/queries/projects/project_query_spec.rb
+++ b/spec/models/queries/projects/project_query_spec.rb
@@ -140,4 +140,17 @@ describe Queries::Projects::ProjectQuery, type: :model do
       end
     end
   end
+
+  context 'with an order by typeahead asc' do
+    before do
+      instance.order(typeahead: :asc)
+    end
+
+    describe '#results' do
+      it 'returns all visible projects ordered by lft asc' do
+        expect(instance.results.to_sql)
+          .to eql base_scope.except(:order).order(lft: :asc, name: :asc, id: :desc).to_sql
+      end
+    end
+  end
 end

--- a/spec/workers/projects/reorder_children_job_integration_spec.rb
+++ b/spec/workers/projects/reorder_children_job_integration_spec.rb
@@ -1,0 +1,56 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe Projects::ReorderChildrenJob, type: :model do
+  subject(:job) { described_class.perform_now }
+
+  shared_let(:parent_project) { create(:project, name: 'Parent') }
+
+  shared_let(:child_a) { create :project, name: 'A', parent: parent_project }
+  shared_let(:child_b) { create :project, name: 'B', parent: parent_project }
+  shared_let(:child_c) { create :project, name: 'C', parent: parent_project }
+
+  let(:ordered) { parent_project.children.reorder(:lft) }
+
+  before do
+    # Update the names
+    child_a.update_column(:name, 'Second')
+    child_b.update_column(:name, 'Third')
+    child_c.update_column(:name, 'First')
+  end
+
+  it 'corrects the order' do
+    expect(ordered.pluck(:name)).to eq %w[Second Third First]
+
+    subject
+
+    expect(ordered.reload.pluck(:name)).to eq %w[First Second Third]
+  end
+end


### PR DESCRIPTION
- [x] Reorders a saved project when creating, or when their name is being changed.
- [x] Add a reorder job that reorders every child project
- [x] Adds a migration to call that job once
- [x] Adds a sort order for typeahead which uses lft and name

https://community.openproject.org/work_packages/40930 