### PR TITLE
replace ineffectual parameter by actual pageSize parameter

### DIFF
--- a/frontend/src/app/features/calendar/op-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-calendar.service.ts
@@ -181,7 +181,7 @@ export class OpCalendarService extends UntilDestroyedMixin {
       const initialQuery = await this
         .apiV3Service
         .queries
-        .find({ perPage: 0 }, queryId)
+        .find({ pageSize: 0 }, queryId)
         .toPromise();
 
       queryProps = this.urlParamsHelper.encodeQueryJsonParams(


### PR DESCRIPTION
Passing `perPage` does nothing at all since it needs to be called `pageSize`.