### PR TITLE
[40957] Remove rounded FC button style

### DIFF
--- a/frontend/src/global_styles/content/_calendars.sass
+++ b/frontend/src/global_styles/content/_calendars.sass
@@ -9,7 +9,7 @@ full-calendar
       height: 34px
 
       &.fc-today-button
-        margin-bottom: 0
+        margin: 0
         margin-left: 0.5rem
 
     // ensure to have higher specificity than above extend

--- a/frontend/src/global_styles/vendor/_full_calendar.sass
+++ b/frontend/src/global_styles/vendor/_full_calendar.sass
@@ -61,23 +61,9 @@
         &:focus
           box-shadow: none
 
-      > .fc-button
-        border-radius: 2rem
-
-      .fc-button-group .fc-button
-        &:first-of-type
-          border-bottom-left-radius: 2rem
-          border-top-left-radius: 2rem
-
-        &:last-of-type
-          border-bottom-right-radius: 2rem
-          border-top-right-radius: 2rem
-
       .fc-prev-button,
       .fc-next-button
-        border-radius: 2rem
         padding: 4px
-        margin: 0 8px 0 0
         font-size: 8px
         height: 32px
         width: 32px


### PR DESCRIPTION
https://community.openproject.org/wp/40957

Also fixes the double margin of the today button