### PR TITLE
Fix (?) "$refs" in OpenAPI V3 API spec

### DIFF
--- a/docs/api/apiv3/components/schemas/file_link_model.yml
+++ b/docs/api/apiv3/components/schemas/file_link_model.yml
@@ -26,7 +26,7 @@ properties:
     description: Time of the most recent change to the file link
     readOnly: true
   originData:
-    $ref: '#/components/schemas/File_Link_Origin_DataModel'
+    $ref: './file_link_origin_data_model.yml'
   _embedded:
     type: object
     readOnly: true
@@ -35,10 +35,10 @@ properties:
       - container
     properties:
       storage:
-        $ref: '#/components/schemas/StorageModel'
+        $ref: './storage_model.yml'
       container:
         oneOf:
-          - $ref: '#/components/schemas/Work_PackageModel'
+          - $ref: './work_package_model.yml'
   _links:
     type: object
     required:

--- a/docs/api/apiv3/components/schemas/query_model.yml
+++ b/docs/api/apiv3/components/schemas/query_model.yml
@@ -21,7 +21,7 @@ properties:
       to determine the resulting work packages
     readOnly: false
     items:
-      $ref: "#/components/schemas/Query_Filter_Instance_SchemaModel"
+      $ref: './query_filter_instance_schema_model.yml'
   sums:
     type: boolean
     description: Should sums (of supported properties) be shown?

--- a/docs/api/apiv3/paths/storage.yml
+++ b/docs/api/apiv3/paths/storage.yml
@@ -21,12 +21,12 @@ get:
       content:
         application/hal+json:
           schema:
-            $ref: '#/components/schemas/StorageModel'
+            $ref: '../components/schemas/storage_model.yml'
     '404':
       content:
         application/hal+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "../components/schemas/error_response.yml"
           example:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:NotFound

--- a/docs/api/apiv3/paths/work_package_file_link.yml
+++ b/docs/api/apiv3/paths/work_package_file_link.yml
@@ -29,12 +29,12 @@ get:
       content:
         application/hal+json:
           schema:
-            $ref: '#/components/schemas/File_LinkModel'
+            $ref: '../components/schemas/file_link_model.yml'
     '404':
       content:
         application/hal+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "../components/schemas/error_response.yml"
           example:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
@@ -76,7 +76,7 @@ delete:
       content:
         application/hal+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "../components/schemas/error_response.yml"
           example:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
@@ -91,7 +91,7 @@ delete:
       content:
         application/hal+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "../components/schemas/error_response.yml"
           example:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:NotFound

--- a/docs/api/apiv3/paths/work_package_file_link_download.yml
+++ b/docs/api/apiv3/paths/work_package_file_link_download.yml
@@ -38,7 +38,7 @@ get:
       content:
         application/hal+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "../components/schemas/error_response.yml"
           example:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:NotFound

--- a/docs/api/apiv3/paths/work_package_file_link_open.yml
+++ b/docs/api/apiv3/paths/work_package_file_link_open.yml
@@ -38,7 +38,7 @@ get:
       content:
         application/hal+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "../components/schemas/error_response.yml"
           example:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:NotFound

--- a/docs/api/apiv3/paths/work_package_file_links.yml
+++ b/docs/api/apiv3/paths/work_package_file_links.yml
@@ -46,7 +46,7 @@ post:
                   type: array
                   items:
                     allOf:
-                      - $ref: '#/components/schemas/File_LinkModel'
+                      - $ref: '../components/schemas/file_link_model.yml'
                       - type: object
                         required:
                           - storageUrl
@@ -101,12 +101,12 @@ post:
                   elements:
                     type: array
                     items:
-                      $ref: '#/components/schemas/File_LinkModel'
+                      $ref: '../components/schemas/file_link_model.yml'
     '400':
       content:
         application/hal+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "../components/schemas/error_response.yml"
           example:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
@@ -116,7 +116,7 @@ post:
       content:
         application/hal+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "../components/schemas/error_response.yml"
           example:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
@@ -131,7 +131,7 @@ post:
       content:
         application/hal+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "../components/schemas/error_response.yml"
           example:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
@@ -189,12 +189,12 @@ get:
                   elements:
                     type: array
                     items:
-                      $ref: '#/components/schemas/File_LinkModel'
+                      $ref: '../components/schemas/file_link_model.yml'
     '403':
       content:
         application/hal+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "../components/schemas/error_response.yml"
           example:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
@@ -209,7 +209,7 @@ get:
       content:
         application/hal+json:
           schema:
-            $ref: "#/components/schemas/ErrorResponse"
+            $ref: "../components/schemas/error_response.yml"
           example:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:NotFound


### PR DESCRIPTION
At least swagger-cli is much more happy then, and it also matched the
style of all other currently existing "$ref"s.

Before:

```
$ swagger-cli bundle -t yaml
openproject_git/docs/api/apiv3/openapi-spec.yml >
"$DATA_DIR"/openapi-spec-bundle.yml
Token "components" does not exist.
$
```

After:

```
$ swagger-cli bundle -t yaml
openproject_git/docs/api/apiv3/openapi-spec.yml >
"$DATA_DIR"/openapi-spec-bundle.yml
$
```

See also: https://community.openproject.org/topics/14323