### PR TITLE
[40031] Move AddExistingButton out of calendar toolbar

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
@@ -4,86 +4,104 @@
   <ng-container
     *ngIf="(calendarOptions$ | async) as calendarOptions"
   >
+    <button
+      class="button op-team-planner--add-existing-toggle"
+      data-qa-selector="op-team-planner--add-existing-toggle"
+      (click)="toggleAddExistingPane()">
+      <op-icon icon-classes="icon-add button--icon"></op-icon>
+      <span
+        class="button--text"
+        [textContent]="text.add_existing">
+      </span>
+    </button>
+
     <op-add-existing-pane
       *ngIf="(showAddExistingPane | async)"
       class="op-team-planner--add-existing-pane"
       data-qa-selector="add-existing-pane"
     >
     </op-add-existing-pane>
-
-    <full-calendar
-      #ucCalendar
-      *ngIf="calendarOptions"
-      [options]="calendarOptions"
-      class="op-team-planner--calendar"
-      [ngClass]="{'op-team-planner--calendar_empty': (isEmpty$ | async)}"
-    ></full-calendar>
-
-    <div
-      [textContent]="calendar.tooManyResultsText"
-      class="op-wp-calendar--notification"></div>
-    <div
-      *ngIf="isEmpty$ | async"
-      class="op-team-planner--no-data">
-      <span [textContent]="text.noData"></span>
-    </div>
   </ng-container>
 
-  <ng-template #resourceContent let-resource="resource">
-    <div
-      *ngIf="resource && resource.extendedProps.principal"
-      class="tp-assignee"
+  <div class="op-team-planner--calendar-pane">
+    <ng-container
+      *ngIf="(calendarOptions$ | async) as calendarOptions"
     >
-      <op-principal
-        [principal]="resource.extendedProps.principal"
-        class="tp-assignee--principal op-principal_wrapped"
-      ></op-principal>
+
+      <full-calendar
+        #ucCalendar
+        *ngIf="calendarOptions"
+        [options]="calendarOptions"
+        class="op-team-planner--calendar"
+        [ngClass]="{'op-team-planner--calendar_empty': (isEmpty$ | async)}"
+      ></full-calendar>
+
+      <div
+        [textContent]="calendar.tooManyResultsText"
+        class="op-wp-calendar--notification"></div>
+      <div
+        *ngIf="isEmpty$ | async"
+        class="op-team-planner--no-data">
+        <span [textContent]="text.noData"></span>
+      </div>
+    </ng-container>
+
+    <ng-template #resourceContent let-resource="resource">
+      <div
+        *ngIf="resource && resource.extendedProps.principal"
+        class="tp-assignee"
+      >
+        <op-principal
+          [principal]="resource.extendedProps.principal"
+          class="tp-assignee--principal op-principal_wrapped"
+        ></op-principal>
+        <button
+          type="button"
+          class="tp-assignee--remove"
+          (click)="removeAssignee(resource.id)"
+          [attr.aria-label]="text.remove_assignee"
+          [attr.data-qa-remove-assignee]="resource.extendedProps.principal.id"
+        >
+          <op-icon icon-classes="icon-remove"></op-icon>
+        </button>
+      </div>
+
+      <op-tp-add-assignee
+        *ngIf="resource && !resource.extendedProps.principal"
+        (selectAssignee)="addAssignee($event)"
+        [alreadySelected]="principalIds$ | async"
+      ></op-tp-add-assignee>
+    </ng-template>
+
+    <ng-template #eventContent let-event="event">
+      <wp-single-card
+        *ngIf="event.extendedProps.workPackage"
+        [workPackage]="event.extendedProps.workPackage"
+        [orientation]="'horizontal'"
+        [highlightingMode]="'type'"
+        [showInfoButton]="true"
+        [disabledInfo]="showDisabledText(event.extendedProps.workPackage)"
+        [isClosed]="isStatusClosed(event.extendedProps.workPackage)"
+        [showAsInlineCard]="true"
+        [showStartDate]="!this.isWpDateInCurrentView(event.extendedProps.workPackage, 'start')"
+        [showEndDate]="!this.isWpDateInCurrentView(event.extendedProps.workPackage, 'end')"
+      >
+      </wp-single-card>
+    </ng-template>
+
+    <div
+      class="wp-inline-create-button op-team-planner--add-assignee"
+      *ngIf="!(showAddAssignee$ | async)"
+    >
       <button
         type="button"
-        class="tp-assignee--remove"
-        (click)="removeAssignee(resource.id)"
-        [attr.aria-label]="text.remove_assignee"
-        [attr.data-qa-remove-assignee]="resource.extendedProps.principal.id"
+        class="wp-inline-create--add-link tp-assignee-add-button"
+        (click)="showAssigneeAddRow()"
+        data-qa-selector="tp-assignee-add-button"
       >
-        <op-icon icon-classes="icon-remove"></op-icon>
+        <op-icon icon-classes="icon-context icon-add"></op-icon>
+        <span [textContent]="text.add_assignee"></span>
       </button>
     </div>
-
-    <op-tp-add-assignee
-      *ngIf="resource && !resource.extendedProps.principal"
-      (selectAssignee)="addAssignee($event)"
-      [alreadySelected]="principalIds$ | async"
-    ></op-tp-add-assignee>
-  </ng-template>
-
-  <ng-template #eventContent let-event="event">
-    <wp-single-card
-      *ngIf="event.extendedProps.workPackage"
-      [workPackage]="event.extendedProps.workPackage"
-      [orientation]="'horizontal'"
-      [highlightingMode]="'type'"
-      [showInfoButton]="true"
-      [disabledInfo]="showDisabledText(event.extendedProps.workPackage)"
-      [isClosed]="isStatusClosed(event.extendedProps.workPackage)"
-      [showAsInlineCard]="true"
-      [showStartDate]="!this.isWpDateInCurrentView(event.extendedProps.workPackage, 'start')"
-      [showEndDate]="!this.isWpDateInCurrentView(event.extendedProps.workPackage, 'end')"
-    >
-    </wp-single-card>
-  </ng-template>
-
-  <div
-    class="wp-inline-create-button op-team-planner--add-assignee"
-    *ngIf="!(showAddAssignee$ | async)"
-  >
-    <button
-      type="button"
-      class="wp-inline-create--add-link tp-assignee-add-button"
-      (click)="showAssigneeAddRow()"
-      data-qa-selector="tp-assignee-add-button"
-    >
-      <op-icon icon-classes="icon-context icon-add"></op-icon>
-      <span [textContent]="text.add_assignee"></span>
-    </button>
   </div>
 </div>

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.sass
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.sass
@@ -4,29 +4,33 @@
   display: block
   height: 100%
   overflow: auto
-  // Avoid empty space on the right since the styled scrollbar would only be visible on hover.
-  @include no-visible-scroll-bar
+
 
 .op-team-planner
   display: grid
   grid-template-columns: auto 1fr
-  grid-template-rows: auto 1fr auto
-  grid-column-gap: 10px
-  grid-template-areas: "addExisting calendar" "addExisting noData" "addExisting addAssignee"
-  max-height: 100%
+  grid-template-rows: 55px 1fr
+  grid-template-areas: ". calendar" "addExisting calendar"
+  height: 100%
+  overflow: hidden
+
+  &--calendar-pane
+    grid-area: calendar
+    overflow: auto  // Avoid empty space on the right since the styled scrollbar would only be visible on hover.
+    @include no-visible-scroll-bar
 
   &--add-existing-pane
     grid-area: addExisting
     width: 264px
+    min-width: 264px
+    overflow: auto
+    margin-right: 10px
+    z-index: 2
 
-  &--calendar
-    grid-area: calendar
-
-  &--add-assignee
-    grid-area: addAssignee
+  &--add-existing-toggle
+    position: absolute
 
   &--no-data
-    grid-area: noData
     min-height: 250px
     background-color: #F3F3F3
     display: flex

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -253,15 +253,8 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
               day: 'numeric',
             },
             initialView: this.calendar.initialView || 'resourceTimelineWeek',
-            customButtons: {
-              addExisting: {
-                text: this.text.add_existing,
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                click: this.toggleAddExistingPane.bind(this),
-              },
-            },
             headerToolbar: {
-              left: 'addExisting',
+              left: '',
               center: 'title',
               right: 'prev,next today resourceTimelineWeek,resourceTimelineTwoWeeks',
             },
@@ -542,7 +535,6 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
   }
 
   private toggleAddExistingPane():void {
-    document.getElementsByClassName('fc-addExisting-button')[0].classList.toggle('-active');
     this.showAddExistingPane.next(!this.showAddExistingPane.getValue());
   }
 }

--- a/frontend/src/global_styles/vendor/_full_calendar.sass
+++ b/frontend/src/global_styles/vendor/_full_calendar.sass
@@ -113,13 +113,6 @@
         @include icon-font-common
         @extend .icon-arrow-right3
 
-      .fc-addExisting-button
-        &:before
-          @include icon-font-common
-          @extend .icon-add
-          margin-right: 10px
-
-
     thead .fc-scroller
       @include no-visible-scroll-bar
 

--- a/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
@@ -87,7 +87,7 @@ describe 'Team planner add existing work packages', type: :feature, js: true do
       end
 
       # Open the left hand pane
-      team_planner.find('.fc-addExisting-button').click
+      page.find('[data-qa-selector="op-team-planner--add-existing-toggle"]').click
 
       add_existing_pane.expect_open
       add_existing_pane.expect_empty
@@ -101,7 +101,7 @@ describe 'Team planner add existing work packages', type: :feature, js: true do
       sleep 2
 
       # Drag it to the team planner...
-      add_existing_pane.drag_wp_by_pixel second_wp, 800, 50
+      add_existing_pane.drag_wp_by_pixel second_wp, 800, 0
 
       team_planner.expect_and_dismiss_toaster(message: "Successful update.")
 
@@ -164,7 +164,7 @@ describe 'Team planner add existing work packages', type: :feature, js: true do
     end
 
     it 'does not show the button to add existing work packages' do
-      expect(page).not_to have_selector('.fc-addExisting-button')
+      expect(page).not_to have_selector('[data-qa-selector="op-team-planner--add-existing-toggle"]')
       add_existing_pane.expect_closed
     end
   end


### PR DESCRIPTION
Include review feedback mentioned [here](https://community.openproject.org/projects/openproject/work_packages/40031?query_id=3006#activity-50):
* Move addExisting button out of calendar toolbar to avoid being pushed to the right when the pane opens
* Take care that the addExisting pane spans the complete height, and scrolls independently of the calendar

**out of scope**
* styling of the button as its going to be reworked anyway

https://community.openproject.org/projects/openproject/work_packages/40031/activity