### PR TITLE
Bump translations to fix rails issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GIT
 
 GIT
   remote: https://github.com/opf/openproject-translations.git
-  revision: 6ce2c62dbfe751aee9fa212fb1768784c42dea81
+  revision: e12a9562a5a186e6b641ed35ebfc9046994a2b4f
   branch: dev
   specs:
     openproject-translations (7.4.0)


### PR DESCRIPTION
Translations plugin has already been removed in dev, so this wasn't noticed outside of the release branch