### PR TITLE
Fix error when changing parent of sub-sub-work_package

### DIFF
--- a/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -340,4 +340,78 @@ describe WorkPackages::UpdateAncestorsService, type: :model, with_mail: false do
       it_behaves_like 'updates the attributes within the new hierarchy'
     end
   end
+
+  context 'with a common ancestor' do
+    let(:status) { open_status }
+    let(:done_ratio) { 50 }
+    let(:estimated_hours) { 7.0 }
+
+    let!(:grandparent) do
+      create :work_package,
+             derived_estimated_hours: estimated_hours,
+             done_ratio: done_ratio
+    end
+    let!(:old_parent) do
+      create :work_package,
+             parent: grandparent,
+             derived_estimated_hours: estimated_hours,
+             done_ratio: done_ratio
+    end
+    let!(:new_parent) do
+      create :work_package,
+             parent: grandparent
+    end
+    let!(:work_package) do
+      create :work_package,
+             parent: old_parent,
+             status: status,
+             estimated_hours: estimated_hours,
+             done_ratio: done_ratio
+    end
+
+    subject do
+      work_package.parent = new_parent
+      # In this test case, derived_estimated_hours and done_ratio will not
+      # inherently change on grandparent.  However, if work_package has siblings
+      # then changing its parent could cause derived_estimated_hours and/or
+      # done_ratio on grandparent to inherently change.  To verify that
+      # grandparent can be properly updated in that case without making this
+      # test dependent on the implementation details of the
+      # derived_estimated_hours and done_ratio calculations, force
+      # derived_estimated_hours and done_ratio to change at the same time as the
+      # parent.
+      work_package.estimated_hours = (estimated_hours + 1)
+      work_package.done_ratio = (done_ratio + 1)
+      work_package.save!
+
+      described_class
+        .new(user: user,
+             work_package: work_package)
+        .call(%i(parent))
+    end
+
+    before do
+      subject
+    end
+
+    it 'is successful' do
+      expect(subject)
+        .to be_success
+    end
+
+    it 'returns both the former and new ancestors in the dependent results without duplicates' do
+      expect(subject.dependent_results.map(&:result))
+        .to match_array [new_parent, grandparent, old_parent]
+    end
+
+    it 'updates the done_ratio of the former parent' do
+      expect(old_parent.reload(select: :done_ratio).done_ratio)
+        .to be 0
+    end
+
+    it 'updates the estimated_hours of the former parent' do
+      expect(old_parent.reload(select: :derived_estimated_hours).derived_estimated_hours)
+        .to be_nil
+    end
+  end
 end


### PR DESCRIPTION
If the parent of a work package is changed and the new parent has any common ancestors with the old parent, then the change will fail and the following message will be shown in the UI:
Could not update the resource because of conflicting modifications. Click here to refresh the resource and update to the newest version.

This happens because ActiveRecord optimistic locking is enabled and update_ancestors_service.rb does the following:
* Retrieve all new ancestors and update estimated_hours and done_ratio without saving.
* Retrieve all old ancestors and update estimated_hours and done_ratio without saving.
* Save both the new and old ancestors.

If there are any work packages that are both new and old ancestors then those work packages will be retrieved from the database twice, both copies will be updated, then both copies will be saved, resulting in an optimistic lock conflict.

This commit corrects this issue by collecting and deduplicating the list of ancestors before updating them.