### PR TITLE
Fix team planner crash when adding a wp from the add existing pane

### DIFF
--- a/frontend/src/app/shared/components/principal/principal.component.ts
+++ b/frontend/src/app/shared/components/principal/principal.component.ts
@@ -45,6 +45,7 @@ import {
 import { PrincipalLike } from './principal-types';
 import { DatasetInputs } from 'core-app/shared/components/dataset-inputs.decorator';
 import { PrincipalType } from 'core-app/shared/components/principal/principal-helper';
+import { PrincipalsResourceService } from 'core-app/core/state/principals/principals.service';
 
 export const principalSelector = 'op-principal';
 
@@ -70,16 +71,21 @@ export class OpPrincipalComponent implements OnInit {
 
   @Input() size:AvatarSize = 'default';
 
-  public constructor(readonly elementRef:ElementRef,
+  public constructor(
+    readonly elementRef:ElementRef,
     readonly PathHelper:PathHelperService,
     readonly principalRenderer:PrincipalRendererService,
+    readonly principalResourceService:PrincipalsResourceService,
     readonly I18n:I18nService,
     readonly apiV3Service:ApiV3Service,
-    readonly timezoneService:TimezoneService) {
-
-  }
+    readonly timezoneService:TimezoneService,
+  ) { }
 
   ngOnInit() {
+    if (!this.principal.name) {
+      return;
+    }
+
     this.principalRenderer.render(
       this.elementRef.nativeElement as HTMLElement,
       this.principal,


### PR DESCRIPTION
When adding from the add existing pane, the assignee will get set to an object that only has the href set without
a name or avatar attribute. When the patch request to update the wp fails, this crashes the principal renderer since
there's only half an assignee available (really this change should be unpatched)

Here is the easy fix; we just don't try rendering an avatar if there's no name. This makes sure the team planner stays
in a usable state.

Closes https://community.openproject.org/projects/openproject/work_packages/41413/activity?query_id=3006