### PR TITLE
[41492] Clicking in "include projects" breaks the page

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/checkbox.sass
+++ b/frontend/src/app/spot/styles/sass/components/checkbox.sass
@@ -9,7 +9,7 @@
     box-sizing: border-box
 
   &--input
-    position: absolute
+    position: fixed
     height: 1px
     width: 1px
     overflow: hidden


### PR DESCRIPTION
A fixed position prevents an effect on the scrolling container compared to an absolute positioning

https://community.openproject.org/projects/openproject/work_packages/41492/activity