### PR TITLE
Remove webfonts generator due to outdated dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18806,32 +18806,6 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz",
       "integrity": "sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ=="
     },
-    "webfonts-generator": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/webfonts-generator/-/webfonts-generator-0.4.0.tgz",
-      "integrity": "sha1-X4n8gccWDm4Mu8m3OH5CpYUf2kY=",
-      "dev": true,
-      "requires": {
-        "handlebars": "^4.0.5",
-        "mkdirp": "^0.5.0",
-        "q": "^1.1.2",
-        "svg2ttf": "^4.0.0",
-        "svgicons2svgfont": "^5.0.0",
-        "ttf2eot": "^2.0.0",
-        "ttf2woff": "^2.0.1",
-        "ttf2woff2": "^2.0.3",
-        "underscore": "^1.7.0",
-        "url-join": "^1.1.0"
-      },
-      "dependencies": {
-        "url-join": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
-          "dev": true
-        }
-      }
-    },
     "webpack": {
       "version": "5.50.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.50.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,6 @@
     "theo": "^8.1.5",
     "ts-node": "~8.3.0",
     "typescript": "~4.2.4",
-    "webfonts-generator": "^0.4.0",
     "webpack-bundle-analyzer": "^4.4.2"
   },
   "dependencies": {


### PR DESCRIPTION
Webfonts generator depends on ttf2woff2 v2 which had a known issue fixed on version 3. Since webfonts won't be maintained any further and thus the dependency not updated, we cannot include it into our package.json .

see: https://github.com/nfroidure/ttf2woff2/issues/49 