### PR TITLE
Format the time for created_at on users

### DIFF
--- a/app/cells/users/row_cell.rb
+++ b/app/cells/users/row_cell.rb
@@ -33,6 +33,10 @@ module Users
       format_time user.last_login_on unless user.last_login_on.nil?
     end
 
+    def created_at
+      format_time user.created_at
+    end
+
     def status
       full_user_status user
     end


### PR DESCRIPTION
The created_at column was not using format_time but outputting the date as is, which results in a utc format

https://community.openproject.org/wp/41444