### PR TITLE
[41235] Add loading indicator toast for team planner

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -31,6 +31,7 @@ en:
     ajax:
       hide: "Hide"
       loading: "Loading ..."
+      updating: "Updating ..."
 
     attachments:
       draggable_hint: |

--- a/frontend/src/app/features/team-planner/team-planner/page/team-planner-page.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/page/team-planner-page.component.ts
@@ -17,7 +17,15 @@ import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { WorkPackageSettingsButtonComponent } from 'core-app/features/work-packages/components/wp-buttons/wp-settings-button/wp-settings-button.component';
 import { CalendarDragDropService } from 'core-app/features/team-planner/team-planner/calendar-drag-drop.service';
 import { OpProjectIncludeComponent } from 'core-app/shared/components/project-include/project-include.component';
+import {
+  EffectCallback,
+  EffectHandler,
+} from 'core-app/core/state/effects/effect-handler.decorator';
+import { teamPlannerEventAdded } from 'core-app/features/team-planner/team-planner/planner/team-planner.actions';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
+import { ActionsService } from 'core-app/core/state/actions/actions.service';
 
+@EffectHandler
 @Component({
   templateUrl: '../../../work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.html',
   styleUrls: [
@@ -30,6 +38,8 @@ import { OpProjectIncludeComponent } from 'core-app/shared/components/project-in
   ],
 })
 export class TeamPlannerPageComponent extends PartitionedQuerySpacePageComponent implements OnInit {
+  @InjectField() actions$:ActionsService;
+
   text = {
     title: this.I18n.t('js.team_planner.title'),
     unsaved_title: this.I18n.t('js.team_planner.unsaved_title'),
@@ -114,5 +124,15 @@ export class TeamPlannerPageComponent extends PartitionedQuerySpacePageComponent
    */
   protected loadInitialQuery():void {
     // We never load the initial query as the calendar service does all that.
+  }
+
+  /**
+   * Reload the team planner page if an external event was added.
+   * This is currently not handled by the HalEvents system, as it only
+   * detects updates to _existing_ or created events already rendered.
+   */
+  @EffectCallback(teamPlannerEventAdded)
+  reloadOnEventAdded():void {
+    void this.refresh(false, false);
   }
 }

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.actions.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.actions.ts
@@ -8,3 +8,8 @@ export const teamPlannerEventRemoved = action(
   '[Team planner] Event removed from team planner',
   props<{ workPackage:ID }>(),
 );
+
+export const teamPlannerEventAdded = action(
+  '[Team planner] External event added to the team planner',
+  props<{ workPackage:ID }>(),
+);

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -18,7 +18,6 @@ import {
 import {
   BehaviorSubject,
   combineLatest,
-  from,
   Subject,
 } from 'rxjs';
 import {
@@ -362,9 +361,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
             // DnD configuration
             editable: true,
             droppable: true,
-            eventResize: (resizeInfo:EventResizeDoneArg) => {
-              const updater = from(this.updateEvent(resizeInfo));
-            },
+            eventResize: (resizeInfo:EventResizeDoneArg) => this.updateEvent(resizeInfo),
             eventDragStart: (dragInfo:EventDragStartArg) => {
               const { el } = dragInfo;
               el.style.pointerEvents = 'none';
@@ -407,6 +404,8 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
           const events = this.mapToCalendarEvents(workPackages.elements);
 
           this.viewLookup.destroyDetached();
+
+          this.removeExternalEvents();
 
           successCallback(events);
         },
@@ -686,5 +685,17 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
   private toggleAddExistingPane():void {
     this.showAddExistingPane.next(!this.showAddExistingPane.getValue());
     (this.addExistingToggle.nativeElement as HTMLElement).blur();
+  }
+
+  private removeExternalEvents():void {
+    this
+      .ucCalendar
+      .getApi()
+      .getEvents()
+      .forEach((evt) => {
+        if (evt.id.includes('external')) {
+          evt.remove();
+        }
+      });
   }
 }

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -18,12 +18,14 @@ import {
 import {
   BehaviorSubject,
   combineLatest,
+  from,
   Subject,
 } from 'rxjs';
 import {
   debounceTime,
   distinctUntilChanged,
   filter,
+  finalize,
   map,
   mergeMap,
   take,
@@ -63,8 +65,12 @@ import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/r
 import { KeepTabService } from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
 import { HalError } from 'core-app/features/hal/services/hal-error';
 import { ActionsService } from 'core-app/core/state/actions/actions.service';
-import { teamPlannerEventRemoved } from 'core-app/features/team-planner/team-planner/planner/team-planner.actions';
+import {
+  teamPlannerEventAdded,
+  teamPlannerEventRemoved,
+} from 'core-app/features/team-planner/team-planner/planner/team-planner.actions';
 import { imagePath } from 'core-app/shared/helpers/images/path-helper';
+import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 
 @Component({
   selector: 'op-team-planner',
@@ -149,6 +155,8 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     map(([principals, showAddAssignee]) => !principals.length && !showAddAssignee),
   );
 
+  private loading$:Subject<unknown>|null = null;
+
   assignees:HalResource[] = [];
 
   statuses:StatusResource[] = [];
@@ -168,6 +176,8 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     today: this.I18n.t('js.team_planner.today'),
     drag_here_to_remove: this.I18n.t('js.team_planner.drag_here_to_remove'),
     cannot_drag_here: this.I18n.t('js.team_planner.cannot_drag_here'),
+    updating: this.I18n.t('js.ajax.updating'),
+    successful_update: this.I18n.t('js.notice_successful_update'),
   };
 
   principals$ = this.principalIds$
@@ -195,6 +205,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     readonly calendarDrag:CalendarDragDropService,
     readonly keepTab:KeepTabService,
     readonly actions$:ActionsService,
+    readonly toastService:ToastService,
   ) {
     super();
   }
@@ -351,7 +362,9 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
             // DnD configuration
             editable: true,
             droppable: true,
-            eventResize: (resizeInfo:EventResizeDoneArg) => this.updateEvent(resizeInfo),
+            eventResize: (resizeInfo:EventResizeDoneArg) => {
+              const updater = from(this.updateEvent(resizeInfo));
+            },
             eventDragStart: (dragInfo:EventDragStartArg) => {
               const { el } = dragInfo;
               el.style.pointerEvents = 'none';
@@ -363,7 +376,11 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
               this.draggingItem$.next(undefined);
             },
             eventDrop: (dropInfo:EventDropArg) => this.updateEvent(dropInfo),
-            eventReceive: (dropInfo:EventReceiveArg) => this.updateEvent(dropInfo),
+            eventReceive: async (dropInfo:EventReceiveArg) => {
+              await this.updateEvent(dropInfo);
+              const wp = dropInfo.event.extendedProps.workPackage as WorkPackageResource;
+              this.actions$.dispatch(teamPlannerEventAdded({ workPackage: wp.id as string }));
+            },
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             eventContent: (data:EventContentArg) => this.renderTemplate(this.eventContent, this.eventId(data), data),
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -381,17 +398,39 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     this
       .calendar
       .currentWorkPackages$
-      .toPromise()
-      .then((workPackages:WorkPackageCollectionResource) => {
-        const events = this.mapToCalendarEvents(workPackages.elements);
+      .pipe(
+        take(1),
+        finalize(() => this.clearLoading()),
+      )
+      .subscribe(
+        (workPackages:WorkPackageCollectionResource) => {
+          const events = this.mapToCalendarEvents(workPackages.elements);
 
-        this.viewLookup.destroyDetached();
+          this.viewLookup.destroyDetached();
 
-        successCallback(events);
-      })
-      .catch(failureCallback);
+          successCallback(events);
+        },
+        failureCallback,
+      );
 
     void this.calendar.updateTimeframe(fetchInfo, this.projectIdentifier);
+  }
+
+  /**
+   * Clear loading and show successful toast if we were reloading the page
+   * @private
+   */
+  private clearLoading():void {
+    const prevLoading = this.loading$;
+    if (!prevLoading) {
+      return;
+    }
+
+    this.loading$ = null;
+    setTimeout(() => {
+      prevLoading.complete();
+      this.toastService.addSuccess(this.text.successful_update);
+    }, 500);
   }
 
   renderTemplate(template:TemplateRef<unknown>, id:string, data:ResourceLabelContentArg|EventContentArg):{ domNodes:unknown[] } {
@@ -594,9 +633,11 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
 
   private async saveChangeset(changeset:ResourceChangeset<WorkPackageResource>, info?:EventResizeDoneArg|EventDropArg|EventReceiveArg) {
     try {
-      const result = await this.halEditing.save(changeset);
-      this.halNotification.showSave(result.resource, result.wasNew);
+      this.loading$ = new Subject<unknown>();
+      this.toastService.addLoading(this.loading$);
+      await this.halEditing.save(changeset);
     } catch (e:unknown) {
+      this.loading$?.complete();
       this.halNotification.showError((e as HalError).resource, changeset.projectedResource);
       this.calendarDrag.handleDropError(changeset.projectedResource);
       info?.revert();

--- a/frontend/src/app/shared/components/toaster/toast.component.html
+++ b/frontend/src/app/shared/components/toaster/toast.component.html
@@ -1,6 +1,19 @@
 <div class="op-toast -{{ type }}" tabindex="0">
   <div class="op-toast--content" role="alert" aria-atomic="true">
-    <p>
+    <ng-container *ngIf="type === 'loading'">
+      <div
+        *ngIf="(loading$ | async)"
+        class="loading-indicator -small"
+      >
+        <div class="block-1"></div>
+        <div class="block-2"></div>
+        <div class="block-3"></div>
+        <div class="block-4"></div>
+        <div class="block-5"></div>
+      </div>
+      <p [textContent]="toast.message"></p>
+    </ng-container>
+    <p *ngIf="type !== 'loading'">
       <span [textContent]="toast.message"></span>
       <span [textContent]="' '"></span>
       <a class="op-toast--target-link"
@@ -11,7 +24,7 @@
     </p>
     <div [ngSwitch]="type">
       <div *ngSwitchCase="'upload'">
-        <div *ngIf="canBeHidden()">
+        <div *ngIf="canBeHidden">
           <a (click)="show = true" [hidden]="show">
             <op-icon icon-classes="icon-arrow-right2"></op-icon>
           </a>
@@ -20,13 +33,13 @@
           </a>
           <span [textContent]="uploadText"></span>
         </div>
-        <div [ngClass]="{ '-hidden': !show && canBeHidden() }">
+        <div [ngClass]="{ '-hidden': !show && canBeHidden }">
           <ul class="op-toast--uploads" *ngIf="data && data.length > 0">
             <op-toasters-upload-progress
-                *ngFor="let upload of data"
-                [upload]="upload"
-                (onSuccess)="onUploadSuccess()"
-                (onError)="onUploadError($event)">
+              *ngFor="let upload of data"
+              [upload]="upload"
+              (onSuccess)="onUploadSuccess()"
+              (onError)="remove()">
             </op-toasters-upload-progress>
           </ul>
         </div>
@@ -38,14 +51,13 @@
         </ul>
       </div>
     </div>
-  </div>
-  <button
-      *ngIf="removable()"
+    <button
+      *ngIf="removable"
       type="button"
       class="op-link op-toast--close"
       [title]="text.close_popup"
       (click)="remove()"
-  >
-    <op-icon icon-classes="icon-context icon-close icon-no-color"></op-icon>
-  </button>
-</div>
+    >
+      <op-icon icon-classes="icon-context icon-close icon-no-color"></op-icon>
+    </button>
+  </div>

--- a/frontend/src/app/shared/components/toaster/toast.component.ts
+++ b/frontend/src/app/shared/components/toaster/toast.component.ts
@@ -27,7 +27,10 @@
 //++
 
 import {
-  ChangeDetectionStrategy, Component, Input, OnInit,
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
 } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
@@ -35,6 +38,16 @@ import {
   ToastService,
   ToastType,
 } from './toast.service';
+import { UploadInProgress } from 'core-app/core/file-upload/op-file-upload.service';
+import {
+  BehaviorSubject,
+  Observable,
+} from 'rxjs';
+import {
+  finalize,
+  timeout,
+} from 'rxjs/operators';
+import { take } from 'rxjs/internal/operators/take';
 
 @Component({
   templateUrl: './toast.component.html',
@@ -54,27 +67,48 @@ export class ToastComponent implements OnInit {
 
   public show = false;
 
+  public canBeHidden = false;
+
+  public removable = true;
+
+  public loading$ = new BehaviorSubject<boolean>(false);
+
   constructor(readonly I18n:I18nService,
     readonly toastService:ToastService) {
   }
 
-  ngOnInit() {
+  ngOnInit():void {
     this.type = this.toast.type;
+
+    this.removable = !['upload', 'loading'].includes(this.type);
+
+    if (this.type === 'upload') {
+      const data = this.data as UploadInProgress[];
+      this.removable = false;
+      this.canBeHidden = data && data.length > 5;
+    }
+
+    if (this.type === 'loading') {
+      this.removable = false;
+      this.loading$.next(true);
+      (this.data as Observable<unknown>)
+        .pipe(
+          take(1),
+          timeout(20000),
+          finalize(() => {
+            this.loading$.next(false);
+            this.remove();
+          }),
+        )
+        .subscribe();
+    }
   }
 
-  public get data() {
+  public get data():unknown {
     return this.toast.data;
   }
 
-  public canBeHidden() {
-    return this.data && this.data.length > 5;
-  }
-
-  public removable() {
-    return this.toast.type !== 'upload';
-  }
-
-  public remove() {
+  public remove():void {
     this.toastService.remove(this.toast);
   }
 
@@ -82,23 +116,19 @@ export class ToastComponent implements OnInit {
    * Execute the link callback from content.link.target
    * and close this toaster.
    */
-  public executeTarget() {
+  public executeTarget():void {
     if (this.toast.link) {
       this.toast.link.target();
       this.remove();
     }
   }
 
-  public onUploadError(message:string) {
-    this.remove();
-  }
-
-  public onUploadSuccess() {
+  public onUploadSuccess():void {
     this.uploadCount += 1;
   }
 
-  public get uploadText() {
+  public get uploadText():string {
     return this.I18n.t('js.label_upload_counter',
-      { done: this.uploadCount, count: this.data.length });
+      { done: this.uploadCount, count: (this.data as UploadInProgress[]).length });
   }
 }

--- a/frontend/src/app/shared/components/toaster/toast.service.ts
+++ b/frontend/src/app/shared/components/toaster/toast.service.ts
@@ -38,19 +38,21 @@ import {
   IHalMultipleError,
 } from 'core-app/features/hal/resources/error-resource';
 import { HttpErrorResponse } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 export function removeSuccessFlashMessages() {
   jQuery('.flash.notice').remove();
 }
 
-export type ToastType = 'success'|'error'|'warning'|'info'|'upload';
+export type ToastType = 'success'|'error'|'warning'|'info'|'upload'|'loading';
 export const OPToastEvent = 'op:toasters:add';
 
 export interface IToast {
   message:string;
   link?:{ text:string, target:Function };
   type:ToastType;
-  data?:any;
+  data?:unknown;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -58,7 +60,10 @@ export class ToastService {
   // The current stack of toasters
   private stack = input<IToast[]>([]);
 
-  constructor(readonly configurationService:ConfigurationService) {
+  constructor(
+    readonly configurationService:ConfigurationService,
+    readonly I18n:I18nService,
+  ) {
     jQuery(window)
       .on(OPToastEvent,
         (event:JQuery.TriggeredEvent, toast:IToast) => {
@@ -79,7 +84,7 @@ export class ToastService {
 
     this.stack.doModify((current) => {
       const nextValue = [toast].concat(current);
-      _.remove(nextValue, (n, i) => i > 0 && (n.type === 'success' || n.type === 'error'));
+      _.remove(nextValue, (n, i) => i > 0 && this.removeOnAdd(n));
       return nextValue;
     });
 
@@ -89,6 +94,10 @@ export class ToastService {
     }
 
     return toast;
+  }
+
+  private removeOnAdd(toast:IToast):boolean {
+    return ['success', 'error', 'loading'].includes(toast.type);
   }
 
   public addError(obj:HttpErrorResponse|IToast|string, additionalErrors:unknown[]|string = []):IToast {
@@ -133,6 +142,10 @@ export class ToastService {
     return this.add(this.createAttachmentUploadToast(message, uploads));
   }
 
+  public addLoading(observable:Observable<unknown>):IToast {
+    return this.add(this.createLoadingToast(this.I18n.t('js.ajax.updating'), observable));
+  }
+
   public remove(toast:IToast):void {
     this.stack.doModify((current) => {
       _.remove(current, (n) => n === toast);
@@ -160,6 +173,13 @@ export class ToastService {
 
     const toast = this.createToast(message, 'upload');
     toast.data = uploads;
+
+    return toast;
+  }
+
+  private createLoadingToast(message:IToast|string, observable:Observable<unknown>) {
+    const toast = this.createToast(message, 'loading');
+    toast.data = observable;
 
     return toast;
   }

--- a/frontend/src/global_styles/content/_loading_indicator.sass
+++ b/frontend/src/global_styles/content/_loading_indicator.sass
@@ -59,7 +59,8 @@
     margin: 20px auto
 
   &.-small
-    height: 34px
+    width: 40px
+    height: 24px
     margin: 0
     text-align: left
 

--- a/frontend/src/global_styles/content/_toast.sass
+++ b/frontend/src/global_styles/content/_toast.sass
@@ -173,9 +173,9 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
 
   //@hack adapting to provided styles
   //messy I dont have all the details for a magic resolve, this might change
-  & p, & ul
+  & p, & div, & ul
     margin-bottom: 0
-  & p, & ul>li, & .button
+  & p, & div, & ul>li, & .button
     font-size: $nm-font-size
 
 
@@ -225,6 +225,7 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
   .op-toast--content
     width: 100%
 
+    > div,
     > p
       margin-bottom: 0
       color: var(--body-font-color)
@@ -238,6 +239,14 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
         border-radius: $nm-pb-border-radius
       &::-webkit-progress-value
         border-radius: $nm-pb-border-radius
+
+.op-toast.-loading
+  width: 150px
+  margin: 0 auto
+
+  .op-toast--content
+    display: flex
+    align-items: center
 
 // upload toaster styles
 %progress-styles


### PR DESCRIPTION
- [x] When a user makes a modification (eg. moves, stretches or shortens a card), show a load/activity indicator before the "success" toast can be seen. This toast:
  - [x] Is blue (Toast/Information)
  - [x] Icon: the basic CSS loading indicator (animated, reduced in size) replacing the icon on the left
  - [x] Text: "Updating..."
- [x] Once the operation is complete in the background, the blue information toast is replaced by the usual green success toast ("Successful update.")

[OP#41235](https://community.openproject.com/wp/41235)
