### PR TITLE
Override type condition set by rails when scoping User

### DIFF
--- a/app/models/principals/scopes/user.rb
+++ b/app/models/principals/scopes/user.rb
@@ -37,7 +37,7 @@ module Principals::Scopes
       def user
         # Have to use the User model here so that the scopes defined on User
         # are also available after the scope is used.
-        where(type: [::User.name])
+        rewhere(type: [::User.name])
       end
     end
   end

--- a/spec/models/queries/users/user_query_spec.rb
+++ b/spec/models/queries/users/user_query_spec.rb
@@ -27,9 +27,6 @@
 #++
 
 require 'spec_helper'
-# prevents test failures where the system user
-# is mentioned in the User.user scope
-require 'system_user'
 
 describe Queries::Users::UserQuery, type: :model do
   let(:instance) { described_class.new }


### PR DESCRIPTION
While running `rspec spec/models/queries` for PR  #10254, I got 15 failing tests, and thus discovered that some of these tests are order dependent. This PR tries to solve the order dependence.

For a minimal failure reproduction, run: 
```
bundle exec rspec --order defined ./spec/models/queries/users/filters/name_filter_spec.rb:90 ./spec/models/queries/users/user_query_spec.rb:52
```

It will fail with something like
```
     Failure/Error: expect(instance.scope.to_sql).to eql expected.to_sql
     
       expected: "SELECT \"users\".* FROM \"users\" WHERE \"users\".\"type\" IN ('User', 'SystemUser') AND \"users\".\"type\" = 'User' AND (LOWER(users.firstname) NOT LIKE '%a name%')"
            got: "SELECT \"users\".* FROM \"users\" WHERE \"users\".\"type\" = 'User' AND \"users\".\"type\" = 'User' AND (LOWER(users.firstname) NOT LIKE '%a name%')"
```

It's because the `SystemUser` class is loaded after `expected` gets evaluated, and before `instance.scope` gets evaluated. Rails adds some type conditions with `ActiveRecord::Inheritance::ClassMethods#type_condition` because User is using Single Table Inheritance. As the ActiveRecord classes are lazily loaded, it can yield different results depending on the descendants classes currently loaded.

One way to fix it is to explicitly load `SystemUser` in all tests, but it has to be done everywhere needed (This PR removed the line doing so in `spec/models/queries/users/user_query_spec.rb`). Another approach is to [`rewhere`](https://apidock.com/rails/ActiveRecord/QueryMethods/rewhere) the `type` condition. This PR does it in `User.user` as it is used almost everywhere.

This PR will check that doing so does not break anything.

BTW, the complete minimal failing tests suite I got was `rspec './spec/models/queries/users/filters/any_name_attribute_filter_spec.rb[1:2:1:1,1:2:2:1]' './spec/models/queries/users/filters/group_filter_spec.rb[1:2:1:1:1,1:2:1:2:1,1:2:1:3:1,1:2:1:4:1]' './spec/models/queries/users/filters/name_filter_spec.rb[1:2:1:1,1:2:2:1,1:2:3:1,1:2:4:1]' './spec/models/queries/users/filters/status_filter_spec.rb[1:2:1:1]' './spec/models/queries/users/user_query_spec.rb[1:2:1:1,1:3:1:1,1:4:1:1,1:7:1:1]'`