### PR TITLE
Better template ID tracking for team planner

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -413,7 +413,13 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
   }
 
   eventId(data:EventContentArg):string {
-    return `${data.event.id},dragging=${data.isDragging.toString()}`;
+    return [
+      data.event.id,
+      data.event.start?.toISOString(),
+      data.event.end?.toISOString(),
+      data.timeText,
+      `dragging=${data.isDragging.toString()}`,
+    ].join('-');
   }
 
   public showAssigneeAddRow():void {


### PR DESCRIPTION
Replaces the team planner ID tracking to match what is suggested in https://github.com/fullcalendar/fullcalendar-angular/issues/204#issuecomment-652881716

@reviewer: Please double check the drag behavior when adding or removing items to the views. It appeared to work fine, but a second set of eyes is certainly needed here 🙇 