### PR TITLE
[41217] Use typeahead filter for "Add existing" on team planner

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.ts
@@ -159,7 +159,7 @@ export class AddExistingPaneComponent extends UntilDestroyedMixin implements OnI
     const activeFilters = this.wpFilters.currentlyVisibleFilters;
     const filters:ApiV3FilterBuilder = this.urlParamsHelper.filterBuilderFrom(activeFilters);
 
-    filters.add('subjectOrId', '**', [searchString]);
+    filters.add('typeahead', '**', [searchString]);
 
     // Add the existing filter, if any
     this.addExistingFilters(filters);


### PR DESCRIPTION
Replace subjectOrId with typeahead fliter

https://community.openproject.org/projects/openproject/work_packages/41217/activity