### PR TITLE
Make the lookup of Contracts and Services in longer namespaces possible

### DIFF
--- a/lib/api/utilities/endpoints/delete.rb
+++ b/lib/api/utilities/endpoints/delete.rb
@@ -30,6 +30,8 @@ module API
   module Utilities
     module Endpoints
       class Delete
+        include NamespacedLookup
+
         def default_instance_generator(model)
           ->(_params) do
             instance_variable_get("@#{model.name.demodulize.underscore}")
@@ -37,14 +39,14 @@ module API
         end
 
         def initialize(model:,
-                       instance_generator: default_instance_generator(model),
+                       instance_generator: nil,
                        process_service: nil,
                        success_status: 204,
-                       api_name: model.name.demodulize)
+                       api_name: nil)
           self.model = model
-          self.instance_generator = instance_generator
+          self.instance_generator = instance_generator || default_instance_generator(model)
           self.process_service = process_service || deduce_process_service
-          self.api_name = api_name
+          self.api_name = api_name || model.name.demodulize
           self.success_status = success_status
         end
 
@@ -97,15 +99,7 @@ module API
         end
 
         def deduce_process_service
-          "::#{deduce_backend_namespace}::DeleteService".constantize
-        end
-
-        def deduce_backend_namespace
-          demodulized_name.pluralize
-        end
-
-        def demodulized_name
-          model.name.demodulize
+          lookup_namespaced_class("DeleteService")
         end
 
         def deduce_api_namespace

--- a/lib/api/utilities/endpoints/modify.rb
+++ b/lib/api/utilities/endpoints/modify.rb
@@ -78,7 +78,7 @@ module API
         end
 
         def deduce_process_service
-          "::#{deduce_backend_namespace}::#{update_or_create}Service".constantize
+          lookup_namespaced_class("#{update_or_create}Service")
         end
 
         def deduce_process_contract

--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/delete.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/delete.rb
@@ -42,9 +42,5 @@ module Bim::Bcf::API::V2_1::Endpoints
     def render_representer
       "::Bim::Bcf::API::V2_1::#{deduce_api_namespace}::SingleRepresenter".constantize
     end
-
-    def deduce_process_service
-      "::Bim::Bcf::#{deduce_backend_namespace}::DeleteService".constantize
-    end
   end
 end

--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/modify_mixin.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/modify_mixin.rb
@@ -36,10 +36,6 @@ module Bim::Bcf::API::V2_1::Endpoints
       ::Bim::Bcf::API::V2_1::ParseResourceParamsService
     end
 
-    def deduce_process_service
-      "::Bim::Bcf::#{deduce_backend_namespace}::#{update_or_create}Service".constantize
-    end
-
     def deduce_in_and_out_representer
       "::Bim::Bcf::API::V2_1::#{deduce_api_namespace}::SingleRepresenter".constantize
     end


### PR DESCRIPTION
For instance, it will make it easier to lookup `Storages::FileLinks::CreateContract` when the model class is `Storages::FileLink`. Previously it was lookin up `FileLinks::CreateContract`. Now it will lookup `Storages::FileLinks::CreateContract` and then `FileLinks::CreateContract` if the previous lookup failed.