### PR TITLE
Add paginated request helper

### DIFF
--- a/frontend/src/app/core/apiv3/endpoints/work_packages/api-v3-work-packages-paths.ts
+++ b/frontend/src/app/core/apiv3/endpoints/work_packages/api-v3-work-packages-paths.ts
@@ -159,11 +159,11 @@ export class ApiV3WorkPackagesPaths extends ApiV3Collection<WorkPackageResource,
       .halResourceService
       .getAllPaginated<WorkPackageCollectionResource>(
       this.path,
-      ids.length,
       {
         filters: ApiV3Filter('id', '=', ids).toJson(),
       },
-    );
+    )
+      .toPromise();
   }
 
   protected createCache():WorkPackageCache {

--- a/frontend/src/app/core/apiv3/endpoints/work_packages/api-v3-work-packages-paths.ts
+++ b/frontend/src/app/core/apiv3/endpoints/work_packages/api-v3-work-packages-paths.ts
@@ -64,6 +64,10 @@ export class ApiV3WorkPackagesPaths extends ApiV3Collection<WorkPackageResource,
    * @param ids
    */
   public requireAll(ids:string[]):Promise<unknown> {
+    if (ids.length === 0) {
+      return Promise.resolve();
+    }
+
     return new Promise<undefined>((resolve, reject) => {
       this
         .loadCollectionsFor(_.uniq(ids))
@@ -157,7 +161,7 @@ export class ApiV3WorkPackagesPaths extends ApiV3Collection<WorkPackageResource,
   protected loadCollectionsFor(ids:string[]):Promise<WorkPackageCollectionResource[]> {
     return this
       .halResourceService
-      .getAllPaginated<WorkPackageCollectionResource>(
+    .getAllPaginated<WorkPackageCollectionResource>(
       this.path,
       {
         filters: ApiV3Filter('id', '=', ids).toJson(),

--- a/frontend/src/app/core/apiv3/helpers/get-paginated-results.ts
+++ b/frontend/src/app/core/apiv3/helpers/get-paginated-results.ts
@@ -1,0 +1,77 @@
+import {
+  map,
+  mergeMap,
+} from 'rxjs/operators';
+import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
+import {
+  forkJoin,
+  Observable,
+  of,
+} from 'rxjs';
+import { ApiV3PaginationParameters } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
+import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+
+/**
+ * The API will resolve pageSize=-1 to the maximum value
+ * we can request in one call. This is configurable under adminstration.
+ */
+export const MAGIC_PAGE_NUMBER = -1;
+
+/**
+ * Right now, we still support HAL-class based collections as well as interface-based responses.
+ */
+type ApiV3CollectionType<T> = CollectionResource<T>|IHALCollection<T>;
+
+/**
+ * Extract the elements of either a HAL class or an interface
+ */
+function extractCollectionElements<T>(collection:ApiV3CollectionType<T>):T[] {
+  if (collection instanceof HalResource) {
+    return collection.elements;
+  }
+
+  return collection._embedded.elements;
+}
+
+/**
+ * Get ALL pages of a potentially paginated APIv3 request.
+ *
+ * @param request The requesting callback to request specific pages
+ * @param pageSize The pageSize parameter to request, defaults to -1 (the maximum magic page number)
+ */
+export function getPaginatedResults<T>(
+  request:(params:ApiV3PaginationParameters) => Observable<ApiV3CollectionType<T>>,
+  pageSize = MAGIC_PAGE_NUMBER,
+):Observable<T[]> {
+  return request({ pageSize, offset: 1 })
+    .pipe(
+      mergeMap((collection:ApiV3CollectionType<T>) => {
+        const resolvedSize = collection.pageSize;
+
+        if (collection.total > collection.count) {
+          const remaining = collection.total - collection.count;
+          const pagesRemaining = Math.ceil(remaining / resolvedSize);
+          const calls = new Array(pagesRemaining)
+            .fill(null)
+            .map((_, i) => request({ pageSize: resolvedSize, offset: i + 2 }));
+
+          // Branch out and fetch all remaining pages in parallel.
+          // Afterwards, merge the resulting list
+          return forkJoin(...calls).pipe(
+            map(
+              (results:ApiV3CollectionType<T>[]) => results.reduce(
+                (acc, next) => acc.concat(extractCollectionElements(next)),
+                extractCollectionElements(collection),
+              ),
+            ),
+          );
+        }
+
+        // The current page is the only page, return the results.
+        return of(extractCollectionElements(collection));
+      }),
+      // Elements may incorrectly be undefined here due to the way the representer works
+      map((elements) => elements || []),
+    );
+}

--- a/frontend/src/app/core/apiv3/helpers/get-paginated-results.ts
+++ b/frontend/src/app/core/apiv3/helpers/get-paginated-results.ts
@@ -27,26 +27,29 @@ type ApiV3CollectionType<T> = CollectionResource<T>|IHALCollection<T>;
  * Extract the elements of either a HAL class or an interface
  */
 function extractCollectionElements<T>(collection:ApiV3CollectionType<T>):T[] {
+  // Some API endpoints return an undefined _embedded.elements
+  // so we ensure we return an array at all times.
   if (collection instanceof HalResource) {
-    return collection.elements;
+    return collection.elements || [];
   }
 
-  return collection._embedded.elements;
+  return collection._embedded?.elements || [];
 }
 
 /**
- * Get ALL pages of a potentially paginated APIv3 request.
+ * Get ALL pages of a potentially paginated APIv3 request, returning an array of collections
  *
  * @param request The requesting callback to request specific pages
  * @param pageSize The pageSize parameter to request, defaults to -1 (the maximum magic page number)
+ * @return an array of HAL collections
  */
-export function getPaginatedResults<T>(
-  request:(params:ApiV3PaginationParameters) => Observable<ApiV3CollectionType<T>>,
+export function getPaginatedCollections<T, C extends ApiV3CollectionType<T>>(
+  request:(params:ApiV3PaginationParameters) => Observable<C>,
   pageSize = MAGIC_PAGE_NUMBER,
-):Observable<T[]> {
+):Observable<ApiV3CollectionType<T>[]> {
   return request({ pageSize, offset: 1 })
     .pipe(
-      mergeMap((collection:ApiV3CollectionType<T>) => {
+      mergeMap((collection:C) => {
         const resolvedSize = collection.pageSize;
 
         if (collection.total > collection.count) {
@@ -58,20 +61,36 @@ export function getPaginatedResults<T>(
 
           // Branch out and fetch all remaining pages in parallel.
           // Afterwards, merge the resulting list
-          return forkJoin(...calls).pipe(
-            map(
-              (results:ApiV3CollectionType<T>[]) => results.reduce(
-                (acc, next) => acc.concat(extractCollectionElements(next)),
-                extractCollectionElements(collection),
-              ),
-            ),
-          );
+          return forkJoin(...calls)
+            .pipe(
+              map((results:C[]) => [collection, ...results]),
+            );
         }
 
         // The current page is the only page, return the results.
-        return of(extractCollectionElements(collection));
+        return of([collection]);
       }),
-      // Elements may incorrectly be undefined here due to the way the representer works
-      map((elements) => elements || []),
+    );
+}
+
+/**
+ * Get ALL pages of a potentially paginated APIv3 request, returning all concatenated elements.
+ *
+ * @param request The requesting callback to request specific pages
+ * @param pageSize The pageSize parameter to request, defaults to -1 (the maximum magic page number)
+ * @return an array of plain HAL resources
+ */
+export function getPaginatedResults<T>(
+  request:(params:ApiV3PaginationParameters) => Observable<ApiV3CollectionType<T>>,
+  pageSize = MAGIC_PAGE_NUMBER,
+):Observable<T[]> {
+  return getPaginatedCollections(request, pageSize)
+    .pipe(
+      map(
+        (results:ApiV3CollectionType<T>[]) => results.reduce(
+          (acc, next) => acc.concat(extractCollectionElements(next)),
+          [] as T[],
+        ),
+      ),
     );
 }

--- a/frontend/src/app/core/apiv3/paths/apiv3-list-resource.interface.ts
+++ b/frontend/src/app/core/apiv3/paths/apiv3-list-resource.interface.ts
@@ -32,13 +32,16 @@ import { ApiV3FilterBuilder, FilterOperator } from 'core-app/shared/helpers/api-
 
 export type ApiV3ListFilter = [string, FilterOperator, boolean|string[]];
 
-export interface ApiV3ListParameters {
+export interface ApiV3PaginationParameters {
+  pageSize:number;
+  offset:number;
+}
+
+export interface ApiV3ListParameters extends Partial<ApiV3PaginationParameters> {
   filters?:ApiV3ListFilter[];
   sortBy?:[string, string][];
   groupBy?:string;
   select?:string[];
-  pageSize?:number;
-  offset?:number;
 }
 
 export interface ApiV3ListResourceInterface<T> {

--- a/frontend/src/app/features/hal/services/hal-resource.service.ts
+++ b/frontend/src/app/features/hal/services/hal-resource.service.ts
@@ -65,7 +65,7 @@ import {
 } from 'core-app/features/hal/resources/hal-resource';
 import { initializeHalProperties } from '../helpers/hal-resource-builder';
 import { HalError } from 'core-app/features/hal/services/hal-error';
-import { getPaginatedResults } from 'core-app/core/apiv3/helpers/get-paginated-results';
+import { getPaginatedCollections } from 'core-app/core/apiv3/helpers/get-paginated-results';
 
 export interface HalResourceFactoryConfigInterface {
   cls?:any;
@@ -153,13 +153,13 @@ export class HalResourceService {
     params:Record<string, string|number> = {},
     headers:HTTPClientHeaders = {},
   ):Observable<T[]> {
-    return getPaginatedResults(
+    return getPaginatedCollections(
       (pageParams) => {
-        const requestParams = { ...params, pageParams };
+        const requestParams = { ...params, ...pageParams };
         return this.request<CollectionResource<T>>('get', href, this.toEprops(requestParams), headers);
       },
       (params.pageSize as number|undefined) || -1,
-    );
+    ) as Observable<T[]>;
   }
 
   /**

--- a/frontend/src/app/features/hal/services/hal-resource.service.ts
+++ b/frontend/src/app/features/hal/services/hal-resource.service.ts
@@ -65,6 +65,7 @@ import {
 } from 'core-app/features/hal/resources/hal-resource';
 import { initializeHalProperties } from '../helpers/hal-resource-builder';
 import { HalError } from 'core-app/features/hal/services/hal-error';
+import { getPaginatedResults } from 'core-app/core/apiv3/helpers/get-paginated-results';
 
 export interface HalResourceFactoryConfigInterface {
   cls?:any;
@@ -142,46 +143,23 @@ export class HalResourceService {
    * Return all potential pages to the request, when the elements returned from API is smaller
    * than the expected.
    *
-   * @param href
-   * @param expected The expected number of elements
-   * @param params
-   * @param headers
-   * @return {Promise<CollectionResource[]>}
+   * @param href The URL to request
+   * @param params Parameters to pass to each paged request
+   * @param headers Headers to pass to each paged request
+   * @return {Observable<CollectionResource[]>}
    */
-  public async getAllPaginated<T extends CollectionResource>(
+  public getAllPaginated<T extends CollectionResource>(
     href:string,
-    expected:number,
     params:Record<string, string|number> = {},
     headers:HTTPClientHeaders = {},
-  ):Promise<T[]> {
-    // Total number retrieved
-    let retrieved = 0;
-    // Current offset page
-    let page = 1;
-    // Accumulated results
-    const allResults:T[] = [];
-    // If possible, request all at once.
-    const requestParams = { ...params };
-    requestParams.pageSize = expected;
-
-    while (retrieved < expected) {
-      requestParams.offset = page;
-
-      const promise = this.request<T>('get', href, this.toEprops(requestParams), headers).toPromise();
-      // eslint-disable-next-line no-await-in-loop
-      const results = await promise;
-
-      if (results.count === 0) {
-        throw new Error('No more results for this query, but expected more.');
-      }
-
-      allResults.push(results);
-
-      retrieved += results.count;
-      page += 1;
-    }
-
-    return allResults;
+  ):Observable<T[]> {
+    return getPaginatedResults(
+      (pageParams) => {
+        const requestParams = { ...params, pageParams };
+        return this.request<CollectionResource<T>>('get', href, this.toEprops(requestParams), headers);
+      },
+      (params.pageSize as number|undefined) || -1,
+    );
   }
 
   /**

--- a/frontend/src/app/shared/components/project-include/project-include.component.ts
+++ b/frontend/src/app/shared/components/project-include/project-include.component.ts
@@ -36,6 +36,7 @@ import { IProject } from 'core-app/core/state/projects/project.model';
 import { IProjectData } from './project-data';
 import { insertInList } from './insert-in-list';
 import { recursiveSort } from './recursive-sort';
+import { getPaginatedResults } from 'core-app/core/apiv3/helpers/get-paginated-results';
 
 @Component({
   selector: 'op-project-include',
@@ -194,6 +195,9 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin {
         'elements/name',
         'elements/self',
         'elements/ancestors',
+        'total',
+        'count',
+        'pageSize',
       ],
     };
   }
@@ -211,7 +215,7 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin {
 
   public toggleOpen():void {
     this.opened = !this.opened;
-    this.searchProjects();
+    this.loadAllProjects();
     this.projectsInFilter$
       .pipe(take(1))
       .subscribe((selectedProjects) => {
@@ -221,14 +225,15 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin {
       });
   }
 
-  public searchProjects():void {
-    const collectionURL = listParamsString(this.params);
-
-    this
-      .http
-      .get<IHALCollection<IProject>>(this.apiV3Service.projects.path + collectionURL)
+  public loadAllProjects():void {
+    getPaginatedResults<IProject>(
+      (params) => {
+        const collectionURL = listParamsString({ ...this.params, ...params });
+        return this.http.get<IHALCollection<IProject>>(this.apiV3Service.projects.path + collectionURL);
+      },
+    )
       .subscribe((projects) => {
-        this.allProjects$.next(projects._embedded.elements);
+        this.allProjects$.next(projects);
       });
   }
 


### PR DESCRIPTION
Adds two helper methods for paginated HAL APIv3 requests:

- [x] A helper to retrieve all collection pages, but return the collections itself as arrays. This is useful if embedded things on the collection resources need to be used (work package collections have schemas embedded, for example).
- [x] A helper to extract all pages and return a flat array of all concatenated elements.

**Cleaning up**
  - [x] Replace the current paginated request in the CurrentUserService with this helper
  - [x] Replace the paginated collection request of the HalResourceService with this helper



https://community.openproject.org/work_packages/41426