### PR TITLE
Fix/speedup for scheduling scope

### DIFF
--- a/app/models/work_packages/scopes/for_scheduling.rb
+++ b/app/models/work_packages/scopes/for_scheduling.rb
@@ -119,52 +119,52 @@ module WorkPackages::Scopes
       def paths_sql(work_packages)
         values = work_packages.map { |wp| "(#{wp.id}, false)" }.join(', ')
 
-        <<~SQL
-             to_schedule (id, manually) AS (
-               SELECT * FROM (VALUES#{values}) AS t(id, manually)
+        <<~SQL.squish
+          to_schedule (id, manually) AS (
+            SELECT * FROM (VALUES#{values}) AS t(id, manually)
 
-               UNION
+            UNION
 
-               SELECT
-                 CASE
-                   WHEN relations.to_id = to_schedule.id
-                   THEN relations.from_id
-                   ELSE relations.to_id
-                 END id,
-                 (related_work_packages.schedule_manually OR COALESCE(descendants.schedule_manually, false)) manually
-               FROM
-                 to_schedule
-               JOIN
-                 relations
-                 ON NOT to_schedule.manually
-                 AND (#{relations_condition_sql})
-                 AND
-                   ((relations.to_id = to_schedule.id)
-                   OR (relations.from_id = to_schedule.id AND relations.follows = 0))
-               LEFT JOIN work_packages related_work_packages
-                 ON (CASE
-                   WHEN relations.to_id = to_schedule.id
-                   THEN relations.from_id
-                   ELSE relations.to_id
-                   END) = related_work_packages.id
-               LEFT JOIN LATERAL (
-                 SELECT
-                   relations.from_id,
-                   bool_and(COALESCE(work_packages.schedule_manually, false)) schedule_manually
-                 FROM relations relations
-                 JOIN work_packages
-                 ON
-                   work_packages.id = relations.to_id
-                   AND related_work_packages.id = relations.from_id
-                   AND relations.follows = 0 AND #{relations_condition_sql(transitive: true)}
-                 GROUP BY relations.from_id
-               ) descendants ON related_work_packages.id = descendants.from_id
-             )
+            SELECT
+              CASE
+                WHEN relations.to_id = to_schedule.id
+                THEN relations.from_id
+                ELSE relations.to_id
+              END id,
+              (related_work_packages.schedule_manually OR COALESCE(descendants.schedule_manually, false)) manually
+            FROM
+              to_schedule
+            JOIN
+              relations
+              ON NOT to_schedule.manually
+              AND (#{relations_condition_sql})
+              AND
+                ((relations.to_id = to_schedule.id)
+                OR (relations.from_id = to_schedule.id AND relations.follows = 0))
+            LEFT JOIN work_packages related_work_packages
+              ON (CASE
+                WHEN relations.to_id = to_schedule.id
+                THEN relations.from_id
+                ELSE relations.to_id
+                END) = related_work_packages.id
+            LEFT JOIN LATERAL (
+              SELECT
+                relations.from_id,
+                bool_and(COALESCE(work_packages.schedule_manually, false)) schedule_manually
+              FROM relations relations
+              JOIN work_packages
+              ON
+                work_packages.id = relations.to_id
+                AND related_work_packages.id = relations.from_id
+                AND relations.follows = 0 AND #{relations_condition_sql(transitive: true)}
+              GROUP BY relations.from_id
+            ) descendants ON related_work_packages.id = descendants.from_id
+          )
         SQL
       end
 
       def relations_condition_sql(transitive: false)
-        <<~SQL
+        <<~SQL.squish
           "relations"."relates" = 0 AND "relations"."duplicates" = 0 AND "relations"."blocks" = 0 AND "relations"."includes" = 0 AND "relations"."requires" = 0
             AND (relations.hierarchy + relations.relates + relations.duplicates + relations.follows + relations.blocks + relations.includes + relations.requires #{transitive ? '>' : ''}= 1)
         SQL


### PR DESCRIPTION
Employs [`LATERAL`](https://www.postgresql.org/docs/13/queries-table-expressions.html) when joining the subquery to fetch all the descendants in the `for_scheduling` scope. That way, only the descendants of the actually related work packages are calculated which in some cases is significantly faster. In other, the effect is negligible but especially when more work packages exist, the speedup is considerable. 

The `for_scheduling` scope is [documented within the class](https://github.com/opf/openproject/blob/dev/app/models/work_packages/scopes/for_scheduling.rb#L35-L116). 

When reviewing, only 5a14418 needs to be actively vetted. The other commit is just linting, mostly changing indentation which is why the whole of the SQL query is marked as changed.

Thanks to @oliverguenther for having introduced me to `LATERAL` some time back.