### PR TITLE
[41516] Hide lists of advanced boards outside EE

### DIFF
--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
@@ -1,11 +1,13 @@
 <ng-container *ngIf="(board$ | async) as board">
-  <div class="boards-list--container"
-       [ngClass]="{ '-free' : board.isFree }"
-       #container
-       cdkDropList
-       [cdkDropListDisabled]="!board.editable"
-       cdkDropListOrientation="horizontal"
-       (cdkDropListDropped)="moveList(board, $event)"
+  <div
+    *ngIf="!eeShowBanners || board.isFree"
+    class="boards-list--container"
+    [ngClass]="{ '-free' : board.isFree }"
+    #container
+    cdkDropList
+    [cdkDropListDisabled]="!board.editable"
+    cdkDropListOrientation="horizontal"
+    (cdkDropListDropped)="moveList(board, $event)"
   >
     <div *ngFor="let boardWidget of boardWidgets; trackBy:trackByQueryId"
          class="boards-list--item"
@@ -38,4 +40,12 @@
       </div>
     </div>
   </div>
+  <enterprise-banner
+    *ngIf="eeShowBanners"
+    [leftMargin]="true"
+    [linkMessage]="text.upgrade_to_ee_text"
+    [textMessage]="text.teaser_text"
+    opReferrer="boards#board-show"
+  >
+  </enterprise-banner>
 </ng-container>

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
@@ -41,6 +41,8 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
     addList: this.I18n.t('js.boards.add_list'),
     unnamedList: this.I18n.t('js.boards.label_unnamed_list'),
     hiddenListWarning: this.I18n.t('js.boards.text_hidden_list_warning'),
+    teaser_text: this.I18n.t('js.boards.upsale.teaser_text'),
+    upgrade_to_ee_text: this.I18n.t('js.boards.upsale.upgrade'),
   };
 
   /** Container reference */
@@ -68,6 +70,8 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
   boardWidgets:GridWidgetResource[] = [];
 
   showHiddenListWarning:boolean = false;
+
+  eeShowBanners = this.Banner.eeShowBanners;
 
   private currentQueryUpdatedMonitoring:Subscription;
 

--- a/frontend/src/app/shared/components/enterprise-banner/enterprise-banner.component.html
+++ b/frontend/src/app/shared/components/enterprise-banner/enterprise-banner.component.html
@@ -1,0 +1,15 @@
+<div
+  class="op-enterprise-banner"
+  data-qa-selector="op-enterprise-banner"
+>
+  <div class="op-toast -ee-upsale"
+       [ngClass]="{'-left-margin': leftMargin }">
+    <div class="op-toast--content">
+      <p class="-bold" [textContent]="text.enterpriseFeature"></p>
+      <p [textContent]="textMessage"></p>
+      <a [href]="link"
+         target='blank'
+         [textContent]="linkMessage"></a>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/shared/components/enterprise-banner/enterprise-banner.component.ts
+++ b/frontend/src/app/shared/components/enterprise-banner/enterprise-banner.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   Component,
   Input,
   OnInit,
@@ -9,20 +10,8 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 @Component({
   selector: 'enterprise-banner',
   styleUrls: ['./enterprise-banner.component.sass'],
-  template: `
-    <div class="op-enterprise-banner">
-      <div class="op-toast -ee-upsale"
-           [ngClass]="{'-left-margin': leftMargin }">
-        <div class="op-toast--content">
-          <p class="-bold" [textContent]="text.enterpriseFeature"></p>
-          <p [textContent]="textMessage"></p>
-          <a [href]="link"
-             target='blank'
-             [textContent]="linkMessage"></a>
-        </div>
-      </div>
-    </div>
-  `
+  templateUrl: './enterprise-banner.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EnterpriseBannerComponent implements OnInit {
   @Input() public leftMargin = false;

--- a/modules/boards/spec/factories/board_factory.rb
+++ b/modules/boards/spec/factories/board_factory.rb
@@ -76,7 +76,7 @@ FactoryBot.define do
       projects_columns { [create(:project)] }
     end
 
-    callback(:after_build) do |board, evaluator| # this is also done after :create
+    callback(:after_create) do |board, evaluator| # this is also done after :create
       evaluator.projects_columns.each do |project|
 
         query = Query.new_default(name: project.name, project: board.project, public: true).tap do |q|
@@ -87,7 +87,6 @@ FactoryBot.define do
 
         filters = [{ "onlySubproject" => { "operator" => "=", "values" => [project.id.to_s] } }]
 
-        board.options = { 'type' => 'action', 'attribute' => 'subproject' }
         board.widgets << create(:grid_widget,
                                 identifier: 'work_package_query',
                                 start_row: 1,
@@ -97,6 +96,9 @@ FactoryBot.define do
                                 options: { 'queryId' => query.id,
                                            'filters' => filters })
       end
+
+      board.options = { 'type' => 'action', 'attribute' => 'subproject' }
+      board.save!
     end
   end
 end

--- a/modules/boards/spec/features/board_enterprise_spec.rb
+++ b/modules/boards/spec/features/board_enterprise_spec.rb
@@ -54,14 +54,25 @@ describe 'Boards enterprise spec', type: :feature, js: true do
     end
 
     it 'disabled all action boards' do
-      # Expect both existing boards to show
-      expect(page).to have_content 'My board'
-      expect(page).to have_content 'Subproject board'
-
       page.find('.toolbar-item a', text: I18n.t('js.button_create')).click
 
       expect(page).to have_selector('[data-qa-selector="op-tile-block"]:not([disabled])', text: 'Basic')
       expect(page).to have_selector('[data-qa-selector="op-tile-block"]:disabled', count: 5)
+    end
+
+    it 'shows a banner on the action board' do
+      # Expect both existing boards to show
+      expect(page).to have_content 'My board'
+      expect(page).to have_content 'Subproject board'
+
+      board_page = board_index.open_board(manual_board)
+      board_page.expect_query 'My board'
+      expect(page).to have_no_selector '[data-qa-selector="op-enterprise-banner"]'
+
+      board_index.visit!
+      board_page = board_index.open_board(action_board)
+      board_page.expect_query 'Subproject board'
+      expect(page).to have_selector '[data-qa-selector="op-enterprise-banner"]'
     end
   end
 
@@ -73,12 +84,24 @@ describe 'Boards enterprise spec', type: :feature, js: true do
     end
 
     it 'enables all options' do
-      expect(page).to have_content 'My board'
-      expect(page).to have_content 'Subproject board'
-
       page.find('.toolbar-item a', text: I18n.t('js.button_create')).click
 
       expect(page).to have_selector('[data-qa-selector="op-tile-block"]:not([disabled])', count: 6)
+    end
+
+    it 'shows the action board' do
+      # Expect both existing boards to show
+      expect(page).to have_content 'My board'
+      expect(page).to have_content 'Subproject board'
+
+      board_page = board_index.open_board(manual_board)
+      board_page.expect_query 'My board'
+      expect(page).to have_no_selector '[data-qa-selector="op-enterprise-banner"]'
+
+      board_index.visit!
+      board_page = board_index.open_board(action_board)
+      board_page.expect_query 'Subproject board'
+      expect(page).to have_no_selector '[data-qa-selector="op-enterprise-banner"]'
     end
   end
 end


### PR DESCRIPTION
Without an EE token

- All existing advanced boards should not be accessible any more, meaning:
  - [x] They remain in the index page and the sidebar
  - [x] From the index page they should be deletable
  - [x] When clicking on them, the blue banner is shown and the actual lists are hidden (like it was before)

https://community.openproject.org/wp/41516