### PR TITLE
[41483] Milestones show dashes without dates

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -514,7 +514,8 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
       return dateCurrentlyVisible;
     }
 
-    return false;
+    // Milestones are always completely in view, everything else is outside
+    return !!workPackage.date;
   }
 
   showDisabledText(workPackage:WorkPackageResource):string {

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -501,13 +501,13 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     if (workPackage.startDate && workPackage.dueDate) {
       let dateToCheck;
 
-      const currentStartDate = this.ucCalendar.getApi().view.currentStart;
-      const currentEndDate = this.ucCalendar.getApi().view.currentEnd;
+      const currentStartDate = this.ucCalendar.getApi().view.currentStart.setHours(0, 0, 0, 0);
+      const currentEndDate = this.ucCalendar.getApi().view.currentEnd.setHours(0, 0, 0, 0);
 
       if (date === 'start') {
-        dateToCheck = new Date(workPackage.startDate);
+        dateToCheck = new Date(workPackage.startDate).setHours(0, 0, 0, 0);
       } else {
-        dateToCheck = new Date(workPackage.dueDate);
+        dateToCheck = new Date(workPackage.dueDate).setHours(0, 0, 0, 0);
       }
 
       const dateCurrentlyVisible = dateToCheck >= currentStartDate && dateToCheck <= currentEndDate;


### PR DESCRIPTION
* Milestone are always completely in view when they are rendered as they only span one day
* Unify the timestamps to avoid that different times falsify the result

https://community.openproject.org/projects/openproject/work_packages/41483/activity