### PR TITLE
Feature/40195 seed data for new team planner module

### DIFF
--- a/app/models/query/timelines.rb
+++ b/app/models/query/timelines.rb
@@ -32,16 +32,16 @@ module Query::Timelines
   extend ActiveSupport::Concern
 
   included do
-    enum timeline_zoom_level: %i(days weeks months quarters years auto)
+    enum timeline_zoom_level: { days: 0, weeks: 1, months: 2, quarters: 3, years: 4, auto: 5 }
     validates :timeline_zoom_level, inclusion: { in: timeline_zoom_levels.keys }
 
     serialize :timeline_labels, Hash
     validate :valid_timeline_labels
 
     def valid_timeline_labels
-      return unless timeline_labels.present?
+      return if timeline_labels.blank?
 
-      valid_keys = %w(farRight left right) == timeline_labels.keys.map(&:to_s).sort
+      valid_keys = timeline_labels.keys.map(&:to_s).sort == %w(farRight left right)
       errors.add :timeline_labels, :invalid unless valid_keys
     end
   end

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -134,7 +134,7 @@ module DemoData
 
     def set_members(project)
       role = Role.find_by(name: translate_with_base_url(:default_role_project_admin))
-      user = User.admin.first
+      user = User.user.admin.first
 
       Member.create!(
         project: project,

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -52,6 +52,7 @@ module DemoData
         name: config[:name],
         user: User.admin.first,
         public: config[:public] != false,
+        starred: config.fetch(:starred, false),
         show_hierarchies: config[:hierarchy] == true,
         timeline_visible: config[:timeline] == true
       }

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -50,11 +50,11 @@ module DemoData
     def base_attributes
       {
         name: config[:name],
-        user: User.admin.first,
-        public: config[:public] != false,
+        user: User.admin.user.first,
+        public: config.fetch(:public, true),
         starred: config.fetch(:starred, false),
-        show_hierarchies: config[:hierarchy] == true,
-        timeline_visible: config[:timeline] == true
+        show_hierarchies: config.fetch(:hierarchy, false),
+        timeline_visible: config.fetch(:timeline, false)
       }
     end
 

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -148,7 +148,7 @@ module DemoData
     end
 
     def set_time_tracking_attributes!(wp_attr, attributes)
-      start_date = attributes[:start] && calculate_start_date(attributes[:start])
+      start_date = calculate_start_date(attributes[:start])
 
       wp_attr[:start_date] = start_date
       wp_attr[:due_date] = calculate_due_date(start_date, attributes[:duration]) if start_date && attributes[:duration]
@@ -207,12 +207,13 @@ module DemoData
     end
 
     def calculate_start_date(days_ahead)
-      monday = Date.today.monday
-      days_ahead > 0 ? monday + days_ahead : monday
+      Time.zone.today.monday + (days_ahead || 0).days
     end
 
+    # Returns the due date based on the starting date and the duration
+    # but ensures that the due date cannot be before the start date.
     def calculate_due_date(date, duration)
-      duration && duration > 1 ? date + duration : date
+      [date + ((duration || 0) - 1).days, date].max
     end
   end
 end

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -36,7 +36,7 @@ module DemoData
     def initialize(project, key)
       self.project = project
       self.key = key
-      self.user = User.admin.first
+      self.user = User.user.admin.first
       self.statuses = Status.all
       self.repository = Repository.first
       self.types = project.types.all.reject(&:is_milestone?)

--- a/app/seeders/seeder.rb
+++ b/app/seeders/seeder.rb
@@ -35,7 +35,7 @@ class Seeder
         seed_data!
       end
     else
-      puts "   *** #{not_applicable_message}"
+      Rails.logger.debug { "   *** #{not_applicable_message}" }
     end
   end
 
@@ -54,27 +54,20 @@ class Seeder
   protected
 
   def print_status(message)
-    print message
+    Rails.logger.info message
 
-    return unless block_given?
-
-    yield
-    puts
+    yield if block_given?
   end
 
   ##
   # Translate the given string with the fixed interpolation for base_url
   # Deep interpolation is required in order for interpolations on hashes to work!
-  def translate_with_base_url(string)
-    I18n.t(string, deep_interpolation: true, base_url: "{{opSetting:base_url}}")
+  def translate_with_base_url(string, **i18n_options)
+    I18n.t(string, deep_interpolation: true, base_url: "{{opSetting:base_url}}", **i18n_options)
   end
 
   def edition_data_for(key)
-    data = translate_with_base_url("seeders.#{OpenProject::Configuration['edition']}.#{key}")
-
-    return nil if data.is_a?(String) && data.start_with?("translation missing")
-
-    data
+    translate_with_base_url("seeders.#{OpenProject::Configuration['edition']}.#{key}", default: nil)
   end
 
   def demo_data_for(key)

--- a/config/locales/en.seeders.standard.yml
+++ b/config/locales/en.seeders.standard.yml
@@ -75,6 +75,7 @@ en:
                 timeline: true
                 sort_by: id
                 hierarchy: true
+                starred: true
                 columns:
                   - id
                   - type

--- a/config/locales/en.seeders.standard.yml
+++ b/config/locales/en.seeders.standard.yml
@@ -57,6 +57,7 @@ en:
               - news
               - wiki
               - board_view
+              - team_planner_view
             news:
               - title: Welcome to your demo project
                 summary: >
@@ -106,6 +107,9 @@ en:
                   - priority
                   - status
                   - assigned_to
+              - name: Team planner
+                module: team_planner
+                assignee: OpenProject Admin
             boards:
               kanban:
                 name: 'Kanban board'
@@ -119,7 +123,7 @@ en:
             # So
             # * start: 0 references Monday
             # * start: 4 references Friday
-
+            # * start: -1 references the last Sunday
             work_packages:
               - start: -1
                 subject: Start of project

--- a/config/locales/en.seeders.standard.yml
+++ b/config/locales/en.seeders.standard.yml
@@ -114,50 +114,74 @@ en:
                 name: 'Basic board'
               parent_child:
                 name: 'Work breakdown structure'
+            # For all dates, the reference is the monday of the current week
+            # So
+            # * start: 0 references Monday
+            # * start: 4 references Friday
+
             work_packages:
-              - start: 4
+              - start: -1
                 subject: Start of project
                 description:
                 status: default_status_closed
                 type: default_type_milestone
                 duration: 0
                 schedule_manually: false
-              - start: 5
+              - start: 0
                 subject: Organize open source conference
                 description:
                 status: default_status_in_progress
                 type: default_type_phase
                 children:
-                  - start: 5
+                  - start: 0
                     subject: Set date and location of conference
                     description: ''
                     status: default_status_in_progress
                     type: default_type_task
-                    duration: 16
+                    children:
+                      - start: 0
+                        subject: Send invitation to speakers
+                        description: ''
+                        status: default_status_in_progress
+                        type: default_type_task
+                        duration: 1
+                      - start: 0
+                        subject: Contact sponsoring partners
+                        description: ''
+                        status: default_status_new
+                        type: default_type_task
+                        duration: 2
+                      - start: 0
+                        subject: Create sponsorship brochure and hand-outs
+                        description: ''
+                        status: default_status_new
+                        type: default_type_task
+                        duration: 4
+                    duration: 4
                     schedule_manually: false
-                  - start: 22
-                    subject: Setup conference website
-                    description: ''
-                    status: default_status_new
-                    type: default_type_task
-                    duration: 35
-                    relations:
-                      - to: Set date and location of conference
-                        type: follows
-                    :schedule_manually: false
-                  - start: 22
+                  - start: 4
                     subject: Invite attendees to conference
                     description: ''
                     status: default_status_new
                     type: default_type_task
-                    duration: 16
+                    duration: 1
                     relations:
                       - to: Set date and location of conference
                         type: follows
                     schedule_manually: false
-                duration: 70
+                  - start: 4
+                    subject: Setup conference website
+                    description: ''
+                    status: default_status_new
+                    type: default_type_task
+                    duration: 11
+                    relations:
+                      - to: Set date and location of conference
+                        type: follows
+                    schedule_manually: false
+                duration: 15
                 schedule_manually: true
-              - start: 76
+              - start: 15
                 subject: Conference
                 description:
                 status: default_status_scheduled
@@ -167,20 +191,20 @@ en:
                   - to: Organize open source conference
                     type: follows
                 schedule_manually: false
-              - start: 77
+              - start: 21
                 subject: Follow-up tasks
                 description:
                 status: default_status_to_be_scheduled
                 type: default_type_phase
                 children:
-                  - start: 77
+                  - start: 21
                     subject: Upload presentations to website
                     description: ''
                     status: default_status_new
                     type: default_type_task
-                    duration: 16
+                    duration: 10
                     schedule_manually: false
-                  - start: 77
+                  - start: 31
                     subject: Party for conference supporters :-)
                     description: |-
                       *   [ ] Beer
@@ -189,11 +213,11 @@ en:
                       *   [ ] Even more beer
                     status: default_status_new
                     type: default_type_task
-                    duration: 0
+                    duration: 1
                     schedule_manually: false
-                duration: 16
+                duration: 11
                 schedule_manually: false
-              - start: 94
+              - start: 32
                 subject: End of project
                 description:
                 status: default_status_new

--- a/modules/bim/config/locales/en.seeders.bim.yml
+++ b/modules/bim/config/locales/en.seeders.bim.yml
@@ -94,6 +94,7 @@ en:
               - news
               - wiki
               - board_view
+              - team_planner_view
             news:
               - title: Welcome to your demo project
                 summary: >
@@ -112,6 +113,7 @@ en:
                 timeline: true
                 sort_by: start_date
                 hierarchy: true
+                starred: true
                 columns:
                   - id
                   - type
@@ -143,6 +145,9 @@ en:
                   - type
                   - status
                   - assigned_to
+              - name: Team planner
+                module: team_planner
+                assignee: OpenProject Admin
             boards:
               bcf:
                 name: "Simple drag'n drop workflow"
@@ -162,6 +167,7 @@ en:
               - news
               - wiki
               - board_view
+              - team_planner_view
             news:
               - title: Welcome to your demo project
                 summary: >
@@ -180,6 +186,7 @@ en:
                 timeline: true
                 sort_by: start_date
                 hierarchy: true
+                starred: true
                 columns:
                   - id
                   - type
@@ -211,6 +218,9 @@ en:
                   - type
                   - status
                   - assigned_to
+              - name: Team planner
+                module: team_planner
+                assignee: OpenProject Admin
             work_packages:
               - :start: 4
                 :subject: Project kick off construction project
@@ -544,6 +554,7 @@ en:
               - news
               - wiki
               - board_view
+              - team_planner_view
             news:
               - title: Welcome to your demo project
                 summary: >
@@ -562,6 +573,7 @@ en:
                 timeline: true
                 sort_by: start_date
                 hierarchy: true
+                starred: true
                 columns:
                   - id
                   - type
@@ -593,6 +605,9 @@ en:
                   - type
                   - status
                   - assigned_to
+              - name: Team planner
+                module: team_planner
+                assignee: OpenProject Admin
             work_packages:
               - :start: 14
                 :subject: Project kick off creating BIM model
@@ -1025,6 +1040,7 @@ en:
               - work_package_tracking
               - bim
               - board_view
+              - team_planner_view
             ifc_models:
               - file: 'hospital_architecture'
                 name: 'Hospital - Architecture (cc-by-sa-3.0 Autodesk Inc.)'
@@ -1067,6 +1083,7 @@ en:
                 timeline: true
                 sort_by: start_date
                 hierarchy: true
+                starred: true
                 columns:
                   - id
                   - type
@@ -1098,6 +1115,9 @@ en:
                   - type
                   - status
                   - assigned_to
+              - name: Team planner
+                module: team_planner
+                assignee: OpenProject Admin
             boards:
               bcf:
                 name: "BCF issues"

--- a/modules/bim/spec/seeders/demo_data_seeder_spec.rb
+++ b/modules/bim/spec/seeders/demo_data_seeder_spec.rb
@@ -41,7 +41,7 @@ describe RootSeeder,
     expect(Project.count).to eq 4
     expect(WorkPackage.count).to eq 76
     expect(Wiki.count).to eq 3
-    expect(Query.count).to eq 25
+    expect(Query.count).to eq 29
     expect(Group.count).to eq 8
     expect(Type.count).to eq 7
     expect(Status.count).to eq 4

--- a/spec/seeders/demo_data_seeder_spec.rb
+++ b/spec/seeders/demo_data_seeder_spec.rb
@@ -39,7 +39,7 @@ describe RootSeeder,
 
     expect(User.where(admin: true).count).to eq 1
     expect(Project.count).to eq 2
-    expect(WorkPackage.count).to eq 33
+    expect(WorkPackage.count).to eq 36
     expect(Wiki.count).to eq 2
     expect(Query.having_views.count).to eq 7
     expect(View.where(type: 'work_packages_table').count).to eq 7

--- a/spec/seeders/demo_data_seeder_spec.rb
+++ b/spec/seeders/demo_data_seeder_spec.rb
@@ -41,9 +41,10 @@ describe RootSeeder,
     expect(Project.count).to eq 2
     expect(WorkPackage.count).to eq 36
     expect(Wiki.count).to eq 2
-    expect(Query.having_views.count).to eq 7
+    expect(Query.having_views.count).to eq 8
     expect(View.where(type: 'work_packages_table').count).to eq 7
-    expect(Query.count).to eq 25
+    expect(View.where(type: 'team_planner').count).to eq 1
+    expect(Query.count).to eq 26
     expect(Projects::Status.count).to eq 2
     expect(Role.where(type: 'Role').count).to eq 5
     expect(GlobalRole.count).to eq 1


### PR DESCRIPTION
Work packages "Project plan"-View:

- ~Days Zoom level~ respecified
- [x] Move start date of the work packages (2, 3 and the new ones) to the Monday of the creation date of the instance
- [x] Move project start work packages (closed) to the Sunday before
- [x] Save as Project plan (for public and favourite views)
- [x] Switch tasks 4 and 5 so that Invite attendees to conference will be displayed above Setup conference website
- [x] Add three work packages as child element of Set date and location of conference:
- ~Adapt filter so that the closed project milestone is visible~

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/617519/156743566-7af6afef-3ecf-4440-9cec-9f8b843abc2f.png">


Module team planner

- [x] Activate the module in the Demo project
- [x] Create a board: "Team planner" and set it to Favored and Public.
- [x] Add the user who created the trial to the board

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/617519/156743615-00b45d2c-cf74-4aa6-86cb-ac3ce01d9ff3.png">

BIM edition:

- [x] Activate the team planner module in all 4 demo projects and seed a board.
- [x] In Work Packages module starred the "Project plan" query. 

https://community.openproject.org/wp/40195
