### PR TITLE
[40934] Add pageSize=-1 to autocompleters

### DIFF
--- a/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.component.ts
+++ b/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.component.ts
@@ -56,7 +56,7 @@ export class AddListModalComponent extends OpModalComponent implements OnInit {
   getAutocompleterData = (searchTerm:string):Observable<HalResource[]> => {
     // Remove prefix # from search
     searchTerm = searchTerm.replace(/^#/, '');
-    return this.actionService.loadAvailable( this.active, searchTerm)
+    return this.actionService.loadAvailable(this.active, searchTerm)
       .pipe(tap((values) => (this.warnIfNoOptions(values))));
   };
 

--- a/frontend/src/app/features/boards/board/board-actions/subtasks/board-subtasks-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/subtasks/board-subtasks-action.service.ts
@@ -59,7 +59,7 @@ export class BoardSubtasksActionService extends BoardActionService {
     return this
       .apiV3Service
       .work_packages
-      .filtered(filters)
+      .filtered(filters, { pageSize: '-1' })
       .get()
       .pipe(
         map((collection) => collection.elements),

--- a/frontend/src/app/features/user-preferences/notifications-settings/inline-create/notification-setting-inline-create.component.ts
+++ b/frontend/src/app/features/user-preferences/notifications-settings/inline-create/notification-setting-inline-create.component.ts
@@ -70,7 +70,7 @@ export class NotificationSettingInlineCreateComponent {
     return this
       .apiV3Service
       .projects
-      .filtered(filters)
+      .filtered(filters, { pageSize: '-1' })
       .get()
       .pipe(
         map((collection) => collection.elements.map((project) => ({

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -10,7 +10,7 @@
     [hideSelected]="hideSelected"
     [appendTo]="appendTo"
     [multiple]="multiple"
-    [loading]="isLoading"
+    [loading]="loading$ | async"
     [addTag]="addTag"
     [virtualScroll]="virtualScroll"
     [required]="required"

--- a/lib/api/utilities/page_size_helper.rb
+++ b/lib/api/utilities/page_size_helper.rb
@@ -49,7 +49,10 @@ module API
       # * the minimum of the per page options specified in the settings
       # * the maximum page size
       def resulting_page_size(value, relation = nil)
-        [value || relation&.base_class&.per_page || Setting.per_page_options_array.min, maximum_page_size]
+        [
+          resolve_page_size(value) || relation&.base_class&.per_page || Setting.per_page_options_array.min,
+          maximum_page_size
+        ]
            .map(&:to_i)
            .min
       end

--- a/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_collection_representer_spec.rb
@@ -350,6 +350,18 @@ describe ::API::V3::WorkPackages::WorkPackageCollectionRepresenter do
     end
   end
 
+
+  context 'with a magic page size' do
+    let(:page_size_parameter) { -1 }
+
+    it_behaves_like 'offset-paginated APIv3 collection' do
+      let(:page) { 1 }
+      let(:page_size) {  Setting.apiv3_max_page_size }
+      let(:actual_count) { 5 }
+      let(:collection_type) { 'WorkPackageCollection' }
+    end
+  end
+
   context 'with a limited page size' do
     let(:page_size_parameter) { 2 }
 


### PR DESCRIPTION
https://community.openproject.org/wp/40934

Backports a tiny section of the op-autocompleter fixes from dev to prevent overriding the typeahead reloading for this bug:
https://community.openproject.org/wp/41206