### PR TITLE
Add lefhook git hooks manager to run rubocop on precommit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ structure.sql
 # Local development direnv files
 /.envrc
 /.direnv
+
+# lefthook.yml user override
+lefthook-local.yml

--- a/Gemfile
+++ b/Gemfile
@@ -279,6 +279,9 @@ group :development, :test do
   gem 'pry-rescue', '~> 1.5.2'
   gem 'pry-stack_explorer', '~> 0.6.0'
 
+  # git hooks manager
+  gem 'lefthook'
+
   # Brakeman scanner
   gem 'brakeman', '~> 5.2.0'
   gem 'danger-brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -574,6 +574,7 @@ GEM
       open4 (~> 1.0)
     launchy (2.5.0)
       addressable (~> 2.7)
+    lefthook (0.7.7)
     letter_opener (1.7.0)
       launchy (~> 2.2)
     listen (3.7.1)
@@ -1029,6 +1030,7 @@ DEPENDENCIES
   json_spec (~> 1.1.4)
   ladle
   launchy (~> 2.5.0)
+  lefthook
   letter_opener
   listen (~> 3.7.0)
   livingstyleguide (~> 2.1.0)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+# Lefthook configuration
+#
+# Add commit hooks with `lefthook install`
+#
+# Refer for explanation to following link:
+# https://github.com/evilmartians/lefthook/blob/master/docs/full_guide.md
+
+pre-commit:
+  parallel: true
+  commands:
+    rubocop:
+      files: git diff --name-only --staged
+      glob: "*.rb"
+      run: bundle exec rubocop --force-exclusion {files}


### PR DESCRIPTION
Install lefthook with `bundle install`
Install git hooks with `lefthook install`
See https://github.com/evilmartians/lefthook/blob/master/docs/full_guide.md for details