### PR TITLE
[41536] Spacing in time and costs module incorrect

### DIFF
--- a/frontend/src/global_styles/layout/_main_menu.sass
+++ b/frontend/src/global_styles/layout/_main_menu.sass
@@ -317,6 +317,8 @@ a.main-menu--parent-node
 #main-menu ul ul.main-menu--children ul.pages-hierarchy
   .tree-menu--hierarchy-indicator
     color: var(--main-menu-font-color)
+  .tree-menu--hierarchy-span + a, a
+    padding-left: 0
   .tree-menu--item
     &.-selected
       background: var(--main-menu-bg-selected-background)


### PR DESCRIPTION
When there is a hierarchy arrow icon beside the title of the menu item, we don't need padding-left.

https://community.openproject.org/projects/openproject/work_packages/41536/activity