### PR TITLE
Use mutex within LDAP group synchronization code

### DIFF
--- a/modules/ldap_groups/app/models/ldap_groups/synchronized_group.rb
+++ b/modules/ldap_groups/app/models/ldap_groups/synchronized_group.rb
@@ -32,7 +32,7 @@ module LdapGroups
 
       self.class.transaction do
         # create synchronized group memberships
-        memberships = new_users.map { |user| { group_id: id, user_id: user_id(user) } }
+        memberships = new_users.to_a.map { |user| { group_id: id, user_id: user_id(user) } }
         # Bulk insert the memberships to improve performance
         ::LdapGroups::Membership.insert_all memberships
 

--- a/modules/ldap_groups/spec/services/synchronization_spec.rb
+++ b/modules/ldap_groups/spec/services/synchronization_spec.rb
@@ -344,8 +344,12 @@ describe LdapGroups::SynchronizeGroupsService, with_ee: %i[ldap_groups] do
     end
 
     it 'does not raise, but print to stderr' do
-      expect(Rails.logger).to receive(:error).with(/Failed to perform LDAP group synchronization/)
+      allow(Rails.logger).to receive(:error)
+
       subject
+
+      expect(Rails.logger).to have_received(:error).once.with(/Failed to synchronize group:/)
+      expect(Rails.logger).to have_received(:error).once.with(/Failed to perform LDAP group synchronization/)
     end
   end
 


### PR DESCRIPTION
We currently do not prevent multiple synchronization calls to interfering with one another (e.g., the cron job, and a manual rake task). This might lead to unexpected behavior when iterating through a synchronized group from two places.