### PR TITLE
Finished model specs for FileLink, adding two validates to the model

### DIFF
--- a/modules/storages/app/models/storages/file_link.rb
+++ b/modules/storages/app/models/storages/file_link.rb
@@ -38,14 +38,23 @@
 # Additional attributes and constraints are defined in
 # db/migrate/20220113144759_create_file_links.rb migration.
 class Storages::FileLink < ApplicationRecord
-  # Every FileLink references it's Storage. A "on delete cascade"
-  # is defined in the migration, so this FileLink will be deleted
-  # when deleting the Storage.
+  # Every FileLink references its Storage. A "on delete cascade" is defined in
+  # the migration, so this FileLink will be deleted when deleting the Storage.
   belongs_to :storage
+
+  # The object who created the FileLink should be of type User.
   belongs_to :creator, class_name: 'User'
+
   # FileLinks are attached to a container ()currently a WorkPackage)
   # Wieland: This needs to become more flexible in the future
   belongs_to :container, class_name: 'WorkPackage'
+
+  # Currently only WorkPackages are supported as containers for FileLinks
+  # For some reason this case is not handled in the belongs_to above.
+  validates :container_type, inclusion: { in: ["WorkPackage"] }
+
+  # origin_id is the Nextcloud ID of the file and should be valid.
+  validates :origin_id, presence: true
 
   # A standard Rails custom query:
   # https://www.rubyguides.com/2019/10/scopes-in-ruby-on-rails/

--- a/modules/storages/spec/models/file_link_spec.rb
+++ b/modules/storages/spec/models/file_link_spec.rb
@@ -53,19 +53,16 @@ describe ::Storages::FileLink, type: :model do
       expect(file_link).to be_valid
     end
 
-    # ToDo: Finish test
-    # rubocop:disable Lint/UselessAssignment
     it "fails when creating an instance with an unsupported container type" do
       file_link = described_class.create(attributes.merge({ container_id: creator.id, container_type: "User" }))
-      # ToDo: expect(file_link).to be_invalid
+      expect(file_link).to be_invalid
     end
 
     it "create instance should fail with empty origin_id" do
       file_link = described_class.create(attributes.merge({ origin_id: "" }))
-      # ToDo: expect(file_link).to be_invalid
+      expect(file_link).to be_invalid
     end
   end
-  # rubocop:enable Lint/UselessAssignment
 
   describe '#destroy' do
     let(:file_link_to_destroy) { described_class.create(attributes) }


### PR DESCRIPTION
./spec/model/file_link_spec.rb had outcommented tests that didn't work.
I've re-enabled the test and added validations to the model to implement the tests:
- FileLink.origin_id should have length > 1
- FileLink.container should be of type WorkPackage