### PR TITLE
[40962] Styling fixes for WP single cards in team planner

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
@@ -76,58 +76,59 @@
     <ng-template #eventContent let-event="event">
       <wp-single-card
         [workPackage]="event.extendedProps.workPackage"
-      [orientation]="'horizontal'"
-      [highlightingMode]="'type'"
-      [showInfoButton]="true"
-      [disabledInfo]="showDisabledText(event.extendedProps.workPackage)"
-      [isClosed]="isStatusClosed(event.extendedProps.workPackage)"
-      [showAsInlineCard]="true"
-      [showStartDate]="!this.isWpDateInCurrentView(event.extendedProps.workPackage, 'start')"
-      [showEndDate]="!this.isWpDateInCurrentView(event.extendedProps.workPackage, 'end')"
-    >
-    </wp-single-card>
-  </ng-template>
+        [orientation]="'horizontal'"
+        [highlightingMode]="'type'"
+        [showInfoButton]="true"
+        [disabledInfo]="showDisabledText(event.extendedProps.workPackage)"
+        [isClosed]="isStatusClosed(event.extendedProps.workPackage)"
+        [showAsInlineCard]="true"
+        [showStartDate]="!this.isWpDateInCurrentView(event.extendedProps.workPackage, 'start')"
+        [showEndDate]="!this.isWpDateInCurrentView(event.extendedProps.workPackage, 'end')"
+        (stateLinkClicked)="openStateLink($event)"
+      >
+      </wp-single-card>
+    </ng-template>
 
-  <div class="op-team-planner--footer" data-qa-selector="op-team-planner-footer">
-    <div class="op-team-planner--add-assignee">
-      <div
-        class="wp-inline-create-button"
-        *ngIf="!(showAddAssignee$ | async)"
-      >
-        <button
-          type="button"
-          class="wp-inline-create--add-link tp-assignee-add-button"
-          (click)="showAssigneeAddRow()"
-          data-qa-selector="tp-assignee-add-button"
+    <div class="op-team-planner--footer" data-qa-selector="op-team-planner-footer">
+      <div class="op-team-planner--add-assignee">
+        <div
+          class="wp-inline-create-button"
+          *ngIf="!(showAddAssignee$ | async)"
         >
-          <op-icon icon-classes="icon-context icon-add"></op-icon>
-          <span [textContent]="text.add_assignee"></span>
-        </button>
+          <button
+            type="button"
+            class="wp-inline-create--add-link tp-assignee-add-button"
+            (click)="showAssigneeAddRow()"
+            data-qa-selector="tp-assignee-add-button"
+          >
+            <op-icon icon-classes="icon-context icon-add"></op-icon>
+            <span [textContent]="text.add_assignee"></span>
+          </button>
+        </div>
       </div>
-    </div>
-    <ng-container *ngIf="(dropzone$ | async) as dropzone">
-      <div
-        *ngIf="dropzone.dragging"
-        #removeDropzone
-        (mouseenter)="dropzoneHovered$.next(true)"
-        (mouseleave)="dropzoneHovered$.next(false)"
-        (mouseup)="dropzone.canDrop && removeEvent(dropzone.dragging)"
-        class="op-team-planner--remove-dropzone"
-        data-qa-selector="op-team-planner-dropzone"
-        [class.op-team-planner--remove-dropzone_active]="dropzone.isHovering && dropzone.canDrop"
-        [class.op-team-planner--remove-dropzone_forbidden]="!dropzone.canDrop"
-      >
+      <ng-container *ngIf="(dropzone$ | async) as dropzone">
+        <div
+          *ngIf="dropzone.dragging"
+          #removeDropzone
+          (mouseenter)="dropzoneHovered$.next(true)"
+          (mouseleave)="dropzoneHovered$.next(false)"
+          (mouseup)="dropzone.canDrop && removeEvent(dropzone.dragging)"
+          class="op-team-planner--remove-dropzone"
+          data-qa-selector="op-team-planner-dropzone"
+          [class.op-team-planner--remove-dropzone_active]="dropzone.isHovering && dropzone.canDrop"
+          [class.op-team-planner--remove-dropzone_forbidden]="!dropzone.canDrop"
+        >
       <span
         *ngIf="dropzone.canDrop"
         class="op-team-planner--dropzone-label"
         [textContent]="text.drag_here_to_remove"
       ></span>
-        <span
-          *ngIf="!dropzone.canDrop"
-          class="op-team-planner--dropzone-label"
-          [textContent]="text.cannot_drag_here"
-        ></span>
-      </div>
-    </ng-container>
+          <span
+            *ngIf="!dropzone.canDrop"
+            class="op-team-planner--dropzone-label"
+            [textContent]="text.cannot_drag_here"
+          ></span>
+        </div>
+      </ng-container>
+    </div>
   </div>
-</div>

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -60,6 +60,8 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { CalendarDragDropService } from 'core-app/features/team-planner/team-planner/calendar-drag-drop.service';
 import { StatusResource } from 'core-app/features/hal/resources/status-resource';
 import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/resource-changeset';
+import { KeepTabService } from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
+import { HalError } from 'core-app/features/hal/services/hal-error';
 
 @Component({
   selector: 'op-team-planner',
@@ -180,6 +182,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     readonly schemaCache:SchemaCacheService,
     readonly apiV3Service:ApiV3Service,
     readonly calendarDrag:CalendarDragDropService,
+    readonly keepTab:KeepTabService,
   ) {
     super();
   }
@@ -226,8 +229,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
         api.getResources().forEach((resource) => resource.remove());
 
         principals.forEach((principal) => {
-          const { self } = principal._links;
-          const id = Array.isArray(self) ? self[0].href : self.href;
+          const id = principal._links.self.href;
           api.addResource({
             principal,
             id,
@@ -332,6 +334,10 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
             // DnD configuration
             editable: true,
             droppable: true,
+            eventClick: (evt) => {
+              const workPackage = evt.event.extendedProps.workPackage as WorkPackageResource;
+              this.calendar.openSplitView(workPackage.id as string, true);
+            },
             eventResize: (resizeInfo:EventResizeDoneArg) => this.updateEvent(resizeInfo),
             eventDragStart: (dragInfo:EventDragStartArg) => {
               const { el } = dragInfo;
@@ -372,7 +378,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
       })
       .catch(failureCallback);
 
-    this.calendar.updateTimeframe(fetchInfo, this.projectIdentifier);
+    void this.calendar.updateTimeframe(fetchInfo, this.projectIdentifier);
   }
 
   renderTemplate(template:TemplateRef<unknown>, id:string, data:ResourceLabelContentArg|EventContentArg):{ domNodes:unknown[] } {
@@ -543,6 +549,16 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     );
   }
 
+  openStateLink(event:{ workPackageId:string; requestedState:string }):void {
+    const params = { workPackageId: event.workPackageId };
+
+    if (event.requestedState === 'split') {
+      this.keepTab.goCurrentDetailsState(params);
+    } else {
+      this.keepTab.goCurrentShowState(params);
+    }
+  }
+
   private async updateEvent(info:EventResizeDoneArg|EventDropArg|EventReceiveArg):Promise<void> {
     const changeset = this.calendar.updateDates(info);
 
@@ -559,8 +575,8 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     try {
       const result = await this.halEditing.save(changeset);
       this.halNotification.showSave(result.resource, result.wasNew);
-    } catch (e) {
-      this.halNotification.showError(e.resource, changeset.projectedResource);
+    } catch (e:unknown) {
+      this.halNotification.showError((e as HalError).resource, changeset.projectedResource);
       this.calendarDrag.handleDropError(changeset.projectedResource);
       info?.revert();
     }

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -14,8 +14,6 @@
   font-size: var(--card-font-size)
 
   &:hover
-    box-shadow: 0px 0px 10px lightgrey
-
     .op-wp-single-card--content-project-name_hideable
       opacity: 0.25
     .op-wp-single-card--inline-buttons

--- a/frontend/src/global_styles/vendor/_full_calendar.sass
+++ b/frontend/src/global_styles/vendor/_full_calendar.sass
@@ -96,6 +96,10 @@
     .fc-event-main
       color: unset
 
+    // Avoid pointer cursor on hover
+    .fc-event-draggable:hover
+      cursor: default
+
     .fc-event:hover
       .fc-event-resizer
         display: flex

--- a/modules/bim/spec/features/bim_navigation_spec.rb
+++ b/modules/bim/spec/features/bim_navigation_spec.rb
@@ -128,7 +128,7 @@ describe 'BIM navigation spec',
 
       it 'after deleting an WP in full view it returns to the model and list view (see #33317)' do
         # Go to full single view
-        card_view.open_full_screen_by_details(work_package)
+        card_view.open_split_view_by_info_icon(work_package)
         details_view.switch_to_fullscreen
         full_view.expect_tab 'Activity'
 
@@ -147,7 +147,7 @@ describe 'BIM navigation spec',
 
       it 'after going to the full view with a selected tab,
         the same tab should be opened in full screen view and after going back to details view(see #33747)' do
-        card_view.open_full_screen_by_details(work_package)
+        card_view.open_split_view_by_info_icon(work_package)
 
         details_view.ensure_page_loaded
         details_view.expect_subject

--- a/modules/bim/spec/features/viewer/create_viewpoint_spec.rb
+++ b/modules/bim/spec/features/viewer/create_viewpoint_spec.rb
@@ -56,7 +56,7 @@ describe 'Create viewpoint from BCF details page',
       show_model_page.visit!
       show_model_page.finished_loading
       card_view.expect_work_package_listed(work_package)
-      card_view.open_full_screen_by_details(work_package)
+      card_view.open_split_view_by_info_icon(work_package)
 
       # Expect no viewpoint
       bcf_details.ensure_page_loaded

--- a/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
@@ -130,7 +130,7 @@ describe 'Team planner add existing work packages', type: :feature, js: true do
       expect(third_wp.assigned_to_id).to eq(user.id)
 
       # New events are directly clickable
-      split_view = team_planner.open_split_view(third_wp)
+      split_view = team_planner.open_split_view_by_info_icon(third_wp)
       split_view.expect_open
     end
 

--- a/modules/team_planner/spec/features/team_planner_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_spec.rb
@@ -162,7 +162,7 @@ describe 'Team planner', type: :feature, js: true do
       end
 
       # Open the split view for that task and change to bug
-      split_view = team_planner.open_split_view(other_task)
+      split_view = team_planner.open_split_view_by_info_icon(other_task)
       split_view.edit_field(:type).update(type_bug)
       split_view.expect_and_dismiss_toaster(message: "Successful update.")
 

--- a/modules/team_planner/spec/features/team_planner_split_view_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_split_view_spec.rb
@@ -1,0 +1,81 @@
+#-- encoding: UTF-8
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2021 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require_relative './shared_context'
+
+describe 'Team planner split view navigation', type: :feature, js: true, with_ee: %i[team_planner_view] do
+  include_context 'with team planner full access'
+
+  let!(:view) { create :view_team_planner, query: query }
+  let!(:query) { create :query, user: user, project: project, public: true }
+
+  let(:start_of_week) { Time.zone.today.beginning_of_week(:sunday) }
+
+  let!(:work_package1) do
+    create :work_package,
+           project: project,
+           subject: 'First task',
+           assigned_to: user,
+           start_date: start_of_week.next_occurring(:tuesday),
+           due_date: start_of_week.next_occurring(:thursday)
+  end
+
+  let!(:work_package2) do
+    create :work_package,
+           project: project,
+           subject: 'Another task',
+           assigned_to: user,
+           start_date: start_of_week.next_occurring(:tuesday),
+           due_date: start_of_week.next_occurring(:thursday)
+  end
+
+  it 'allows to navigate to the split view' do
+    team_planner.visit!
+
+    team_planner.add_assignee user
+    team_planner.within_lane(user) do
+      team_planner.expect_event work_package1
+      team_planner.expect_event work_package2
+    end
+
+    # Expect clicking on a work package does not open the details
+    page.find('[data-qa-selector="op-wp-single-card--content-subject"]', text: work_package1.subject).click
+    expect(page).to have_no_current_path /team_planner\/details\/#{work_package1.id}/
+
+    # Open split view through info icon
+    team_planner.open_split_view_by_info_icon work_package1
+    expect(page).to have_current_path /team_planner\/details\/#{work_package1.id}/
+
+    # now clicking on another card switches
+    page.find('[data-qa-selector="op-wp-single-card--content-subject"]', text: work_package2.subject).click
+    expect(page).to have_current_path /team_planner\/details\/#{work_package2.id}/
+  end
+end

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -27,18 +27,17 @@
 #++
 
 require 'support/pages/page'
+require 'support/pages/work_packages/work_package_cards'
 
 module Pages
-  class TeamPlanner < ::Pages::Page
+  class TeamPlanner < ::Pages::WorkPackageCards
     include ::Components::NgSelectAutocompleteHelpers
 
-    attr_reader :project,
-                :filters
+    attr_reader :filters
 
     def initialize(project)
-      super()
+      super(project)
 
-      @project = project
       @filters = ::Components::WorkPackages::Filters.new
     end
 
@@ -127,12 +126,6 @@ module Pages
 
     def expect_event(work_package, present: true)
       expect(page).to have_conditional_selector(present, '.fc-event', text: work_package.subject)
-    end
-
-    def open_split_view(work_package)
-      event(work_package).click
-
-      ::Pages::SplitWorkPackage.new(work_package, project)
     end
 
     def add_assignee(name)

--- a/spec/features/work_packages/navigation_spec.rb
+++ b/spec/features/work_packages/navigation_spec.rb
@@ -276,11 +276,11 @@ RSpec.feature 'Work package navigation', js: true, selenium: true do
       cards.expect_work_package_listed work_package, work_package2
 
       # move to first details
-      split = cards.open_full_screen_by_details work_package
+      split = cards.open_split_view_by_info_icon work_package
       split.expect_subject
 
       # move to second details
-      split2 = cards.open_full_screen_by_details work_package2
+      split2 = cards.open_split_view_by_info_icon work_package2
       split2.expect_subject
     end
   end

--- a/spec/support/pages/work_packages/work_package_cards.rb
+++ b/spec/support/pages/work_packages/work_package_cards.rb
@@ -71,7 +71,7 @@ module Pages
       Pages::FullWorkPackage.new(work_package, project)
     end
 
-    def open_full_screen_by_details(work_package)
+    def open_split_view_by_info_icon(work_package)
       element = card(work_package)
       scroll_to_element(element)
       element.hover


### PR DESCRIPTION
https://community.openproject.org/work_packages/40962

Addresses:

- [x] 5/ On hover the pointer should be a regular point, and clicking on the card to open the split screen should not be possible. 
- [x] 5/To open the split screen, the user should have to click on the i icon on the top right corner. This behaviour should be the same as in the Add Existing. (Nevertheless, the split screen is already open, users should nevertheless be able to move from one card to another).

- [x] 6/ Shadows should not be modified on hover over a card. Today a stronger shadow is applied on hover.

