### PR TITLE
Add open_?project to sentry app patterns

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -41,6 +41,9 @@ if OpenProject::Logging::SentryLogger.enabled?
       event
     end
 
+    # Add plugins with openproject/open_project in backtraces to internal
+    config.app_dirs_pattern = /(bin|exe|app|config|lib|open_?project)/
+
     # Don't send loaded modules
     config.send_modules = false
 


### PR DESCRIPTION
Treat any backtrace that has openproject / open_project in their backtrace as an app dir. Prevents sentry from collapsing the trace line

This is related to
[OP#39012](https://community.openproject.com/wp/39012)

https://github.com/getsentry/sentry-ruby/issues/1700