### PR TITLE
[40323] Empty state is visible during team planner query reload

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
@@ -41,7 +41,9 @@
 
       <div
         [textContent]="calendar.tooManyResultsText"
-        class="op-wp-calendar--notification"></div>
+        class="op-wp-calendar--notification">
+      </div>
+
       <div
         *ngIf="isEmpty$ | async"
         class="op-team-planner--no-data">
@@ -53,7 +55,8 @@
           data-qa-selector="op-team-planner--empty-state-button"
           (click)="showAssigneeAddRow()"
           [textContent]="text.add_assignee"
-        ></button>
+        >
+        </button>
       </div>
     </ng-container>
 

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -80,6 +80,7 @@ import { imagePath } from 'core-app/shared/helpers/images/path-helper';
 import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
 import { ICapability } from 'core-app/core/state/capabilities/capability.model';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
+import { LoadingIndicatorService } from 'core-app/core/loading-indicator/loading-indicator.service';
 
 @Component({
   selector: 'op-team-planner',
@@ -206,7 +207,11 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     this.principalIds$,
     this.showAddAssignee$,
   ]).pipe(
-    map(([principals, showAddAssignee]) => !principals.length && !showAddAssignee),
+    debounceTime(250),
+    map(([principals, showAddAssignee]) => {
+      this.loadingIndicatorService.table.stop();
+      return !principals.length && !showAddAssignee;
+    }),
   );
 
   private loading$:Subject<unknown>|null = null;
@@ -263,6 +268,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     readonly keepTab:KeepTabService,
     readonly actions$:ActionsService,
     readonly toastService:ToastService,
+    readonly loadingIndicatorService:LoadingIndicatorService,
   ) {
     super();
   }


### PR DESCRIPTION
Stop loading indicator before showing the empty state. The debounce is necessary because it would otherwise be done before the loading indicator even started.

https://community.openproject.org/projects/openproject/work_packages/40323/activity