### PR TITLE
[40863] Hide 1-week and 2-week buttons when split screen is opened

### DIFF
--- a/frontend/src/global_styles/content/modules/_team_planner.sass
+++ b/frontend/src/global_styles/content/modules/_team_planner.sass
@@ -10,7 +10,7 @@
       .fc-resourceTimelineWeek-button,
       .fc-resourceTimelineTwoWeeks-button,
       .fc-today-button
-        display: none
+        display: none !important
 
 .op-team-planner
   --fc-border-color: #cccccc


### PR DESCRIPTION
Overwrite default display behaviour when the split screen is opened to ensure that the buttons are hidden.


https://community.openproject.org/projects/openproject/work_packages/40863/activity