### PR TITLE
remove ruby magic comment for utf-8

### DIFF
--- a/app/cells/individual_principal_base_filter_cell.rb
+++ b/app/cells/individual_principal_base_filter_cell.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/cells/placeholder_users/placeholder_user_filter_cell.rb
+++ b/app/cells/placeholder_users/placeholder_user_filter_cell.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/cells/placeholder_users/row_cell.rb
+++ b/app/cells/placeholder_users/row_cell.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/cells/placeholder_users/table_cell.rb
+++ b/app/cells/placeholder_users/table_cell.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/cells/user_filter_cell.rb
+++ b/app/cells/user_filter_cell.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/cells/users/user_filter_cell.rb
+++ b/app/cells/users/user_filter_cell.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/contracts/attachments/create_contract.rb
+++ b/app/contracts/attachments/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/attachments/delete_contract.rb
+++ b/app/contracts/attachments/delete_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/attachments/prepare_upload_contract.rb
+++ b/app/contracts/attachments/prepare_upload_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/attachments/validate_replacements.rb
+++ b/app/contracts/attachments/validate_replacements.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/attribute_help_texts/base_contract.rb
+++ b/app/contracts/attribute_help_texts/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/attribute_help_texts/create_contract.rb
+++ b/app/contracts/attribute_help_texts/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/attribute_help_texts/update_contract.rb
+++ b/app/contracts/attribute_help_texts/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/authentication/omniauth_auth_hash_contract.rb
+++ b/app/contracts/authentication/omniauth_auth_hash_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/base_contract.rb
+++ b/app/contracts/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/concerns/assignable_custom_field_values.rb
+++ b/app/contracts/concerns/assignable_custom_field_values.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/concerns/requires_admin_guard.rb
+++ b/app/contracts/concerns/requires_admin_guard.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/concerns/requires_enterprise_guard.rb
+++ b/app/contracts/concerns/requires_enterprise_guard.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/concerns/single_table_inheritance_model_contract.rb
+++ b/app/contracts/concerns/single_table_inheritance_model_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/concerns/unchanged_project.rb
+++ b/app/contracts/concerns/unchanged_project.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/custom_actions/cu_contract.rb
+++ b/app/contracts/custom_actions/cu_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/custom_actions/execute_contract.rb
+++ b/app/contracts/custom_actions/execute_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/custom_fields/base_contract.rb
+++ b/app/contracts/custom_fields/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/custom_fields/create_contract.rb
+++ b/app/contracts/custom_fields/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/custom_fields/update_contract.rb
+++ b/app/contracts/custom_fields/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/empty_contract.rb
+++ b/app/contracts/empty_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/groups/create_contract.rb
+++ b/app/contracts/groups/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/groups/delete_contract.rb
+++ b/app/contracts/groups/delete_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/groups/update_contract.rb
+++ b/app/contracts/groups/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/messages/base_contract.rb
+++ b/app/contracts/messages/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/messages/create_contract.rb
+++ b/app/contracts/messages/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/messages/update_contract.rb
+++ b/app/contracts/messages/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/model_contract.rb
+++ b/app/contracts/model_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/oauth/application_contract.rb
+++ b/app/contracts/oauth/application_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/params_contract.rb
+++ b/app/contracts/params_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/placeholder_users/base_contract.rb
+++ b/app/contracts/placeholder_users/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/placeholder_users/create_contract.rb
+++ b/app/contracts/placeholder_users/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/placeholder_users/delete_contract.rb
+++ b/app/contracts/placeholder_users/delete_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/placeholder_users/update_contract.rb
+++ b/app/contracts/placeholder_users/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/projects/delete_contract.rb
+++ b/app/contracts/projects/delete_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/queries/base_contract.rb
+++ b/app/contracts/queries/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/queries/copy_contract.rb
+++ b/app/contracts/queries/copy_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/queries/create_contract.rb
+++ b/app/contracts/queries/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/queries/update_contract.rb
+++ b/app/contracts/queries/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/queries/update_form_contract.rb
+++ b/app/contracts/queries/update_form_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/relations/base_contract.rb
+++ b/app/contracts/relations/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/relations/create_contract.rb
+++ b/app/contracts/relations/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/relations/delete_contract.rb
+++ b/app/contracts/relations/delete_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/relations/update_contract.rb
+++ b/app/contracts/relations/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/settings/update_contract.rb
+++ b/app/contracts/settings/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/types/base_contract.rb
+++ b/app/contracts/types/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/user_preferences/base_contract.rb
+++ b/app/contracts/user_preferences/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/user_preferences/params_contract.rb
+++ b/app/contracts/user_preferences/params_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/user_preferences/update_contract.rb
+++ b/app/contracts/user_preferences/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/users/base_contract.rb
+++ b/app/contracts/users/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/users/create_contract.rb
+++ b/app/contracts/users/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/users/delete_contract.rb
+++ b/app/contracts/users/delete_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/users/update_contract.rb
+++ b/app/contracts/users/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/work_packages/create_contract.rb
+++ b/app/contracts/work_packages/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/work_packages/create_note_contract.rb
+++ b/app/contracts/work_packages/create_note_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/work_packages/delete_contract.rb
+++ b/app/contracts/work_packages/delete_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/contracts/work_packages/update_contract.rb
+++ b/app/contracts/work_packages/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/backups_controller.rb
+++ b/app/controllers/admin/backups_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings/api_settings_controller.rb
+++ b/app/controllers/admin/settings/api_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings/attachments_settings_controller.rb
+++ b/app/controllers/admin/settings/attachments_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings/authentication_settings_controller.rb
+++ b/app/controllers/admin/settings/authentication_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings/display_settings_controller.rb
+++ b/app/controllers/admin/settings/display_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings/general_settings_controller.rb
+++ b/app/controllers/admin/settings/general_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings/incoming_mails_settings_controller.rb
+++ b/app/controllers/admin/settings/incoming_mails_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings/mail_notifications_settings_controller.rb
+++ b/app/controllers/admin/settings/mail_notifications_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings/notifications_settings_controller.rb
+++ b/app/controllers/admin/settings/notifications_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings/projects_settings_controller.rb
+++ b/app/controllers/admin/settings/projects_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings/repositories_settings_controller.rb
+++ b/app/controllers/admin/settings/repositories_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings/users_settings_controller.rb
+++ b/app/controllers/admin/settings/users_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings/work_packages_settings_controller.rb
+++ b/app/controllers/admin/settings/work_packages_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/angular_controller.rb
+++ b/app/controllers/angular_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/api_docs_controller.rb
+++ b/app/controllers/api_docs_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/attribute_help_texts_controller.rb
+++ b/app/controllers/attribute_help_texts_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/auth_sources_controller.rb
+++ b/app/controllers/auth_sources_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/colors_controller.rb
+++ b/app/controllers/colors_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/concerns/layout.rb
+++ b/app/controllers/concerns/layout.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/custom_actions_controller.rb
+++ b/app/controllers/custom_actions_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/custom_fields_controller.rb
+++ b/app/controllers/custom_fields_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/custom_styles_controller.rb
+++ b/app/controllers/custom_styles_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/enumerations_controller.rb
+++ b/app/controllers/enumerations_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/highlighting_controller.rb
+++ b/app/controllers/highlighting_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/homescreen_controller.rb
+++ b/app/controllers/homescreen_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/ldap_auth_sources_controller.rb
+++ b/app/controllers/ldap_auth_sources_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/news/comments_controller.rb
+++ b/app/controllers/news/comments_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/oauth/auth_base_controller.rb
+++ b/app/controllers/oauth/auth_base_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/oauth/grants_controller.rb
+++ b/app/controllers/oauth/grants_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/onboarding_controller.rb
+++ b/app/controllers/onboarding_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/placeholder_users/memberships_controller.rb
+++ b/app/controllers/placeholder_users/memberships_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/controllers/placeholder_users_controller.rb
+++ b/app/controllers/placeholder_users_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/controllers/projects/archive_controller.rb
+++ b/app/controllers/projects/archive_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/projects/identifier_controller.rb
+++ b/app/controllers/projects/identifier_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/projects/settings/categories_controller.rb
+++ b/app/controllers/projects/settings/categories_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/projects/settings/custom_fields_controller.rb
+++ b/app/controllers/projects/settings/custom_fields_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/projects/settings/general_controller.rb
+++ b/app/controllers/projects/settings/general_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/projects/settings/modules_controller.rb
+++ b/app/controllers/projects/settings/modules_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/projects/settings/repository_controller.rb
+++ b/app/controllers/projects/settings/repository_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/projects/settings/storage_controller.rb
+++ b/app/controllers/projects/settings/storage_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/projects/settings/types_controller.rb
+++ b/app/controllers/projects/settings/types_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/projects/settings/versions_controller.rb
+++ b/app/controllers/projects/settings/versions_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/projects/settings_controller.rb
+++ b/app/controllers/projects/settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/projects/templated_controller.rb
+++ b/app/controllers/projects/templated_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/sys_controller.rb
+++ b/app/controllers/sys_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/users/memberships_controller.rb
+++ b/app/controllers/users/memberships_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/watchers_controller.rb
+++ b/app/controllers/watchers_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/wiki_menu_items_controller.rb
+++ b/app/controllers/wiki_menu_items_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/work_packages/auto_completes_controller.rb
+++ b/app/controllers/work_packages/auto_completes_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/work_packages/bulk_controller.rb
+++ b/app/controllers/work_packages/bulk_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/work_packages/flash_bulk_error.rb
+++ b/app/controllers/work_packages/flash_bulk_error.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/work_packages/moves_controller.rb
+++ b/app/controllers/work_packages/moves_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/work_packages/reports_controller.rb
+++ b/app/controllers/work_packages/reports_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/work_packages_controller.rb
+++ b/app/controllers/work_packages_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/accessibility_helper.rb
+++ b/app/helpers/accessibility_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/angular_helper.rb
+++ b/app/helpers/angular_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/attribute_help_texts_helper.rb
+++ b/app/helpers/attribute_help_texts_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/augmenting_helper.rb
+++ b/app/helpers/augmenting_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/authentication_stage_path_helper.rb
+++ b/app/helpers/authentication_stage_path_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/avatar_helper.rb
+++ b/app/helpers/avatar_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/backup_helper.rb
+++ b/app/helpers/backup_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/calendars_helper.rb
+++ b/app/helpers/calendars_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/colors_helper.rb
+++ b/app/helpers/colors_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/content_for_helper.rb
+++ b/app/helpers/content_for_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/custom_styles_helper.rb
+++ b/app/helpers/custom_styles_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/error_message_helper.rb
+++ b/app/helpers/error_message_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/frontend_asset_helper.rb
+++ b/app/helpers/frontend_asset_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/hide_sections_helper.rb
+++ b/app/helpers/hide_sections_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/homescreen_helper.rb
+++ b/app/helpers/homescreen_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/individual_principal_hooks_helper.rb
+++ b/app/helpers/individual_principal_hooks_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/mail_digest_helper.rb
+++ b/app/helpers/mail_digest_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/mail_notification_helper.rb
+++ b/app/helpers/mail_notification_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/no_results_helper.rb
+++ b/app/helpers/no_results_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/oauth_helper.rb
+++ b/app/helpers/oauth_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/omniauth_helper.rb
+++ b/app/helpers/omniauth_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/password_helper.rb
+++ b/app/helpers/password_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/placeholder_users_helper.rb
+++ b/app/helpers/placeholder_users_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/project_status_helper.rb
+++ b/app/helpers/project_status_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/relations_helper.rb
+++ b/app/helpers/relations_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/removed_js_helpers_helper.rb
+++ b/app/helpers/removed_js_helpers_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/reorder_links_helper.rb
+++ b/app/helpers/reorder_links_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/repositories_helper.rb
+++ b/app/helpers/repositories_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/roles_helper.rb
+++ b/app/helpers/roles_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/security_badge_helper.rb
+++ b/app/helpers/security_badge_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/sort_helper.rb
+++ b/app/helpers/sort_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/static_links_helper.rb
+++ b/app/helpers/static_links_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/text_formatting_helper.rb
+++ b/app/helpers/text_formatting_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/tooltip_helper.rb
+++ b/app/helpers/tooltip_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/user_consent_helper.rb
+++ b/app/helpers/user_consent_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/warning_bar_helper.rb
+++ b/app/helpers/warning_bar_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/watchers_helper.rb
+++ b/app/helpers/watchers_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/wiki_helper.rb
+++ b/app/helpers/wiki_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/work_packages_filter_helper.rb
+++ b/app/helpers/work_packages_filter_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/mailers/member_mailer.rb
+++ b/app/mailers/member_mailer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/mailers/work_package_mailer.rb
+++ b/app/mailers/work_package_mailer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/activities/base_activity_provider.rb
+++ b/app/models/activities/base_activity_provider.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/activities/changeset_activity_provider.rb
+++ b/app/models/activities/changeset_activity_provider.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/activities/fetcher.rb
+++ b/app/models/activities/fetcher.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/activities/message_activity_provider.rb
+++ b/app/models/activities/message_activity_provider.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/activities/news_activity_provider.rb
+++ b/app/models/activities/news_activity_provider.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/activities/wiki_content_activity_provider.rb
+++ b/app/models/activities/wiki_content_activity_provider.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/activities/work_package_activity_provider.rb
+++ b/app/models/activities/work_package_activity_provider.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/models/associations/groupable.rb
+++ b/app/models/associations/groupable.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/capabilities/scopes/default.rb
+++ b/app/models/capabilities/scopes/default.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/capability.rb
+++ b/app/models/capability.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_action.rb
+++ b/app/models/custom_action.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/assigned_to.rb
+++ b/app/models/custom_actions/actions/assigned_to.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/base.rb
+++ b/app/models/custom_actions/actions/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/custom_field.rb
+++ b/app/models/custom_actions/actions/custom_field.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/date.rb
+++ b/app/models/custom_actions/actions/date.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/done_ratio.rb
+++ b/app/models/custom_actions/actions/done_ratio.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/due_date.rb
+++ b/app/models/custom_actions/actions/due_date.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/estimated_hours.rb
+++ b/app/models/custom_actions/actions/estimated_hours.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/inexistent.rb
+++ b/app/models/custom_actions/actions/inexistent.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/notify.rb
+++ b/app/models/custom_actions/actions/notify.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/priority.rb
+++ b/app/models/custom_actions/actions/priority.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/project.rb
+++ b/app/models/custom_actions/actions/project.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/serializer.rb
+++ b/app/models/custom_actions/actions/serializer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/start_date.rb
+++ b/app/models/custom_actions/actions/start_date.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/status.rb
+++ b/app/models/custom_actions/actions/status.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/strategies/associated.rb
+++ b/app/models/custom_actions/actions/strategies/associated.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/strategies/associated_custom_field.rb
+++ b/app/models/custom_actions/actions/strategies/associated_custom_field.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/strategies/custom_field.rb
+++ b/app/models/custom_actions/actions/strategies/custom_field.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/strategies/date.rb
+++ b/app/models/custom_actions/actions/strategies/date.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/strategies/date_property.rb
+++ b/app/models/custom_actions/actions/strategies/date_property.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/strategies/float.rb
+++ b/app/models/custom_actions/actions/strategies/float.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/strategies/integer.rb
+++ b/app/models/custom_actions/actions/strategies/integer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/strategies/me_associated.rb
+++ b/app/models/custom_actions/actions/strategies/me_associated.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/strategies/string.rb
+++ b/app/models/custom_actions/actions/strategies/string.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/strategies/text.rb
+++ b/app/models/custom_actions/actions/strategies/text.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/strategies/user_custom_field.rb
+++ b/app/models/custom_actions/actions/strategies/user_custom_field.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/actions/type.rb
+++ b/app/models/custom_actions/actions/type.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/conditions/base.rb
+++ b/app/models/custom_actions/conditions/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/conditions/inexistent.rb
+++ b/app/models/custom_actions/conditions/inexistent.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/conditions/project.rb
+++ b/app/models/custom_actions/conditions/project.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/conditions/role.rb
+++ b/app/models/custom_actions/conditions/role.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/conditions/status.rb
+++ b/app/models/custom_actions/conditions/status.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_actions/conditions/type.rb
+++ b/app/models/custom_actions/conditions/type.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_field/order_statements.rb
+++ b/app/models/custom_field/order_statements.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_option.rb
+++ b/app/models/custom_option.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value.rb
+++ b/app/models/custom_value.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value/ar_object_strategy.rb
+++ b/app/models/custom_value/ar_object_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value/bool_strategy.rb
+++ b/app/models/custom_value/bool_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value/date_strategy.rb
+++ b/app/models/custom_value/date_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value/empty_strategy.rb
+++ b/app/models/custom_value/empty_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value/float_strategy.rb
+++ b/app/models/custom_value/float_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value/format_strategy.rb
+++ b/app/models/custom_value/format_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value/formattable_strategy.rb
+++ b/app/models/custom_value/formattable_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value/int_strategy.rb
+++ b/app/models/custom_value/int_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value/list_strategy.rb
+++ b/app/models/custom_value/list_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value/string_strategy.rb
+++ b/app/models/custom_value/string_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value/user_strategy.rb
+++ b/app/models/custom_value/user_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/custom_value/version_strategy.rb
+++ b/app/models/custom_value/version_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/enabled_module.rb
+++ b/app/models/enabled_module.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/enumeration.rb
+++ b/app/models/enumeration.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/exports/concerns/csv.rb
+++ b/app/models/exports/concerns/csv.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/exports/export_error.rb
+++ b/app/models/exports/export_error.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/exports/exporter.rb
+++ b/app/models/exports/exporter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/exports/register.rb
+++ b/app/models/exports/register.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/exports/result.rb
+++ b/app/models/exports/result.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/forum.rb
+++ b/app/models/forum.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/group_custom_field.rb
+++ b/app/models/group_custom_field.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/groups/scopes/visible.rb
+++ b/app/models/groups/scopes/visible.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/issue_priority.rb
+++ b/app/models/issue_priority.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/journal/attachable_journal.rb
+++ b/app/models/journal/attachable_journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/journal/attachment_journal.rb
+++ b/app/models/journal/attachment_journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/journal/changeset_journal.rb
+++ b/app/models/journal/changeset_journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/journal/customizable_journal.rb
+++ b/app/models/journal/customizable_journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/journal/message_journal.rb
+++ b/app/models/journal/message_journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/journal/news_journal.rb
+++ b/app/models/journal/news_journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/journal/notification_configuration.rb
+++ b/app/models/journal/notification_configuration.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/journal/wiki_content_journal.rb
+++ b/app/models/journal/wiki_content_journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/journal/work_package_journal.rb
+++ b/app/models/journal/work_package_journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/ldap_auth_source.rb
+++ b/app/models/ldap_auth_source.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/member_role.rb
+++ b/app/models/member_role.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/members/scopes/assignable.rb
+++ b/app/models/members/scopes/assignable.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/members/scopes/global.rb
+++ b/app/models/members/scopes/global.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/members/scopes/not_locked.rb
+++ b/app/models/members/scopes/not_locked.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/members/scopes/of.rb
+++ b/app/models/members/scopes/of.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/members/scopes/visible.rb
+++ b/app/models/members/scopes/visible.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/menu_items/wiki_menu_item.rb
+++ b/app/models/menu_items/wiki_menu_item.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/notification_settings/scopes/applicable.rb
+++ b/app/models/notification_settings/scopes/applicable.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/notifications/scopes/mail_alert_unsent.rb
+++ b/app/models/notifications/scopes/mail_alert_unsent.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/notifications/scopes/mail_reminder_unsent.rb
+++ b/app/models/notifications/scopes/mail_reminder_unsent.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/notifications/scopes/recipient.rb
+++ b/app/models/notifications/scopes/recipient.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/notifications/scopes/unsent_reminders_before.rb
+++ b/app/models/notifications/scopes/unsent_reminders_before.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/ordered_work_package.rb
+++ b/app/models/ordered_work_package.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/placeholder_user.rb
+++ b/app/models/placeholder_user.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/models/placeholder_users/scopes/visible.rb
+++ b/app/models/placeholder_users/scopes/visible.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/principals/scopes/human.rb
+++ b/app/models/principals/scopes/human.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/principals/scopes/like.rb
+++ b/app/models/principals/scopes/like.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/principals/scopes/not_builtin.rb
+++ b/app/models/principals/scopes/not_builtin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/principals/scopes/ordered_by_name.rb
+++ b/app/models/principals/scopes/ordered_by_name.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/principals/scopes/possible_assignee.rb
+++ b/app/models/principals/scopes/possible_assignee.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/principals/scopes/possible_member.rb
+++ b/app/models/principals/scopes/possible_member.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/principals/scopes/status.rb
+++ b/app/models/principals/scopes/status.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/principals/scopes/user.rb
+++ b/app/models/principals/scopes/user.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/principals/scopes/visible.rb
+++ b/app/models/principals/scopes/visible.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/priority/inexistent_priority.rb
+++ b/app/models/priority/inexistent_priority.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/project_custom_field.rb
+++ b/app/models/project_custom_field.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/projects/activity.rb
+++ b/app/models/projects/activity.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/projects/ancestors_from_root.rb
+++ b/app/models/projects/ancestors_from_root.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/projects/exports/csv.rb
+++ b/app/models/projects/exports/csv.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/projects/exports/formatters/status.rb
+++ b/app/models/projects/exports/formatters/status.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/projects/exports/query_exporter.rb
+++ b/app/models/projects/exports/query_exporter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/projects/hierarchy.rb
+++ b/app/models/projects/hierarchy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/projects/status.rb
+++ b/app/models/projects/status.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/projects/storage.rb
+++ b/app/models/projects/storage.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/actions/filters/action_filter.rb
+++ b/app/models/queries/actions/filters/action_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/capabilities.rb
+++ b/app/models/queries/capabilities.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/capabilities/filters/capability_filter.rb
+++ b/app/models/queries/capabilities/filters/capability_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/capabilities/filters/principal_id_filter.rb
+++ b/app/models/queries/capabilities/filters/principal_id_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/capabilities/orders/id_order.rb
+++ b/app/models/queries/capabilities/orders/id_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/columns/base.rb
+++ b/app/models/queries/columns/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters.rb
+++ b/app/models/queries/filters.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/available_filters.rb
+++ b/app/models/queries/filters/available_filters.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/base.rb
+++ b/app/models/queries/filters/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/empty_filter.rb
+++ b/app/models/queries/filters/empty_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/me_value.rb
+++ b/app/models/queries/filters/me_value.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/not_existing_filter.rb
+++ b/app/models/queries/filters/not_existing_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/serializable.rb
+++ b/app/models/queries/filters/serializable.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/any_user_name_attribute_filter.rb
+++ b/app/models/queries/filters/shared/any_user_name_attribute_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/boolean_filter.rb
+++ b/app/models/queries/filters/shared/boolean_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/custom_field_filter.rb
+++ b/app/models/queries/filters/shared/custom_field_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/custom_fields/base.rb
+++ b/app/models/queries/filters/shared/custom_fields/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/custom_fields/bool.rb
+++ b/app/models/queries/filters/shared/custom_fields/bool.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/custom_fields/list_optional.rb
+++ b/app/models/queries/filters/shared/custom_fields/list_optional.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/custom_fields/user.rb
+++ b/app/models/queries/filters/shared/custom_fields/user.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/group_filter.rb
+++ b/app/models/queries/filters/shared/group_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/me_value_filter.rb
+++ b/app/models/queries/filters/shared/me_value_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/project_filter.rb
+++ b/app/models/queries/filters/shared/project_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/user_blocked_filter.rb
+++ b/app/models/queries/filters/shared/user_blocked_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/user_name_filter.rb
+++ b/app/models/queries/filters/shared/user_name_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/shared/user_status_filter.rb
+++ b/app/models/queries/filters/shared/user_status_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies.rb
+++ b/app/models/queries/filters/strategies.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/base_strategy.rb
+++ b/app/models/queries/filters/strategies/base_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/boolean_list.rb
+++ b/app/models/queries/filters/strategies/boolean_list.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/boolean_list_strict.rb
+++ b/app/models/queries/filters/strategies/boolean_list_strict.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/cf_float.rb
+++ b/app/models/queries/filters/strategies/cf_float.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/cf_integer.rb
+++ b/app/models/queries/filters/strategies/cf_integer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/cf_list_optional.rb
+++ b/app/models/queries/filters/strategies/cf_list_optional.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/cf_numeric.rb
+++ b/app/models/queries/filters/strategies/cf_numeric.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/date.rb
+++ b/app/models/queries/filters/strategies/date.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/date_interval.rb
+++ b/app/models/queries/filters/strategies/date_interval.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/date_time_past.rb
+++ b/app/models/queries/filters/strategies/date_time_past.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/empty_value.rb
+++ b/app/models/queries/filters/strategies/empty_value.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/float.rb
+++ b/app/models/queries/filters/strategies/float.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/float_numeric.rb
+++ b/app/models/queries/filters/strategies/float_numeric.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/huge_list.rb
+++ b/app/models/queries/filters/strategies/huge_list.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/inexistent.rb
+++ b/app/models/queries/filters/strategies/inexistent.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/integer.rb
+++ b/app/models/queries/filters/strategies/integer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/integer_list.rb
+++ b/app/models/queries/filters/strategies/integer_list.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/integer_numeric.rb
+++ b/app/models/queries/filters/strategies/integer_numeric.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/list.rb
+++ b/app/models/queries/filters/strategies/list.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/list_all.rb
+++ b/app/models/queries/filters/strategies/list_all.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/list_optional.rb
+++ b/app/models/queries/filters/strategies/list_optional.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/numeric.rb
+++ b/app/models/queries/filters/strategies/numeric.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/relation.rb
+++ b/app/models/queries/filters/strategies/relation.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/search.rb
+++ b/app/models/queries/filters/strategies/search.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/string.rb
+++ b/app/models/queries/filters/strategies/string.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/text.rb
+++ b/app/models/queries/filters/strategies/text.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/strategies/validations.rb
+++ b/app/models/queries/filters/strategies/validations.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/filters/templated_value.rb
+++ b/app/models/queries/filters/templated_value.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/group_bys/available_group_bys.rb
+++ b/app/models/queries/group_bys/available_group_bys.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/group_bys/base.rb
+++ b/app/models/queries/group_bys/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/group_bys/not_existing_group_by.rb
+++ b/app/models/queries/group_bys/not_existing_group_by.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/groups.rb
+++ b/app/models/queries/groups.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/groups/orders/default_order.rb
+++ b/app/models/queries/groups/orders/default_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/individual_principals/orders/group_order.rb
+++ b/app/models/queries/individual_principals/orders/group_order.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/individual_principals/orders/name_order.rb
+++ b/app/models/queries/individual_principals/orders/name_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members.rb
+++ b/app/models/queries/members.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/filters/any_name_attribute_filter.rb
+++ b/app/models/queries/members/filters/any_name_attribute_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/filters/blocked_filter.rb
+++ b/app/models/queries/members/filters/blocked_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/filters/created_at_filter.rb
+++ b/app/models/queries/members/filters/created_at_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/filters/group_filter.rb
+++ b/app/models/queries/members/filters/group_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/filters/member_filter.rb
+++ b/app/models/queries/members/filters/member_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/filters/name_filter.rb
+++ b/app/models/queries/members/filters/name_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/filters/principal_filter.rb
+++ b/app/models/queries/members/filters/principal_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/filters/project_filter.rb
+++ b/app/models/queries/members/filters/project_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/filters/role_filter.rb
+++ b/app/models/queries/members/filters/role_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/filters/status_filter.rb
+++ b/app/models/queries/members/filters/status_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/filters/updated_at_filter.rb
+++ b/app/models/queries/members/filters/updated_at_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/orders/default_order.rb
+++ b/app/models/queries/members/orders/default_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/orders/email_order.rb
+++ b/app/models/queries/members/orders/email_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/orders/name_order.rb
+++ b/app/models/queries/members/orders/name_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/members/orders/status_order.rb
+++ b/app/models/queries/members/orders/status_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/news.rb
+++ b/app/models/queries/news.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/news/filters/news_filter.rb
+++ b/app/models/queries/news/filters/news_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/news/filters/project_filter.rb
+++ b/app/models/queries/news/filters/project_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/news/orders/default_order.rb
+++ b/app/models/queries/news/orders/default_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications.rb
+++ b/app/models/queries/notifications.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/models/queries/notifications/filters/id_filter.rb
+++ b/app/models/queries/notifications/filters/id_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications/filters/notification_filter.rb
+++ b/app/models/queries/notifications/filters/notification_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications/filters/project_filter.rb
+++ b/app/models/queries/notifications/filters/project_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications/filters/read_ian_filter.rb
+++ b/app/models/queries/notifications/filters/read_ian_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications/filters/reason_filter.rb
+++ b/app/models/queries/notifications/filters/reason_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications/filters/resource_id_filter.rb
+++ b/app/models/queries/notifications/filters/resource_id_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications/filters/resource_type_filter.rb
+++ b/app/models/queries/notifications/filters/resource_type_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications/group_bys/group_by_project.rb
+++ b/app/models/queries/notifications/group_bys/group_by_project.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications/group_bys/group_by_reason.rb
+++ b/app/models/queries/notifications/group_bys/group_by_reason.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications/notification_query.rb
+++ b/app/models/queries/notifications/notification_query.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/models/queries/notifications/orders/default_order.rb
+++ b/app/models/queries/notifications/orders/default_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications/orders/project_order.rb
+++ b/app/models/queries/notifications/orders/project_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications/orders/read_ian_order.rb
+++ b/app/models/queries/notifications/orders/read_ian_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/notifications/orders/reason_order.rb
+++ b/app/models/queries/notifications/orders/reason_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators.rb
+++ b/app/models/queries/operators.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/ago.rb
+++ b/app/models/queries/operators/ago.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/all.rb
+++ b/app/models/queries/operators/all.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/all_and_non_blank.rb
+++ b/app/models/queries/operators/all_and_non_blank.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/base.rb
+++ b/app/models/queries/operators/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/between_date.rb
+++ b/app/models/queries/operators/between_date.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/between_date_time.rb
+++ b/app/models/queries/operators/between_date_time.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/blocked.rb
+++ b/app/models/queries/operators/blocked.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/blocks.rb
+++ b/app/models/queries/operators/blocks.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/boolean_equals.rb
+++ b/app/models/queries/operators/boolean_equals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/boolean_equals_strict.rb
+++ b/app/models/queries/operators/boolean_equals_strict.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/boolean_not_equals.rb
+++ b/app/models/queries/operators/boolean_not_equals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/casted_greater_or_equal.rb
+++ b/app/models/queries/operators/casted_greater_or_equal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/casted_less_or_equal.rb
+++ b/app/models/queries/operators/casted_less_or_equal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/children.rb
+++ b/app/models/queries/operators/children.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/closed_work_packages.rb
+++ b/app/models/queries/operators/closed_work_packages.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/concerns/contains_all_values.rb
+++ b/app/models/queries/operators/concerns/contains_all_values.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/contains.rb
+++ b/app/models/queries/operators/contains.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/date_range_clauses.rb
+++ b/app/models/queries/operators/date_range_clauses.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/datetime_range_clauses.rb
+++ b/app/models/queries/operators/datetime_range_clauses.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/duplicated.rb
+++ b/app/models/queries/operators/duplicated.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/duplicates.rb
+++ b/app/models/queries/operators/duplicates.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/equals.rb
+++ b/app/models/queries/operators/equals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/everywhere.rb
+++ b/app/models/queries/operators/everywhere.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/follows.rb
+++ b/app/models/queries/operators/follows.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/greater_or_equal.rb
+++ b/app/models/queries/operators/greater_or_equal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/in.rb
+++ b/app/models/queries/operators/in.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/in_less_than.rb
+++ b/app/models/queries/operators/in_less_than.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/in_more_than.rb
+++ b/app/models/queries/operators/in_more_than.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/includes.rb
+++ b/app/models/queries/operators/includes.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/less_or_equal.rb
+++ b/app/models/queries/operators/less_or_equal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/less_than_ago.rb
+++ b/app/models/queries/operators/less_than_ago.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/more_than_ago.rb
+++ b/app/models/queries/operators/more_than_ago.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/none.rb
+++ b/app/models/queries/operators/none.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/none_or_blank.rb
+++ b/app/models/queries/operators/none_or_blank.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/not_contains.rb
+++ b/app/models/queries/operators/not_contains.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/not_equals.rb
+++ b/app/models/queries/operators/not_equals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/on_date.rb
+++ b/app/models/queries/operators/on_date.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/on_date_time.rb
+++ b/app/models/queries/operators/on_date_time.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/open_work_packages.rb
+++ b/app/models/queries/operators/open_work_packages.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/ordered_work_packages.rb
+++ b/app/models/queries/operators/ordered_work_packages.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/parent.rb
+++ b/app/models/queries/operators/parent.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/part_of.rb
+++ b/app/models/queries/operators/part_of.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/precedes.rb
+++ b/app/models/queries/operators/precedes.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/relates.rb
+++ b/app/models/queries/operators/relates.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/required.rb
+++ b/app/models/queries/operators/required.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/requires.rb
+++ b/app/models/queries/operators/requires.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/this_week.rb
+++ b/app/models/queries/operators/this_week.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/operators/today.rb
+++ b/app/models/queries/operators/today.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/orders/available_orders.rb
+++ b/app/models/queries/orders/available_orders.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/orders/base.rb
+++ b/app/models/queries/orders/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/orders/not_existing_order.rb
+++ b/app/models/queries/orders/not_existing_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/placeholder_users.rb
+++ b/app/models/queries/placeholder_users.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/models/queries/placeholder_users/filters/any_name_attribute_filter.rb
+++ b/app/models/queries/placeholder_users/filters/any_name_attribute_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/placeholder_users/filters/group_filter.rb
+++ b/app/models/queries/placeholder_users/filters/group_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/placeholder_users/filters/name_filter.rb
+++ b/app/models/queries/placeholder_users/filters/name_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/placeholder_users/filters/placeholder_user_filter.rb
+++ b/app/models/queries/placeholder_users/filters/placeholder_user_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/placeholder_users/filters/status_filter.rb
+++ b/app/models/queries/placeholder_users/filters/status_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/placeholder_users/orders/default_order.rb
+++ b/app/models/queries/placeholder_users/orders/default_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/placeholder_users/orders/group_order.rb
+++ b/app/models/queries/placeholder_users/orders/group_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/placeholder_users/orders/name_order.rb
+++ b/app/models/queries/placeholder_users/orders/name_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/placeholder_users/placeholder_user_query.rb
+++ b/app/models/queries/placeholder_users/placeholder_user_query.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/models/queries/principals.rb
+++ b/app/models/queries/principals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/principals/filters/any_name_attribute_filter.rb
+++ b/app/models/queries/principals/filters/any_name_attribute_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/principals/filters/id_filter.rb
+++ b/app/models/queries/principals/filters/id_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/principals/filters/member_filter.rb
+++ b/app/models/queries/principals/filters/member_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/principals/filters/name_filter.rb
+++ b/app/models/queries/principals/filters/name_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/principals/filters/principal_filter.rb
+++ b/app/models/queries/principals/filters/principal_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/principals/filters/status_filter.rb
+++ b/app/models/queries/principals/filters/status_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/principals/filters/type_filter.rb
+++ b/app/models/queries/principals/filters/type_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/principals/filters/typeahead_filter.rb
+++ b/app/models/queries/principals/filters/typeahead_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/principals/orders/name_order.rb
+++ b/app/models/queries/principals/orders/name_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects.rb
+++ b/app/models/queries/projects.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/active_filter.rb
+++ b/app/models/queries/projects/filters/active_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/ancestor_filter.rb
+++ b/app/models/queries/projects/filters/ancestor_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/created_at_filter.rb
+++ b/app/models/queries/projects/filters/created_at_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/custom_field_context.rb
+++ b/app/models/queries/projects/filters/custom_field_context.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/custom_field_filter.rb
+++ b/app/models/queries/projects/filters/custom_field_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/id_filter.rb
+++ b/app/models/queries/projects/filters/id_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/latest_activity_at_filter.rb
+++ b/app/models/queries/projects/filters/latest_activity_at_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/name_and_identifier_filter.rb
+++ b/app/models/queries/projects/filters/name_and_identifier_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/parent_filter.rb
+++ b/app/models/queries/projects/filters/parent_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/principal_filter.rb
+++ b/app/models/queries/projects/filters/principal_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/project_filter.rb
+++ b/app/models/queries/projects/filters/project_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/project_status_filter.rb
+++ b/app/models/queries/projects/filters/project_status_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/public_filter.rb
+++ b/app/models/queries/projects/filters/public_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/templated_filter.rb
+++ b/app/models/queries/projects/filters/templated_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/type_filter.rb
+++ b/app/models/queries/projects/filters/type_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/typeahead_filter.rb
+++ b/app/models/queries/projects/filters/typeahead_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/user_action_filter.rb
+++ b/app/models/queries/projects/filters/user_action_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/filters/visible_filter.rb
+++ b/app/models/queries/projects/filters/visible_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/orders/custom_field_order.rb
+++ b/app/models/queries/projects/orders/custom_field_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/orders/default_order.rb
+++ b/app/models/queries/projects/orders/default_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/orders/latest_activity_at_order.rb
+++ b/app/models/queries/projects/orders/latest_activity_at_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/orders/name_order.rb
+++ b/app/models/queries/projects/orders/name_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/orders/project_status_order.rb
+++ b/app/models/queries/projects/orders/project_status_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/orders/required_disk_space_order.rb
+++ b/app/models/queries/projects/orders/required_disk_space_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/projects/orders/typeahead_order.rb
+++ b/app/models/queries/projects/orders/typeahead_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/queries.rb
+++ b/app/models/queries/queries.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/queries/filters/hidden_filter.rb
+++ b/app/models/queries/queries/filters/hidden_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/queries/filters/id_filter.rb
+++ b/app/models/queries/queries/filters/id_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/queries/filters/project_filter.rb
+++ b/app/models/queries/queries/filters/project_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/queries/filters/project_identifier_filter.rb
+++ b/app/models/queries/queries/filters/project_identifier_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/queries/filters/query_filter.rb
+++ b/app/models/queries/queries/filters/query_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/queries/filters/updated_at_filter.rb
+++ b/app/models/queries/queries/filters/updated_at_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/register.rb
+++ b/app/models/queries/register.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/relations.rb
+++ b/app/models/queries/relations.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/relations/filters/from_filter.rb
+++ b/app/models/queries/relations/filters/from_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/relations/filters/id_filter.rb
+++ b/app/models/queries/relations/filters/id_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/relations/filters/involved_filter.rb
+++ b/app/models/queries/relations/filters/involved_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/relations/filters/relation_filter.rb
+++ b/app/models/queries/relations/filters/relation_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/relations/filters/to_filter.rb
+++ b/app/models/queries/relations/filters/to_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/relations/filters/type_filter.rb
+++ b/app/models/queries/relations/filters/type_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/relations/filters/visibility_checking.rb
+++ b/app/models/queries/relations/filters/visibility_checking.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/relations/orders/default_order.rb
+++ b/app/models/queries/relations/orders/default_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/roles.rb
+++ b/app/models/queries/roles.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/roles/filters/grantable_filter.rb
+++ b/app/models/queries/roles/filters/grantable_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/roles/filters/role_filter.rb
+++ b/app/models/queries/roles/filters/role_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/roles/filters/unit_filter.rb
+++ b/app/models/queries/roles/filters/unit_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/users.rb
+++ b/app/models/queries/users.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/users/filters/any_name_attribute_filter.rb
+++ b/app/models/queries/users/filters/any_name_attribute_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/users/filters/blocked_filter.rb
+++ b/app/models/queries/users/filters/blocked_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/users/filters/group_filter.rb
+++ b/app/models/queries/users/filters/group_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/users/filters/login_filter.rb
+++ b/app/models/queries/users/filters/login_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/users/filters/name_filter.rb
+++ b/app/models/queries/users/filters/name_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/users/filters/status_filter.rb
+++ b/app/models/queries/users/filters/status_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/users/filters/user_filter.rb
+++ b/app/models/queries/users/filters/user_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/users/orders/default_order.rb
+++ b/app/models/queries/users/orders/default_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/users/orders/group_order.rb
+++ b/app/models/queries/users/orders/group_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/users/orders/name_order.rb
+++ b/app/models/queries/users/orders/name_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/versions.rb
+++ b/app/models/queries/versions.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/versions/filters/sharing_filter.rb
+++ b/app/models/queries/versions/filters/sharing_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/versions/filters/version_filter.rb
+++ b/app/models/queries/versions/filters/version_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/versions/orders/name_order.rb
+++ b/app/models/queries/versions/orders/name_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/versions/orders/semver_name_order.rb
+++ b/app/models/queries/versions/orders/semver_name_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/views/orders/default_order.rb
+++ b/app/models/queries/views/orders/default_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages.rb
+++ b/app/models/queries/work_packages.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/columns/custom_field_column.rb
+++ b/app/models/queries/work_packages/columns/custom_field_column.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/columns/manual_sorting_column.rb
+++ b/app/models/queries/work_packages/columns/manual_sorting_column.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/columns/property_column.rb
+++ b/app/models/queries/work_packages/columns/property_column.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/columns/relation_column.rb
+++ b/app/models/queries/work_packages/columns/relation_column.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/columns/relation_of_type_column.rb
+++ b/app/models/queries/work_packages/columns/relation_of_type_column.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/columns/relation_to_type_column.rb
+++ b/app/models/queries/work_packages/columns/relation_to_type_column.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/columns/work_package_column.rb
+++ b/app/models/queries/work_packages/columns/work_package_column.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/common/manual_sorting.rb
+++ b/app/models/queries/work_packages/common/manual_sorting.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter.rb
+++ b/app/models/queries/work_packages/filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/assigned_to_filter.rb
+++ b/app/models/queries/work_packages/filter/assigned_to_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/assignee_or_group_filter.rb
+++ b/app/models/queries/work_packages/filter/assignee_or_group_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/attachment_base_filter.rb
+++ b/app/models/queries/work_packages/filter/attachment_base_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/attachment_content_filter.rb
+++ b/app/models/queries/work_packages/filter/attachment_content_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/attachment_file_name_filter.rb
+++ b/app/models/queries/work_packages/filter/attachment_file_name_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/author_filter.rb
+++ b/app/models/queries/work_packages/filter/author_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/blocked_filter.rb
+++ b/app/models/queries/work_packages/filter/blocked_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/blocks_filter.rb
+++ b/app/models/queries/work_packages/filter/blocks_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/category_filter.rb
+++ b/app/models/queries/work_packages/filter/category_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/comment_filter.rb
+++ b/app/models/queries/work_packages/filter/comment_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/created_at_filter.rb
+++ b/app/models/queries/work_packages/filter/created_at_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/custom_field_context.rb
+++ b/app/models/queries/work_packages/filter/custom_field_context.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/custom_field_filter.rb
+++ b/app/models/queries/work_packages/filter/custom_field_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/dates_interval_filter.rb
+++ b/app/models/queries/work_packages/filter/dates_interval_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/description_filter.rb
+++ b/app/models/queries/work_packages/filter/description_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/done_ratio_filter.rb
+++ b/app/models/queries/work_packages/filter/done_ratio_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/due_date_filter.rb
+++ b/app/models/queries/work_packages/filter/due_date_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/duplicated_filter.rb
+++ b/app/models/queries/work_packages/filter/duplicated_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/duplicates_filter.rb
+++ b/app/models/queries/work_packages/filter/duplicates_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/estimated_hours_filter.rb
+++ b/app/models/queries/work_packages/filter/estimated_hours_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/filter_configuration.rb
+++ b/app/models/queries/work_packages/filter/filter_configuration.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/filter_for_wp_mixin.rb
+++ b/app/models/queries/work_packages/filter/filter_for_wp_mixin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/filter_on_directed_relations_mixin.rb
+++ b/app/models/queries/work_packages/filter/filter_on_directed_relations_mixin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/filter_on_undirected_relations_mixin.rb
+++ b/app/models/queries/work_packages/filter/filter_on_undirected_relations_mixin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/follows_filter.rb
+++ b/app/models/queries/work_packages/filter/follows_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/group_filter.rb
+++ b/app/models/queries/work_packages/filter/group_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/id_filter.rb
+++ b/app/models/queries/work_packages/filter/id_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/includes_filter.rb
+++ b/app/models/queries/work_packages/filter/includes_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/manual_sort_filter.rb
+++ b/app/models/queries/work_packages/filter/manual_sort_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/me_value_filter_mixin.rb
+++ b/app/models/queries/work_packages/filter/me_value_filter_mixin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/milestone_filter.rb
+++ b/app/models/queries/work_packages/filter/milestone_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/only_subproject_filter.rb
+++ b/app/models/queries/work_packages/filter/only_subproject_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/or_filter_for_wp_mixin.rb
+++ b/app/models/queries/work_packages/filter/or_filter_for_wp_mixin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/parent_filter.rb
+++ b/app/models/queries/work_packages/filter/parent_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/partof_filter.rb
+++ b/app/models/queries/work_packages/filter/partof_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/precedes_filter.rb
+++ b/app/models/queries/work_packages/filter/precedes_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/principal_base_filter.rb
+++ b/app/models/queries/work_packages/filter/principal_base_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/principal_loader.rb
+++ b/app/models/queries/work_packages/filter/principal_loader.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/priority_filter.rb
+++ b/app/models/queries/work_packages/filter/priority_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/project_filter.rb
+++ b/app/models/queries/work_packages/filter/project_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/relatable_filter.rb
+++ b/app/models/queries/work_packages/filter/relatable_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/relates_filter.rb
+++ b/app/models/queries/work_packages/filter/relates_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/required_filter.rb
+++ b/app/models/queries/work_packages/filter/required_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/requires_filter.rb
+++ b/app/models/queries/work_packages/filter/requires_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/responsible_filter.rb
+++ b/app/models/queries/work_packages/filter/responsible_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/role_filter.rb
+++ b/app/models/queries/work_packages/filter/role_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/search_filter.rb
+++ b/app/models/queries/work_packages/filter/search_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/start_date_filter.rb
+++ b/app/models/queries/work_packages/filter/start_date_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/status_filter.rb
+++ b/app/models/queries/work_packages/filter/status_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/subject_filter.rb
+++ b/app/models/queries/work_packages/filter/subject_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/subject_or_id_filter.rb
+++ b/app/models/queries/work_packages/filter/subject_or_id_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/subproject_filter.rb
+++ b/app/models/queries/work_packages/filter/subproject_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/text_filter_on_join_mixin.rb
+++ b/app/models/queries/work_packages/filter/text_filter_on_join_mixin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/type_filter.rb
+++ b/app/models/queries/work_packages/filter/type_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/typeahead_filter.rb
+++ b/app/models/queries/work_packages/filter/typeahead_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/updated_at_filter.rb
+++ b/app/models/queries/work_packages/filter/updated_at_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/version_filter.rb
+++ b/app/models/queries/work_packages/filter/version_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/watcher_filter.rb
+++ b/app/models/queries/work_packages/filter/watcher_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter/work_package_filter.rb
+++ b/app/models/queries/work_packages/filter/work_package_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/queries/work_packages/filter_serializer.rb
+++ b/app/models/queries/work_packages/filter_serializer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/query/highlighting.rb
+++ b/app/models/query/highlighting.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/query/manual_sorting.rb
+++ b/app/models/query/manual_sorting.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/query/results/group_by.rb
+++ b/app/models/query/results/group_by.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/query/results/sums.rb
+++ b/app/models/query/results/sums.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/query/sort_criteria.rb
+++ b/app/models/query/sort_criteria.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/query/statement_invalid.rb
+++ b/app/models/query/statement_invalid.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/query/timelines.rb
+++ b/app/models/query/timelines.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/relation.rb
+++ b/app/models/relation.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/relations/scopes/follows_non_manual_ancestors.rb
+++ b/app/models/relations/scopes/follows_non_manual_ancestors.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/relations/scopes/visible.rb
+++ b/app/models/relations/scopes/visible.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/repository/git.rb
+++ b/app/models/repository/git.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/repository/subversion.rb
+++ b/app/models/repository/subversion.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/role_permission.rb
+++ b/app/models/role_permission.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/serializers/indifferent_hash_serializer.rb
+++ b/app/models/serializers/indifferent_hash_serializer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/sessions/sql_bypass.rb
+++ b/app/models/sessions/sql_bypass.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/sessions/user_session.rb
+++ b/app/models/sessions/user_session.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/setting/aliases.rb
+++ b/app/models/setting/aliases.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/setting/callbacks_helper.rb
+++ b/app/models/setting/callbacks_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/setting/self_registration.rb
+++ b/app/models/setting/self_registration.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/status/inexistent_status.rb
+++ b/app/models/status/inexistent_status.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/system_user.rb
+++ b/app/models/system_user.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/token/api.rb
+++ b/app/models/token/api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/token/auto_login.rb
+++ b/app/models/token/auto_login.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/token/backup.rb
+++ b/app/models/token/backup.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/token/enterprise_trial_key.rb
+++ b/app/models/token/enterprise_trial_key.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/token/invitation.rb
+++ b/app/models/token/invitation.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/token/recovery.rb
+++ b/app/models/token/recovery.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/token/rss.rb
+++ b/app/models/token/rss.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/type/attribute_group.rb
+++ b/app/models/type/attribute_group.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/type/attribute_groups.rb
+++ b/app/models/type/attribute_groups.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/type/form_group.rb
+++ b/app/models/type/form_group.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/type/inexistent_type.rb
+++ b/app/models/type/inexistent_type.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/type/query_group.rb
+++ b/app/models/type/query_group.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/types/scopes/milestone.rb
+++ b/app/models/types/scopes/milestone.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/user_custom_field.rb
+++ b/app/models/user_custom_field.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/user_password.rb
+++ b/app/models/user_password.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/user_password/bcrypt.rb
+++ b/app/models/user_password/bcrypt.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/user_password/sha1.rb
+++ b/app/models/user_password/sha1.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/user_preferences/schema.rb
+++ b/app/models/user_preferences/schema.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/users/inexistent_user.rb
+++ b/app/models/users/inexistent_user.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/users/project_authorization_cache.rb
+++ b/app/models/users/project_authorization_cache.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/users/project_role_cache.rb
+++ b/app/models/users/project_role_cache.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/users/scopes/find_by_login.rb
+++ b/app/models/users/scopes/find_by_login.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/users/scopes/having_reminder_mail_to_send.rb
+++ b/app/models/users/scopes/having_reminder_mail_to_send.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/users/scopes/newest.rb
+++ b/app/models/users/scopes/newest.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/users/scopes/notified_globally.rb
+++ b/app/models/users/scopes/notified_globally.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/users/scopes/watcher_recipients.rb
+++ b/app/models/users/scopes/watcher_recipients.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/version_custom_field.rb
+++ b/app/models/version_custom_field.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/versions/project_sharing.rb
+++ b/app/models/versions/project_sharing.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/versions/scopes/order_by_semver_name.rb
+++ b/app/models/versions/scopes/order_by_semver_name.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/versions/scopes/rolled_up.rb
+++ b/app/models/versions/scopes/rolled_up.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/versions/scopes/shared_with.rb
+++ b/app/models/versions/scopes/shared_with.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/watcher.rb
+++ b/app/models/watcher.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/wiki_content.rb
+++ b/app/models/wiki_content.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/wiki_redirect.rb
+++ b/app/models/wiki_redirect.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/wikis/annotate.rb
+++ b/app/models/wikis/annotate.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/wikis/diff.rb
+++ b/app/models/wikis/diff.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/ancestors.rb
+++ b/app/models/work_package/ancestors.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/ask_before_destruction.rb
+++ b/app/models/work_package/ask_before_destruction.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/custom_actioned.rb
+++ b/app/models/work_package/custom_actioned.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/exports/csv.rb
+++ b/app/models/work_package/exports/csv.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/exports/formatters/costs.rb
+++ b/app/models/work_package/exports/formatters/costs.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/exports/formatters/estimated_hours.rb
+++ b/app/models/work_package/exports/formatters/estimated_hours.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/exports/query_exporter.rb
+++ b/app/models/work_package/exports/query_exporter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/hooks.rb
+++ b/app/models/work_package/hooks.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/inexistent_work_package.rb
+++ b/app/models/work_package/inexistent_work_package.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/parent.rb
+++ b/app/models/work_package/parent.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/pdf_export/attachments.rb
+++ b/app/models/work_package/pdf_export/attachments.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/pdf_export/common.rb
+++ b/app/models/work_package/pdf_export/common.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/pdf_export/formattable.rb
+++ b/app/models/work_package/pdf_export/formattable.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/pdf_export/view.rb
+++ b/app/models/work_package/pdf_export/view.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/scheduling_rules.rb
+++ b/app/models/work_package/scheduling_rules.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/status_transitions.rb
+++ b/app/models/work_package/status_transitions.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/time_entries_cleaner.rb
+++ b/app/models/work_package/time_entries_cleaner.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/typed_dag_defaults.rb
+++ b/app/models/work_package/typed_dag_defaults.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package/validations.rb
+++ b/app/models/work_package/validations.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_package_custom_field.rb
+++ b/app/models/work_package_custom_field.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_packages/costs.rb
+++ b/app/models/work_packages/costs.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_packages/derived_dates.rb
+++ b/app/models/work_packages/derived_dates.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_packages/scopes/for_scheduling.rb
+++ b/app/models/work_packages/scopes/for_scheduling.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_packages/scopes/include_derived_dates.rb
+++ b/app/models/work_packages/scopes/include_derived_dates.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_packages/scopes/include_spent_time.rb
+++ b/app/models/work_packages/scopes/include_spent_time.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_packages/scopes/left_join_self_and_descendants.rb
+++ b/app/models/work_packages/scopes/left_join_self_and_descendants.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/work_packages/spent_time.rb
+++ b/app/models/work_packages/spent_time.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/admin_user_seeder.rb
+++ b/app/seeders/admin_user_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/basic_data/activity_seeder.rb
+++ b/app/seeders/basic_data/activity_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/basic_data/builtin_roles_seeder.rb
+++ b/app/seeders/basic_data/builtin_roles_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/basic_data/color_scheme_seeder.rb
+++ b/app/seeders/basic_data/color_scheme_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/basic_data/color_seeder.rb
+++ b/app/seeders/basic_data/color_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/basic_data/priority_seeder.rb
+++ b/app/seeders/basic_data/priority_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/basic_data/role_seeder.rb
+++ b/app/seeders/basic_data/role_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/basic_data/setting_seeder.rb
+++ b/app/seeders/basic_data/setting_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/basic_data/status_seeder.rb
+++ b/app/seeders/basic_data/status_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/basic_data/type_seeder.rb
+++ b/app/seeders/basic_data/type_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/basic_data/workflow_seeder.rb
+++ b/app/seeders/basic_data/workflow_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/basic_data_seeder.rb
+++ b/app/seeders/basic_data_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/composite_seeder.rb
+++ b/app/seeders/composite_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/demo_data/attribute_help_text_seeder.rb
+++ b/app/seeders/demo_data/attribute_help_text_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 
 # OpenProject is an open source project management software.

--- a/app/seeders/demo_data/custom_field_seeder.rb
+++ b/app/seeders/demo_data/custom_field_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/demo_data/global_query_seeder.rb
+++ b/app/seeders/demo_data/global_query_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 
 # OpenProject is an open source project management software.

--- a/app/seeders/demo_data/group_seeder.rb
+++ b/app/seeders/demo_data/group_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 
 # OpenProject is an open source project management software.

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 
 # OpenProject is an open source project management software.

--- a/app/seeders/demo_data/query_builder.rb
+++ b/app/seeders/demo_data/query_builder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/demo_data/references.rb
+++ b/app/seeders/demo_data/references.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/demo_data/version_builder.rb
+++ b/app/seeders/demo_data/version_builder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/demo_data/wiki_seeder.rb
+++ b/app/seeders/demo_data/wiki_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/demo_data/work_package_board_seeder.rb
+++ b/app/seeders/demo_data/work_package_board_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 
 # OpenProject is an open source project management software.

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/demo_data_seeder.rb
+++ b/app/seeders/demo_data_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/development_data/custom_fields_seeder.rb
+++ b/app/seeders/development_data/custom_fields_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/development_data/projects_seeder.rb
+++ b/app/seeders/development_data/projects_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/development_data/users_seeder.rb
+++ b/app/seeders/development_data/users_seeder.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH
@@ -26,8 +25,6 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/development_data_seeder.rb
+++ b/app/seeders/development_data_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/random_data/forum_seeder.rb
+++ b/app/seeders/random_data/forum_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/random_data/news_seeder.rb
+++ b/app/seeders/random_data/news_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/random_data/wiki_seeder.rb
+++ b/app/seeders/random_data/wiki_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/random_data/work_package_seeder.rb
+++ b/app/seeders/random_data/work_package_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/random_data_seeder.rb
+++ b/app/seeders/random_data_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/seeders/root_seeder.rb
+++ b/app/seeders/root_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/seeder.rb
+++ b/app/seeders/seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/standard_seeder/basic_data/activity_seeder.rb
+++ b/app/seeders/standard_seeder/basic_data/activity_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/standard_seeder/basic_data/priority_seeder.rb
+++ b/app/seeders/standard_seeder/basic_data/priority_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/standard_seeder/basic_data/status_seeder.rb
+++ b/app/seeders/standard_seeder/basic_data/status_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/standard_seeder/basic_data/type_seeder.rb
+++ b/app/seeders/standard_seeder/basic_data/type_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/standard_seeder/basic_data/workflow_seeder.rb
+++ b/app/seeders/standard_seeder/basic_data/workflow_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/seeders/standard_seeder/basic_data_seeder.rb
+++ b/app/seeders/standard_seeder/basic_data_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/add_work_package_note_service.rb
+++ b/app/services/add_work_package_note_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/attachments/replace_attachments.rb
+++ b/app/services/attachments/replace_attachments.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/attachments/set_attributes_service.rb
+++ b/app/services/attachments/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/attachments/set_prepared_attributes_service.rb
+++ b/app/services/attachments/set_prepared_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/attachments/set_replacements.rb
+++ b/app/services/attachments/set_replacements.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/attachments/touch_container.rb
+++ b/app/services/attachments/touch_container.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/attribute_help_texts/create_service.rb
+++ b/app/services/attribute_help_texts/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/attribute_help_texts/set_attributes_service.rb
+++ b/app/services/attribute_help_texts/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/attribute_help_texts/update_service.rb
+++ b/app/services/attribute_help_texts/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization.rb
+++ b/app/services/authorization.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/abstract_query.rb
+++ b/app/services/authorization/abstract_query.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/abstract_user_query.rb
+++ b/app/services/authorization/abstract_user_query.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/enterprise_service.rb
+++ b/app/services/authorization/enterprise_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/project_query.rb
+++ b/app/services/authorization/project_query.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/query_transformation.rb
+++ b/app/services/authorization/query_transformation.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/query_transformation_visitor.rb
+++ b/app/services/authorization/query_transformation_visitor.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/query_transformations.rb
+++ b/app/services/authorization/query_transformations.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/query_transformations_order.rb
+++ b/app/services/authorization/query_transformations_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/user_allowed_query.rb
+++ b/app/services/authorization/user_allowed_query.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/user_allowed_service.rb
+++ b/app/services/authorization/user_allowed_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/user_global_roles_query.rb
+++ b/app/services/authorization/user_global_roles_query.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/user_project_roles_query.rb
+++ b/app/services/authorization/user_project_roles_query.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization/user_roles_query.rb
+++ b/app/services/authorization/user_roles_query.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/authorization_service.rb
+++ b/app/services/authorization_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/backups/create_service.rb
+++ b/app/services/backups/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/backups/set_attributes_service.rb
+++ b/app/services/backups/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/base_project_service.rb
+++ b/app/services/base_project_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/base_services/base_callable.rb
+++ b/app/services/base_services/base_callable.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/base_services/base_contracted.rb
+++ b/app/services/base_services/base_contracted.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/base_services/copy.rb
+++ b/app/services/base_services/copy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/base_services/create.rb
+++ b/app/services/base_services/create.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/base_services/set_attributes.rb
+++ b/app/services/base_services/set_attributes.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/base_services/update.rb
+++ b/app/services/base_services/update.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/base_services/write.rb
+++ b/app/services/base_services/write.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/changesets/log_time_service.rb
+++ b/app/services/changesets/log_time_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/concerns/contracted.rb
+++ b/app/services/concerns/contracted.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/concerns/with_reversible_state.rb
+++ b/app/services/concerns/with_reversible_state.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/copy/dependency.rb
+++ b/app/services/copy/dependency.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/create_type_service.rb
+++ b/app/services/create_type_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/custom_actions/base_service.rb
+++ b/app/services/custom_actions/base_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/custom_actions/create_service.rb
+++ b/app/services/custom_actions/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/custom_actions/update_service.rb
+++ b/app/services/custom_actions/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/custom_actions/update_work_package_service.rb
+++ b/app/services/custom_actions/update_work_package_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/custom_fields/create_service.rb
+++ b/app/services/custom_fields/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/custom_fields/set_attributes_service.rb
+++ b/app/services/custom_fields/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/custom_fields/update_service.rb
+++ b/app/services/custom_fields/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/grids/copy/widgets_dependent_service.rb
+++ b/app/services/grids/copy/widgets_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/grids/copy_service.rb
+++ b/app/services/grids/copy_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/groups/add_users_service.rb
+++ b/app/services/groups/add_users_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/groups/create_service.rb
+++ b/app/services/groups/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/groups/set_attributes_service.rb
+++ b/app/services/groups/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/groups/update_service.rb
+++ b/app/services/groups/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/members/create_service.rb
+++ b/app/services/members/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/members/edit_membership_service.rb
+++ b/app/services/members/edit_membership_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/members/set_attributes_service.rb
+++ b/app/services/members/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/members/update_service.rb
+++ b/app/services/members/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/messages/create_service.rb
+++ b/app/services/messages/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/messages/set_attributes_service.rb
+++ b/app/services/messages/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/messages/update_service.rb
+++ b/app/services/messages/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/notifications/aggregated_journal_service.rb
+++ b/app/services/notifications/aggregated_journal_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/notifications/create_from_model_service.rb
+++ b/app/services/notifications/create_from_model_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/notifications/create_from_model_service/comment_strategy.rb
+++ b/app/services/notifications/create_from_model_service/comment_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/notifications/create_from_model_service/message_strategy.rb
+++ b/app/services/notifications/create_from_model_service/message_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/notifications/create_from_model_service/news_strategy.rb
+++ b/app/services/notifications/create_from_model_service/news_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/notifications/create_from_model_service/wiki_content_strategy.rb
+++ b/app/services/notifications/create_from_model_service/wiki_content_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/notifications/create_from_model_service/work_package_strategy.rb
+++ b/app/services/notifications/create_from_model_service/work_package_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/notifications/create_service.rb
+++ b/app/services/notifications/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/oauth/persist_application_service.rb
+++ b/app/services/oauth/persist_application_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/parse_schema_filter_params_service.rb
+++ b/app/services/parse_schema_filter_params_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/placeholder_users/create_service.rb
+++ b/app/services/placeholder_users/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/placeholder_users/delete_service.rb
+++ b/app/services/placeholder_users/delete_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/placeholder_users/set_attributes_service.rb
+++ b/app/services/placeholder_users/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/placeholder_users/update_service.rb
+++ b/app/services/placeholder_users/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/principals/replace_references_service.rb
+++ b/app/services/principals/replace_references_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/archive_service.rb
+++ b/app/services/projects/archive_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/concerns/new_project_service.rb
+++ b/app/services/projects/concerns/new_project_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/concerns/update_demo_data.rb
+++ b/app/services/projects/concerns/update_demo_data.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy/boards_dependent_service.rb
+++ b/app/services/projects/copy/boards_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy/categories_dependent_service.rb
+++ b/app/services/projects/copy/categories_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy/dependency.rb
+++ b/app/services/projects/copy/dependency.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy/forums_dependent_service.rb
+++ b/app/services/projects/copy/forums_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy/members_dependent_service.rb
+++ b/app/services/projects/copy/members_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy/overview_dependent_service.rb
+++ b/app/services/projects/copy/overview_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy/queries_dependent_service.rb
+++ b/app/services/projects/copy/queries_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy/versions_dependent_service.rb
+++ b/app/services/projects/copy/versions_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy/wiki_dependent_service.rb
+++ b/app/services/projects/copy/wiki_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy/wiki_page_attachments_dependent_service.rb
+++ b/app/services/projects/copy/wiki_page_attachments_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy/work_package_attachments_dependent_service.rb
+++ b/app/services/projects/copy/work_package_attachments_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy/work_packages_dependent_service.rb
+++ b/app/services/projects/copy/work_packages_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/copy_service.rb
+++ b/app/services/projects/copy_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/create_service.rb
+++ b/app/services/projects/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/delete_service.rb
+++ b/app/services/projects/delete_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/enabled_modules_service.rb
+++ b/app/services/projects/enabled_modules_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/enqueue_copy_service.rb
+++ b/app/services/projects/enqueue_copy_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/gantt_query_generator_service.rb
+++ b/app/services/projects/gantt_query_generator_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/schedule_deletion_service.rb
+++ b/app/services/projects/schedule_deletion_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/set_attributes_service.rb
+++ b/app/services/projects/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/unarchive_service.rb
+++ b/app/services/projects/unarchive_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/projects/update_service.rb
+++ b/app/services/projects/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/queries/base_service.rb
+++ b/app/services/queries/base_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/queries/copy/filters_mapper.rb
+++ b/app/services/queries/copy/filters_mapper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/queries/copy/ordered_work_packages_dependent_service.rb
+++ b/app/services/queries/copy/ordered_work_packages_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/queries/copy_service.rb
+++ b/app/services/queries/copy_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/queries/create_service.rb
+++ b/app/services/queries/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/queries/update_service.rb
+++ b/app/services/queries/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/relations/base_service.rb
+++ b/app/services/relations/base_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/relations/create_service.rb
+++ b/app/services/relations/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/relations/update_service.rb
+++ b/app/services/relations/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/reports/assignee_report.rb
+++ b/app/services/reports/assignee_report.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/reports/author_report.rb
+++ b/app/services/reports/author_report.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/reports/category_report.rb
+++ b/app/services/reports/category_report.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/reports/priority_report.rb
+++ b/app/services/reports/priority_report.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/reports/report.rb
+++ b/app/services/reports/report.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/reports/reports_service.rb
+++ b/app/services/reports/reports_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/reports/responsible_report.rb
+++ b/app/services/reports/responsible_report.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/reports/subproject_report.rb
+++ b/app/services/reports/subproject_report.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/reports/type_report.rb
+++ b/app/services/reports/type_report.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/reports/version_report.rb
+++ b/app/services/reports/version_report.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/roles/create_service.rb
+++ b/app/services/roles/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/roles/notify_mixin.rb
+++ b/app/services/roles/notify_mixin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/roles/set_attributes_service.rb
+++ b/app/services/roles/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/roles/update_service.rb
+++ b/app/services/roles/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/scm/base_repository_service.rb
+++ b/app/services/scm/base_repository_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/scm/checkout_instructions_service.rb
+++ b/app/services/scm/checkout_instructions_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/scm/create_managed_repository_service.rb
+++ b/app/services/scm/create_managed_repository_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/scm/delete_managed_repository_service.rb
+++ b/app/services/scm/delete_managed_repository_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/scm/repository_factory_service.rb
+++ b/app/services/scm/repository_factory_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/sessions/base_service.rb
+++ b/app/services/sessions/base_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/sessions/drop_other_sessions_service.rb
+++ b/app/services/sessions/drop_other_sessions_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/sessions/initialize_session_service.rb
+++ b/app/services/sessions/initialize_session_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/settings/update_service.rb
+++ b/app/services/settings/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/shared/block_service.rb
+++ b/app/services/shared/block_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/shared/service_context.rb
+++ b/app/services/shared/service_context.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/shared/service_state.rb
+++ b/app/services/shared/service_state.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/update_projects_types_service.rb
+++ b/app/services/update_projects_types_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/update_type_service.rb
+++ b/app/services/update_type_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/user_preferences/set_attributes_service.rb
+++ b/app/services/user_preferences/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/user_preferences/update_service.rb
+++ b/app/services/user_preferences/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/user_search_service.rb
+++ b/app/services/user_search_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/users/change_password_service.rb
+++ b/app/services/users/change_password_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/users/create_service.rb
+++ b/app/services/users/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/users/delete_service.rb
+++ b/app/services/users/delete_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/users/logout_service.rb
+++ b/app/services/users/logout_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/users/register_user_service.rb
+++ b/app/services/users/register_user_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/users/set_attributes_service.rb
+++ b/app/services/users/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/users/update_service.rb
+++ b/app/services/users/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/versions/create_service.rb
+++ b/app/services/versions/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/versions/set_attributes_service.rb
+++ b/app/services/versions/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/versions/update_service.rb
+++ b/app/services/versions/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/wiki_pages/copy_service.rb
+++ b/app/services/wiki_pages/copy_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/wiki_pages/create_service.rb
+++ b/app/services/wiki_pages/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/wiki_pages/set_attributes_service.rb
+++ b/app/services/wiki_pages/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/wiki_pages/update_service.rb
+++ b/app/services/wiki_pages/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/bulk/bulked_service.rb
+++ b/app/services/work_packages/bulk/bulked_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/bulk/copy_service.rb
+++ b/app/services/work_packages/bulk/copy_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/bulk/move_service.rb
+++ b/app/services/work_packages/bulk/move_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/bulk/update_service.rb
+++ b/app/services/work_packages/bulk/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/copy_service.rb
+++ b/app/services/work_packages/copy_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/create_service.rb
+++ b/app/services/work_packages/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/delete_service.rb
+++ b/app/services/work_packages/delete_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/exports/schedule_service.rb
+++ b/app/services/work_packages/exports/schedule_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/schedule_dependency.rb
+++ b/app/services/work_packages/schedule_dependency.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/shared/update_ancestors.rb
+++ b/app/services/work_packages/shared/update_ancestors.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/update_ancestors_service.rb
+++ b/app/services/work_packages/update_ancestors_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/services/workflows/bulk_update_service.rb
+++ b/app/services/workflows/bulk_update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/validators/not_nil_validator.rb
+++ b/app/validators/not_nil_validator.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/attachments/cleanup_uncontainered_job.rb
+++ b/app/workers/attachments/cleanup_uncontainered_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/attachments/finish_direct_upload_job.rb
+++ b/app/workers/attachments/finish_direct_upload_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/backup_job.rb
+++ b/app/workers/backup_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/concerns/state_machine_job.rb
+++ b/app/workers/concerns/state_machine_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/copy_project_job.rb
+++ b/app/workers/copy_project_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/cron/clear_old_sessions_job.rb
+++ b/app/workers/cron/clear_old_sessions_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/cron/clear_tmp_cache_job.rb
+++ b/app/workers/cron/clear_tmp_cache_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/app/workers/cron/clear_uploaded_files_job.rb
+++ b/app/workers/cron/clear_uploaded_files_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/cron/cron_job.rb
+++ b/app/workers/cron/cron_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/exports/cleanup_outdated_job.rb
+++ b/app/workers/exports/cleanup_outdated_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/extract_fulltext_job.rb
+++ b/app/workers/extract_fulltext_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/journals/completed_job.rb
+++ b/app/workers/journals/completed_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/mails/deliver_job.rb
+++ b/app/workers/mails/deliver_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/mails/invitation_job.rb
+++ b/app/workers/mails/invitation_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/mails/mailer_job.rb
+++ b/app/workers/mails/mailer_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/mails/reminder_job.rb
+++ b/app/workers/mails/reminder_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/mails/watcher_added_job.rb
+++ b/app/workers/mails/watcher_added_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/mails/watcher_job.rb
+++ b/app/workers/mails/watcher_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/mails/watcher_removed_job.rb
+++ b/app/workers/mails/watcher_removed_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/mails/with_sender.rb
+++ b/app/workers/mails/with_sender.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/notifications/cleanup_job.rb
+++ b/app/workers/notifications/cleanup_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/notifications/group_member_altered_job.rb
+++ b/app/workers/notifications/group_member_altered_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/notifications/schedule_reminder_mails_job.rb
+++ b/app/workers/notifications/schedule_reminder_mails_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/notifications/with_marked_notifications.rb
+++ b/app/workers/notifications/with_marked_notifications.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/notifications/workflow_job.rb
+++ b/app/workers/notifications/workflow_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/oauth/cleanup_job.rb
+++ b/app/workers/oauth/cleanup_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/principals/delete_job.rb
+++ b/app/workers/principals/delete_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/projects/delete_project_job.rb
+++ b/app/workers/projects/delete_project_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/projects/reorder_children_job.rb
+++ b/app/workers/projects/reorder_children_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/scm/create_local_repository_job.rb
+++ b/app/workers/scm/create_local_repository_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/scm/create_remote_repository_job.rb
+++ b/app/workers/scm/create_remote_repository_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/scm/delete_local_repository_job.rb
+++ b/app/workers/scm/delete_local_repository_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/scm/delete_remote_repository_job.rb
+++ b/app/workers/scm/delete_remote_repository_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/scm/relocate_repository_job.rb
+++ b/app/workers/scm/relocate_repository_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/scm/remote_repository_job.rb
+++ b/app/workers/scm/remote_repository_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/app/workers/scm/storage_updater_job.rb
+++ b/app/workers/scm/storage_updater_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/additional_environment.rb.example
+++ b/config/additional_environment.rb.example
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/constants/open_project/activity.rb
+++ b/config/constants/open_project/activity.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/constants/project_activity.rb
+++ b/config/constants/project_activity.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/environments/test_pgsql.rb
+++ b/config/environments/test_pgsql.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/00-core_plugins.rb
+++ b/config/initializers/00-core_plugins.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/05-null_db_fallback.rb
+++ b/config/initializers/05-null_db_fallback.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/06-pending_migrations_check.rb
+++ b/config/initializers/06-pending_migrations_check.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/10-load_patches.rb
+++ b/config/initializers/10-load_patches.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/30-open_project_loading.rb
+++ b/config/initializers/30-open_project_loading.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/activity.rb
+++ b/config/initializers/activity.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/bcrypt.rb
+++ b/config/initializers/bcrypt.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/custom_field_format.rb
+++ b/config/initializers/custom_field_format.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/enforce_isolation_level.rb
+++ b/config/initializers/enforce_isolation_level.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/homescreen.rb
+++ b/config/initializers/homescreen.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/livingstyleguide_patches.rb
+++ b/config/initializers/livingstyleguide_patches.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/module_handler.rb
+++ b/config/initializers/module_handler.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/rack-cors.rb
+++ b/config/initializers/rack-cors.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/rails_footnotes.rb
+++ b/config/initializers/rails_footnotes.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/register_mail_interceptors.rb
+++ b/config/initializers/register_mail_interceptors.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/register_renderer.rb
+++ b/config/initializers/register_renderer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/search.rb
+++ b/config/initializers/search.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/subscribe_listeners.rb
+++ b/config/initializers/subscribe_listeners.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/typed_dag.rb
+++ b/config/initializers/typed_dag.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/10000000000000_to_v710_aggregated_migrations.rb
+++ b/db/migrate/10000000000000_to_v710_aggregated_migrations.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/20171129145631_add_fulltext_to_attachments.rb
+++ b/db/migrate/20171129145631_add_fulltext_to_attachments.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/20180116065518_add_hierarchy_paths.rb
+++ b/db/migrate/20180116065518_add_hierarchy_paths.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/20180117065255_remove_timelines_and_reportings.rb
+++ b/db/migrate/20180117065255_remove_timelines_and_reportings.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/20180122135443_add_tsv_columns_to_attachments.rb
+++ b/db/migrate/20180122135443_add_tsv_columns_to_attachments.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/20180305130811_remove_wiki_content_versions.rb
+++ b/db/migrate/20180305130811_remove_wiki_content_versions.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/20180524084654_remove_non_null_container_on_attachments.rb
+++ b/db/migrate/20180524084654_remove_non_null_container_on_attachments.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/20201005120137_ensure_integer_for_relations_foreign_keys.rb
+++ b/db/migrate/20201005120137_ensure_integer_for_relations_foreign_keys.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/20201125121949_remove_renamed_cron_job.rb
+++ b/db/migrate/20201125121949_remove_renamed_cron_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/20211005080304_tzinfo_time_zones.rb
+++ b/db/migrate/20211005080304_tzinfo_time_zones.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/aggregated/base.rb
+++ b/db/migrate/aggregated/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/aggregated/to_3_0.rb
+++ b/db/migrate/aggregated/to_3_0.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/aggregated/to_7_1.rb
+++ b/db/migrate/aggregated/to_7_1.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/migration_utils/migration_squasher.rb
+++ b/db/migrate/migration_utils/migration_squasher.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/migration_utils/module_renamer.rb
+++ b/db/migrate/migration_utils/module_renamer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/migration_utils/permission_adder.rb
+++ b/db/migrate/migration_utils/permission_adder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/migration_utils/setting_renamer.rb
+++ b/db/migrate/migration_utils/setting_renamer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/migration_utils/utils.rb
+++ b/db/migrate/migration_utils/utils.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/announcements.rb
+++ b/db/migrate/tables/announcements.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/attachable_journals.rb
+++ b/db/migrate/tables/attachable_journals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/attachment_journals.rb
+++ b/db/migrate/tables/attachment_journals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/attachments.rb
+++ b/db/migrate/tables/attachments.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/auth_sources.rb
+++ b/db/migrate/tables/auth_sources.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/base.rb
+++ b/db/migrate/tables/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/boards.rb
+++ b/db/migrate/tables/boards.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/changes.rb
+++ b/db/migrate/tables/changes.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/changeset_journals.rb
+++ b/db/migrate/tables/changeset_journals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/changesets.rb
+++ b/db/migrate/tables/changesets.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/changesets_work_packages.rb
+++ b/db/migrate/tables/changesets_work_packages.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/comments.rb
+++ b/db/migrate/tables/comments.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/custom_fields.rb
+++ b/db/migrate/tables/custom_fields.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/custom_fields_projects.rb
+++ b/db/migrate/tables/custom_fields_projects.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/custom_fields_types.rb
+++ b/db/migrate/tables/custom_fields_types.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/custom_options.rb
+++ b/db/migrate/tables/custom_options.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/custom_values.rb
+++ b/db/migrate/tables/custom_values.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/customizable_journals_table.rb
+++ b/db/migrate/tables/customizable_journals_table.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/enabled_modules.rb
+++ b/db/migrate/tables/enabled_modules.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/enumerations.rb
+++ b/db/migrate/tables/enumerations.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/forums.rb
+++ b/db/migrate/tables/forums.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/group_users.rb
+++ b/db/migrate/tables/group_users.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/journals.rb
+++ b/db/migrate/tables/journals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/message_journals.rb
+++ b/db/migrate/tables/message_journals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/messages.rb
+++ b/db/migrate/tables/messages.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/news_journals.rb
+++ b/db/migrate/tables/news_journals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/sessions.rb
+++ b/db/migrate/tables/sessions.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/time_entries.rb
+++ b/db/migrate/tables/time_entries.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/time_entry_journals.rb
+++ b/db/migrate/tables/time_entry_journals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/users.rb
+++ b/db/migrate/tables/users.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/wiki_content_journals.rb
+++ b/db/migrate/tables/wiki_content_journals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/work_package_journals.rb
+++ b/db/migrate/tables/work_package_journals.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/migrate/tables/work_packages.rb
+++ b/db/migrate/tables/work_packages.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/extra/mail_handler/rdm-mailhandler.rb
+++ b/extra/mail_handler/rdm-mailhandler.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/extra/svn/reposman.rb
+++ b/extra/svn/reposman.rb
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/caching/cached_representer.rb
+++ b/lib/api/caching/cached_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/aggregation_group.rb
+++ b/lib/api/decorators/aggregation_group.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/allowed_values_by_collection_representer.rb
+++ b/lib/api/decorators/allowed_values_by_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/allowed_values_by_link_representer.rb
+++ b/lib/api/decorators/allowed_values_by_link_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/collection.rb
+++ b/lib/api/decorators/collection.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/create_form.rb
+++ b/lib/api/decorators/create_form.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/date_property.rb
+++ b/lib/api/decorators/date_property.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/digest.rb
+++ b/lib/api/decorators/digest.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/form.rb
+++ b/lib/api/decorators/form.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/formattable.rb
+++ b/lib/api/decorators/formattable.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/formattable_property.rb
+++ b/lib/api/decorators/formattable_property.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/link_object.rb
+++ b/lib/api/decorators/link_object.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/linked_resource.rb
+++ b/lib/api/decorators/linked_resource.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/offset_paginated_collection.rb
+++ b/lib/api/decorators/offset_paginated_collection.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/polymorphic_resource.rb
+++ b/lib/api/decorators/polymorphic_resource.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/property_schema_representer.rb
+++ b/lib/api/decorators/property_schema_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/schema_representer.rb
+++ b/lib/api/decorators/schema_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/simple_form.rb
+++ b/lib/api/decorators/simple_form.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/single.rb
+++ b/lib/api/decorators/single.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/sql/hal.rb
+++ b/lib/api/decorators/sql/hal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/lib/api/decorators/unpaginated_collection.rb
+++ b/lib/api/decorators/unpaginated_collection.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/decorators/update_form.rb
+++ b/lib/api/decorators/update_form.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/bad_request.rb
+++ b/lib/api/errors/bad_request.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/conflict.rb
+++ b/lib/api/errors/conflict.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/error_base.rb
+++ b/lib/api/errors/error_base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/internal_error.rb
+++ b/lib/api/errors/internal_error.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/invalid_query.rb
+++ b/lib/api/errors/invalid_query.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/invalid_render_context.rb
+++ b/lib/api/errors/invalid_render_context.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/invalid_request_body.rb
+++ b/lib/api/errors/invalid_request_body.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/invalid_resource_link.rb
+++ b/lib/api/errors/invalid_resource_link.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/invalid_signal.rb
+++ b/lib/api/errors/invalid_signal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/invalid_user_status_transition.rb
+++ b/lib/api/errors/invalid_user_status_transition.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/multiple_errors.rb
+++ b/lib/api/errors/multiple_errors.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/not_found.rb
+++ b/lib/api/errors/not_found.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/not_implemented.rb
+++ b/lib/api/errors/not_implemented.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/parse_error.rb
+++ b/lib/api/errors/parse_error.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/property_format_error.rb
+++ b/lib/api/errors/property_format_error.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/too_many_requests.rb
+++ b/lib/api/errors/too_many_requests.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/unauthenticated.rb
+++ b/lib/api/errors/unauthenticated.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/unauthorized.rb
+++ b/lib/api/errors/unauthorized.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/unsupported_media_type.rb
+++ b/lib/api/errors/unsupported_media_type.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/unwritable_property.rb
+++ b/lib/api/errors/unwritable_property.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/errors/validation.rb
+++ b/lib/api/errors/validation.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/formatter.rb
+++ b/lib/api/formatter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/helpers/attachment_renderer.rb
+++ b/lib/api/helpers/attachment_renderer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/camel_casing_strategy.rb
+++ b/lib/api/utilities/camel_casing_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/decorator_factory.rb
+++ b/lib/api/utilities/decorator_factory.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/endpoints/namespaced_lookup.rb
+++ b/lib/api/utilities/endpoints/namespaced_lookup.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/grape_helper.rb
+++ b/lib/api/utilities/grape_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/meta_property.rb
+++ b/lib/api/utilities/meta_property.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/payload_representer.rb
+++ b/lib/api/utilities/payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/property_name_converter.rb
+++ b/lib/api/utilities/property_name_converter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/property_name_converter_query_context.rb
+++ b/lib/api/utilities/property_name_converter_query_context.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/query_filters_name_converter.rb
+++ b/lib/api/utilities/query_filters_name_converter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/representer_to_json_cache.rb
+++ b/lib/api/utilities/representer_to_json_cache.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/resource_link_parser.rb
+++ b/lib/api/utilities/resource_link_parser.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/text_renderer.rb
+++ b/lib/api/utilities/text_renderer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/url_helper.rb
+++ b/lib/api/utilities/url_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/url_props_parsing_helper.rb
+++ b/lib/api/utilities/url_props_parsing_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/utilities/wp_property_name_converter.rb
+++ b/lib/api/utilities/wp_property_name_converter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/activities/activity_collection_representer.rb
+++ b/lib/api/v3/activities/activity_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/activities/activity_eager_loading_wrapper.rb
+++ b/lib/api/v3/activities/activity_eager_loading_wrapper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/activities/activity_property_formatters.rb
+++ b/lib/api/v3/activities/activity_property_formatters.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/attachments/attachable_payload_representer_mixin.rb
+++ b/lib/api/v3/attachments/attachable_payload_representer_mixin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/attachments/attachable_representer_mixin.rb
+++ b/lib/api/v3/attachments/attachable_representer_mixin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/attachments/attachment_collection_representer.rb
+++ b/lib/api/v3/attachments/attachment_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/attachments/attachment_parsing_representer.rb
+++ b/lib/api/v3/attachments/attachment_parsing_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/attachments/attachment_representer.rb
+++ b/lib/api/v3/attachments/attachment_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/attachments/attachment_upload_representer.rb
+++ b/lib/api/v3/attachments/attachment_upload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/capabilities/capability_sql_representer.rb
+++ b/lib/api/v3/capabilities/capability_sql_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/lib/api/v3/capabilities/contexts/global_representer.rb
+++ b/lib/api/v3/capabilities/contexts/global_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/categories/categories_api.rb
+++ b/lib/api/v3/categories/categories_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/categories/categories_by_project_api.rb
+++ b/lib/api/v3/categories/categories_by_project_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/categories/category_collection_representer.rb
+++ b/lib/api/v3/categories/category_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/categories/category_representer.rb
+++ b/lib/api/v3/categories/category_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/configuration/configuration_representer.rb
+++ b/lib/api/v3/configuration/configuration_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/cors.rb
+++ b/lib/api/v3/cors.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/custom_actions/custom_action_execute_representer.rb
+++ b/lib/api/v3/custom_actions/custom_action_execute_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/custom_actions/custom_action_representer.rb
+++ b/lib/api/v3/custom_actions/custom_action_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/custom_options/custom_option_representer.rb
+++ b/lib/api/v3/custom_options/custom_option_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/custom_options/custom_options_api.rb
+++ b/lib/api/v3/custom_options/custom_options_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/errors/error_representer.rb
+++ b/lib/api/v3/errors/error_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/groups/group_collection_representer.rb
+++ b/lib/api/v3/groups/group_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/groups/group_payload_representer.rb
+++ b/lib/api/v3/groups/group_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/groups/group_representer.rb
+++ b/lib/api/v3/groups/group_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/help_texts/help_text_collection_representer.rb
+++ b/lib/api/v3/help_texts/help_text_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/help_texts/help_text_representer.rb
+++ b/lib/api/v3/help_texts/help_text_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/memberships/create_form_representer.rb
+++ b/lib/api/v3/memberships/create_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/memberships/form_representer.rb
+++ b/lib/api/v3/memberships/form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/memberships/membership_collection_representer.rb
+++ b/lib/api/v3/memberships/membership_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/memberships/membership_meta_representer.rb
+++ b/lib/api/v3/memberships/membership_meta_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/memberships/membership_payload_representer.rb
+++ b/lib/api/v3/memberships/membership_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/memberships/membership_representer.rb
+++ b/lib/api/v3/memberships/membership_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/memberships/update_form_representer.rb
+++ b/lib/api/v3/memberships/update_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/news/news_collection_representer.rb
+++ b/lib/api/v3/news/news_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/notifications/notification_collection_representer.rb
+++ b/lib/api/v3/notifications/notification_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/notifications/notification_eager_loading_wrapper.rb
+++ b/lib/api/v3/notifications/notification_eager_loading_wrapper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/notifications/notification_representer.rb
+++ b/lib/api/v3/notifications/notification_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/parser.rb
+++ b/lib/api/v3/parser.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/placeholder_users/placeholder_user_collection_representer.rb
+++ b/lib/api/v3/placeholder_users/placeholder_user_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/placeholder_users/placeholder_user_payload_representer.rb
+++ b/lib/api/v3/placeholder_users/placeholder_user_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/placeholder_users/placeholder_user_representer.rb
+++ b/lib/api/v3/placeholder_users/placeholder_user_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/principals/not_builtin_elements.rb
+++ b/lib/api/v3/principals/not_builtin_elements.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/principals/principal_collection_representer.rb
+++ b/lib/api/v3/principals/principal_collection_representer.rb
@@ -24,8 +24,6 @@
 #
 #  See COPYRIGHT and LICENSE files for more details.
 
-#-- encoding: UTF-8
-
 # Exists to satisfy the expectations of the default end points.
 module API
   module V3

--- a/lib/api/v3/principals/principal_representer.rb
+++ b/lib/api/v3/principals/principal_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/principals/principal_representer_factory.rb
+++ b/lib/api/v3/principals/principal_representer_factory.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/principals/principal_type.rb
+++ b/lib/api/v3/principals/principal_type.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/priorities/priorities_api.rb
+++ b/lib/api/v3/priorities/priorities_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/priorities/priority_collection_representer.rb
+++ b/lib/api/v3/priorities/priority_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/priorities/priority_representer.rb
+++ b/lib/api/v3/priorities/priority_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/copy/create_form_representer.rb
+++ b/lib/api/v3/projects/copy/create_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/copy/form_representer.rb
+++ b/lib/api/v3/projects/copy/form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/copy/project_copy_meta_representer.rb
+++ b/lib/api/v3/projects/copy/project_copy_meta_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/copy/project_copy_payload_representer.rb
+++ b/lib/api/v3/projects/copy/project_copy_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/copy/project_copy_schema_representer.rb
+++ b/lib/api/v3/projects/copy/project_copy_schema_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/create_form_representer.rb
+++ b/lib/api/v3/projects/create_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/form_representer.rb
+++ b/lib/api/v3/projects/form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/project_collection_representer.rb
+++ b/lib/api/v3/projects/project_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/project_eager_loading_wrapper.rb
+++ b/lib/api/v3/projects/project_eager_loading_wrapper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/project_payload_representer.rb
+++ b/lib/api/v3/projects/project_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/schemas/project_schema_representer.rb
+++ b/lib/api/v3/projects/schemas/project_schema_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/statuses/status_representer.rb
+++ b/lib/api/v3/projects/statuses/status_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/projects/update_form_representer.rb
+++ b/lib/api/v3/projects/update_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/columns/query_column_representer.rb
+++ b/lib/api/v3/queries/columns/query_column_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/columns/query_property_column_representer.rb
+++ b/lib/api/v3/queries/columns/query_property_column_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/columns/query_relation_of_type_column_representer.rb
+++ b/lib/api/v3/queries/columns/query_relation_of_type_column_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/columns/query_relation_to_type_column_representer.rb
+++ b/lib/api/v3/queries/columns/query_relation_to_type_column_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/create_form_representer.rb
+++ b/lib/api/v3/queries/create_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/filters/query_filter_decorator.rb
+++ b/lib/api/v3/queries/filters/query_filter_decorator.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/filters/query_filter_instance_payload_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_instance_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/filters/query_filter_instance_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_instance_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/filters/query_filter_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/form_representer.rb
+++ b/lib/api/v3/queries/form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/group_bys/query_group_by_representer.rb
+++ b/lib/api/v3/queries/group_bys/query_group_by_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/operators/query_operator_representer.rb
+++ b/lib/api/v3/queries/operators/query_operator_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/projections/query_projection_representer.rb
+++ b/lib/api/v3/queries/projections/query_projection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/query_collection_representer.rb
+++ b/lib/api/v3/queries/query_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/query_params_representer.rb
+++ b/lib/api/v3/queries/query_params_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/query_payload_representer.rb
+++ b/lib/api/v3/queries/query_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/all_principals_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/all_principals_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/assignee_or_group_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/assignee_or_group_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/blocked_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/blocked_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/blocks_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/blocks_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/boolean_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/boolean_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/by_work_package_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/by_work_package_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/category_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/category_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/custom_field_json_cache_key_mixin.rb
+++ b/lib/api/v3/queries/schemas/custom_field_json_cache_key_mixin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/custom_option_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/custom_option_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/date_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/date_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/date_time_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/date_time_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/duplicated_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/duplicated_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/duplicates_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/duplicates_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/filter_dependency_decorator.rb
+++ b/lib/api/v3/queries/schemas/filter_dependency_decorator.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/float_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/float_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/follows_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/follows_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/group_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/group_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/id_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/id_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/includes_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/includes_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/integer_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/integer_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/manual_sort_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/manual_sort_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/only_subproject_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/only_subproject_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/parent_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/parent_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/partof_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/partof_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/precedes_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/precedes_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/principal_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/principal_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/priority_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/priority_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/project_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/project_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/query_filter_instance_schema_collection_representer.rb
+++ b/lib/api/v3/queries/schemas/query_filter_instance_schema_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/relates_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/relates_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/required_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/required_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/requires_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/requires_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/role_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/role_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/search_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/search_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/status_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/status_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/subproject_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/subproject_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/text_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/text_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/type_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/type_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/user_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/user_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/version_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/sort_bys/query_sort_by_representer.rb
+++ b/lib/api/v3/queries/sort_bys/query_sort_by_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/sort_bys/sort_by_decorator.rb
+++ b/lib/api/v3/queries/sort_bys/sort_by_decorator.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/queries/update_form_representer.rb
+++ b/lib/api/v3/queries/update_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/relations/relation_collection_representer.rb
+++ b/lib/api/v3/relations/relation_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/relations/relation_paginated_collection_representer.rb
+++ b/lib/api/v3/relations/relation_paginated_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/relations/relation_payload_representer.rb
+++ b/lib/api/v3/relations/relation_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/relations/relation_representer.rb
+++ b/lib/api/v3/relations/relation_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/render/render_api.rb
+++ b/lib/api/v3/render/render_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/repositories/revision_collection_representer.rb
+++ b/lib/api/v3/repositories/revision_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/repositories/revision_representer.rb
+++ b/lib/api/v3/repositories/revision_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/roles/role_collection_representer.rb
+++ b/lib/api/v3/roles/role_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/roles/role_representer.rb
+++ b/lib/api/v3/roles/role_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/roles/roles_api.rb
+++ b/lib/api/v3/roles/roles_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/root_representer.rb
+++ b/lib/api/v3/root_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/schemas/schema_collection_representer.rb
+++ b/lib/api/v3/schemas/schema_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/schemas/schema_dependency_representer.rb
+++ b/lib/api/v3/schemas/schema_dependency_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/statuses/status_collection_representer.rb
+++ b/lib/api/v3/statuses/status_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/statuses/status_representer.rb
+++ b/lib/api/v3/statuses/status_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/statuses/statuses_api.rb
+++ b/lib/api/v3/statuses/statuses_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/string_objects/string_objects_api.rb
+++ b/lib/api/v3/string_objects/string_objects_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/types/type_collection_representer.rb
+++ b/lib/api/v3/types/type_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/types/type_representer.rb
+++ b/lib/api/v3/types/type_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/types/types_api.rb
+++ b/lib/api/v3/types/types_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/types/types_by_project_api.rb
+++ b/lib/api/v3/types/types_by_project_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/user_preferences/notification_setting_representer.rb
+++ b/lib/api/v3/user_preferences/notification_setting_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/user_preferences/user_preference_payload_representer.rb
+++ b/lib/api/v3/user_preferences/user_preference_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/user_preferences/user_preference_representer.rb
+++ b/lib/api/v3/user_preferences/user_preference_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/users/create_form_representer.rb
+++ b/lib/api/v3/users/create_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/users/form_representer.rb
+++ b/lib/api/v3/users/form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/users/schemas/user_schema_representer.rb
+++ b/lib/api/v3/users/schemas/user_schema_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/users/unpaginated_user_collection_representer.rb
+++ b/lib/api/v3/users/unpaginated_user_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/users/update_form_representer.rb
+++ b/lib/api/v3/users/update_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/users/user_collection_representer.rb
+++ b/lib/api/v3/users/user_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/users/user_payload_representer.rb
+++ b/lib/api/v3/users/user_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/utilities/custom_field_injector/link_value_getter.rb
+++ b/lib/api/v3/utilities/custom_field_injector/link_value_getter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/utilities/custom_field_sum_injector.rb
+++ b/lib/api/v3/utilities/custom_field_sum_injector.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/utilities/date_time_formatter.rb
+++ b/lib/api/v3/utilities/date_time_formatter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/utilities/eager_loading/custom_field_accessor.rb
+++ b/lib/api/v3/utilities/eager_loading/custom_field_accessor.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/utilities/eager_loading/eager_loading_wrapper.rb
+++ b/lib/api/v3/utilities/eager_loading/eager_loading_wrapper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/utilities/resource_link_generator.rb
+++ b/lib/api/v3/utilities/resource_link_generator.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/utilities/sql_representer_walker.rb
+++ b/lib/api/v3/utilities/sql_representer_walker.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/lib/api/v3/utilities/sql_walker_results.rb
+++ b/lib/api/v3/utilities/sql_walker_results.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/lib/api/v3/versions/create_form_representer.rb
+++ b/lib/api/v3/versions/create_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/versions/form_representer.rb
+++ b/lib/api/v3/versions/form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/versions/projects_by_version_api.rb
+++ b/lib/api/v3/versions/projects_by_version_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/versions/schemas/version_schema_representer.rb
+++ b/lib/api/v3/versions/schemas/version_schema_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/versions/update_form_representer.rb
+++ b/lib/api/v3/versions/update_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/versions/version_collection_representer.rb
+++ b/lib/api/v3/versions/version_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/versions/version_payload_representer.rb
+++ b/lib/api/v3/versions/version_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/versions/version_representer.rb
+++ b/lib/api/v3/versions/version_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/versions/versions_api.rb
+++ b/lib/api/v3/versions/versions_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/versions/versions_by_project_api.rb
+++ b/lib/api/v3/versions/versions_by_project_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/watchers/watcher_representer.rb
+++ b/lib/api/v3/watchers/watcher_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/wiki_pages/wiki_page_representer.rb
+++ b/lib/api/v3/wiki_pages/wiki_page_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/create_form_representer.rb
+++ b/lib/api/v3/work_packages/create_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/create_project_form_representer.rb
+++ b/lib/api/v3/work_packages/create_project_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/eager_loading/ancestor.rb
+++ b/lib/api/v3/work_packages/eager_loading/ancestor.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/eager_loading/base.rb
+++ b/lib/api/v3/work_packages/eager_loading/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/eager_loading/checksum.rb
+++ b/lib/api/v3/work_packages/eager_loading/checksum.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/eager_loading/custom_action.rb
+++ b/lib/api/v3/work_packages/eager_loading/custom_action.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/eager_loading/custom_value.rb
+++ b/lib/api/v3/work_packages/eager_loading/custom_value.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/eager_loading/hierarchy.rb
+++ b/lib/api/v3/work_packages/eager_loading/hierarchy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/eager_loading/neutral_wrapper.rb
+++ b/lib/api/v3/work_packages/eager_loading/neutral_wrapper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/eager_loading/project.rb
+++ b/lib/api/v3/work_packages/eager_loading/project.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/form_representer.rb
+++ b/lib/api/v3/work_packages/form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/link_to_object_extractor.rb
+++ b/lib/api/v3/work_packages/link_to_object_extractor.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/principal_setter.rb
+++ b/lib/api/v3/work_packages/principal_setter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/schema/base_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/base_work_package_schema.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/specific_work_package_schema.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/schema/typed_schema_contract.rb
+++ b/lib/api/v3/work_packages/schema/typed_schema_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/schema/typed_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/typed_work_package_schema.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/schema/work_package_schema_collection_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/schema/work_package_sums_schema.rb
+++ b/lib/api/v3/work_packages/schema/work_package_sums_schema.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/schema/work_package_sums_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_sums_schema_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/update_form_representer.rb
+++ b/lib/api/v3/work_packages/update_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/work_package_aggregation_group.rb
+++ b/lib/api/v3/work_packages/work_package_aggregation_group.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
+++ b/lib/api/v3/work_packages/work_package_eager_loading_wrapper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/work_package_lock_version_payload_representer.rb
+++ b/lib/api/v3/work_packages/work_package_lock_version_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/work_package_payload_representer.rb
+++ b/lib/api/v3/work_packages/work_package_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/ar_condition.rb
+++ b/lib/ar_condition.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/constraints/enterprise.rb
+++ b/lib/constraints/enterprise.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/core_extensions/string.rb
+++ b/lib/core_extensions/string.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/custom_field_form_builder.rb
+++ b/lib/custom_field_form_builder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/generators/open_project/plugin/templates/%full_name%.gemspec.tt
+++ b/lib/generators/open_project/plugin/templates/%full_name%.gemspec.tt
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 $:.push File.expand_path("../lib", __FILE__)
 $:.push File.expand_path("../../lib", __dir__)
 

--- a/lib/open_project.rb
+++ b/lib/open_project.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/access_control.rb
+++ b/lib/open_project/access_control.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/access_control/mapper.rb
+++ b/lib/open_project/access_control/mapper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/access_control/permission.rb
+++ b/lib/open_project/access_control/permission.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/access_keys.rb
+++ b/lib/open_project/access_keys.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/acts_as_url/adapter/op_active_record.rb
+++ b/lib/open_project/acts_as_url/adapter/op_active_record.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/assets.rb
+++ b/lib/open_project/assets.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/changed_by_system.rb
+++ b/lib/open_project/changed_by_system.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/configuration.rb
+++ b/lib/open_project/configuration.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/configuration/helpers.rb
+++ b/lib/open_project/configuration/helpers.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/content_type_detector.rb
+++ b/lib/open_project/content_type_detector.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/custom_field_format.rb
+++ b/lib/open_project/custom_field_format.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/custom_styles/color_themes.rb
+++ b/lib/open_project/custom_styles/color_themes.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/custom_styles/design.rb
+++ b/lib/open_project/custom_styles/design.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/database.rb
+++ b/lib/open_project/database.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/default_wp_queries.rb
+++ b/lib/open_project/default_wp_queries.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/file_command_content_type_detector.rb
+++ b/lib/open_project/file_command_content_type_detector.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/footer.rb
+++ b/lib/open_project/footer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/form_tag_helper.rb
+++ b/lib/open_project/form_tag_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/full_text_search.rb
+++ b/lib/open_project/full_text_search.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/hook.rb
+++ b/lib/open_project/hook.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/info.rb
+++ b/lib/open_project/info.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/journal/attachment_helper.rb
+++ b/lib/open_project/journal/attachment_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/locale_helper.rb
+++ b/lib/open_project/locale_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/mime_type.rb
+++ b/lib/open_project/mime_type.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/mutex.rb
+++ b/lib/open_project/mutex.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/nested_set/rebuild_patch.rb
+++ b/lib/open_project/nested_set/rebuild_patch.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/null_db_fallback.rb
+++ b/lib/open_project/null_db_fallback.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/object_linking.rb
+++ b/lib/open_project/object_linking.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/page_hierarchy_helper.rb
+++ b/lib/open_project/page_hierarchy_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/passwords.rb
+++ b/lib/open_project/passwords.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/patches.rb
+++ b/lib/open_project/patches.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/patches/action_view_helpers_asset_tag_helper.rb
+++ b/lib/open_project/patches/action_view_helpers_asset_tag_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/patches/active_model_errors.rb
+++ b/lib/open_project/patches/active_model_errors.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/patches/string.rb
+++ b/lib/open_project/patches/string.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/plugins/module_handler.rb
+++ b/lib/open_project/plugins/module_handler.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/repository_authentication.rb
+++ b/lib/open_project/repository_authentication.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/safe_params.rb
+++ b/lib/open_project/safe_params.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/scm/adapters.rb
+++ b/lib/open_project/scm/adapters.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/scm/adapters/base.rb
+++ b/lib/open_project/scm/adapters/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/scm/adapters/checkout_instructions.rb
+++ b/lib/open_project/scm/adapters/checkout_instructions.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/scm/adapters/git.rb
+++ b/lib/open_project/scm/adapters/git.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/scm/adapters/local_client.rb
+++ b/lib/open_project/scm/adapters/local_client.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/scm/adapters/subversion.rb
+++ b/lib/open_project/scm/adapters/subversion.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/scm/exceptions.rb
+++ b/lib/open_project/scm/exceptions.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/scm/manageable_repository.rb
+++ b/lib/open_project/scm/manageable_repository.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/scm/manager.rb
+++ b/lib/open_project/scm/manager.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/sql_sanitization.rb
+++ b/lib/open_project/sql_sanitization.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/static/homescreen.rb
+++ b/lib/open_project/static/homescreen.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/static/links.rb
+++ b/lib/open_project/static/links.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/storage.rb
+++ b/lib/open_project/storage.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/syntax_highlighting.rb
+++ b/lib/open_project/syntax_highlighting.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting.rb
+++ b/lib/open_project/text_formatting.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/attachment_filter.rb
+++ b/lib/open_project/text_formatting/filters/attachment_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/autolink_filter.rb
+++ b/lib/open_project/text_formatting/filters/autolink_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/bem_css_filter.rb
+++ b/lib/open_project/text_formatting/filters/bem_css_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/figure_wrapped_filter.rb
+++ b/lib/open_project/text_formatting/filters/figure_wrapped_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/link_attribute_filter.rb
+++ b/lib/open_project/text_formatting/filters/link_attribute_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/macro_filter.rb
+++ b/lib/open_project/text_formatting/filters/macro_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/macros/child_pages.rb
+++ b/lib/open_project/text_formatting/filters/macros/child_pages.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/macros/child_pages/child_pages_context.rb
+++ b/lib/open_project/text_formatting/filters/macros/child_pages/child_pages_context.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/macros/create_work_package_link.rb
+++ b/lib/open_project/text_formatting/filters/macros/create_work_package_link.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/macros/embedded_table.rb
+++ b/lib/open_project/text_formatting/filters/macros/embedded_table.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/macros/include_wiki_page.rb
+++ b/lib/open_project/text_formatting/filters/macros/include_wiki_page.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/macros/toc.rb
+++ b/lib/open_project/text_formatting/filters/macros/toc.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/markdown_filter.rb
+++ b/lib/open_project/text_formatting/filters/markdown_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/mention_filter.rb
+++ b/lib/open_project/text_formatting/filters/mention_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/pattern_matcher_filter.rb
+++ b/lib/open_project/text_formatting/filters/pattern_matcher_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/plain_filter.rb
+++ b/lib/open_project/text_formatting/filters/plain_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/relative_link_filter.rb
+++ b/lib/open_project/text_formatting/filters/relative_link_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/sanitization_filter.rb
+++ b/lib/open_project/text_formatting/filters/sanitization_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/setting_macros_filter.rb
+++ b/lib/open_project/text_formatting/filters/setting_macros_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/syntax_highlight_filter.rb
+++ b/lib/open_project/text_formatting/filters/syntax_highlight_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
+++ b/lib/open_project/text_formatting/filters/table_of_contents_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/filters/task_list_filter.rb
+++ b/lib/open_project/text_formatting/filters/task_list_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats.rb
+++ b/lib/open_project/text_formatting/formats.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/base_format.rb
+++ b/lib/open_project/text_formatting/formats/base_format.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/base_formatter.rb
+++ b/lib/open_project/text_formatting/formats/base_formatter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/markdown/format.rb
+++ b/lib/open_project/text_formatting/formats/markdown/format.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/markdown/formatter.rb
+++ b/lib/open_project/text_formatting/formats/markdown/formatter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/markdown/helper.rb
+++ b/lib/open_project/text_formatting/formats/markdown/helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/markdown/pandoc_downloader.rb
+++ b/lib/open_project/text_formatting/formats/markdown/pandoc_downloader.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/markdown/pandoc_wrapper.rb
+++ b/lib/open_project/text_formatting/formats/markdown/pandoc_wrapper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/markdown/textile_converter.rb
+++ b/lib/open_project/text_formatting/formats/markdown/textile_converter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/plain/format.rb
+++ b/lib/open_project/text_formatting/formats/plain/format.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/plain/formatter.rb
+++ b/lib/open_project/text_formatting/formats/plain/formatter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/formats/plain/helper.rb
+++ b/lib/open_project/text_formatting/formats/plain/helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/helpers/link_rewriter.rb
+++ b/lib/open_project/text_formatting/helpers/link_rewriter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/attribute_macros.rb
+++ b/lib/open_project/text_formatting/matchers/attribute_macros.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/link_handlers/base.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/base.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/link_handlers/hash_separator.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/hash_separator.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/link_handlers/revisions.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/revisions.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/link_handlers/work_packages.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/work_packages.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/regex_matcher.rb
+++ b/lib/open_project/text_formatting/matchers/regex_matcher.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/resource_links_matcher.rb
+++ b/lib/open_project/text_formatting/matchers/resource_links_matcher.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/matchers/wiki_links_matcher.rb
+++ b/lib/open_project/text_formatting/matchers/wiki_links_matcher.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/renderer.rb
+++ b/lib/open_project/text_formatting/renderer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/text_formatting/truncation.rb
+++ b/lib/open_project/text_formatting/truncation.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/ui/extensible_tabs.rb
+++ b/lib/open_project/ui/extensible_tabs.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/open_project/version.rb
+++ b/lib/open_project/version.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/plugins/acts_as_attachable/init.rb
+++ b/lib/plugins/acts_as_attachable/init.rb
@@ -26,7 +26,5 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 require File.dirname(__FILE__) + '/lib/acts_as_attachable'
 ActiveRecord::Base.include Redmine::Acts::Attachable

--- a/lib/plugins/acts_as_customizable/init.rb
+++ b/lib/plugins/acts_as_customizable/init.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 require File.dirname(__FILE__) + '/lib/acts_as_customizable'
 require File.dirname(__FILE__) + '/lib/human_attribute_name'
 ActiveRecord::Base.include Redmine::Acts::Customizable

--- a/lib/plugins/acts_as_event/init.rb
+++ b/lib/plugins/acts_as_event/init.rb
@@ -26,7 +26,5 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 require File.dirname(__FILE__) + '/lib/acts_as_event'
 ActiveRecord::Base.include Redmine::Acts::Event

--- a/lib/plugins/acts_as_journalized/init.rb
+++ b/lib/plugins/acts_as_journalized/init.rb
@@ -26,7 +26,5 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 require 'acts_as_journalized'
 ActiveRecord::Base.include(Acts::Journalized)

--- a/lib/plugins/acts_as_journalized/lib/acts/journalized/creation.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts/journalized/creation.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 # This file included as part of the acts_as_journalized plugin for
 # the redMine project management software; You can redistribute it
 # and/or modify it under the terms of the GNU General Public License

--- a/lib/plugins/acts_as_journalized/lib/acts/journalized/format_hooks.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts/journalized/format_hooks.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 # This file is part of the acts_as_journalized plugin for the redMine
 # project management software
 #

--- a/lib/plugins/acts_as_journalized/lib/acts/journalized/journalized.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts/journalized/journalized.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 # This file included as part of the acts_as_journalized plugin for
 # the redMine project management software; You can redistribute it
 # and/or modify it under the terms of the GNU General Public License

--- a/lib/plugins/acts_as_journalized/lib/acts/journalized/options.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts/journalized/options.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 # This file included as part of the acts_as_journalized plugin for
 # the redMine project management software; You can redistribute it
 # and/or modify it under the terms of the GNU General Public License

--- a/lib/plugins/acts_as_journalized/lib/acts/journalized/permissions.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts/journalized/permissions.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 # This file is part of the acts_as_journalized plugin for the redMine
 # project management software
 #

--- a/lib/plugins/acts_as_journalized/lib/acts/journalized/reversion.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts/journalized/reversion.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 # This file included as part of the acts_as_journalized plugin for
 # the redMine project management software; You can redistribute it
 # and/or modify it under the terms of the GNU General Public License

--- a/lib/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts/journalized/save_hooks.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 # This file is part of the acts_as_journalized plugin for the redMine
 # project management software
 #

--- a/lib/plugins/acts_as_journalized/lib/acts_as_journalized.rb
+++ b/lib/plugins/acts_as_journalized/lib/acts_as_journalized.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 # This file is part of the acts_as_journalized plugin for the redMine
 # project management software
 #

--- a/lib/plugins/acts_as_journalized/lib/journal_changes.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_changes.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/plugins/acts_as_journalized/lib/journal_deprecated.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_deprecated.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 # This file is part of the acts_as_journalized plugin for the redMine
 # project management software
 #

--- a/lib/plugins/acts_as_journalized/lib/journal_detail.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_detail.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 class JournalDetail
   attr_reader :prop_key, :value, :old_value
 

--- a/lib/plugins/acts_as_journalized/lib/journal_formatter.rb
+++ b/lib/plugins/acts_as_journalized/lib/journal_formatter.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 # This file is part of the acts_as_journalized plugin for the redMine
 # project management software
 #

--- a/lib/plugins/acts_as_searchable/init.rb
+++ b/lib/plugins/acts_as_searchable/init.rb
@@ -26,7 +26,5 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 require File.dirname(__FILE__) + '/lib/acts_as_searchable'
 ActiveRecord::Base.include Redmine::Acts::Searchable

--- a/lib/plugins/acts_as_watchable/init.rb
+++ b/lib/plugins/acts_as_watchable/init.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 # Include hook code here
 require File.dirname(__FILE__) + '/lib/acts_as_watchable'
 require File.dirname(__FILE__) + '/lib/acts_as_watchable/routes.rb'

--- a/lib/plugins/acts_as_watchable/lib/acts_as_watchable.rb
+++ b/lib/plugins/acts_as_watchable/lib/acts_as_watchable.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-#-- encoding: UTF-8
-
 # ActsAsWatchable
 module Redmine
   module Acts

--- a/lib/redmine/about.rb
+++ b/lib/redmine/about.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/ciphering.rb
+++ b/lib/redmine/ciphering.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/diff.rb
+++ b/lib/redmine/diff.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/diff_table.rb
+++ b/lib/redmine/diff_table.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/helpers/diff.rb
+++ b/lib/redmine/helpers/diff.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/i18n.rb
+++ b/lib/redmine/i18n.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/imap.rb
+++ b/lib/redmine/imap.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/menu_manager.rb
+++ b/lib/redmine/menu_manager.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/menu_manager/mapper.rb
+++ b/lib/redmine/menu_manager/mapper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/menu_manager/menu_controller.rb
+++ b/lib/redmine/menu_manager/menu_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/menu_manager/menu_error.rb
+++ b/lib/redmine/menu_manager/menu_error.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/menu_manager/menu_item.rb
+++ b/lib/redmine/menu_manager/menu_item.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/menu_manager/tree_node.rb
+++ b/lib/redmine/menu_manager/tree_node.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/menu_manager/wiki_menu_helper.rb
+++ b/lib/redmine/menu_manager/wiki_menu_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/platform.rb
+++ b/lib/redmine/platform.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/plugin.rb
+++ b/lib/redmine/plugin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/pop3.rb
+++ b/lib/redmine/pop3.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/search.rb
+++ b/lib/redmine/search.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/unified_diff.rb
+++ b/lib/redmine/unified_diff.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/redmine/views/other_formats_builder.rb
+++ b/lib/redmine/views/other_formats_builder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tabular_form_builder.rb
+++ b/lib/tabular_form_builder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/attachment_migrations.rake
+++ b/lib/tasks/attachment_migrations.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/attachments.rake
+++ b/lib/tasks/attachments.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/ciphering.rake
+++ b/lib/tasks/ciphering.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/code.rake
+++ b/lib/tasks/code.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH
@@ -41,34 +39,6 @@ namespace :code do
       # handle files in chunks of 50 to avoid too long command lines
       while (slice = files.slice!(0, 50)).present?
         system('ruby', '-i', '-pe', 'gsub(/\s+\z/,"\n")', *slice)
-      end
-    end
-  end
-
-  desc 'Set the magic encoding comment everywhere to UTF-8'
-  task :source_encoding do
-    shebang = '\s*#!.*?(\n|\r\n)'
-    magic_regex = /\A(#{shebang})?\s*(#\W*(en)?coding:.*?$)/mi
-
-    magic_comment = '#-- encoding: UTF-8'
-
-    (Dir['script/**/**'] + Dir['**/**{.rb,.rake}']).each do |file_name|
-      next unless File.file?(file_name)
-
-      # We don't skip code here, as we need ALL code files to have UTF-8
-      # source encoding
-      file_content = File.read(file_name)
-      if file_content =~ magic_regex
-        file_content.gsub!(magic_regex, "\\1#{magic_comment}")
-      elsif file_content.start_with?('#!')
-        file_content.sub!(/(\n|\r\n)/, "\\1#{magic_comment}\\1")
-      # We have a shebang. Encoding comment is to put on the second line
-      else
-        file_content = magic_comment + "\n" + file_content
-      end
-
-      File.open(file_name, 'w') do |file|
-        file.write file_content
       end
     end
   end

--- a/lib/tasks/copyright.rake
+++ b/lib/tasks/copyright.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/copyright_authors.rake
+++ b/lib/tasks/copyright_authors.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/delayed_job.rake
+++ b/lib/tasks/delayed_job.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/delete_documents.rake
+++ b/lib/tasks/delete_documents.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/deprecated.rake
+++ b/lib/tasks/deprecated.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/environment.rake
+++ b/lib/tasks/environment.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/extract_fixtures.rake
+++ b/lib/tasks/extract_fixtures.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/fetch_changesets.rake
+++ b/lib/tasks/fetch_changesets.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/jdbc.rake
+++ b/lib/tasks/jdbc.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/ldap.rake
+++ b/lib/tasks/ldap.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/load_default_data.rake
+++ b/lib/tasks/load_default_data.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/packager.rake
+++ b/lib/tasks/packager.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/parallel_testing.rake
+++ b/lib/tasks/parallel_testing.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/permissions.rake
+++ b/lib/tasks/permissions.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/plugins.rake
+++ b/lib/tasks/plugins.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/reminder.rake
+++ b/lib/tasks/reminder.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/reregister_password_migrations.rake
+++ b/lib/tasks/reregister_password_migrations.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/scm.rake
+++ b/lib/tasks/scm.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/secret_token.rake
+++ b/lib/tasks/secret_token.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/shared/user_feedback.rb
+++ b/lib/tasks/shared/user_feedback.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/version.rake
+++ b/lib/tasks/version.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/watchers.rake
+++ b/lib/tasks/watchers.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/lib/tasks/yardoc.rake
+++ b/lib/tasks/yardoc.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/auth_plugins/lib/omni_auth/flexible_builder.rb
+++ b/modules/auth_plugins/lib/omni_auth/flexible_builder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/auth_plugins/lib/omni_auth/flexible_strategy.rb
+++ b/modules/auth_plugins/lib/omni_auth/flexible_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/auth_plugins/lib/open_project/auth_plugins.rb
+++ b/modules/auth_plugins/lib/open_project/auth_plugins.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/auth_plugins/lib/open_project/auth_plugins/engine.rb
+++ b/modules/auth_plugins/lib/open_project/auth_plugins/engine.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/auth_plugins/lib/open_project/auth_plugins/hooks.rb
+++ b/modules/auth_plugins/lib/open_project/auth_plugins/hooks.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/auth_plugins/lib/open_project/plugins/auth_plugin.rb
+++ b/modules/auth_plugins/lib/open_project/plugins/auth_plugin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/auth_plugins/lib/openproject-auth_plugins.rb
+++ b/modules/auth_plugins/lib/openproject-auth_plugins.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/auth_plugins/openproject-auth_plugins.gemspec
+++ b/modules/auth_plugins/openproject-auth_plugins.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = 'openproject-auth_plugins'
   s.version     = '1.0.0'

--- a/modules/auth_saml/openproject-auth_saml.gemspec
+++ b/modules/auth_saml/openproject-auth_saml.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = 'openproject-auth_saml'
   s.version     = '1.0.0'

--- a/modules/avatars/lib/api/v3/users/user_avatar_api.rb
+++ b/modules/avatars/lib/api/v3/users/user_avatar_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/avatars/openproject-avatars.gemspec
+++ b/modules/avatars/openproject-avatars.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "openproject-avatars"
   s.version     = '1.0.0'

--- a/modules/backlogs/app/controllers/backlogs_settings_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs_settings_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/backlogs/app/controllers/projects/settings/backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/projects/settings/backlogs_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/backlogs/app/seeders/basic_data/backlogs/setting_seeder.rb
+++ b/modules/backlogs/app/seeders/basic_data/backlogs/setting_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/contracts/bim/bcf/concerns/manage_bcf_guarded.rb
+++ b/modules/bim/app/contracts/bim/bcf/concerns/manage_bcf_guarded.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/contracts/bim/bcf/issues/base_contract.rb
+++ b/modules/bim/app/contracts/bim/bcf/issues/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/contracts/bim/bcf/work_packages/update_contract.rb
+++ b/modules/bim/app/contracts/bim/bcf/work_packages/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/controllers/bim/bcf/api/root.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/root.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/create.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/create.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/delete.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/delete.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/index.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/index.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/modify_mixin.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/modify_mixin.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/show.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/show.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/update.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/endpoints/update.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/controllers/bim/bcf/issues_controller.rb
+++ b/modules/bim/app/controllers/bim/bcf/issues_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/controllers/bim/ifc_models/ifc_viewer_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_viewer_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/formatters/bim/bcf/api/error_formatter/json.rb
+++ b/modules/bim/app/formatters/bim/bcf/api/error_formatter/json.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/models/bim/queries/work_packages/columns/bcf_thumbnail_column.rb
+++ b/modules/bim/app/models/bim/queries/work_packages/columns/bcf_thumbnail_column.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/models/bim/queries/work_packages/filter/bcf_issue_associated_filter.rb
+++ b/modules/bim/app/models/bim/queries/work_packages/filter/bcf_issue_associated_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/representers/bim/bcf/api/v2_1/auth/single_representer.rb
+++ b/modules/bim/app/representers/bim/bcf/api/v2_1/auth/single_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/representers/bim/bcf/api/v2_1/base_representer.rb
+++ b/modules/bim/app/representers/bim/bcf/api/v2_1/base_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/representers/bim/bcf/api/v2_1/errors/error_mapper.rb
+++ b/modules/bim/app/representers/bim/bcf/api/v2_1/errors/error_mapper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/representers/bim/bcf/api/v2_1/errors/error_representer.rb
+++ b/modules/bim/app/representers/bim/bcf/api/v2_1/errors/error_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/representers/bim/bcf/api/v2_1/project_extensions/representer.rb
+++ b/modules/bim/app/representers/bim/bcf/api/v2_1/project_extensions/representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/representers/bim/bcf/api/v2_1/projects/single_representer.rb
+++ b/modules/bim/app/representers/bim/bcf/api/v2_1/projects/single_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/representers/bim/bcf/api/v2_1/topics/authorization_representer.rb
+++ b/modules/bim/app/representers/bim/bcf/api/v2_1/topics/authorization_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/representers/bim/bcf/api/v2_1/topics/single_representer.rb
+++ b/modules/bim/app/representers/bim/bcf/api/v2_1/topics/single_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/representers/bim/bcf/api/v2_1/users/single_representer.rb
+++ b/modules/bim/app/representers/bim/bcf/api/v2_1/users/single_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/seeders/bim/basic_data/activity_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data/activity_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/seeders/bim/basic_data/priority_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data/priority_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/seeders/bim/basic_data/role_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data/role_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/seeders/bim/basic_data/setting_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data/setting_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/seeders/bim/basic_data/status_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data/status_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/seeders/bim/basic_data/theme_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data/theme_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/seeders/bim/basic_data/type_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data/type_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/seeders/bim/basic_data/workflow_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data/workflow_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/seeders/bim/basic_data_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/seeders/bim/demo_data/bcf_xml_seeder.rb
+++ b/modules/bim/app/seeders/bim/demo_data/bcf_xml_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/seeders/bim/demo_data/ifc_model_seeder.rb
+++ b/modules/bim/app/seeders/bim/demo_data/ifc_model_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/services/bim/bcf/issues/create_service.rb
+++ b/modules/bim/app/services/bim/bcf/issues/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/services/bim/bcf/issues/delete_service.rb
+++ b/modules/bim/app/services/bim/bcf/issues/delete_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/services/bim/bcf/issues/set_attributes_service.rb
+++ b/modules/bim/app/services/bim/bcf/issues/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/services/bim/bcf/issues/transform_attributes_service.rb
+++ b/modules/bim/app/services/bim/bcf/issues/transform_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/services/bim/bcf/issues/update_service.rb
+++ b/modules/bim/app/services/bim/bcf/issues/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/services/bim/bcf/viewpoints/delete_service.rb
+++ b/modules/bim/app/services/bim/bcf/viewpoints/delete_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/app/services/bim/ifc_models/set_attributes_service.rb
+++ b/modules/bim/app/services/bim/ifc_models/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/db/migrate/20201105154216_seed_custom_style_with_bim_theme.rb
+++ b/modules/bim/db/migrate/20201105154216_seed_custom_style_with_bim_theme.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/lib/api/bim/utilities/path_helper.rb
+++ b/modules/bim/lib/api/bim/utilities/path_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/lib/open_project/bim/patches/query_builder_patch.rb
+++ b/modules/bim/lib/open_project/bim/patches/query_builder_patch.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/modules/bim/lib/tasks/openproject-bim.rake
+++ b/modules/bim/lib/tasks/openproject-bim.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/openproject-bcf.gemspec
+++ b/modules/bim/openproject-bcf.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "openproject-bim"

--- a/modules/bim/spec/contracts/ifc_models/create_contract_spec.rb
+++ b/modules/bim/spec/contracts/ifc_models/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/spec/contracts/ifc_models/shared_contract_examples.rb
+++ b/modules/bim/spec/contracts/ifc_models/shared_contract_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/spec/contracts/ifc_models/update_contract_spec.rb
+++ b/modules/bim/spec/contracts/ifc_models/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/spec/controllers/work_packages_controller_spec.rb
+++ b/modules/bim/spec/controllers/work_packages_controller_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/spec/factories/bcf_issue_factory.rb
+++ b/modules/bim/spec/factories/bcf_issue_factory.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
+++ b/modules/bim/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/spec/models/queries/work_packages/filter/bcf_issue_associated_filter_spec.rb
+++ b/modules/bim/spec/models/queries/work_packages/filter/bcf_issue_associated_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/spec/seeders/demo_data_seeder_spec.rb
+++ b/modules/bim/spec/seeders/demo_data_seeder_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/spec/services/bcf/issues/create_service_spec.rb
+++ b/modules/bim/spec/services/bcf/issues/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/spec/services/bcf/viewpoints/create_service_spec.rb
+++ b/modules/bim/spec/services/bcf/viewpoints/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/spec/services/bcf/viewpoints/set_attributes_service_spec.rb
+++ b/modules/bim/spec/services/bcf/viewpoints/set_attributes_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/spec/services/ifc_models/set_attributes_service_spec.rb
+++ b/modules/bim/spec/services/ifc_models/set_attributes_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/bim/spec/workers/work_packages/exports/export_job_spec.rb
+++ b/modules/bim/spec/workers/work_packages/exports/export_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/boards/app/models/boards/grid.rb
+++ b/modules/boards/app/models/boards/grid.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/boards/app/services/boards/copy/widgets_dependent_service.rb
+++ b/modules/boards/app/services/boards/copy/widgets_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/boards/app/services/boards/copy_service.rb
+++ b/modules/boards/app/services/boards/copy_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/boards/openproject-boards.gemspec
+++ b/modules/boards/openproject-boards.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = 'openproject-boards'
   s.version     = '1.0.0'

--- a/modules/boards/spec/contracts/grids/create_contract_spec.rb
+++ b/modules/boards/spec/contracts/grids/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/boards/spec/services/copy_service_integration_spec.rb
+++ b/modules/boards/spec/services/copy_service_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/app/contracts/budgets/base_contract.rb
+++ b/modules/budgets/app/contracts/budgets/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/app/contracts/budgets/create_contract.rb
+++ b/modules/budgets/app/contracts/budgets/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/app/contracts/budgets/update_contract.rb
+++ b/modules/budgets/app/contracts/budgets/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/app/services/budgets/set_attributes_service.rb
+++ b/modules/budgets/app/services/budgets/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/app/services/budgets/update_service.rb
+++ b/modules/budgets/app/services/budgets/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/budgets.gemspec
+++ b/modules/budgets/budgets.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "budgets"
   s.version     = '1.0.0'

--- a/modules/budgets/config/routes.rb
+++ b/modules/budgets/config/routes.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/db/migrate/20200807083950_keep_enabled_module.rb
+++ b/modules/budgets/db/migrate/20200807083950_keep_enabled_module.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/lib/api/v3/budgets/budget_collection_representer.rb
+++ b/modules/budgets/lib/api/v3/budgets/budget_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/lib/api/v3/budgets/budgets_api.rb
+++ b/modules/budgets/lib/api/v3/budgets/budgets_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/lib/api/v3/budgets/budgets_by_project_api.rb
+++ b/modules/budgets/lib/api/v3/budgets/budgets_by_project_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/spec/features/budgets/attachment_upload_spec.rb
+++ b/modules/budgets/spec/features/budgets/attachment_upload_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/spec/services/budgets/create_service_spec.rb
+++ b/modules/budgets/spec/services/budgets/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/budgets/spec/services/budgets/update_service_spec.rb
+++ b/modules/budgets/spec/services/budgets/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/calendar/app/cells/calendar/row_cell.rb
+++ b/modules/calendar/app/cells/calendar/row_cell.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/modules/calendar/app/cells/calendar/table_cell.rb
+++ b/modules/calendar/app/cells/calendar/table_cell.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/modules/calendar/app/controllers/calendar/calendars_controller.rb
+++ b/modules/calendar/app/controllers/calendar/calendars_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/calendar/openproject-calendar.gemspec
+++ b/modules/calendar/openproject-calendar.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = 'openproject-calendar'
   s.version     = '1.0.0'

--- a/modules/calendar/spec/features/calendar_create_work_package_spec.rb
+++ b/modules/calendar/spec/features/calendar_create_work_package_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/calendar/spec/features/calendar_project_include_spec.rb
+++ b/modules/calendar/spec/features/calendar_project_include_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/calendar/spec/features/calendar_user_interaction_spec.rb
+++ b/modules/calendar/spec/features/calendar_user_interaction_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/calendar/spec/features/calendars_index_spec.rb
+++ b/modules/calendar/spec/features/calendars_index_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/calendar/spec/features/calendars_spec.rb
+++ b/modules/calendar/spec/features/calendars_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/calendar/spec/features/query_handling_spec.rb
+++ b/modules/calendar/spec/features/query_handling_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/calendar/spec/features/shared_context.rb
+++ b/modules/calendar/spec/features/shared_context.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/contracts/time_entries/base_contract.rb
+++ b/modules/costs/app/contracts/time_entries/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/contracts/time_entries/create_contract.rb
+++ b/modules/costs/app/contracts/time_entries/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/contracts/time_entries/delete_contract.rb
+++ b/modules/costs/app/contracts/time_entries/delete_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/contracts/time_entries/update_contract.rb
+++ b/modules/costs/app/contracts/time_entries/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/controllers/projects/settings/time_entry_activities_controller.rb
+++ b/modules/costs/app/controllers/projects/settings/time_entry_activities_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/activities/time_entry_activity_provider.rb
+++ b/modules/costs/app/models/activities/time_entry_activity_provider.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/entry/costs.rb
+++ b/modules/costs/app/models/entry/costs.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/entry/splashed_dates.rb
+++ b/modules/costs/app/models/entry/splashed_dates.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/journal/time_entry_journal.rb
+++ b/modules/costs/app/models/journal/time_entry_journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/projects/scopes/activated_time_activity.rb
+++ b/modules/costs/app/models/projects/scopes/activated_time_activity.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/projects/scopes/visible_with_activated_time_activity.rb
+++ b/modules/costs/app/models/projects/scopes/visible_with_activated_time_activity.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/queries/time_entries.rb
+++ b/modules/costs/app/models/queries/time_entries.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/queries/time_entries/filters/activity_filter.rb
+++ b/modules/costs/app/models/queries/time_entries/filters/activity_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/queries/time_entries/filters/created_at_filter.rb
+++ b/modules/costs/app/models/queries/time_entries/filters/created_at_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/queries/time_entries/filters/project_filter.rb
+++ b/modules/costs/app/models/queries/time_entries/filters/project_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/queries/time_entries/filters/spent_on_filter.rb
+++ b/modules/costs/app/models/queries/time_entries/filters/spent_on_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/queries/time_entries/filters/time_entry_filter.rb
+++ b/modules/costs/app/models/queries/time_entries/filters/time_entry_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/queries/time_entries/filters/updated_at_filter.rb
+++ b/modules/costs/app/models/queries/time_entries/filters/updated_at_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/queries/time_entries/filters/user_filter.rb
+++ b/modules/costs/app/models/queries/time_entries/filters/user_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/queries/time_entries/filters/work_package_filter.rb
+++ b/modules/costs/app/models/queries/time_entries/filters/work_package_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/queries/time_entries/orders/default_order.rb
+++ b/modules/costs/app/models/queries/time_entries/orders/default_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/time_entries/scopes/of_user_and_day.rb
+++ b/modules/costs/app/models/time_entries/scopes/of_user_and_day.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/time_entries/scopes/visible.rb
+++ b/modules/costs/app/models/time_entries/scopes/visible.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/time_entry_activities/scopes/active_in_project.rb
+++ b/modules/costs/app/models/time_entry_activities/scopes/active_in_project.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/time_entry_activities_project.rb
+++ b/modules/costs/app/models/time_entry_activities_project.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/time_entry_activity.rb
+++ b/modules/costs/app/models/time_entry_activity.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/models/time_entry_custom_field.rb
+++ b/modules/costs/app/models/time_entry_custom_field.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/services/time_entries/create_service.rb
+++ b/modules/costs/app/services/time_entries/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/services/time_entries/delete_service.rb
+++ b/modules/costs/app/services/time_entries/delete_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/services/time_entries/set_attributes_service.rb
+++ b/modules/costs/app/services/time_entries/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/app/services/time_entries/update_service.rb
+++ b/modules/costs/app/services/time_entries/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/db/migrate/20200807083952_rename_time_and_cost_module.rb
+++ b/modules/costs/db/migrate/20200807083952_rename_time_and_cost_module.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/lib/api/v3/cost_entries/cost_entries_api.rb
+++ b/modules/costs/lib/api/v3/cost_entries/cost_entries_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/lib/api/v3/cost_entries/cost_entries_by_work_package_api.rb
+++ b/modules/costs/lib/api/v3/cost_entries/cost_entries_by_work_package_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/lib/api/v3/cost_entries/cost_entry_collection_representer.rb
+++ b/modules/costs/lib/api/v3/cost_entries/cost_entry_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/lib/api/v3/cost_entries/work_package_costs_by_type_representer.rb
+++ b/modules/costs/lib/api/v3/cost_entries/work_package_costs_by_type_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/lib/api/v3/cost_types/cost_types_api.rb
+++ b/modules/costs/lib/api/v3/cost_types/cost_types_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/lib/api/v3/time_entries/create_form_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/create_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/lib/api/v3/time_entries/form_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/lib/api/v3/time_entries/time_entries_activity_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entries_activity_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/lib/api/v3/time_entries/time_entry_collection_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/lib/api/v3/time_entries/update_form_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/update_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/contracts/time_entries/create_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/contracts/time_entries/delete_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/delete_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
+++ b/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/contracts/time_entries/update_contract_spec.rb
+++ b/modules/costs/spec/contracts/time_entries/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/models/projects/scopes/activated_time_activity_spec.rb
+++ b/modules/costs/spec/models/projects/scopes/activated_time_activity_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/models/projects/scopes/visible_with_activated_time_activity_spec.rb
+++ b/modules/costs/spec/models/projects/scopes/visible_with_activated_time_activity_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/models/queries/time_entries/filters/activity_filter_spec.rb
+++ b/modules/costs/spec/models/queries/time_entries/filters/activity_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/models/queries/time_entries/filters/project_filter_spec.rb
+++ b/modules/costs/spec/models/queries/time_entries/filters/project_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/models/queries/time_entries/filters/user_filter_spec.rb
+++ b/modules/costs/spec/models/queries/time_entries/filters/user_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/models/queries/time_entries/filters/work_package_filter_spec.rb
+++ b/modules/costs/spec/models/queries/time_entries/filters/work_package_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/models/time_entries/scopes/of_user_and_day_spec.rb
+++ b/modules/costs/spec/models/time_entries/scopes/of_user_and_day_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/models/time_entries/scopes/visible_spec.rb
+++ b/modules/costs/spec/models/time_entries/scopes/visible_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/models/time_entry_activities/scopes/active_in_project_spec.rb
+++ b/modules/costs/spec/models/time_entry_activities/scopes/active_in_project_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/models/time_entry_activity_spec.rb
+++ b/modules/costs/spec/models/time_entry_activity_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/models/time_entry_spec.rb
+++ b/modules/costs/spec/models/time_entry_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/costs/spec/requests/api/time_entries/create_form_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entries/create_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/modules/costs/spec/requests/api/time_entries/update_form_resource_spec.rb
+++ b/modules/costs/spec/requests/api/time_entries/update_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/modules/dashboards/app/models/grids/dashboard.rb
+++ b/modules/dashboards/app/models/grids/dashboard.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/dashboards/dashboards.gemspec
+++ b/modules/dashboards/dashboards.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "dashboards"
   s.version     = '1.0.0'

--- a/modules/dashboards/spec/contracts/grids/create_contract_spec.rb
+++ b/modules/dashboards/spec/contracts/grids/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/dashboards/spec/contracts/grids/shared_examples.rb
+++ b/modules/dashboards/spec/contracts/grids/shared_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/contracts/documents/base_contract.rb
+++ b/modules/documents/app/contracts/documents/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/contracts/documents/create_contract.rb
+++ b/modules/documents/app/contracts/documents/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/contracts/documents/update_contract.rb
+++ b/modules/documents/app/contracts/documents/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/helpers/documents_helper.rb
+++ b/modules/documents/app/helpers/documents_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/models/document.rb
+++ b/modules/documents/app/models/document.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/models/document_category.rb
+++ b/modules/documents/app/models/document_category.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/models/journal/document_journal.rb
+++ b/modules/documents/app/models/journal/document_journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/models/queries/documents.rb
+++ b/modules/documents/app/models/queries/documents.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/models/queries/documents/filters/document_filter.rb
+++ b/modules/documents/app/models/queries/documents/filters/document_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/models/queries/documents/filters/project_filter.rb
+++ b/modules/documents/app/models/queries/documents/filters/project_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/models/queries/documents/orders/default_order.rb
+++ b/modules/documents/app/models/queries/documents/orders/default_order.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/seeders/basic_data/documents/enumeration_seeder.rb
+++ b/modules/documents/app/seeders/basic_data/documents/enumeration_seeder.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/services/documents/create_service.rb
+++ b/modules/documents/app/services/documents/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/services/documents/set_attributes_service.rb
+++ b/modules/documents/app/services/documents/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/services/documents/update_service.rb
+++ b/modules/documents/app/services/documents/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/app/services/notifications/create_from_model_service/document_strategy.rb
+++ b/modules/documents/app/services/notifications/create_from_model_service/document_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/lib/api/v3/documents/document_collection_representer.rb
+++ b/modules/documents/lib/api/v3/documents/document_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/openproject-documents.gemspec
+++ b/modules/documents/openproject-documents.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "openproject-documents"
   s.version     = '1.0.0'

--- a/modules/documents/spec/models/queries/documents/filters/project_filter_spec.rb
+++ b/modules/documents/spec/models/queries/documents/filters/project_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/spec/services/notifications/create_from_model_service_document_spec.rb
+++ b/modules/documents/spec/services/notifications/create_from_model_service_document_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/documents/spec/services/notifications/mail_service_spec.rb
+++ b/modules/documents/spec/services/notifications/mail_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/github_integration/app/models/github_check_run.rb
+++ b/modules/github_integration/app/models/github_check_run.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/github_integration/app/models/github_pull_request.rb
+++ b/modules/github_integration/app/models/github_pull_request.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/github_integration/app/models/github_user.rb
+++ b/modules/github_integration/app/models/github_user.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/github_integration/app/workers/cron/clear_old_pull_requests_job.rb
+++ b/modules/github_integration/app/workers/cron/clear_old_pull_requests_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/github_integration/lib/api/v3/github_pull_requests/github_pull_request_collection_representer.rb
+++ b/modules/github_integration/lib/api/v3/github_pull_requests/github_pull_request_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/github_integration/lib/api/v3/github_pull_requests/github_pull_requests_by_work_package_api.rb
+++ b/modules/github_integration/lib/api/v3/github_pull_requests/github_pull_requests_by_work_package_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/github_integration/lib/open_project/github_integration/services/upsert_check_run.rb
+++ b/modules/github_integration/lib/open_project/github_integration/services/upsert_check_run.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/github_integration/lib/open_project/github_integration/services/upsert_github_user.rb
+++ b/modules/github_integration/lib/open_project/github_integration/services/upsert_github_user.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/github_integration/lib/open_project/github_integration/services/upsert_partial_pull_request.rb
+++ b/modules/github_integration/lib/open_project/github_integration/services/upsert_partial_pull_request.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/github_integration/lib/open_project/github_integration/services/upsert_pull_request.rb
+++ b/modules/github_integration/lib/open_project/github_integration/services/upsert_pull_request.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/github_integration/openproject-github_integration.gemspec
+++ b/modules/github_integration/openproject-github_integration.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "openproject-github_integration"
   s.version     = '1.0.0'

--- a/modules/github_integration/spec/workers/cron/clear_old_pull_requests_job_spec.rb
+++ b/modules/github_integration/spec/workers/cron/clear_old_pull_requests_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/contracts/grids/base_contract.rb
+++ b/modules/grids/app/contracts/grids/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/contracts/grids/create_contract.rb
+++ b/modules/grids/app/contracts/grids/create_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/contracts/grids/delete_contract.rb
+++ b/modules/grids/app/contracts/grids/delete_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/contracts/grids/update_contract.rb
+++ b/modules/grids/app/contracts/grids/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/models/grids/grid.rb
+++ b/modules/grids/app/models/grids/grid.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/models/grids/widget.rb
+++ b/modules/grids/app/models/grids/widget.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/queries/grids/filters/grid_filter.rb
+++ b/modules/grids/app/queries/grids/filters/grid_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/queries/grids/filters/page_filter.rb
+++ b/modules/grids/app/queries/grids/filters/page_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/queries/grids/filters/scope_filter.rb
+++ b/modules/grids/app/queries/grids/filters/scope_filter.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/representers/api/v3/grids/create_form_representer.rb
+++ b/modules/grids/app/representers/api/v3/grids/create_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/representers/api/v3/grids/form_representer.rb
+++ b/modules/grids/app/representers/api/v3/grids/form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/representers/api/v3/grids/grid_collection_representer.rb
+++ b/modules/grids/app/representers/api/v3/grids/grid_collection_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/representers/api/v3/grids/grid_payload_representer.rb
+++ b/modules/grids/app/representers/api/v3/grids/grid_payload_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/representers/api/v3/grids/schemas/grid_schema_representer.rb
+++ b/modules/grids/app/representers/api/v3/grids/schemas/grid_schema_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/representers/api/v3/grids/update_form_representer.rb
+++ b/modules/grids/app/representers/api/v3/grids/update_form_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/services/grids/create_service.rb
+++ b/modules/grids/app/services/grids/create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/services/grids/delete_service.rb
+++ b/modules/grids/app/services/grids/delete_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/services/grids/set_attributes_service.rb
+++ b/modules/grids/app/services/grids/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/app/services/grids/update_service.rb
+++ b/modules/grids/app/services/grids/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/grids.gemspec
+++ b/modules/grids/grids.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "grids"
   s.version     = '1.0.0'

--- a/modules/grids/lib/grids/configuration.rb
+++ b/modules/grids/lib/grids/configuration.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/lib/grids/configuration/registration.rb
+++ b/modules/grids/lib/grids/configuration/registration.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/lib/grids/configuration/widget_strategy.rb
+++ b/modules/grids/lib/grids/configuration/widget_strategy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/lib/grids/factory.rb
+++ b/modules/grids/lib/grids/factory.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/spec/contracts/grids/create_contract_spec.rb
+++ b/modules/grids/spec/contracts/grids/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/spec/contracts/grids/delete_contract_spec.rb
+++ b/modules/grids/spec/contracts/grids/delete_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/spec/contracts/grids/shared_examples.rb
+++ b/modules/grids/spec/contracts/grids/shared_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/spec/contracts/grids/update_contract_spec.rb
+++ b/modules/grids/spec/contracts/grids/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/spec/services/grids/create_service_spec.rb
+++ b/modules/grids/spec/services/grids/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/spec/services/grids/set_attributes_service_spec.rb
+++ b/modules/grids/spec/services/grids/set_attributes_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/grids/spec/services/grids/update_service_spec.rb
+++ b/modules/grids/spec/services/grids/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/job_status/app/workers/job_status/application_job_with_status.rb
+++ b/modules/job_status/app/workers/job_status/application_job_with_status.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/job_status/app/workers/job_status/cron/clear_old_job_status_job.rb
+++ b/modules/job_status/app/workers/job_status/cron/clear_old_job_status_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/job_status/lib/api/v3/job_status/job_status_api.rb
+++ b/modules/job_status/lib/api/v3/job_status/job_status_api.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/job_status/lib/api/v3/job_status/job_status_representer.rb
+++ b/modules/job_status/lib/api/v3/job_status/job_status_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/job_status/lib/open_project/job_status.rb
+++ b/modules/job_status/lib/open_project/job_status.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/job_status/lib/open_project/job_status/engine.rb
+++ b/modules/job_status/lib/open_project/job_status/engine.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/job_status/lib/open_project/job_status/event_listener.rb
+++ b/modules/job_status/lib/open_project/job_status/event_listener.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/job_status/lib/openproject-job_status.rb
+++ b/modules/job_status/lib/openproject-job_status.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/job_status/openproject-job_status.gemspec
+++ b/modules/job_status/openproject-job_status.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = 'openproject-job_status'
   s.version     = '1.0.0'

--- a/modules/job_status/spec/services/documents/update_service_spec.rb
+++ b/modules/job_status/spec/services/documents/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/ldap_groups/app/workers/ldap_groups/synchronization_job.rb
+++ b/modules/ldap_groups/app/workers/ldap_groups/synchronization_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/ldap_groups/lib/tasks/ldap_groups.rake
+++ b/modules/ldap_groups/lib/tasks/ldap_groups.rake
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/ldap_groups/openproject-ldap_groups.gemspec
+++ b/modules/ldap_groups/openproject-ldap_groups.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "openproject-ldap_groups"
   s.version     = '1.0.0'

--- a/modules/meeting/app/contracts/meeting_contents/base_contract.rb
+++ b/modules/meeting/app/contracts/meeting_contents/base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/meeting/app/contracts/meeting_contents/update_contract.rb
+++ b/modules/meeting/app/contracts/meeting_contents/update_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/meeting/app/models/activities/meeting_activity_provider.rb
+++ b/modules/meeting/app/models/activities/meeting_activity_provider.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/meeting/app/models/journal/meeting_content_journal.rb
+++ b/modules/meeting/app/models/journal/meeting_content_journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/meeting/app/models/journal/meeting_journal.rb
+++ b/modules/meeting/app/models/journal/meeting_journal.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/meeting/app/services/meeting_contents/set_attributes_service.rb
+++ b/modules/meeting/app/services/meeting_contents/set_attributes_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/meeting/app/services/meeting_contents/update_service.rb
+++ b/modules/meeting/app/services/meeting_contents/update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/meeting/lib/api/v3/meeting_agendas/meeting_agenda_representer.rb
+++ b/modules/meeting/lib/api/v3/meeting_agendas/meeting_agenda_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/meeting/lib/api/v3/meeting_contents/meeting_content_representer.rb
+++ b/modules/meeting/lib/api/v3/meeting_contents/meeting_content_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/meeting/lib/api/v3/meeting_minutes/meeting_minutes_representer.rb
+++ b/modules/meeting/lib/api/v3/meeting_minutes/meeting_minutes_representer.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/meeting/lib/open_project/meeting/patches/textile_converter_patch.rb
+++ b/modules/meeting/lib/open_project/meeting/patches/textile_converter_patch.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/meeting/openproject-meeting.gemspec
+++ b/modules/meeting/openproject-meeting.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = 'openproject-meeting'

--- a/modules/meeting/spec/contracts/meeting_contents/update_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meeting_contents/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/meeting/spec/services/meeting_contents/update_service_spec.rb
+++ b/modules/meeting/spec/services/meeting_contents/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/my_page/app/models/grids/my_page.rb
+++ b/modules/my_page/app/models/grids/my_page.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/my_page/config/routes.rb
+++ b/modules/my_page/config/routes.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/my_page/my_page.gemspec
+++ b/modules/my_page/my_page.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "my_page"
   s.version     = '1.0.0'

--- a/modules/my_page/spec/contracts/grids/create_contract_spec.rb
+++ b/modules/my_page/spec/contracts/grids/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/my_page/spec/contracts/grids/shared_examples.rb
+++ b/modules/my_page/spec/contracts/grids/shared_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/my_page/spec/contracts/grids/update_contract_spec.rb
+++ b/modules/my_page/spec/contracts/grids/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/my_page/spec/queries/grids/filters/scope_filter_spec.rb
+++ b/modules/my_page/spec/queries/grids/filters/scope_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/openid_connect/openproject-openid_connect.gemspec
+++ b/modules/openid_connect/openproject-openid_connect.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = 'openproject-openid_connect'
   s.version     = '1.0.0'

--- a/modules/overviews/app/models/grids/overview.rb
+++ b/modules/overviews/app/models/grids/overview.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/overviews/app/services/overviews/copy/widgets_dependent_service.rb
+++ b/modules/overviews/app/services/overviews/copy/widgets_dependent_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/overviews/app/services/overviews/copy_service.rb
+++ b/modules/overviews/app/services/overviews/copy_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/overviews/overviews.gemspec
+++ b/modules/overviews/overviews.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "overviews"
   s.version     = '1.0.0'

--- a/modules/overviews/spec/contracts/grids/create_contract_spec.rb
+++ b/modules/overviews/spec/contracts/grids/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/overviews/spec/services/copy_service_integration_spec.rb
+++ b/modules/overviews/spec/services/copy_service_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/pdf_export/openproject-pdf_export.gemspec
+++ b/modules/pdf_export/openproject-pdf_export.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "openproject-pdf_export"
   s.version     = '1.0.0'

--- a/modules/recaptcha/openproject-recaptcha.gemspec
+++ b/modules/recaptcha/openproject-recaptcha.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "openproject-recaptcha"
   s.version     = '1.0.0'

--- a/modules/reporting/lib/report/table.rb
+++ b/modules/reporting/lib/report/table.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# encoding: UTF-8
-
 class Report::Table
   attr_accessor :query
 

--- a/modules/reporting/lib/report/transformer.rb
+++ b/modules/reporting/lib/report/transformer.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# encoding: UTF-8
-
 class Report::Transformer
   attr_reader :query
 

--- a/modules/reporting/openproject-reporting.gemspec
+++ b/modules/reporting/openproject-reporting.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "openproject-reporting"
   s.version     = '1.0.0'

--- a/modules/team_planner/app/cells/team_planner/row_cell.rb
+++ b/modules/team_planner/app/cells/team_planner/row_cell.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/modules/team_planner/app/cells/team_planner/table_cell.rb
+++ b/modules/team_planner/app/cells/team_planner/table_cell.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/modules/team_planner/openproject-team_planner.gemspec
+++ b/modules/team_planner/openproject-team_planner.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = 'openproject-team_planner'
   s.version     = '1.0.0'

--- a/modules/team_planner/spec/features/query_handling_spec.rb
+++ b/modules/team_planner/spec/features/query_handling_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/shared_context.rb
+++ b/modules/team_planner/spec/features/shared_context.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_add_existing_work_packages_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/team_planner_create_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_create_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/team_planner_error_handling_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_error_handling_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/team_planner_index_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_index_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/team_planner_menu_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_menu_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/team_planner_project_include_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_project_include_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/team_planner_remove_event_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_remove_event_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/team_planner_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/team_planner_split_view_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_split_view_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/team_planner_upsale_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_upsale_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/team_planner_user_interaction_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_user_interaction_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/team_planner/spec/features/team_planner_view_modes_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_view_modes_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/two_factor_authentication/openproject-two_factor_authentication.gemspec
+++ b/modules/two_factor_authentication/openproject-two_factor_authentication.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "openproject-two_factor_authentication"
   s.version     = '1.0.0'

--- a/modules/webhooks/app/controllers/webhooks/incoming/hooks_controller.rb
+++ b/modules/webhooks/app/controllers/webhooks/incoming/hooks_controller.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/webhooks/app/workers/attachment_webhook_job.rb
+++ b/modules/webhooks/app/workers/attachment_webhook_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/webhooks/app/workers/project_webhook_job.rb
+++ b/modules/webhooks/app/workers/project_webhook_job.rb
@@ -1,6 +1,4 @@
 require 'rest-client'
-
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/webhooks/app/workers/represented_webhook_job.rb
+++ b/modules/webhooks/app/workers/represented_webhook_job.rb
@@ -1,6 +1,4 @@
 require 'rest-client'
-
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/webhooks/app/workers/time_entry_webhook_job.rb
+++ b/modules/webhooks/app/workers/time_entry_webhook_job.rb
@@ -1,6 +1,4 @@
 require 'rest-client'
-
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/webhooks/app/workers/webhook_job.rb
+++ b/modules/webhooks/app/workers/webhook_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/webhooks/app/workers/work_package_webhook_job.rb
+++ b/modules/webhooks/app/workers/work_package_webhook_job.rb
@@ -1,6 +1,4 @@
 require 'rest-client'
-
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/webhooks/openproject-webhooks.gemspec
+++ b/modules/webhooks/openproject-webhooks.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "openproject-webhooks"
   s.version     = '1.0.0'

--- a/modules/webhooks/spec/workers/attachment_webhook_job_spec.rb
+++ b/modules/webhooks/spec/workers/attachment_webhook_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/webhooks/spec/workers/project_webhook_job_spec.rb
+++ b/modules/webhooks/spec/workers/project_webhook_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/webhooks/spec/workers/time_entry_webhook_job_spec.rb
+++ b/modules/webhooks/spec/workers/time_entry_webhook_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/webhooks/spec/workers/work_package_webhook_job_spec.rb
+++ b/modules/webhooks/spec/workers/work_package_webhook_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/modules/xls_export/openproject-xls_export.gemspec
+++ b/modules/xls_export/openproject-xls_export.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 Gem::Specification.new do |s|
   s.name        = "openproject-xls_export"
   s.version     = '1.0.0'

--- a/modules/xls_export/spec/patches/work_packages_controller_patch_spec.rb
+++ b/modules/xls_export/spec/patches/work_packages_controller_patch_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/script/ci/cache_prepare.sh
+++ b/script/ci/cache_prepare.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)

--- a/script/ci/db_setup.sh
+++ b/script/ci/db_setup.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)

--- a/script/ci/runner.sh
+++ b/script/ci/runner.sh
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)

--- a/script/ci/setup.sh
+++ b/script/ci/setup.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is a project management system.
 # Copyright (C) 2012-2015 the OpenProject Foundation (OPF)

--- a/spec/cells/rails_cell_spec.rb
+++ b/spec/cells/rails_cell_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/attachments/create_contract_spec.rb
+++ b/spec/contracts/attachments/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/authentication/omniauth_auth_hash_contract_spec.rb
+++ b/spec/contracts/authentication/omniauth_auth_hash_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/backups/create_contract_spec.rb
+++ b/spec/contracts/backups/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/custom_actions/cu_contract_spec.rb
+++ b/spec/contracts/custom_actions/cu_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/custom_fields/create_contract_spec.rb
+++ b/spec/contracts/custom_fields/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/custom_fields/update_contract_spec.rb
+++ b/spec/contracts/custom_fields/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/groups/create_contract_spec.rb
+++ b/spec/contracts/groups/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/groups/shared_contract_examples.rb
+++ b/spec/contracts/groups/shared_contract_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/groups/update_contract_spec.rb
+++ b/spec/contracts/groups/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/messages/create_contract_spec.rb
+++ b/spec/contracts/messages/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/messages/shared_contract_examples.rb
+++ b/spec/contracts/messages/shared_contract_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/messages/update_contract_spec.rb
+++ b/spec/contracts/messages/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/placeholder_users/create_contract_spec.rb
+++ b/spec/contracts/placeholder_users/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/placeholder_users/delete_contract_spec.rb
+++ b/spec/contracts/placeholder_users/delete_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/placeholder_users/shared_contract_examples.rb
+++ b/spec/contracts/placeholder_users/shared_contract_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/placeholder_users/update_contract_spec.rb
+++ b/spec/contracts/placeholder_users/update_contract_spec.rb
@@ -1,4 +1,3 @@
-#-- encoding: UTF-8
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/projects/archive_contract_spec.rb
+++ b/spec/contracts/projects/archive_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/projects/delete_contract_spec.rb
+++ b/spec/contracts/projects/delete_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/projects/enabled_modules_contract_spec.rb
+++ b/spec/contracts/projects/enabled_modules_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/projects/unarchive_contract_spec.rb
+++ b/spec/contracts/projects/unarchive_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/queries/update_contract_spec.rb
+++ b/spec/contracts/queries/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/relations/create_contract_spec.rb
+++ b/spec/contracts/relations/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/settings/update_contract_spec.rb
+++ b/spec/contracts/settings/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/user_preferences/params_contract_spec.rb
+++ b/spec/contracts/user_preferences/params_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/user_preferences/update_contract_spec.rb
+++ b/spec/contracts/user_preferences/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/users/create_contract_spec.rb
+++ b/spec/contracts/users/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/users/shared_contract_examples.rb
+++ b/spec/contracts/users/shared_contract_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/users/update_contract_spec.rb
+++ b/spec/contracts/users/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/work_packages/create_contract_spec.rb
+++ b/spec/contracts/work_packages/create_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/work_packages/create_note_contract_spec.rb
+++ b/spec/contracts/work_packages/create_note_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/contracts/work_packages/shared_base_contract.rb
+++ b/spec/contracts/work_packages/shared_base_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/contracts/work_packages/update_contract_spec.rb
+++ b/spec/contracts/work_packages/update_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/controllers/enumerations_controller_spec.rb
+++ b/spec/controllers/enumerations_controller_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/decorators/single_spec.rb
+++ b/spec/decorators/single_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/factories/project_status.rb
+++ b/spec/factories/project_status.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/features/forums/attachment_upload_spec.rb
+++ b/spec/features/forums/attachment_upload_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/features/localization_spec.rb
+++ b/spec/features/localization_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/features/news/creation_and_commenting_spec.rb
+++ b/spec/features/news/creation_and_commenting_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/features/wiki/attachment_upload_spec.rb
+++ b/spec/features/wiki/attachment_upload_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/features/work_packages/project_include/project_include_shared_examples.rb
+++ b/spec/features/work_packages/project_include/project_include_shared_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/features/work_packages/table/work_packages_table_project_include_spec.rb
+++ b/spec/features/work_packages/table/work_packages_table_project_include_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/features/work_packages/work_package_workflow_form_spec.rb
+++ b/spec/features/work_packages/work_package_workflow_form_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/features/wysiwyg/macros/child_pages_spec.rb
+++ b/spec/features/wysiwyg/macros/child_pages_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/helpers/hook_helper_spec.rb
+++ b/spec/helpers/hook_helper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/helpers/individual_principal_hooks_helper_spec.rb
+++ b/spec/helpers/individual_principal_hooks_helper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/helpers/text_formatting_helper_spec.rb
+++ b/spec/helpers/text_formatting_helper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/helpers/toolbar_helper_spec.rb
+++ b/spec/helpers/toolbar_helper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/api/contracts/model_contract_spec.rb
+++ b/spec/lib/api/contracts/model_contract_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/lib/api/v3/utilities/resource_link_generator_spec.rb
+++ b/spec/lib/api/v3/utilities/resource_link_generator_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/create_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_form_representer_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/cache_checksum_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/eager_loading/custom_actions_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/custom_actions_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/eager_loading/custom_value_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/custom_value_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/eager_loading/eager_loading_mock_wrapper.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/eager_loading_mock_wrapper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/eager_loading/project_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/project_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/api/v3/work_packages/update_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/update_form_representer_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/lib/custom_field_form_builder_spec.rb
+++ b/spec/lib/custom_field_form_builder_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/database_spec.rb
+++ b/spec/lib/database_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/content_type_detector_spec.rb
+++ b/spec/lib/open_project/content_type_detector_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/file_command_content_type_detector_spec.rb
+++ b/spec/lib/open_project/file_command_content_type_detector_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/files_spec.rb
+++ b/spec/lib/open_project/files_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/form_tag_helper_spec.rb
+++ b/spec/lib/open_project/form_tag_helper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/hook_spec.rb
+++ b/spec/lib/open_project/hook_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/mime_type_spec.rb
+++ b/spec/lib/open_project/mime_type_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/object_linking_spec.rb
+++ b/spec/lib/open_project/object_linking_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/scm/adapters/git_adapter_spec.rb
+++ b/spec/lib/open_project/scm/adapters/git_adapter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/scm/adapters/subversion_adapter_spec.rb
+++ b/spec/lib/open_project/scm/adapters/subversion_adapter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/scm/manager_spec.rb
+++ b/spec/lib/open_project/scm/manager_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/images_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/images_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/markdown_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/markdown_formatting_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/markdown/pandoc_wrapper_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/pandoc_wrapper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/plain_spec.rb
+++ b/spec/lib/open_project/text_formatting/plain_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/open_project/text_formatting/text_formatting_spec.rb
+++ b/spec/lib/open_project/text_formatting/text_formatting_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/representable_spec.rb
+++ b/spec/lib/representable_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/lib/tabular_form_builder_spec.rb
+++ b/spec/lib/tabular_form_builder_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/mailers/work_package_mailer_spec.rb
+++ b/spec/mailers/work_package_mailer_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/activities/fetcher_integration_spec.rb
+++ b/spec/models/activities/fetcher_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/enabled_module_spec.rb
+++ b/spec/models/enabled_module_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/issue_priority_spec.rb
+++ b/spec/models/issue_priority_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/members/scopes/not_locked_spec.rb
+++ b/spec/models/members/scopes/not_locked_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/placeholder_users/scopes/visible_spec.rb
+++ b/spec/models/placeholder_users/scopes/visible_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/principals/scopes/human_spec.rb
+++ b/spec/models/principals/scopes/human_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/principals/scopes/like_spec.rb
+++ b/spec/models/principals/scopes/like_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/principals/scopes/not_builtin_spec.rb
+++ b/spec/models/principals/scopes/not_builtin_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/principals/scopes/ordered_by_name_spec.rb
+++ b/spec/models/principals/scopes/ordered_by_name_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/principals/scopes/possible_assignee_spec.rb
+++ b/spec/models/principals/scopes/possible_assignee_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/principals/scopes/possible_member_spec.rb
+++ b/spec/models/principals/scopes/possible_member_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/principals/scopes/user_spec.rb
+++ b/spec/models/principals/scopes/user_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/principals/scopes/visible_spec.rb
+++ b/spec/models/principals/scopes/visible_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/projects/allowed_to_scope_spec.rb
+++ b/spec/models/projects/allowed_to_scope_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/projects/exporter/csv_integration_spec.rb
+++ b/spec/models/projects/exporter/csv_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/projects/reorder_nested_set_spec.rb
+++ b/spec/models/projects/reorder_nested_set_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/capabilities/filters/principal_id_filter_spec.rb
+++ b/spec/models/queries/capabilities/filters/principal_id_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/members/filters/blocked_filter_spec.rb
+++ b/spec/models/queries/members/filters/blocked_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/members/filters/created_at_filter_spec.rb
+++ b/spec/models/queries/members/filters/created_at_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/members/filters/group_filter_spec.rb
+++ b/spec/models/queries/members/filters/group_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/members/filters/name_filter_spec.rb
+++ b/spec/models/queries/members/filters/name_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/members/filters/project_filter_spec.rb
+++ b/spec/models/queries/members/filters/project_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/members/filters/role_filter_spec.rb
+++ b/spec/models/queries/members/filters/role_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/members/filters/status_filter_spec.rb
+++ b/spec/models/queries/members/filters/status_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/members/filters/updated_at_filter_spec.rb
+++ b/spec/models/queries/members/filters/updated_at_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/news/filters/project_filter_spec.rb
+++ b/spec/models/queries/news/filters/project_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/notifications/filters/id_filter_spec.rb
+++ b/spec/models/queries/notifications/filters/id_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/projects/filters/active_filter_spec.rb
+++ b/spec/models/queries/projects/filters/active_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/projects/filters/created_at_filter_spec.rb
+++ b/spec/models/queries/projects/filters/created_at_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/projects/filters/latest_activity_at_filter_spec.rb
+++ b/spec/models/queries/projects/filters/latest_activity_at_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/projects/filters/name_and_identifier_filter_spec.rb
+++ b/spec/models/queries/projects/filters/name_and_identifier_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/projects/filters/parent_filter_spec.rb
+++ b/spec/models/queries/projects/filters/parent_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/projects/filters/principal_filter_spec.rb
+++ b/spec/models/queries/projects/filters/principal_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/projects/filters/project_status_filter_spec.rb
+++ b/spec/models/queries/projects/filters/project_status_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/projects/filters/public_filter_spec.rb
+++ b/spec/models/queries/projects/filters/public_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/projects/filters/type_filter_spec.rb
+++ b/spec/models/queries/projects/filters/type_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/projects/filters/user_action_filter_spec.rb
+++ b/spec/models/queries/projects/filters/user_action_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/projects/orders/latest_activity_at_order_spec.rb
+++ b/spec/models/queries/projects/orders/latest_activity_at_order_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/projects/orders/required_disk_space_order_spec.rb
+++ b/spec/models/queries/projects/orders/required_disk_space_order_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/queries/filters/hidden_filter_spec.rb
+++ b/spec/models/queries/queries/filters/hidden_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/queries/filters/project_filter_spec.rb
+++ b/spec/models/queries/queries/filters/project_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/relations/filters/from_filter_spec.rb
+++ b/spec/models/queries/relations/filters/from_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/relations/filters/involved_filter_spec.rb
+++ b/spec/models/queries/relations/filters/involved_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/relations/filters/to_filter_spec.rb
+++ b/spec/models/queries/relations/filters/to_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/roles/filters/grantable_filter_spec.rb
+++ b/spec/models/queries/roles/filters/grantable_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/roles/filters/unit_filter_spec.rb
+++ b/spec/models/queries/roles/filters/unit_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/users/filters/any_name_attribute_filter_spec.rb
+++ b/spec/models/queries/users/filters/any_name_attribute_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/users/filters/group_filter_spec.rb
+++ b/spec/models/queries/users/filters/group_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/users/filters/name_filter_spec.rb
+++ b/spec/models/queries/users/filters/name_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/users/filters/status_filter_spec.rb
+++ b/spec/models/queries/users/filters/status_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/id_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/id_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/manual_sort_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/manual_sort_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/queries/work_packages/filter/parent_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/parent_filter_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/relation_spec.rb
+++ b/spec/models/relation_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/relations/scopes/visible_spec.rb
+++ b/spec/models/relations/scopes/visible_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/type/attribute_groups_spec.rb
+++ b/spec/models/type/attribute_groups_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/type_spec.rb
+++ b/spec/models/type_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/types/scopes/milestone_spec.rb
+++ b/spec/models/types/scopes/milestone_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/users/scopes/find_by_login_spec.rb
+++ b/spec/models/users/scopes/find_by_login_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/users/scopes/having_reminder_mail_to_send_spec.rb
+++ b/spec/models/users/scopes/having_reminder_mail_to_send_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/users/scopes/newest_spec.rb
+++ b/spec/models/users/scopes/newest_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/versions/scopes/rolled_up_spec.rb
+++ b/spec/models/versions/scopes/rolled_up_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/versions/scopes/shared_with_spec.rb
+++ b/spec/models/versions/scopes/shared_with_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/wiki_redirect_spec.rb
+++ b/spec/models/wiki_redirect_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/work_package/exporter/csv_integration_spec.rb
+++ b/spec/models/work_package/exporter/csv_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/work_package/openproject_notifications_spec.rb
+++ b/spec/models/work_package/openproject_notifications_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/models/work_package/work_package_custom_actions_spec.rb
+++ b/spec/models/work_package/work_package_custom_actions_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/requests/api/v3/memberships/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/memberships/create_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/memberships/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/memberships/update_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/bulk_read_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/bulk_read_ian_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/bulk_unread_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/bulk_unread_ian_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/index_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/index_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/read_ian_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/read_ian_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/show_resource_examples.rb
+++ b/spec/requests/api/v3/notifications/show_resource_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/notifications/show_resource_spec.rb
+++ b/spec/requests/api/v3/notifications/show_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/create_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/create_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/create_shared_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/create_shared_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/delete_resource_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/delete_resource_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/delete_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/delete_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/index_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/index_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/show_resource_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/show_resource_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/show_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/show_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/update_resource_examples.rb
+++ b/spec/requests/api/v3/placeholder_users/update_resource_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/placeholder_users/update_resource_spec.rb
+++ b/spec/requests/api/v3/placeholder_users/update_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/projects/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/create_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/projects/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/queries/create_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/create_form_api_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/queries/order/query_order_api_spec.rb
+++ b/spec/requests/api/v3/queries/order/query_order_api_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/queries/update_form_api_spec.rb
+++ b/spec/requests/api/v3/queries/update_form_api_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/user/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/create_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/user/create_user_common_examples.rb
+++ b/spec/requests/api/v3/user/create_user_common_examples.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/user/create_user_resource_spec.rb
+++ b/spec/requests/api/v3/user/create_user_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/user/filters_spec.rb
+++ b/spec/requests/api/v3/user/filters_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/user/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/user/update_user_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_user_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/versions/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/versions/create_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/versions/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/versions/update_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/views/show_resource_spec.rb
+++ b/spec/requests/api/v3/views/show_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/by_project_create_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/by_project_create_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/by_project_index_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/by_project_index_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/api/v3/work_packages/create_project_form_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/create_project_form_resource_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/requests/auth/auth_source_sso_spec.rb
+++ b/spec/requests/auth/auth_source_sso_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/requests/auth/oauth_login_csp_spec.rb
+++ b/spec/requests/auth/oauth_login_csp_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/requests/auth/token_based_access_spec.rb
+++ b/spec/requests/auth/token_based_access_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/security/active_support_to_json_spec.rb
+++ b/spec/security/active_support_to_json_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/seeders/demo_data_seeder_spec.rb
+++ b/spec/seeders/demo_data_seeder_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/seeders/setting_seeder_spec.rb
+++ b/spec/seeders/setting_seeder_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/add_work_package_note_service_spec.rb
+++ b/spec/services/add_work_package_note_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/attachments/create_service_integration_spec.rb
+++ b/spec/services/attachments/create_service_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/attachments/delete_service_integration_spec.rb
+++ b/spec/services/attachments/delete_service_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/attachments/prepare_upload_service_integration_spec.rb
+++ b/spec/services/attachments/prepare_upload_service_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/authentication/omniauth_service_spec.rb
+++ b/spec/services/authentication/omniauth_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/backups/create_service_spec.rb
+++ b/spec/services/backups/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/base_services/behaves_like_create_service.rb
+++ b/spec/services/base_services/behaves_like_create_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/base_services/behaves_like_update_service.rb
+++ b/spec/services/base_services/behaves_like_update_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/create_type_service_spec.rb
+++ b/spec/services/create_type_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/custom_actions/update_service_spec.rb
+++ b/spec/services/custom_actions/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/custom_actions/update_work_package_service_spec.rb
+++ b/spec/services/custom_actions/update_work_package_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/custom_fields/create_service_spec.rb
+++ b/spec/services/custom_fields/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/custom_fields/update_service_spec.rb
+++ b/spec/services/custom_fields/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/groups/set_attributes_service_spec.rb
+++ b/spec/services/groups/set_attributes_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/groups/update_service_spec.rb
+++ b/spec/services/groups/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/members/create_service_spec.rb
+++ b/spec/services/members/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/members/set_attributes_service_spec.rb
+++ b/spec/services/members/set_attributes_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/members/update_service_spec.rb
+++ b/spec/services/members/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/messages/create_service_spec.rb
+++ b/spec/services/messages/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/messages/update_service_spec.rb
+++ b/spec/services/messages/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/notifications/aggregated_journal_service_integration_spec.rb
+++ b/spec/services/notifications/aggregated_journal_service_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/notifications/create_from_journal_job_shared.rb
+++ b/spec/services/notifications/create_from_journal_job_shared.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/notifications/create_from_model_service_comment_spec.rb
+++ b/spec/services/notifications/create_from_model_service_comment_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/notifications/create_from_model_service_message_spec.rb
+++ b/spec/services/notifications/create_from_model_service_message_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/notifications/create_from_model_service_news_spec.rb
+++ b/spec/services/notifications/create_from_model_service_news_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/notifications/create_from_model_service_wiki_spec.rb
+++ b/spec/services/notifications/create_from_model_service_wiki_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/notifications/create_from_model_service_work_package_spec.rb
+++ b/spec/services/notifications/create_from_model_service_work_package_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/notifications/create_service_spec.rb
+++ b/spec/services/notifications/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/notifications/mail_service_mentioned_integration_spec.rb
+++ b/spec/services/notifications/mail_service_mentioned_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/notifications/mail_service_spec.rb
+++ b/spec/services/notifications/mail_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/notifications/mentioned_journals_shared.rb
+++ b/spec/services/notifications/mentioned_journals_shared.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/notifications/set_attributes_service_spec.rb
+++ b/spec/services/notifications/set_attributes_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/parse_schema_filter_params_service_spec.rb
+++ b/spec/services/parse_schema_filter_params_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/placeholder_users/create_service_spec.rb
+++ b/spec/services/placeholder_users/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/placeholder_users/update_service_spec.rb
+++ b/spec/services/placeholder_users/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/projects/create_service_spec.rb
+++ b/spec/services/projects/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/projects/gantt_query_generator_service_spec.rb
+++ b/spec/services/projects/gantt_query_generator_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/projects/update_service_spec.rb
+++ b/spec/services/projects/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/queries/create_service_spec.rb
+++ b/spec/services/queries/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/queries/filter_mappper_spec.rb
+++ b/spec/services/queries/filter_mappper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/queries/update_service_spec.rb
+++ b/spec/services/queries/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/relations/create_service_spec.rb
+++ b/spec/services/relations/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/relations/update_service_spec.rb
+++ b/spec/services/relations/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/scm/checkout_instructions_service_spec.rb
+++ b/spec/services/scm/checkout_instructions_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/scm/create_managed_repository_service_spec.rb
+++ b/spec/services/scm/create_managed_repository_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/scm/delete_managed_repository_service_spec.rb
+++ b/spec/services/scm/delete_managed_repository_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/scm/repository_factory_service_spec.rb
+++ b/spec/services/scm/repository_factory_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/service_result_spec.rb
+++ b/spec/services/service_result_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/shared/service_context_integration_spec.rb
+++ b/spec/services/shared/service_context_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/shared_type_service.rb
+++ b/spec/services/shared_type_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/update_projects_types_service.rb
+++ b/spec/services/update_projects_types_service.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/update_type_service_spec.rb
+++ b/spec/services/update_type_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/user_preferences/update_service_spec.rb
+++ b/spec/services/user_preferences/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/users/create_service_spec.rb
+++ b/spec/services/users/create_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/users/register_user_service_spec.rb
+++ b/spec/services/users/register_user_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/users/update_service_spec.rb
+++ b/spec/services/users/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/services/wiki_pages/set_attributes_service_spec.rb
+++ b/spec/services/wiki_pages/set_attributes_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/work_packages/delete_service_spec.rb
+++ b/spec/services/work_packages/delete_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/services/work_packages/update_service_spec.rb
+++ b/spec/services/work_packages/update_service_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/api/v3/work_packages/work_package_representer_eager_loading.rb
+++ b/spec/support/api/v3/work_packages/work_package_representer_eager_loading.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/clear_notification_subscriptions.rb
+++ b/spec/support/clear_notification_subscriptions.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/flash.rb
+++ b/spec/support/flash.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/matchers/be_html_eql.rb
+++ b/spec/support/matchers/be_html_eql.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/matchers/has_conditional_selector.rb
+++ b/spec/support/matchers/has_conditional_selector.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/matchers/has_focus_on.rb
+++ b/spec/support/matchers/has_focus_on.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/matchers/raise_if_found.rb
+++ b/spec/support/matchers/raise_if_found.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/noop_contract.rb
+++ b/spec/support/noop_contract.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/permission_specs.rb
+++ b/spec/support/permission_specs.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/puffing_billy_proxy.rb
+++ b/spec/support/puffing_billy_proxy.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/repository_helpers.rb
+++ b/spec/support/repository_helpers.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/shared/become_member.rb
+++ b/spec/support/shared/become_member.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/shared/clear_cache.rb
+++ b/spec/support/shared/clear_cache.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/shared/forms_html.rb
+++ b/spec/support/shared/forms_html.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/shared/with_config.rb
+++ b/spec/support/shared/with_config.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/shared/with_direct_uploads.rb
+++ b/spec/support/shared/with_direct_uploads.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/shared/with_ee.rb
+++ b/spec/support/shared/with_ee.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/shared/with_settings.rb
+++ b/spec/support/shared/with_settings.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/tempdir.rb
+++ b/spec/support/tempdir.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/attachments/cleanup_uncontainered_job_integration_spec.rb
+++ b/spec/workers/attachments/cleanup_uncontainered_job_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/attachments/finish_direct_upload_job_integration_spec.rb
+++ b/spec/workers/attachments/finish_direct_upload_job_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2020 the OpenProject GmbH

--- a/spec/workers/extract_fulltext_job_spec.rb
+++ b/spec/workers/extract_fulltext_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/journals/completed_job_spec.rb
+++ b/spec/workers/journals/completed_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/mails/reminder_job_spec.rb
+++ b/spec/workers/mails/reminder_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/mails/shared/watcher_job.rb
+++ b/spec/workers/mails/shared/watcher_job.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/mails/watcher_added_job_spec.rb
+++ b/spec/workers/mails/watcher_added_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/mails/watcher_removed_job_spec.rb
+++ b/spec/workers/mails/watcher_removed_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/notifications/group_member_altered_job_spec.rb
+++ b/spec/workers/notifications/group_member_altered_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/notifications/schedule_reminder_mails_job_spec.rb
+++ b/spec/workers/notifications/schedule_reminder_mails_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/notifications/workflow_job_spec.rb
+++ b/spec/workers/notifications/workflow_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/scm/create_local_repository_job_spec.rb
+++ b/spec/workers/scm/create_local_repository_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/user_job_spec.rb
+++ b/spec/workers/user_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/work_packages/exports/export_job_integration_spec.rb
+++ b/spec/workers/work_packages/exports/export_job_integration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec/workers/work_packages/exports/export_job_spec.rb
+++ b/spec/workers/work_packages/exports/export_job_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/fixtures/files/060719210727_source.rb
+++ b/spec_legacy/fixtures/files/060719210727_source.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/functional/roles_controller_spec.rb
+++ b/spec_legacy/functional/roles_controller_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/functional/wiki_controller_spec.rb
+++ b/spec_legacy/functional/wiki_controller_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/functional/workflows_controller_spec.rb
+++ b/spec_legacy/functional/workflows_controller_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/legacy_spec_helper.rb
+++ b/spec_legacy/legacy_spec_helper.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/support/legacy_assertions.rb
+++ b/spec_legacy/support/legacy_assertions.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/comment_spec.rb
+++ b/spec_legacy/unit/comment_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/custom_value_spec.rb
+++ b/spec_legacy/unit/custom_value_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/enumeration_spec.rb
+++ b/spec_legacy/unit/enumeration_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/helpers/sort_helper_spec.rb
+++ b/spec_legacy/unit/helpers/sort_helper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/lib/redmine/i18n_spec.rb
+++ b/spec_legacy/unit/lib/redmine/i18n_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/lib/redmine/menu_manager/mapper_spec.rb
+++ b/spec_legacy/unit/lib/redmine/menu_manager/mapper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/lib/redmine/menu_manager/menu_helper_spec.rb
+++ b/spec_legacy/unit/lib/redmine/menu_manager/menu_helper_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/lib/redmine/menu_manager/menu_item_spec.rb
+++ b/spec_legacy/unit/lib/redmine/menu_manager/menu_item_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/lib/redmine/plugin_spec.rb
+++ b/spec_legacy/unit/lib/redmine/plugin_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/lib/redmine/unified_diff_spec.rb
+++ b/spec_legacy/unit/lib/redmine/unified_diff_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/lib/redmine_spec.rb
+++ b/spec_legacy/unit/lib/redmine_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/mail_handler_spec.rb
+++ b/spec_legacy/unit/mail_handler_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/project_spec.rb
+++ b/spec_legacy/unit/project_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/search_spec.rb
+++ b/spec_legacy/unit/search_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/user_spec.rb
+++ b/spec_legacy/unit/user_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/version_spec.rb
+++ b/spec_legacy/unit/version_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH

--- a/spec_legacy/unit/wiki_page_spec.rb
+++ b/spec_legacy/unit/wiki_page_spec.rb
@@ -1,5 +1,3 @@
-#-- encoding: UTF-8
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) 2012-2022 the OpenProject GmbH


### PR DESCRIPTION
Ruby interprets source encoding as utf-8 since 2.0.0, making magic comment redundant and useless

Also removed the `code:source_encoding` rake task.