### PR TITLE
Prevent saving from wpList with no form loaded

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
@@ -307,10 +307,10 @@ export class WorkPackagesListService {
     return promise;
   }
 
-  public save(query?:QueryResource) {
-    query = query || this.currentQuery;
+  public async save(givenQuery?:QueryResource):Promise<unknown> {
+    const query = givenQuery || this.currentQuery;
 
-    const form = this.querySpace.queryForm.value!;
+    const form = await this.querySpace.queryForm.valuesPromise();
 
     const promise = this
       .apiV3Service


### PR DESCRIPTION
./spec/features/work_packages/table/queries/query_name_inline_edit_spec.rb
is failing because some change made the form load slower, or load the page faster.

This unearthed a bug when trying to save a query too early, before the form is being present.