### PR TITLE
[408663] Decrease team planner toolbar when split screen is opened

### DIFF
--- a/frontend/src/global_styles/content/modules/_team_planner.sass
+++ b/frontend/src/global_styles/content/modules/_team_planner.sass
@@ -4,6 +4,14 @@
   #content
     height: 100%
 
+  &.router--work-packages-partitioned-split-view-details,
+  &.router--work-packages-partitioned-split-view-new
+    full-calendar.op-team-planner--calendar .fc-header-toolbar
+      .fc-resourceTimelineWeek-button,
+      .fc-resourceTimelineTwoWeeks-button,
+      .fc-today-button
+        display: none
+
 .op-team-planner
   &--calendar_empty
     .fc-scrollgrid-section-body,


### PR DESCRIPTION
Hide buttons when split screen is opened, to avoid ugly wrapping

https://community.openproject.org/projects/openproject/work_packages/40863/activity