### PR TITLE
[41416] Fix API docs naming custom_objects -> custom_options

### DIFF
--- a/docs/api/apiv3/components/schemas/custom_option_model.yml
+++ b/docs/api/apiv3/components/schemas/custom_option_model.yml
@@ -1,4 +1,4 @@
-# Schema: Custom_ObjectModel
+# Schema: Custom_OptionModel
 ---
 type: object
 properties:
@@ -8,7 +8,7 @@ properties:
     readOnly: true
   value:
     type: string
-    description: The value defined for this custom object
+    description: The value defined for this custom option
     readOnly: true
   _links:
     type: object
@@ -19,13 +19,13 @@ properties:
         allOf:
         - "$ref": "./link.yml"
         - description: |-
-            This custom object
+            This custom option.
 
-            **Resource**: CustomObject
+            **Resource**: CustomOption
           readOnly: true
 example:
   _links:
     self:
-      href: "/api/v3/custom_objects/1"
-  _type: CustomObject
+      href: "/api/v3/custom_options/1"
+  _type: CustomOption
   value: Foo

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -164,8 +164,8 @@ paths:
     "$ref": "./paths/custom_action.yml"
   "/api/v3/custom_actions/{id}/execute":
     "$ref": "./paths/custom_action_execute.yml"
-  "/api/v3/custom_objects/{id}":
-    "$ref": "./paths/custom_object.yml"
+  "/api/v3/custom_options/{id}":
+    "$ref": "./paths/custom_option.yml"
   "/api/v3/documents":
     "$ref": "./paths/documents.yml"
   "/api/v3/documents/{id}":
@@ -465,8 +465,8 @@ components:
       "$ref": "./components/schemas/cursor_based_pagination.yml"
     Custom_ActionModel:
       "$ref": "./components/schemas/custom_action_model.yml"
-    Custom_ObjectModel:
-      "$ref": "./components/schemas/custom_object_model.yml"
+    Custom_OptionModel:
+      "$ref": "./components/schemas/custom_option_model.yml"
     CustomactionModel:
       "$ref": "./components/schemas/customaction_model.yml"
     Default_QueryModel:
@@ -747,7 +747,7 @@ tags:
 - "$ref": "./tags/categories.yml"
 - "$ref": "./tags/configuration.yml"
 - "$ref": "./tags/custom_actions.yml"
-- "$ref": "./tags/custom_objects.yml"
+- "$ref": "./tags/custom_options.yml"
 - "$ref": "./tags/documents.yml"
 - "$ref": "./tags/grids.yml"
 - "$ref": "./tags/groups.yml"

--- a/docs/api/apiv3/paths/custom_option.yml
+++ b/docs/api/apiv3/paths/custom_option.yml
@@ -1,8 +1,8 @@
-# /api/v3/custom_objects/{id}
+# /api/v3/custom_options/{id}
 ---
 get:
   parameters:
-  - description: The custom object's identifier
+  - description: The custom option's identifier
     example: '1'
     in: path
     name: id
@@ -18,11 +18,11 @@ get:
               value:
                 _links:
                   self:
-                    href: "/api/v3/custom_objects/1"
-                _type: CustomObject
+                    href: "/api/v3/custom_options/1"
+                _type: CustomOption
                 value: Foo
           schema:
-            "$ref": "../components/schemas/custom_object_model.yml"
+            "$ref": "../components/schemas/custom_option_model.yml"
       description: OK
       headers: {}
     '404':
@@ -35,12 +35,12 @@ get:
                 errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
                 message: The requested resource could not be found.
       description: |-
-        Returned if the custom object does not exist or the client does not have sufficient permissions to see it.
+        Returned if the custom option does not exist or the client does not have sufficient permissions to see it.
 
-        **Required permission:** view work package in any project the custom object's custom field is active in.
+        **Required permission:** view work package in any project the custom option's custom field is active in.
       headers: {}
   tags:
-  - Custom Objects
+  - Custom Options
   description: ''
-  operationId: View_Custom_Object
-  summary: View Custom Object
+  operationId: View_Custom_Option
+  summary: View Custom Option

--- a/docs/api/apiv3/tags/custom_options.yml
+++ b/docs/api/apiv3/tags/custom_options.yml
@@ -4,14 +4,14 @@ description: |-
 
   |  Link         | Description               | Type          | Constraints | Supported operations |
   |:-------------:|-------------------------- | ------------- | ----------- | -------------------- |
-  | self          | This custom object        | CustomObject  | not null    | READ                 |
+  | self          | This custom option        | CustomOption  | not null    | READ                 |
 
   ## Local Properties
 
   | Property         | Description                                    | Type     | Constraints | Supported operations |
   |:----------------:| ---------------------------------------------- | -------- | ----------- | -------------------- |
   | id               | The identifier                                 | Integer  |             | READ                 |
-  | value            | The value defined for this custom object       | String   |             | READ                 |
+  | value            | The value defined for this custom option       | String   |             | READ                 |
 
-  Custom objects are options of list custom fields.
-name: Custom Objects
+  custom options are options of list custom fields.
+name: Custom Options


### PR DESCRIPTION
The API docs reference an API endpoint called `custom_objects`, which does not exist.

[OP#41416](https://community.openproject.com/wp/41416)