### PR TITLE
Allow calling #create instead of #new on collection representers

### DIFF
--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -48,8 +48,10 @@ module API
 
       # Use this to create our own representers, giving them a chance to override the instantiation
       # if desired.
-      def self.create(model, current_user:, embed_links: false)
-        new(model, current_user: current_user, embed_links: embed_links)
+      # Explicitly forwards all arguments to new, to avoid having to override #create on subclasses
+      # such as collection
+      def self.create(...)
+        new(...)
       end
 
       def initialize(model, current_user:, embed_links: false)

--- a/lib/api/v3/utilities/endpoints/index.rb
+++ b/lib/api/v3/utilities/endpoints/index.rb
@@ -90,13 +90,13 @@ module API
             resulting_params = calculate_resulting_params(query, params)
 
             render_representer
-              .new(results,
-                   self_link: self_path,
-                   query: resulting_params,
-                   page: resulting_params[:offset],
-                   per_page: resulting_params[:pageSize],
-                   groups: calculate_groups(query),
-                   current_user: User.current)
+              .create(results,
+                      self_link: self_path,
+                      query: resulting_params,
+                      page: resulting_params[:offset],
+                      per_page: resulting_params[:pageSize],
+                      groups: calculate_groups(query),
+                      current_user: User.current)
           end
 
           def render_unpaginated_success(results, self_path)


### PR DESCRIPTION
Using `#create` on collection representers will fail as the method of single is used https://github.com/opf/openproject/blob/dev/lib/api/decorators/single.rb#L51-L53 , which is not signature compatible with subclassed constructors.

To avoid this, we can simply forward all arguments to new in the create method.