### PR TITLE
Remove "oneOf" in case of a single referenced schema.

### DIFF
--- a/docs/api/apiv3/components/schemas/file_link_model.yml
+++ b/docs/api/apiv3/components/schemas/file_link_model.yml
@@ -38,8 +38,7 @@ properties:
       storage:
         $ref: './storage_model.yml'
       container:
-        oneOf:
-          - $ref: './work_package_model.yml'
+        $ref: './work_package_model.yml'
   _links:
     type: object
     required:


### PR DESCRIPTION
"oneOf" currently is not yet supported by the OpenAPI Code Generator, so
removing it here (where it's not necessary as far as I can see) resolves
an issue with invalid code generation.

This place is the first ocurrence of `oneOf` in `schemas`. Apparently, support for `oneOf` in the current OpenAPI Code Generator version is not yet fully finished, so hopefully things like that will be supported in the future. However, possibly the problem is caused in the first place because this `oneOf` only has a single option - not sure.