### PR TITLE
[40856] Team planner animation - fix test failed issues

### DIFF
--- a/app/views/common/upsale.html.erb
+++ b/app/views/common/upsale.html.erb
@@ -22,7 +22,7 @@
 
     <% if feature_video.empty? %>
       <% if feature_image.empty? %>
-        <%= image_tag "enterprise_edition.png", class: "widget-box--teaser-image" %>
+        <%= image_tag "enterprise_edition.png", class: "widget-box--teaser-image_default" %>
       <% else %>
         <%= image_tag feature_image, class: "widget-box--teaser-image" %>
       <% end %>

--- a/app/views/types/form/_form_configuration.html.erb
+++ b/app/views/types/form/_form_configuration.html.erb
@@ -33,44 +33,16 @@ See COPYRIGHT and LICENSE files for more details.
   <div>
     <div class="grid-block -visible-overflow wrap">
       <div class="grid-content -visible-overflow small-12 large-10">
-        <div class="op-toast -info">
-          <div class="op-toast--content">
-            <p><%= t('text_form_configuration') %></p>
-            <br>
-            <p><%= t('text_custom_field_hint_activate_per_project') %></p>
-          </div>
-        </div>
 
         <% if EnterpriseToken.show_banners? %>
-          <div class="op-toast upsale-notification">
-            <div class="op-toast--content">
-              <h3><%= t('admin.enterprise.upgrade_to_ee') %></h3>
-              <%= image_tag "enterprise_edition.png", class: "widget-box--teaser-image" %>
-
-              <p><%= t('ee.upsale.form_configuration.description') %></p>
-
-              <ul class="">
-                <li>
-                  <%= t('ee.upsale.form_configuration.add_groups') %>
-                </li>
-                <li>
-                  <%= t('ee.upsale.form_configuration.rename_groups') %>
-                </li>
-              </ul>
-              <p>
-                <br/>
-                <b><%= t('js.admin.enterprise.upsale.become_hero') %></b> <%= t('js.admin.enterprise.upsale.you_contribute') %>
-              </p>
-              <%= link_to("#{OpenProject::Static::Links.links[:upsale][:href]}/?utm_source=unknown&utm_medium=community-edition&utm_campaign=form-configuration",
-                          { class: 'button -alt-highlight',
-                            aria: { label: t('admin.enterprise.order') },
-                            target: '_blank',
-                            title: t('admin.enterprise.order') }) do %>
-                <%= op_icon('button--icon icon-add') %>
-                <span class="button--text"><%= t('admin.enterprise.order') %></span>
-              <% end %>
-            </div>
-          </div>
+        <%= render template: 'common/upsale',
+           locals: {
+               feature_title:  t('types.edit.form_configuration'),
+               feature_description: t('text_form_configuration') + t('text_custom_field_hint_activate_per_project'),
+               feature_reference: 'form-configuration',
+               feature_image: '',
+               feature_video: ''
+           } %>
         <% end %>
         <% no_filter_query = ::API::V3::Queries::QueryParamsRepresenter.new(Query.new_default.tap { |q| q.filters = [] }).to_json %>
         <%= f.hidden_field :attribute_groups, value: '', class: 'admin-type-form--hidden-field'  %>

--- a/frontend/src/global_styles/content/_enterprise.sass
+++ b/frontend/src/global_styles/content/_enterprise.sass
@@ -1,21 +1,28 @@
 @import '../../app/spot/styles/sass/variables'
 
 .upsale-notification
-  max-width: 900px
+  max-width: 800px
   margin: auto
   padding-top: 20px
   text-align: center
 
+
   .widget-box--teaser-image
     width: 100%
-    max-height: 500px
-    padding: 20px
+    height: 40vh
+    margin-bottom: 20px
+    border: 1px solid $spot-color-main-dark
+    border-radius: 20px
+  
+  .widget-box--teaser-image_default
+    width: 30%
     margin-bottom: 20px
     border: 1px solid $spot-color-main-dark
     border-radius: 20px
     
   .widget-box--teaser-video
     width: 100%
+    height: 40vh
     margin-bottom: 20px
     border: 1px solid $spot-color-main-dark
     border-radius: 20px

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/upsale.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/upsale.html.erb
@@ -1,30 +1,10 @@
 <% html_title(t(:label_administration), t('ldap_groups.synchronized_groups.plural')) -%>
 
-<%= breadcrumb_toolbar(t('ldap_groups.synchronized_groups.plural')) %>
-<div class="op-toast upsale-notification">
-  <div class="op-toast--content">
-    <h3><%= t('admin.enterprise.upgrade_to_ee') %></h3>
-    <%= image_tag "enterprise_edition.png", class: "widget-box--teaser-image" %>
-
-    <p><%= t('js.admin.enterprise.upsale.benefits.description') %></p>
-
-    <ul class="">
-      <li>
-        <%= t('js.admin.enterprise.upsale.benefits.premium_features_text') %>
-      </li>
-      <li>
-        <%= t('js.admin.enterprise.upsale.benefits.professional_support_text') %>
-      </li>
-    </ul>
-    <p>
-      <b><%= t('js.admin.enterprise.upsale.become_hero') %></b> <%= t('js.admin.enterprise.upsale.you_contribute') %>
-    </p>
-    <%= link_to( "#{OpenProject::Static::Links.links[:upsale][:href]}/?utm_source=unknown&utm_medium=community-edition&utm_campaign=enterprise-ldap-groups",
-                 { class: 'button -alt-highlight',
-                   aria: {label: t('admin.enterprise.order')},
-                   title: t('admin.enterprise.order')}) do %>
-      <%= op_icon('button--icon icon-add') %>
-      <span class="button--text"><%= t('admin.enterprise.order') %></span>
-    <% end %>
-  </div>
-</div>
+<%= render template: 'common/upsale',
+           locals: {
+               feature_title:  t('ldap_groups.synchronized_groups.plural'),
+               feature_description: '',
+               feature_reference: 'enterprise-ldap-groups',
+               feature_image: '',
+               feature_video: ''
+           } %>

--- a/modules/openid_connect/app/views/openid_connect/providers/upsale.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/upsale.html.erb
@@ -1,31 +1,10 @@
 <% html_title(t(:label_administration), t('openid_connect.providers.plural')) -%>
 
-
-<%= breadcrumb_toolbar(t('openid_connect.providers.plural')) %>
-<div class="op-toast upsale-notification">
-  <div class="op-toast--content">
-    <h3><%= t('admin.enterprise.upgrade_to_ee') %></h3>
-    <%= image_tag "enterprise_edition.png", class: "widget-box--teaser-image" %>
-
-    <p><%= t('js.admin.enterprise.upsale.benefits.description') %></p>
-
-    <ul class="">
-      <li>
-        <%= t('js.admin.enterprise.upsale.benefits.premium_features_text') %>
-      </li>
-      <li>
-        <%= t('js.admin.enterprise.upsale.benefits.professional_support_text') %>
-      </li>
-    </ul>
-    <p>
-      <b><%= t('js.admin.enterprise.upsale.become_hero') %></b> <%= t('js.admin.enterprise.upsale.you_contribute') %>
-    </p>
-    <%= link_to( "#{OpenProject::Static::Links.links[:upsale][:href]}/?utm_source=unknown&utm_medium=community-edition&utm_campaign=enterprise-openid-connect",
-                 { class: 'button -alt-highlight',
-                   aria: {label: t('admin.enterprise.order')},
-                   title: t('admin.enterprise.order')}) do %>
-      <%= op_icon('button--icon icon-add') %>
-      <span class="button--text"><%= t('admin.enterprise.order') %></span>
-    <% end %>
-  </div>
-</div>
+<%= render template: 'common/upsale',
+           locals: {
+               feature_title:  t('openid_connect.providers.plural'),
+               feature_description: '',
+               feature_reference: 'enterprise-openid-connect',
+               feature_image: '',
+               feature_video: ''
+           } %>


### PR DESCRIPTION
Remove padding around the image.
Reduce the size of default image.
Use common upsale template in OpenID-providers, LDAP groups, and Form configuration.

https://community.openproject.org/work_packages/40856/activity