### PR TITLE
Fix issues in the mysql migration script

### DIFF
--- a/db/migrate/20201005184411_rename_timestamps.rb
+++ b/db/migrate/20201005184411_rename_timestamps.rb
@@ -36,6 +36,15 @@ class RenameTimestamps < ActiveRecord::Migration[6.0]
     rename_column table, old_column_name, new_column_name
 
     change_column_default table, new_column_name, from: nil, to: -> { 'CURRENT_TIMESTAMP' }
+
+    # Ensure we reset column information because otherwise,
+    # +updated_on+ will still be used.
+    begin
+      cls = table.to_s.singularize.classify.constantize
+      cls.reset_column_information
+    rescue StandardError => e
+      warn "Could not reset_column_information for table #{table}: #{e.message}"
+    end
   end
 
   def add_timestamp_column(table, column_name, from_column = nil)

--- a/db/migrate/20210427065703_make_system_user_admin.rb
+++ b/db/migrate/20210427065703_make_system_user_admin.rb
@@ -1,9 +1,9 @@
 class MakeSystemUserAdmin < ActiveRecord::Migration[6.1]
   def up
-    User.system.update_attribute(:admin, true)
+    User.system.update_column(:admin, true)
   end
 
   def down
-    User.system.update_attribute(:admin, false)
+    User.system.update_column(:admin, false)
   end
 end


### PR DESCRIPTION
- [x] It is not possible to pass SKIP_STEP_1 to avoid trying to migrate to OP7 with older migration schemes in case of a newer database
  - [ ]  Update documentation for SKIP_STEP_1
- [x] If skipping the first step, the MySQL database container does not get started
- [ ] The migration fails with outdated column information on settings

```
ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column "updated_on" does not exist
LINE 1: SELECT MAX(updated_on) FROM "settings"
                   ^
HINT:  Perhaps you meant to reference the column "settings.updated_at".
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/postgresql_adapter.rb:672:in `async_exec_params'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/postgresql_adapter.rb:672:in `block (2 levels) in exec_no_cache'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/postgresql_adapter.rb:671:in `block in exec_no_cache'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract_adapter.rb:718:in `block (2 levels) in log'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract_adapter.rb:717:in `block in log'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract_adapter.rb:708:in `log'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/postgresql_adapter.rb:670:in `exec_no_cache'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/postgresql_adapter.rb:651:in `execute_and_clear'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:98:in `exec_query'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract/database_statements.rb:487:in `select'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract/database_statements.rb:70:in `select_all'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract/query_cache.rb:107:in `select_all'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/relation/calculations.rb:298:in `block in execute_simple_calculation'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/relation.rb:828:in `skip_query_cache_if_necessary'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/relation/calculations.rb:298:in `execute_simple_calculation'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/relation/calculations.rb:252:in `perform_calculation'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/relation/calculations.rb:142:in `calculate'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/relation/calculations.rb:76:in `maximum'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/querying.rb:21:in `maximum'
/app/app/models/setting.rb:284:in `cache_key'
/app/app/models/setting.rb:277:in `block in cached_settings'
/app/vendor/bundle/ruby/2.6.0/gems/request_store-1.4.1/lib/request_store.rb:47:in `fetch'
/app/app/models/setting.rb:276:in `cached_settings'
/app/app/models/setting.rb:265:in `cached_or_default'
/app/app/models/setting.rb:249:in `filtered_cached_or_default'
/app/app/models/setting.rb:159:in `[]'
/app/app/models/setting.rb:123:in `available_languages'
/app/config/initializers/locale_fallbacks.rb:38:in `<top (required)>'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:319:in `load'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:319:in `block in load'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:291:in `load_dependency'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:319:in `load'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/engine.rb:667:in `block in load_config_initializer'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/notifications.rb:182:in `instrument'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/engine.rb:666:in `load_config_initializer'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/engine.rb:624:in `block (2 levels) in <class:Engine>'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/engine.rb:623:in `each'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/engine.rb:623:in `block in <class:Engine>'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/initializable.rb:32:in `instance_exec'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/initializable.rb:32:in `run'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/initializable.rb:61:in `block in run_initializers'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/initializable.rb:50:in `each'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/initializable.rb:50:in `tsort_each_child'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/initializable.rb:60:in `run_initializers'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/application.rb:363:in `initialize!'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/railtie.rb:190:in `public_send'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/railtie.rb:190:in `method_missing'
/app/config/environment.rb:34:in `<top (required)>'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:325:in `require'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:325:in `block in require'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:291:in `load_dependency'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:325:in `require'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/application.rb:339:in `require_environment!'
/app/lib/tasks/environment.rake:37:in `block (2 levels) in <top (required)>'
/app/vendor/bundle/ruby/2.6.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
/usr/local/bundle/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
/usr/local/bundle/bin/bundle:23:in `load'
/usr/local/bundle/bin/bundle:23:in `<main>'

Caused by:
PG::UndefinedColumn: ERROR:  column "updated_on" does not exist
LINE 1: SELECT MAX(updated_on) FROM "settings"
                   ^
HINT:  Perhaps you meant to reference the column "settings.updated_at".
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/postgresql_adapter.rb:672:in `async_exec_params'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/postgresql_adapter.rb:672:in `block (2 levels) in exec_no_cache'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/postgresql_adapter.rb:671:in `block in exec_no_cache'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract_adapter.rb:718:in `block (2 levels) in log'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract_adapter.rb:717:in `block in log'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract_adapter.rb:708:in `log'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/postgresql_adapter.rb:670:in `exec_no_cache'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/postgresql_adapter.rb:651:in `execute_and_clear'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:98:in `exec_query'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract/database_statements.rb:487:in `select'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract/database_statements.rb:70:in `select_all'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract/query_cache.rb:107:in `select_all'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/relation/calculations.rb:298:in `block in execute_simple_calculation'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/relation.rb:828:in `skip_query_cache_if_necessary'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/relation/calculations.rb:298:in `execute_simple_calculation'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/relation/calculations.rb:252:in `perform_calculation'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/relation/calculations.rb:142:in `calculate'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/relation/calculations.rb:76:in `maximum'
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.1/lib/active_record/querying.rb:21:in `maximum'
/app/app/models/setting.rb:284:in `cache_key'
/app/app/models/setting.rb:277:in `block in cached_settings'
/app/vendor/bundle/ruby/2.6.0/gems/request_store-1.4.1/lib/request_store.rb:47:in `fetch'
/app/app/models/setting.rb:276:in `cached_settings'
/app/app/models/setting.rb:265:in `cached_or_default'
/app/app/models/setting.rb:249:in `filtered_cached_or_default'
/app/app/models/setting.rb:159:in `[]'
/app/app/models/setting.rb:123:in `available_languages'
/app/config/initializers/locale_fallbacks.rb:38:in `<top (required)>'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:319:in `load'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:319:in `block in load'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:291:in `load_dependency'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:319:in `load'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/engine.rb:667:in `block in load_config_initializer'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/notifications.rb:182:in `instrument'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/engine.rb:666:in `load_config_initializer'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/engine.rb:624:in `block (2 levels) in <class:Engine>'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/engine.rb:623:in `each'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/engine.rb:623:in `block in <class:Engine>'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/initializable.rb:32:in `instance_exec'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/initializable.rb:32:in `run'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/initializable.rb:61:in `block in run_initializers'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/initializable.rb:50:in `each'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/initializable.rb:50:in `tsort_each_child'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/initializable.rb:60:in `run_initializers'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/application.rb:363:in `initialize!'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/railtie.rb:190:in `public_send'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/railtie.rb:190:in `method_missing'
/app/config/environment.rb:34:in `<top (required)>'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:325:in `require'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:325:in `block in require'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:291:in `load_dependency'
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-6.0.1/lib/active_support/dependencies.rb:325:in `require'
/app/vendor/bundle/ruby/2.6.0/gems/railties-6.0.1/lib/rails/application.rb:339:in `require_environment!'
/app/lib/tasks/environment.rake:37:in `block (2 levels) in <top (required)>'
/app/vendor/bundle/ruby/2.6.0/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
/usr/local/bundle/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
/usr/local/bundle/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/usr/local/bundle/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
/usr/local/bundle/bin/bundle:23:in `load'
/usr/local/bundle/bin/bundle:23:in `<main>'
Tasks: TOP => jobs:work => jobs:environment_options => environment:full
```