### PR TITLE
[41075] Hide date indicators when dragging a WP in the team planner

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -463,7 +463,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
       }
 
       const dateCurrentlyVisible = dateToCheck >= currentStartDate && dateToCheck <= currentEndDate;
-      return dateCurrentlyVisible && this.calendar.eventDurationEditable(workPackage);
+      return dateCurrentlyVisible;
     }
 
     return false;

--- a/frontend/src/global_styles/content/modules/_team_planner.sass
+++ b/frontend/src/global_styles/content/modules/_team_planner.sass
@@ -26,3 +26,7 @@
   &_with_left_side_pane
     .fc-header-toolbar
       margin-left: -136px
+
+  .fc-event-dragging
+    .op-wp-single-card--content-inline-date
+      visibility: hidden


### PR DESCRIPTION
Hide dates in cards when dragging within the team planner

https://community.openproject.org/projects/openproject/work_packages/41075/activity