### PR TITLE
[41134] Wrong name in mail for "wiki page has been updated by"

### DIFF
--- a/app/services/wiki_pages/update_service.rb
+++ b/app/services/wiki_pages/update_service.rb
@@ -38,6 +38,7 @@ class WikiPages::UpdateService < ::BaseServices::Update
 
     page = service_result.result
     content = page.content
+    content.author_id = user.id
 
     unless page.save && content.save
       service_result.errors = page.errors


### PR DESCRIPTION
Write the id of the changing user as author to the wiki_content object. Before the `author_id` was copied from the page content resulting in the author of the page being named as author for all changes.

https://community.openproject.org/projects/openproject/work_packages/41134/activity