### PR TITLE
[41405] Add Basic Board to onboarding tour for Community edition

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -545,7 +545,8 @@ en:
           task_board: "The task board visualizes the <b>progress for this sprint</b>. Click on the plus (+) icon next to a user story to add new tasks or impediments. <br> The status can be updated by drag and drop."
         boards:
           overview: 'Select <b>boards</b> to shift the view and manage your project using the agile boards view.'
-          lists: 'Here you can create multiple lists (columns) within your board. This feature allows you to create a <b>Kanban board</b>, for example.'
+          lists_kanban: 'Here you can create multiple lists (columns) within your board. This feature allows you to create a <b>Kanban board</b>, for example.'
+          lists_basic: 'Here you can create multiple lists (columns) within your agile board.'
           add: 'Click on the plus (+) icon to <b>create a new card</b> or <b>add an existing card</b> to the list on the board.'
           drag: 'Drag and drop your cards within a given list to reorder them, or to move them to another list. <br> You can click the info (i) icon in the upper right-hand corner or double-click a card to open its details.'
         wp:

--- a/frontend/src/app/core/setup/globals/onboarding/helpers.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/helpers.ts
@@ -2,6 +2,7 @@ export const demoProjectName = 'Demo project';
 export const scrumDemoProjectName = 'Scrum project';
 export const onboardingTourStorageKey = 'openProject-onboardingTour';
 export type OnboardingTourNames = 'prepareBacklogs'|'backlogs'|'taskboard'|'homescreen'|'main';
+export type ProjectName = 'demo'|'scrum';
 
 export function waitForElement(element:string, container:string, execFunction:Function) {
   // Wait for the element to be ready

--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
@@ -4,6 +4,7 @@ import {
   OnboardingTourNames,
   onboardingTourStorageKey,
   preventClickHandler,
+  ProjectName,
   waitForElement,
 } from 'core-app/core/setup/globals/onboarding/helpers';
 import { boardTourSteps } from 'core-app/core/setup/globals/onboarding/tours/boards_tour';
@@ -73,7 +74,7 @@ function moduleVisible(name:string):boolean {
   return document.getElementsByClassName(`${name}-view-menu-item`).length > 0;
 }
 
-function mainTour() {
+function mainTour(project:ProjectName = 'demo') {
   initializeTour('mainTourFinished');
 
   const boardsDemoDataAvailable = jQuery('meta[name=boards_demo_data_available]').attr('content') === 'true';
@@ -88,7 +89,7 @@ function mainTour() {
       // ... and available seed data of boards.
       // Then add boards to the tour, otherwise skip it.
       if (boardsDemoDataAvailable && moduleVisible('board')) {
-        steps = steps.concat(boardTourSteps('enterprise'));
+        steps = steps.concat(boardTourSteps('enterprise', project));
       }
 
       // ... same for team planners
@@ -96,7 +97,7 @@ function mainTour() {
         steps = steps.concat(teamPlannerTourSteps());
       }
     } else if (boardsDemoDataAvailable && moduleVisible('board')) {
-      steps = steps.concat(boardTourSteps('basic'));
+      steps = steps.concat(boardTourSteps('basic', project));
     }
 
     steps = steps.concat(menuTourSteps());
@@ -105,7 +106,7 @@ function mainTour() {
   });
 }
 
-export function start(name:OnboardingTourNames):void {
+export function start(name:OnboardingTourNames, project?:ProjectName):void {
   switch (name) {
     case 'prepareBacklogs':
       initializeTour('prepareTaskBoardTour');
@@ -124,7 +125,7 @@ export function start(name:OnboardingTourNames):void {
       startTour(homescreenOnboardingTourSteps());
       break;
     case 'main':
-      mainTour();
+      mainTour(project);
       break;
     default:
       break;

--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
@@ -88,13 +88,15 @@ function mainTour() {
       // ... and available seed data of boards.
       // Then add boards to the tour, otherwise skip it.
       if (boardsDemoDataAvailable && moduleVisible('board')) {
-        steps = steps.concat(boardTourSteps());
+        steps = steps.concat(boardTourSteps('enterprise'));
       }
 
       // ... same for team planners
       if (teamPlannerDemoDataAvailable && moduleVisible('team-planner')) {
         steps = steps.concat(teamPlannerTourSteps());
       }
+    } else if (boardsDemoDataAvailable && moduleVisible('board')) {
+      steps = steps.concat(boardTourSteps('basic'));
     }
 
     steps = steps.concat(menuTourSteps());

--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour_trigger.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour_trigger.ts
@@ -4,14 +4,15 @@ import {
   demoProjectsLinks,
   OnboardingTourNames,
   onboardingTourStorageKey,
+  ProjectName,
   waitForElement,
 } from 'core-app/core/setup/globals/onboarding/helpers';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 
-async function triggerTour(name:OnboardingTourNames):Promise<void> {
+async function triggerTour(name:OnboardingTourNames, project?:ProjectName):Promise<void> {
   debugLog(`Loading and triggering onboarding tour ${name}`);
   await import(/* webpackChunkName: "onboarding-tour" */ './onboarding_tour').then((tour) => {
-    tour.start(name);
+    tour.start(name, project);
   });
 }
 
@@ -56,26 +57,27 @@ export function detectOnboardingTour():void {
 
     // ------------------------------- Tutorial WP page -------------------------------
     if (currentTourPart === 'startMainTourFromBacklogs' || url.searchParams.get('start_onboarding_tour')) {
-      void triggerTour('main');
+      const projectName:ProjectName = currentTourPart === 'startMainTourFromBacklogs' ? 'scrum' : 'demo';
+      void triggerTour('main', projectName);
     }
 
     // ------------------------------- Prepare Backlogs page -------------------------------
     if (url.searchParams.get('start_scrum_onboarding_tour')) {
       if (jQuery('.backlogs-menu-item').length > 0) {
-        void triggerTour('prepareBacklogs');
+        void triggerTour('prepareBacklogs', 'scrum');
       } else {
-        void triggerTour('taskboard');
+        void triggerTour('taskboard', 'scrum');
       }
     }
 
     // ------------------------------- Tutorial Backlogs page -------------------------------
     if (currentTourPart === 'prepareTaskBoardTour') {
-      void triggerTour('backlogs');
+      void triggerTour('backlogs', 'scrum');
     }
 
     // ------------------------------- Tutorial Task Board page -------------------------------
     if (currentTourPart === 'startTaskBoardTour') {
-      void triggerTour('taskboard');
+      void triggerTour('taskboard', 'scrum');
     }
   }
 }

--- a/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
@@ -1,7 +1,10 @@
 import { waitForElement } from 'core-app/core/setup/globals/onboarding/helpers';
 import { OnboardingStep } from 'core-app/core/setup/globals/onboarding/onboarding_tour';
 
-export function boardTourSteps():OnboardingStep[] {
+export function boardTourSteps(edition:'basic'|'enterprise'):OnboardingStep[] {
+  const boardName = edition === 'basic' ? 'Basic board' : 'Kanban';
+  const listExplanation = edition === 'basic' ? 'basic' : 'kanban';
+
   return [
     {
       'next .board-view-menu-item': I18n.t('js.onboarding.steps.boards.overview'),
@@ -10,12 +13,12 @@ export function boardTourSteps():OnboardingStep[] {
       onNext() {
         jQuery('.board-view-menu-item ~ .toggler')[0].click();
         waitForElement('.op-sidemenu--items', '#main-menu', () => {
-          jQuery(".op-sidemenu--item-action:contains('Kanban')")[0].click();
+          jQuery(`.op-sidemenu--item-action:contains(${boardName})`)[0].click();
         });
       },
     },
     {
-      'next [data-qa-selector="op-board-list"]': I18n.t('js.onboarding.steps.boards.lists'),
+      'next [data-qa-selector="op-board-list"]': I18n.t(`js.onboarding.steps.boards.lists_${listExplanation}`),
       showSkip: false,
       nextButton: { text: I18n.t('js.onboarding.buttons.next') },
       containerClass: '-dark -hidden-arrow',

--- a/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
@@ -1,8 +1,17 @@
-import { waitForElement } from 'core-app/core/setup/globals/onboarding/helpers';
+import {
+  ProjectName,
+  waitForElement,
+} from 'core-app/core/setup/globals/onboarding/helpers';
 import { OnboardingStep } from 'core-app/core/setup/globals/onboarding/onboarding_tour';
 
-export function boardTourSteps(edition:'basic'|'enterprise'):OnboardingStep[] {
-  const boardName = edition === 'basic' ? 'Basic board' : 'Kanban';
+export function boardTourSteps(edition:'basic'|'enterprise', project:ProjectName):OnboardingStep[] {
+  let boardName:string;
+  if (edition === 'basic') {
+    boardName = project === 'demo' ? 'Basic board' : 'Task board';
+  } else {
+    boardName = 'Kanban';
+  }
+
   const listExplanation = edition === 'basic' ? 'basic' : 'kanban';
 
   return [

--- a/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
+++ b/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
@@ -66,12 +66,12 @@ describe 'boards onboarding tour', js: true do
   let!(:wp_2) { create(:work_package, project: scrum_project) }
 
   let!(:demo_board_view) { create :board_grid_with_query, project: demo_project, name: 'Kanban', query: query }
+  let!(:demo_basic_board_view) { create :board_grid_with_query, project: demo_project, name: 'Basic board', query: query }
   let!(:scrum_board_view) { create :board_grid_with_query, project: scrum_project, name: 'Kanban', query: query }
+  let!(:scrum_basic_board_view) { create :board_grid_with_query, project: scrum_project, name: 'Task board', query: query }
   let(:query) { create :query, user: user, project: demo_project }
 
   before do
-    with_enterprise_token :board_view
-    login_as user
     ::OrderedWorkPackage.create(query: query, work_package: wp_1, position: 0)
     allow(Setting).to receive(:demo_projects_available).and_return(true)
     allow(Setting).to receive(:boards_demo_data_available).and_return(true)
@@ -83,29 +83,67 @@ describe 'boards onboarding tour', js: true do
   end
 
   context 'as a new user' do
-    it 'I see the board onboarding tour in the demo project' do
-      # Set the tour parameter so that we can start on the wp page
-      visit "/projects/#{demo_project.identifier}/work_packages?start_onboarding_tour=true"
+    context 'with an EE token' do
+      before do
+        with_enterprise_token :board_view
+        login_as user
+      end
 
-      step_through_onboarding_wp_tour demo_project, wp_1
+      it 'I see the board onboarding tour in the demo project' do
+        # Set the tour parameter so that we can start on the wp page
+        visit "/projects/#{demo_project.identifier}/work_packages?start_onboarding_tour=true"
 
-      step_through_onboarding_board_tour
+        step_through_onboarding_wp_tour demo_project, wp_1
 
-      step_through_onboarding_main_menu_tour has_full_capabilities: true
+        step_through_onboarding_board_tour
+
+        step_through_onboarding_main_menu_tour has_full_capabilities: true
+      end
+
+      it "I see the board onboarding tour in the scrum project" do
+        # Set sessionStorage value so that the tour knows that it is in the scum tour
+        page.execute_script("window.sessionStorage.setItem('openProject-onboardingTour', 'startMainTourFromBacklogs');")
+
+        # Set the tour parameter so that we can start on the wp page
+        visit "/projects/#{scrum_project.identifier}/work_packages?start_onboarding_tour=true"
+
+        step_through_onboarding_wp_tour scrum_project, wp_2
+
+        step_through_onboarding_board_tour
+
+        step_through_onboarding_main_menu_tour has_full_capabilities: true
+      end
     end
 
-    it "I see the board onboarding tour in the scrum project" do
-      # Set sessionStorage value so that the tour knows that it is in the scum tour
-      page.execute_script("window.sessionStorage.setItem('openProject-onboardingTour', 'startMainTourFromBacklogs');")
+    context 'without an EE token' do
+      before do
+        login_as user
+      end
 
-      # Set the tour parameter so that we can start on the wp page
-      visit "/projects/#{scrum_project.identifier}/work_packages?start_onboarding_tour=true"
+      it 'I see the board onboarding tour in the demo project' do
+        # Set the tour parameter so that we can start on the wp page
+        visit "/projects/#{demo_project.identifier}/work_packages?start_onboarding_tour=true"
 
-      step_through_onboarding_wp_tour scrum_project, wp_2
+        step_through_onboarding_wp_tour demo_project, wp_1
 
-      step_through_onboarding_board_tour
+        step_through_onboarding_board_tour with_ee_token: false
 
-      step_through_onboarding_main_menu_tour has_full_capabilities: true
+        step_through_onboarding_main_menu_tour has_full_capabilities: true
+      end
+
+      it "I see the board onboarding tour in the scrum project" do
+        # Set sessionStorage value so that the tour knows that it is in the scum tour
+        page.execute_script("window.sessionStorage.setItem('openProject-onboardingTour', 'startMainTourFromBacklogs');")
+
+        # Set the tour parameter so that we can start on the wp page
+        visit "/projects/#{scrum_project.identifier}/work_packages?start_onboarding_tour=true"
+
+        step_through_onboarding_wp_tour scrum_project, wp_2
+
+        step_through_onboarding_board_tour with_ee_token: false
+
+        step_through_onboarding_main_menu_tour has_full_capabilities: true
+      end
     end
   end
 end

--- a/modules/boards/spec/features/support/onboarding_steps.rb
+++ b/modules/boards/spec/features/support/onboarding_steps.rb
@@ -27,13 +27,18 @@
 #++
 
 module OnboardingSteps
-  def step_through_onboarding_board_tour
+  def step_through_onboarding_board_tour(with_ee_token: true)
     next_button.click
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.boards.overview')), normalize_ws: true
 
     next_button.click
-    expect(page)
-      .to have_text sanitize_string(I18n.t('js.onboarding.steps.boards.lists_kanban')), normalize_ws: true
+    if with_ee_token
+      expect(page)
+        .to have_text sanitize_string(I18n.t('js.onboarding.steps.boards.lists_kanban')), normalize_ws: true
+    else
+      expect(page)
+        .to have_text sanitize_string(I18n.t('js.onboarding.steps.boards.lists_basic')), normalize_ws: true
+    end
 
     next_button.click
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.boards.add')), normalize_ws: true

--- a/modules/boards/spec/features/support/onboarding_steps.rb
+++ b/modules/boards/spec/features/support/onboarding_steps.rb
@@ -33,7 +33,7 @@ module OnboardingSteps
 
     next_button.click
     expect(page)
-      .to have_text sanitize_string(I18n.t('js.onboarding.steps.boards.lists')), normalize_ws: true
+      .to have_text sanitize_string(I18n.t('js.onboarding.steps.boards.lists_kanban')), normalize_ws: true
 
     next_button.click
     expect(page).to have_text sanitize_string(I18n.t('js.onboarding.steps.boards.add')), normalize_ws: true


### PR DESCRIPTION
Adaptations to the onboarding tour:

- [x] Without an EE token
  - [x] In the demo project, show the "Basic board"
  - [x] In the scrum project, show the "Task board"
- [x] With an EE token show the "Kanban board" in both projects (unchanged behaviour) 
- [x] Add a test

https://community.openproject.org/projects/openproject/work_packages/41405/activity