### PR TITLE
Backport: use default end points on wp#available_projects_on_...

### DIFF
--- a/lib/api/v3/utilities/endpoints/index.rb
+++ b/lib/api/v3/utilities/endpoints/index.rb
@@ -31,6 +31,16 @@ module API
     module Utilities
       module Endpoints
         class Index < API::Utilities::Endpoints::Index
+          def initialize(model:,
+                         api_name: model.name.demodulize,
+                         scope: nil,
+                         render_representer: nil,
+                         self_path: api_name.underscore.pluralize)
+            super(model: model, api_name: api_name, scope: scope, render_representer: render_representer)
+
+            self.self_path = self_path
+          end
+
           def mount
             index = self
 
@@ -51,21 +61,18 @@ module API
             if query.valid?
               render_success(query,
                              request.params,
-                             request.api_v3_paths.send(self_path),
+                             calculated_self_path(request),
                              scope ? request.instance_exec(&scope) : model)
             else
               render_error(query)
             end
           end
 
-          def self_path
-            api_name.underscore.pluralize
-          end
-
           attr_accessor :model,
                         :api_name,
                         :scope,
-                        :render_representer
+                        :render_representer,
+                        :self_path
 
           private
 
@@ -126,6 +133,14 @@ module API
 
           def render_error(query)
             raise ::API::Errors::InvalidQuery.new(query.errors.full_messages)
+          end
+
+          def calculated_self_path(request)
+            if self_path.respond_to?(:call)
+              request.instance_exec(&self_path)
+            else
+              request.api_v3_paths.send(self_path)
+            end
           end
 
           def deduce_render_representer

--- a/lib/api/v3/work_packages/available_projects_on_create_api.rb
+++ b/lib/api/v3/work_packages/available_projects_on_create_api.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'api/v3/projects/project_collection_representer'
-
 module API
   module V3
     module WorkPackages
@@ -35,31 +33,32 @@ module API
         resource :available_projects do
           after_validation do
             authorize(:add_work_packages, global: true)
+
+            checked_permissions = Projects::ProjectCollectionRepresenter.checked_permissions
+            current_user.preload_projects_allowed_to(checked_permissions)
           end
 
           params do
             optional :for_type, type: Integer
           end
 
-          get do
-            checked_permissions = Projects::ProjectCollectionRepresenter.checked_permissions
-            current_user.preload_projects_allowed_to(checked_permissions)
+          get &::API::V3::Utilities::Endpoints::Index
+                 .new(model: Project,
+                      self_path: -> { api_v3_paths.available_projects_on_create(params[:for_type]) },
+                      scope: -> {
+                        available_projects = WorkPackage
+                                             .allowed_target_projects_on_create(current_user)
+                                             .includes(Projects::ProjectCollectionRepresenter.to_eager_load)
 
-            available_projects = WorkPackage
-                                 .allowed_target_projects_on_create(current_user)
-                                 .includes(Projects::ProjectCollectionRepresenter.to_eager_load)
-
-            query = ::Queries::Projects::ProjectQuery.new(user: current_user)
-            if params[:for_type]
-              query.where('type_id', '=', params[:for_type])
-              available_projects = query.results.merge(available_projects)
-            end
-
-            self_link = api_v3_paths.available_projects_on_create(params[:for_type])
-            Projects::ProjectCollectionRepresenter.new(available_projects,
-                                                       self_link: self_link,
-                                                       current_user: current_user)
-          end
+                        if params[:for_type]
+                          query = ::Queries::Projects::ProjectQuery.new(user: current_user)
+                          query.where('type_id', '=', params[:for_type])
+                          query.results.merge(available_projects)
+                        else
+                          available_projects
+                        end
+                      })
+                 .mount
         end
       end
     end

--- a/lib/api/v3/work_packages/available_projects_on_edit_api.rb
+++ b/lib/api/v3/work_packages/available_projects_on_edit_api.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require 'api/v3/projects/project_collection_representer'
-
 module API
   module V3
     module WorkPackages
@@ -35,20 +33,20 @@ module API
         resource :available_projects do
           after_validation do
             authorize(:edit_work_packages, context: @work_package.project)
-          end
 
-          get do
             checked_permissions = Projects::ProjectCollectionRepresenter.checked_permissions
             current_user.preload_projects_allowed_to(checked_permissions)
-
-            available_projects = WorkPackage
-                                 .allowed_target_projects_on_move(current_user)
-                                 .includes(Projects::ProjectCollectionRepresenter.to_eager_load)
-            self_link = api_v3_paths.available_projects_on_edit(@work_package.id)
-            Projects::ProjectCollectionRepresenter.new(available_projects,
-                                                       self_link: self_link,
-                                                       current_user: current_user)
           end
+
+          get &::API::V3::Utilities::Endpoints::Index
+                 .new(model: Project,
+                      self_path: -> { api_v3_paths.available_projects_on_edit(@work_package.id) },
+                      scope: -> {
+                        WorkPackage
+                          .allowed_target_projects_on_move(current_user)
+                          .includes(Projects::ProjectCollectionRepresenter.to_eager_load)
+                      })
+                 .mount
         end
       end
     end


### PR DESCRIPTION
Same as #10329 but does not include:

* The support for signaling since 12.0 does not support it
* The cleanup of the spec files as the removal of `FactoryBot` causes a lot of conflicts. Should not affect what is tested, though.

It also includes the ability to set the self_path for the `API::V3::...::Index`.