### PR TITLE
[40990] Show "Start trial" button in EE upsale templates

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -34,8 +34,6 @@ module Admin
     before_action :require_admin
     before_action :find_plugin, only: %i[show_plugin update_plugin]
 
-    helper_method :gon
-
     current_menu_item [:show] do
       :settings
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,6 +39,7 @@ class ApplicationController < ActionController::Base
   class_attribute :accept_key_auth_actions
 
   helper_method :render_to_string
+  helper_method :gon
 
   protected
 

--- a/app/controllers/attribute_help_texts_controller.rb
+++ b/app/controllers/attribute_help_texts_controller.rb
@@ -37,8 +37,6 @@ class AttributeHelpTextsController < ApplicationController
   before_action :find_type_scope
   before_action :require_enterprise_token_grant
 
-  helper_method :gon
-
   def new
     @attribute_help_text = AttributeHelpText.new type: @attribute_scope
   end

--- a/app/controllers/custom_actions_controller.rb
+++ b/app/controllers/custom_actions_controller.rb
@@ -30,7 +30,6 @@
 
 class CustomActionsController < ApplicationController
   include EnterpriseTrialHelper
-  before_action :augur_content_security_policy
   before_action :require_admin
   before_action :require_enterprise_token
 

--- a/app/controllers/custom_actions_controller.rb
+++ b/app/controllers/custom_actions_controller.rb
@@ -29,13 +29,15 @@
 #++
 
 class CustomActionsController < ApplicationController
+  include EnterpriseTrialHelper
+  before_action :augur_content_security_policy
   before_action :require_admin
   before_action :require_enterprise_token
-
+ 
   self._model_object = CustomAction
   before_action :find_model_object, only: %i(edit update destroy)
   before_action :pad_params, only: %i(create update)
-
+  
   layout 'admin'
 
   def index

--- a/app/controllers/custom_actions_controller.rb
+++ b/app/controllers/custom_actions_controller.rb
@@ -33,11 +33,11 @@ class CustomActionsController < ApplicationController
   before_action :augur_content_security_policy
   before_action :require_admin
   before_action :require_enterprise_token
- 
+
   self._model_object = CustomAction
   before_action :find_model_object, only: %i(edit update destroy)
   before_action :pad_params, only: %i(create update)
-  
+
   layout 'admin'
 
   def index

--- a/app/controllers/custom_actions_controller.rb
+++ b/app/controllers/custom_actions_controller.rb
@@ -38,8 +38,6 @@ class CustomActionsController < ApplicationController
 
   layout 'admin'
 
-  helper_method :gon
-
   def index
     @custom_actions = CustomAction.order_by_position
   end

--- a/app/controllers/custom_fields_controller.rb
+++ b/app/controllers/custom_fields_controller.rb
@@ -31,8 +31,6 @@
 class CustomFieldsController < ApplicationController
   layout 'admin'
 
-  helper_method :gon
-
   before_action :require_admin
   before_action :find_custom_field, only: %i(edit update destroy delete_option reorder_alphabetical)
   before_action :prepare_custom_option_position, only: %i(update create)

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -31,7 +31,6 @@ class EnterprisesController < ApplicationController
   layout 'admin'
   menu_item :enterprise
 
-  before_action :augur_content_security_policy
   before_action :chargebee_content_security_policy
   before_action :youtube_content_security_policy
   before_action :require_admin

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -45,7 +45,7 @@ class EnterprisesController < ApplicationController
     helpers.write_augur_to_gon
 
     if !@current_token.present?
-      write_trial_key_to_gon
+      helpers.write_trial_key_to_gon
     end
   end
 
@@ -95,16 +95,6 @@ class EnterprisesController < ApplicationController
   end
 
   private
-
-  def write_trial_key_to_gon
-    @trial_key = Token::EnterpriseTrialKey.find_by(user_id: User.system.id)
-    if @trial_key
-      gon.ee_trial_key = {
-        value: @trial_key.value,
-        created: @trial_key.created_at
-      }
-    end
-  end
 
   def default_breadcrumb
     t(:label_enterprise_edition)

--- a/app/controllers/enterprises_controller.rb
+++ b/app/controllers/enterprises_controller.rb
@@ -31,8 +31,6 @@ class EnterprisesController < ApplicationController
   layout 'admin'
   menu_item :enterprise
 
-  helper_method :gon
-
   before_action :augur_content_security_policy
   before_action :chargebee_content_security_policy
   before_action :youtube_content_security_policy
@@ -44,7 +42,7 @@ class EnterprisesController < ApplicationController
     @current_token = EnterpriseToken.current
     @token = @current_token || EnterpriseToken.new
 
-    write_augur_to_gon
+    helpers.write_augur_to_gon
 
     if !@current_token.present?
       write_trial_key_to_gon
@@ -106,11 +104,6 @@ class EnterprisesController < ApplicationController
         created: @trial_key.created_at
       }
     end
-  end
-
-  def write_augur_to_gon
-    gon.augur_url = OpenProject::Configuration.enterprise_trial_creation_host
-    gon.token_version = OpenProject::Token::VERSION
   end
 
   def default_breadcrumb

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -32,8 +32,6 @@ class GroupsController < ApplicationController
   include GroupsHelper
   layout 'admin'
 
-  helper_method :gon
-
   before_action :require_admin, except: %i[show]
   before_action :find_group, only: %i[destroy update show create_memberships destroy_membership
                                       edit_membership add_users]

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -35,8 +35,6 @@ class MyController < ApplicationController
 
   layout 'my'
 
-  helper_method :gon
-
   before_action :require_login
   before_action :set_current_user
   before_action :check_password_confirmation, only: %i[update_account]

--- a/app/controllers/placeholder_users_controller.rb
+++ b/app/controllers/placeholder_users_controller.rb
@@ -31,7 +31,6 @@
 class PlaceholderUsersController < ApplicationController
   include EnterpriseTrialHelper
   layout 'admin'
-  before_action :augur_content_security_policy
   before_action :authorize_global, except: %i[show]
 
   before_action :find_placeholder_user, only: %i[show

--- a/app/controllers/placeholder_users_controller.rb
+++ b/app/controllers/placeholder_users_controller.rb
@@ -31,8 +31,6 @@
 class PlaceholderUsersController < ApplicationController
   layout 'admin'
 
-  helper_method :gon
-
   before_action :authorize_global, except: %i[show]
 
   before_action :find_placeholder_user, only: %i[show

--- a/app/controllers/placeholder_users_controller.rb
+++ b/app/controllers/placeholder_users_controller.rb
@@ -29,8 +29,9 @@
 #++
 
 class PlaceholderUsersController < ApplicationController
+  include EnterpriseTrialHelper
   layout 'admin'
-
+  before_action :augur_content_security_policy
   before_action :authorize_global, except: %i[show]
 
   before_action :find_placeholder_user, only: %i[show

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -34,7 +34,6 @@ class TypesController < ApplicationController
   layout 'admin'
 
   before_action :require_admin
-  helper_method :gon
 
   def index
     @types = ::Type.page(page_param).per_page(per_page_param)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,8 +31,6 @@
 class UsersController < ApplicationController
   layout 'admin'
 
-  helper_method :gon
-
   before_action :authorize_global, except: %i[show deletion_info destroy]
 
   before_action :find_user, only: %i[show

--- a/app/helpers/enterprise_helper.rb
+++ b/app/helpers/enterprise_helper.rb
@@ -1,0 +1,6 @@
+module EnterpriseHelper
+  def write_augur_to_gon
+    gon.augur_url = OpenProject::Configuration.enterprise_trial_creation_host
+    gon.token_version = OpenProject::Token::VERSION
+  end
+end

--- a/app/helpers/enterprise_helper.rb
+++ b/app/helpers/enterprise_helper.rb
@@ -3,4 +3,14 @@ module EnterpriseHelper
     gon.augur_url = OpenProject::Configuration.enterprise_trial_creation_host
     gon.token_version = OpenProject::Token::VERSION
   end
+
+  def write_trial_key_to_gon
+    @trial_key = Token::EnterpriseTrialKey.find_by(user_id: User.system.id)
+    if @trial_key
+      gon.ee_trial_key = {
+        value: @trial_key.value,
+        created: @trial_key.created_at
+      }
+    end
+  end
 end

--- a/app/helpers/enterprise_helper.rb
+++ b/app/helpers/enterprise_helper.rb
@@ -5,11 +5,11 @@ module EnterpriseHelper
   end
 
   def write_trial_key_to_gon
-    @trial_key = Token::EnterpriseTrialKey.find_by(user_id: User.system.id)
-    if @trial_key
+    trial_key = Token::EnterpriseTrialKey.find_by(user_id: User.system.id)
+    if trial_key
       gon.ee_trial_key = {
-        value: @trial_key.value,
-        created: @trial_key.created_at
+        value: trial_key.value,
+        created: trial_key.created_at
       }
     end
   end

--- a/app/helpers/enterprise_trial_helper.rb
+++ b/app/helpers/enterprise_trial_helper.rb
@@ -1,9 +1,4 @@
 module EnterpriseTrialHelper
-  def augur_content_security_policy
-    append_content_security_policy_directives(
-      connect_src: [OpenProject::Configuration.enterprise_trial_creation_host]
-    )
-  end
 
   def chargebee_content_security_policy
     script_src = %w(js.chargebee.com)

--- a/app/helpers/hide_sections_helper.rb
+++ b/app/helpers/hide_sections_helper.rb
@@ -31,14 +31,10 @@
 module HideSectionsHelper
   def initialize_hide_sections_with(all, active)
     gon.push(
-      hide_sections: {
+      hideSections: {
         all: all,
         active: active
       }
     )
-
-    nonced_javascript_tag do
-      include_gon(need_tag: false, nonce: content_security_policy_script_nonce, camel_case: true, camel_depth: 15)
-    end
   end
 end

--- a/app/views/common/_tabs.html.erb
+++ b/app/views/common/_tabs.html.erb
@@ -27,9 +27,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 <% gon.contentTabs = { tabs: tabs.to_json.html_safe, selected: selected_tab.to_json.html_safe } %>
-<%= nonced_javascript_tag do %>
-  <%= include_gon(need_tag: false) -%>
-<% end %>
 
 <content-tabs></content-tabs>
 

--- a/app/views/common/upsale.html.erb
+++ b/app/views/common/upsale.html.erb
@@ -1,5 +1,9 @@
 <% write_augur_to_gon %>
 
+<% if !EnterpriseToken.current.present? %>
+  <% write_trial_key_to_gon %>
+<% end %>
+
 <div class="upsale-notification">
     <h2><%= feature_title %></h2>
     <% if feature_description.empty? %>

--- a/app/views/common/upsale.html.erb
+++ b/app/views/common/upsale.html.erb
@@ -1,5 +1,6 @@
-<div class="upsale-notification">
+<% write_augur_to_gon %>
 
+<div class="upsale-notification">
     <h2><%= feature_title %></h2>
     <% if feature_description.empty? %>
       <p class="upsale--feature-reference">

--- a/app/views/common/upsale.html.erb
+++ b/app/views/common/upsale.html.erb
@@ -25,7 +25,6 @@
     </br>
     <%= t('admin.enterprise.upgrade_info') %>
     </p>
-
     <%= link_to( "https://www.openproject.org/contact-us/",
                  { class: 'button -highlight-inverted -round',
                    aria: {label: t('admin.enterprise.buttons.contact')},
@@ -42,4 +41,5 @@
       <%= op_icon('button--icon icon-medal') %>
       <span class="button--text"><%= t('admin.enterprise.buttons.upgrade') %></span>
     <% end %>
+    <free-trial-button></free-trial-button>
 </div>

--- a/app/views/custom_actions/_form.html.erb
+++ b/app/views/custom_actions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= initialize_hide_sections_with @custom_action.all_actions.map { |a| { key: a.key, label: a.human_name } },
+<% initialize_hide_sections_with @custom_action.all_actions.map { |a| { key: a.key, label: a.human_name } },
                                   @custom_action.actions.map { |a| { key: a.key, label: a.human_name } } %>
 
 <div class="form--field -required">

--- a/app/views/enterprises/show.html.erb
+++ b/app/views/enterprises/show.html.erb
@@ -2,10 +2,6 @@
 
 <%= toolbar title: t("admin.enterprise.upgrade_to_ee") %>
 
-<%= nonced_javascript_tag do %>
-  <%= include_gon(need_tag: false) -%>
-<% end %>
-
 <%= error_messages_for 'token' %>
 
 <% if @current_token.present? %>

--- a/app/views/layouts/_common_head.html.erb
+++ b/app/views/layouts/_common_head.html.erb
@@ -29,6 +29,9 @@
 
 <%= render 'common/favicons' %>
 
+<%# Allow gon output when necessary %>
+<%= include_gon(nonce: content_security_policy_script_nonce) %>
+
 <%# Include CLI assets (development) or prod build assets %>
 <%= include_frontend_assets %>
 

--- a/app/views/layouts/angular/angular.html.erb
+++ b/app/views/layouts/angular/angular.html.erb
@@ -29,9 +29,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= content_for :header_tags do %>
   <% html_title(*local_assigns[:page_title]) if local_assigns[:page_title].present? %>
-  <%= nonced_javascript_tag do %>
-    <%= include_gon(need_tag: false) -%>
-  <% end %>
   <!-- plug-in specific tags -->
   <%= call_hook :view_work_package_overview_attributes %>
 <% end -%>

--- a/app/views/layouts/angular/notifications.html.erb
+++ b/app/views/layouts/angular/notifications.html.erb
@@ -27,12 +27,6 @@ See docs/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<%= content_for :header_tags do %>
-  <%= nonced_javascript_tag do %>
-    <%= include_gon(need_tag: false) -%>
-  <% end %>
-<% end -%>
-
 <%= content_for :content_body do %>
   <openproject-base></openproject-base>
 <% end -%>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% content_for :header_tags do %>
   <%= call_hook :search_index_head %>
-  <%= include_gon(nonce: content_security_policy_script_nonce) %>
+
 <% end %>
 
 <global-search-title></global-search-title>

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -24,7 +24,7 @@ SecureHeaders::Configuration.default do |config|
   default_src = %w('self') + OpenProject::Configuration.remote_storage_hosts
 
   # Allow requests to CLI in dev mode
-  connect_src = default_src
+  connect_src = default_src + [OpenProject::Configuration.enterprise_trial_creation_host]
 
   if OpenProject::Configuration.sentry_frontend_dsn.present?
     connect_src += [OpenProject::Configuration.sentry_host]

--- a/frontend/src/app/core/setup/global-dynamic-components.const.ts
+++ b/frontend/src/app/core/setup/global-dynamic-components.const.ts
@@ -147,6 +147,10 @@ import {
   enterpriseBaseSelector,
 } from 'core-app/features/enterprise/enterprise-base.component';
 import {
+  FreeTrialButtonComponent,
+  freeTrialButtonSelector,
+} from 'core-app/features/enterprise/free-trial-button/free-trial-button.component';
+import {
   EEActiveSavedTrialComponent,
   enterpriseActiveSavedTrialSelector,
 } from 'core-app/features/enterprise/enterprise-active-trial/ee-active-saved-trial.component';
@@ -219,6 +223,7 @@ export const globalDynamicComponents:OptionalBootstrapDefinition[] = [
   { selector: collapsibleSectionAugmentSelector, cls: CollapsibleSectionComponent },
   { selector: enterpriseBannerSelector, cls: EnterpriseBannerBootstrapComponent },
   { selector: enterpriseBaseSelector, cls: EnterpriseBaseComponent },
+  { selector: freeTrialButtonSelector, cls: FreeTrialButtonComponent },
   { selector: enterpriseActiveSavedTrialSelector, cls: EEActiveSavedTrialComponent },
   { selector: projectMenuAutocompleteSelector, cls: ProjectMenuAutocompleteComponent },
   { selector: remoteFieldUpdaterSelector, cls: RemoteFieldUpdaterComponent },

--- a/frontend/src/app/features/enterprise/enterprise-base.component.ts
+++ b/frontend/src/app/features/enterprise/enterprise-base.component.ts
@@ -66,7 +66,6 @@ export class EnterpriseBaseComponent {
   }
 
   public get noTrialRequested() {
-    
     return window.gon.ee_trial_key === undefined;
   }
 }

--- a/frontend/src/app/features/enterprise/enterprise-base.component.ts
+++ b/frontend/src/app/features/enterprise/enterprise-base.component.ts
@@ -66,6 +66,7 @@ export class EnterpriseBaseComponent {
   }
 
   public get noTrialRequested() {
-    return this.eeTrialService.status === undefined;
+    
+    return window.gon.ee_trial_key === undefined;
   }
 }

--- a/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial.modal.html
+++ b/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial.modal.html
@@ -1,5 +1,5 @@
 <div class="op-modal op-enterprise-modal">
-  <op-modal-header (close)="closeMe($event)">{{headerText()}}</op-modal-header>
+  <op-modal-header (close)="closeModal($event)">{{headerText()}}</op-modal-header>
 
   <div [ngSwitch]="openWindow()" class="op-modal--body">
     <!-- first modal window -->

--- a/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial.modal.ts
+++ b/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial.modal.ts
@@ -114,6 +114,10 @@ export class EnterpriseTrialModalComponent extends OpModalComponent implements A
     if (this.eeTrialService.trialStarted || this.eeTrialService.confirmed) {
       window.location.reload();
     }
+    else if(this.eeTrialService.mailSubmitted) {
+      window.location.reload();
+      return;
+    }
     this.eeTrialService.modalOpen = false;
   }
 

--- a/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial.modal.ts
+++ b/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial.modal.ts
@@ -114,7 +114,7 @@ export class EnterpriseTrialModalComponent extends OpModalComponent implements A
     if (this.eeTrialService.trialStarted || this.eeTrialService.confirmed) {
       window.location.reload();
     }
-    else if(this.eeTrialService.mailSubmitted) {
+    else if (this.eeTrialService.mailSubmitted) {
       window.location.reload();
       return;
     }

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.html
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.html
@@ -1,0 +1,3 @@
+<button class="button -alt-highlight" (click)="openTrialModal()">
+  {{ text.button_trial }}
+</button>

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.html
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.html
@@ -1,3 +1,5 @@
-<button class="button -alt-highlight -round" (click)="openTrialModal()">
-  {{ text.button_trial }}
-</button>
+<div [attr.data-tooltip]="text.confirmation_info(created, email)" [ngClass]="{'tooltip--top': trialRequested}">
+  <button [disabled]="trialRequested" class="button -alt-highlight -round" (click)="openTrialModal()">
+    {{ text.button_trial }}
+  </button>
+</div>

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.html
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.html
@@ -1,3 +1,3 @@
-<button class="button -alt-highlight" (click)="openTrialModal()">
+<button class="button -alt-highlight -round" (click)="openTrialModal()">
   {{ text.button_trial }}
 </button>

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.html
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.html
@@ -1,4 +1,4 @@
-<div [attr.data-tooltip]="text.confirmation_info(created, email)" [ngClass]="{'tooltip--top': trialRequested}">
+<div [attr.data-tooltip]="trialRequested ? text.confirmation_info(created, email) : ''" [ngClass]="{'tooltip--top': trialRequested}">
   <button [disabled]="trialRequested" class="button -alt-highlight -round" (click)="openTrialModal()">
     {{ text.button_trial }}
   </button>

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.sass
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.sass
@@ -1,2 +1,0 @@
-.button 
-    float: left

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.sass
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.sass
@@ -1,0 +1,2 @@
+.button 
+    float: left

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
@@ -39,7 +39,7 @@ import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { EnterpriseTrialService } from 'core-app/features/enterprise/enterprise-trial.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { distinctUntilChanged } from 'rxjs/operators';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { GonService } from 'core-app/core/gon/gon.service';
 
 export const freeTrialButtonSelector = 'free-trial-button';
@@ -56,11 +56,10 @@ export class FreeTrialButtonComponent implements OnInit {
 
   public text = {
     button_trial: this.I18n.t('js.admin.enterprise.upsale.button_start_trial'),
-    confirmation_info: (date:string, email:string) =>
-      this.trialRequested ? this.I18n.t('js.admin.enterprise.trial.confirmation_info', {
+    confirmation_info: (date:string, email:string) => this.I18n.t('js.admin.enterprise.trial.confirmation_info', {
       date,
       email,
-    }) : '',
+    }),
   };
 
   constructor(protected I18n:I18nService,
@@ -122,7 +121,7 @@ export class FreeTrialButtonComponent implements OnInit {
     this.opModalService.show(EnterpriseTrialModalComponent, this.injector);
   }
 
-  public get trialRequested() {
+  public get trialRequested(): boolean {
     const eeTrialKey = this.Gon.get('ee_trial_key') as any;
     return (eeTrialKey && eeTrialKey !== undefined);
   }

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
@@ -44,6 +44,19 @@ import { GonService } from 'core-app/core/gon/gon.service';
 
 export const freeTrialButtonSelector = 'free-trial-button';
 
+export interface EETrialKey {
+  created:string;
+  value:string;
+};
+
+export interface TrialDetails {
+  first_name:string;
+  last_name:string;
+  email:string;
+  company:string;
+  domain:string;
+};
+
 @Component({
   selector: freeTrialButtonSelector,
   templateUrl: './free-trial-button.component.html',
@@ -56,7 +69,7 @@ export class FreeTrialButtonComponent implements OnInit {
 
   public text = {
     button_trial: this.I18n.t('js.admin.enterprise.upsale.button_start_trial'),
-    confirmation_info: (date:string, email:string) => this.I18n.t('js.admin.enterprise.trial.confirmation_info', {
+    confirmation_info: (date:string, email:string):string => this.I18n.t('js.admin.enterprise.trial.confirmation_info', {
       date,
       email,
     }),
@@ -87,7 +100,7 @@ export class FreeTrialButtonComponent implements OnInit {
   }
 
   private initialize():void {
-    const eeTrialKey = this.Gon.get('ee_trial_key') as any;
+    const eeTrialKey = this.Gon.get('ee_trial_key') as EETrialKey;
     if (eeTrialKey) {
       const savedDateStr = eeTrialKey.created.split(' ')[0];
       this.created = this.timezoneService.formattedDate(savedDateStr);
@@ -102,9 +115,9 @@ export class FreeTrialButtonComponent implements OnInit {
 
   private getUserDataFromAugur():void {
     this.http
-      .get<any>(`${this.eeTrialService.trialLink}/details`)
+      .get<TrialDetails>(`${this.eeTrialService.trialLink}/details`)
       .toPromise()
-      .then((userForm:any) => {
+      .then((userForm:TrialDetails) => {
         this.eeTrialService.userData$.putValue(userForm);
         this.eeTrialService.retryConfirmation();
       })
@@ -121,8 +134,8 @@ export class FreeTrialButtonComponent implements OnInit {
     this.opModalService.show(EnterpriseTrialModalComponent, this.injector);
   }
 
-  public get trialRequested(): boolean {
-    const eeTrialKey = this.Gon.get('ee_trial_key') as any;
+  public get trialRequested():boolean {
+    const eeTrialKey = this.Gon.get('ee_trial_key') as EETrialKey;
     return (eeTrialKey && eeTrialKey !== undefined);
   }
 }

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
@@ -47,7 +47,7 @@ export const freeTrialButtonSelector = 'free-trial-button';
 export interface EETrialKey {
   created:string;
   value:string;
-};
+}
 
 export interface TrialDetails {
   first_name:string;
@@ -55,7 +55,7 @@ export interface TrialDetails {
   email:string;
   company:string;
   domain:string;
-};
+}
 
 @Component({
   selector: freeTrialButtonSelector,

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
@@ -42,10 +42,9 @@ export const freeTrialButtonSelector = 'free-trial-button';
 @Component({
   selector: freeTrialButtonSelector,
   templateUrl: './free-trial-button.component.html',
-  styleUrls: ['./free-trial-button.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FreeTrialButtonComponent implements OnInit {
+export class FreeTrialButtonComponent {
   public text = {
     button_trial: this.I18n.t('js.admin.enterprise.upsale.button_start_trial'),
   };
@@ -55,16 +54,13 @@ export class FreeTrialButtonComponent implements OnInit {
     readonly injector:Injector,
     public eeTrialService:EnterpriseTrialService) {
   }
-
-  ngOnInit() {
-    console.warn('HELLO');
-  }
-
-  public openTrialModal() {
+  public openTrialModal():void {
     // cancel request and open first modal window
     this.eeTrialService.cancelled = true;
     this.eeTrialService.modalOpen = true;
     this.opModalService.show(EnterpriseTrialModalComponent, this.injector);
   }
-
+  public get noTrialRequested() {
+    return this.eeTrialService.status === undefined;
+  }
 }

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
@@ -1,0 +1,60 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2021 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Component, Injector } from '@angular/core';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { EnterpriseTrialModalComponent } from 'core-app/features/enterprise/enterprise-modal/enterprise-trial.modal';
+import { OpModalService } from 'core-app/shared/components/modal/modal.service';
+import { EnterpriseTrialService } from 'core-app/features/enterprise/enterprise-trial.service';
+
+export const freeTrialButtonSelector = 'free-trial-button';
+
+@Component({
+  selector: freeTrialButtonSelector,
+  templateUrl: './free-trial-button.component.html',
+  styleUrls: ['./free-trial-button.component.sass'],
+})
+export class FreeTrialButtonComponent {
+  public text = {
+    button_trial: this.I18n.t('js.admin.enterprise.upsale.button_start_trial'),
+  };
+
+  constructor(protected I18n:I18nService,
+    protected opModalService:OpModalService,
+    readonly injector:Injector,
+    public eeTrialService:EnterpriseTrialService) {
+  }
+
+  public openTrialModal() {
+    // cancel request and open first modal window
+    this.eeTrialService.cancelled = true;
+    this.eeTrialService.modalOpen = true;
+    this.opModalService.show(EnterpriseTrialModalComponent, this.injector);
+  }
+
+}

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
@@ -26,7 +26,12 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Component, Injector } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Injector,
+  OnInit,
+} from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { EnterpriseTrialModalComponent } from 'core-app/features/enterprise/enterprise-modal/enterprise-trial.modal';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
@@ -38,8 +43,9 @@ export const freeTrialButtonSelector = 'free-trial-button';
   selector: freeTrialButtonSelector,
   templateUrl: './free-trial-button.component.html',
   styleUrls: ['./free-trial-button.component.sass'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FreeTrialButtonComponent {
+export class FreeTrialButtonComponent implements OnInit {
   public text = {
     button_trial: this.I18n.t('js.admin.enterprise.upsale.button_start_trial'),
   };
@@ -48,6 +54,10 @@ export class FreeTrialButtonComponent {
     protected opModalService:OpModalService,
     readonly injector:Injector,
     public eeTrialService:EnterpriseTrialService) {
+  }
+
+  ngOnInit() {
+    console.warn('HELLO');
   }
 
   public openTrialModal() {

--- a/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
+++ b/frontend/src/app/features/enterprise/free-trial-button/free-trial-button.component.ts
@@ -46,17 +46,17 @@ export const freeTrialButtonSelector = 'free-trial-button';
   templateUrl: './free-trial-button.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FreeTrialButtonComponent {
+export class FreeTrialButtonComponent implements OnInit {
   created = this.timezoneService.formattedDate(new Date().toString());
 
   email = '';
 
   public text = {
     button_trial: this.I18n.t('js.admin.enterprise.upsale.button_start_trial'),
-    confirmation_info: (date:string, email:string) => this.trialRequested ? this.I18n.t('js.admin.enterprise.trial.confirmation_info', {
+    confirmation_info: (date:string, email:string) => { return this.trialRequested ? this.I18n.t('js.admin.enterprise.trial.confirmation_info', {
       date,
       email,
-    }): '',
+    }) : ''},
   };
 
   constructor(protected I18n:I18nService,
@@ -65,9 +65,10 @@ export class FreeTrialButtonComponent {
     public eeTrialService:EnterpriseTrialService,
     readonly timezoneService:TimezoneService) {
   }
+
   ngOnInit() {
     const eeTrialKey = (window as any).gon.ee_trial_key;
-    if (eeTrialKey) {
+    if (window.gon.ee_trial_key) {
       const savedDateStr = eeTrialKey.created.split(' ')[0];
       this.created = this.timezoneService.formattedDate(savedDateStr);
     }
@@ -80,12 +81,14 @@ export class FreeTrialButtonComponent {
         this.email = userForm.email;
       });
   }
+
   public openTrialModal():void {
     // cancel request and open first modal window
     this.eeTrialService.cancelled = true;
     this.eeTrialService.modalOpen = true;
     this.opModalService.show(EnterpriseTrialModalComponent, this.injector);
   }
+
   public get trialRequested() {
     return window.gon.ee_trial_key !== undefined;
   }

--- a/frontend/src/app/features/enterprise/openproject-enterprise.module.ts
+++ b/frontend/src/app/features/enterprise/openproject-enterprise.module.ts
@@ -37,6 +37,7 @@ import { EETrialWaitingComponent } from 'core-app/features/enterprise/enterprise
 import { EEActiveTrialComponent } from 'core-app/features/enterprise/enterprise-active-trial/ee-active-trial.component';
 import { EEActiveSavedTrialComponent } from 'core-app/features/enterprise/enterprise-active-trial/ee-active-saved-trial.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FreeTrialButtonComponent } from 'core-app/features/enterprise/free-trial-button/free-trial-button.component';
 
 @NgModule({
   imports: [
@@ -48,6 +49,9 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
   providers: [
     EnterpriseTrialService,
   ],
+  exports:[
+    FreeTrialButtonComponent,
+  ],
   declarations: [
     EnterpriseBaseComponent,
     EnterpriseTrialModalComponent,
@@ -55,6 +59,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
     EETrialWaitingComponent,
     EEActiveTrialComponent,
     EEActiveSavedTrialComponent,
+    FreeTrialButtonComponent,
   ],
 })
 export class OpenprojectEnterpriseModule {

--- a/frontend/src/app/features/enterprise/openproject-enterprise.module.ts
+++ b/frontend/src/app/features/enterprise/openproject-enterprise.module.ts
@@ -49,7 +49,7 @@ import { FreeTrialButtonComponent } from 'core-app/features/enterprise/free-tria
   providers: [
     EnterpriseTrialService,
   ],
-  exports:[
+  exports: [
     FreeTrialButtonComponent,
   ],
   declarations: [

--- a/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
@@ -31,8 +31,6 @@
 module Bim
   module IfcModels
     class IfcModelsController < BaseController
-      helper_method :gon
-
       before_action :find_project_by_project_id,
                     only: %i[index new create show defaults edit update destroy direct_upload_finished]
       before_action :find_ifc_model_object, only: %i[edit update destroy]

--- a/modules/bim/app/controllers/bim/ifc_models/ifc_viewer_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_viewer_controller.rb
@@ -31,8 +31,6 @@
 module Bim
   module IfcModels
     class IfcViewerController < BaseController
-      helper_method :gon
-
       before_action :find_project_by_project_id
       before_action :authorize
       before_action :find_all_ifc_models

--- a/modules/bim/app/views/bim/ifc_models/ifc_viewer/show.html.erb
+++ b/modules/bim/app/views/bim/ifc_models/ifc_viewer/show.html.erb
@@ -29,7 +29,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% content_for :header_tags do %>
   <% provision_gon_for_ifc_model(@ifc_models, @shown_model_ids) %>
-  <%= include_gon(nonce: content_security_policy_script_nonce) %>
 <% end %>
 
 <% unconverted = @shown_ifc_models.reject(&:converted?) %>

--- a/modules/meeting/app/controllers/meeting_contents_controller.rb
+++ b/modules/meeting/app/controllers/meeting_contents_controller.rb
@@ -39,8 +39,6 @@ class MeetingContentsController < ApplicationController
   helper :watchers
   helper :meetings
 
-  helper_method :gon
-
   before_action :find_meeting, :find_content
   before_action :authorize
 

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -35,7 +35,6 @@ class MeetingsController < ApplicationController
 
   helper :watchers
   helper :meeting_contents
-  helper_method :gon
   include WatchersHelper
   include PaginationHelper
 

--- a/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
+++ b/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
@@ -5,7 +5,6 @@ module ::TeamPlanner
     before_action :authorize, only: %i[index]
     before_action :require_ee_token, only: %i[index]
     before_action :redirect_to_first_plan, only: :index
-    before_action :augur_content_security_policy, only: :upsale
 
     menu_item :team_planner_view
 

--- a/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
+++ b/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
@@ -1,9 +1,11 @@
 module ::TeamPlanner
   class TeamPlannerController < BaseController
+    include EnterpriseTrialHelper
     before_action :find_optional_project
     before_action :authorize, only: %i[index]
     before_action :require_ee_token, only: %i[index]
     before_action :redirect_to_first_plan, only: :index
+    before_action :augur_content_security_policy, only: :upsale
 
     menu_item :team_planner_view
 

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/two_factor_settings_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/two_factor_settings_controller.rb
@@ -1,7 +1,6 @@
 module ::TwoFactorAuthentication
   class TwoFactorSettingsController < ApplicationController
     include EnterpriseTrialHelper
-    before_action :augur_content_security_policy
     before_action :require_admin
     before_action :check_enabled
     before_action :check_ee

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/two_factor_settings_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/two_factor_settings_controller.rb
@@ -1,5 +1,7 @@
 module ::TwoFactorAuthentication
   class TwoFactorSettingsController < ApplicationController
+    include EnterpriseTrialHelper
+    before_action :augur_content_security_policy
     before_action :require_admin
     before_action :check_enabled
     before_action :check_ee


### PR DESCRIPTION
Add a button to the common upsale template for starting free trial. After clicking on this button, similar to the functionality that we have on the enterprise page, a modal should be opened.

https://community.openproject.org/work_packages/40990/activity