### PR TITLE
Replace spec with nbsp

### DIFF
--- a/spec/features/wysiwyg/non_breaking_spaces_spec.rb
+++ b/spec/features/wysiwyg/non_breaking_spaces_spec.rb
@@ -55,7 +55,9 @@ describe 'Wysiwyg &nbsp; behavior',
         expect(page).to have_selector('.flash.notice')
 
         within('#content') do
-          expect(page).to have_selector('p', text: 'some text with bold')
+          expect(page).to have_selector('p') do |node|
+            node.text.include?('some text') && node.text.include?('with bold')
+          end
           expect(page).to have_selector('strong', text: 'with bold')
         end
       end


### PR DESCRIPTION
It's been failing recently probably to a gem bump or a browser update