### PR TITLE
[40958] Updated placement and design of the create button in the sidebar

### DIFF
--- a/app/views/work_packages/_menu_query_select.html.erb
+++ b/app/views/work_packages/_menu_query_select.html.erb
@@ -1,9 +1,12 @@
-<%=
-  angular_component_tag 'op-view-select',
-                        inputs: {
-                          projectId: (@project ? @project.id.to_s : ''),
-                          menuItems: [parent_name, name],
-                          baseRoute: 'work-packages',
-                          viewType: 'WorkPackagesTable',
-                        }
-%>
+<div class="op-sidebar">
+  <%=
+    angular_component_tag 'op-view-select',
+                          inputs: {
+                            projectId: (@project ? @project.id.to_s : ''),
+                            menuItems: [parent_name, name],
+                            baseRoute: 'work-packages',
+                            viewType: 'WorkPackagesTable',
+                          },
+                          class: 'op-sidebar--body'
+  %>
+</div>

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -497,7 +497,6 @@ en:
     label_starred_queries: "Favorite views"
     label_global_queries: "Public views"
     label_custom_queries: "Private views"
-    label_create_new_query: "Create new"
     label_columns: "Columns"
     label_attachments: Files
     label_drop_files: Drop files here

--- a/frontend/src/app/core/setup/global-dynamic-components.const.ts
+++ b/frontend/src/app/core/setup/global-dynamic-components.const.ts
@@ -191,6 +191,10 @@ import {
   opTeamPlannerSidemenuSelector,
   TeamPlannerSidemenuComponent,
 } from 'core-app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component';
+import {
+  CalendarSidemenuComponent,
+  opCalendarSidemenuSelector,
+} from 'core-app/features/calendar/sidemenu/calendar-sidemenu.component';
 
 export const globalDynamicComponents:OptionalBootstrapDefinition[] = [
   { selector: appBaseSelector, cls: ApplicationBaseComponent },
@@ -234,6 +238,7 @@ export const globalDynamicComponents:OptionalBootstrapDefinition[] = [
   { selector: wpOverviewGraphSelector, cls: WorkPackageOverviewGraphComponent },
   { selector: opViewSelectSelector, cls: ViewSelectComponent },
   { selector: opTeamPlannerSidemenuSelector, cls: TeamPlannerSidemenuComponent },
+  { selector: opCalendarSidemenuSelector, cls: CalendarSidemenuComponent },
   { selector: triggerActionsEntryComponentSelector, cls: TriggerActionsEntryComponent, embeddable: true },
   { selector: backlogsPageComponentSelector, cls: BacklogsPageComponent },
   { selector: attributeValueMacro, cls: AttributeValueMacroComponent, embeddable: true },

--- a/frontend/src/app/core/setup/global-dynamic-components.const.ts
+++ b/frontend/src/app/core/setup/global-dynamic-components.const.ts
@@ -187,6 +187,10 @@ import {
   IanMenuComponent,
   ianMenuSelector,
 } from 'core-app/features/in-app-notifications/center/menu/menu.component';
+import {
+  opTeamPlannerSidemenuSelector,
+  TeamPlannerSidemenuComponent,
+} from 'core-app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component';
 
 export const globalDynamicComponents:OptionalBootstrapDefinition[] = [
   { selector: appBaseSelector, cls: ApplicationBaseComponent },
@@ -229,6 +233,7 @@ export const globalDynamicComponents:OptionalBootstrapDefinition[] = [
   { selector: remoteFieldUpdaterSelector, cls: RemoteFieldUpdaterComponent },
   { selector: wpOverviewGraphSelector, cls: WorkPackageOverviewGraphComponent },
   { selector: opViewSelectSelector, cls: ViewSelectComponent },
+  { selector: opTeamPlannerSidemenuSelector, cls: TeamPlannerSidemenuComponent },
   { selector: triggerActionsEntryComponentSelector, cls: TriggerActionsEntryComponent, embeddable: true },
   { selector: backlogsPageComponentSelector, cls: BacklogsPageComponent },
   { selector: attributeValueMacro, cls: AttributeValueMacroComponent, embeddable: true },

--- a/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
@@ -9,8 +9,8 @@ export function boardTourSteps():OnboardingStep[] {
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       onNext() {
         jQuery('.board-view-menu-item ~ .toggler')[0].click();
-        waitForElement('.boards--menu-items', '#main-menu', () => {
-          jQuery(".main-menu--children-sub-item:contains('Kanban')")[0].click();
+        waitForElement('.op-sidemenu--items', '#main-menu', () => {
+          jQuery(".op-sidemenu--item-action:contains('Kanban')")[0].click();
         });
       },
     },

--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/styles/generic.sass
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/styles/generic.sass
@@ -38,6 +38,9 @@
 [data-name="bim"] .main-menu--children
   overflow-x: hidden !important
 
+[data-name="ifc_viewer_panels"]
+  height: initial !important
+
 // -------------------------- XEOKIT specific rules for BUTTONS --------------------------
 .xeokit-btn-group
   vertical-align: middle

--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
@@ -1,18 +1,8 @@
-<div *ngIf="(boards$ | async) as boards">
-  <ul class="main-menu--children boards--menu-items">
-    <li *ngFor="let board of boards;trackBy:trackById">
-      <a [textContent]="board.name"
-         uiSref="boards.partitioned.show"
-         [uiOptions]="{ reload: true }"
-         [uiParams]="{ board_id: board.id, query_props: '', projects: 'projects', projectPath: currentProjectIdentifier }"
-         class="main-menu--children-sub-item ellipsis"
-         [ngClass]=" {'selected': selectedBoardId === board.id }"
-         data-qa-selector="boards-menu--item"
-      >
-      </a>
-    </li>
-  </ul>
-</div>
+<op-sidemenu
+  *ngIf="(boardOptions$ | async) as items"
+  [items]="items"
+>
+</op-sidemenu>
 
 <button
   *ngIf="(canCreateBoards$ | async)"

--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
@@ -1,13 +1,16 @@
 <op-sidemenu
   *ngIf="(boardOptions$ | async) as items"
   [items]="items"
+  class="op-sidebar--body"
 >
 </op-sidemenu>
 
-<button
-  *ngIf="(canCreateBoards$ | async)"
-  class="spot-button spot-button_outlined"
-  (click)="showNewBoardModal()"
->
-  {{text.create_new_board}}
-</button>
+<div class="op-sidebar--footer">
+  <button
+    *ngIf="canCreateBoards$ | async"
+    class="spot-button spot-button_outlined"
+    (click)="showNewBoardModal()"
+  >
+    {{text.create_new_board}}
+  </button>
+</div>

--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
@@ -13,3 +13,11 @@
     </li>
   </ul>
 </div>
+
+<button
+  *ngIf="(canCreateBoards$ | async)"
+  class="spot-button spot-button_outlined"
+  (click)="showNewBoardModal()"
+>
+  {{text.create_new_board}}
+</button>

--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.ts
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  HostBinding,
   Injector,
   OnInit,
 } from '@angular/core';
@@ -28,6 +29,8 @@ export const boardsMenuSelector = 'boards-menu';
 })
 
 export class BoardsMenuComponent extends UntilDestroyedMixin implements OnInit {
+  @HostBinding('class.op-sidebar') className = true;
+
   selectedBoardId:string;
 
   boardOptions$:Observable<IOpSidemenuItem[]> = this

--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.ts
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.ts
@@ -1,4 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import {
+  Component,
+  Injector,
+  OnInit,
+} from '@angular/core';
 import { Observable } from 'rxjs';
 import { BoardService } from 'core-app/features/boards/board/board.service';
 import { Board } from 'core-app/features/boards/board/board';
@@ -8,6 +12,10 @@ import { CurrentProjectService } from 'core-app/core/current-project/current-pro
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { MainMenuNavigationService } from 'core-app/core/main-menu/main-menu-navigation.service';
+import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { NewBoardModalComponent } from 'core-app/features/boards/new-board-modal/new-board-modal.component';
+import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 
 export const boardsMenuSelector = 'boards-menu';
 
@@ -23,7 +31,7 @@ export class BoardsMenuComponent extends UntilDestroyedMixin implements OnInit {
 
   selectedBoardId:string;
 
-  public boards$:Observable<Board[]> = this
+  boards$:Observable<Board[]> = this
     .apiV3Service
     .boards
     .observeAll()
@@ -31,14 +39,32 @@ export class BoardsMenuComponent extends UntilDestroyedMixin implements OnInit {
       map((boards:Board[]) => boards.sort((a, b) => a.name.localeCompare(b.name))),
     );
 
-  constructor(private readonly boardService:BoardService,
+  canCreateBoards$ = this
+    .currentUserService
+    .hasCapabilities$(
+      'boards/create',
+      this.currentProject.id || undefined,
+      )
+    .pipe(this.untilDestroyed());
+
+  text = {
+    create_new_board: this.I18n.t('js.boards.create_new'),
+  };
+
+  constructor(
+    private readonly boardService:BoardService,
     private readonly apiV3Service:ApiV3Service,
     private readonly currentProject:CurrentProjectService,
-    private readonly mainMenuService:MainMenuNavigationService) {
+    private readonly mainMenuService:MainMenuNavigationService,
+    readonly currentUserService:CurrentUserService,
+    readonly I18n:I18nService,
+    private readonly opModalService:OpModalService,
+    private readonly injector:Injector,
+  ) {
     super();
   }
 
-  ngOnInit() {
+  ngOnInit():void {
     // When activating the boards submenu,
     // either initially or through click on the toggle, load the results
     this.mainMenuService
@@ -59,7 +85,11 @@ export class BoardsMenuComponent extends UntilDestroyedMixin implements OnInit {
       });
   }
 
-  private focusBackArrow() {
+  showNewBoardModal():void {
+    this.opModalService.show(NewBoardModalComponent, this.injector);
+  }
+
+  private focusBackArrow():void {
     const buttonArrowLeft = jQuery('*[data-name="board_view"] .main-menu--arrow-left-to-project');
     buttonArrowLeft.focus();
   }

--- a/frontend/src/app/features/calendar/openproject-calendar.module.ts
+++ b/frontend/src/app/features/calendar/openproject-calendar.module.ts
@@ -37,6 +37,7 @@ import { OpenprojectFieldsModule } from 'core-app/shared/components/fields/openp
 import { OpenprojectTimeEntriesModule } from 'core-app/shared/components/time_entries/openproject-time-entries.module';
 import { WorkPackagesCalendarPageComponent } from 'core-app/features/calendar/wp-calendar-page/wp-calendar-page.component';
 import { CALENDAR_ROUTES } from 'core-app/features/calendar/calendar.routes';
+import { CalendarSidemenuComponent } from './sidemenu/calendar-sidemenu.component';
 
 @NgModule({
   imports: [
@@ -63,6 +64,7 @@ import { CALENDAR_ROUTES } from 'core-app/features/calendar/calendar.routes';
     WorkPackagesCalendarPageComponent,
     WorkPackagesCalendarComponent,
     TimeEntryCalendarComponent,
+    CalendarSidemenuComponent,
   ],
   exports: [
     WorkPackagesCalendarComponent,

--- a/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.html
+++ b/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.html
@@ -3,14 +3,18 @@
   [menuItems]="menuItems"
   baseRoute="calendar.page.show"
   viewType="WorkPackagesCalendar"
+  class="op-sidebar--body"
 >
 </op-view-select>
 
-<button
-  *ngIf="(canCreateCalendar$ | async)"
-  class="spot-button spot-button_outlined"
-  [uiSref]="createButton.uiSref"
-  [uiParams]="createButton.uiParams"
->
-  {{createButton.title}}
-</button>
+
+<div class="op-sidebar--footer">
+  <button
+    *ngIf="(canCreateCalendar$ | async)"
+    class="spot-button spot-button_outlined"
+    [uiSref]="createButton.uiSref"
+    [uiParams]="createButton.uiParams"
+  >
+    {{createButton.title}}
+  </button>
+</div>

--- a/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.html
+++ b/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.html
@@ -1,0 +1,16 @@
+<op-view-select
+  [projectId]="projectId"
+  [menuItems]="menuItems"
+  baseRoute="calendar.page.show"
+  viewType="WorkPackagesCalendar"
+>
+</op-view-select>
+
+<button
+  *ngIf="(canCreateCalendar$ | async)"
+  class="spot-button spot-button_outlined"
+  [uiSref]="createButton.uiSref"
+  [uiParams]="createButton.uiParams"
+>
+  {{createButton.title}}
+</button>

--- a/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.ts
+++ b/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   Input,
   ElementRef,
+  HostBinding,
 } from '@angular/core';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
@@ -19,6 +20,8 @@ export const opCalendarSidemenuSelector = 'op-calendar-sidemenu';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CalendarSidemenuComponent extends UntilDestroyedMixin {
+  @HostBinding('class.op-sidebar') className = true;
+
   @Input() menuItems:string[] = [];
 
   @Input() projectId:string|undefined;

--- a/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.ts
+++ b/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.ts
@@ -1,0 +1,53 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  Input,
+  ElementRef,
+} from '@angular/core';
+import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
+import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
+import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { DatasetInputs } from 'core-app/shared/components/dataset-inputs.decorator';
+
+export const opCalendarSidemenuSelector = 'op-calendar-sidemenu';
+
+@DatasetInputs
+@Component({
+  selector: opCalendarSidemenuSelector,
+  templateUrl: './calendar-sidemenu.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CalendarSidemenuComponent extends UntilDestroyedMixin {
+  @Input() menuItems:string[] = [];
+
+  @Input() projectId:string|undefined;
+
+  canCreateCalendar$ = this.currentUserService.hasCapabilities$(
+    'calendars/create',
+    this.currentProjectService.id || undefined,
+  )
+    .pipe(this.untilDestroyed());
+
+  text = {
+    create_new_calendar: this.I18n.t('js.calendar.create_new'),
+  };
+
+  createButton = {
+    title: this.text.create_new_calendar,
+    uiSref: 'calendar.page.show',
+    uiParams: {
+      query_id: null,
+      query_props: '',
+    },
+  };
+
+  constructor(
+    readonly elementRef:ElementRef,
+    readonly currentUserService:CurrentUserService,
+    readonly currentProjectService:CurrentProjectService,
+    readonly I18n:I18nService,
+  ) {
+    super();
+  }
+}

--- a/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
@@ -1,0 +1,16 @@
+<op-view-select
+  [projectId]="projectId"
+  [menuItems]="menuItems"
+  baseRoute="team_planner.page.show"
+  viewType="TeamPlanner"
+>
+</op-view-select>
+
+<button
+  *ngIf="(canAddTeamPlanner$ | async)"
+  class="spot-button spot-button_outlined"
+  [uiSref]="createButton.uiSref"
+  [uiParams]="createButton.uiParams"
+>
+  {{createButton.title}}
+</button>

--- a/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
@@ -3,14 +3,18 @@
   [menuItems]="menuItems"
   baseRoute="team_planner.page.show"
   viewType="TeamPlanner"
+  class="op-sidebar--body"
 >
 </op-view-select>
 
-<button
-  *ngIf="(canAddTeamPlanner$ | async)"
-  class="spot-button spot-button_outlined"
-  [uiSref]="createButton.uiSref"
-  [uiParams]="createButton.uiParams"
->
-  {{createButton.title}}
-</button>
+<div class="op-sidebar--footer">
+  <button
+    *ngIf="(canAddTeamPlanner$ | async)"
+    class="spot-button spot-button_outlined"
+    [uiSref]="createButton.uiSref"
+    [uiParams]="createButton.uiParams"
+  >
+    <span class="spot-icon spot-icon_add"></span>
+    <span [textContent]="createButton.title"></span>
+  </button>
+</div>

--- a/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
@@ -13,6 +13,7 @@
     class="spot-button spot-button_outlined"
     [uiSref]="createButton.uiSref"
     [uiParams]="createButton.uiParams"
+    data-qa-selector="team-planner--create-button"
   >
     <span class="spot-icon spot-icon_add"></span>
     <span [textContent]="createButton.title"></span>

--- a/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   Input,
   ElementRef,
+  HostBinding,
 } from '@angular/core';
 import { DatasetInputs } from 'core-app/shared/components/dataset-inputs.decorator';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
@@ -19,6 +20,8 @@ export const opTeamPlannerSidemenuSelector = 'op-team-planner-sidemenu';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TeamPlannerSidemenuComponent extends UntilDestroyedMixin {
+  @HostBinding('class.op-sidebar') className = true;
+
   @Input() menuItems:string[] = [];
 
   @Input() projectId:string|undefined;

--- a/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.ts
@@ -1,0 +1,53 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  Input,
+  ElementRef,
+} from '@angular/core';
+import { DatasetInputs } from 'core-app/shared/components/dataset-inputs.decorator';
+import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
+import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
+import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+
+export const opTeamPlannerSidemenuSelector = 'op-team-planner-sidemenu';
+
+@DatasetInputs
+@Component({
+  selector: opTeamPlannerSidemenuSelector,
+  templateUrl: './team-planner-sidemenu.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TeamPlannerSidemenuComponent extends UntilDestroyedMixin {
+  @Input() menuItems:string[] = [];
+
+  @Input() projectId:string|undefined;
+
+  canAddTeamPlanner$ = this.currentUserService.hasCapabilities$(
+    'team_planners/create',
+    this.currentProjectService.id || undefined,
+  )
+    .pipe(this.untilDestroyed());
+
+  text = {
+    create_new_team_planner: this.I18n.t('js.team_planner.create_new'),
+  };
+
+  createButton = {
+    title: this.text.create_new_team_planner,
+    uiSref: 'team_planner.page.show',
+    uiParams: {
+      query_id: null,
+      query_props: '',
+    },
+  };
+
+  constructor(
+    readonly elementRef:ElementRef,
+    readonly currentUserService:CurrentUserService,
+    readonly currentProjectService:CurrentProjectService,
+    readonly I18n:I18nService,
+  ) {
+    super();
+  }
+}

--- a/frontend/src/app/features/team-planner/team-planner/team-planner.module.ts
+++ b/frontend/src/app/features/team-planner/team-planner/team-planner.module.ts
@@ -22,7 +22,7 @@ import { TeamPlannerSidemenuComponent } from 'core-app/features/team-planner/tea
     TeamPlannerPageComponent,
     AddAssigneeComponent,
     AddExistingPaneComponent,
-    TeamPlannerSidemenuComponent
+    TeamPlannerSidemenuComponent,
   ],
   imports: [
     OPSharedModule,

--- a/frontend/src/app/features/team-planner/team-planner/team-planner.module.ts
+++ b/frontend/src/app/features/team-planner/team-planner/team-planner.module.ts
@@ -14,6 +14,7 @@ import { TeamPlannerPageComponent } from 'core-app/features/team-planner/team-pl
 import { OPSharedModule } from 'core-app/shared/shared.module';
 import { AddExistingPaneComponent } from './add-work-packages/add-existing-pane.component';
 import { OpenprojectContentLoaderModule } from 'core-app/shared/components/op-content-loader/openproject-content-loader.module';
+import { TeamPlannerSidemenuComponent } from 'core-app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component';
 
 @NgModule({
   declarations: [
@@ -21,6 +22,7 @@ import { OpenprojectContentLoaderModule } from 'core-app/shared/components/op-co
     TeamPlannerPageComponent,
     AddAssigneeComponent,
     AddExistingPaneComponent,
+    TeamPlannerSidemenuComponent
   ],
   imports: [
     OPSharedModule,

--- a/frontend/src/app/shared/components/op-view-select/op-static-queries.service.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-static-queries.service.ts
@@ -66,7 +66,6 @@ export class StaticQueriesService {
     recently_created: this.I18n.t('js.work_packages.default_queries.recently_created'),
     all_open: this.I18n.t('js.work_packages.default_queries.all_open'),
     summary: this.I18n.t('js.work_packages.default_queries.summary'),
-    create_new_team_planner: this.I18n.t('js.team_planner.create_new'),
   };
 
   public getStaticName(query:QueryResource):string {
@@ -182,23 +181,6 @@ export class StaticQueriesService {
   public getStaticQueriesForView(view:ViewType):IOpSidemenuItem[] {
     return this.staticQueries
       .filter((query) => query.view === view);
-  }
-
-  public getCreateNewQueryForView(view:ViewType):IOpSidemenuItem[] {
-    return this.buildCreateNewQuery()
-      .filter((query) => query.view === view);
-  }
-
-  private buildCreateNewQuery():IStaticQuery[] {
-    return [{
-      title: this.text.create_new_team_planner,
-      uiSref: 'team_planner.page.show',
-      uiParams: {
-        query_id: null,
-        query_props: '',
-      },
-      view: 'TeamPlanner',
-    }];
   }
 
   private projectDependentQueries(projectIdentifier:string):IStaticQuery[] {

--- a/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
@@ -52,8 +52,6 @@ import { ViewsResourceService } from 'core-app/core/state/views/views.service';
 import { IView } from 'core-app/core/state/views/view.model';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
-import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
-import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 
 export type ViewType = 'WorkPackagesTable'|'Bim'|'TeamPlanner'|'WorkPackagesCalendar';
 
@@ -104,8 +102,6 @@ export class ViewSelectComponent extends UntilDestroyedMixin implements OnInit {
     readonly mainMenuService:MainMenuNavigationService,
     readonly cdRef:ChangeDetectorRef,
     readonly viewsService:ViewsResourceService,
-    readonly currentUserService:CurrentUserService,
-    readonly currentProjectService:CurrentProjectService,
   ) {
     super();
   }
@@ -187,15 +183,9 @@ export class ViewSelectComponent extends UntilDestroyedMixin implements OnInit {
       );
     }
 
-    combineLatest(
-      this.viewsService.fetchViews(params),
-      this.currentUserService.hasCapabilities$(
-        'team_planners/create',
-        this.currentProjectService.id || undefined,
-      ),
-    )
+    this.viewsService.fetchViews(params)
       .pipe(this.untilDestroyed())
-      .subscribe(([queryCollection, canAddTeamPlanners]) => {
+      .subscribe((queryCollection) => {
         queryCollection
           ._embedded
           .elements
@@ -213,7 +203,6 @@ export class ViewSelectComponent extends UntilDestroyedMixin implements OnInit {
           });
 
         const staticQueries = this.opStaticQueries.getStaticQueriesForView(this.viewType);
-        const newQueryLink = this.opStaticQueries.getCreateNewQueryForView(this.viewType);
         const viewCategories = [
           { title: this.text.scope_starred, children: categories.starred, collapsible: true },
           { title: this.text.scope_default, children: staticQueries, collapsible: true },
@@ -221,9 +210,6 @@ export class ViewSelectComponent extends UntilDestroyedMixin implements OnInit {
           { title: this.text.scope_private, children: categories.private, collapsible: true },
         ];
 
-        if (canAddTeamPlanners) {
-          viewCategories.push({ title: this.text.scope_new, children: newQueryLink, collapsible: true });
-        }
         this.viewCategories$.next(viewCategories);
       });
   }

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -198,6 +198,8 @@ export function bootstrapModule(injector:Injector) {
     OpSidemenuComponent,
     OpProjectIncludeComponent,
     OpProjectListComponent,
+
+    ViewSelectComponent,
   ],
   providers: [
     StaticQueriesService,

--- a/frontend/src/global_styles/content/_index.sass
+++ b/frontend/src/global_styles/content/_index.sass
@@ -74,6 +74,7 @@
 @import resizer
 @import version
 @import project_status
+@import sidebar
 
 @import menus/project_autocompletion
 @import menus/menu_blocks

--- a/frontend/src/global_styles/content/_sidebar.sass
+++ b/frontend/src/global_styles/content/_sidebar.sass
@@ -1,0 +1,17 @@
+.op-sidebar
+  height: 100%
+  display: flex
+  flex-direction: column
+  overflow: hidden
+
+  &--body
+    flex-grow: 1
+    overflow: auto
+    @include styled-scroll-bar
+
+    &:only-child
+      padding-bottom: 10px
+
+  &--footer
+    text-align: center
+    padding: 16px

--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -61,9 +61,6 @@ $arrow-left-width: 40px
     .main-menu--children > li.partial:only-child
       height: 100%
 
-    .main-menu--children > li.partial
-      height: initial
-
     .main-menu--children
       height: calc(100% - (var(--main-menu-item-height) + 10px)) // 10px spacing
       overflow: auto
@@ -164,9 +161,6 @@ $arrow-left-width: 40px
   &.unattached
     border-top: 1px solid #ddd
   li
-    &.partial
-      padding-bottom: 10px
-
     &:hover
       // simultaneously hover all menu item anchor tags
       > a

--- a/modules/bim/app/views/bim/ifc_models/ifc_models/_panels.html.erb
+++ b/modules/bim/app/views/bim/ifc_models/ifc_models/_panels.html.erb
@@ -1,15 +1,17 @@
-<div class="op-ifc-viewer--sidemenu">
-  <%=
-    angular_component_tag 'op-view-select',
-                          inputs: {
-                            projectId: (@project ? @project.id.to_s : ''),
-                            menuItems: [parent_name, name],
-                            baseRoute: 'bim.partitioned.list',
-                            viewType: 'Bim',
-                          }
-  %>
+<div class="op-ifc-viewer--sidemenu op-sidebar">
+  <div class="op-sidebar--body">
+    <%=
+      angular_component_tag 'op-view-select',
+                            inputs: {
+                              projectId: (@project ? @project.id.to_s : ''),
+                              menuItems: [parent_name, name],
+                              baseRoute: 'bim.partitioned.list',
+                              viewType: 'Bim',
+                            }
+    %>
 
-  <hr>
+    <hr>
 
-  <div class="op-ifc-viewer--tree-panel active" data-qa-selector="op-ifc-viewer--tree-panel"></div>
+    <div class="op-ifc-viewer--tree-panel active" data-qa-selector="op-ifc-viewer--tree-panel"></div>
+  </div>
 </div>

--- a/modules/boards/config/locales/js-en.yml
+++ b/modules/boards/config/locales/js-en.yml
@@ -2,6 +2,7 @@
 en:
   js:
     boards:
+      create_new: 'New board'
       label_unnamed_board: 'Unnamed board'
       label_unnamed_list: 'Unnamed list'
       label_board_type: 'Board type'

--- a/modules/boards/lib/open_project/boards/engine.rb
+++ b/modules/boards/lib/open_project/boards/engine.rb
@@ -28,8 +28,14 @@ module OpenProject::Boards
              settings: {},
              name: 'OpenProject Boards' do
       project_module :board_view, dependencies: :work_package_tracking, order: 80 do
-        permission :show_board_views, 'boards/boards': %i[index], dependencies: :view_work_packages
-        permission :manage_board_views, 'boards/boards': %i[index], dependencies: :manage_public_queries
+        permission :show_board_views,
+                   { 'boards/boards': %i[index] },
+                   dependencies: :view_work_packages,
+                   contract_actions: { boards: %i[read] }
+        permission :manage_board_views,
+                   { 'boards/boards': %i[index] },
+                   dependencies: :manage_public_queries,
+                   contract_actions: { boards: %i[create update destroy] }
       end
 
       menu :project_menu,

--- a/modules/boards/spec/features/board_navigation_spec.rb
+++ b/modules/boards/spec/features/board_navigation_spec.rb
@@ -102,7 +102,7 @@ describe 'Work Package boards spec', type: :feature, js: true do
     item = page.find('#menu-sidebar li[data-name="board_view"]', wait: 10)
     item.find('.toggler').click
 
-    subitem = page.find('.main-menu--children-sub-item', text: 'My board', wait: 10)
+    subitem = page.find('[data-qa-selector="op-sidemenu--item-action--Myboard"]', wait: 10)
     # Ends with boards due to lazy route
     expect(subitem[:href]).to end_with "/projects/#{project.identifier}/boards"
 

--- a/modules/boards/spec/features/boards_sorting_spec.rb
+++ b/modules/boards/spec/features/boards_sorting_spec.rb
@@ -36,6 +36,7 @@ describe 'Work Package boards sorting spec', type: :feature, js: true do
   let(:board_index) { Pages::BoardIndex.new(project) }
   let!(:status) { create :default_status }
   let(:version) { @version ||= create(:version, project: project) }
+  let(:query_menu) { ::Components::WorkPackages::QueryMenu.new }
 
   before do
     with_enterprise_token :board_view
@@ -52,23 +53,20 @@ describe 'Work Package boards sorting spec', type: :feature, js: true do
 
     expect(page.first('[data-qa-selector="boards-table-column--name"]'))
       .to have_text('Unnamed board')
-    expect(page.first('[data-qa-selector="boards-menu--item"]'))
-      .to have_text('Unnamed board')
+    query_menu.expect_menu_entry 'Unnamed board'
 
     board_page = board_index.create_board action: :Version, expect_empty: true
     board_page.back_to_index
 
     expect(page.first('[data-qa-selector="boards-table-column--name"]'))
       .to have_text('Action board (version)')
-    expect(page.first('[data-qa-selector="boards-menu--item"]'))
-      .to have_text('Action board (version)')
+    query_menu.expect_menu_entry 'Action board (version)'
 
     board_page = board_index.create_board action: :Status
     board_page.back_to_index
 
     expect(page.first('[data-qa-selector="boards-table-column--name"]'))
       .to have_text('Action board (status)')
-    expect(page.first('[data-qa-selector="boards-menu--item"]'))
-      .to have_text('Action board (status)')
+    query_menu.expect_menu_entry 'Action board (status)'
   end
 end

--- a/modules/calendar/app/views/calendar/calendars/_menu.html.erb
+++ b/modules/calendar/app/views/calendar/calendars/_menu.html.erb
@@ -1,9 +1,7 @@
   <%=
-    angular_component_tag 'op-view-select',
+    angular_component_tag 'op-calendar-sidemenu',
                           inputs: {
                             projectId: (@project ? @project.id.to_s : ''),
                             menuItems: [parent_name, name],
-                            baseRoute: 'calendar.page.show',
-                            viewType: 'WorkPackagesCalendar',
                           }
   %>

--- a/modules/calendar/config/locales/js-en.yml
+++ b/modules/calendar/config/locales/js-en.yml
@@ -2,6 +2,7 @@
 en:
   js:
     calendar:
+      create_new: 'New calendar'
       title: 'Calendar'
       too_many: 'There are %{count} work packages in total, but only %{max} can be shown.'
       unsaved_title: 'Unnamed calendar'

--- a/modules/team_planner/app/views/team_planner/team_planner/_menu.html.erb
+++ b/modules/team_planner/app/views/team_planner/team_planner/_menu.html.erb
@@ -1,9 +1,7 @@
   <%=
-    angular_component_tag 'op-view-select',
+    angular_component_tag 'op-team-planner-sidemenu',
                           inputs: {
                             projectId: (@project ? @project.id.to_s : ''),
                             menuItems: [parent_name, name],
-                            baseRoute: 'team_planner.page.show',
-                            viewType: 'TeamPlanner',
                           }
   %>

--- a/modules/team_planner/config/locales/js-en.yml
+++ b/modules/team_planner/config/locales/js-en.yml
@@ -3,7 +3,7 @@ en:
   js:
     team_planner:
       add_existing: 'Add Existing'
-      create_new: New team planner'
+      create_new: 'New team planner'
       title: 'Team planner'
       unsaved_title: 'Unnamed team planner'
       label_assignee_plural: 'Assignees'

--- a/modules/team_planner/config/locales/js-en.yml
+++ b/modules/team_planner/config/locales/js-en.yml
@@ -3,7 +3,7 @@ en:
   js:
     team_planner:
       add_existing: 'Add Existing'
-      create_new: 'Create new planner'
+      create_new: New team planner'
       title: 'Team planner'
       unsaved_title: 'Unnamed team planner'
       label_assignee_plural: 'Assignees'

--- a/modules/team_planner/spec/features/query_handling_spec.rb
+++ b/modules/team_planner/spec/features/query_handling_spec.rb
@@ -117,7 +117,8 @@ describe 'Team planner query handling', type: :feature, js: true do
 
   it 'shows only team planner queries' do
     # Go to team planner where no query is shown, only the create option
-    query_menu.expect_menu_entry 'Create new planner'
+    query_menu.expect_no_menu_entry
+    expect(page).to have_selector('[data-qa-selector="team-planner--create-button"]')
 
     # Change filter
     filters.open

--- a/modules/team_planner/spec/features/team_planner_index_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_index_spec.rb
@@ -53,12 +53,12 @@ describe 'Team planner index', type: :feature, js: true, with_ee: %i[team_planne
     end
 
     it 'can create an action through the sidebar' do
-      click_on 'Create new planner'
+      click_on 'New team planner'
 
       team_planner.expect_title
 
       # Also works from the frontend
-      click_on 'Create new planner'
+      click_on 'New team planner'
 
       team_planner.expect_no_toaster
       team_planner.expect_title

--- a/modules/team_planner/spec/features/team_planner_menu_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_menu_spec.rb
@@ -29,13 +29,11 @@
 #++
 
 require 'spec_helper'
-require_relative '../../../../spec/support/components/work_packages/query_menu'
 
 describe 'Team planner sidemenu', type: :feature, js: true do
   shared_let(:project) do
     create(:project, enabled_module_names: %w[work_package_tracking team_planner_view])
   end
-  let(:query_menu) { ::Components::WorkPackages::QueryMenu.new }
 
   context 'with a user that does not have create rights' do
     shared_let(:user_without_rights) do
@@ -56,7 +54,7 @@ describe 'Team planner sidemenu', type: :feature, js: true do
         click_link 'Team planners'
       end
 
-      query_menu.expect_menu_entry_not_visible('Create new planner')
+      expect(page).not_to have_selector('[data-qa-selector="team-planner--create-button"]')
     end
   end
 
@@ -72,14 +70,14 @@ describe 'Team planner sidemenu', type: :feature, js: true do
 
     current_user { user_with_rights }
 
-    it 'hides the create team planner option if you do not have rights' do
+    it 'shows the create team planner option' do
       visit project_path(project)
 
       within '#main-menu' do
         click_link 'Team planners'
       end
 
-      query_menu.expect_menu_entry('Create new planner')
+      expect(page).to have_selector('[data-qa-selector="team-planner--create-button"]')
     end
   end
 end

--- a/modules/team_planner/spec/features/team_planner_upsale_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_upsale_spec.rb
@@ -45,7 +45,7 @@ describe 'Team planner index', type: :feature, js: true do
 
     expect(page).to have_text 'Upgrade now'
 
-    click_on 'Create new planner'
+    click_on 'New team planner'
 
     expect(page).to have_text 'Upgrade now'
 


### PR DESCRIPTION
### ToDo

- [x] For the following modules there should be a "+ New _module name_" button on the bottom edge of the sidebar.
  - [x] Team planner (text: "+ New team planner")
  - [x] Calendar (text:  "+ New calendar")
  - [x] Boards (text:  "+ New board")
- [x] The button is sticky at the bottom with a 16px padding
- [x] This button corresponds to the "Outline" variant with the "Light" style, with the add icon. ( ⚠️  depends on #10200)
- [x] Remove the current "Create new planner" menu item from the sidebar

@Reviewer this changes parts of the main menu, especially the sub-pages of Boards, Calendar, WP, BIM, and Team  planner. So please double check that everything looks and feels fine there.


https://community.openproject.org/projects/openproject/work_packages/40958/activity