### PR TITLE
[40981] Change scrolling behavior of team planner

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
@@ -35,7 +35,7 @@
         #ucCalendar
         *ngIf="calendarOptions"
         [options]="calendarOptions"
-        class="op-team-planner--calendar"
+        class="op-team-planner--calendar fc-scroller"
         [ngClass]="{'op-team-planner--calendar_empty': (isEmpty$ | async)}"
       ></full-calendar>
 

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.sass
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.sass
@@ -21,8 +21,12 @@ $op-team-planner-resource-width: 180px
 
   &--calendar-pane
     grid-area: calendar
-    overflow: auto  // Avoid empty space on the right since the styled scrollbar would only be visible on hover.
-    @include no-visible-scroll-bar
+    display: flex
+    flex-direction: column
+    overflow: hidden
+
+  &--calendar
+    overflow: auto
 
   &--add-existing-pane
     grid-area: addExisting


### PR DESCRIPTION
Make footer of the team planner (drop-zone and add-assignee button) sticky. In order to let the team planner autoscroll, the `.fc-scroller` class needs to be set on the scrolling container.


https://community.openproject.org/projects/openproject/work_packages/40981/activity