### PR TITLE
elevated priority for jobs users might wait for

### DIFF
--- a/app/workers/application_job.rb
+++ b/app/workers/application_job.rb
@@ -46,6 +46,10 @@ class ApplicationJob < ::ActiveJob::Base
       0
     when :notification
       5
+    when :above_normal
+      7
+    when :below_normal
+      13
     when :low
       20
     else

--- a/app/workers/backup_job.rb
+++ b/app/workers/backup_job.rb
@@ -32,7 +32,7 @@ require 'tempfile'
 require 'zip'
 
 class BackupJob < ::ApplicationJob
-  queue_with_priority :low
+  queue_with_priority :above_normal
 
   attr_reader :backup, :user
 

--- a/app/workers/copy_project_job.rb
+++ b/app/workers/copy_project_job.rb
@@ -29,7 +29,7 @@
 #++
 
 class CopyProjectJob < ApplicationJob
-  queue_with_priority :low
+  queue_with_priority :above_normal
   include OpenProject::LocaleHelper
 
   attr_reader :user_id,

--- a/app/workers/exports/export_job.rb
+++ b/app/workers/exports/export_job.rb
@@ -2,6 +2,8 @@ require 'active_storage/filename'
 
 module Exports
   class ExportJob < ::ApplicationJob
+    queue_with_priority :above_normal
+
     def perform(export:, user:, mime_type:, query:, **options)
       self.export = export
       self.current_user = user

--- a/app/workers/principals/delete_job.rb
+++ b/app/workers/principals/delete_job.rb
@@ -29,7 +29,7 @@
 #++
 
 class Principals::DeleteJob < ApplicationJob
-  queue_with_priority :low
+  queue_with_priority :below_normal
 
   def perform(principal)
     Principal.transaction do

--- a/app/workers/projects/delete_project_job.rb
+++ b/app/workers/projects/delete_project_job.rb
@@ -30,7 +30,7 @@
 
 module Projects
   class DeleteProjectJob < UserJob
-    queue_with_priority :low
+    queue_with_priority :below_normal
     include OpenProject::LocaleHelper
 
     attr_reader :project

--- a/app/workers/scm/relocate_repository_job.rb
+++ b/app/workers/scm/relocate_repository_job.rb
@@ -31,7 +31,7 @@
 ##
 # Provides an asynchronous job to relocate a managed repository on the local or remote system
 class SCM::RelocateRepositoryJob < SCM::RemoteRepositoryJob
-  queue_with_priority :low
+  queue_with_priority :below_normal
 
   def perform(repository)
     super(repository)


### PR DESCRIPTION
Currently if someone uploads lots of documents it can happen that copying projects (which includes creating new ones based on a template) is delayed because of ExtractFulltextJobs (which used to have the same (low) priority) clogging the worker queue.

While at it I also increased the priorities for other jobs which users might actively wait for. 