### PR TITLE
[40555] Lanes are misaligned in team planner

### DIFF
--- a/frontend/src/global_styles/vendor/_full_calendar.sass
+++ b/frontend/src/global_styles/vendor/_full_calendar.sass
@@ -14,9 +14,6 @@
     .fc-timeline-slot-lane
       border-color: #c1c1c1
 
-    .fc-timeline-lane-frame
-      padding: 4px 0
-
     .fc-resource-timeline-divider
       width: 1px
       background: none


### PR DESCRIPTION
Remove padding that caused a misalignment with the resource cells and is not needed any more since the strips have been replaced by the cards

https://community.openproject.org/projects/openproject/work_packages/40555/activity