### PR TITLE
[41080] Pass selection of cards from add existing to calendar service

### DIFF
--- a/frontend/src/app/features/calendar/op-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-calendar.service.ts
@@ -44,6 +44,7 @@ import { HalResourceEditingService } from 'core-app/shared/components/fields/edi
 import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/resource-changeset';
 import * as moment from 'moment';
 import { WorkPackageViewSelectionService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
+import { isClickedWithModifier } from 'core-app/shared/helpers/link-handling/link-handling';
 
 export interface CalendarViewEvent {
   el:HTMLElement;
@@ -264,6 +265,14 @@ export class OpCalendarService extends UntilDestroyedMixin {
     );
   }
 
+  public onCardClicked({ workPackageId, event }:{ workPackageId:string, event:MouseEvent }):void {
+    if (isClickedWithModifier(event)) {
+      return;
+    }
+
+    this.openSplitView(workPackageId, true);
+  }
+
   private defaultOptions():CalendarOptions {
     return {
       editable: false,
@@ -280,10 +289,6 @@ export class OpCalendarService extends UntilDestroyedMixin {
       initialDate: this.initialDate,
       initialView: this.initialView,
       datesSet: (dates) => this.updateDateParam(dates),
-      eventClick: (evt) => {
-        const workPackage = evt.event.extendedProps.workPackage as WorkPackageResource;
-        this.openSplitView(workPackage.id as string);
-      },
     };
   }
 

--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -6,6 +6,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import {
+  EventClickArg,
   FullCalendarComponent,
   ToolbarInput,
 } from '@fullcalendar/angular';
@@ -142,6 +143,10 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
       editable: true,
       eventResize: (resizeInfo:EventResizeDoneArg) => this.updateEvent(resizeInfo),
       eventDrop: (dropInfo:EventDropArg) => this.updateEvent(dropInfo),
+      eventClick: (evt:EventClickArg) => {
+        const workPackage = evt.event.extendedProps.workPackage as WorkPackageResource;
+        this.calendar.openSplitView(workPackage.id as string);
+      },
     };
 
     if (this.static) {

--- a/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.html
@@ -42,6 +42,7 @@
           class="op-add-existing-pane--wp"
           [attr.data-qa-selector]="'op-add-existing-pane--wp-' + wp.id"
           (stateLinkClicked)="openStateLink($event)"
+          (cardClicked)="calendar.onCardClicked($event)"
         ></wp-single-card>
       </ng-container>
     </div>

--- a/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.ts
@@ -37,6 +37,7 @@ import { StateService } from '@uirouter/core';
 import { ActionsService } from 'core-app/core/state/actions/actions.service';
 import { teamPlannerEventRemoved } from 'core-app/features/team-planner/team-planner/planner/team-planner.actions';
 import { WorkPackageViewFiltersService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service';
+import { OpCalendarService } from 'core-app/features/calendar/op-calendar.service';
 
 @Component({
   selector: 'op-add-existing-pane',
@@ -100,6 +101,7 @@ export class AddExistingPaneComponent extends UntilDestroyedMixin implements OnI
     private readonly notificationService:WorkPackageNotificationService,
     private readonly currentProject:CurrentProjectService,
     private readonly urlParamsHelper:UrlParamsHelperService,
+    private readonly calendar:OpCalendarService,
     private readonly calendarDrag:CalendarDragDropService,
     private readonly $state:StateService,
     private readonly actions$:ActionsService,

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
@@ -88,6 +88,7 @@
         [showStartDate]="!this.isWpDateInCurrentView(event.extendedProps.workPackage, 'start')"
         [showEndDate]="!this.isWpDateInCurrentView(event.extendedProps.workPackage, 'end')"
         (stateLinkClicked)="openStateLink($event)"
+        (cardClicked)="calendar.onCardClicked($event)"
       >
       </wp-single-card>
     </ng-template>

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -346,10 +346,6 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
             // DnD configuration
             editable: true,
             droppable: true,
-            eventClick: (evt) => {
-              const workPackage = evt.event.extendedProps.workPackage as WorkPackageResource;
-              this.calendar.openSplitView(workPackage.id as string, true);
-            },
             eventResize: (resizeInfo:EventResizeDoneArg) => this.updateEvent(resizeInfo),
             eventDragStart: (dragInfo:EventDragStartArg) => {
               const { el } = dragInfo;

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.html
@@ -5,6 +5,7 @@
   [attr.data-qa-checked]="isSelected(workPackage) || undefined"
   [ngClass]="cardClasses()"
   [title]="cardTitle()"
+  (click)="cardClicked.emit({ workPackageId: workPackage.id, event: $event })"
 >
 
   <div class="op-wp-single-card--highlighting"

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.ts
@@ -61,6 +61,8 @@ export class WorkPackageSingleCardComponent extends UntilDestroyedMixin implemen
 
   @Output() stateLinkClicked = new EventEmitter<{ workPackageId:string, requestedState:string }>();
 
+  @Output() cardClicked = new EventEmitter<{ workPackageId:string, event:MouseEvent }>();
+
   public uiStateLinkClass:string = uiStateLinkClass;
 
   public text = {

--- a/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
@@ -119,6 +119,23 @@ describe 'Team planner add existing work packages', type: :feature, js: true do
       end
     end
 
+    it 'allows to click cards to open split view when open' do
+      # Search for a work package
+      add_existing_pane.search 'Task'
+      add_existing_pane.expect_result second_wp
+
+      # Open first wp
+      split_screen = team_planner.open_split_view_by_info_icon first_wp
+      split_screen.expect_subject
+      expect(page).to have_current_path /\/details\/#{first_wp.id}/
+
+      # Select work package in add existing
+      add_existing_pane.card(second_wp).click
+      split_screen = ::Pages::SplitWorkPackage.new second_wp
+      split_screen.expect_subject
+      expect(page).to have_current_path /\/details\/#{second_wp.id}/
+    end
+
     it 'allows to add work packages via drag&drop from the left hand shortlist' do
       # Search for a work package
       add_existing_pane.search 'Task'

--- a/modules/team_planner/spec/support/components/add_existing_pane.rb
+++ b/modules/team_planner/spec/support/components/add_existing_pane.rb
@@ -74,5 +74,9 @@ module Components
 
       drag_by_pixel(element: source, by_x: by_x, by_y: by_y)
     end
+
+    def card(work_package)
+      page.find(".op-wp-single-card-#{work_package.id}")
+    end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/wp/41080

- [x] Extend selection behaviour to the cards in the Add Existing pane, so that users can click on them to change the contents of the split screen.
- [x] The selection changes to the card in the add existing and vice versa. They share a common selection "store"