### PR TITLE
Fix the bulk copy link in the single WP context menu

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -35,7 +35,7 @@ import { WorkPackageViewHierarchyIdentationService } from 'core-app/features/wor
 import { WorkPackageViewDisplayRepresentationService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-display-representation.service';
 
 export type WorkPackageAction = {
-  text:string;
+  text?:string;
   key:string;
   icon?:string;
   indexBy?:(actions:WorkPackageAction[]) => number,

--- a/frontend/src/app/features/work-packages/services/work-package-authorization.service.ts
+++ b/frontend/src/app/features/work-packages/services/work-package-authorization.service.ts
@@ -29,57 +29,60 @@
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { StateService } from '@uirouter/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import { WorkPackageAction } from 'core-app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service';
+import { HalLink } from 'core-app/features/hal/hal-link/hal-link';
+import { ProjectResource } from 'core-app/features/hal/resources/project-resource';
 
 export class WorkPackageAuthorization {
-  public project:any;
+  public project:ProjectResource;
 
   constructor(public workPackage:WorkPackageResource,
     readonly PathHelper:PathHelperService,
     readonly $state:StateService) {
-    this.project = workPackage.project;
+    this.project = workPackage.project as ProjectResource;
   }
 
-  public get allActions():any {
-    return {
-      workPackage: this.workPackage,
-      project: this.project,
-    };
+  public linkForAction(action:WorkPackageAction):WorkPackageAction {
+    let link:string;
+    switch (action.key) {
+      case 'copy':
+        link = this.copyLink();
+        break;
+      case 'copy_to_other_project':
+        link = this.bulkCopyLink();
+        break;
+      default:
+        link = (this.workPackage[action.link as string] as HalLink).href as string;
+    }
+
+    return { ...action, link };
   }
 
-  public copyLink() {
+  public isPermitted(action:WorkPackageAction):boolean {
+    return this.workPackage[action.link as string] !== undefined;
+  }
+
+  public permittedActionKeys(allowedActions:WorkPackageAction[]):string[] {
+    return allowedActions
+      .filter((action) => this.isPermitted(action))
+      .map((action) => action.key);
+  }
+
+  public permittedActionsWithLinks(allowedActions:WorkPackageAction[]):WorkPackageAction[] {
+    return allowedActions
+      .filter((action) => this.isPermitted(action))
+      .map((action) => this.linkForAction(action));
+  }
+
+  private copyLink() {
     const stateName = this.$state.current.name as string;
     if (stateName.indexOf('work-packages.partitioned.list.details') === 0) {
-      return this.PathHelper.workPackageDetailsCopyPath(this.project.identifier, this.workPackage.id!);
+      return this.PathHelper.workPackageDetailsCopyPath(this.project.identifier, this.workPackage.id as string);
     }
-    return this.PathHelper.workPackageCopyPath(this.workPackage.id!);
+    return this.PathHelper.workPackageCopyPath(this.workPackage.id as string);
   }
 
-  public linkForAction(action:any) {
-    if (action.key === 'copy') {
-      action.link = this.copyLink();
-    } else {
-      action.link = this.allActions[action.resource][action.link].href;
-    }
-
-    return action;
-  }
-
-  public isPermitted(action:any) {
-    return this.allActions[action.resource] !== undefined
-      && this.allActions[action.resource][action.link] !== undefined;
-  }
-
-  public permittedActionKeys(allowedActions:any) {
-    const validActions = _.filter(allowedActions, (action:any) => this.isPermitted(action));
-
-    return _.map(validActions, (action:any) => action.key);
-  }
-
-  public permittedActionsWithLinks(allowedActions:any) {
-    const validActions = _.filter(_.cloneDeep(allowedActions), (action:any) => this.isPermitted(action));
-
-    const allowed = _.map(validActions, (action:any) => this.linkForAction(action));
-
-    return allowed;
+  private bulkCopyLink():string {
+    return `${this.PathHelper.staticBase}/work_packages/move/new?copy=true&ids[]=${this.workPackage.id as string}`;
   }
 }

--- a/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
+++ b/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-single-context-menu.ts
@@ -53,6 +53,10 @@ export class WorkPackageSingleContextMenuDirective extends OpContextMenuTrigger 
     const { link } = action;
 
     switch (key) {
+      case 'copy_to_other_project':
+        window.location.href = `${this.PathHelper.staticBase}/work_packages/move/new?copy=true&ids[]=${this.workPackage.id as string}`;
+        break;
+
       case 'copy':
         this.$state.go('work-packages.copy', { copiedFromWorkPackageId: this.workPackage.id });
         break;

--- a/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-static-context-menu-actions.ts
+++ b/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-static-context-menu-actions.ts
@@ -1,39 +1,34 @@
-export const PERMITTED_CONTEXT_MENU_ACTIONS = [
+import { WorkPackageAction } from 'core-app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service';
+
+export const PERMITTED_CONTEXT_MENU_ACTIONS:WorkPackageAction[] = [
   {
     key: 'log_time',
     link: 'logTime',
-    resource: 'workPackage',
   },
   {
     key: 'change_project',
     icon: 'icon-move',
     link: 'move',
-    resource: 'workPackage',
   },
   {
     key: 'copy',
     link: 'copy',
-    resource: 'workPackage',
   },
   {
     key: 'copy_to_other_project',
     link: 'copy',
     icon: 'icon-project-types',
-    resource: 'workPackage',
   },
   {
     key: 'delete',
     link: 'delete',
-    resource: 'workPackage',
   },
   {
     key: 'export-pdf',
     link: 'pdf',
-    resource: 'workPackage',
   },
   {
     key: 'export-atom',
     link: 'atom',
-    resource: 'workPackage',
   },
 ];

--- a/spec/features/work_packages/details/context_menu_spec.rb
+++ b/spec/features/work_packages/details/context_menu_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'Work package single context menu', js: true do
+  let(:user) { create(:admin) }
+  let(:work_package) { create(:work_package) }
+
+  let(:wp_view) { Pages::FullWorkPackage.new(work_package, work_package.project) }
+
+  before do
+    login_as(user)
+    wp_view.visit!
+  end
+
+  it 'sets the correct copy project link' do
+    find('#action-show-more-dropdown-menu .button').click
+    find('.menu-item', text: 'Copy to other project', exact_text: true).click
+
+    expect(page).to have_selector('h2', text: I18n.t(:button_copy))
+    expect(page).to have_selector('a.work_package', text: "##{work_package.id}")
+    expect(page).to have_current_path /work_packages\/move\/new\?copy=true&ids\[\]=#{work_package.id}/
+  end
+end


### PR DESCRIPTION
The link behind "Copy to other project" for the single context menu (split/full view) was not working. Fixed and added a test