### PR TITLE
Fix argument alignment since f08bea3467 for modules specs

### DIFF
--- a/modules/backlogs/spec/api/work_package_resource_spec.rb
+++ b/modules/backlogs/spec/api/work_package_resource_spec.rb
@@ -37,9 +37,9 @@ describe 'API v3 Work package resource' do
   let(:project) { create(:project) }
   let(:work_package) do
     create(:work_package,
-                      project: project,
-                      story_points: 8,
-                      remaining_hours: 5)
+           project: project,
+           story_points: 8,
+           remaining_hours: 5)
   end
   let(:wp_path) { "/api/v3/work_packages/#{work_package.id}" }
 

--- a/modules/backlogs/spec/api/work_packages/schema/specific_work_package_schema_spec.rb
+++ b/modules/backlogs/spec/api/work_packages/schema/specific_work_package_schema_spec.rb
@@ -33,8 +33,8 @@ describe ::API::V3::WorkPackages::Schema::SpecificWorkPackageSchema do
   let(:type) { build(:type) }
   let(:work_package) do
     build(:work_package,
-                     project: project,
-                     type: type)
+          project: project,
+          type: type)
   end
   let(:current_user) do
     build_stubbed(:user).tap do |u|

--- a/modules/backlogs/spec/contracts/work_packages/base_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/work_packages/base_contract_spec.rb
@@ -42,8 +42,8 @@ describe WorkPackages::BaseContract, type: :model do
 
   let(:project) do
     p = build(:project, members: [build(:member,
-                                                              principal: user,
-                                                              roles: [role])],
+                                        principal: user,
+                                        roles: [role])],
                                    types: [type_feature, type_task, type_bug])
 
     allow(p)
@@ -58,8 +58,8 @@ describe WorkPackages::BaseContract, type: :model do
 
   let(:other_project) do
     p = build(:project, members: [build(:member,
-                                                              principal: user,
-                                                              roles: [role])],
+                                        principal: user,
+                                        roles: [role])],
                                    types: [type_feature, type_task, type_bug])
 
     allow(p)
@@ -73,68 +73,68 @@ describe WorkPackages::BaseContract, type: :model do
 
   let(:story) do
     build_stubbed(:stubbed_work_package,
-                             subject: 'Story',
-                             project: project,
-                             type: type_feature,
-                             version: version1,
-                             status: status,
-                             author: user,
-                             priority: issue_priority)
+                  subject: 'Story',
+                  project: project,
+                  type: type_feature,
+                  version: version1,
+                  status: status,
+                  author: user,
+                  priority: issue_priority)
   end
 
   let(:story2) do
     build_stubbed(:stubbed_work_package,
-                             subject: 'Story2',
-                             project: project,
-                             type: type_feature,
-                             version: version1,
-                             status: status,
-                             author: user,
-                             priority: issue_priority)
+                  subject: 'Story2',
+                  project: project,
+                  type: type_feature,
+                  version: version1,
+                  status: status,
+                  author: user,
+                  priority: issue_priority)
   end
 
   let(:task) do
     build_stubbed(:stubbed_work_package,
-                             subject: 'Task',
-                             type: type_task,
-                             version: version1,
-                             project: project,
-                             status: status,
-                             author: user,
-                             priority: issue_priority)
+                  subject: 'Task',
+                  type: type_task,
+                  version: version1,
+                  project: project,
+                  status: status,
+                  author: user,
+                  priority: issue_priority)
   end
 
   let(:task2) do
     build_stubbed(:stubbed_work_package,
-                             subject: 'Task2',
-                             type: type_task,
-                             version: version1,
-                             project: project,
-                             status: status,
-                             author: user,
-                             priority: issue_priority)
+                  subject: 'Task2',
+                  type: type_task,
+                  version: version1,
+                  project: project,
+                  status: status,
+                  author: user,
+                  priority: issue_priority)
   end
 
   let(:bug) do
     build_stubbed(:stubbed_work_package,
-                             subject: 'Bug',
-                             type: type_bug,
-                             version: version1,
-                             project: project,
-                             status: status,
-                             author: user,
-                             priority: issue_priority)
+                  subject: 'Bug',
+                  type: type_bug,
+                  version: version1,
+                  project: project,
+                  status: status,
+                  author: user,
+                  priority: issue_priority)
   end
 
   let(:bug2) do
     build_stubbed(:stubbed_work_package,
-                             subject: 'Bug2',
-                             type: type_bug,
-                             version: version1,
-                             project: project,
-                             status: status,
-                             author: user,
-                             priority: issue_priority)
+                  subject: 'Bug2',
+                  type: type_bug,
+                  version: version1,
+                  project: project,
+                  status: status,
+                  author: user,
+                  priority: issue_priority)
   end
 
   subject(:valid) { instance.validate }

--- a/modules/backlogs/spec/contracts/work_packages/update_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/work_packages/update_contract_spec.rb
@@ -31,9 +31,9 @@ require 'spec_helper'
 describe WorkPackages::UpdateContract do
   let(:work_package) do
     create(:work_package,
-                      done_ratio: 50,
-                      estimated_hours: 6.0,
-                      project: project)
+           done_ratio: 50,
+           estimated_hours: 6.0,
+           project: project)
   end
   let(:member) { create(:user, member_in_project: project, member_through_role: role) }
   let(:project) { create(:project) }

--- a/modules/backlogs/spec/controllers/versions_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/versions_controller_spec.rb
@@ -31,22 +31,22 @@ require 'spec_helper'
 describe VersionsController, type: :controller do
   let(:version) do
     create(:version,
-                      sharing: 'system')
+           sharing: 'system')
   end
 
   let(:other_project) do
     create(:project).tap do |p|
       create(:member,
-                        user: current_user,
-                        roles: [create(:role, permissions: [:manage_versions])],
-                        project: p)
+             user: current_user,
+             roles: [create(:role, permissions: [:manage_versions])],
+             project: p)
     end
   end
 
   let(:current_user) do
     create(:user,
-                      member_in_project: version.project,
-                      member_with_permissions: [:manage_versions])
+           member_in_project: version.project,
+           member_with_permissions: [:manage_versions])
   end
 
   before do

--- a/modules/backlogs/spec/features/backlogs/create_story_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_story_spec.rb
@@ -52,11 +52,11 @@ describe 'Backlogs', js: true do
 
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_with_permissions: %i(add_work_packages
-                                                  view_master_backlog
-                                                  view_work_packages
-                                                  assign_versions)
+           member_in_project: project,
+           member_with_permissions: %i(add_work_packages
+                                       view_master_backlog
+                                       view_work_packages
+                                       assign_versions)
   end
   let(:project) { create :project }
 
@@ -64,23 +64,23 @@ describe 'Backlogs', js: true do
 
   let!(:existing_story1) do
     create(:work_package,
-                      type: story_type,
-                      project: project,
-                      status: default_status,
-                      priority: default_priority,
-                      position: 1,
-                      story_points: 3,
-                      version: backlog_version)
+           type: story_type,
+           project: project,
+           status: default_status,
+           priority: default_priority,
+           position: 1,
+           story_points: 3,
+           version: backlog_version)
   end
   let!(:existing_story2) do
     create(:work_package,
-                      type: story_type,
-                      project: project,
-                      status: default_status,
-                      priority: default_priority,
-                      position: 2,
-                      story_points: 4,
-                      version: backlog_version)
+           type: story_type,
+           project: project,
+           status: default_status,
+           priority: default_priority,
+           position: 2,
+           story_points: 4,
+           version: backlog_version)
   end
   let!(:default_status) do
     create(:default_status)

--- a/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
+++ b/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
@@ -34,8 +34,8 @@ describe 'Backlogs in backlog view',
          js: true do
   let!(:project) do
     create(:project,
-                      types: [story, task],
-                      enabled_module_names: %w(work_package_tracking backlogs))
+           types: [story, task],
+           enabled_module_names: %w(work_package_tracking backlogs))
   end
   let!(:story) { create(:type_feature) }
   let!(:other_story) { create(:type) }
@@ -45,57 +45,57 @@ describe 'Backlogs in backlog view',
   let!(:other_status) { create(:status) }
   let!(:workflows) do
     create(:workflow,
-                      old_status: default_status,
-                      new_status: other_status,
-                      role: role,
-                      type_id: story.id)
+           old_status: default_status,
+           new_status: other_status,
+           role: role,
+           type_id: story.id)
   end
   let(:role) do
     create(:role,
-                      permissions: %i(view_master_backlog
-                                      add_work_packages
-                                      view_work_packages
-                                      edit_work_packages
-                                      manage_subtasks
-                                      manage_versions
-                                      update_sprints
-                                      assign_versions))
+           permissions: %i(view_master_backlog
+                           add_work_packages
+                           view_work_packages
+                           edit_work_packages
+                           manage_subtasks
+                           manage_versions
+                           update_sprints
+                           assign_versions))
   end
   let!(:current_user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let!(:sprint) do
     create(:version,
-                      project: project,
-                      start_date: Date.today - 10.days,
-                      effective_date: Date.today + 10.days,
-                      version_settings_attributes: [{ project: project, display: VersionSetting::DISPLAY_LEFT }])
+           project: project,
+           start_date: Date.today - 10.days,
+           effective_date: Date.today + 10.days,
+           version_settings_attributes: [{ project: project, display: VersionSetting::DISPLAY_LEFT }])
   end
   let!(:backlog) do
     create(:version,
-                      project: project,
-                      version_settings_attributes: [{ project: project, display: VersionSetting::DISPLAY_RIGHT }])
+           project: project,
+           version_settings_attributes: [{ project: project, display: VersionSetting::DISPLAY_RIGHT }])
   end
   let!(:other_project) do
     create(:project)
   end
   let!(:other_project_sprint) do
     create(:version,
-                      project: other_project,
-                      sharing: 'system',
-                      start_date: Date.today - 10.days,
-                      effective_date: Date.today + 10.days)
+           project: other_project,
+           sharing: 'system',
+           start_date: Date.today - 10.days,
+           effective_date: Date.today + 10.days)
   end
   let!(:sprint_story1) do
     create(:work_package,
-                      project: project,
-                      type: story,
-                      status: default_status,
-                      version: sprint,
-                      position: 1,
-                      story_points: 10)
+           project: project,
+           type: story,
+           status: default_status,
+           version: sprint,
+           position: 1,
+           story_points: 10)
   end
   let(:backlogs_page) { Pages::Backlogs.new(project) }
 

--- a/modules/backlogs/spec/features/impediments_spec.rb
+++ b/modules/backlogs/spec/features/impediments_spec.rb
@@ -33,8 +33,8 @@ describe 'Impediments on taskboard',
          js: true do
   let!(:project) do
     create(:project,
-                      types: [story, task],
-                      enabled_module_names: %w(work_package_tracking backlogs))
+           types: [story, task],
+           enabled_module_names: %w(work_package_tracking backlogs))
   end
   let!(:story) { create(:type_feature) }
   let!(:task) { create(:type_task) }
@@ -43,56 +43,56 @@ describe 'Impediments on taskboard',
   let!(:other_status) { create(:status) }
   let!(:workflows) do
     create(:workflow,
-                      old_status: status,
-                      new_status: other_status,
-                      role: role,
-                      type_id: story.id)
+           old_status: status,
+           new_status: other_status,
+           role: role,
+           type_id: story.id)
     create(:workflow,
-                      old_status: status,
-                      new_status: other_status,
-                      role: role,
-                      type_id: task.id)
+           old_status: status,
+           new_status: other_status,
+           role: role,
+           type_id: task.id)
   end
   let(:role) do
     create(:role,
-                      permissions: %i(view_taskboards
-                                      add_work_packages
-                                      view_work_packages
-                                      edit_work_packages
-                                      manage_subtasks
-                                      assign_versions))
+           permissions: %i(view_taskboards
+                           add_work_packages
+                           view_work_packages
+                           edit_work_packages
+                           manage_subtasks
+                           assign_versions))
   end
   let!(:current_user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let!(:task1) do
     create(:work_package,
-                      status: status,
-                      project: project,
-                      type: task,
-                      version: sprint,
-                      parent: story1)
+           status: status,
+           project: project,
+           type: task,
+           version: sprint,
+           parent: story1)
   end
   let!(:story1) do
     create(:work_package,
-                      project: project,
-                      type: story,
-                      version: sprint)
+           project: project,
+           type: story,
+           version: sprint)
   end
   let!(:other_task) do
     create(:work_package,
-                      project: project,
-                      type: task,
-                      version: sprint,
-                      parent: other_story)
+           project: project,
+           type: task,
+           version: sprint,
+           parent: other_story)
   end
   let!(:other_story) do
     create(:work_package,
-                      project: project,
-                      type: story,
-                      version: other_sprint)
+           project: project,
+           type: story,
+           version: other_sprint)
   end
   let!(:sprint) do
     create(:version, project: project)

--- a/modules/backlogs/spec/features/onboarding/backlogs_onboarding_tour_spec.rb
+++ b/modules/backlogs/spec/features/onboarding/backlogs_onboarding_tour_spec.rb
@@ -33,17 +33,17 @@ describe 'backlogs onboarding tour', js: true do
   let(:user) { create :admin }
   let(:demo_project) do
     create :project,
-                      name: 'Demo project',
-                      identifier: 'demo-project',
-                      public: true,
-                      enabled_module_names: %w[work_package_tracking wiki]
+           name: 'Demo project',
+           identifier: 'demo-project',
+           public: true,
+           enabled_module_names: %w[work_package_tracking wiki]
   end
   let(:project) do
     create :project,
-                      name: 'Scrum project',
-                      identifier: 'your-scrum-project',
-                      public: true,
-                      enabled_module_names: %w[work_package_tracking wiki backlogs]
+           name: 'Scrum project',
+           identifier: 'your-scrum-project',
+           public: true,
+           enabled_module_names: %w[work_package_tracking wiki backlogs]
   end
   let(:sprint) { create(:version, project: project, name: 'Sprint 1') }
   let(:status) { create(:default_status) }
@@ -68,13 +68,13 @@ describe 'backlogs onboarding tour', js: true do
 
   let!(:existing_story) do
     create(:work_package,
-                      type: story_type,
-                      project: project,
-                      status: status,
-                      priority: priority,
-                      position: 1,
-                      story_points: 3,
-                      version: sprint)
+           type: story_type,
+           project: project,
+           status: status,
+           priority: priority,
+           position: 1,
+           story_points: 3,
+           version: sprint)
   end
 
   before do

--- a/modules/backlogs/spec/features/resolved_status_spec.rb
+++ b/modules/backlogs/spec/features/resolved_status_spec.rb
@@ -32,17 +32,17 @@ describe 'Resolved status',
          type: :feature do
   let!(:project) do
     create(:project,
-                      enabled_module_names: %w(backlogs))
+           enabled_module_names: %w(backlogs))
   end
   let!(:status) { create(:status, is_default: true) }
   let(:role) do
     create(:role,
-                      permissions: %i[select_done_statuses])
+           permissions: %i[select_done_statuses])
   end
   let!(:current_user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:settings_page) { Pages::Projects::Settings.new(project) }
 

--- a/modules/backlogs/spec/features/stories_in_backlog_spec.rb
+++ b/modules/backlogs/spec/features/stories_in_backlog_spec.rb
@@ -34,8 +34,8 @@ describe 'Stories in backlog',
          js: true do
   let!(:project) do
     create(:project,
-                      types: [story, task, other_story],
-                      enabled_module_names: %w(work_package_tracking backlogs))
+           types: [story, task, other_story],
+           enabled_module_names: %w(work_package_tracking backlogs))
   end
   let!(:story) { create(:type_feature) }
   let!(:other_story) { create(:type) }
@@ -45,91 +45,91 @@ describe 'Stories in backlog',
   let!(:other_status) { create(:status) }
   let!(:workflows) do
     create(:workflow,
-                      old_status: default_status,
-                      new_status: other_status,
-                      role: role,
-                      type_id: story.id)
+           old_status: default_status,
+           new_status: other_status,
+           role: role,
+           type_id: story.id)
   end
   let(:role) do
     create(:role,
-                      permissions: %i(view_master_backlog
-                                      add_work_packages
-                                      view_work_packages
-                                      edit_work_packages
-                                      manage_subtasks
-                                      assign_versions))
+           permissions: %i(view_master_backlog
+                           add_work_packages
+                           view_work_packages
+                           edit_work_packages
+                           manage_subtasks
+                           assign_versions))
   end
   let!(:current_user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let!(:sprint_story1) do
     create(:work_package,
-                      project: project,
-                      type: story,
-                      status: default_status,
-                      version: sprint,
-                      position: 1,
-                      story_points: 10)
+           project: project,
+           type: story,
+           status: default_status,
+           version: sprint,
+           position: 1,
+           story_points: 10)
   end
   let!(:sprint_story1_task) do
     create(:work_package,
-                      project: project,
-                      type: task,
-                      status: default_status,
-                      version: sprint)
+           project: project,
+           type: task,
+           status: default_status,
+           version: sprint)
   end
   let!(:sprint_story2_parent) do
     create(:work_package,
-                      project: project,
-                      type: create(:type),
-                      status: default_status,
-                      version: sprint)
+           project: project,
+           type: create(:type),
+           status: default_status,
+           version: sprint)
   end
   let!(:sprint_story2) do
     create(:work_package,
-                      project: project,
-                      type: story,
-                      status: default_status,
-                      version: sprint,
-                      position: 2,
-                      story_points: 20)
+           project: project,
+           type: story,
+           status: default_status,
+           version: sprint,
+           position: 2,
+           story_points: 20)
   end
   let!(:backlog_story1) do
     create(:work_package,
-                      project: project,
-                      type: story,
-                      status: default_status,
-                      version: backlog)
+           project: project,
+           type: story,
+           status: default_status,
+           version: backlog)
   end
   let!(:sprint) do
     create(:version,
-                      project: project,
-                      start_date: Date.today - 10.days,
-                      effective_date: Date.today + 10.days,
-                      version_settings_attributes: [{ project: project, display: VersionSetting::DISPLAY_LEFT }])
+           project: project,
+           start_date: Date.today - 10.days,
+           effective_date: Date.today + 10.days,
+           version_settings_attributes: [{ project: project, display: VersionSetting::DISPLAY_LEFT }])
   end
   let!(:backlog) do
     create(:version,
-                      project: project,
-                      version_settings_attributes: [{ project: project, display: VersionSetting::DISPLAY_RIGHT }])
+           project: project,
+           version_settings_attributes: [{ project: project, display: VersionSetting::DISPLAY_RIGHT }])
   end
   let!(:other_project) do
     create(:project).tap do |p|
       create(:member,
-                        principal: current_user,
-                        project: p,
-                        roles: [role])
+             principal: current_user,
+             project: p,
+             roles: [role])
     end
   end
   let!(:sprint_story_in_other_project) do
     create(:work_package,
-                      project: other_project,
-                      type: story,
-                      status: default_status,
-                      version: sprint,
-                      story_points: 10)
+           project: other_project,
+           type: story,
+           status: default_status,
+           version: sprint,
+           story_points: 10)
   end
   let!(:export_card_configurations) do
     ExportCardConfiguration.create!(name: 'Default',

--- a/modules/backlogs/spec/features/tasks_on_taskboard_spec.rb
+++ b/modules/backlogs/spec/features/tasks_on_taskboard_spec.rb
@@ -34,8 +34,8 @@ describe 'Tasks on taskboard',
          js: true do
   let!(:project) do
     create(:project,
-                      types: [story, task, other_story],
-                      enabled_module_names: %w(work_package_tracking backlogs))
+           types: [story, task, other_story],
+           enabled_module_names: %w(work_package_tracking backlogs))
   end
   let!(:story) { create(:type_feature) }
   let!(:other_story) { create(:type) }
@@ -45,96 +45,96 @@ describe 'Tasks on taskboard',
   let!(:other_status) { create(:status) }
   let!(:workflows) do
     create(:workflow,
-                      old_status: default_status,
-                      new_status: other_status,
-                      role: role,
-                      type_id: task.id)
+           old_status: default_status,
+           new_status: other_status,
+           role: role,
+           type_id: task.id)
   end
   let(:role) do
     create(:role,
-                      permissions: %i(view_taskboards
-                                      add_work_packages
-                                      view_work_packages
-                                      edit_work_packages
-                                      manage_subtasks
-                                      assign_versions))
+           permissions: %i(view_taskboards
+                           add_work_packages
+                           view_work_packages
+                           edit_work_packages
+                           manage_subtasks
+                           assign_versions))
   end
   let!(:current_user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let!(:story1) do
     create(:work_package,
-                      project: project,
-                      type: story,
-                      status: default_status,
-                      version: sprint,
-                      position: 1,
-                      story_points: 10)
+           project: project,
+           type: story,
+           status: default_status,
+           version: sprint,
+           position: 1,
+           story_points: 10)
   end
   let!(:story1_task) do
     create(:work_package,
-                      project: project,
-                      parent: story1,
-                      type: task,
-                      status: default_status,
-                      version: sprint)
+           project: project,
+           parent: story1,
+           type: task,
+           status: default_status,
+           version: sprint)
   end
   let!(:story1_task_subtask) do
     create(:work_package,
-                      project: project,
-                      parent: story1_task,
-                      type: task,
-                      status: default_status,
-                      version: sprint)
+           project: project,
+           parent: story1_task,
+           type: task,
+           status: default_status,
+           version: sprint)
   end
   let!(:other_work_package) do
     create(:work_package,
-                      project: project,
-                      type: create(:type),
-                      status: default_status,
-                      version: sprint)
+           project: project,
+           type: create(:type),
+           status: default_status,
+           version: sprint)
   end
   let!(:other_work_package_subtask) do
     create(:work_package,
-                      project: project,
-                      parent: other_work_package,
-                      type: task,
-                      status: default_status,
-                      version: sprint)
+           project: project,
+           parent: other_work_package,
+           type: task,
+           status: default_status,
+           version: sprint)
   end
   let!(:story2) do
     create(:work_package,
-                      project: project,
-                      type: story,
-                      status: default_status,
-                      version: sprint,
-                      position: 2,
-                      story_points: 20)
+           project: project,
+           type: story,
+           status: default_status,
+           version: sprint,
+           position: 2,
+           story_points: 20)
   end
   let!(:sprint) do
     create(:version,
-                      project: project,
-                      start_date: Date.today - 10.days,
-                      effective_date: Date.today + 10.days,
-                      version_settings_attributes: [{ project: project, display: VersionSetting::DISPLAY_LEFT }])
+           project: project,
+           start_date: Date.today - 10.days,
+           effective_date: Date.today + 10.days,
+           version_settings_attributes: [{ project: project, display: VersionSetting::DISPLAY_LEFT }])
   end
   let!(:other_project) do
     create(:project).tap do |p|
       create(:member,
-                        principal: current_user,
-                        project: p,
-                        roles: [role])
+             principal: current_user,
+             project: p,
+             roles: [role])
     end
   end
   let!(:story_in_other_project) do
     create(:work_package,
-                      project: other_project,
-                      type: story,
-                      status: default_status,
-                      version: sprint,
-                      story_points: 10)
+           project: other_project,
+           type: story,
+           status: default_status,
+           version: sprint,
+           story_points: 10)
   end
   let!(:export_card_configurations) do
     ExportCardConfiguration.create!(name: 'Default',

--- a/modules/backlogs/spec/features/work_packages/filter_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/filter_spec.rb
@@ -51,20 +51,20 @@ describe 'Filter by backlog type', js: true do
 
   let(:member) do
     create(:member,
-                      user: user,
-                      project: project,
-                      roles: [create(:role)])
+           user: user,
+           project: project,
+           roles: [create(:role)])
   end
 
   let(:work_package_with_story_type) do
     create(:work_package,
-                      type: story_type,
-                      project: project)
+           type: story_type,
+           project: project)
   end
   let(:work_package_with_task_type) do
     create(:work_package,
-                      type: task_type,
-                      project: project)
+           type: task_type,
+           project: project)
   end
 
   before do

--- a/modules/backlogs/spec/features/work_packages/story_points_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/story_points_spec.rb
@@ -41,7 +41,7 @@ describe 'Work packages having story points', type: :feature, js: true do
   let(:current_user) { create(:admin) }
   let(:project) do
     create(:project,
-                      enabled_module_names: %w(work_package_tracking backlogs))
+           enabled_module_names: %w(work_package_tracking backlogs))
   end
   let(:status) { create :default_status }
   let(:story_type) { create(:type_feature) }
@@ -51,11 +51,11 @@ describe 'Work packages having story points', type: :feature, js: true do
     let(:story_points) { 42 }
     let(:story_with_sp) do
       create(:story,
-                        type: story_type,
-                        author: current_user,
-                        project: project,
-                        status: status,
-                        story_points: story_points)
+             type: story_type,
+             author: current_user,
+             project: project,
+             status: status,
+             story_points: story_points)
     end
 
     it 'should be displayed' do

--- a/modules/backlogs/spec/models/burndown_spec.rb
+++ b/modules/backlogs/spec/models/burndown_spec.rb
@@ -74,10 +74,10 @@ describe Burndown, type: :model do
 
     [issue_open, issue_closed, issue_resolved].permutation(2).each do |transition|
       create(:workflow,
-                        old_status: transition[0],
-                        new_status: transition[1],
-                        role: role,
-                        type_id: type_feature.id)
+             old_status: transition[0],
+             new_status: transition[1],
+             role: role,
+             type_id: type_feature.id)
     end
   end
 

--- a/modules/backlogs/spec/models/issue_position_spec.rb
+++ b/modules/backlogs/spec/models/issue_position_spec.rb
@@ -32,10 +32,10 @@ describe WorkPackage, type: :model do
   describe 'Story positions' do
     def build_work_package(options)
       build(:work_package, options.reverse_merge(version_id: sprint_1.id,
-                                                            priority_id: priority.id,
-                                                            project_id: project.id,
-                                                            status_id: status.id,
-                                                            type_id: story_type.id))
+                                                 priority_id: priority.id,
+                                                 project_id: project.id,
+                                                 status_id: status.id,
+                                                 type_id: story_type.id))
     end
 
     def create_work_package(options)
@@ -254,15 +254,15 @@ describe WorkPackage, type: :model do
 
       let(:shared_sprint) do
         create(:version,
-                          project_id: project.id,
-                          name: 'Shared Sprint',
-                          sharing: 'descendants')
+               project_id: project.id,
+               name: 'Shared Sprint',
+               sharing: 'descendants')
       end
 
       let(:version_go_live) do
         create(:version,
-                          project_id: project_wo_backlogs.id,
-                          name: 'Go-Live')
+               project_id: project_wo_backlogs.id,
+               name: 'Go-Live')
       end
       shared_let(:admin) { create :admin }
 

--- a/modules/backlogs/spec/models/task_spec.rb
+++ b/modules/backlogs/spec/models/task_spec.rb
@@ -34,9 +34,9 @@ describe Task, type: :model do
   let(:project) { create(:project) }
   let(:task) do
     build(:task,
-                     project: project,
-                     status: default_status,
-                     type: task_type)
+          project: project,
+          status: default_status,
+          type: task_type)
   end
 
   before(:each) do

--- a/modules/backlogs/spec/models/version_spec.rb
+++ b/modules/backlogs/spec/models/version_spec.rb
@@ -34,9 +34,9 @@ describe Version, type: :model do
   describe 'rebuild positions' do
     def build_work_package(options = {})
       build(:work_package, options.reverse_merge(version_id: version.id,
-                                                            priority_id: priority.id,
-                                                            project_id: project.id,
-                                                            status_id: status.id))
+                                                 priority_id: priority.id,
+                                                 project_id: project.id,
+                                                 status_id: status.id))
     end
 
     def create_work_package(options = {})

--- a/modules/backlogs/spec/services/impediments/create_services_spec.rb
+++ b/modules/backlogs/spec/services/impediments/create_services_spec.rb
@@ -38,11 +38,11 @@ describe Impediments::CreateService do
   let(:priority) { create(:priority, is_default: true) }
   let(:feature) do
     build(:work_package,
-                     type: type_feature,
-                     project: project,
-                     author: user,
-                     priority: priority,
-                     status: status1)
+          type: type_feature,
+          project: project,
+          author: user,
+          priority: priority,
+          status: status1)
   end
   let(:version) { create(:version, project: project) }
 

--- a/modules/backlogs/spec/services/impediments/update_service_spec.rb
+++ b/modules/backlogs/spec/services/impediments/update_service_spec.rb
@@ -135,12 +135,12 @@ describe Impediments::UpdateService, type: :model do
   describe 'WHEN changing the blocking relationship to another story' do
     let(:story) do
       build(:work_package,
-                       subject: 'another story',
-                       type: type_feature,
-                       project: project,
-                       author: user,
-                       priority: priority,
-                       status: status1)
+            subject: 'another story',
+            type: type_feature,
+            project: project,
+            author: user,
+            priority: priority,
+            status: status1)
     end
     let(:blocks) { story.id.to_s }
     let(:story_version) { version }

--- a/modules/backlogs/spec/services/stories/create_service_spec.rb
+++ b/modules/backlogs/spec/services/stories/create_service_spec.rb
@@ -34,9 +34,9 @@ describe Stories::CreateService, type: :model do
     project = create(:project, types: [type_feature])
 
     create(:member,
-                      principal: user,
-                      project: project,
-                      roles: [role])
+           principal: user,
+           project: project,
+           roles: [role])
     project
   end
   let(:role) { create(:role, permissions: permissions) }
@@ -71,11 +71,11 @@ describe Stories::CreateService, type: :model do
     project.enabled_module_names += ['backlogs']
 
     create(:story,
-                      version: version,
-                      project: project,
-                      status: status,
-                      type: type_feature,
-                      priority: priority)
+           version: version,
+           project: project,
+           status: status,
+           type: type_feature,
+           priority: priority)
   end
 
   before do

--- a/modules/backlogs/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/modules/backlogs/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -39,19 +39,19 @@ describe WorkPackages::UpdateAncestorsService do
   end
   let!(:parent) do
     create :work_package,
-                      parent: grandparent
+           parent: grandparent
   end
   let!(:sibling) do
     create :work_package,
-                      parent: parent,
-                      remaining_hours: sibling_remaining_hours
+           parent: parent,
+           remaining_hours: sibling_remaining_hours
   end
 
   context 'for a new ancestors' do
     let!(:work_package) do
       create :work_package,
-                        remaining_hours: work_package_remaining_hours,
-                        parent: parent
+             remaining_hours: work_package_remaining_hours,
+             parent: parent
     end
 
     subject do
@@ -83,8 +83,8 @@ describe WorkPackages::UpdateAncestorsService do
   context 'for the previous ancestors' do
     let!(:work_package) do
       create :work_package,
-                        remaining_hours: work_package_remaining_hours,
-                        parent: parent
+             remaining_hours: work_package_remaining_hours,
+             parent: parent
     end
 
     subject do

--- a/modules/backlogs/spec/services/work_packages/update_service_version_inheritance_spec.rb
+++ b/modules/backlogs/spec/services/work_packages/update_service_version_inheritance_spec.rb
@@ -41,10 +41,10 @@ describe WorkPackages::UpdateService, "version inheritance", type: :model do
 
   let(:project) do
     p = build(:project,
-                         members: [build(:member,
-                                                    principal: user,
-                                                    roles: [role])],
-                         types: [type_feature, type_task, type_bug])
+              members: [build(:member,
+                              principal: user,
+                              roles: [role])],
+              types: [type_feature, type_task, type_bug])
 
     p.versions << build(:version, name: 'Version1', project: p)
     p.versions << build(:version, name: 'Version2', project: p)
@@ -54,137 +54,137 @@ describe WorkPackages::UpdateService, "version inheritance", type: :model do
 
   let(:story) do
     story = build(:work_package,
-                             subject: 'Story',
-                             project: project,
-                             type: type_feature,
-                             version: version1,
-                             status: status,
-                             author: user,
-                             priority: issue_priority)
+                  subject: 'Story',
+                  project: project,
+                  type: type_feature,
+                  version: version1,
+                  status: status,
+                  author: user,
+                  priority: issue_priority)
     story
   end
 
   let(:story2) do
     story = build(:work_package,
-                             subject: 'Story2',
-                             project: project,
-                             type: type_feature,
-                             version: version1,
-                             status: status,
-                             author: user,
-                             priority: issue_priority)
+                  subject: 'Story2',
+                  project: project,
+                  type: type_feature,
+                  version: version1,
+                  status: status,
+                  author: user,
+                  priority: issue_priority)
     story
   end
 
   let(:story3) do
     story = build(:work_package,
-                             subject: 'Story3',
-                             project: project,
-                             type: type_feature,
-                             version: version1,
-                             status: status,
-                             author: user,
-                             priority: issue_priority)
+                  subject: 'Story3',
+                  project: project,
+                  type: type_feature,
+                  version: version1,
+                  status: status,
+                  author: user,
+                  priority: issue_priority)
     story
   end
 
   let(:task) do
     build(:work_package,
-                     subject: 'Task',
-                     type: type_task,
-                     version: version1,
-                     project: project,
-                     status: status,
-                     author: user,
-                     priority: issue_priority)
+          subject: 'Task',
+          type: type_task,
+          version: version1,
+          project: project,
+          status: status,
+          author: user,
+          priority: issue_priority)
   end
 
   let(:task2) do
     build(:work_package,
-                     subject: 'Task2',
-                     type: type_task,
-                     version: version1,
-                     project: project,
-                     status: status,
-                     author: user,
-                     priority: issue_priority)
+          subject: 'Task2',
+          type: type_task,
+          version: version1,
+          project: project,
+          status: status,
+          author: user,
+          priority: issue_priority)
   end
 
   let(:task3) do
     build(:work_package,
-                     subject: 'Task3',
-                     type: type_task,
-                     version: version1,
-                     project: project,
-                     status: status,
-                     author: user,
-                     priority: issue_priority)
+          subject: 'Task3',
+          type: type_task,
+          version: version1,
+          project: project,
+          status: status,
+          author: user,
+          priority: issue_priority)
   end
 
   let(:task4) do
     build(:work_package,
-                     subject: 'Task4',
-                     type: type_task,
-                     version: version1,
-                     project: project,
-                     status: status,
-                     author: user,
-                     priority: issue_priority)
+          subject: 'Task4',
+          type: type_task,
+          version: version1,
+          project: project,
+          status: status,
+          author: user,
+          priority: issue_priority)
   end
 
   let(:task5) do
     build(:work_package,
-                     subject: 'Task5',
-                     type: type_task,
-                     version: version1,
-                     project: project,
-                     status: status,
-                     author: user,
-                     priority: issue_priority)
+          subject: 'Task5',
+          type: type_task,
+          version: version1,
+          project: project,
+          status: status,
+          author: user,
+          priority: issue_priority)
   end
 
   let(:task6) do
     build(:work_package,
-                     subject: 'Task6',
-                     type: type_task,
-                     version: version1,
-                     project: project,
-                     status: status,
-                     author: user,
-                     priority: issue_priority)
+          subject: 'Task6',
+          type: type_task,
+          version: version1,
+          project: project,
+          status: status,
+          author: user,
+          priority: issue_priority)
   end
 
   let(:bug) do
     build(:work_package,
-                     subject: 'Bug',
-                     type: type_bug,
-                     version: version1,
-                     project: project,
-                     status: status,
-                     author: user,
-                     priority: issue_priority)
+          subject: 'Bug',
+          type: type_bug,
+          version: version1,
+          project: project,
+          status: status,
+          author: user,
+          priority: issue_priority)
   end
 
   let(:bug2) do
     build(:work_package,
-                     subject: 'Bug2',
-                     type: type_bug,
-                     version: version1,
-                     project: project,
-                     status: status,
-                     author: user,
-                     priority: issue_priority)
+          subject: 'Bug2',
+          type: type_bug,
+          version: version1,
+          project: project,
+          status: status,
+          author: user,
+          priority: issue_priority)
   end
 
   let(:bug3) do
     build(:work_package,
-                     subject: 'Bug3',
-                     type: type_bug,
-                     version: version1,
-                     project: project,
-                     status: status,
-                     author: user,
-                     priority: issue_priority)
+          subject: 'Bug3',
+          type: type_bug,
+          version: version1,
+          project: project,
+          status: status,
+          author: user,
+          priority: issue_priority)
   end
 
   before(:each) do

--- a/modules/backlogs/spec/views/rb_burndown_charts/show_spec.rb
+++ b/modules/backlogs/spec/views/rb_burndown_charts/show_spec.rb
@@ -33,7 +33,7 @@ describe 'rb_burndown_charts/show', type: :view do
   let(:user2) { create(:user) }
   let(:role_allowed) do
     create(:role,
-                      permissions: %i[add_work_packages manage_subtasks])
+           permissions: %i[add_work_packages manage_subtasks])
   end
   let(:role_forbidden) { create(:role) }
   # We need to create these as some view helpers access the database

--- a/modules/backlogs/spec/views/rb_master_backlogs/index.html.erb_spec.rb
+++ b/modules/backlogs/spec/views/rb_master_backlogs/index.html.erb_spec.rb
@@ -32,7 +32,7 @@ describe 'rb_master_backlogs/index', type: :view do
   let(:user) { create(:user) }
   let(:role_allowed) do
     create(:role,
-                      permissions: %i[view_master_backlog view_taskboards])
+           permissions: %i[view_master_backlog view_taskboards])
   end
   let(:statuses) do
     [create(:status, is_default: true),

--- a/modules/backlogs/spec/views/rb_taskboards/show_spec.rb
+++ b/modules/backlogs/spec/views/rb_taskboards/show_spec.rb
@@ -33,7 +33,7 @@ describe 'rb_taskboards/show', type: :view do
   let(:user2) { create(:user) }
   let(:role_allowed) do
     create(:role,
-                      permissions: %i[add_work_packages edit_work_packages manage_subtasks])
+           permissions: %i[add_work_packages edit_work_packages manage_subtasks])
   end
   let(:role_forbidden) { create(:role) }
   # We need to create these as some view helpers access the database

--- a/modules/bim/spec/bcf/bcf_xml/importer_spec.rb
+++ b/modules/bim/spec/bcf/bcf_xml/importer_spec.rb
@@ -39,13 +39,13 @@ describe ::OpenProject::Bim::BcfXml::Importer do
   let(:type) { create :type, name: 'Issue', is_standard: true, is_default: true }
   let(:project) do
     create(:project,
-                      identifier: 'bim_project',
-                      enabled_module_names: %w[bim work_package_tracking],
-                      types: [type])
+           identifier: 'bim_project',
+           enabled_module_names: %w[bim work_package_tracking],
+           types: [type])
   end
   let(:member_role) do
     create(:role,
-                      permissions: %i[view_linked_issues view_work_packages])
+           permissions: %i[view_linked_issues view_work_packages])
   end
   let(:manage_bcf_role) do
     create(
@@ -56,15 +56,15 @@ describe ::OpenProject::Bim::BcfXml::Importer do
   let(:bcf_manager) { create(:user) }
   let(:workflow) do
     create(:workflow_with_default_status,
-                      role: manage_bcf_role,
-                      type: type)
+           role: manage_bcf_role,
+           type: type)
   end
   let(:priority) { create :default_priority }
   let(:bcf_manager_member) do
     create(:member,
-                      project: project,
-                      user: bcf_manager,
-                      roles: [manage_bcf_role, member_role])
+           project: project,
+           user: bcf_manager,
+           roles: [manage_bcf_role, member_role])
   end
 
   subject { described_class.new file, project, current_user: bcf_manager }

--- a/modules/bim/spec/bcf/bcf_xml/issue_reader_spec.rb
+++ b/modules/bim/spec/bcf/bcf_xml/issue_reader_spec.rb
@@ -33,8 +33,8 @@ describe ::OpenProject::Bim::BcfXml::IssueReader do
   let(:type) { create :type, name: 'Issue', is_standard: true, is_default: true }
   let(:project) do
     create(:project,
-                      identifier: 'bim_project',
-                      types: [type])
+           identifier: 'bim_project',
+           types: [type])
   end
   let(:manage_bcf_role) do
     create(
@@ -45,15 +45,15 @@ describe ::OpenProject::Bim::BcfXml::IssueReader do
   let(:bcf_manager) { create(:user) }
   let(:workflow) do
     create(:workflow_with_default_status,
-                      role: manage_bcf_role,
-                      type: type)
+           role: manage_bcf_role,
+           type: type)
   end
   let(:priority) { create :default_priority }
   let(:bcf_manager_member) do
     create(:member,
-                      project: project,
-                      user: bcf_manager,
-                      roles: [manage_bcf_role])
+           project: project,
+           user: bcf_manager,
+           roles: [manage_bcf_role])
   end
   let(:markup) do
     <<-MARKUP

--- a/modules/bim/spec/bcf/bcf_xml/issue_writer_spec.rb
+++ b/modules/bim/spec/bcf/bcf_xml/issue_writer_spec.rb
@@ -84,8 +84,8 @@ describe ::OpenProject::Bim::BcfXml::IssueWriter do
   end
   let(:bcf_issue) do
     create(:bcf_issue_with_comment,
-                      work_package: work_package,
-                      markup: markup)
+           work_package: work_package,
+           markup: markup)
   end
   let(:priority) { create :priority_low }
   let(:current_user) { create(:user) }
@@ -93,12 +93,12 @@ describe ::OpenProject::Bim::BcfXml::IssueWriter do
   let(:type) { create :type, name: 'Issue' }
   let(:work_package) do
     create(:work_package,
-                      project_id: project.id,
-                      priority: priority,
-                      author: current_user,
-                      assigned_to: current_user,
-                      due_date: due_date,
-                      type: type)
+           project_id: project.id,
+           priority: priority,
+           author: current_user,
+           assigned_to: current_user,
+           due_date: due_date,
+           type: type)
   end
 
   before do

--- a/modules/bim/spec/contracts/bcf/issues/update_contract_spec.rb
+++ b/modules/bim/spec/contracts/bcf/issues/update_contract_spec.rb
@@ -33,7 +33,7 @@ describe Bim::Bcf::Issues::UpdateContract do
   it_behaves_like 'issues contract' do
     let(:issue) do
       build_stubbed(:bcf_issue,
-                               work_package: issue_work_package).tap do |i|
+                    work_package: issue_work_package).tap do |i|
         # in order to actually have something changed
         i.index = issue_index
       end

--- a/modules/bim/spec/contracts/ifc_models/update_contract_spec.rb
+++ b/modules/bim/spec/contracts/ifc_models/update_contract_spec.rb
@@ -37,9 +37,9 @@ describe Bim::IfcModels::UpdateContract do
 
     let(:ifc_model) do
       build_stubbed(:ifc_model,
-                               uploader: model_user,
-                               title: model_title,
-                               project: model_project).tap do |model|
+                    uploader: model_user,
+                    title: model_title,
+                    project: model_project).tap do |model|
         model.extend(OpenProject::ChangedBySystem)
 
         if changed_by_system

--- a/modules/bim/spec/controllers/issues_controller_spec.rb
+++ b/modules/bim/spec/controllers/issues_controller_spec.rb
@@ -31,11 +31,11 @@ require 'spec_helper'
 describe ::Bim::Bcf::IssuesController, type: :controller do
   let(:manage_bcf_role) do
     create(:role,
-                      permissions: %i[manage_bcf view_linked_issues view_work_packages add_work_packages edit_work_packages])
+           permissions: %i[manage_bcf view_linked_issues view_work_packages add_work_packages edit_work_packages])
   end
   let(:collaborator_role) do
     create(:role,
-                      permissions: %i[view_linked_issues view_work_packages add_work_packages edit_work_packages])
+           permissions: %i[view_linked_issues view_work_packages add_work_packages edit_work_packages])
   end
   let(:bcf_manager) { create(:user, firstname: "BCF Manager") }
   let(:collaborator) { create(:user) }
@@ -46,15 +46,15 @@ describe ::Bim::Bcf::IssuesController, type: :controller do
   end
   let(:member) do
     create(:member,
-                      project: project,
-                      user: collaborator,
-                      roles: [collaborator_role])
+           project: project,
+           user: collaborator,
+           roles: [collaborator_role])
   end
   let(:bcf_manager_member) do
     create(:member,
-                      project: project,
-                      user: bcf_manager,
-                      roles: [manage_bcf_role])
+           project: project,
+           user: bcf_manager,
+           roles: [manage_bcf_role])
   end
   before do
     bcf_manager_member
@@ -76,9 +76,9 @@ describe ::Bim::Bcf::IssuesController, type: :controller do
       context 'no manage_bcf permission' do
         let(:bcf_manager_member) do
           create(:member,
-                            project: project,
-                            user: bcf_manager,
-                            roles: [collaborator_role])
+                 project: project,
+                 user: bcf_manager,
+                 roles: [collaborator_role])
         end
         it 'will return "not authorized"' do
           expect(response).to_not be_successful

--- a/modules/bim/spec/features/bcf/bcf_snapshot_column_spec.rb
+++ b/modules/bim/spec/features/bcf/bcf_snapshot_column_spec.rb
@@ -12,8 +12,8 @@ describe 'BCF snapshot column',
   let!(:bcf_issue) { create(:bcf_issue_with_viewpoint, work_package: work_package) }
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_with_permissions: permissions
+           member_in_project: project,
+           member_with_permissions: permissions
   end
   let!(:query) do
     query              = build(:query, user: user, project: project)

--- a/modules/bim/spec/features/bcf/create_spec.rb
+++ b/modules/bim/spec/features/bcf/create_spec.rb
@@ -7,9 +7,9 @@ describe 'Create BCF',
          with_mail: false do
   let(:project) do
     create(:project,
-                      types: [type, type_with_cf],
-                      enabled_module_names: %i[bim work_package_tracking],
-                      work_package_custom_fields: [integer_cf])
+           types: [type, type_with_cf],
+           enabled_module_names: %i[bim work_package_tracking],
+           work_package_custom_fields: [integer_cf])
   end
   let(:index_page) { Pages::IfcModels::ShowDefault.new(project) }
   let(:permissions) { %i[view_ifc_models view_linked_issues manage_bcf add_work_packages edit_work_packages view_work_packages] }
@@ -18,14 +18,14 @@ describe 'Create BCF',
 
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_with_permissions: permissions
+           member_in_project: project,
+           member_with_permissions: permissions
   end
 
   let!(:model) do
     create(:ifc_model_minimal_converted,
-                      project: project,
-                      uploader: user)
+           project: project,
+           uploader: user)
   end
   let(:type) { create(:type) }
   let(:type_with_cf) do

--- a/modules/bim/spec/features/bcf/export_spec.rb
+++ b/modules/bim/spec/features/bcf/export_spec.rb
@@ -53,14 +53,14 @@ describe 'bcf export',
 
   let(:current_user) do
     create :user,
-                      member_in_project: project,
-                      member_with_permissions: permissions
+           member_in_project: project,
+           member_with_permissions: permissions
   end
 
   let!(:model) do
     create(:ifc_model_minimal_converted,
-                      project: project,
-                      uploader: current_user)
+           project: project,
+           uploader: current_user)
   end
 
   let(:model_page) { ::Pages::IfcModels::ShowDefault.new project }

--- a/modules/bim/spec/features/bcf_view_management_spec.rb
+++ b/modules/bim/spec/features/bcf_view_management_spec.rb
@@ -39,27 +39,27 @@ describe 'bcf view management',
   let(:bcf_page) { ::Pages::IfcModels::ShowDefault.new(project) }
   let(:role) do
     create :role,
-                      permissions: %w[
-                        view_work_packages
-                        save_queries
-                        save_public_queries
-                        view_ifc_models
-                        save_bcf_queries
-                        manage_public_bcf_queries
-                      ]
+           permissions: %w[
+             view_work_packages
+             save_queries
+             save_public_queries
+             view_ifc_models
+             save_bcf_queries
+             manage_public_bcf_queries
+           ]
   end
 
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
 
   let!(:model) do
     create(:ifc_model_minimal_converted,
-                      project: project,
-                      uploader: user,
-                      is_default: true)
+           project: project,
+           uploader: user,
+           is_default: true)
   end
 
   before do

--- a/modules/bim/spec/features/bim_filter_spec.rb
+++ b/modules/bim/spec/features/bim_filter_spec.rb
@@ -46,8 +46,8 @@ describe 'BIM filter spec',
 
   let!(:model) do
     create(:ifc_model_minimal_converted,
-                      project: project,
-                      uploader: admin)
+           project: project,
+           uploader: admin)
   end
 
   let(:card_view) { ::Pages::WorkPackageCards.new(project) }

--- a/modules/bim/spec/features/bim_navigation_spec.rb
+++ b/modules/bim/spec/features/bim_navigation_spec.rb
@@ -40,14 +40,14 @@ describe 'BIM navigation spec',
 
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
 
   let(:model) do
     create(:ifc_model_minimal_converted,
-                      project: project,
-                      uploader: user)
+           project: project,
+           uploader: user)
   end
 
   let(:card_view) { ::Pages::WorkPackageCards.new(project) }

--- a/modules/bim/spec/features/model_management_spec.rb
+++ b/modules/bim/spec/features/model_management_spec.rb
@@ -40,21 +40,21 @@ describe 'model management',
 
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
 
   let!(:model) do
     create(:ifc_model_minimal_converted,
-                      project: project,
-                      uploader: user,
-                      is_default: true)
+           project: project,
+           uploader: user,
+           is_default: true)
   end
 
   let!(:model2) do
     create(:ifc_model_minimal_converted,
-                      project: project,
-                      uploader: user)
+           project: project,
+           uploader: user)
   end
 
   context 'with all permissions' do
@@ -91,8 +91,8 @@ describe 'model management',
     let(:view_role) { create(:role, permissions: %i[view_ifc_models view_work_packages]) }
     let(:view_user) do
       create :user,
-                        member_in_project: project,
-                        member_through_role: view_role
+             member_in_project: project,
+             member_through_role: view_role
     end
 
     before do
@@ -124,8 +124,8 @@ describe 'model management',
     let(:no_permissions_role) { create(:role, permissions: %i[]) }
     let(:user_without_permissions) do
       create :user,
-                        member_in_project: project,
-                        member_through_role: no_permissions_role
+             member_in_project: project,
+             member_through_role: no_permissions_role
     end
 
     before do

--- a/modules/bim/spec/features/model_viewer_spec.rb
+++ b/modules/bim/spec/features/model_viewer_spec.rb
@@ -39,14 +39,14 @@ describe 'model viewer',
 
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
 
   let!(:model) do
     create(:ifc_model_minimal_converted,
-                      project: project,
-                      uploader: user)
+           project: project,
+           uploader: user)
   end
 
   let(:show_model_page) { Pages::IfcModels::Show.new(project, model.id) }
@@ -106,8 +106,8 @@ describe 'model viewer',
     let(:view_role) { create(:role, permissions: %i[view_ifc_models view_work_packages view_linked_issues]) }
     let(:view_user) do
       create :user,
-                        member_in_project: project,
-                        member_through_role: view_role
+             member_in_project: project,
+             member_through_role: view_role
     end
 
     before do
@@ -128,8 +128,8 @@ describe 'model viewer',
     let(:no_permissions_role) { create(:role, permissions: %i[]) }
     let(:user_without_permissions) do
       create :user,
-                        member_in_project: project,
-                        member_through_role: no_permissions_role
+             member_in_project: project,
+             member_through_role: no_permissions_role
     end
 
     before do

--- a/modules/bim/spec/features/revit_add_in/bim_revit_add_in_navigation_spec.rb
+++ b/modules/bim/spec/features/revit_add_in/bim_revit_add_in_navigation_spec.rb
@@ -37,14 +37,14 @@ describe 'BIM Revit Add-in navigation spec',
   let!(:work_package) { create(:work_package, project: project) }
   let(:role) do
     create(:role,
-                      permissions: %i[view_ifc_models manage_ifc_models add_work_packages edit_work_packages view_work_packages])
+           permissions: %i[view_ifc_models manage_ifc_models add_work_packages edit_work_packages view_work_packages])
   end
   let(:model_page) { ::Pages::IfcModels::ShowDefault.new(project) }
 
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
 
   context "when logged in on model page" do

--- a/modules/bim/spec/features/revit_add_in/bim_revit_add_in_refresh_button_spec.rb
+++ b/modules/bim/spec/features/revit_add_in/bim_revit_add_in_refresh_button_spec.rb
@@ -37,14 +37,14 @@ describe 'BIM Revit Add-in navigation spec',
   let!(:work_package) { create(:work_package, project: project) }
   let(:role) do
     create(:role,
-                      permissions: %i[view_ifc_models manage_ifc_models add_work_packages edit_work_packages view_work_packages])
+           permissions: %i[view_ifc_models manage_ifc_models add_work_packages edit_work_packages view_work_packages])
   end
   let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
 
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
 
   let(:model_page) { ::Pages::IfcModels::ShowDefault.new(project) }

--- a/modules/bim/spec/features/show_default_spec.rb
+++ b/modules/bim/spec/features/show_default_spec.rb
@@ -39,15 +39,15 @@ describe 'show default model',
 
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
 
   let(:model) do
     create(:ifc_model_minimal_converted,
-                      is_default: model_is_default,
-                      project: project,
-                      uploader: user)
+           is_default: model_is_default,
+           project: project,
+           uploader: user)
   end
   let(:model_is_default) { true }
   let(:model_tree) { ::Components::XeokitModelTree.new }
@@ -101,7 +101,7 @@ describe 'show default model',
     it 'renders a notification' do
       show_default_page
         .expect_toast(type: :info,
-                             message: I18n.t(:'ifc_models.processing_notice.processing_default'))
+                      message: I18n.t(:'ifc_models.processing_notice.processing_default'))
     end
   end
 end

--- a/modules/bim/spec/features/viewer/create_viewpoint_spec.rb
+++ b/modules/bim/spec/features/viewer/create_viewpoint_spec.rb
@@ -37,9 +37,9 @@ describe 'Create viewpoint from BCF details page',
 
   let!(:model) do
     create(:ifc_model_minimal_converted,
-                      title: 'minimal',
-                      project: project,
-                      uploader: user)
+           title: 'minimal',
+           project: project,
+           uploader: user)
   end
 
   let(:show_model_page) { Pages::IfcModels::ShowDefault.new(project) }

--- a/modules/bim/spec/features/viewer/delete_viewpoint_spec.rb
+++ b/modules/bim/spec/features/viewer/delete_viewpoint_spec.rb
@@ -41,9 +41,9 @@ describe 'Delete viewpoint in model viewer',
 
   let!(:model) do
     create(:ifc_model_minimal_converted,
-                      title: 'minimal',
-                      project: project,
-                      uploader: user)
+           title: 'minimal',
+           project: project,
+           uploader: user)
   end
 
   let(:model_tree) { ::Components::XeokitModelTree.new }

--- a/modules/bim/spec/features/viewer/show_viewpoint_spec.rb
+++ b/modules/bim/spec/features/viewer/show_viewpoint_spec.rb
@@ -34,8 +34,8 @@ describe 'Show viewpoint in model viewer',
          js: true do
   let(:project) do
     create(:project,
-                      enabled_module_names: %i[bim work_package_tracking],
-                      parent: parent_project)
+           enabled_module_names: %i[bim work_package_tracking],
+           parent: parent_project)
   end
   let(:parent_project) { nil }
   let(:user) { create :admin }
@@ -46,9 +46,9 @@ describe 'Show viewpoint in model viewer',
 
   let!(:model) do
     create(:ifc_model_minimal_converted,
-                      title: 'minimal',
-                      project: project,
-                      uploader: user)
+           title: 'minimal',
+           project: project,
+           uploader: user)
   end
 
   let(:model_tree) { ::Components::XeokitModelTree.new }
@@ -140,8 +140,8 @@ describe 'Show viewpoint in model viewer',
 
       let(:user) do
         create(:user,
-                          member_in_project: project,
-                          member_with_permissions: permissions)
+               member_in_project: project,
+               member_with_permissions: permissions)
       end
 
       it 'does not show the viewpoint' do

--- a/modules/bim/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
+++ b/modules/bim/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
@@ -34,7 +34,7 @@ require Rails.root + 'spec/lib/api/v3/work_packages/eager_loading/eager_loading_
 describe ::API::V3::WorkPackages::EagerLoading::Checksum do
   let!(:bcf_issue) do
     create(:bcf_issue,
-                      work_package: work_package)
+           work_package: work_package)
   end
   let!(:work_package) do
     create(:work_package)
@@ -58,7 +58,7 @@ describe ::API::V3::WorkPackages::EagerLoading::Checksum do
     it 'produces a different checksum on changes to the bcf issue id' do
       bcf_issue.delete
       create(:bcf_issue,
-                        work_package: work_package)
+             work_package: work_package)
 
       expect(new_checksum)
         .not_to eql orig_checksum

--- a/modules/bim/spec/models/ifc_model_spec.rb
+++ b/modules/bim/spec/models/ifc_model_spec.rb
@@ -24,8 +24,8 @@ describe ::Bim::IfcModels::IfcModel, type: :model do
     subject { create :ifc_model_minimal_converted, project: project }
     current_user do
       create :user,
-                        member_in_project: project,
-                        member_with_permissions: %i[manage_ifc_models]
+             member_in_project: project,
+             member_with_permissions: %i[manage_ifc_models]
     end
 
     it 'replaces the previous attachment' do

--- a/modules/bim/spec/representers/bcf/api/v2_1/topics/single_representer_rendering_spec.rb
+++ b/modules/bim/spec/representers/bcf/api/v2_1/topics/single_representer_rendering_spec.rb
@@ -44,11 +44,11 @@ describe Bim::Bcf::API::V2_1::Topics::SingleRepresenter, 'rendering' do
   let(:priority) { build_stubbed(:priority) }
   let(:work_package) do
     build_stubbed(:stubbed_work_package,
-                             assigned_to: assignee,
-                             due_date: Date.today,
-                             status: status,
-                             priority: priority,
-                             type: type).tap do |wp|
+                  assigned_to: assignee,
+                  due_date: Date.today,
+                  status: status,
+                  priority: priority,
+                  type: type).tap do |wp|
       allow(wp)
         .to receive(:journals)
         .and_return(journals)

--- a/modules/bim/spec/requests/api/bcf/v2_1/comments_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/comments_api_spec.rb
@@ -41,14 +41,14 @@ describe 'BCF 2.1 comments resource', type: :request, content_type: :json, with_
 
   let(:view_only_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_linked_issues view_work_packages])
+           member_in_project: project,
+           member_with_permissions: %i[view_linked_issues view_work_packages])
   end
 
   let(:edit_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_linked_issues view_work_packages manage_bcf])
+           member_in_project: project,
+           member_with_permissions: %i[view_linked_issues view_work_packages manage_bcf])
   end
 
   let(:user_without_permission) { create(:user, member_in_project: project) }
@@ -563,10 +563,10 @@ describe 'BCF 2.1 comments resource', type: :request, content_type: :json, with_
     context 'if the updated comment contains viewpoint reference and is a reply, but update does not set those attributes' do
       let(:updated_comment) do
         create(:bcf_comment,
-                          issue: bcf_issue,
-                          viewpoint: viewpoint,
-                          reply_to: bcf_comment,
-                          author: edit_user)
+               issue: bcf_issue,
+               viewpoint: viewpoint,
+               reply_to: bcf_comment,
+               author: edit_user)
       end
 
       let(:params) { { comment: "Only change the comment text and leave the reply and viewpoint guid empty." } }

--- a/modules/bim/spec/requests/api/bcf/v2_1/project_extensions_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/project_extensions_api_spec.rb
@@ -44,8 +44,8 @@ describe 'BCF 2.1 project extensions resource', type: :request, content_type: :j
   context 'with only view_project permissions' do
     let(:current_user) do
       create(:user,
-                        member_in_project: project,
-                        member_with_permissions: [:view_project])
+             member_in_project: project,
+             member_with_permissions: [:view_project])
     end
 
     before do
@@ -74,14 +74,14 @@ describe 'BCF 2.1 project extensions resource', type: :request, content_type: :j
   context 'with edit permissions in project' do
     let(:current_user) do
       create(:user,
-                        member_in_project: project,
-                        member_with_permissions: %i[view_project edit_project manage_bcf view_members])
+             member_in_project: project,
+             member_with_permissions: %i[view_project edit_project manage_bcf view_members])
     end
 
     let(:other_user) do
       create(:user,
-                        member_in_project: project,
-                        member_with_permissions: [:view_project])
+             member_in_project: project,
+             member_with_permissions: [:view_project])
     end
 
     before do

--- a/modules/bim/spec/requests/api/bcf/v2_1/projects_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/projects_api_spec.rb
@@ -36,12 +36,12 @@ describe 'BCF 2.1 projects resource', type: :request, content_type: :json do
 
   let(:view_only_user) do
     create(:user,
-                      member_in_project: project)
+           member_in_project: project)
   end
   let(:edit_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: [:edit_project])
+           member_in_project: project,
+           member_with_permissions: [:edit_project])
   end
   let(:non_member_user) do
     create(:user)
@@ -132,9 +132,9 @@ describe 'BCF 2.1 projects resource', type: :request, content_type: :json do
     let!(:non_bcf_project) do
       create(:project, enabled_module_names: [:work_packages]).tap do |p|
         create(:member,
-                          project: p,
-                          user: view_only_user,
-                          roles: view_only_user.members.first.roles)
+               project: p,
+               user: view_only_user,
+               roles: view_only_user.members.first.roles)
       end
     end
 

--- a/modules/bim/spec/requests/api/bcf/v2_1/topics_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/topics_api_spec.rb
@@ -37,40 +37,40 @@ describe 'BCF 2.1 topics resource', type: :request, content_type: :json, with_ma
 
   let(:view_only_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_linked_issues view_work_packages])
+           member_in_project: project,
+           member_with_permissions: %i[view_linked_issues view_work_packages])
   end
   let(:only_member_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: [])
+           member_in_project: project,
+           member_with_permissions: [])
   end
   let(:edit_member_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[manage_bcf
-                                                  add_work_packages
-                                                  view_linked_issues
-                                                  view_work_packages
-                                                  edit_work_packages])
+           member_in_project: project,
+           member_with_permissions: %i[manage_bcf
+                                       add_work_packages
+                                       view_linked_issues
+                                       view_work_packages
+                                       edit_work_packages])
   end
   let(:edit_and_delete_member_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[delete_bcf
-                                                  delete_work_packages
-                                                  manage_bcf
-                                                  add_work_packages
-                                                  view_linked_issues
-                                                  view_work_packages])
+           member_in_project: project,
+           member_with_permissions: %i[delete_bcf
+                                       delete_work_packages
+                                       manage_bcf
+                                       add_work_packages
+                                       view_linked_issues
+                                       view_work_packages])
   end
   let(:edit_work_package_member_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[add_work_packages
-                                                  view_linked_issues
-                                                  edit_work_packages
-                                                  view_work_packages])
+           member_in_project: project,
+           member_with_permissions: %i[add_work_packages
+                                       view_linked_issues
+                                       edit_work_packages
+                                       view_work_packages])
   end
   let(:non_member_user) do
     create(:user)
@@ -78,14 +78,14 @@ describe 'BCF 2.1 topics resource', type: :request, content_type: :json, with_ma
 
   let(:project) do
     create(:project,
-                      enabled_module_names: %i[bim work_package_tracking])
+           enabled_module_names: %i[bim work_package_tracking])
   end
   let(:assignee) { create(:user) }
   let(:work_package) do
     create(:work_package,
-                      assigned_to: assignee,
-                      due_date: Date.today,
-                      project: project)
+           assigned_to: assignee,
+           due_date: Date.today,
+           project: project)
   end
   let(:other_status) do
     create(:status).tap do |s|
@@ -93,10 +93,10 @@ describe 'BCF 2.1 topics resource', type: :request, content_type: :json, with_ma
 
       if member
         create(:workflow,
-                          old_status: work_package.status,
-                          new_status: s,
-                          type: work_package.type,
-                          role: member.roles.first)
+               old_status: work_package.status,
+               new_status: s,
+               type: work_package.type,
+               role: member.roles.first)
       end
     end
   end
@@ -505,10 +505,10 @@ describe 'BCF 2.1 topics resource', type: :request, content_type: :json, with_ma
 
         if member
           create(:workflow,
-                            old_status: status,
-                            new_status: s,
-                            type: type,
-                            role: member.roles.first)
+                 old_status: status,
+                 new_status: s,
+                 type: type,
+                 role: member.roles.first)
         end
       end
     end
@@ -760,10 +760,10 @@ describe 'BCF 2.1 topics resource', type: :request, content_type: :json, with_ma
 
         if member
           create(:workflow,
-                            old_status: status,
-                            new_status: s,
-                            type: type,
-                            role: member.roles.first)
+                 old_status: status,
+                 new_status: s,
+                 type: type,
+                 role: member.roles.first)
         end
       end
     end

--- a/modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/viewpoints_api_spec.rb
@@ -37,19 +37,19 @@ describe 'BCF 2.1 viewpoints resource', type: :request, content_type: :json, wit
 
   shared_let(:project) do
     create(:project,
-                      enabled_module_names: [:bim])
+           enabled_module_names: [:bim])
   end
 
   shared_let(:view_only_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: [:view_linked_issues])
+           member_in_project: project,
+           member_with_permissions: [:view_linked_issues])
   end
 
   shared_let(:create_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_linked_issues manage_bcf])
+           member_in_project: project,
+           member_with_permissions: %i[view_linked_issues manage_bcf])
   end
 
   shared_let(:non_member_user) do

--- a/modules/bim/spec/views/bim/ifc_models/ifc_models/index.html.erb_spec.rb
+++ b/modules/bim/spec/views/bim/ifc_models/ifc_models/index.html.erb_spec.rb
@@ -32,20 +32,20 @@ describe 'bim/ifc_models/ifc_models/index', type: :view do
   let(:project) { create(:project, enabled_module_names: %i[bim]) }
   let(:ifc_model) do
     create(:ifc_model,
-                      uploader: uploader_user,
-                      title: "office.ifc",
-                      project: project).tap do |model|
+           uploader: uploader_user,
+           title: "office.ifc",
+           project: project).tap do |model|
       model.uploader = uploader_user
     end
   end
   let(:role) do
     create(:role,
-                      permissions: %i[view_ifc_models manage_ifc_models])
+           permissions: %i[view_ifc_models manage_ifc_models])
   end
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
   let(:uploader_user) { user }
 
@@ -90,8 +90,8 @@ describe 'bim/ifc_models/ifc_models/index', type: :view do
     context 'without ifc_attachment' do
       let(:ifc_model) do
         create(:ifc_model_without_ifc_attachment,
-                          title: "office.ifc",
-                          project: project)
+               title: "office.ifc",
+               project: project)
       end
 
       it 'lists the IFC model with all but the download button' do

--- a/modules/boards/spec/factories/board_factory.rb
+++ b/modules/boards/spec/factories/board_factory.rb
@@ -26,13 +26,13 @@ FactoryBot.define do
       end
 
       board.widgets << create(:grid_widget,
-                                         identifier: 'work_package_query',
-                                         start_row: 1,
-                                         end_row: 2,
-                                         start_column: 1,
-                                         end_column: 1,
-                                         options: { 'queryId' => query.id,
-                                                    "filters" => [{ "manualSort" => { "operator" => "ow", "values" => [] } }] })
+                              identifier: 'work_package_query',
+                              start_row: 1,
+                              end_row: 2,
+                              start_column: 1,
+                              end_column: 1,
+                              options: { 'queryId' => query.id,
+                                         "filters" => [{ "manualSort" => { "operator" => "ow", "values" => [] } }] })
     end
   end
 
@@ -55,13 +55,13 @@ FactoryBot.define do
         end
 
         board.widgets << create(:grid_widget,
-                                           identifier: 'work_package_query',
-                                           start_row: 1,
-                                           end_row: 2,
-                                           start_column: 1,
-                                           end_column: 1,
-                                           options: { 'queryId' => query.id,
-                                                      "filters" => [{ "manualSort" => { "operator" => "ow", "values" => [] } }] })
+                                identifier: 'work_package_query',
+                                start_row: 1,
+                                end_row: 2,
+                                start_column: 1,
+                                end_column: 1,
+                                options: { 'queryId' => query.id,
+                                           "filters" => [{ "manualSort" => { "operator" => "ow", "values" => [] } }] })
       end
     end
   end
@@ -89,13 +89,13 @@ FactoryBot.define do
 
         board.options = { 'type' => 'action', 'attribute' => 'subproject' }
         board.widgets << create(:grid_widget,
-                                           identifier: 'work_package_query',
-                                           start_row: 1,
-                                           end_row: 2,
-                                           start_column: 1,
-                                           end_column: 1,
-                                           options: { 'queryId' => query.id,
-                                                      'filters' => filters })
+                                identifier: 'work_package_query',
+                                start_row: 1,
+                                end_row: 2,
+                                start_column: 1,
+                                end_column: 1,
+                                options: { 'queryId' => query.id,
+                                           'filters' => filters })
       end
     end
   end

--- a/modules/boards/spec/features/action_boards/assignee_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/assignee_board_spec.rb
@@ -35,10 +35,10 @@ describe 'Assignee action board',
          js: true do
   let(:bobself_user) do
     create(:user,
-                      firstname: 'Bob',
-                      lastname: 'Self',
-                      member_in_project: project,
-                      member_through_role: role)
+           firstname: 'Bob',
+           lastname: 'Self',
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:admin) { create(:admin) }
   let(:type) { create(:type_standard) }
@@ -60,26 +60,26 @@ describe 'Assignee action board',
 
   let!(:foobar_user) do
     create(:user,
-                      firstname: 'Foo',
-                      lastname: 'Bar',
-                      member_in_project: project,
-                      member_through_role: role)
+           firstname: 'Foo',
+           lastname: 'Bar',
+           member_in_project: project,
+           member_through_role: role)
   end
 
   let!(:group) do
     create(:group, name: 'Grouped').tap do |group|
       create(:member,
-                        principal: group,
-                        project: project,
-                        roles: [role])
+             principal: group,
+             project: project,
+             roles: [role])
     end
   end
 
   let!(:work_package) do
     create :work_package,
-                      project: project,
-                      assigned_to: bobself_user,
-                      subject: 'Some Task'
+           project: project,
+           assigned_to: bobself_user,
+           subject: 'Some Task'
   end
 
   context 'in a project with members' do

--- a/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
+++ b/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
@@ -33,8 +33,8 @@ require_relative './../support/board_page'
 describe 'Custom field filter in boards', type: :feature, js: true do
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:type) { create(:type_standard) }
   let(:project) { create(:project, types: [type], enabled_module_names: %i[work_package_tracking board_view]) }
@@ -53,10 +53,10 @@ describe 'Custom field filter in boards', type: :feature, js: true do
 
   let!(:work_package) do
     wp = build :work_package,
-                          project: project,
-                          type: type,
-                          subject: 'Foo',
-                          status: open_status
+               project: project,
+               type: type,
+               subject: 'Foo',
+               status: open_status
 
     wp.custom_field_values = {
       custom_field.id => %w[B].map { |s| custom_value_for(s) }

--- a/modules/boards/spec/features/action_boards/status_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/status_board_spec.rb
@@ -33,8 +33,8 @@ require_relative './../support/board_page'
 describe 'Status action board', type: :feature, js: true do
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:type) { create(:type_standard) }
   let(:project) { create(:project, types: [type], enabled_module_names: %i[work_package_tracking board_view]) }
@@ -57,24 +57,24 @@ describe 'Status action board', type: :feature, js: true do
 
   let!(:workflow_type) do
     create(:workflow,
-                      type: type,
-                      role: role,
-                      old_status_id: open_status.id,
-                      new_status_id: closed_status.id)
+           type: type,
+           role: role,
+           old_status_id: open_status.id,
+           new_status_id: closed_status.id)
   end
   let!(:workflow_type_back) do
     create(:workflow,
-                      type: type,
-                      role: role,
-                      old_status_id: other_status.id,
-                      new_status_id: open_status.id)
+           type: type,
+           role: role,
+           old_status_id: other_status.id,
+           new_status_id: open_status.id)
   end
   let!(:workflow_type_back_open) do
     create(:workflow,
-                      type: type,
-                      role: role,
-                      old_status_id: closed_status.id,
-                      new_status_id: open_status.id)
+           type: type,
+           role: role,
+           old_status_id: closed_status.id,
+           new_status_id: open_status.id)
   end
 
   before do

--- a/modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb
@@ -33,8 +33,8 @@ require_relative './../support/board_page'
 describe 'Status action board', type: :feature, js: true do
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:permissions) do
     %i[show_board_views manage_board_views add_work_packages
@@ -56,47 +56,47 @@ describe 'Status action board', type: :feature, js: true do
 
   let(:task_wp) do
     create :work_package,
-                      project: project,
-                      type: type_task,
-                      subject: 'Open task item',
-                      status: open_status
+           project: project,
+           type: type_task,
+           subject: 'Open task item',
+           status: open_status
   end
   let(:bug_wp) do
     create :work_package,
-                      project: project,
-                      type: type_bug,
-                      subject: 'Closed bug item',
-                      status: closed_status
+           project: project,
+           type: type_bug,
+           subject: 'Closed bug item',
+           status: closed_status
   end
 
   let!(:workflow_task) do
     create(:workflow,
-                      type: type_task,
-                      role: role,
-                      old_status_id: open_status.id,
-                      new_status_id: closed_status.id)
+           type: type_task,
+           role: role,
+           old_status_id: open_status.id,
+           new_status_id: closed_status.id)
   end
   let!(:workflow_task_back) do
     create(:workflow,
-                      type: type_task,
-                      role: role,
-                      old_status_id: closed_status.id,
-                      new_status_id: open_status.id)
+           type: type_task,
+           role: role,
+           old_status_id: closed_status.id,
+           new_status_id: open_status.id)
   end
 
   let!(:workflow_bug) do
     create(:workflow,
-                      type: type_bug,
-                      role: role,
-                      old_status_id: open_status.id,
-                      new_status_id: closed_status.id)
+           type: type_bug,
+           role: role,
+           old_status_id: open_status.id,
+           new_status_id: closed_status.id)
   end
   let!(:workflow_bug_back) do
     create(:workflow,
-                      type: type_bug,
-                      role: role,
-                      old_status_id: closed_status.id,
-                      new_status_id: open_status.id)
+           type: type_bug,
+           role: role,
+           old_status_id: closed_status.id,
+           new_status_id: open_status.id)
   end
 
   let(:filters) { ::Components::WorkPackages::Filters.new }

--- a/modules/boards/spec/features/action_boards/subproject_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/subproject_board_spec.rb
@@ -33,8 +33,8 @@ require_relative './../support/board_page'
 describe 'Subproject action board', type: :feature, js: true do
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:type) { create(:type_standard) }
   let(:project) do
@@ -75,8 +75,8 @@ describe 'Subproject action board', type: :feature, js: true do
 
     let(:user) do
       create(:user,
-                        member_in_projects: [project, subproject1, subproject2],
-                        member_through_role: role)
+             member_in_projects: [project, subproject1, subproject2],
+             member_through_role: role)
     end
 
     it 'does not allow to move work packages' do
@@ -98,14 +98,14 @@ describe 'Subproject action board', type: :feature, js: true do
   context 'with permissions in all subprojects' do
     let(:user) do
       create(:user,
-                        member_in_projects: [project, subproject1, subproject2],
-                        member_through_role: role)
+             member_in_projects: [project, subproject1, subproject2],
+             member_through_role: role)
     end
 
     let(:only_parent_user) do
       create(:user,
-                        member_in_project: project,
-                        member_through_role: role)
+             member_in_project: project,
+             member_through_role: role)
     end
 
     it 'allows management of subproject work packages' do
@@ -179,14 +179,14 @@ describe 'Subproject action board', type: :feature, js: true do
     let(:user) do
       create(:user,
                         # The membership in subproject2 gets removed later on
-                        member_in_projects: [project, subproject1, subproject2],
-                        member_through_role: role)
+             member_in_projects: [project, subproject1, subproject2],
+             member_through_role: role)
     end
 
     let!(:board) do
       create(:subproject_board,
-                        project: project,
-                        projects_columns: [subproject1, subproject2])
+             project: project,
+             projects_columns: [subproject1, subproject2])
     end
 
     let(:board_page) { Pages::Board.new(board) }
@@ -219,14 +219,14 @@ describe 'Subproject action board', type: :feature, js: true do
   context 'with an archived subproject' do
     let(:user) do
       create(:user,
-                        member_in_projects: [project, subproject1, subproject2],
-                        member_through_role: role)
+             member_in_projects: [project, subproject1, subproject2],
+             member_through_role: role)
     end
 
     let!(:board) do
       create(:subproject_board,
-                        project: project,
-                        projects_columns: [subproject1])
+             project: project,
+             projects_columns: [subproject1])
     end
 
     let(:board_page) { Pages::Board.new(board) }

--- a/modules/boards/spec/features/action_boards/subtasks_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/subtasks_board_spec.rb
@@ -37,8 +37,8 @@ describe 'Subtasks action board', type: :feature, js: true do
 
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
 
   let(:board_index) { Pages::BoardIndex.new(project) }
@@ -170,7 +170,7 @@ describe 'Subtasks action board', type: :feature, js: true do
       board_page.move_card(0, from: 'Parent WP', to: 'Child WP')
 
       board_page.expect_and_dismiss_toaster type: :error,
-                                                 message: I18n.t('js.boards.error_cannot_move_into_self')
+                                            message: I18n.t('js.boards.error_cannot_move_into_self')
 
       child.reload
       expect(child.parent).to eq parent

--- a/modules/boards/spec/features/action_boards/version_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/version_board_spec.rb
@@ -34,14 +34,14 @@ require_relative './../support/board_page'
 describe 'Version action board', type: :feature, js: true do
   let(:user) do
     create(:user,
-                      member_in_projects: [project, second_project],
-                      member_through_role: role)
+           member_in_projects: [project, second_project],
+           member_through_role: role)
   end
 
   let(:second_user) do
     create(:user,
-                      member_in_projects: [project, second_project],
-                      member_through_role: role_board_manager)
+           member_in_projects: [project, second_project],
+           member_through_role: role_board_manager)
   end
   let(:type) { create(:type_standard) }
   let!(:priority) { create :default_priority }
@@ -308,8 +308,8 @@ describe 'Version action board', type: :feature, js: true do
   context 'a user with edit_work_packages, but missing assign_versions permissions' do
     let(:no_version_edit_user) do
       create(:user,
-                        member_in_projects: [project],
-                        member_through_role: no_version_edit_role)
+             member_in_projects: [project],
+             member_through_role: no_version_edit_role)
     end
     let(:no_version_edit_role) { create(:role, permissions: no_version_edit_permissions) }
     let(:no_version_edit_permissions) do

--- a/modules/boards/spec/features/board_conflicts_spec.rb
+++ b/modules/boards/spec/features/board_conflicts_spec.rb
@@ -33,8 +33,8 @@ require_relative './support/board_page'
 describe 'Board remote changes resolution', type: :feature, js: true do
   let(:user1) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:type) { create(:type_standard) }
   let(:project) { create(:project, types: [type], enabled_module_names: %i[work_package_tracking board_view]) }

--- a/modules/boards/spec/features/board_highlighting_spec.rb
+++ b/modules/boards/spec/features/board_highlighting_spec.rb
@@ -33,8 +33,8 @@ require_relative './support/board_page'
 describe 'Work Package boards spec', type: :feature, js: true do
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:project) { create(:project, enabled_module_names: %i[work_package_tracking board_view]) }
   let(:permissions) { %i[show_board_views manage_board_views add_work_packages view_work_packages manage_public_queries] }
@@ -42,17 +42,17 @@ describe 'Work Package boards spec', type: :feature, js: true do
 
   let!(:wp) do
     create(:work_package,
-                      project: project,
-                      type: type,
-                      priority: priority,
-                      status: open_status)
+           project: project,
+           type: type,
+           priority: priority,
+           status: open_status)
   end
   let!(:wp2) do
     create(:work_package,
-                      project: project,
-                      type: type2,
-                      priority: priority2,
-                      status: open_status)
+           project: project,
+           type: type2,
+           priority: priority2,
+           status: open_status)
   end
 
   let!(:priority) { create :priority, color: color }

--- a/modules/boards/spec/features/board_management_spec.rb
+++ b/modules/boards/spec/features/board_management_spec.rb
@@ -33,8 +33,8 @@ require_relative './support/board_page'
 describe 'Board management spec', type: :feature, js: true do
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:project) { create(:project, enabled_module_names: %i[work_package_tracking board_view]) }
   let(:role) { create(:role, permissions: permissions) }

--- a/modules/boards/spec/features/board_navigation_spec.rb
+++ b/modules/boards/spec/features/board_navigation_spec.rb
@@ -33,8 +33,8 @@ require_relative './support/board_page'
 describe 'Work Package boards spec', type: :feature, js: true do
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   # The identifier is important to test https://community.openproject.com/wp/29754
   let(:project) { create(:project, identifier: 'boards', enabled_module_names: %i[work_package_tracking board_view]) }

--- a/modules/boards/spec/features/board_reference_work_package_spec.rb
+++ b/modules/boards/spec/features/board_reference_work_package_spec.rb
@@ -33,8 +33,8 @@ require_relative './support/board_page'
 describe 'Board reference work package spec', type: :feature, js: true do
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:project) { create(:project, enabled_module_names: %i[work_package_tracking board_view]) }
   let(:role) { create(:role, permissions: permissions) }
@@ -100,8 +100,8 @@ describe 'Board reference work package spec', type: :feature, js: true do
 
     let(:user) do
       create(:user,
-                        member_in_projects: [project, child_project],
-                        member_through_role: role)
+             member_in_projects: [project, child_project],
+             member_through_role: role)
     end
 
     it 'returns the work package when subproject filters is added' do

--- a/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
+++ b/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
@@ -33,8 +33,8 @@ describe 'boards onboarding tour', js: true do
   let(:next_button) { find('.enjoyhint_next_btn') }
   let(:user) do
     create :admin,
-                      member_in_project: demo_project,
-                      member_through_role: role
+           member_in_project: demo_project,
+           member_through_role: role
   end
   let(:permissions) do
     %i[
@@ -50,17 +50,17 @@ describe 'boards onboarding tour', js: true do
 
   let(:demo_project) do
     create :project,
-                      name: 'Demo project',
-                      identifier: 'demo-project',
-                      public: true,
-                      enabled_module_names: %w[work_package_tracking wiki board_view]
+           name: 'Demo project',
+           identifier: 'demo-project',
+           public: true,
+           enabled_module_names: %w[work_package_tracking wiki board_view]
   end
   let(:scrum_project) do
     create :project,
-                      name: 'Scrum project',
-                      identifier: 'your-scrum-project',
-                      public: true,
-                      enabled_module_names: %w[work_package_tracking wiki board_view]
+           name: 'Scrum project',
+           identifier: 'your-scrum-project',
+           public: true,
+           enabled_module_names: %w[work_package_tracking wiki board_view]
   end
   let!(:wp_1) { create(:work_package, project: demo_project) }
   let!(:wp_2) { create(:work_package, project: scrum_project) }

--- a/modules/boards/spec/lib/open_project/boards/grid_registration_spec.rb
+++ b/modules/boards/spec/lib/open_project/boards/grid_registration_spec.rb
@@ -6,8 +6,8 @@ describe OpenProject::Boards::GridRegistration do
   let(:board) { create(:board_grid, project: project) }
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
 
   describe 'from_scope' do

--- a/modules/boards/spec/services/copy_service_integration_spec.rb
+++ b/modules/boards/spec/services/copy_service_integration_spec.rb
@@ -33,8 +33,8 @@ require 'spec_helper'
 describe Projects::CopyService, 'integration', type: :model do
   let(:current_user) do
     create(:user,
-                      member_in_project: source,
-                      member_through_role: role)
+           member_in_project: source,
+           member_through_role: role)
   end
   let!(:source) { create :project, enabled_module_names: %w[boards work_package_tracking] }
   let(:query) { board_view.contained_queries.first }
@@ -57,15 +57,15 @@ describe Projects::CopyService, 'integration', type: :model do
   describe 'for a subproject board' do
     let(:current_user) do
       create(:user,
-                        member_in_projects: [source, child_project],
-                        member_through_role: role)
+             member_in_projects: [source, child_project],
+             member_through_role: role)
     end
     let!(:child_project) { create :project, parent: source }
     let!(:board_view) do
       create :board_grid_with_query,
-                        project: source,
-                        name: 'Subproject board',
-                        options: { "type" => "action", "attribute" => "subproject" }
+             project: source,
+             name: 'Subproject board',
+             options: { "type" => "action", "attribute" => "subproject" }
     end
 
     before do

--- a/modules/budgets/spec/features/budgets/attachment_upload_spec.rb
+++ b/modules/budgets/spec/features/budgets/attachment_upload_spec.rb
@@ -34,9 +34,9 @@ require 'features/page_objects/notification'
 describe 'Upload attachment to budget', js: true do
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_budgets
-                                                  edit_budgets]
+           member_in_project: project,
+           member_with_permissions: %i[view_budgets
+                                       edit_budgets]
   end
   let(:project) { create(:project) }
   let(:attachments) { ::Components::Attachments.new }

--- a/modules/budgets/spec/features/budgets/copy_budget_spec.rb
+++ b/modules/budgets/spec/features/budgets/copy_budget_spec.rb
@@ -32,18 +32,18 @@ describe 'Copying a budget', type: :feature, js: true do
   let(:project) { create :project, enabled_module_names: %i[budgets costs] }
   let(:current_user) do
     create :user,
-                      member_in_project: project,
-                      member_with_permissions: %i(view_budgets edit_budgets view_hourly_rates view_cost_rates)
+           member_in_project: project,
+           member_with_permissions: %i(view_budgets edit_budgets view_hourly_rates view_cost_rates)
   end
   let(:original_author) { create :user }
   let(:budget_subject) { "A budget subject" }
   let(:budget_description) { "A budget description" }
   let!(:budget) do
     create :budget,
-                      subject: budget_subject,
-                      description: budget_description,
-                      author: original_author,
-                      project: project
+           subject: budget_subject,
+           description: budget_description,
+           author: original_author,
+           project: project
   end
   let!(:cost_type) do
     create :cost_type, name: 'Post-war', unit: 'cap', unit_plural: 'caps'
@@ -52,23 +52,23 @@ describe 'Copying a budget', type: :feature, js: true do
   let!(:default_hourly_rate) { create :default_hourly_rate, user: original_author, rate: 25.0 }
   let!(:material_budget_item) do
     create :material_budget_item,
-                      units: 3,
-                      cost_type: cost_type,
-                      budget: budget
+           units: 3,
+           cost_type: cost_type,
+           budget: budget
   end
   let!(:overwritten_material_budget_item) do
     create :material_budget_item,
-                      units: 10,
-                      cost_type: cost_type,
-                      budget: budget,
-                      amount: 600000.00
+           units: 10,
+           cost_type: cost_type,
+           budget: budget,
+           amount: 600000.00
   end
 
   let!(:labor_budget_item) do
     create :labor_budget_item,
-                      hours: 5,
-                      user: original_author,
-                      budget: budget
+           hours: 5,
+           user: original_author,
+           budget: budget
   end
   let(:budget_page) { Pages::EditBudget.new budget.id }
 

--- a/modules/budgets/spec/features/budgets/delete_budget_spec.rb
+++ b/modules/budgets/spec/features/budgets/delete_budget_spec.rb
@@ -35,10 +35,10 @@ describe 'Deleting a budget', type: :feature, js: true do
   let(:budget_description) { "A budget description" }
   let!(:budget) do
     create :budget,
-                      subject: budget_subject,
-                      description: budget_description,
-                      author: user,
-                      project: project
+           subject: budget_subject,
+           description: budget_description,
+           author: user,
+           project: project
   end
 
   let(:budget_page) { Pages::EditBudget.new budget.id }
@@ -101,10 +101,10 @@ describe 'Deleting a budget', type: :feature, js: true do
     context 'with another budget to assign to' do
       let(:budget2) do
         create :budget,
-                          subject: 'Another budget',
-                          description: budget_description,
-                          author: user,
-                          project: project
+               subject: 'Another budget',
+               description: budget_description,
+               author: user,
+               project: project
       end
 
       before do

--- a/modules/budgets/spec/features/budgets/update_budget_spec.rb
+++ b/modules/budgets/spec/features/budgets/update_budget_spec.rb
@@ -31,8 +31,8 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper.rb')
 describe 'updating a budget', type: :feature, js: true do
   let(:project) do
     create :project_with_types,
-                      enabled_module_names: %i[budgets costs],
-                      members: { user => create(:role) }
+           enabled_module_names: %i[budgets costs],
+           members: { user => create(:role) }
   end
   let(:user) { create :admin }
   let(:budget) { create :budget, author: user, project: project }
@@ -81,16 +81,16 @@ describe 'updating a budget', type: :feature, js: true do
 
     let(:material_budget_item) do
       create :material_budget_item,
-                        units: 3,
-                        cost_type: cost_type,
-                        budget: budget
+             units: 3,
+             cost_type: cost_type,
+             budget: budget
     end
 
     let(:labor_budget_item) do
       create :labor_budget_item,
-                        hours: 5,
-                        user: user,
-                        budget: budget
+             hours: 5,
+             user: user,
+             budget: budget
     end
 
     let(:budget_page) { Pages::EditBudget.new budget.id }
@@ -145,10 +145,10 @@ describe 'updating a budget', type: :feature, js: true do
 
       let(:material_budget_item2) do
         create :material_budget_item,
-                          units: 3,
-                          cost_type: cost_type2,
-                          budget: budget,
-                          amount: 1000.0
+               units: 3,
+               cost_type: cost_type2,
+               budget: budget,
+               amount: 1000.0
       end
 
       it 'retains the overridden budget when opening, but not editing (Regression #32822)' do
@@ -176,9 +176,9 @@ describe 'updating a budget', type: :feature, js: true do
     context 'with two material budget items' do
       let!(:material_budget_item_2) do
         create :material_budget_item,
-                          units: 5,
-                          cost_type: cost_type,
-                          budget: budget
+               units: 5,
+               cost_type: cost_type,
+               budget: budget
       end
 
       it 'keeps previous planned material costs (Regression test #27692)' do
@@ -253,9 +253,9 @@ describe 'updating a budget', type: :feature, js: true do
     context 'with two labor budget items' do
       let!(:labor_budget_item_2) do
         create :labor_budget_item,
-                          hours: 5,
-                          user: user,
-                          budget: budget
+               hours: 5,
+               user: user,
+               budget: budget
       end
 
       it 'keeps previous planned labor costs (Regression test #27692)' do

--- a/modules/budgets/spec/features/work_package_filter_spec.rb
+++ b/modules/budgets/spec/features/work_package_filter_spec.rb
@@ -37,9 +37,9 @@ describe 'Filter by budget', js: true do
 
   let(:member) do
     create(:member,
-                      user: user,
-                      project: project,
-                      roles: [create(:role)])
+           user: user,
+           project: project,
+           roles: [create(:role)])
   end
   let(:status) do
     create(:status)
@@ -51,13 +51,13 @@ describe 'Filter by budget', js: true do
 
   let(:work_package_with_budget) do
     create(:work_package,
-                      project: project,
-                      budget: budget)
+           project: project,
+           budget: budget)
   end
 
   let(:work_package_without_budget) do
     create(:work_package,
-                      project: project)
+           project: project)
   end
 
   before do

--- a/modules/budgets/spec/lib/api/v3/budgets/budget_representer_spec.rb
+++ b/modules/budgets/spec/lib/api/v3/budgets/budget_representer_spec.rb
@@ -34,16 +34,16 @@ describe ::API::V3::Budgets::BudgetRepresenter do
   let(:project) { build(:project, id: 999) }
   let(:user) do
     create(:user,
-                     member_in_project: project,
-                     created_at: 1.day.ago,
-                     updated_at: Date.today)
+           member_in_project: project,
+           created_at: 1.day.ago,
+           updated_at: Date.today)
   end
   let(:budget) do
     create(:budget,
-                      author: user,
-                      project: project,
-                      created_at: 1.day.ago,
-                      updated_at: Date.today)
+           author: user,
+           project: project,
+           created_at: 1.day.ago,
+           updated_at: Date.today)
   end
 
   let(:representer) { described_class.new(budget, current_user: user) }

--- a/modules/budgets/spec/models/labor_budget_item_spec.rb
+++ b/modules/budgets/spec/models/labor_budget_item_spec.rb
@@ -44,9 +44,9 @@ describe LaborBudgetItem, type: :model do
 
   def is_member(project, user, permissions)
     create(:member,
-                      project: project,
-                      user: user,
-                      roles: [create(:role, permissions: permissions)])
+           project: project,
+           user: user,
+           roles: [create(:role, permissions: permissions)])
   end
 
   describe '#calculated_costs' do

--- a/modules/budgets/spec/requests/api/v3/budgets/budget_resource_spec.rb
+++ b/modules/budgets/spec/requests/api/v3/budgets/budget_resource_spec.rb
@@ -36,8 +36,8 @@ describe 'API v3 Budget resource' do
   let(:project) { create(:project, public: false) }
   let(:current_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: [:view_budgets])
+           member_in_project: project,
+           member_with_permissions: [:view_budgets])
   end
   subject(:response) { last_response }
 

--- a/modules/calendar/spec/features/calendar_user_interaction_spec.rb
+++ b/modules/calendar/spec/features/calendar_user_interaction_spec.rb
@@ -36,18 +36,18 @@ describe 'Calendar drag&dop and resizing', type: :feature, js: true do
 
   let!(:other_user) do
     create :user,
-                      firstname: 'Bernd',
-                      member_in_project: project,
-                      member_with_permissions: %w[
-                        view_work_packages view_calendar
-                      ]
+           firstname: 'Bernd',
+           member_in_project: project,
+           member_with_permissions: %w[
+             view_work_packages view_calendar
+           ]
   end
 
   let!(:work_package) do
     create :work_package,
-                      project: project,
-                      start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
-                      due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
+           project: project,
+           start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
+           due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
   end
 
   before do

--- a/modules/calendar/spec/features/calendars_spec.rb
+++ b/modules/calendar/spec/features/calendars_spec.rb
@@ -34,36 +34,36 @@ describe 'Work package calendars', type: :feature, js: true do
   let(:project) { create(:project) }
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_work_packages view_calendar])
+           member_in_project: project,
+           member_with_permissions: %i[view_work_packages view_calendar])
   end
   let!(:current_work_package) do
     create(:work_package,
-                      subject: 'Current work package',
-                      project: project,
-                      start_date: Date.today.at_beginning_of_month + 15.days,
-                      due_date: Date.today.at_beginning_of_month + 15.days)
+           subject: 'Current work package',
+           project: project,
+           start_date: Date.today.at_beginning_of_month + 15.days,
+           due_date: Date.today.at_beginning_of_month + 15.days)
   end
   let!(:another_current_work_package) do
     create(:work_package,
-                      subject: 'Another current work package',
-                      project: project,
-                      start_date: Date.today.at_beginning_of_month + 12.days,
-                      due_date: Date.today.at_beginning_of_month + 18.days)
+           subject: 'Another current work package',
+           project: project,
+           start_date: Date.today.at_beginning_of_month + 12.days,
+           due_date: Date.today.at_beginning_of_month + 18.days)
   end
   let!(:future_work_package) do
     create(:work_package,
-                      subject: 'Future work package',
-                      project: project,
-                      start_date: Date.today.at_beginning_of_month.next_month + 15.days,
-                      due_date: Date.today.at_beginning_of_month.next_month + 15.days)
+           subject: 'Future work package',
+           project: project,
+           start_date: Date.today.at_beginning_of_month.next_month + 15.days,
+           due_date: Date.today.at_beginning_of_month.next_month + 15.days)
   end
   let!(:another_future_work_package) do
     create(:work_package,
-                      subject: 'Another future work package',
-                      project: project,
-                      start_date: Date.today.at_beginning_of_month.next_month + 12.days,
-                      due_date: Date.today.at_beginning_of_month.next_month + 18.days)
+           subject: 'Another future work package',
+           project: project,
+           start_date: Date.today.at_beginning_of_month.next_month + 12.days,
+           due_date: Date.today.at_beginning_of_month.next_month + 18.days)
   end
   let(:filters) { ::Components::WorkPackages::Filters.new }
   let(:current_wp_split_screen) { Pages::SplitWorkPackage.new(current_work_package, project) }

--- a/modules/calendar/spec/features/query_handling_spec.rb
+++ b/modules/calendar/spec/features/query_handling_spec.rb
@@ -37,45 +37,45 @@ describe 'Calendar query handling', type: :feature, js: true do
   shared_let(:type_bug) { create(:type_bug) }
   shared_let(:project) do
     create(:project,
-                      enabled_module_names: %w[work_package_tracking calendar_view],
-                      types: [type_task, type_bug])
+           enabled_module_names: %w[work_package_tracking calendar_view],
+           types: [type_task, type_bug])
   end
 
   shared_let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_with_permissions: %w[
-                        view_work_packages
-                        edit_work_packages
-                        save_queries
-                        save_public_queries
-                        view_calendar
-                      ]
+           member_in_project: project,
+           member_with_permissions: %w[
+             view_work_packages
+             edit_work_packages
+             save_queries
+             save_public_queries
+             view_calendar
+           ]
   end
 
   shared_let(:task) do
     create :work_package,
-                      project: project,
-                      type: type_task,
-                      assigned_to: user,
-                      start_date: Time.zone.today - 1.day,
-                      due_date: Time.zone.today + 1.day,
-                      subject: 'A task for the user'
+           project: project,
+           type: type_task,
+           assigned_to: user,
+           start_date: Time.zone.today - 1.day,
+           due_date: Time.zone.today + 1.day,
+           subject: 'A task for the user'
   end
   shared_let(:bug) do
     create :work_package,
-                      project: project,
-                      type: type_bug,
-                      assigned_to: user,
-                      start_date: Time.zone.today - 1.day,
-                      due_date: Time.zone.today + 1.day,
-                      subject: 'A bug for the user'
+           project: project,
+           type: type_bug,
+           assigned_to: user,
+           start_date: Time.zone.today - 1.day,
+           due_date: Time.zone.today + 1.day,
+           subject: 'A bug for the user'
   end
 
   shared_let(:saved_query) do
     create(:query_with_view_work_packages_calendar,
-                      project: project,
-                      public: true)
+           project: project,
+           public: true)
   end
 
   let(:calendar_page) { ::Pages::Calendar.new project }

--- a/modules/calendar/spec/features/shared_context.rb
+++ b/modules/calendar/spec/features/shared_context.rb
@@ -38,11 +38,11 @@ shared_context 'with calendar full access' do
 
   shared_let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_with_permissions: %w[
-                        view_work_packages edit_work_packages add_work_packages
-                        view_calendar
-                      ]
+           member_in_project: project,
+           member_with_permissions: %w[
+             view_work_packages edit_work_packages add_work_packages
+             view_calendar
+           ]
   end
 
   let(:calendar) { ::Pages::Calendar.new project }

--- a/modules/costs/spec/contracts/time_entries/delete_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/delete_contract_spec.rb
@@ -42,7 +42,7 @@ describe TimeEntries::DeleteContract do
   let(:other_user) { build_stubbed(:user) }
   let(:time_entry_work_package) do
     build_stubbed(:work_package,
-                             project: time_entry_project)
+                  project: time_entry_project)
   end
   let(:time_entry_project) { build_stubbed(:project) }
   let(:time_entry_user) { current_user }
@@ -55,13 +55,13 @@ describe TimeEntries::DeleteContract do
 
   let(:time_entry) do
     build_stubbed(:time_entry,
-                             project: time_entry_project,
-                             work_package: time_entry_work_package,
-                             user: time_entry_user,
-                             activity: time_entry_activity,
-                             spent_on: time_entry_spent_on,
-                             hours: time_entry_hours,
-                             comments: time_entry_comments)
+                  project: time_entry_project,
+                  work_package: time_entry_work_package,
+                  user: time_entry_user,
+                  activity: time_entry_activity,
+                  spent_on: time_entry_spent_on,
+                  hours: time_entry_hours,
+                  comments: time_entry_comments)
   end
 
   before do

--- a/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
+++ b/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
@@ -42,7 +42,7 @@ shared_examples_for 'time entry contract' do
   let(:other_user) { build_stubbed(:user) }
   let(:time_entry_work_package) do
     build_stubbed(:work_package,
-                             project: time_entry_project)
+                  project: time_entry_project)
   end
   let(:time_entry_project) { build_stubbed(:project) }
   let(:time_entry_user) { current_user }

--- a/modules/costs/spec/contracts/time_entries/update_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/update_contract_spec.rb
@@ -35,13 +35,13 @@ describe TimeEntries::UpdateContract do
   it_behaves_like 'time entry contract' do
     let(:time_entry) do
       build_stubbed(:time_entry,
-                               project: time_entry_project,
-                               work_package: time_entry_work_package,
-                               user: time_entry_user,
-                               activity: time_entry_activity,
-                               spent_on: time_entry_spent_on,
-                               hours: time_entry_hours,
-                               comments: time_entry_comments)
+                    project: time_entry_project,
+                    work_package: time_entry_work_package,
+                    user: time_entry_user,
+                    activity: time_entry_activity,
+                    spent_on: time_entry_spent_on,
+                    hours: time_entry_hours,
+                    comments: time_entry_comments)
     end
     subject(:contract) { described_class.new(time_entry, current_user) }
     let(:permissions) { %i(edit_time_entries) }

--- a/modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb
+++ b/modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb
@@ -45,8 +45,8 @@ describe 'Work Package cost fields', type: :feature, js: true do
   end
   shared_let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
   shared_let(:cost_type1) do
     type = create :cost_type, name: 'A', unit: 'A single', unit_plural: 'A plural'
@@ -166,8 +166,8 @@ describe 'Work Package cost fields', type: :feature, js: true do
   context 'with an additional placeholder user in the project' do
     let!(:placeholder_user) do
       create :placeholder_user,
-                        member_in_project: project,
-                        member_through_role: role
+             member_in_project: project,
+             member_through_role: role
     end
 
     it 'does not allow to select them (Regression #36353)' do

--- a/modules/costs/spec/features/cost_entries/add_entry_without_rate_permission_spec.rb
+++ b/modules/costs/spec/features/cost_entries/add_entry_without_rate_permission_spec.rb
@@ -42,8 +42,8 @@ describe 'Create cost entry without rate permissions', type: :feature, js: true 
   end
   shared_let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
 
   shared_let(:cost_type) do

--- a/modules/costs/spec/features/destroy_work_package_with_cost_entries_spec.rb
+++ b/modules/costs/spec/features/destroy_work_package_with_cost_entries_spec.rb
@@ -32,23 +32,23 @@ describe 'Deleting time entries', type: :feature, js: true do
   let(:project) { work_package.project }
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
   let(:role) do
     create :role,
-                      permissions: %i[view_work_packages
-                                      delete_work_packages
-                                      edit_cost_entries
-                                      view_cost_entries]
+           permissions: %i[view_work_packages
+                           delete_work_packages
+                           edit_cost_entries
+                           view_cost_entries]
   end
   let(:work_package) { create :work_package }
   let(:destroy_modal) { Components::WorkPackages::DestroyModal.new }
   let(:cost_type) do
     type = create :cost_type, name: 'Translations'
     create :cost_rate,
-                      cost_type: type,
-                      rate: 7.00
+           cost_type: type,
+           rate: 7.00
     type
   end
   let(:budget) do
@@ -57,11 +57,11 @@ describe 'Deleting time entries', type: :feature, js: true do
   let(:other_work_package) { create :work_package, project: project, budget: budget }
   let(:cost_entry) do
     create :cost_entry,
-                      work_package: work_package,
-                      project: project,
-                      units: 2.00,
-                      cost_type: cost_type,
-                      user: user
+           work_package: work_package,
+           project: project,
+           units: 2.00,
+           cost_type: cost_type,
+           user: user
   end
 
   it 'allows to move the time entry to a different work package' do

--- a/modules/costs/spec/features/members_hourly_rates_spec.rb
+++ b/modules/costs/spec/features/members_hourly_rates_spec.rb
@@ -32,7 +32,7 @@ describe 'hourly rates on a member', type: :feature, js: true do
   let(:project) { build :project }
   let(:user) do
     create :admin,
-                      member_in_project: project
+           member_in_project: project
   end
   let(:member) { Member.find_by(project: project, principal: user) }
 

--- a/modules/costs/spec/features/time_entries_spec.rb
+++ b/modules/costs/spec/features/time_entries_spec.rb
@@ -38,18 +38,18 @@ describe 'Work Package table cost entries', type: :feature, js: true do
 
   let!(:time_entry1) do
     create :time_entry,
-                      user: user,
-                      work_package: parent,
-                      project: project,
-                      hours: 10
+           user: user,
+           work_package: parent,
+           project: project,
+           hours: 10
   end
 
   let!(:time_entry2) do
     create :time_entry,
-                      user: user,
-                      work_package: work_package,
-                      project: project,
-                      hours: 2.50
+           user: user,
+           work_package: work_package,
+           project: project,
+           hours: 2.50
   end
 
   let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }

--- a/modules/costs/spec/features/view_own_rates_spec.rb
+++ b/modules/costs/spec/features/view_own_rates_spec.rb
@@ -32,8 +32,8 @@ describe 'Only see your own rates', type: :feature, js: true do
   let(:project) { work_package.project }
   let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
   let(:role) do
     create :role, permissions: %i[view_own_hourly_rate
@@ -72,8 +72,8 @@ describe 'Only see your own rates', type: :feature, js: true do
   let(:other_role) { create :role, permissions: [] }
   let(:other_user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: other_role
+           member_in_project: project,
+           member_through_role: other_role
   end
   let(:other_hourly_rate) do
     create :default_hourly_rate, user: other_user,

--- a/modules/costs/spec/lib/api/v3/cost_entries/work_package_costs_by_type_representer_spec.rb
+++ b/modules/costs/spec/lib/api/v3/cost_entries/work_package_costs_by_type_representer_spec.rb
@@ -37,19 +37,19 @@ describe ::API::V3::CostEntries::WorkPackageCostsByTypeRepresenter do
   let(:cost_type_B) { create(:cost_type) }
   let(:cost_entries_A) do
     create_list(:cost_entry,
-                           2,
-                           units: 1,
-                           work_package: work_package,
-                           project: project,
-                           cost_type: cost_type_A)
+                2,
+                units: 1,
+                work_package: work_package,
+                project: project,
+                cost_type: cost_type_A)
   end
   let(:cost_entries_B) do
     create_list(:cost_entry,
-                           3,
-                           units: 2,
-                           work_package: work_package,
-                           project: project,
-                           cost_type: cost_type_B)
+                3,
+                units: 2,
+                work_package: work_package,
+                project: project,
+                cost_type: cost_type_B)
   end
   let(:current_user) do
     create(:user, member_in_project: project, member_through_role: role)

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_parsing_spec.rb
@@ -33,13 +33,13 @@ describe ::API::V3::TimeEntries::TimeEntryRepresenter, 'parsing' do
 
   let(:time_entry) do
     build_stubbed(:time_entry,
-                             comments: 'blubs',
-                             spent_on: Date.today - 3.days,
-                             created_at: DateTime.now - 6.hours,
-                             updated_at: DateTime.now - 3.hours,
-                             activity: activity,
-                             project: project,
-                             user: user)
+                  comments: 'blubs',
+                  spent_on: Date.today - 3.days,
+                  created_at: DateTime.now - 6.hours,
+                  updated_at: DateTime.now - 3.hours,
+                  activity: activity,
+                  project: project,
+                  user: user)
   end
   let(:project) { build_stubbed(:project) }
   let(:project2) { build_stubbed(:project) }

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
@@ -33,14 +33,14 @@ describe ::API::V3::TimeEntries::TimeEntryRepresenter, 'rendering' do
 
   let(:time_entry) do
     build_stubbed(:time_entry,
-                             comments: 'blubs',
-                             spent_on: Date.today,
-                             created_at: DateTime.now - 6.hours,
-                             updated_at: DateTime.now - 3.hours,
-                             hours: hours,
-                             activity: activity,
-                             project: project,
-                             user: user)
+                  comments: 'blubs',
+                  spent_on: Date.today,
+                  created_at: DateTime.now - 6.hours,
+                  updated_at: DateTime.now - 3.hours,
+                  hours: hours,
+                  activity: activity,
+                  project: project,
+                  user: user)
   end
   let(:project) { build_stubbed(:project) }
   let(:work_package) { time_entry.work_package }

--- a/modules/costs/spec/models/project/activity_spec.rb
+++ b/modules/costs/spec/models/project/activity_spec.rb
@@ -37,17 +37,17 @@ describe Projects::Activity, type: :model do
 
   let(:budget) do
     create(:budget,
-                      project: project)
+           project: project)
   end
 
   let(:budget2) do
     create(:budget,
-                      project: project)
+           project: project)
   end
 
   let(:work_package) do
     create(:work_package,
-                      project: project)
+           project: project)
   end
 
   def latest_activity

--- a/modules/costs/spec/models/projects/scopes/visible_with_activated_time_activity_spec.rb
+++ b/modules/costs/spec/models/projects/scopes/visible_with_activated_time_activity_spec.rb
@@ -39,14 +39,14 @@ describe Projects::Scopes::VisibleWithActivatedTimeActivity, type: :model do
   let(:current_user) do
     create(:user).tap do |u|
       create(:member,
-                        project: project,
-                        principal: u,
-                        roles: [create(:role, permissions: project_permissions)])
+             project: project,
+             principal: u,
+             roles: [create(:role, permissions: project_permissions)])
 
       create(:member,
-                        project: other_project,
-                        principal: u,
-                        roles: [create(:role, permissions: other_project_permissions)])
+             project: other_project,
+             principal: u,
+             roles: [create(:role, permissions: other_project_permissions)])
     end
   end
 

--- a/modules/costs/spec/models/time_entries/scopes/of_user_and_day_spec.rb
+++ b/modules/costs/spec/models/time_entries/scopes/of_user_and_day_spec.rb
@@ -35,23 +35,23 @@ describe TimeEntries::Scopes::OfUserAndDay, type: :model do
   let(:spent_on) { Date.today }
   let!(:time_entry) do
     create(:time_entry,
-                      user: user,
-                      spent_on: spent_on)
+           user: user,
+           spent_on: spent_on)
   end
   let!(:other_time_entry) do
     create(:time_entry,
-                      user: user,
-                      spent_on: spent_on)
+           user: user,
+           spent_on: spent_on)
   end
   let!(:other_user_time_entry) do
     create(:time_entry,
-                      user: create(:user),
-                      spent_on: spent_on)
+           user: create(:user),
+           spent_on: spent_on)
   end
   let!(:other_date_time_entry) do
     create(:time_entry,
-                      user: user,
-                      spent_on: spent_on - 3.days)
+           user: user,
+           spent_on: spent_on - 3.days)
   end
 
   describe '.of_user_and_day' do

--- a/modules/costs/spec/models/time_entries/scopes/visible_spec.rb
+++ b/modules/costs/spec/models/time_entries/scopes/visible_spec.rb
@@ -34,37 +34,37 @@ describe TimeEntries::Scopes::Visible, type: :model do
   let(:project) { create(:project) }
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
   let(:permissions) { [:view_time_entries] }
 
   let(:work_package) do
     create(:work_package,
-                      project: project,
-                      author: user2)
+           project: project,
+           author: user2)
   end
   let(:user2) do
     create(:user)
   end
   let!(:own_project_time_entry) do
     create(:time_entry,
-                      project: project,
-                      work_package: work_package,
-                      hours: 2,
-                      user: user)
+           project: project,
+           work_package: work_package,
+           hours: 2,
+           user: user)
   end
   let!(:project_time_entry) do
     create(:time_entry,
-                      project: project,
-                      work_package: work_package,
-                      hours: 2,
-                      user: user2)
+           project: project,
+           work_package: work_package,
+           hours: 2,
+           user: user2)
   end
   let!(:own_other_project_time_entry) do
     create(:time_entry,
-                      project: create(:project),
-                      user: user)
+           project: create(:project),
+           user: user)
   end
 
   describe '.visible' do

--- a/modules/costs/spec/models/time_entry_spec.rb
+++ b/modules/costs/spec/models/time_entry_spec.rb
@@ -56,31 +56,31 @@ describe TimeEntry, type: :model do
   let(:hours) { 5.0 }
   let(:time_entry) do
     create(:time_entry,
-                      project: project,
-                      work_package: work_package,
-                      spent_on: date,
-                      hours: hours,
-                      user: user,
-                      rate: hourly_one,
-                      comments: 'lorem')
+           project: project,
+           work_package: work_package,
+           spent_on: date,
+           hours: hours,
+           user: user,
+           rate: hourly_one,
+           comments: 'lorem')
   end
 
   let(:time_entry2) do
     create(:time_entry,
-                      project: project,
-                      work_package: work_package,
-                      spent_on: date,
-                      hours: hours,
-                      user: user,
-                      rate: hourly_one,
-                      comments: 'lorem')
+           project: project,
+           work_package: work_package,
+           spent_on: date,
+           hours: hours,
+           user: user,
+           rate: hourly_one,
+           comments: 'lorem')
   end
 
   def is_member(project, user, permissions)
     create(:member,
-                      project: project,
-                      user: user,
-                      roles: [create(:role, permissions: permissions)])
+           project: project,
+           user: user,
+           roles: [create(:role, permissions: permissions)])
   end
 
   describe '#hours' do

--- a/modules/costs/spec/requests/api/cost_entries/cost_entries_by_work_package_resource_spec.rb
+++ b/modules/costs/spec/requests/api/cost_entries/cost_entries_by_work_package_resource_spec.rb
@@ -46,9 +46,9 @@ describe 'API v3 Cost Entry resource' do
 
   let(:cost_entry) do
     create(:cost_entry,
-                      project: project,
-                      work_package: work_package,
-                      user: current_user)
+           project: project,
+           work_package: work_package,
+           user: current_user)
   end
 
   before do

--- a/modules/costs/spec/requests/api/time_entries/available_projects_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entries/available_projects_resource_spec.rb
@@ -42,41 +42,41 @@ describe 'API v3 time entries available projects resource', type: :request do
   let(:project_with_log_permission) do
     create(:project).tap do |p|
       create(:member,
-                        roles: [create(:role, permissions: [:log_time])],
-                        project: p,
-                        user: current_user)
+             roles: [create(:role, permissions: [:log_time])],
+             project: p,
+             user: current_user)
     end
   end
   let(:project_with_edit_permission) do
     create(:project).tap do |p|
       create(:member,
-                        roles: [create(:role, permissions: [:edit_time_entries])],
-                        project: p,
-                        user: current_user)
+             roles: [create(:role, permissions: [:edit_time_entries])],
+             project: p,
+             user: current_user)
     end
   end
   let(:project_with_edit_own_permission) do
     create(:project).tap do |p|
       create(:member,
-                        roles: [create(:role, permissions: [:edit_own_time_entries])],
-                        project: p,
-                        user: current_user)
+             roles: [create(:role, permissions: [:edit_own_time_entries])],
+             project: p,
+             user: current_user)
     end
   end
   let(:project_with_view_permission) do
     create(:project).tap do |p|
       create(:member,
-                        roles: [create(:role, permissions: [:view_time_entries])],
-                        project: p,
-                        user: current_user)
+             roles: [create(:role, permissions: [:view_time_entries])],
+             project: p,
+             user: current_user)
     end
   end
   let(:project_without_permission) do
     create(:project).tap do |p|
       create(:member,
-                        roles: [create(:role, permissions: [])],
-                        project: p,
-                        user: current_user)
+             roles: [create(:role, permissions: [])],
+             project: p,
+             user: current_user)
     end
   end
   let(:project_without_membership) do

--- a/modules/costs/spec/requests/api/time_entries/create_form_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entries/create_form_resource_spec.rb
@@ -44,8 +44,8 @@ describe ::API::V3::TimeEntries::CreateFormAPI, content_type: :json do
   let(:custom_field) { create(:time_entry_custom_field) }
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
   let(:work_package) do
     create(:work_package, project: project)

--- a/modules/costs/spec/requests/api/time_entries/schemas/time_entry_schema_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entries/schemas/time_entry_schema_resource_spec.rb
@@ -36,8 +36,8 @@ describe 'API v3 Time entry schema resource', type: :request, content_type: :jso
   let(:project) { create(:project) }
   let(:current_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
 
   let(:permissions) { [:view_time_entries] }

--- a/modules/costs/spec/requests/api/time_entries/update_form_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entries/update_form_resource_spec.rb
@@ -45,8 +45,8 @@ describe ::API::V3::TimeEntries::UpdateFormAPI, content_type: :json do
   let(:custom_field) { create(:time_entry_custom_field) }
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
   let(:work_package) do
     create(:work_package, project: project)
@@ -200,9 +200,9 @@ describe ::API::V3::TimeEntries::UpdateFormAPI, content_type: :json do
           user = time_entry.user
 
           create(:member,
-                            project: time_entry.project,
-                            roles: [create(:role, permissions: permissions)],
-                            principal: user)
+                 project: time_entry.project,
+                 roles: [create(:role, permissions: permissions)],
+                 principal: user)
 
           user
         end

--- a/modules/costs/spec/requests/api/time_entry_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entry_resource_spec.rb
@@ -214,9 +214,9 @@ describe 'API v3 time_entry resource', type: :request do
 
       before do
         create(:member,
-                          roles: [role],
-                          project: other_project,
-                          user: current_user)
+               roles: [role],
+               project: other_project,
+               user: current_user)
 
         time_entry
         other_time_entry
@@ -253,31 +253,31 @@ describe 'API v3 time_entry resource', type: :request do
       end
       let!(:time_entry) do
         create(:time_entry,
-                          project: project,
-                          work_package: work_package,
-                          user: current_user,
-                          activity: activity)
+               project: project,
+               work_package: work_package,
+               user: current_user,
+               activity: activity)
       end
       let!(:other_time_entry) do
         create(:time_entry,
-                          project: other_project,
-                          work_package: other_work_package,
-                          user: current_user,
-                          activity: activity)
+               project: other_project,
+               work_package: other_work_package,
+               user: current_user,
+               activity: activity)
       end
       let!(:another_time_entry) do
         create(:time_entry,
-                          project: project,
-                          work_package: work_package,
-                          user: current_user,
-                          activity: another_activity)
+               project: project,
+               work_package: work_package,
+               user: current_user,
+               activity: another_activity)
       end
 
       before do
         create(:member,
-                          roles: [role],
-                          project: other_project,
-                          user: current_user)
+               roles: [role],
+               project: other_project,
+               user: current_user)
         get path
       end
 

--- a/modules/dashboards/spec/factories/grid_factory.rb
+++ b/modules/dashboards/spec/factories/grid_factory.rb
@@ -25,15 +25,15 @@ FactoryBot.define do
       query = create(:query, project: dashboard.project, public: true)
 
       widget = build(:grid_widget,
-                                identifier: 'work_packages_table',
-                                start_row: 1,
-                                end_row: 7,
-                                start_column: 1,
-                                end_column: 3,
-                                options: {
-                                  name: 'Work package table',
-                                  queryId: query.id
-                                })
+                     identifier: 'work_packages_table',
+                     start_row: 1,
+                     end_row: 7,
+                     start_column: 1,
+                     end_column: 3,
+                     options: {
+                       name: 'Work package table',
+                       queryId: query.id
+                     })
 
       dashboard.widgets = [widget]
     end
@@ -46,15 +46,15 @@ FactoryBot.define do
 
     callback(:after_build) do |dashboard|
       widget = build(:grid_widget,
-                                identifier: 'custom_text',
-                                start_row: 1,
-                                end_row: 7,
-                                start_column: 1,
-                                end_column: 3,
-                                options: {
-                                  name: 'Custom text',
-                                  text: 'Lorem ipsum'
-                                })
+                     identifier: 'custom_text',
+                     start_row: 1,
+                     end_row: 7,
+                     start_column: 1,
+                     end_column: 3,
+                     options: {
+                       name: 'Custom text',
+                       text: 'Lorem ipsum'
+                     })
 
       dashboard.widgets = [widget]
     end

--- a/modules/dashboards/spec/features/docments_spec.rb
+++ b/modules/dashboards/spec/features/docments_spec.rb
@@ -35,18 +35,18 @@ describe 'Documents widget on dashboard', type: :feature, js: true do
   let!(:other_project) { create :project }
   let!(:visible_document) do
     create :document,
-                      project: project,
-                      description: 'blubs'
+           project: project,
+           description: 'blubs'
   end
   let!(:invisible_document) do
     create :document,
-                      project: other_project
+           project: other_project
   end
   let(:role) do
     create(:role,
-                      permissions: %i[view_documents
-                                      view_dashboards
-                                      manage_dashboards])
+           permissions: %i[view_documents
+                           view_dashboards
+                           manage_dashboards])
   end
   let(:user) do
     create(:user).tap do |u|

--- a/modules/dashboards/spec/features/members_principals_spec.rb
+++ b/modules/dashboards/spec/features/members_principals_spec.rb
@@ -43,24 +43,24 @@ describe 'Dashboard page members', type: :feature, js: true, with_mail: false do
 
   shared_let(:user) do
     create(:user,
-                      firstname: 'Foo',
-                      lastname: 'Bar',
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           firstname: 'Foo',
+           lastname: 'Bar',
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
 
   shared_let(:group) do
     create(:group,
-                      name: 'DEV Team',
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           name: 'DEV Team',
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
 
   shared_let(:placeholder) do
     create(:placeholder_user,
-                      name: 'DEVELOPER PLACEHOLDER',
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           name: 'DEVELOPER PLACEHOLDER',
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
 
   let(:dashboard_page) do

--- a/modules/dashboards/spec/features/members_spec.rb
+++ b/modules/dashboards/spec/features/members_spec.rb
@@ -45,9 +45,9 @@ describe 'Members widget on dashboard', type: :feature, js: true do
   end
   let!(:placeholder_user) do
     create :placeholder_user,
-                      lastname: "Placeholder user",
-                      member_in_project: project,
-                      member_through_role: no_view_member_role
+           lastname: "Placeholder user",
+           member_in_project: project,
+           member_through_role: no_view_member_role
   end
   let!(:invisible_user) do
     create :user, lastname: "Invisible", member_in_project: other_project, member_through_role: role
@@ -55,21 +55,21 @@ describe 'Members widget on dashboard', type: :feature, js: true do
 
   let(:no_view_member_role) do
     create(:role,
-                      permissions: %i[manage_dashboards
-                                      view_dashboards])
+           permissions: %i[manage_dashboards
+                           view_dashboards])
   end
   let(:no_edit_member_role) do
     create(:role,
-                      permissions: %i[manage_dashboards
-                                      view_dashboards
-                                      view_members])
+           permissions: %i[manage_dashboards
+                           view_dashboards
+                           view_members])
   end
   let(:role) do
     create(:role,
-                      permissions: %i[manage_dashboards
-                                      view_dashboards
-                                      manage_members
-                                      view_members])
+           permissions: %i[manage_dashboards
+                           view_dashboards
+                           manage_members
+                           view_members])
   end
   let(:dashboard) do
     Pages::Dashboard.new(project)

--- a/modules/dashboards/spec/features/modifying_with_unallowed_spec.rb
+++ b/modules/dashboards/spec/features/modifying_with_unallowed_spec.rb
@@ -51,7 +51,7 @@ describe 'Modifying a dashboard which already has widgets for which permissions 
   end
   let!(:news) do
     create :news,
-                      project: project
+           project: project
   end
 
   before do

--- a/modules/dashboards/spec/features/navigation_spec.rb
+++ b/modules/dashboards/spec/features/navigation_spec.rb
@@ -33,8 +33,8 @@ describe 'Navigate to dashboard', type: :feature, js: true do
   let(:permissions) { [:view_dashboards] }
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
 
   before do

--- a/modules/dashboards/spec/features/news_spec.rb
+++ b/modules/dashboards/spec/features/news_spec.rb
@@ -35,18 +35,18 @@ describe 'News widget on dashboard', type: :feature, js: true do
   let!(:other_project) { create :project }
   let!(:visible_news) do
     create :news,
-                      project: project,
-                      description: 'blubs'
+           project: project,
+           description: 'blubs'
   end
   let!(:invisible_news) do
     create :news,
-                      project: other_project
+           project: other_project
   end
   let(:role) do
     create(:role,
-                      permissions: %i[view_news
-                                      view_dashboards
-                                      manage_dashboards])
+           permissions: %i[view_news
+                           view_dashboards
+                           manage_dashboards])
   end
   let(:user) do
     create(:user).tap do |u|

--- a/modules/dashboards/spec/features/project_details_spec.rb
+++ b/modules/dashboards/spec/features/project_details_spec.rb
@@ -77,15 +77,15 @@ describe 'Project details widget on dashboard', type: :feature, js: true do
   end
   let(:editing_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: editing_permissions,
-                      firstname: 'Cool',
-                      lastname: 'Guy')
+           member_in_project: project,
+           member_with_permissions: editing_permissions,
+           firstname: 'Cool',
+           lastname: 'Guy')
   end
   let(:other_user) do
     create(:user,
-                      firstname: 'Other',
-                      lastname: 'User')
+           firstname: 'Other',
+           lastname: 'User')
   end
   let(:dashboard_page) do
     Pages::Dashboard.new(project)

--- a/modules/dashboards/spec/features/project_status_spec.rb
+++ b/modules/dashboards/spec/features/project_status_spec.rb
@@ -48,14 +48,14 @@ describe 'Project status widget on dashboard', type: :feature, js: true do
 
   let(:read_only_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: read_only_permissions)
+           member_in_project: project,
+           member_with_permissions: read_only_permissions)
   end
 
   let(:editing_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: editing_permissions)
+           member_in_project: project,
+           member_with_permissions: editing_permissions)
   end
 
   let(:dashboard_page) do

--- a/modules/dashboards/spec/features/read_only_allowed_spec.rb
+++ b/modules/dashboards/spec/features/read_only_allowed_spec.rb
@@ -35,10 +35,10 @@ describe 'Read only mode when user lacks edit permission on dashboard', type: :f
   let!(:project) { create :project, types: [type] }
   let!(:work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      author: user,
-                      responsible: user
+           project: project,
+           type: type,
+           author: user,
+           responsible: user
   end
   let!(:dashboard) do
     create(:dashboard_with_table, project: project)

--- a/modules/dashboards/spec/features/time_entries_spec.rb
+++ b/modules/dashboards/spec/features/time_entries_spec.rb
@@ -36,40 +36,40 @@ describe 'Time entries widget on dashboard', type: :feature, js: true, with_mail
   let!(:other_project) { create :project, types: [type] }
   let!(:work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      author: user
+           project: project,
+           type: type,
+           author: user
   end
   let!(:visible_time_entry) do
     create :time_entry,
-                      work_package: work_package,
-                      project: project,
-                      user: user,
-                      spent_on: Date.today,
-                      hours: 6,
-                      comments: 'My comment'
+           work_package: work_package,
+           project: project,
+           user: user,
+           spent_on: Date.today,
+           hours: 6,
+           comments: 'My comment'
   end
   let!(:other_visible_time_entry) do
     create :time_entry,
-                      work_package: work_package,
-                      project: project,
-                      user: other_user,
-                      spent_on: Date.today - 1.day,
-                      hours: 5,
-                      comments: 'Another`s comment'
+           work_package: work_package,
+           project: project,
+           user: other_user,
+           spent_on: Date.today - 1.day,
+           hours: 5,
+           comments: 'Another`s comment'
   end
   let!(:invisible_time_entry) do
     create :time_entry,
-                      work_package: work_package,
-                      project: other_project,
-                      user: user,
-                      hours: 4
+           work_package: work_package,
+           project: other_project,
+           user: user,
+           hours: 4
   end
   let(:role) do
     create(:role,
-                      permissions: %i[view_time_entries
-                                      view_dashboards
-                                      manage_dashboards])
+           permissions: %i[view_time_entries
+                           view_dashboards
+                           manage_dashboards])
   end
   let(:other_user) do
     create(:user)

--- a/modules/dashboards/spec/features/work_package_calendar_spec.rb
+++ b/modules/dashboards/spec/features/work_package_calendar_spec.rb
@@ -41,53 +41,53 @@ describe 'Work package calendar widget on dashboard',
   let!(:open_status) { create :default_status }
   let!(:spanning_work_package) do
     create :work_package,
-                      subject: 'Spanning work package',
-                      project: project,
-                      start_date: Date.today - 8.days,
-                      due_date: Date.today + 8.days,
-                      type: type,
-                      author: user,
-                      responsible: user
+           subject: 'Spanning work package',
+           project: project,
+           start_date: Date.today - 8.days,
+           due_date: Date.today + 8.days,
+           type: type,
+           author: user,
+           responsible: user
   end
   let!(:starting_work_package) do
     create :work_package,
-                      subject: 'Starting work package',
-                      project: project,
-                      start_date: Date.today,
-                      due_date: Date.today + 8.days,
-                      type: type,
-                      author: user,
-                      responsible: user
+           subject: 'Starting work package',
+           project: project,
+           start_date: Date.today,
+           due_date: Date.today + 8.days,
+           type: type,
+           author: user,
+           responsible: user
   end
   let!(:ending_work_package) do
     create :work_package,
-                      subject: 'Ending work package',
-                      project: project,
-                      start_date: Date.today - 8.days,
-                      due_date: Date.today,
-                      type: type,
-                      author: user,
-                      responsible: user
+           subject: 'Ending work package',
+           project: project,
+           start_date: Date.today - 8.days,
+           due_date: Date.today,
+           type: type,
+           author: user,
+           responsible: user
   end
   let!(:outdated_work_package) do
     create :work_package,
-                      subject: 'Outdated work package',
-                      project: project,
-                      start_date: Date.today - 9.days,
-                      due_date: Date.today - 7.days,
-                      type: type,
-                      author: user,
-                      responsible: user
+           subject: 'Outdated work package',
+           project: project,
+           start_date: Date.today - 9.days,
+           due_date: Date.today - 7.days,
+           type: type,
+           author: user,
+           responsible: user
   end
   let!(:other_project_work_package) do
     create :work_package,
-                      subject: 'Other project work package',
-                      project: other_project,
-                      start_date: Date.today - 9.days,
-                      due_date: Date.today + 7.days,
-                      type: type,
-                      author: user,
-                      responsible: user
+           subject: 'Other project work package',
+           project: other_project,
+           start_date: Date.today - 9.days,
+           due_date: Date.today + 7.days,
+           type: type,
+           author: user,
+           responsible: user
   end
 
   let(:permissions) do

--- a/modules/dashboards/spec/features/work_package_graph_overview_spec.rb
+++ b/modules/dashboards/spec/features/work_package_graph_overview_spec.rb
@@ -41,21 +41,21 @@ describe 'Work package overview graph widget on dashboard',
   let!(:closed_status) { create :closed_status }
   let!(:open_work_package) do
     create :work_package,
-                      subject: 'Spanning work package',
-                      project: project,
-                      status: open_status,
-                      type: type,
-                      author: user,
-                      responsible: user
+           subject: 'Spanning work package',
+           project: project,
+           status: open_status,
+           type: type,
+           author: user,
+           responsible: user
   end
   let!(:closed) do
     create :work_package,
-                      subject: 'Starting work package',
-                      project: project,
-                      status: closed_status,
-                      type: type,
-                      author: user,
-                      responsible: user
+           subject: 'Starting work package',
+           project: project,
+           status: closed_status,
+           type: type,
+           author: user,
+           responsible: user
   end
 
   let(:permissions) do

--- a/modules/dashboards/spec/features/work_package_graph_spec.rb
+++ b/modules/dashboards/spec/features/work_package_graph_spec.rb
@@ -40,27 +40,27 @@ describe 'Arbitrary WorkPackage query graph widget dashboard', type: :feature, j
   let!(:closed_status) { create :status, is_closed: true }
   let!(:type_work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      author: user,
-                      status: open_status,
-                      responsible: user
+           project: project,
+           type: type,
+           author: user,
+           status: open_status,
+           responsible: user
   end
   let!(:other_type_work_package) do
     create :work_package,
-                      project: project,
-                      type: other_type,
-                      author: user,
-                      status: closed_status,
-                      responsible: user
+           project: project,
+           type: other_type,
+           author: user,
+           status: closed_status,
+           responsible: user
   end
   let!(:other_project_work_package) do
     create :work_package,
-                      project: other_project,
-                      type: type,
-                      author: user,
-                      status: open_status,
-                      responsible: user
+           project: other_project,
+           type: type,
+           author: user,
+           status: open_status,
+           responsible: user
   end
 
   let(:permissions) do

--- a/modules/dashboards/spec/features/work_package_table_spec.rb
+++ b/modules/dashboards/spec/features/work_package_table_spec.rb
@@ -39,24 +39,24 @@ describe 'Arbitrary WorkPackage query table widget dashboard', type: :feature, j
   let!(:open_status) { create :default_status }
   let!(:type_work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      author: user,
-                      responsible: user
+           project: project,
+           type: type,
+           author: user,
+           responsible: user
   end
   let!(:other_type_work_package) do
     create :work_package,
-                      project: project,
-                      type: other_type,
-                      author: user,
-                      responsible: user
+           project: project,
+           type: other_type,
+           author: user,
+           responsible: user
   end
   let!(:other_project_work_package) do
     create :work_package,
-                      project: other_project,
-                      type: type,
-                      author: user,
-                      responsible: user
+           project: other_project,
+           type: type,
+           author: user,
+           responsible: user
   end
 
   let(:permissions) do

--- a/modules/dashboards/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
+++ b/modules/dashboards/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
@@ -41,20 +41,20 @@ describe "POST /api/v3/grids/form for Dashboard Grids", type: :request, content_
 
   shared_let(:allowed_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_dashboards manage_dashboards save_queries manage_public_queries])
+           member_in_project: project,
+           member_with_permissions: %i[view_dashboards manage_dashboards save_queries manage_public_queries])
   end
 
   shared_let(:no_save_query_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_dashboards manage_dashboards])
+           member_in_project: project,
+           member_with_permissions: %i[view_dashboards manage_dashboards])
   end
 
   shared_let(:prohibited_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: [])
+           member_in_project: project,
+           member_with_permissions: [])
   end
 
   let(:path) { api_v3_paths.create_grid_form }

--- a/modules/dashboards/spec/requests/api/v3/grids/grids_resource_spec.rb
+++ b/modules/dashboards/spec/requests/api/v3/grids/grids_resource_spec.rb
@@ -35,26 +35,26 @@ describe 'API v3 Grids resource', type: :request, content_type: :json do
 
   let(:current_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
   let(:permissions) { %i[view_dashboards manage_dashboards] }
   let(:project) { create(:project) }
   let(:grid) do
     create(:dashboard,
-                      project: project,
-                      widgets: widgets)
+           project: project,
+           widgets: widgets)
   end
   let(:widgets) do
     [create(:grid_widget,
-                       identifier: 'custom_text',
-                       start_column: 1,
-                       end_column: 3,
-                       start_row: 1,
-                       end_row: 3,
-                       options: {
-                         text: custom_text
-                       })]
+            identifier: 'custom_text',
+            start_column: 1,
+            end_column: 3,
+            start_row: 1,
+            end_row: 3,
+            options: {
+              text: custom_text
+            })]
   end
   let(:custom_text) { "Some text a user wrote" }
 

--- a/modules/documents/spec/api/v3/documents/document_representer_rendering_spec.rb
+++ b/modules/documents/spec/api/v3/documents/document_representer_rendering_spec.rb
@@ -33,7 +33,7 @@ describe ::API::V3::Documents::DocumentRepresenter, 'rendering' do
 
   let(:document) do
     build_stubbed(:document,
-                             description: 'Some description') do |document|
+                  description: 'Some description') do |document|
       allow(document)
         .to receive(:project)
         .and_return(project)

--- a/modules/documents/spec/application_helper_spec.rb
+++ b/modules/documents/spec/application_helper_spec.rb
@@ -48,8 +48,8 @@ describe ApplicationHelper do
     end
     let(:document) do
       create :document,
-                        title: 'Test document',
-                        project: project
+             title: 'Test document',
+             project: project
     end
 
     before do

--- a/modules/documents/spec/controllers/documents_controller_spec.rb
+++ b/modules/documents/spec/controllers/documents_controller_spec.rb
@@ -99,9 +99,9 @@ describe DocumentsController do
   describe "create" do
     let(:document_attributes) do
       attributes_for(:document,
-                                title: "New Document",
-                                project_id: project.id,
-                                category_id: default_category.id)
+                     title: "New Document",
+                     project_id: project.id,
+                     category_id: default_category.id)
     end
 
     before do
@@ -140,9 +140,9 @@ describe DocumentsController do
              params: {
                project_id: notify_project.identifier,
                document: attributes_for(:document,
-                                                   title: "New Document",
-                                                   project_id: notify_project.id,
-                                                   category_id: default_category.id),
+                                        title: "New Document",
+                                        project_id: notify_project.id,
+                                        category_id: default_category.id),
                attachments: { '1' => { id: uncontainered.id } }
              }
       end

--- a/modules/documents/spec/features/attachment_upload_spec.rb
+++ b/modules/documents/spec/features/attachment_upload_spec.rb
@@ -36,14 +36,14 @@ describe 'Upload attachment to documents',
          } do
   let!(:user) do
     create :user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_documents
-                                                  manage_documents]
+           member_in_project: project,
+           member_with_permissions: %i[view_documents
+                                       manage_documents]
   end
   let!(:other_user) do
     create :user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_documents]
+           member_in_project: project,
+           member_with_permissions: %i[view_documents]
   end
   let!(:category) do
     create(:document_category)

--- a/modules/documents/spec/models/document_spec.rb
+++ b/modules/documents/spec/models/document_spec.rb
@@ -89,7 +89,7 @@ describe Document do
     let(:now) { Time.zone.now }
     let(:document) do
       build(:document,
-                       created_at: now)
+            created_at: now)
     end
 
     it { expect(document.event_datetime.to_i).to eq(now.to_i) }

--- a/modules/documents/spec/services/notifications/create_from_model_service_document_spec.rb
+++ b/modules/documents/spec/services/notifications/create_from_model_service_document_spec.rb
@@ -44,7 +44,7 @@ describe Notifications::CreateFromModelService, 'document', with_settings: { jou
 
   let(:resource) do
     create(:document,
-                      project: project)
+           project: project)
   end
   let(:journal) { resource.journals.last }
   let(:author) { other_user }

--- a/modules/documents/spec/services/notifications/mail_service_spec.rb
+++ b/modules/documents/spec/services/notifications/mail_service_spec.rb
@@ -44,7 +44,7 @@ describe Notifications::MailService, type: :model do
   context 'with a document journal notification' do
     let(:journal) do
       build_stubbed(:journal,
-                               journable: build_stubbed(:document)).tap do |j|
+                    journable: build_stubbed(:document)).tap do |j|
         allow(j)
           .to receive(:initial?)
                 .and_return(initial_journal)
@@ -53,11 +53,11 @@ describe Notifications::MailService, type: :model do
     let(:read_ian) { false }
     let(:notification) do
       build_stubbed(:notification,
-                               journal: journal,
-                               resource: journal.journable,
-                               recipient: recipient,
-                               actor: actor,
-                               read_ian: read_ian)
+                    journal: journal,
+                    resource: journal.journable,
+                    recipient: recipient,
+                    actor: actor,
+                    read_ian: read_ian)
     end
     let(:notification_setting) { %w(document_added) }
     let(:mail) do

--- a/modules/github_integration/spec/features/work_package_github_tab_spec.rb
+++ b/modules/github_integration/spec/features/work_package_github_tab_spec.rb
@@ -32,14 +32,14 @@ require_relative '../support/pages/work_package_github_tab'
 describe 'Open the GitHub tab', type: :feature, js: true do
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:role) do
     create(:role,
-                      permissions: %i(view_work_packages
-                                      add_work_package_notes
-                                      show_github_content))
+           permissions: %i(view_work_packages
+                           add_work_package_notes
+                           show_github_content))
   end
   let(:project) { create :project }
   let(:work_package) { create(:work_package, project: project, subject: 'A test work_package') }
@@ -94,8 +94,8 @@ describe 'Open the GitHub tab', type: :feature, js: true do
     context 'when the user does not have the permissions to see the github tab' do
       let(:role) do
         create(:role,
-                          permissions: %i(view_work_packages
-                                          add_work_package_notes))
+               permissions: %i(view_work_packages
+                               add_work_package_notes))
       end
 
       it 'does not show the github tab' do

--- a/modules/github_integration/spec/lib/api/v3/github_pull_requests/github_pull_request_representer_spec.rb
+++ b/modules/github_integration/spec/lib/api/v3/github_pull_requests/github_pull_request_representer_spec.rb
@@ -35,10 +35,10 @@ describe ::API::V3::GithubPullRequests::GithubPullRequestRepresenter do
 
   let(:github_pull_request) do
     build_stubbed(:github_pull_request,
-                             state: 'open',
-                             labels: labels,
-                             github_user: github_user,
-                             merged_by: merged_by).tap do |pr|
+                  state: 'open',
+                  labels: labels,
+                  github_user: github_user,
+                  merged_by: merged_by).tap do |pr|
       allow(pr)
         .to receive(:latest_check_runs)
         .and_return(latest_check_runs)

--- a/modules/github_integration/spec/lib/open_project/github_integration/hook_handler_integration_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/hook_handler_integration_spec.rb
@@ -50,7 +50,7 @@ describe OpenProject::GithubIntegration::HookHandler do
   let(:user) { create(:user) }
   let(:role) do
     create(:role,
-                      permissions: %i[view_work_packages add_work_package_notes])
+           permissions: %i[view_work_packages add_work_package_notes])
   end
   let(:project) do
     create(:project, members: { user => role })

--- a/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_partial_pull_request_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_partial_pull_request_spec.rb
@@ -87,7 +87,7 @@ describe OpenProject::GithubIntegration::Services::UpsertPartialPullRequest do
   context 'when a github pull request with that html_url already exists' do
     let(:github_pull_request) do
       create(:github_pull_request,
-                        github_html_url: 'https://github.com/pulls/1')
+             github_html_url: 'https://github.com/pulls/1')
     end
 
     it 'updates the github pull request' do
@@ -98,8 +98,8 @@ describe OpenProject::GithubIntegration::Services::UpsertPartialPullRequest do
   context 'when a github pull request with that html_url and work_package exists' do
     let(:github_pull_request) do
       create(:github_pull_request,
-                        github_html_url: 'https://github.com/pulls/1',
-                        work_packages: work_packages)
+             github_html_url: 'https://github.com/pulls/1',
+             work_packages: work_packages)
     end
 
     it 'does not change the associated work packages' do
@@ -110,8 +110,8 @@ describe OpenProject::GithubIntegration::Services::UpsertPartialPullRequest do
   context 'when a github pull request with that html_url and work_package exists and a new work_package is referenced' do
     let(:github_pull_request) do
       create(:github_pull_request,
-                        github_html_url: 'https://github.com/pulls/1',
-                        work_packages: already_known_work_packages)
+             github_html_url: 'https://github.com/pulls/1',
+             work_packages: already_known_work_packages)
     end
     let(:work_packages) { create_list(:work_package, 2) }
     let(:already_known_work_packages) { [work_packages[0]] }
@@ -127,11 +127,11 @@ describe OpenProject::GithubIntegration::Services::UpsertPartialPullRequest do
   context 'when an open github pull request with that html_url and work_package exists and a new work_package is referenced' do
     let(:github_pull_request) do
       create(:github_pull_request,
-                        github_html_url: 'https://github.com/pulls/1',
-                        repository: 'some_user/a_repository',
-                        state: 'open',
-                        github_id: 1,
-                        work_packages: already_known_work_packages)
+             github_html_url: 'https://github.com/pulls/1',
+             repository: 'some_user/a_repository',
+             state: 'open',
+             github_id: 1,
+             work_packages: already_known_work_packages)
     end
     let(:work_packages) { create_list(:work_package, 2) }
     let(:already_known_work_packages) { [work_packages[0]] }

--- a/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_pull_request_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/services/upsert_pull_request_spec.rb
@@ -124,15 +124,15 @@ describe OpenProject::GithubIntegration::Services::UpsertPullRequest do
   context 'when a partial github pull request with that html_url already exists' do
     let(:github_pull_request) do
       create(:github_pull_request,
-                        github_id: nil,
-                        changed_files_count: nil,
-                        body: nil,
-                        comments_count: nil,
-                        review_comments_count: nil,
-                        additions_count: nil,
-                        deletions_count: nil,
-                        github_html_url: 'https://github.com/test_user/repo',
-                        state: 'closed')
+             github_id: nil,
+             changed_files_count: nil,
+             body: nil,
+             comments_count: nil,
+             review_comments_count: nil,
+             additions_count: nil,
+             deletions_count: nil,
+             github_html_url: 'https://github.com/test_user/repo',
+             state: 'closed')
     end
 
     it 'updates the github pull request' do

--- a/modules/github_integration/spec/models/github_pull_request_spec.rb
+++ b/modules/github_integration/spec/models/github_pull_request_spec.rb
@@ -85,8 +85,8 @@ describe GithubPullRequest do
     let(:github_url) { 'https://github.com/opf/openproject/pull/123' }
     let(:pull_request) do
       create(:github_pull_request,
-                        github_id: github_id,
-                        github_html_url: github_url)
+             github_id: github_id,
+             github_html_url: github_url)
     end
 
     context 'when the github_id attribute matches' do

--- a/modules/grids/spec/services/grids/set_attributes_service_spec.rb
+++ b/modules/grids/spec/services/grids/set_attributes_service_spec.rb
@@ -98,11 +98,11 @@ describe Grids::SetAttributesService, type: :model do
       let(:widgets) do
         [
           build_stubbed(:grid_widget,
-                                   identifier: 'work_packages_assigned',
-                                   start_row: 3,
-                                   end_row: 5,
-                                   start_column: 1,
-                                   end_column: 3)
+                        identifier: 'work_packages_assigned',
+                        start_row: 3,
+                        end_row: 5,
+                        start_column: 1,
+                        end_column: 3)
         ]
       end
 
@@ -143,11 +143,11 @@ describe Grids::SetAttributesService, type: :model do
           let(:existing_widgets) do
             [
               build(:grid_widget,
-                               identifier: 'work_packages_assigned',
-                               start_row: 3,
-                               end_row: 5,
-                               start_column: 1,
-                               end_column: 3)
+                    identifier: 'work_packages_assigned',
+                    start_row: 3,
+                    end_row: 5,
+                    start_column: 1,
+                    end_column: 3)
             ]
           end
 
@@ -177,11 +177,11 @@ describe Grids::SetAttributesService, type: :model do
       let(:existing_widgets) do
         [
           build_stubbed(:grid_widget,
-                                   identifier: 'work_packages_assigned',
-                                   start_row: 3,
-                                   end_row: 5,
-                                   start_column: 1,
-                                   end_column: 3)
+                        identifier: 'work_packages_assigned',
+                        start_row: 3,
+                        end_row: 5,
+                        start_column: 1,
+                        end_column: 3)
         ]
       end
       let(:grid) do
@@ -223,11 +223,11 @@ describe Grids::SetAttributesService, type: :model do
           let(:existing_widgets) do
             [
               build(:grid_widget,
-                               identifier: 'work_packages_assigned',
-                               start_row: 3,
-                               end_row: 5,
-                               start_column: 1,
-                               end_column: 3)
+                    identifier: 'work_packages_assigned',
+                    start_row: 3,
+                    end_row: 5,
+                    start_column: 1,
+                    end_column: 3)
             ]
           end
 
@@ -257,11 +257,11 @@ describe Grids::SetAttributesService, type: :model do
       let(:existing_widgets) do
         [
           build_stubbed(:grid_widget,
-                                   identifier: 'work_packages_assigned',
-                                   start_row: 3,
-                                   end_row: 5,
-                                   start_column: 1,
-                                   end_column: 3)
+                        identifier: 'work_packages_assigned',
+                        start_row: 3,
+                        end_row: 5,
+                        start_column: 1,
+                        end_column: 3)
         ]
       end
       let(:grid) do
@@ -299,11 +299,11 @@ describe Grids::SetAttributesService, type: :model do
           let(:existing_widgets) do
             [
               build(:grid_widget,
-                               identifier: 'work_packages_assigned',
-                               start_row: 3,
-                               end_row: 5,
-                               start_column: 1,
-                               end_column: 3)
+                    identifier: 'work_packages_assigned',
+                    start_row: 3,
+                    end_row: 5,
+                    start_column: 1,
+                    end_column: 3)
             ]
           end
 
@@ -333,22 +333,22 @@ describe Grids::SetAttributesService, type: :model do
       let(:widgets) do
         [
           build_stubbed(:grid_widget,
-                                   id: existing_widgets[0].id,
-                                   identifier: 'work_packages_assigned',
-                                   start_row: 3,
-                                   end_row: 5,
-                                   start_column: 1,
-                                   end_column: 3)
+                        id: existing_widgets[0].id,
+                        identifier: 'work_packages_assigned',
+                        start_row: 3,
+                        end_row: 5,
+                        start_column: 1,
+                        end_column: 3)
         ]
       end
       let(:existing_widgets) do
         [
           build_stubbed(:grid_widget,
-                                   identifier: 'work_packages_assigned',
-                                   start_row: 2,
-                                   end_row: 5,
-                                   start_column: 1,
-                                   end_column: 3)
+                        identifier: 'work_packages_assigned',
+                        start_row: 2,
+                        end_row: 5,
+                        start_column: 1,
+                        end_column: 3)
         ]
       end
       let(:grid) do
@@ -379,51 +379,51 @@ describe Grids::SetAttributesService, type: :model do
       let(:widgets) do
         [
           build_stubbed(:grid_widget,
-                                   identifier: 'work_packages_assigned',
-                                   start_row: 3,
-                                   end_row: 5,
-                                   start_column: 1,
-                                   end_column: 3),
+                        identifier: 'work_packages_assigned',
+                        start_row: 3,
+                        end_row: 5,
+                        start_column: 1,
+                        end_column: 3),
           build_stubbed(:grid_widget,
-                                   identifier: 'work_packages_watched',
-                                   start_row: 1,
-                                   end_row: 2,
-                                   start_column: 1,
-                                   end_column: 2),
+                        identifier: 'work_packages_watched',
+                        start_row: 1,
+                        end_row: 2,
+                        start_column: 1,
+                        end_column: 2),
           build_stubbed(:grid_widget,
-                                   identifier: 'work_packages_calendar',
-                                   start_row: 2,
-                                   end_row: 4,
-                                   start_column: 1,
-                                   end_column: 2),
+                        identifier: 'work_packages_calendar',
+                        start_row: 2,
+                        end_row: 4,
+                        start_column: 1,
+                        end_column: 2),
           build_stubbed(:grid_widget,
-                                   identifier: 'work_packages_calendar',
-                                   start_row: 1,
-                                   end_row: 2,
-                                   start_column: 4,
-                                   end_column: 4)
+                        identifier: 'work_packages_calendar',
+                        start_row: 1,
+                        end_row: 2,
+                        start_column: 4,
+                        end_column: 4)
         ]
       end
       let(:existing_widgets) do
         [
           build_stubbed(:grid_widget,
-                                   identifier: 'work_packages_assigned',
-                                   start_row: 2,
-                                   end_row: 5,
-                                   start_column: 1,
-                                   end_column: 3),
+                        identifier: 'work_packages_assigned',
+                        start_row: 2,
+                        end_row: 5,
+                        start_column: 1,
+                        end_column: 3),
           build_stubbed(:grid_widget,
-                                   identifier: 'work_packages_assigned',
-                                   start_row: 1,
-                                   end_row: 2,
-                                   start_column: 3,
-                                   end_column: 4),
+                        identifier: 'work_packages_assigned',
+                        start_row: 1,
+                        end_row: 2,
+                        start_column: 3,
+                        end_column: 4),
           build_stubbed(:grid_widget,
-                                   identifier: 'work_packages_calendar',
-                                   start_row: 1,
-                                   end_row: 2,
-                                   start_column: 1,
-                                   end_column: 2)
+                        identifier: 'work_packages_calendar',
+                        start_row: 1,
+                        end_row: 2,
+                        start_column: 1,
+                        end_column: 2)
         ]
       end
       let(:grid) do

--- a/modules/ldap_groups/spec/services/synchronization_spec.rb
+++ b/modules/ldap_groups/spec/services/synchronization_spec.rb
@@ -21,16 +21,16 @@ describe LdapGroups::SynchronizeGroupsService, with_ee: %i[ldap_groups] do
   # two groups foo (aa729), bar(aa729, bb459, cc414)
   let(:auth_source) do
     create :ldap_auth_source,
-                      port: ParallelHelper.port_for_ldap.to_s,
-                      account: 'uid=admin,ou=system',
-                      account_password: 'secret',
-                      base_dn: 'ou=people,dc=example,dc=com',
-                      onthefly_register: onthefly_register,
-                      filter_string: ldap_filter,
-                      attr_login: 'uid',
-                      attr_firstname: 'givenName',
-                      attr_lastname: 'sn',
-                      attr_mail: 'mail'
+           port: ParallelHelper.port_for_ldap.to_s,
+           account: 'uid=admin,ou=system',
+           account_password: 'secret',
+           base_dn: 'ou=people,dc=example,dc=com',
+           onthefly_register: onthefly_register,
+           filter_string: ldap_filter,
+           attr_login: 'uid',
+           attr_firstname: 'givenName',
+           attr_lastname: 'sn',
+           attr_mail: 'mail'
   end
 
   let(:onthefly_register) { false }
@@ -46,17 +46,17 @@ describe LdapGroups::SynchronizeGroupsService, with_ee: %i[ldap_groups] do
 
   let(:synced_foo) do
     create :ldap_synchronized_group,
-                      dn: 'cn=foo,ou=groups,dc=example,dc=com',
-                      group: group_foo,
-                      sync_users: sync_users,
-                      auth_source: auth_source
+           dn: 'cn=foo,ou=groups,dc=example,dc=com',
+           group: group_foo,
+           sync_users: sync_users,
+           auth_source: auth_source
   end
   let(:synced_bar) do
     create :ldap_synchronized_group,
-                      dn: 'cn=bar,ou=groups,dc=example,dc=com',
-                      group: group_bar,
-                      sync_users: sync_users,
-                      auth_source: auth_source
+           dn: 'cn=bar,ou=groups,dc=example,dc=com',
+           group: group_bar,
+           sync_users: sync_users,
+           auth_source: auth_source
   end
 
   subject do

--- a/modules/ldap_groups/spec/services/synchronize_filter_spec.rb
+++ b/modules/ldap_groups/spec/services/synchronize_filter_spec.rb
@@ -17,11 +17,11 @@ describe LdapGroups::SynchronizeFilterService, with_ee: %i[ldap_groups] do
   # two groups foo (aa729), bar(aa729, bb459, cc414)
   let(:auth_source) do
     create :ldap_auth_source,
-                      port: ParallelHelper.port_for_ldap.to_s,
-                      account: 'uid=admin,ou=system',
-                      account_password: 'secret',
-                      base_dn: 'dc=example,dc=com',
-                      attr_login: 'uid'
+           port: ParallelHelper.port_for_ldap.to_s,
+           account: 'uid=admin,ou=system',
+           account_password: 'secret',
+           base_dn: 'dc=example,dc=com',
+           attr_login: 'uid'
   end
 
   let(:group_foo) { create :group, lastname: 'foo' }
@@ -94,15 +94,15 @@ describe LdapGroups::SynchronizeFilterService, with_ee: %i[ldap_groups] do
   describe 'when one group already exists with different settings' do
     let(:synced_foo) do
       create :ldap_synchronized_group,
-                        dn: 'cn=foo,ou=groups,dc=example,dc=com',
-                        group: group_foo,
-                        sync_users: false,
-                        auth_source: auth_source
+             dn: 'cn=foo,ou=groups,dc=example,dc=com',
+             group: group_foo,
+             sync_users: false,
+             auth_source: auth_source
     end
     let(:filter_foo_bar) do
       create :ldap_synchronized_filter,
-                        sync_users: true,
-                        auth_source: auth_source
+             sync_users: true,
+             auth_source: auth_source
     end
 
     before do
@@ -122,10 +122,10 @@ describe LdapGroups::SynchronizeFilterService, with_ee: %i[ldap_groups] do
     let!(:group_doesnotexist) { create :group, lastname: 'doesnotexist' }
     let!(:synced_doesnotexist) do
       create :ldap_synchronized_group,
-                        dn: 'cn=doesnotexist,ou=groups,dc=example,dc=com',
-                        group: group_doesnotexist,
-                        filter: filter_foo_bar,
-                        auth_source: auth_source
+             dn: 'cn=doesnotexist,ou=groups,dc=example,dc=com',
+             group: group_doesnotexist,
+             filter: filter_foo_bar,
+             auth_source: auth_source
     end
 
     it 'removes that group' do
@@ -154,8 +154,8 @@ describe LdapGroups::SynchronizeFilterService, with_ee: %i[ldap_groups] do
   describe 'when filter has its own base dn' do
     let(:filter_foo_bar) do
       create :ldap_synchronized_filter,
-                        auth_source: auth_source,
-                        base_dn: 'ou=users,dc=example,dc=com'
+             auth_source: auth_source,
+             base_dn: 'ou=users,dc=example,dc=com'
     end
 
     it 'uses that base for searching and doesnt find any groups' do

--- a/modules/meeting/spec/features/meetings_close_spec.rb
+++ b/modules/meeting/spec/features/meetings_close_spec.rb
@@ -32,13 +32,13 @@ describe 'Meetings close', type: :feature do
   let(:project) { create :project, enabled_module_names: %w[meetings] }
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
   let(:other_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
 
   let!(:meeting) { create :meeting, project: project, title: 'Own awesome meeting!', author: user }

--- a/modules/meeting/spec/features/meetings_copy_spec.rb
+++ b/modules/meeting/spec/features/meetings_copy_spec.rb
@@ -32,8 +32,8 @@ describe 'Meetings copy', type: :feature, js: true do
   let(:project) { create :project, enabled_module_names: %w[meetings] }
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions).tap do |u|
+           member_in_project: project,
+           member_with_permissions: permissions).tap do |u|
       u.pref[:time_zone] = 'UTC'
 
       u.save!
@@ -41,20 +41,20 @@ describe 'Meetings copy', type: :feature, js: true do
   end
   let(:other_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
   let(:permissions) { %i[view_meetings create_meetings] }
 
   let(:agenda_text) { "We will talk" }
   let!(:meeting) do
     create(:meeting,
-                      author: other_user,
-                      project: project,
-                      title: 'Awesome meeting!',
-                      location: 'Meeting room',
-                      duration: 1.5,
-                      start_time: DateTime.parse("2013-03-27 18:55:00")).tap do |m|
+           author: other_user,
+           project: project,
+           title: 'Awesome meeting!',
+           location: 'Meeting room',
+           duration: 1.5,
+           start_time: DateTime.parse("2013-03-27 18:55:00")).tap do |m|
       create(:meeting_agenda, meeting: m, text: agenda_text)
       m.participants.build(user: other_user, attended: true)
     end

--- a/modules/meeting/spec/features/meetings_delete_spec.rb
+++ b/modules/meeting/spec/features/meetings_delete_spec.rb
@@ -32,13 +32,13 @@ describe 'Meetings deletion', type: :feature do
   let(:project) { create :project, enabled_module_names: %w[meetings] }
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
   let(:other_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
 
   let!(:meeting) { create :meeting, project: project, title: 'Own awesome meeting!', author: user }

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -39,9 +39,9 @@ describe 'Meetings', type: :feature do
     create(:user) do |user|
       [project, other_project].each do |p|
         create(:member,
-                          project: p,
-                          principal: user,
-                          roles: [role])
+               project: p,
+               principal: user,
+               roles: [role])
       end
     end
   end

--- a/modules/meeting/spec/features/meetings_new_spec.rb
+++ b/modules/meeting/spec/features/meetings_new_spec.rb
@@ -35,9 +35,9 @@ describe 'Meetings new', type: :feature do
   let(:time_zone) { 'utc' }
   let(:user) do
     create(:user,
-                      lastname: 'First',
-                      member_in_project: project,
-                      member_with_permissions: permissions).tap do |u|
+           lastname: 'First',
+           member_in_project: project,
+           member_with_permissions: permissions).tap do |u|
       u.pref[:time_zone] = time_zone
 
       u.save!
@@ -45,9 +45,9 @@ describe 'Meetings new', type: :feature do
   end
   let(:other_user) do
     create(:user,
-                      lastname: 'Second',
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           lastname: 'Second',
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
   let(:admin) do
     create(:admin)

--- a/modules/meeting/spec/features/meetings_participants_spec.rb
+++ b/modules/meeting/spec/features/meetings_participants_spec.rb
@@ -34,21 +34,21 @@ describe 'Meetings participants', type: :feature do
   let(:project) { create :project, enabled_module_names: %w[meetings] }
   let!(:user) do
     create(:user,
-                      firstname: 'Current',
-                      member_in_project: project,
-                      member_with_permissions: %i[view_meetings edit_meetings])
+           firstname: 'Current',
+           member_in_project: project,
+           member_with_permissions: %i[view_meetings edit_meetings])
   end
   let!(:viewer_user) do
     create(:user,
-                      firstname: 'Viewer',
-                      member_in_project: project,
-                      member_with_permissions: %i[view_meetings])
+           firstname: 'Viewer',
+           member_in_project: project,
+           member_with_permissions: %i[view_meetings])
   end
   let!(:non_viewer_user) do
     create(:user,
-                      firstname: 'Nonviewer',
-                      member_in_project: project,
-                      member_with_permissions: %i[])
+           firstname: 'Nonviewer',
+           member_in_project: project,
+           member_with_permissions: %i[])
   end
   let(:meeting) { create(:meeting, project: project) }
   let(:edit_page) { Pages::Meetings::Edit.new(meeting) }

--- a/modules/meeting/spec/features/meetings_show_spec.rb
+++ b/modules/meeting/spec/features/meetings_show_spec.rb
@@ -33,8 +33,8 @@ describe 'Meetings', type: :feature, js: true do
   let(:role) { create(:role, permissions: permissions) }
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
 
   let!(:meeting) { create :meeting, project: project, title: 'Awesome meeting!' }

--- a/modules/meeting/spec/mailers/meeting_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_mailer_spec.rb
@@ -33,17 +33,17 @@ describe MeetingMailer, type: :mailer do
   shared_let(:project) { create(:project, name: 'My project') }
   shared_let(:author) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role,
-                      preferences: { time_zone: 'Europe/Berlin' }
+           member_in_project: project,
+           member_through_role: role,
+           preferences: { time_zone: 'Europe/Berlin' }
   end
   shared_let(:watcher1) { create(:user, member_in_project: project, member_through_role: role) }
   shared_let(:watcher2) { create(:user, member_in_project: project, member_through_role: role) }
 
   let(:meeting) do
     create :meeting,
-                      author: author,
-                      project: project
+           author: author,
+           project: project
   end
   let(:meeting_agenda) do
     create(:meeting_agenda, meeting: meeting)
@@ -99,9 +99,9 @@ describe MeetingMailer, type: :mailer do
     context 'when the meeting time results in another date' do
       let(:meeting) do
         create :meeting,
-                          author: author,
-                          project: project,
-                          start_time: '2021-11-09T23:00:00 +0100'.to_datetime.utc
+               author: author,
+               project: project,
+               start_time: '2021-11-09T23:00:00 +0100'.to_datetime.utc
       end
 
       describe 'it renders november 9th for Berlin zone' do
@@ -132,11 +132,11 @@ describe MeetingMailer, type: :mailer do
   describe 'icalendar' do
     let(:meeting) do
       create :meeting,
-                        author: author,
-                        project: project,
-                        title: 'Important meeting',
-                        start_time: "2021-01-19T10:00:00Z".to_time(:utc),
-                        duration: 1.0
+             author: author,
+             project: project,
+             title: 'Important meeting',
+             start_time: "2021-01-19T10:00:00Z".to_time(:utc),
+             duration: 1.0
     end
     let(:mail) { described_class.icalendar_notification meeting_agenda, 'meeting_agenda', author }
 
@@ -204,9 +204,9 @@ describe MeetingMailer, type: :mailer do
     context 'when the meeting time results in another date' do
       let(:meeting) do
         create :meeting,
-                          author: author,
-                          project: project,
-                          start_time: '2021-11-09T23:00:00 +0100'.to_datetime.utc
+               author: author,
+               project: project,
+               start_time: '2021-11-09T23:00:00 +0100'.to_datetime.utc
       end
 
       describe 'it renders november 9th for Berlin zone' do

--- a/modules/meeting/spec/models/project/activity_spec.rb
+++ b/modules/meeting/spec/models/project/activity_spec.rb
@@ -37,17 +37,17 @@ describe Projects::Activity, type: :model do
 
   let(:meeting) do
     create(:meeting,
-                      project: project)
+           project: project)
   end
 
   let(:meeting2) do
     create(:meeting,
-                      project: project)
+           project: project)
   end
 
   let(:work_package) do
     create(:work_package,
-                      project: project)
+           project: project)
   end
 
   def latest_activity

--- a/modules/my_page/spec/features/my/accountable_spec.rb
+++ b/modules/my_page/spec/features/my/accountable_spec.rb
@@ -38,24 +38,24 @@ describe 'Accountable widget on my page', type: :feature, js: true do
   let!(:open_status) { create :default_status }
   let!(:accountable_work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      author: user,
-                      responsible: user
+           project: project,
+           type: type,
+           author: user,
+           responsible: user
   end
   let!(:accountable_by_other_work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      author: user,
-                      responsible: other_user
+           project: project,
+           type: type,
+           author: user,
+           responsible: other_user
   end
   let!(:accountable_but_invisible_work_package) do
     create :work_package,
-                      project: other_project,
-                      type: type,
-                      author: user,
-                      responsible: user
+           project: other_project,
+           type: type,
+           author: user,
+           responsible: user
   end
   let(:other_user) do
     create(:user)
@@ -65,8 +65,8 @@ describe 'Accountable widget on my page', type: :feature, js: true do
 
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:my_page) do
     Pages::My::Page.new

--- a/modules/my_page/spec/features/my/assigned_to_me_spec.rb
+++ b/modules/my_page/spec/features/my/assigned_to_me_spec.rb
@@ -37,27 +37,27 @@ describe 'Assigned to me embedded query on my page', type: :feature, js: true do
   let!(:open_status) { create :default_status }
   let!(:assigned_work_package) do
     create :work_package,
-                      project: project,
-                      subject: 'Assigned to me',
-                      type: type,
-                      author: user,
-                      assigned_to: user
+           project: project,
+           subject: 'Assigned to me',
+           type: type,
+           author: user,
+           assigned_to: user
   end
   let!(:assigned_work_package_2) do
     create :work_package,
-                      project: project,
-                      subject: 'My task 2',
-                      type: type,
-                      author: user,
-                      assigned_to: user
+           project: project,
+           subject: 'My task 2',
+           type: type,
+           author: user,
+           assigned_to: user
   end
   let!(:assigned_to_other_work_package) do
     create :work_package,
-                      project: project,
-                      subject: 'Not assigned to me',
-                      type: type,
-                      author: user,
-                      assigned_to: other_user
+           project: project,
+           subject: 'Not assigned to me',
+           type: type,
+           author: user,
+           assigned_to: other_user
   end
   let(:other_user) do
     create(:user)
@@ -67,8 +67,8 @@ describe 'Assigned to me embedded query on my page', type: :feature, js: true do
 
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_through_role: role)
+           member_in_project: project,
+           member_through_role: role)
   end
   let(:my_page) do
     Pages::My::Page.new
@@ -85,12 +85,12 @@ describe 'Assigned to me embedded query on my page', type: :feature, js: true do
   context 'with parent work package' do
     let!(:assigned_work_package_child) do
       create :work_package,
-                        subject: 'Child',
-                        parent: assigned_work_package,
-                        project: project,
-                        type: type,
-                        author: user,
-                        assigned_to: user
+             subject: 'Child',
+             parent: assigned_work_package,
+             project: project,
+             type: type,
+             author: user,
+             assigned_to: user
     end
 
     it 'can toggle hierarchy mode in embedded tables (Regression test #29578)' do

--- a/modules/my_page/spec/features/my/documents_spec.rb
+++ b/modules/my_page/spec/features/my/documents_spec.rb
@@ -35,20 +35,20 @@ describe 'My page documents widget', type: :feature, js: true do
   let!(:other_project) { create :project }
   let!(:visible_document) do
     create :document,
-                      project: project,
-                      description: 'blubs'
+           project: project,
+           description: 'blubs'
   end
   let!(:invisible_document) do
     create :document,
-                      project: other_project
+           project: other_project
   end
   let(:other_user) do
     create(:user)
   end
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_documents])
+           member_in_project: project,
+           member_with_permissions: %i[view_documents])
   end
   let(:my_page) do
     Pages::My::Page.new

--- a/modules/my_page/spec/features/my/my_page_spec.rb
+++ b/modules/my_page/spec/features/my/my_page_spec.rb
@@ -36,21 +36,21 @@ describe 'My page', type: :feature, js: true do
   let!(:open_status) { create :default_status }
   let!(:created_work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      author: user
+           project: project,
+           type: type,
+           author: user
   end
   let!(:assigned_work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      assigned_to: user
+           project: project,
+           type: type,
+           assigned_to: user
   end
 
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_work_packages add_work_packages save_queries])
+           member_in_project: project,
+           member_with_permissions: %i[view_work_packages add_work_packages save_queries])
   end
   let(:my_page) do
     Pages::My::Page.new

--- a/modules/my_page/spec/features/my/news_spec.rb
+++ b/modules/my_page/spec/features/my/news_spec.rb
@@ -35,20 +35,20 @@ describe 'My page news widget spec', type: :feature, js: true do
   let!(:other_project) { create :project }
   let!(:visible_news) do
     create :news,
-                      project: project,
-                      description: 'blubs'
+           project: project,
+           description: 'blubs'
   end
   let!(:invisible_news) do
     create :news,
-                      project: other_project
+           project: other_project
   end
   let(:other_user) do
     create(:user)
   end
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[])
+           member_in_project: project,
+           member_with_permissions: %i[])
   end
   let(:my_page) do
     Pages::My::Page.new

--- a/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
+++ b/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
@@ -37,53 +37,53 @@ describe 'My page time entries current user widget spec', type: :feature, js: tr
   let!(:other_activity) { create :time_entry_activity }
   let!(:work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      author: user
+           project: project,
+           type: type,
+           author: user
   end
   let!(:other_work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      author: user
+           project: project,
+           type: type,
+           author: user
   end
   let!(:visible_time_entry) do
     create :time_entry,
-                      work_package: work_package,
-                      project: project,
-                      activity: activity,
-                      user: user,
-                      spent_on: Date.today.beginning_of_week(:sunday) + 1.day,
-                      hours: 3,
-                      comments: 'My comment'
+           work_package: work_package,
+           project: project,
+           activity: activity,
+           user: user,
+           spent_on: Date.today.beginning_of_week(:sunday) + 1.day,
+           hours: 3,
+           comments: 'My comment'
   end
   let!(:other_visible_time_entry) do
     create :time_entry,
-                      work_package: work_package,
-                      project: project,
-                      activity: activity,
-                      user: user,
-                      spent_on: Date.today.beginning_of_week(:sunday) + 4.days,
-                      hours: 2,
-                      comments: 'My other comment'
+           work_package: work_package,
+           project: project,
+           activity: activity,
+           user: user,
+           spent_on: Date.today.beginning_of_week(:sunday) + 4.days,
+           hours: 2,
+           comments: 'My other comment'
   end
   let!(:last_week_visible_time_entry) do
     create :time_entry,
-                      work_package: work_package,
-                      project: project,
-                      activity: activity,
-                      user: user,
-                      spent_on: Date.today - (Date.today.wday + 3).days,
-                      hours: 8,
-                      comments: 'My last week comment'
+           work_package: work_package,
+           project: project,
+           activity: activity,
+           user: user,
+           spent_on: Date.today - (Date.today.wday + 3).days,
+           hours: 8,
+           comments: 'My last week comment'
   end
   let!(:invisible_time_entry) do
     create :time_entry,
-                      work_package: work_package,
-                      project: project,
-                      activity: activity,
-                      user: other_user,
-                      hours: 4
+           work_package: work_package,
+           project: project,
+           activity: activity,
+           user: other_user,
+           hours: 4
   end
   let!(:custom_field) do
     create :time_entry_custom_field, field_format: 'text'
@@ -93,8 +93,8 @@ describe 'My page time entries current user widget spec', type: :feature, js: tr
   end
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[view_time_entries edit_time_entries view_work_packages log_time])
+           member_in_project: project,
+           member_with_permissions: %i[view_time_entries edit_time_entries view_work_packages log_time])
   end
   let(:my_page) do
     Pages::My::Page.new

--- a/modules/my_page/spec/features/my/work_package_table_spec.rb
+++ b/modules/my_page/spec/features/my/work_package_table_spec.rb
@@ -39,25 +39,25 @@ describe 'Arbitrary WorkPackage query table widget on my page', type: :feature, 
   let!(:open_status) { create :default_status }
   let!(:type_work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      author: user,
-                      responsible: user
+           project: project,
+           type: type,
+           author: user,
+           responsible: user
   end
   let!(:other_type_work_package) do
     create :work_package,
-                      project: project,
-                      type: other_type,
-                      author: user,
-                      responsible: user
+           project: project,
+           type: other_type,
+           author: user,
+           responsible: user
   end
 
   let(:permissions) { %i[view_work_packages add_work_packages save_queries] }
 
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
   let(:my_page) do
     Pages::My::Page.new

--- a/modules/my_page/spec/models/grids/my_page_spec.rb
+++ b/modules/my_page/spec/models/grids/my_page_spec.rb
@@ -49,7 +49,7 @@ describe Grids::MyPage, type: :model do
       let(:user) { create(:user) }
       let(:query) do
         create(:query,
-                          user: user)
+               user: user)
       end
 
       before do

--- a/modules/my_page/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
+++ b/modules/my_page/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
@@ -38,8 +38,8 @@ describe "POST /api/v3/grids/form", type: :request, content_type: :json do
   end
   shared_let(:current_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: %i[save_queries])
+           member_in_project: project,
+           member_with_permissions: %i[save_queries])
   end
 
   let(:path) { api_v3_paths.create_grid_form }

--- a/modules/overviews/spec/features/low_permissions_page_creation_spec.rb
+++ b/modules/overviews/spec/features/low_permissions_page_creation_spec.rb
@@ -42,8 +42,8 @@ describe 'Overview page on the fly creation if user lacks :mange_overview permis
 
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
   let(:overview_page) do
     Pages::Overview.new(project)

--- a/modules/overviews/spec/features/managing_overview_page_spec.rb
+++ b/modules/overviews/spec/features/managing_overview_page_spec.rb
@@ -36,15 +36,15 @@ describe 'Overview page managing', type: :feature, js: true, with_mail: false do
   let!(:open_status) { create :default_status }
   let!(:created_work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      author: user
+           project: project,
+           type: type,
+           author: user
   end
   let!(:assigned_work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      assigned_to: user
+           project: project,
+           type: type,
+           assigned_to: user
   end
 
   let(:permissions) do
@@ -58,8 +58,8 @@ describe 'Overview page managing', type: :feature, js: true, with_mail: false do
 
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
   let(:overview_page) do
     Pages::Overview.new(project)

--- a/modules/overviews/spec/features/navigation_spec.rb
+++ b/modules/overviews/spec/features/navigation_spec.rb
@@ -33,8 +33,8 @@ describe 'Navigate to overview', type: :feature, js: true do
   let(:permissions) { [] }
   let(:user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
 
   before do

--- a/modules/overviews/spec/requests/api/v3/grids/grids_resource_spec.rb
+++ b/modules/overviews/spec/requests/api/v3/grids/grids_resource_spec.rb
@@ -35,26 +35,26 @@ describe 'API v3 Grids resource', type: :request, content_type: :json do
 
   let(:current_user) do
     create(:user,
-                      member_in_project: project,
-                      member_with_permissions: permissions)
+           member_in_project: project,
+           member_with_permissions: permissions)
   end
   let(:permissions) { %i[] }
   let(:project) { create(:project) }
   let(:grid) do
     create(:overview,
-                      project: project,
-                      widgets: widgets)
+           project: project,
+           widgets: widgets)
   end
   let(:widgets) do
     [create(:grid_widget,
-                       identifier: 'custom_text',
-                       start_column: 1,
-                       end_column: 3,
-                       start_row: 1,
-                       end_row: 3,
-                       options: {
-                         text: custom_text
-                       })]
+            identifier: 'custom_text',
+            start_column: 1,
+            end_column: 3,
+            start_row: 1,
+            end_row: 3,
+            options: {
+              text: custom_text
+            })]
   end
   let(:custom_text) { "Some text a user wrote" }
 

--- a/modules/overviews/spec/services/copy_service_integration_spec.rb
+++ b/modules/overviews/spec/services/copy_service_integration_spec.rb
@@ -37,8 +37,8 @@ describe Projects::CopyService, 'integration', type: :model do
 
   let(:current_user) do
     create(:user,
-                      member_in_project: source,
-                      member_through_role: role)
+           member_in_project: source,
+           member_through_role: role)
   end
   let(:role) { create :role, permissions: %i[copy_projects] }
   let(:instance) do

--- a/modules/reporting/spec/features/calculations_spec.rb
+++ b/modules/reporting/spec/features/calculations_spec.rb
@@ -11,27 +11,27 @@ describe 'Cost report calculations', type: :feature, js: true do
 
   let!(:time_entry1) do
     create :time_entry,
-                      spent_on: 6.months.ago,
-                      user: user,
-                      work_package: work_package,
-                      project: project,
-                      hours: 10
+           spent_on: 6.months.ago,
+           user: user,
+           work_package: work_package,
+           project: project,
+           hours: 10
   end
   let!(:time_entry2) do
     create :time_entry,
-                      spent_on: 18.months.ago,
-                      user: user,
-                      work_package: work_package,
-                      project: project,
-                      hours: 10
+           spent_on: 18.months.ago,
+           user: user,
+           work_package: work_package,
+           project: project,
+           hours: 10
   end
   let!(:time_entry3) do
     create :time_entry,
-                      spent_on: 30.months.ago,
-                      user: user,
-                      work_package: work_package,
-                      project: project,
-                      hours: 10
+           spent_on: 30.months.ago,
+           user: user,
+           work_package: work_package,
+           project: project,
+           hours: 10
   end
 
   before do

--- a/modules/reporting/spec/features/custom_fields_spec.rb
+++ b/modules/reporting/spec/features/custom_fields_spec.rb
@@ -36,25 +36,25 @@ describe 'Custom fields reporting', type: :feature, js: true do
 
   let(:work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      custom_values: initial_custom_values
+           project: project,
+           type: type,
+           custom_values: initial_custom_values
   end
 
   let!(:time_entry1) do
     create :time_entry,
-                      user: user,
-                      work_package: work_package,
-                      project: project,
-                      hours: 10
+           user: user,
+           work_package: work_package,
+           project: project,
+           hours: 10
   end
 
   let!(:time_entry2) do
     create :time_entry,
-                      user: user,
-                      work_package: work_package,
-                      project: project,
-                      hours: 2.50
+           user: user,
+           work_package: work_package,
+           project: project,
+           hours: 2.50
   end
 
   def custom_value_for(cf, str)
@@ -64,11 +64,11 @@ describe 'Custom fields reporting', type: :feature, js: true do
   context 'with multi value cf' do
     let!(:custom_field) do
       create(:list_wp_custom_field,
-                        name: "List CF",
-                        multi_value: true,
-                        types: [type],
-                        projects: [project],
-                        possible_values: ['First option', 'Second option'])
+             name: "List CF",
+             multi_value: true,
+             types: [type],
+             projects: [project],
+             possible_values: ['First option', 'Second option'])
     end
 
     let(:initial_custom_values) { { custom_field.id => custom_value_for(custom_field, 'First option') } }
@@ -78,8 +78,8 @@ describe 'Custom fields reporting', type: :feature, js: true do
     # as this caused problems with casting the nil value of the custom value to 0.
     let!(:work_package2) do
       create :work_package,
-                        project: project,
-                        type: type
+             project: project,
+             type: type
     end
 
     before do
@@ -148,25 +148,25 @@ describe 'Custom fields reporting', type: :feature, js: true do
     context 'with additional WP with invalid value' do
       let!(:custom_field_2) do
         create(:list_wp_custom_field,
-                          name: "Invalid List CF",
-                          multi_value: true,
-                          types: [type],
-                          projects: [project],
-                          possible_values: %w[A B])
+               name: "Invalid List CF",
+               multi_value: true,
+               types: [type],
+               projects: [project],
+               possible_values: %w[A B])
       end
 
       let!(:work_package2) do
         create :work_package,
-                          project: project,
-                          custom_values: { custom_field_2.id => custom_value_for(custom_field_2, 'A') }
+               project: project,
+               custom_values: { custom_field_2.id => custom_value_for(custom_field_2, 'A') }
       end
 
       let!(:time_entry1) do
         create :time_entry,
-                          user: user,
-                          work_package: work_package2,
-                          project: project,
-                          hours: 10
+               user: user,
+               work_package: work_package2,
+               project: project,
+               hours: 10
       end
 
       before do
@@ -201,9 +201,9 @@ describe 'Custom fields reporting', type: :feature, js: true do
   context 'with text CF' do
     let(:custom_field) do
       create(:text_wp_custom_field,
-                        name: 'Text CF',
-                        types: [type],
-                        projects: [project])
+             name: 'Text CF',
+             types: [type],
+             projects: [project])
     end
     let(:initial_custom_values) { { custom_field.id => 'foo' } }
 

--- a/modules/reporting/spec/features/group_by_spec.rb
+++ b/modules/reporting/spec/features/group_by_spec.rb
@@ -12,11 +12,11 @@ describe 'Cost report calculations', type: :feature, js: true do
 
   let!(:time_entry1) do
     create :time_entry,
-                      spent_on: 6.months.ago,
-                      user: user,
-                      work_package: work_package,
-                      project: project,
-                      hours: 10
+           spent_on: 6.months.ago,
+           user: user,
+           work_package: work_package,
+           project: project,
+           hours: 10
   end
   before do
     login_as(user)

--- a/modules/reporting/spec/features/me_value_spec.rb
+++ b/modules/reporting/spec/features/me_value_spec.rb
@@ -10,17 +10,17 @@ describe 'Cost report showing my own times', type: :feature, js: true do
 
   let!(:time_entry1) do
     create :time_entry,
-                      user: user,
-                      work_package: work_package,
-                      project: project,
-                      hours: 10
+           user: user,
+           work_package: work_package,
+           project: project,
+           hours: 10
   end
   let!(:time_entry2) do
     create :time_entry,
-                      user: user2,
-                      work_package: work_package,
-                      project: project,
-                      hours: 15
+           user: user2,
+           work_package: work_package,
+           project: project,
+           hours: 15
   end
 
   before do
@@ -68,17 +68,17 @@ describe 'Cost report showing my own times', type: :feature, js: true do
 
     let!(:time_entry1) do
       create :time_entry,
-                        user: user,
-                        work_package: work_package,
-                        project: project,
-                        hours: 10
+             user: user,
+             work_package: work_package,
+             project: project,
+             hours: 10
     end
     let!(:time_entry2) do
       create :time_entry,
-                        user: user2,
-                        work_package: work_package2,
-                        project: project,
-                        hours: 15
+             user: user2,
+             work_package: work_package2,
+             project: project,
+             hours: 15
     end
 
     before do

--- a/modules/reporting/spec/features/my_time_spec.rb
+++ b/modules/reporting/spec/features/my_time_spec.rb
@@ -10,10 +10,10 @@ describe 'Cost report showing my own times', type: :feature, js: true do
 
   let!(:time_entry1) do
     create :time_entry,
-                      user: user,
-                      work_package: work_package,
-                      project: project,
-                      hours: 10
+           user: user,
+           work_package: work_package,
+           project: project,
+           hours: 10
   end
 
   before do

--- a/modules/reporting/spec/features/permissions_spec.rb
+++ b/modules/reporting/spec/features/permissions_spec.rb
@@ -9,8 +9,8 @@ describe 'Cost report calculations', type: :feature, js: true do
   let!(:role) { create :role, permissions: permissions }
   let!(:user) do
     create :user,
-                      member_in_project: project,
-                      member_through_role: role
+           member_in_project: project,
+           member_through_role: role
   end
 
   let(:work_package) { create :work_package, project: project }
@@ -21,17 +21,17 @@ describe 'Cost report calculations', type: :feature, js: true do
 
   let!(:time_entry_user) do
     create :time_entry,
-                      user: admin,
-                      work_package: work_package,
-                      project: project,
-                      hours: 10
+           user: admin,
+           work_package: work_package,
+           project: project,
+           hours: 10
   end
   let!(:time_entry_admin) do
     create :time_entry,
-                      user: user,
-                      work_package: work_package,
-                      project: project,
-                      hours: 5
+           user: user,
+           work_package: work_package,
+           project: project,
+           hours: 5
   end
   let!(:cost_type) do
     type = create :cost_type, name: 'Translations'
@@ -40,11 +40,11 @@ describe 'Cost report calculations', type: :feature, js: true do
   end
   let!(:cost_entry_user) do
     create :cost_entry,
-                      work_package: work_package,
-                      project: project,
-                      units: 3.00,
-                      cost_type: cost_type,
-                      user: user
+           work_package: work_package,
+           project: project,
+           units: 3.00,
+           cost_type: cost_type,
+           user: user
   end
 
   before do

--- a/modules/reporting/spec/features/saving_spec.rb
+++ b/modules/reporting/spec/features/saving_spec.rb
@@ -50,8 +50,8 @@ describe 'Cost report saving', type: :feature, js: true do
     let(:role) { create :role, permissions: %i(view_time_entries) }
     let!(:user) do
       create :user,
-                        member_in_project: project,
-                        member_through_role: role
+             member_in_project: project,
+             member_through_role: role
     end
 
     it 'cannot save reports' do

--- a/modules/reporting/spec/features/subproject_spec.rb
+++ b/modules/reporting/spec/features/subproject_spec.rb
@@ -7,8 +7,8 @@ describe 'Cost report in subproject', type: :feature, js: true do
   let!(:role) { create :role, permissions: %i(view_cost_entries view_own_cost_entries) }
   let!(:user) do
     create :user,
-                      member_in_project: subproject,
-                      member_through_role: role
+           member_in_project: subproject,
+           member_through_role: role
   end
 
   before do

--- a/modules/reporting/spec/features/update_entries_spec.rb
+++ b/modules/reporting/spec/features/update_entries_spec.rb
@@ -37,10 +37,10 @@ describe 'Updating entries within the cost report', type: :feature, js: true do
 
   let!(:time_entry_user) do
     create :time_entry,
-                      user: user,
-                      work_package: work_package,
-                      project: project,
-                      hours: 5
+           user: user,
+           work_package: work_package,
+           project: project,
+           hours: 5
   end
 
   let(:cost_type) do
@@ -51,11 +51,11 @@ describe 'Updating entries within the cost report', type: :feature, js: true do
 
   let!(:cost_entry_user) do
     create :cost_entry,
-                      work_package: work_package,
-                      project: project,
-                      units: 3.00,
-                      cost_type: cost_type,
-                      user: user
+           work_package: work_package,
+           project: project,
+           units: 3.00,
+           cost_type: cost_type,
+           user: user
   end
 
   let(:report_page) { ::Pages::CostReportPage.new project }
@@ -121,8 +121,8 @@ describe 'Updating entries within the cost report', type: :feature, js: true do
     let(:role) { create :role, permissions: %i(view_time_entries) }
     let!(:user) do
       create :user,
-                        member_in_project: project,
-                        member_through_role: role
+             member_in_project: project,
+             member_through_role: role
     end
 
     it 'cannot edit or delete' do

--- a/modules/reporting/spec/features/work_package_costlog_spec.rb
+++ b/modules/reporting/spec/features/work_package_costlog_spec.rb
@@ -17,13 +17,13 @@ describe 'Cost report showing my own times', type: :feature, js: true do
 
   let(:cost_entry) do
     build(:cost_entry,
-                     cost_type: cost_type,
-                     project: project,
-                     work_package: work_package,
-                     spent_on: Date.today,
-                     units: '10',
-                     user: user,
-                     comments: 'foobar')
+          cost_type: cost_type,
+          project: project,
+          work_package: work_package,
+          spent_on: Date.today,
+          units: '10',
+          user: user,
+          comments: 'foobar')
   end
 
   before do

--- a/modules/reporting/spec/models/cost_query/filter_spec.rb
+++ b/modules/reporting/spec/models/cost_query/filter_spec.rb
@@ -81,24 +81,24 @@ describe CostQuery, type: :model, reporting_query_helper: true do
         let!(:author) { create(:user, member_in_project: project) }
         let!(:work_package) do
           create(:work_package,
-                            project: project,
-                            author: author)
+                 project: project,
+                 author: author)
         end
         let!(:cost_type) { create(:cost_type) }
         let!(:cost_entry) do
           create(:cost_entry,
-                            work_package: work_package,
-                            user: user,
-                            project: project,
-                            cost_type: cost_type)
+                 work_package: work_package,
+                 user: user,
+                 project: project,
+                 cost_type: cost_type)
         end
         let!(:activity) { create(:time_entry_activity) }
         let!(:time_entry) do
           create(:time_entry,
-                            work_package: work_package,
-                            user: user,
-                            project: project,
-                            activity: activity)
+                 work_package: work_package,
+                 user: user,
+                 project: project,
+                 activity: activity)
         end
 
         it "should only return entries from the given #{filter}" do
@@ -136,24 +136,24 @@ describe CostQuery, type: :model, reporting_query_helper: true do
       let!(:author) { create(:user, member_in_project: project) }
       let!(:work_package) do
         create(:work_package,
-                          project: project,
-                          author: author)
+               project: project,
+               author: author)
       end
       let!(:cost_type) { create(:cost_type) }
       let!(:cost_entry) do
         create(:cost_entry,
-                          work_package: work_package,
-                          user: user,
-                          project: project,
-                          cost_type: cost_type)
+               work_package: work_package,
+               user: user,
+               project: project,
+               cost_type: cost_type)
       end
       let!(:activity) { create(:time_entry_activity) }
       let!(:time_entry) do
         create(:time_entry,
-                          work_package: work_package,
-                          user: user,
-                          project: project,
-                          activity: activity)
+               work_package: work_package,
+               user: user,
+               project: project,
+               activity: activity)
       end
 
       it "should only return entries from the given CostQuery::Filter::AuthorId" do
@@ -353,7 +353,7 @@ describe CostQuery, type: :model, reporting_query_helper: true do
     describe CostQuery::Filter::CustomFieldEntries do
       let!(:custom_field) do
         cf = create(:work_package_custom_field,
-                               name: 'My custom field')
+                    name: 'My custom field')
         clear_cache
         cf
       end
@@ -438,19 +438,19 @@ describe CostQuery, type: :model, reporting_query_helper: true do
 
       def create_searchable_fields_and_values
         searchable_field = create(:work_package_custom_field,
-                                             field_format: "text",
-                                             name: "Searchable Field")
+                                  field_format: "text",
+                                  name: "Searchable Field")
         2.times do
           work_package = create_work_package_with_entry(:cost_entry)
           create(:work_package_custom_value,
-                            custom_field: searchable_field,
-                            customized: work_package,
-                            value: "125")
+                 custom_field: searchable_field,
+                 customized: work_package,
+                 value: "125")
         end
         work_package = create_work_package_with_entry(:cost_entry)
         create(:custom_value,
-                          custom_field: searchable_field,
-                          value: "non-matching value")
+               custom_field: searchable_field,
+               value: "non-matching value")
         clear_cache
       end
 

--- a/modules/team_planner/spec/features/query_handling_spec.rb
+++ b/modules/team_planner/spec/features/query_handling_spec.rb
@@ -37,40 +37,40 @@ describe 'Team planner query handling', type: :feature, js: true do
   shared_let(:type_bug) { create(:type_bug) }
   shared_let(:project) do
     create(:project,
-                      enabled_module_names: %w[work_package_tracking team_planner_view],
-                      types: [type_task, type_bug])
+           enabled_module_names: %w[work_package_tracking team_planner_view],
+           types: [type_task, type_bug])
   end
 
   shared_let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_with_permissions: %w[
-                        view_work_packages
-                        edit_work_packages
-                        save_queries
-                        save_public_queries
-                        view_team_planner
-                        manage_team_planner
-                      ]
+           member_in_project: project,
+           member_with_permissions: %w[
+             view_work_packages
+             edit_work_packages
+             save_queries
+             save_public_queries
+             view_team_planner
+             manage_team_planner
+           ]
   end
 
   shared_let(:task) do
     create :work_package,
-                      project: project,
-                      type: type_task,
-                      assigned_to: user,
-                      start_date: Time.zone.today - 1.day,
-                      due_date: Time.zone.today + 1.day,
-                      subject: 'A task for the user'
+           project: project,
+           type: type_task,
+           assigned_to: user,
+           start_date: Time.zone.today - 1.day,
+           due_date: Time.zone.today + 1.day,
+           subject: 'A task for the user'
   end
   shared_let(:bug) do
     create :work_package,
-                      project: project,
-                      type: type_bug,
-                      assigned_to: user,
-                      start_date: Time.zone.today - 1.day,
-                      due_date: Time.zone.today + 1.day,
-                      subject: 'A bug for the user'
+           project: project,
+           type: type_bug,
+           assigned_to: user,
+           start_date: Time.zone.today - 1.day,
+           due_date: Time.zone.today + 1.day,
+           subject: 'A bug for the user'
   end
 
   let(:team_planner) { ::Pages::TeamPlanner.new project }

--- a/modules/team_planner/spec/features/shared_context.rb
+++ b/modules/team_planner/spec/features/shared_context.rb
@@ -38,11 +38,11 @@ shared_context 'with team planner full access' do
 
   shared_let(:user) do
     create :user,
-                      member_in_project: project,
-                      member_with_permissions: %w[
-                        view_work_packages edit_work_packages add_work_packages
-                        view_team_planner manage_team_planner save_queries manage_public_queries
-                      ]
+           member_in_project: project,
+           member_with_permissions: %w[
+             view_work_packages edit_work_packages add_work_packages
+             view_team_planner manage_team_planner save_queries manage_public_queries
+           ]
   end
 
   let(:team_planner) { ::Pages::TeamPlanner.new project }

--- a/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
@@ -39,35 +39,35 @@ describe 'Team planner add existing work packages', type: :feature, js: true do
 
   let!(:other_user) do
     create :user,
-                      firstname: 'Bernd',
-                      member_in_project: project,
-                      member_with_permissions: %w[
-                        view_work_packages view_team_planner
-                      ]
+           firstname: 'Bernd',
+           member_in_project: project,
+           member_with_permissions: %w[
+             view_work_packages view_team_planner
+           ]
   end
 
   let!(:first_wp) do
     create :work_package,
-                      project: project,
-                      subject: 'Task 1',
-                      assigned_to: user,
-                      start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
-                      due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
+           project: project,
+           subject: 'Task 1',
+           assigned_to: user,
+           start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
+           due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
   end
   let!(:second_wp) do
     create :work_package,
-                      project: project,
-                      subject: 'Task 2',
-                      parent: first_wp,
-                      assigned_to: other_user,
-                      start_date: 10.days.from_now,
-                      due_date: 12.days.from_now
+           project: project,
+           subject: 'Task 2',
+           parent: first_wp,
+           assigned_to: other_user,
+           start_date: 10.days.from_now,
+           due_date: 12.days.from_now
   end
   let!(:third_wp) do
     create :work_package,
-                      project: project,
-                      subject: 'TA Aufgabe 3',
-                      status: closed_status
+           project: project,
+           subject: 'TA Aufgabe 3',
+           status: closed_status
   end
 
   let(:add_existing_pane) { ::Components::AddExistingPane.new }

--- a/modules/team_planner/spec/features/team_planner_error_handling_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_error_handling_spec.rb
@@ -36,18 +36,18 @@ describe 'Team planner error handling', type: :feature, js: true do
 
   let!(:work_package) do
     create :work_package,
-                      project: project,
-                      type: type,
-                      assigned_to: user,
-                      start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
-                      due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
+           project: project,
+           type: type,
+           assigned_to: user,
+           start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
+           due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
   end
 
   let!(:custom_field) do
     create :work_package_custom_field,
-                      default_value: nil,
-                      is_for_all: true,
-                      is_required: false
+           default_value: nil,
+           is_for_all: true,
+           is_required: false
   end
 
   let(:type) { create(:type, custom_fields: [custom_field]) }

--- a/modules/team_planner/spec/features/team_planner_menu_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_menu_spec.rb
@@ -40,11 +40,11 @@ describe 'Team planner sidemenu', type: :feature, js: true do
   context 'with a user that does not have create rights' do
     shared_let(:user_without_rights) do
       create :user,
-                        member_in_project: project,
-                        member_with_permissions: %w[
-                          view_work_packages edit_work_packages add_work_packages
-                          view_team_planner
-                        ]
+             member_in_project: project,
+             member_with_permissions: %w[
+               view_work_packages edit_work_packages add_work_packages
+               view_team_planner
+             ]
     end
 
     current_user { user_without_rights }
@@ -63,11 +63,11 @@ describe 'Team planner sidemenu', type: :feature, js: true do
   context 'with a user that has create rights' do
     shared_let(:user_with_rights) do
       create :user,
-                        member_in_project: project,
-                        member_with_permissions: %w[
-                          view_work_packages edit_work_packages add_work_packages
-                          view_team_planner manage_team_planner
-                        ]
+             member_in_project: project,
+             member_with_permissions: %w[
+               view_work_packages edit_work_packages add_work_packages
+               view_team_planner manage_team_planner
+             ]
     end
 
     current_user { user_with_rights }

--- a/modules/team_planner/spec/features/team_planner_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_spec.rb
@@ -64,12 +64,12 @@ describe 'Team planner', type: :feature, js: true do
   context 'with an assigned work package' do
     let!(:other_user) do
       create :user,
-                        firstname: 'Other',
-                        lastname: 'User',
-                        member_in_project: project,
-                        member_with_permissions: %w[
-                          view_work_packages edit_work_packages view_team_planner manage_team_planner
-                        ]
+             firstname: 'Other',
+             lastname: 'User',
+             member_in_project: project,
+             member_with_permissions: %w[
+               view_work_packages edit_work_packages view_team_planner manage_team_planner
+             ]
     end
     let!(:user_outside_project) { create :user, firstname: 'Not', lastname: 'In Project' }
     let(:type_task) { create :type_task }
@@ -78,31 +78,31 @@ describe 'Team planner', type: :feature, js: true do
 
     let!(:other_task) do
       create :work_package,
-                        project: project,
-                        type: type_task,
-                        assigned_to: other_user,
-                        start_date: Time.zone.today - 1.day,
-                        due_date: Time.zone.today + 1.day,
-                        subject: 'A task for the other user'
+             project: project,
+             type: type_task,
+             assigned_to: other_user,
+             start_date: Time.zone.today - 1.day,
+             due_date: Time.zone.today + 1.day,
+             subject: 'A task for the other user'
     end
     let!(:other_bug) do
       create :work_package,
-                        project: project,
-                        type: type_bug,
-                        assigned_to: other_user,
-                        status: closed_status,
-                        start_date: Time.zone.today - 1.day,
-                        due_date: Time.zone.today + 1.day,
-                        subject: 'Another task for the other user'
+             project: project,
+             type: type_bug,
+             assigned_to: other_user,
+             status: closed_status,
+             start_date: Time.zone.today - 1.day,
+             due_date: Time.zone.today + 1.day,
+             subject: 'Another task for the other user'
     end
     let!(:user_bug) do
       create :work_package,
-                        project: project,
-                        type: type_bug,
-                        assigned_to: user,
-                        start_date: Time.zone.today - 10.days,
-                        due_date: Time.zone.today + 20.days,
-                        subject: 'A task for the logged in user'
+             project: project,
+             type: type_bug,
+             assigned_to: user,
+             start_date: Time.zone.today - 10.days,
+             due_date: Time.zone.today + 20.days,
+             subject: 'A task for the logged in user'
     end
 
     before do

--- a/modules/team_planner/spec/features/team_planner_user_interaction_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_user_interaction_spec.rb
@@ -40,34 +40,34 @@ describe 'Team planner drag&dop and resizing', type: :feature, js: true do
 
   let!(:other_user) do
     create :user,
-                      firstname: 'Bernd',
-                      member_in_project: project,
-                      member_with_permissions: %w[
-                        view_work_packages view_team_planner
-                      ]
+           firstname: 'Bernd',
+           member_in_project: project,
+           member_with_permissions: %w[
+             view_work_packages view_team_planner
+           ]
   end
 
   let!(:first_wp) do
     create :work_package,
-                      project: project,
-                      assigned_to: other_user,
-                      start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
-                      due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
+           project: project,
+           assigned_to: other_user,
+           start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
+           due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
   end
   let!(:second_wp) do
     create :work_package,
-                      project: project,
-                      parent: first_wp,
-                      assigned_to: other_user,
-                      start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
-                      due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
+           project: project,
+           parent: first_wp,
+           assigned_to: other_user,
+           start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
+           due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
   end
   let!(:third_wp) do
     create :work_package,
-                      project: project,
-                      assigned_to: user,
-                      start_date: Time.zone.today - 10.days,
-                      due_date: Time.zone.today + 20.days
+           project: project,
+           assigned_to: user,
+           start_date: Time.zone.today - 10.days,
+           due_date: Time.zone.today + 20.days
   end
 
   context 'with full permissions' do

--- a/modules/team_planner/spec/requests/api/v3/views/create_resource_spec.rb
+++ b/modules/team_planner/spec/requests/api/v3/views/create_resource_spec.rb
@@ -36,19 +36,19 @@ describe ::API::V3::Views::ViewsAPI,
   shared_let(:permitted_user) { create(:user) }
   shared_let(:role) do
     create(:role,
-                      permissions: %w[view_work_packages
-                                      save_queries
-                                      manage_public_queries
-                                      manage_team_planner])
+           permissions: %w[view_work_packages
+                           save_queries
+                           manage_public_queries
+                           manage_team_planner])
   end
   shared_let(:project) do
     create(:project,
-                      members: { permitted_user => role })
+           members: { permitted_user => role })
   end
   shared_let(:public_query) do
     create(:query,
-                      project: project,
-                      public: true)
+           project: project,
+           public: true)
   end
 
   let(:additional_setup) do

--- a/modules/two_factor_authentication/spec/features/admin_edit_two_factor_devices_spec.rb
+++ b/modules/two_factor_authentication/spec/features/admin_edit_two_factor_devices_spec.rb
@@ -8,8 +8,8 @@ describe 'Admin 2FA management', with_2fa_ee: true, type: :feature,
   let(:other_user) { create :user, login: 'bob' }
   let(:admin) do
     create(:admin,
-                      password: user_password,
-                      password_confirmation: user_password)
+           password: user_password,
+           password_confirmation: user_password)
   end
 
   before do

--- a/modules/two_factor_authentication/spec/features/backup_codes/generate_backup_codes.rb
+++ b/modules/two_factor_authentication/spec/features/backup_codes/generate_backup_codes.rb
@@ -7,9 +7,9 @@ describe 'Generate 2FA backup codes', with_2fa_ee: true, type: :feature,
   let(:user_password) { 'bob!' * 4 }
   let(:user) do
     create(:user,
-                      login: 'bob',
-                      password: user_password,
-                      password_confirmation: user_password)
+           login: 'bob',
+           password: user_password,
+           password_confirmation: user_password)
   end
   let(:dialog) { ::Components::PasswordConfirmationDialog.new }
 

--- a/modules/two_factor_authentication/spec/features/backup_codes/login_with_backup_code_spec.rb
+++ b/modules/two_factor_authentication/spec/features/backup_codes/login_with_backup_code_spec.rb
@@ -7,9 +7,9 @@ describe 'Login with 2FA backup code', with_2fa_ee: true, type: :feature,
   let(:user_password) { 'bob!' * 4 }
   let(:user) do
     create(:user,
-                      login: 'bob',
-                      password: user_password,
-                      password_confirmation: user_password)
+           login: 'bob',
+           password: user_password,
+           password_confirmation: user_password)
   end
   let!(:device) { create :two_factor_authentication_device_sms, user: user, active: true, default: true }
 

--- a/modules/two_factor_authentication/spec/features/login/login_enforced_2fa_spec.rb
+++ b/modules/two_factor_authentication/spec/features/login/login_enforced_2fa_spec.rb
@@ -7,9 +7,9 @@ describe 'Login with enforced 2FA', with_2fa_ee: true, type: :feature,
   let(:user_password) { 'bob!' * 4 }
   let(:user) do
     create(:user,
-                      login: 'bob',
-                      password: user_password,
-                      password_confirmation: user_password)
+           login: 'bob',
+           password: user_password,
+           password_confirmation: user_password)
   end
 
   context 'with a default device' do

--- a/modules/two_factor_authentication/spec/features/login/login_with_2fa_spec.rb
+++ b/modules/two_factor_authentication/spec/features/login/login_with_2fa_spec.rb
@@ -7,9 +7,9 @@ describe 'Login with 2FA device', with_2fa_ee: true, type: :feature,
   let(:user_password) { 'bob!' * 4 }
   let(:user) do
     create(:user,
-                      login: 'bob',
-                      password: user_password,
-                      password_confirmation: user_password)
+           login: 'bob',
+           password: user_password,
+           password_confirmation: user_password)
   end
 
   context 'with a default device' do

--- a/modules/two_factor_authentication/spec/features/login/login_without_2fa_spec.rb
+++ b/modules/two_factor_authentication/spec/features/login/login_without_2fa_spec.rb
@@ -7,9 +7,9 @@ describe 'Login with no required OTP', with_2fa_ee: true, type: :feature,
   let(:user_password) { 'bob!' * 4 }
   let(:user) do
     create(:user,
-                      login: 'bob',
-                      password: user_password,
-                      password_confirmation: user_password)
+           login: 'bob',
+           password: user_password,
+           password_confirmation: user_password)
   end
 
   context 'non-default device' do

--- a/modules/two_factor_authentication/spec/features/login/switch_available_devices_spec.rb
+++ b/modules/two_factor_authentication/spec/features/login/switch_available_devices_spec.rb
@@ -7,9 +7,9 @@ describe 'Login by switching 2FA device', with_2fa_ee: true, type: :feature,
   let(:user_password) { 'bob!' * 4 }
   let(:user) do
     create(:user,
-                      login: 'bob',
-                      password: user_password,
-                      password_confirmation: user_password)
+           login: 'bob',
+           password: user_password,
+           password_confirmation: user_password)
   end
 
   context 'with two default device' do

--- a/modules/two_factor_authentication/spec/features/my_two_factor_devices_spec.rb
+++ b/modules/two_factor_authentication/spec/features/my_two_factor_devices_spec.rb
@@ -8,9 +8,9 @@ describe 'My Account 2FA configuration', with_2fa_ee: true,
   let(:user_password) { 'boB!4' * 4 }
   let(:user) do
     create(:user,
-                      login: 'bob',
-                      password: user_password,
-                      password_confirmation: user_password)
+           login: 'bob',
+           password: user_password,
+           password_confirmation: user_password)
   end
 
   before do

--- a/modules/two_factor_authentication/spec/features/password_change_spec.rb
+++ b/modules/two_factor_authentication/spec/features/password_change_spec.rb
@@ -7,9 +7,9 @@ describe 'Password change with OTP', with_2fa_ee: true, type: :feature,
   let(:new_user_password) { '%obB' * 4 }
   let(:user) do
     create(:user,
-                      login: 'bob',
-                      password: user_password,
-                      password_confirmation: user_password)
+           login: 'bob',
+           password: user_password,
+           password_confirmation: user_password)
   end
   let(:expected_path_after_login) { my_page_path }
 
@@ -88,11 +88,11 @@ describe 'Password change with OTP', with_2fa_ee: true, type: :feature,
   context 'when force password change is set' do
     let(:user) do
       create(:user,
-                        force_password_change: true,
-                        first_login: true,
-                        login: 'bob',
-                        password: user_password,
-                        password_confirmation: user_password)
+             force_password_change: true,
+             first_login: true,
+             login: 'bob',
+             password: user_password,
+             password_confirmation: user_password)
     end
     let(:expected_path_after_login) { home_path }
 

--- a/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/work_package/exporter/xls_integration_spec.rb
@@ -172,11 +172,11 @@ describe XlsExport::WorkPackage::Exporter::XLS do
 
     let(:custom_field) do
       create(:float_wp_custom_field,
-                        name: 'unit costs')
+             name: 'unit costs')
     end
     let(:custom_value) do
       create(:custom_value,
-                        custom_field: custom_field)
+             custom_field: custom_field)
     end
     let(:type) do
       type = project.types.first
@@ -185,12 +185,12 @@ describe XlsExport::WorkPackage::Exporter::XLS do
     end
     let(:project) do
       create(:project,
-                        work_package_custom_fields: [custom_field])
+             work_package_custom_fields: [custom_field])
     end
     let(:work_packages) do
       wps = create_list(:work_package, 4,
-                                   project: project,
-                                   type: type)
+                        project: project,
+                        type: type)
       wps[0].estimated_hours = 27.5
       wps[0].save!
       wps[1].send(:"custom_field_#{custom_field.id}=", 1)
@@ -248,9 +248,9 @@ describe XlsExport::WorkPackage::Exporter::XLS do
 
     let(:work_package) do
       create(:work_package,
-                        description: 'some arbitrary description',
-                        project: project,
-                        type: project.types.first)
+             description: 'some arbitrary description',
+             project: project,
+             type: project.types.first)
     end
     let(:work_packages) { [work_package] }
     let(:column_names) { %w[id] }
@@ -266,9 +266,9 @@ describe XlsExport::WorkPackage::Exporter::XLS do
   context 'with underscore in subject' do
     let(:work_package) do
       create(:work_package,
-                        subject: 'underscore_is included',
-                        project: project,
-                        type: project.types.first)
+             subject: 'underscore_is included',
+             project: project,
+             type: project.types.first)
     end
     let(:work_packages) { [work_package] }
     let(:column_names) { %w[id subject] }
@@ -293,8 +293,8 @@ describe XlsExport::WorkPackage::Exporter::XLS do
     let(:zone) { +2 }
     let(:work_package) do
       create(:work_package,
-                        project: project,
-                        type: project.types.first)
+             project: project,
+             type: project.types.first)
     end
     let(:work_packages) { [work_package] }
 
@@ -320,9 +320,9 @@ describe XlsExport::WorkPackage::Exporter::XLS do
   describe 'with derived estimated hours' do
     let(:work_package) do
       create(:work_package,
-                        project: project,
-                        derived_estimated_hours: 15.0,
-                        type: project.types.first)
+             project: project,
+             derived_estimated_hours: 15.0,
+             type: project.types.first)
     end
     let(:work_packages) { [work_package] }
 
@@ -338,10 +338,10 @@ describe XlsExport::WorkPackage::Exporter::XLS do
   describe 'with derived estimated hours and estimated_hours set to zero' do
     let(:work_package) do
       create(:work_package,
-                        project: project,
-                        derived_estimated_hours: 15.0,
-                        estimated_hours: 0.0,
-                        type: project.types.first)
+             project: project,
+             derived_estimated_hours: 15.0,
+             estimated_hours: 0.0,
+             type: project.types.first)
     end
     let(:work_packages) { [work_package] }
 

--- a/modules/xls_export/spec/patches/work_packages_controller_patch_spec.rb
+++ b/modules/xls_export/spec/patches/work_packages_controller_patch_spec.rb
@@ -40,9 +40,9 @@ describe WorkPackagesController, type: :controller do
   let(:type) { build_stubbed(:type) }
   let(:stub_work_package) do
     build_stubbed(:stubbed_work_package,
-                             id: 1337,
-                             type: type,
-                             project: stub_project)
+                  id: 1337,
+                  type: type,
+                  project: stub_project)
   end
 
   let(:current_user) { create(:user) }


### PR DESCRIPTION
The FactoryBot.* prefix has been removed in f08bea3. Since then rubocop complains about Layout/ArgumentAlignment. This commit fixes it.

I forgot some files in modules/*/spec.