### PR TITLE
use default end points on wp#available_projects_on_...

### DIFF
--- a/lib/api/v3/utilities/endpoints/index.rb
+++ b/lib/api/v3/utilities/endpoints/index.rb
@@ -61,7 +61,7 @@ module API
             if query.valid?
               render_success(query,
                              request.params,
-                             request.api_v3_paths.send(self_path),
+                             calculated_self_path(request),
                              scope ? request.instance_exec(&scope) : model)
             else
               render_error(query)
@@ -133,6 +133,14 @@ module API
 
           def render_error(query)
             raise ::API::Errors::InvalidQuery.new(query.errors.full_messages)
+          end
+
+          def calculated_self_path(request)
+            if self_path.respond_to?(:call)
+              request.instance_exec(&self_path)
+            else
+              request.api_v3_paths.send(self_path)
+            end
           end
 
           def deduce_render_representer

--- a/lib/api/v3/work_packages/available_projects_on_create_api.rb
+++ b/lib/api/v3/work_packages/available_projects_on_create_api.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'api/v3/projects/project_collection_representer'
-
 module API
   module V3
     module WorkPackages
@@ -35,31 +33,32 @@ module API
         resource :available_projects do
           after_validation do
             authorize(:add_work_packages, global: true)
+
+            checked_permissions = Projects::ProjectCollectionRepresenter.checked_permissions
+            current_user.preload_projects_allowed_to(checked_permissions)
           end
 
           params do
             optional :for_type, type: Integer
           end
 
-          get do
-            checked_permissions = Projects::ProjectCollectionRepresenter.checked_permissions
-            current_user.preload_projects_allowed_to(checked_permissions)
+          get &::API::V3::Utilities::Endpoints::SqlFallbackedIndex
+                 .new(model: Project,
+                      self_path: -> { api_v3_paths.available_projects_on_create(params[:for_type]) },
+                      scope: -> {
+                        available_projects = WorkPackage
+                                             .allowed_target_projects_on_create(current_user)
+                                             .includes(Projects::ProjectCollectionRepresenter.to_eager_load)
 
-            available_projects = WorkPackage
-                                 .allowed_target_projects_on_create(current_user)
-                                 .includes(Projects::ProjectCollectionRepresenter.to_eager_load)
-
-            query = ::Queries::Projects::ProjectQuery.new(user: current_user)
-            if params[:for_type]
-              query.where('type_id', '=', params[:for_type])
-              available_projects = query.results.merge(available_projects)
-            end
-
-            self_link = api_v3_paths.available_projects_on_create(params[:for_type])
-            Projects::ProjectCollectionRepresenter.new(available_projects,
-                                                       self_link: self_link,
-                                                       current_user: current_user)
-          end
+                        if params[:for_type]
+                          query = ::Queries::Projects::ProjectQuery.new(user: current_user)
+                          query.where('type_id', '=', params[:for_type])
+                          query.results.merge(available_projects)
+                        else
+                          available_projects
+                        end
+                      })
+                 .mount
         end
       end
     end

--- a/lib/api/v3/work_packages/available_projects_on_edit_api.rb
+++ b/lib/api/v3/work_packages/available_projects_on_edit_api.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'api/v3/projects/project_collection_representer'
-
 module API
   module V3
     module WorkPackages
@@ -35,20 +33,20 @@ module API
         resource :available_projects do
           after_validation do
             authorize(:edit_work_packages, context: @work_package.project)
-          end
 
-          get do
             checked_permissions = Projects::ProjectCollectionRepresenter.checked_permissions
             current_user.preload_projects_allowed_to(checked_permissions)
-
-            available_projects = WorkPackage
-                                 .allowed_target_projects_on_move(current_user)
-                                 .includes(Projects::ProjectCollectionRepresenter.to_eager_load)
-            self_link = api_v3_paths.available_projects_on_edit(@work_package.id)
-            Projects::ProjectCollectionRepresenter.new(available_projects,
-                                                       self_link: self_link,
-                                                       current_user: current_user)
           end
+
+          get &::API::V3::Utilities::Endpoints::SqlFallbackedIndex
+                 .new(model: Project,
+                      self_path: -> { api_v3_paths.available_projects_on_edit(@work_package.id) },
+                      scope: -> {
+                        WorkPackage
+                          .allowed_target_projects_on_move(current_user)
+                          .includes(Projects::ProjectCollectionRepresenter.to_eager_load)
+                      })
+                 .mount
         end
       end
     end

--- a/spec/requests/api/v3/work_packages/available_projects_on_create_api_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_projects_on_create_api_spec.rb
@@ -36,19 +36,20 @@ describe API::V3::WorkPackages::AvailableProjectsOnCreateAPI, type: :request do
     create(:role, permissions: [:add_work_packages])
   end
   let(:project) { create(:project) }
-  let(:user) do
+  let(:type_id) { nil }
+
+  current_user do
     create(:user,
            member_in_project: project,
            member_through_role: add_role)
   end
-  let(:type_id) { nil }
 
   context 'with a type filter present' do
     let(:type) { create :type }
     let(:type_id) { type.id }
     let(:project_with_type) { create :project, types: [type] }
     let(:member) do
-      create(:member, principal: user, project: project_with_type, roles: [add_role])
+      create(:member, principal: current_user, project: project_with_type, roles: [add_role])
     end
 
     before do
@@ -56,13 +57,11 @@ describe API::V3::WorkPackages::AvailableProjectsOnCreateAPI, type: :request do
       project_with_type
       member
 
-      allow(User).to receive(:current).and_return(user)
       get api_v3_paths.available_projects_on_create(type_id)
     end
 
-    it 'returns only the filtered one' do
-      expect(last_response.body).to be_json_eql(1).at_path('total')
-      expect(last_response.body).to be_json_eql(project_with_type.id).at_path('_embedded/elements/0/id')
+    it_behaves_like 'API V3 collection response', 1, 1, 'Project' do
+      let(:elements) { [project_with_type] }
     end
   end
 
@@ -70,24 +69,21 @@ describe API::V3::WorkPackages::AvailableProjectsOnCreateAPI, type: :request do
     before do
       project
 
-      allow(User).to receive(:current).and_return(user)
       get api_v3_paths.available_projects_on_create(type_id)
     end
 
-    context 'w/ the necessary permissions' do
-      it_behaves_like 'API V3 collection response', 1, 1, 'Project'
-
-      it 'has the project for which the add_work_packages permission exists' do
-        expect(last_response.body).to be_json_eql(project.id).at_path('_embedded/elements/0/id')
+    context 'with the necessary permissions' do
+      it_behaves_like 'API V3 collection response', 1, 1, 'Project' do
+        let(:elements) { [project] }
       end
     end
 
-    context 'w/o any add_work_packages permission' do
+    context 'without any add_work_packages permission' do
       let(:add_role) do
         create(:role, permissions: [])
       end
 
-      it { expect(last_response.status).to eq(403) }
+      it_behaves_like 'unauthorized access'
     end
   end
 end

--- a/spec/requests/api/v3/work_packages/available_projects_on_edit_api_spec.rb
+++ b/spec/requests/api/v3/work_packages/available_projects_on_edit_api_spec.rb
@@ -34,7 +34,7 @@ describe 'API::V3::WorkPackages::AvailableProjectsOnEditAPI', type: :request do
 
   let(:edit_role) do
     create(:role, permissions: %i[edit_work_packages
-                                             view_work_packages])
+                                  view_work_packages])
   end
   let(:move_role) do
     create(:role, permissions: [:move_work_packages])
@@ -42,45 +42,33 @@ describe 'API::V3::WorkPackages::AvailableProjectsOnEditAPI', type: :request do
   let(:project) { create(:project) }
   let(:target_project) { create(:project) }
   let(:work_package) { create(:work_package, project: project) }
-  let(:user) do
-    user = create(:user,
-                  member_in_project: project,
-                  member_through_role: edit_role)
 
-    create(:member,
-           user: user,
-           project: target_project,
-           roles: [move_role])
-
-    user
-  end
-
-  before do
-    allow(User).to receive(:current).and_return(user)
-    get api_v3_paths.available_projects_on_edit(work_package.id)
-  end
-
-  context 'w/ the necessary permissions' do
-    it_behaves_like 'API V3 collection response', 1, 1, 'Project'
-
-    it 'has the project for which the move_work_packages permission exists' do
-      expect(last_response.body).to be_json_eql(target_project.id).at_path('_embedded/elements/0/id')
+  current_user do
+    create(:user,
+           member_in_project: project,
+           member_through_role: edit_role).tap do |user|
+      create(:member,
+             user: user,
+             project: target_project,
+             roles: [move_role])
     end
   end
 
-  context 'w/o the edit_work_packages permission' do
+  before do
+    get api_v3_paths.available_projects_on_edit(work_package.id)
+  end
+
+  context 'with the necessary permissions' do
+    it_behaves_like 'API V3 collection response', 1, 1, 'Project' do
+      let(:elements) { [target_project] }
+    end
+  end
+
+  context 'without the edit_work_packages permission' do
     let(:edit_role) do
       create(:role, permissions: [:view_work_packages])
     end
 
-    it { expect(last_response.status).to eq(403) }
-  end
-
-  context 'w/o the view_work_packages permission' do
-    let(:edit_role) do
-      create(:role, permissions: [:edit_work_packages])
-    end
-
-    it { expect(last_response.status).to eq(404) }
+    it_behaves_like 'unauthorized access'
   end
 end


### PR DESCRIPTION
The end points now use the default implementation enabling them to:

* understand the `pageSize=-1` param
* understand the `select` param

Since the `self` href differs from the default, the calculation on the default index can now take a lambda which is dynamically executed within the context of the request.