### PR TITLE
[bugfix] Added additional visibility check for file links

### DIFF
--- a/modules/storages/app/models/queries/storages/work_packages/filter/file_link_origin_id_filter.rb
+++ b/modules/storages/app/models/queries/storages/work_packages/filter/file_link_origin_id_filter.rb
@@ -41,5 +41,13 @@ module Queries::Storages::WorkPackages::Filter
     def permission
       :view_file_links
     end
+
+    def joins
+      %i[file_links storages]
+    end
+
+    def additional_where_condition
+      "AND #{::Storages::FileLink.table_name}.storage_id = #{::Storages::Storage.table_name}.id"
+    end
   end
 end

--- a/modules/storages/app/models/queries/storages/work_packages/filter/storage_id_filter.rb
+++ b/modules/storages/app/models/queries/storages/work_packages/filter/storage_id_filter.rb
@@ -41,5 +41,13 @@ module Queries::Storages::WorkPackages::Filter
     def permission
       :view_file_links
     end
+
+    def joins
+      [:file_links, { project: :projects_storages }]
+    end
+
+    def additional_where_condition
+      "AND #{::Storages::FileLink.table_name}.storage_id = #{::Storages::ProjectStorage.table_name}.storage_id"
+    end
   end
 end

--- a/modules/storages/app/models/queries/storages/work_packages/filter/storage_url_filter.rb
+++ b/modules/storages/app/models/queries/storages/work_packages/filter/storage_url_filter.rb
@@ -47,7 +47,11 @@ module Queries::Storages::WorkPackages::Filter
     end
 
     def joins
-      { file_links: :storage }
+      [{ file_links: :storage }, { project: :projects_storages }]
+    end
+
+    def additional_where_condition
+      "AND #{::Storages::FileLink.table_name}.storage_id = #{::Storages::ProjectStorage.table_name}.storage_id"
     end
   end
 end

--- a/modules/storages/app/models/queries/storages/work_packages/filter/storages_filter_mixin.rb
+++ b/modules/storages/app/models/queries/storages/work_packages/filter/storages_filter_mixin.rb
@@ -55,11 +55,16 @@ module Queries::Storages::WorkPackages::Filter::StoragesFilterMixin
     <<-SQL.squish
       #{::Queries::Operators::Equals.sql_for_field(where_values, filter_model.table_name, filter_column)}
       AND work_packages.project_id IN (#{Project.allowed_to(User.current, permission).select(:id).to_sql})
+      #{additional_where_condition}
     SQL
   end
 
   def where_values
     values
+  end
+
+  def additional_where_condition
+    ''
   end
 
   def joins

--- a/modules/storages/app/models/storages/file_link.rb
+++ b/modules/storages/app/models/storages/file_link.rb
@@ -64,9 +64,10 @@ class Storages::FileLink < ApplicationRecord
     # join projects through the container, and filter on projects visible from
     # the user
     includes(:container)
-      .includes(container: :project)
+      .includes(container: { project: :projects_storages })
       .references(:projects)
       .merge(Project.allowed_to(user, :view_file_links))
+      .where('projects_storages.storage_id = file_links.storage_id')
   }
 
   delegate :project, to: :container

--- a/modules/storages/spec/requests/api/v3/file_links/file_links_spec.rb
+++ b/modules/storages/spec/requests/api/v3/file_links/file_links_spec.rb
@@ -86,6 +86,14 @@ describe 'API v3 file links resource', type: :request do
         let(:elements) { [] }
       end
     end
+
+    context 'if storages module is deactivated for the work package\'s project' do
+      let(:project) { create(:project, disable_modules: :storages) }
+
+      it_behaves_like 'API V3 collection response', 0, 0, 'FileLink', 'Collection' do
+        let(:elements) { [] }
+      end
+    end
   end
 
   describe 'POST /api/v3/work_packages/:work_package_id/file_links' do
@@ -168,15 +176,17 @@ describe 'API v3 file links resource', type: :request do
 
     context 'when some file link elements with matching origin_id, container, and storage already exist in database' do
       let(:existing_file_link) do
-        create(:file_link, origin_name: 'original name',
-                           creator: current_user,
-                           container: work_package,
-                           storage: storage)
+        create(:file_link,
+               origin_name: 'original name',
+               creator: current_user,
+               container: work_package,
+               storage: storage)
       end
       let(:already_existing_file_link_payload) do
-        build(:file_link_element, origin_name: 'new name',
-                                  origin_id: existing_file_link.origin_id,
-                                  storage_url: existing_file_link.storage.host)
+        build(:file_link_element,
+              origin_name: 'new name',
+              origin_id: existing_file_link.origin_id,
+              storage_url: existing_file_link.storage.host)
       end
       let(:some_file_link_payload) do
         build(:file_link_element, storage_url: existing_file_link.storage.host)
@@ -326,6 +336,12 @@ describe 'API v3 file links resource', type: :request do
 
     context 'if file link is in a work package, while its project is not mapped to the file link\'s storage.' do
       let(:path) { api_v3_paths.file_link(file_link_of_unlinked_storage.id) }
+
+      it_behaves_like 'not found'
+    end
+
+    context 'if file link is in a work package, while the storages module is deactivated in its project.' do
+      let(:project) { create(:project, disable_modules: :storages) }
 
       it_behaves_like 'not found'
     end

--- a/modules/storages/spec/requests/api/v3/work_packages/work_packages_linkable_filter_spec.rb
+++ b/modules/storages/spec/requests/api/v3/work_packages/work_packages_linkable_filter_spec.rb
@@ -106,6 +106,14 @@ describe 'API v3 work packages resource with filters for the linkable to storage
         end
       end
 
+      context 'if a project has the storages module deactivated' do
+        let(:project1) { create(:project, disable_modules: :storages, members: { current_user => role1 }) }
+
+        it_behaves_like 'API V3 collection response', 2, 2, 'WorkPackage', 'WorkPackageCollection' do
+          let(:elements) { [work_package3, work_package4] }
+        end
+      end
+
       context 'if the filter is set to an unknown storage id' do
         let(:storage_id) { "1337" }
 
@@ -137,6 +145,14 @@ describe 'API v3 work packages resource with filters for the linkable to storage
 
         it_behaves_like 'API V3 collection response', 2, 2, 'WorkPackage', 'WorkPackageCollection' do
           let(:elements) { [work_package1, work_package2] }
+        end
+      end
+
+      context 'if a project has the storages module deactivated' do
+        let(:project1) { create(:project, disable_modules: :storages, members: { current_user => role1 }) }
+
+        it_behaves_like 'API V3 collection response', 2, 2, 'WorkPackage', 'WorkPackageCollection' do
+          let(:elements) { [work_package3, work_package4] }
         end
       end
 

--- a/modules/storages/spec/requests/api/v3/work_packages/work_packages_linked_filter_spec.rb
+++ b/modules/storages/spec/requests/api/v3/work_packages/work_packages_linked_filter_spec.rb
@@ -113,6 +113,14 @@ describe 'API v3 work packages resource with filters for linked storage file',
         end
       end
 
+      context 'if a project has the storages module deactivated' do
+        let(:project1) { create(:project, disable_modules: :storages, members: { current_user => role1 }) }
+
+        it_behaves_like 'API V3 collection response', 1, 1, 'WorkPackage', 'WorkPackageCollection' do
+          let(:elements) { [work_package3] }
+        end
+      end
+
       context 'if the filter is set to an unknown file id from origin' do
         let(:origin_id_value) { "1337" }
 

--- a/modules/storages/spec/requests/api/v3/work_packages/work_packages_linked_filter_spec.rb
+++ b/modules/storages/spec/requests/api/v3/work_packages/work_packages_linked_filter_spec.rb
@@ -63,6 +63,9 @@ describe 'API v3 work packages resource with filters for linked storage file',
            storage: storage2,
            origin_id: file_link1.origin_id)
   end
+  # This link is considered invisible, as it is linking a work package to a file, where the work package's project
+  # and the file's storage are not linked together.
+  let(:file_link4) { create(:file_link, creator: current_user, container: work_package3, storage: storage1) }
 
   subject(:response) { last_response }
 
@@ -73,6 +76,7 @@ describe 'API v3 work packages resource with filters for linked storage file',
     file_link1
     file_link2
     file_link3
+    file_link4
 
     login_as current_user
   end
@@ -111,6 +115,14 @@ describe 'API v3 work packages resource with filters for linked storage file',
 
       context 'if the filter is set to an unknown file id from origin' do
         let(:origin_id_value) { "1337" }
+
+        it_behaves_like 'API V3 collection response', 0, 0, 'WorkPackage', 'WorkPackageCollection' do
+          let(:elements) { [] }
+        end
+      end
+
+      context 'if the filter is set to a file linked to a work package in an unlinked project' do
+        let(:origin_id_value) { file_link4.origin_id.to_s }
 
         it_behaves_like 'API V3 collection response', 0, 0, 'WorkPackage', 'WorkPackageCollection' do
           let(:elements) { [] }
@@ -167,6 +179,14 @@ describe 'API v3 work packages resource with filters for linked storage file',
 
       it_behaves_like 'API V3 collection response', 1, 1, 'WorkPackage', 'WorkPackageCollection' do
         let(:elements) { [work_package3] }
+      end
+
+      context 'if any of the matching work packages is in a project without a mapping to that storage' do
+        let(:storage_url_value) { CGI.escape(storage1.host) }
+
+        it_behaves_like 'API V3 collection response', 2, 2, 'WorkPackage', 'WorkPackageCollection' do
+          let(:elements) { [work_package1, work_package2] }
+        end
       end
 
       context 'if one project has not sufficient permissions' do

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -36,14 +36,14 @@ FactoryBot.define do
 
     sequence(:name) { |n| "My Project No. #{n}" }
     sequence(:identifier) { |n| "myproject_no_#{n}" }
-    created_at { Time.now }
-    updated_at { Time.now }
+    created_at { Time.zone.now }
+    updated_at { Time.zone.now }
     enabled_module_names { OpenProject::AccessControl.available_project_modules }
     public { false }
     templated { false }
 
     callback(:after_build) do |project, evaluator|
-      disabled_modules = Array(evaluator.disable_modules)
+      disabled_modules = Array(evaluator.disable_modules).map(&:to_s)
       project.enabled_module_names = project.enabled_module_names - disabled_modules
 
       if !evaluator.no_types && project.types.empty?


### PR DESCRIPTION
This PR is part of https://community.openproject.org/wp/41523

With [work package 41523](https://community.openproject.org/wp/41523) we explicitly allow states where `FileLink`s that belong to a work package should become "invisible". Which means that they shall get treated as if they didn't exists.

A file link is in this invisible state when either first or both of the following conditions are met:
- The "File storages" module is not activated for the work package's project
- The `FileLink`'s `storage` is not activated for the work package's project.

This PR ensures that 
- the file links endpoint does not return any "invisible" file links, no matter if requested as a collection or a single resource.
- filter on work package collections no longer return results when they are filtered with attributes of "invisible" `FileLink`s 

Both changes are covered with additional tests and test data.