### PR TITLE
[40958] Fine tuning for sidebar create button

### DIFF
--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
@@ -1,9 +1,12 @@
-<op-sidemenu
-  *ngIf="(boardOptions$ | async) as items"
-  [items]="items"
+<div
   class="op-sidebar--body"
 >
-</op-sidemenu>
+  <op-sidemenu
+    *ngIf="(boardOptions$ | async) as items"
+    [items]="items"
+  >
+  </op-sidemenu>
+</div>
 
 <div class="op-sidebar--footer">
   <button
@@ -11,6 +14,7 @@
     class="spot-button spot-button_outlined"
     (click)="showNewBoardModal()"
   >
-    {{text.create_new_board}}
+    <span class="spot-icon spot-icon_add"></span>
+    <span [textContent]="text.create_new_board"></span>
   </button>
 </div>

--- a/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.html
+++ b/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.html
@@ -15,6 +15,7 @@
     [uiSref]="createButton.uiSref"
     [uiParams]="createButton.uiParams"
   >
-    {{createButton.title}}
+    <span class="spot-icon spot-icon_add"></span>
+    <span [textContent]="createButton.title"></span>
   </button>
 </div>

--- a/frontend/src/app/spot/styles/sass/components/button.sass
+++ b/frontend/src/app/spot/styles/sass/components/button.sass
@@ -4,6 +4,7 @@
   display: inline-flex
   flex-direction: row
   align-items: center
+  justify-content: center
   flex-wrap: nowrap
   line-height: calc(#{$spot-spacing-2} - 2px) // The border needs to be removed from this
   min-height: $spot-spacing-2

--- a/frontend/src/global_styles/content/_sidebar.sass
+++ b/frontend/src/global_styles/content/_sidebar.sass
@@ -13,5 +13,6 @@
       padding-bottom: 10px
 
   &--footer
+    display: grid
     text-align: center
-    padding: 16px
+    padding: 1rem 2.5rem


### PR DESCRIPTION
- [x] The left-side + icon missing in Calendar and Boards module
- [x] The width of the button should cover the entire width of the sidebar
  - [x] with 40px (2.5 REM) margin on left and right.
- [x] When there are no saved views in the Boards module, the button jumps to the top instead of being anchored to the bottom:



https://community.openproject.org/projects/openproject/work_packages/40958