### PR TITLE
Stop autoloading constants during initialization

### DIFF
--- a/app/models/activities/fetcher.rb
+++ b/app/models/activities/fetcher.rb
@@ -48,7 +48,7 @@ module Activities
 
     # Returns an array of available event types
     def event_types
-      @event_types ||= begin
+      @event_types ||=
         if @project
           OpenProject::Activity.available_event_types.select do |o|
             @project.self_and_descendants.detect do |_p|
@@ -60,9 +60,8 @@ module Activities
             end
           end
         else
-          OpenProject::Activity.available_event_types
+          OpenProject::Activity.available_event_types.to_a
         end
-      end
     end
 
     # Returns an array of events for the given date range
@@ -92,7 +91,7 @@ module Activities
 
     # Resets the scope to the default scope
     def default_scope!
-      @scope = OpenProject::Activity.default_event_types
+      @scope = OpenProject::Activity.default_event_types.to_a
     end
 
     def events_from_providers(from, to, limit)

--- a/config/constants/open_project/activity.rb
+++ b/config/constants/open_project/activity.rb
@@ -32,15 +32,15 @@ module OpenProject
   module Activity
     class << self
       def available_event_types
-        @available_event_types ||= []
+        @available_event_types ||= Set.new
       end
 
       def default_event_types
-        @default_event_types ||= []
+        @default_event_types ||= Set.new
       end
 
       def providers
-        @providers ||= Hash.new { |h, k| h[k] = [] }
+        @providers ||= Hash.new { |h, k| h[k] = Set.new }
       end
 
       def map(&_block)
@@ -52,12 +52,11 @@ module OpenProject
         options.assert_valid_keys(:class_name, :default)
 
         event_type = event_type.to_s
-        providers = options[:class_name] || event_type.classify
-        providers = ([] << providers) unless providers.is_a?(Array)
+        available_event_types << event_type
+        default_event_types << event_type unless options[:default] == false
 
-        available_event_types << event_type unless available_event_types.include?(event_type)
-        default_event_types << event_type unless default_event_types.include?(event_type) || options[:default] == false
-        self.providers[event_type] += providers
+        providers = options[:class_name] || event_type.classify
+        self.providers[event_type] += Array(providers)
       end
     end
   end

--- a/config/constants/project_activity.rb
+++ b/config/constants/project_activity.rb
@@ -32,7 +32,7 @@ module Constants
   module ProjectActivity
     class << self
       def register(on:, attribute:, chain: [])
-        @registered ||= []
+        @registered ||= Set.new
 
         @registered << { on: on,
                          chain: chain,

--- a/config/initializers/activity.rb
+++ b/config/initializers/activity.rb
@@ -28,31 +28,33 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-OpenProject::Activity.map do |activity|
-  activity.register :work_packages, class_name: '::Activities::WorkPackageActivityProvider'
-  activity.register :changesets, class_name: 'Activities::ChangesetActivityProvider'
-  activity.register :news, class_name: 'Activities::NewsActivityProvider',
-                           default: false
-  activity.register :wiki_edits, class_name: 'Activities::WikiContentActivityProvider',
+Rails.application.reloader.to_prepare do
+  OpenProject::Activity.map do |activity|
+    activity.register :work_packages, class_name: '::Activities::WorkPackageActivityProvider'
+    activity.register :changesets, class_name: 'Activities::ChangesetActivityProvider'
+    activity.register :news, class_name: 'Activities::NewsActivityProvider',
+                             default: false
+    activity.register :wiki_edits, class_name: 'Activities::WikiContentActivityProvider',
+                                   default: false
+    activity.register :messages, class_name: 'Activities::MessageActivityProvider',
                                  default: false
-  activity.register :messages, class_name: 'Activities::MessageActivityProvider',
-                               default: false
+  end
+
+  Project.register_latest_project_activity on: 'WorkPackage',
+                                           attribute: :updated_at
+
+  Project.register_latest_project_activity on: 'News',
+                                           attribute: :updated_at
+
+  Project.register_latest_project_activity on: 'Changeset',
+                                           chain: 'Repository',
+                                           attribute: :committed_on
+
+  Project.register_latest_project_activity on: 'WikiContent',
+                                           chain: %w(Wiki WikiPage),
+                                           attribute: :updated_at
+
+  Project.register_latest_project_activity on: 'Message',
+                                           chain: 'Forum',
+                                           attribute: :updated_at
 end
-
-Project.register_latest_project_activity on: 'WorkPackage',
-                                         attribute: :updated_at
-
-Project.register_latest_project_activity on: 'News',
-                                         attribute: :updated_at
-
-Project.register_latest_project_activity on: 'Changeset',
-                                         chain: 'Repository',
-                                         attribute: :committed_on
-
-Project.register_latest_project_activity on: 'WikiContent',
-                                         chain: %w(Wiki WikiPage),
-                                         attribute: :updated_at
-
-Project.register_latest_project_activity on: 'Message',
-                                         chain: 'Forum',
-                                         attribute: :updated_at

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -34,9 +34,12 @@ Delayed::Worker.logger = nil
 # By default bypass worker queue and execute asynchronous tasks at once
 Delayed::Worker.delay_jobs = true
 
-# Set default priority (lower = higher priority)
-# Example ordering, see ApplicationJob.priority_number
-Delayed::Worker.default_priority = ::ApplicationJob.priority_number(:default)
+# Prevent loading ApplicationJob during initialization
+Rails.application.reloader.to_prepare do
+  # Set default priority (lower = higher priority)
+  # Example ordering, see ApplicationJob.priority_number
+  Delayed::Worker.default_priority = ::ApplicationJob.priority_number(:default)
+end
 
 # Do not retry jobs from delayed_job
 # instead use 'retry_on' activejob functionality

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -6,10 +6,12 @@ I18n::Backend::Simple.include OpenProject::Translations::PluralizationBackend
 # Adds fallback to default locale for untranslated strings
 I18n::Backend::Simple.include I18n::Backend::Fallbacks
 
-# As we enabled +config.i18n.fallbacks+, Rails will fall back
-# to the default locale.
-# When other locales are available, fall back to them.
-if Setting.table_exists? # don't want to prevent migrations
-  defaults = Set.new I18n.fallbacks.defaults + Setting.available_languages.map(&:to_sym)
-  I18n.fallbacks.defaults = defaults
+Rails.application.reloader.to_prepare do
+  # As we enabled +config.i18n.fallbacks+, Rails will fall back
+  # to the default locale.
+  # When other locales are available, fall back to them.
+  if Setting.table_exists? # don't want to prevent migrations
+    defaults = Set.new I18n.fallbacks.defaults + Setting.available_languages.map(&:to_sym)
+    I18n.fallbacks.defaults = defaults
+  end
 end

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -38,7 +38,7 @@ OpenProject::AccessControl.map do |map|
                    global: true,
                    contract_actions: { projects: %i[create] }
 
-    map.permission Backup.permission,
+    map.permission :create_backup,
                    { backups: %i[index] },
                    require: :loggedin,
                    global: true,

--- a/config/initializers/register_mail_interceptors.rb
+++ b/config/initializers/register_mail_interceptors.rb
@@ -31,6 +31,8 @@
 # Register interceptors defined in app/mailers/user_mailer.rb
 # Do this here, so they aren't registered multiple times due to reloading in development mode.
 
-ApplicationMailer.register_interceptor(DefaultHeadersInterceptor)
-# following needs to be the last interceptor
-ApplicationMailer.register_interceptor(DoNotSendMailsWithoutReceiverInterceptor)
+Rails.application.config.action_mailer.interceptors = [
+  "DefaultHeadersInterceptor",
+  # following needs to be the last interceptor
+  "DoNotSendMailsWithoutReceiverInterceptor"
+]

--- a/lib/plugins/acts_as_journalized/lib/acts/journalized/options.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts/journalized/options.rb
@@ -103,7 +103,7 @@ module Acts::Journalized
 
       def options_with_defaults(options)
         {
-          class_name: Journal.name,
+          class_name: 'Journal',
           dependent: :destroy,
           foreign_key: :journable_id,
           timestamp: :updated_at,

--- a/modules/budgets/lib/budgets/engine.rb
+++ b/modules/budgets/lib/budgets/engine.rb
@@ -42,17 +42,15 @@ module Budgets
       mount ::API::V3::Budgets::BudgetsByProjectAPI
     end
 
-    initializer 'budgets.register_latest_project_activity' do
-      Project.register_latest_project_activity on: 'Budget',
-                                               attribute: :updated_at
-    end
-
     initializer 'budgets.register_hooks' do
       # TODO: avoid hooks as this is part of the core now
       require 'budgets/hooks/work_package_hook'
     end
 
     config.to_prepare do
+      Project.register_latest_project_activity on: 'Budget',
+                                               attribute: :updated_at
+
       # Add to the budget to the costs group
       ::Type.add_default_mapping(:costs, :budget)
 

--- a/modules/costs/lib/costs/engine.rb
+++ b/modules/costs/lib/costs/engine.rb
@@ -248,12 +248,10 @@ module Costs
              writable: false
     end
 
-    initializer 'costs.register_latest_project_activity' do
+    config.to_prepare do
       Project.register_latest_project_activity on: 'TimeEntry',
                                                attribute: :updated_at
-    end
 
-    config.to_prepare do
       Costs::Patches::MembersPatch.mixin!
 
       ##

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -80,12 +80,10 @@ module OpenProject::Meeting
       mount ::API::V3::Meetings::MeetingContentsAPI
     end
 
-    initializer 'meeting.register_latest_project_activity' do
+    config.to_prepare do
       Project.register_latest_project_activity on: 'Meeting',
                                                attribute: :updated_at
-    end
 
-    config.to_prepare do
       PermittedParams.permit(:search, :meetings)
     end
 


### PR DESCRIPTION
When running test, we get this warning:

```
DEPRECATION WARNING: Initialization autoloaded the constants Redmine::I18n, OpenProject::NullDbFallback, Redmine::Diff, Redmine::Diff::Diffable, JobStatus, JobStatus::ApplicationJobWithStatus, OpenProject::TextFormatting::Truncation, OpenProject::TextFormatting, OpenProject::ObjectLinking, OpenProject::SafeParams, HookHelper, IconsHelper, AuthenticationStagePathHelper, AdditionalUrlHelpers, OpenProject::PageHierarchyHelper, ApplicationHelper, ApplicationRecord, Pagination, Pagination::Model, Projects, Projects::Storage, Projects::Activity, Projects::Hierarchy, Projects::AncestorsFromRoot, Scopes, Scopes::Scoped, OpenProject::ActsAsUrl, OpenProject::ActsAsUrl::Adapter, OpenProject::ActsAsUrl::Adapter::OpActiveRecord, Projects::Scopes, Projects::Scopes::ActivatedTimeActivity, Projects::Scopes::VisibleWithActivatedTimeActivity, Project, ApplicationJob, OpenProject::Database, API, API::V3, API::V3::Utilities, API::Utilities, OpenProject::StaticRouting, API::Utilities::UrlHelper, API::V3::Utilities::PathHelper, OpenProject::Deprecation, Setting::CallbacksHelper, Setting::Aliases, Setting, OpenProject::AccessControl::Mapper, OpenProject::AccessControl::Permission, Export, OpenProject::JournalFormatter, OpenProject::JournalFormatter::Diff, OpenProject::JournalFormatter::Attachment, CustomFieldsHelper, OpenProject::JournalFormatter::CustomField, OpenProject::JournalFormatter::ScheduleManually, Journal, FileUploader, LocalFileUploader, Attachment, Backup, OpenProjectErrorHelper, AccessibilityHelper, DeprecatedAlias, WorkPackagesHelper, OpenProject::LocaleHelper, Mails, Mails::MailerJob, ApplicationMailer, DefaultHeadersInterceptor, DoNotSendMailsWithoutReceiverInterceptor, FrontendAssetHelper, OpenProject::Logging::SentryLogger, Sessions, Sessions::SqlBypass, OpenProject::Notifications, OpenProject::Events, UserInvitation, OpenProject::Authentication::Strategies::Warden::AnonymousFallback, RbCommonHelper, AngularHelper, RailsCell, and OpenProject::JobStatus::EventListener.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload Redmine::I18n, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

    Rails.application.reloader.to_prepare do
      # Autoload classes and modules needed at boot time here.
    end

That block runs when the application boots, and every time there is a reload.
For historical reasons, it may run twice, so it has to be idempotent.

Check the "Autoloading and Reloading Constants" guide to learn more about how
Rails autoloads and reloads.
```

Autoloading constants in initializers will be a blocker when we'll migrate to Rails 7.

The tricky part when moving to `to_prepare` call back is that it can be called multiple times, and thus needs to be idempotent.