### PR TITLE
Fix source typos

### DIFF
--- a/frontend/src/app/features/work-packages/components/filters/filter-string-value/filter-string-value.component.html
+++ b/frontend/src/app/features/work-packages/components/filters/filter-string-value/filter-string-value.component.html
@@ -1,7 +1,7 @@
 <div id="div-values-{{filter.name}}">
   <input [(ngModel)]="value"
          [opAutofocus]="shouldFocus"
-         requried="true"
+         required="true"
          class="advanced-filters--text-field"
          id="values-{{filter.name}}"
          name="v[{{filter.name}}]"

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/modes/hierarchy/hierarchy-render-pass.ts
@@ -105,7 +105,7 @@ export class HierarchyRenderPass extends PrimaryRenderPass {
 
     // Cases for wp
     // 1. No wp.ancestors in table -> Render them immediately (defer=false)
-    // 2. Parent in table -> deffered[parent] = wp
+    // 2. Parent in table -> defered[parent] = wp
     // 3. Parent not in table BUT a ancestor in table
     // -> deferred[a ancestor] = parent
     // -> deferred[parent] = wp

--- a/frontend/src/global_styles/content/_list.lsg
+++ b/frontend/src/global_styles/content/_list.lsg
@@ -12,7 +12,7 @@
     <div class="description">Lorem ipsum</div>
     <div class="author">
       <img class="avatar-mini" src="/assets/default-avatar.png" />
-      Anonymus
+      Anonymous
     </div>
   </li>
   <li class="news me">

--- a/frontend/src/global_styles/layout/_toolbar.lsg
+++ b/frontend/src/global_styles/layout/_toolbar.lsg
@@ -40,7 +40,7 @@ A toolbar that can and should be used for actions on the current view. Initially
     </div>
     <ul class="toolbar-items">
       <li class="toolbar-item">
-        <select name="attribue">
+        <select name="attribute">
           <option value="" selected></option>
           <option value="super">Super</option>
         </select>

--- a/frontend/src/global_styles/vendor/foundation-apps/scss/components/_block-list.scss
+++ b/frontend/src/global_styles/vendor/foundation-apps/scss/components/_block-list.scss
@@ -2,7 +2,7 @@
   BLOCK LIST
   ----------
 
-  A generic list component that can accomodate a variety of styles and controls.
+  A generic list component that can accommodate a variety of styles and controls.
 
   Features:
    - Icons

--- a/frontend/src/global_styles/vendor/foundation-apps/scss/components/_grid.scss
+++ b/frontend/src/global_styles/vendor/foundation-apps/scss/components/_grid.scss
@@ -216,7 +216,7 @@ $block-grid-max-size: 6 !default;
 }
 
 /*
-  Frames are containers that stretch to the full dimmensions of the browser window.
+  Frames are containers that stretch to the full dimensions of the browser window.
 */
 @mixin grid-frame($size: expand, $orientation: horizontal, $wrap: false, $align: left, $order: 0) {
   display: flex;

--- a/frontend/src/global_styles/vendor/foundation-apps/scss/components/_modal.scss
+++ b/frontend/src/global_styles/vendor/foundation-apps/scss/components/_modal.scss
@@ -2,7 +2,7 @@
   MODAL
   -----
 
-  The humble modal hides off-canvas until summoned with an fa-open directive. Modals appear over an overlay that darkens the rest of the page, and have a maxmimum width. You can construct a grid inside a modal, or attach panels to it.
+  The humble modal hides off-canvas until summoned with an fa-open directive. Modals appear over an overlay that darkens the rest of the page, and have a maximum width. You can construct a grid inside a modal, or attach panels to it.
 
   Note that the modal overlay is hardcoded into the CSS, because whether or not you build your modal semantically, the overlay is always required and will always look the same.
 */

--- a/frontend/src/global_styles/vendor/foundation-apps/scss/components/_switch.scss
+++ b/frontend/src/global_styles/vendor/foundation-apps/scss/components/_switch.scss
@@ -49,7 +49,7 @@ $switch-paddle-offset: 4px !default;
 }
 
 /*
-  Defines the dimmensions of the switch.
+  Defines the dimensions of the switch.
 
   $width - width of the switch.
   $height - height of the switch.

--- a/frontend/src/global_styles/vendor/foundation-apps/scss/components/_toast.scss
+++ b/frontend/src/global_styles/vendor/foundation-apps/scss/components/_toast.scss
@@ -2,7 +2,7 @@
   TOAST
   ------------
 
-  An alert that pins to the corner of the screen when triggered by JavaScript. It can be set to disappear after a certain period of time, or to stay put until the user clicks on it. A custom action can be asigned to a toaster as well.
+  An alert that pins to the corner of the screen when triggered by JavaScript. It can be set to disappear after a certain period of time, or to stay put until the user clicks on it. A custom action can be assigned to a toaster as well.
 
   Optionally, the toasters directive can also tap into the browser's native toaster support, if it exists.
 */

--- a/frontend/src/global_styles/vendor/foundation-apps/scss/helpers/_breakpoints.scss
+++ b/frontend/src/global_styles/vendor/foundation-apps/scss/helpers/_breakpoints.scss
@@ -144,7 +144,7 @@ $breakpoint-classes: (small medium large) !default;
 // 3. CSS Output
 // - - - - - - - - - - - - - - -
 
-// Meta styles are included in all builds, as they are a dependancy of the Javascript.
+// Meta styles are included in all builds, as they are a dependency of the Javascript.
 // Used to provide media query values for javascript components.
 // Forward slash placed around everything to convince PhantomJS to read the value.
 

--- a/frontend/src/vendor/i18n.js
+++ b/frontend/src/vendor/i18n.js
@@ -510,7 +510,7 @@
     }
   };
 
-  // Merge serveral hash options, checking if value is set before
+  // Merge several hash options, checking if value is set before
   // overwriting any value. The precedence is from left to right.
   //
   //     I18n.prepareOptions({name: "John Doe"}, {name: "Mary Doe", role: "user"});

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -216,7 +216,7 @@ shared_examples 'work package relations tab', js: true, selenium: true do
           expect(page).to have_no_selector('.wp-relation--parent-change')
 
           # Test for add children
-          expect(page).to have_no_selector('#hierarchy--add-exisiting-child')
+          expect(page).to have_no_selector('#hierarchy--add-existing-child')
           expect(page).to have_no_selector('#hierarchy--add-new-child')
 
           # But it should show the linked parent


### PR DESCRIPTION
This PR addresses some source typos. 
Found via `codespell -q 3 -S ./config/locales,./modules/xls_export/config/locales,./modules/job_status/config/locales,./modules/two_factor_authentication/config/locales,./modules/backlogs/config/locales/crowdin -L ba,nd,parms,sur,varius`