### PR TITLE
[41086] Load assignable capabilities for selected projects to check constraints

### DIFF
--- a/frontend/src/app/core/state/capabilities/capabilities.query.ts
+++ b/frontend/src/app/core/state/capabilities/capabilities.query.ts
@@ -1,0 +1,5 @@
+import { QueryEntity } from '@datorama/akita';
+import { CapabilitiesState } from 'core-app/core/state/capabilities/capabilities.store';
+
+export class CapabilitiesQuery extends QueryEntity<CapabilitiesState> {
+}

--- a/frontend/src/app/core/state/capabilities/capabilities.service.ts
+++ b/frontend/src/app/core/state/capabilities/capabilities.service.ts
@@ -4,33 +4,30 @@ import {
   tap,
 } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import {
-  applyTransaction,
-  ID,
-} from '@datorama/akita';
+import { ID } from '@datorama/akita';
 import { HttpClient } from '@angular/common/http';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
-import { ProjectsQuery } from 'core-app/core/state/projects/projects.query';
 import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
 import {
   collectionKey,
   insertCollectionIntoState,
 } from 'core-app/core/state/collection-store';
-import { ProjectsStore } from './projects.store';
-import { IProject } from './project.model';
+import { ICapability } from 'core-app/core/state/capabilities/capability.model';
+import { CapabilitiesStore } from 'core-app/core/state/capabilities/capabilities.store';
+import { CapabilitiesQuery } from 'core-app/core/state/capabilities/capabilities.query';
 
 @Injectable()
-export class ProjectsResourceService {
-  protected store = new ProjectsStore();
+export class CapabilitiesResourceService {
+  protected store = new CapabilitiesStore();
 
-  readonly query = new ProjectsQuery(this.store);
+  readonly query = new CapabilitiesQuery(this.store);
 
-  private get projectsPath():string {
+  private get capabilitiesPath():string {
     return this
       .apiV3Service
-      .projects
+      .capabilities
       .path;
   }
 
@@ -41,12 +38,12 @@ export class ProjectsResourceService {
   ) {
   }
 
-  fetchProjects(params:ApiV3ListParameters):Observable<IHALCollection<IProject>> {
+  fetchCapabilities(params:ApiV3ListParameters):Observable<IHALCollection<ICapability>> {
     const collectionURL = collectionKey(params);
 
     return this
       .http
-      .get<IHALCollection<IProject>>(this.projectsPath + collectionURL)
+      .get<IHALCollection<ICapability>>(this.capabilitiesPath + collectionURL)
       .pipe(
         tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
         catchError((error) => {
@@ -56,22 +53,7 @@ export class ProjectsResourceService {
       );
   }
 
-  update(id:ID, project:Partial<IProject>):void {
+  update(id:ID, project:Partial<ICapability>):void {
     this.store.update(id, project);
-  }
-
-  modifyCollection(params:ApiV3ListParameters, callback:(collection:ID[]) => ID[]):void {
-    const key = collectionKey(params);
-    this.store.update(({ collections }) => (
-      {
-        collections: {
-          ...collections,
-          [key]: {
-            ...collections[key],
-            ids: [...callback(collections[key]?.ids || [])],
-          },
-        },
-      }
-    ));
   }
 }

--- a/frontend/src/app/core/state/capabilities/capabilities.store.ts
+++ b/frontend/src/app/core/state/capabilities/capabilities.store.ts
@@ -1,0 +1,13 @@
+import { EntityStore, StoreConfig } from '@datorama/akita';
+import { CollectionState, createInitialCollectionState } from 'core-app/core/state/collection-store';
+import { ICapability } from 'core-app/core/state/capabilities/capability.model';
+
+export interface CapabilitiesState extends CollectionState<ICapability> {
+}
+
+@StoreConfig({ name: 'capabilities' })
+export class CapabilitiesStore extends EntityStore<CapabilitiesState> {
+  constructor() {
+    super(createInitialCollectionState());
+  }
+}

--- a/frontend/src/app/core/state/capabilities/capability.model.ts
+++ b/frontend/src/app/core/state/capabilities/capability.model.ts
@@ -1,0 +1,17 @@
+import {
+  IHalResourceLink,
+  IHalResourceLinks,
+} from 'core-app/core/state/hal-resource';
+
+export interface ICapabilityHalResourceLinks extends IHalResourceLinks {
+  self:IHalResourceLink;
+
+  action:IHalResourceLink;
+  context:IHalResourceLink;
+  principal:IHalResourceLink;
+}
+
+export interface ICapability {
+  id:string;
+  _links:ICapabilityHalResourceLinks;
+}

--- a/frontend/src/app/core/state/collection-store.ts
+++ b/frontend/src/app/core/state/collection-store.ts
@@ -11,10 +11,7 @@ import {
   listParamsString,
 } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
 import { Observable } from 'rxjs';
-import {
-  filter,
-} from 'rxjs/operators';
-import { HasId } from 'core-app/core/apiv3/cache/state-cache.service';
+import { filter } from 'rxjs/operators';
 
 export interface CollectionResponse {
   ids:ID[];

--- a/frontend/src/app/core/state/collection-store.ts
+++ b/frontend/src/app/core/state/collection-store.ts
@@ -1,5 +1,7 @@
 import {
+  applyTransaction,
   EntityState,
+  EntityStore,
   ID,
   QueryEntity,
 } from '@datorama/akita';
@@ -12,6 +14,7 @@ import { Observable } from 'rxjs';
 import {
   filter,
 } from 'rxjs/operators';
+import { HasId } from 'core-app/core/apiv3/cache/state-cache.service';
 
 export interface CollectionResponse {
   ids:ID[];
@@ -99,4 +102,34 @@ export function selectCollectionAsEntities$<T extends CollectionItem>(service:Co
   const collection = state.collections[key];
 
   return selectEntitiesFromIDCollection(service, collection);
+}
+
+/**
+ * Insert a collection into the given entity store
+ *
+ * @param store An entity store for the collection
+ * @param collection A loaded collection
+ * @param collectionUrl The key to insert the collection at
+ */
+export function insertCollectionIntoState<T extends { id:ID }>(
+  store:EntityStore<CollectionState<T>>,
+  collection:IHALCollection<T>,
+  collectionUrl:string,
+):void {
+  // Some JSON endpoints return no elements result if there are no elements
+  const ids = collection._embedded.elements?.map((el) => el.id) || [];
+
+  applyTransaction(() => {
+    store.add(collection._embedded.elements);
+    store.update(({ collections }) => (
+      {
+        collections: {
+          ...collections,
+          [collectionUrl]: {
+            ids,
+          },
+        },
+      }
+    ));
+  });
 }

--- a/frontend/src/app/core/state/in-app-notifications/in-app-notifications.service.ts
+++ b/frontend/src/app/core/state/in-app-notifications/in-app-notifications.service.ts
@@ -14,7 +14,10 @@ import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
 import { HttpClient } from '@angular/common/http';
 import { InAppNotificationsQuery } from 'core-app/core/state/in-app-notifications/in-app-notifications.query';
 import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
-import { collectionKey } from 'core-app/core/state/collection-store';
+import {
+  collectionKey,
+  insertCollectionIntoState,
+} from 'core-app/core/state/collection-store';
 import {
   markNotificationsAsRead,
   notificationsMarkedRead,
@@ -56,22 +59,7 @@ export class InAppNotificationsResourceService {
       .http
       .get<IHALCollection<InAppNotification>>(this.notificationsPath + collectionURL)
       .pipe(
-        tap((events) => {
-          applyTransaction(() => {
-            this.store.add(events._embedded.elements);
-            this.store.update(({ collections }) => (
-              {
-                collections: {
-                  ...collections,
-                  [collectionURL]: {
-                    ...collections[collectionURL],
-                    ids: events._embedded.elements.map((el) => el.id),
-                  },
-                },
-              }
-            ));
-          });
-        }),
+        tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
         catchError((error) => {
           this.toastService.addError(error);
           throw error;

--- a/frontend/src/app/core/state/openproject-state.module.ts
+++ b/frontend/src/app/core/state/openproject-state.module.ts
@@ -32,12 +32,14 @@ import {
 import { InAppNotificationsResourceService } from './in-app-notifications/in-app-notifications.service';
 import { ProjectsResourceService } from './projects/projects.service';
 import { PrincipalsResourceService } from './principals/principals.service';
+import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
 
 @NgModule({
   providers: [
     InAppNotificationsResourceService,
     ProjectsResourceService,
     PrincipalsResourceService,
+    CapabilitiesResourceService,
   ],
 })
 export class OpenProjectStateModule {

--- a/frontend/src/app/core/state/principals/principals.service.ts
+++ b/frontend/src/app/core/state/principals/principals.service.ts
@@ -14,7 +14,10 @@ import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
 import { HttpClient } from '@angular/common/http';
 import { PrincipalsQuery } from 'core-app/core/state/principals/principals.query';
 import { ApiV3ListParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
-import { collectionKey } from 'core-app/core/state/collection-store';
+import {
+  collectionKey,
+  insertCollectionIntoState,
+} from 'core-app/core/state/collection-store';
 import {
   EffectHandler,
 } from 'core-app/core/state/effects/effect-handler.decorator';
@@ -51,22 +54,7 @@ export class PrincipalsResourceService {
       .http
       .get<IHALCollection<IPrincipal>>(this.principalsPath + collectionURL)
       .pipe(
-        tap((events) => {
-          applyTransaction(() => {
-            this.store.add(events._embedded.elements);
-            this.store.update(({ collections }) => (
-              {
-                collections: {
-                  ...collections,
-                  [collectionURL]: {
-                    ...collections[collectionURL],
-                    ids: events._embedded.elements.map((el) => el.id),
-                  },
-                },
-              }
-            ));
-          });
-        }),
+        tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
         catchError((error) => {
           this.toastService.addError(error);
           throw error;

--- a/frontend/src/app/features/calendar/op-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-calendar.service.ts
@@ -301,6 +301,8 @@ export class OpCalendarService extends UntilDestroyedMixin {
         { n: 'status', o: '*', v: [] },
         this.dateFilter(startDate, endDate),
       ],
+      dr: 'cards',
+      hi: false,
       pp: OpCalendarService.MAX_DISPLAYED,
       pa: 1,
     };

--- a/modules/team_planner/spec/features/team_planner_subproject_constraints_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_subproject_constraints_spec.rb
@@ -1,0 +1,97 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require_relative './shared_context'
+
+describe 'Team planner constraints for a subproject', type: :feature, js: true do
+  before do
+    with_enterprise_token(:team_planner_view)
+  end
+
+  include_context 'with team planner full access'
+
+  let!(:other_user) do
+    create :user,
+           firstname: 'Bernd',
+           member_in_project: project,
+           member_with_permissions: %w[
+             view_work_packages view_team_planner work_package_assigned
+           ]
+  end
+
+  let!(:subproject) { create :project, parent: project }
+  let!(:role) { create :role, permissions: %i[view_work_packages edit_work_packages work_package_assigned] }
+  let!(:member) { create :member, principal: user, project: subproject, roles: [role] }
+  let(:project_include) { ::Components::ProjectIncludeComponent.new }
+
+  let!(:work_package) do
+    create :work_package,
+           project: subproject,
+           assigned_to: user,
+           start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
+           due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
+  end
+
+  it 'shows a visual aid that the other user cannot be assigned' do
+    team_planner.visit!
+
+    team_planner.add_assignee user
+    retry_block do
+      team_planner.add_assignee other_user
+    end
+
+    # Include the subproject
+    project_include.toggle!
+    project_include.toggle_checkbox(subproject.id)
+    project_include.click_button 'Apply'
+    project_include.expect_count 2
+
+    team_planner.within_lane(user) do
+      team_planner.expect_event work_package
+    end
+
+    retry_block do
+      # Ensure we're not dragging anything
+      drag_release
+
+      # Try to drag work package to other user
+      start_dragging team_planner.event(work_package)
+      drag_element_to find(".fc-timeline-lane[data-resource-id='/api/v3/users/#{other_user.id}']")
+
+      # Expect background event on other user
+      page.find(".fc-timeline-lane[data-resource-id='/api/v3/users/#{other_user.id}'] .fc-bg-event")
+      drag_element_to find(".fc-timeline-lane[data-resource-id='/api/v3/users/#{user.id}']")
+      drag_release
+
+      unless page.has_no_selector?(".fc-timeline-lane[data-resource-id='/api/v3/users/#{other_user.id}'] .fc-bg-event")
+        raise "Expected to have no bg-event after release"
+      end
+    end
+  end
+end

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -122,7 +122,11 @@ module Pages
     end
 
     def expect_event(work_package, present: true)
-      expect(page).to have_conditional_selector(present, '.fc-event', text: work_package.subject)
+      if present
+        expect(page).to have_selector('.fc-event', text: work_package.subject, wait: 10)
+      else
+        expect(page).to have_no_selector('.fc-event', text: work_package.subject)
+      end
     end
 
     def add_assignee(name)


### PR DESCRIPTION
[OP#41086](https://community.openproject.com/wp/41086)

**Acceptance criteria**
- Adding other projects via the include project dialogue will not change the scope of the assignees that can be added to the team planner; this is limited by the users in the parent project. (Unchanged, existing behavior)
- For each assignee, the team planner will also view display work packages that they are assigneed to in the included project(s).(Unchanged, existing behavior)
- Removing these included projects will then also remove these work packages. (Unchanged, existing behavior)
- Work packages from other projects are more likely to have resctrictions in terms of assignee changes (depending on which user is attempting the modification), so on drag start:
  - [x] Indicate which assignees are unable to receive dragged work package by providing a visual reference (a red highlight or dimmed overlay over invalid assignees).
  - [x] The determination of which assignees can "receive" which work packages should ideally determined pre-drag, in a way that reduces visible lag.