### PR TITLE
[40859] Today column is not highlighted in FF

### DIFF
--- a/frontend/src/global_styles/vendor/_full_calendar.sass
+++ b/frontend/src/global_styles/vendor/_full_calendar.sass
@@ -17,19 +17,18 @@
       cursor: unset
 
     // Note the greater specificity than the standard background colours
-    tbody td.fc-day-today,
-    thead th.fc-day-today
+    table .fc-day-today
       background: rgb(255 255 120 / 20%)
 
-    td.fc-day-sat,
-    td.fc-day-sun
+    .fc-day-sat,
+    .fc-day-sun
       background: rgb(109 109 109 / 20%)
 
-    td.fc-day-mon,
-    td.fc-day-tue,
-    td.fc-day-wed,
-    td.fc-day-thu,
-    td.fc-day-fri
+    .fc-day-mon,
+    .fc-day-tue,
+    .fc-day-wed,
+    .fc-day-thu,
+    .fc-day-fri
       background: rgb(205 205 205 / 20%)
 
     // The days in full calendar are anchor elements which we do not


### PR DESCRIPTION
Because of reasons I don't know, FullCalendar has a different internal HTML structure depending on the browser. Among others the `th` elements were not part of a `thead` but of a `tbody` in FF 🤷‍♀️ . Because of that the selector for the today column did not match. 

https://community.openproject.org/projects/openproject/work_packages/40859/activity