### PR TITLE
Allow setting the status on User create/update contracts

### DIFF
--- a/app/contracts/users/base_contract.rb
+++ b/app/contracts/users/base_contract.rb
@@ -42,6 +42,9 @@ module Users
     attribute :auth_source_id,
               writeable: ->(*) { user.allowed_to_globally?(:manage_user) }
 
+    attribute :status,
+              writeable: ->(*) { user.allowed_to_globally?(:manage_user) }
+
     attribute :identity_url,
               writeable: ->(*) { user.admin? }
 

--- a/app/models/ldap_auth_source.rb
+++ b/app/models/ldap_auth_source.rb
@@ -176,6 +176,7 @@ class LdapAuthSource < AuthSource
     Rails.logger.debug do
       "LDAP initializing search (BASE=#{base_dn}), (FILTER=#{filter})"
     end
+
     ldap_con.search(base: base_dn,
                     filter: filter,
                     attributes: search_attributes) do |entry|

--- a/spec/contracts/users/shared_contract_examples.rb
+++ b/spec/contracts/users/shared_contract_examples.rb
@@ -55,6 +55,15 @@ shared_examples_for 'user contract' do
       it_behaves_like 'contract is invalid', password: :error_readonly
     end
 
+    describe 'can set the status' do
+      before do
+        user.password = user.password_confirmation = nil
+        user.status = Principal.statuses[:invited]
+      end
+
+      it_behaves_like 'contract is valid'
+    end
+
     describe 'can set the auth_source' do
       let!(:auth_source) { create :auth_source }
 

--- a/spec/contracts/users/update_contract_spec.rb
+++ b/spec/contracts/users/update_contract_spec.rb
@@ -45,14 +45,36 @@ describe Users::UpdateContract do
       }
     end
 
-    describe "validations" do
-      describe "#user_allowed_to_update" do
-        context "updated user is current user" do
-          # That scenario is the only that is not covered by the shared examples
-          let(:current_user) { user }
+    context 'when global user' do
+      let(:current_user) { create :user, global_permission: :manage_user }
 
-          it_behaves_like 'contract is valid'
+      describe 'can lock the user' do
+        before do
+          # needed for the stub
+          user.password = user.password_confirmation = nil
+
+          user.status = Principal.statuses[:locked]
         end
+
+        it_behaves_like 'contract is valid'
+      end
+    end
+
+    context "when updated user is current user" do
+      # That scenario is the only that is not covered by the shared examples
+      let(:current_user) { user }
+
+      it_behaves_like 'contract is valid'
+
+      context 'when setting status' do
+        before do
+          # needed for the stub
+          user.password = user.password_confirmation = nil
+
+          user.status = Principal.statuses[:locked]
+        end
+
+        it_behaves_like 'contract is invalid', status: :error_readonly
       end
     end
   end

--- a/spec/requests/api/v3/user/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_form_resource_spec.rb
@@ -86,27 +86,24 @@ describe ::API::V3::Users::UpdateFormAPI, content_type: :json do
       end
     end
 
-    describe 'with a non-writable status' do
+    describe 'with a writable status' do
       let(:payload) do
         {
-          "status": 'locked'
+          status: 'locked'
         }
       end
 
-      it 'returns an invalid form', :aggregate_failures do
+      it 'returns a valid response', :aggregate_failures do
         expect(response.status).to eq(200)
         expect(response.body).to be_json_eql('Form'.to_json).at_path('_type')
 
         expect(subject.body)
-          .to have_json_size(1)
+          .to have_json_size(0)
                 .at_path('_embedded/validationErrors')
 
-        expect(subject.body)
-          .to have_json_path('_embedded/validationErrors/status')
-
         expect(body)
-          .to be_json_eql('urn:openproject-org:api:v3:errors:PropertyIsReadOnly'.to_json)
-                .at_path('_embedded/validationErrors/status/errorIdentifier')
+          .to be_json_eql('locked'.to_json)
+                .at_path('_embedded/payload/status')
 
         # Does not change the user's status
         user.reload
@@ -117,7 +114,7 @@ describe ::API::V3::Users::UpdateFormAPI, content_type: :json do
     describe 'with an empty firstname' do
       let(:payload) do
         {
-          "firstName": nil
+          firstName: nil
         }
       end
 
@@ -167,5 +164,4 @@ describe ::API::V3::Users::UpdateFormAPI, content_type: :json do
 
     it_behaves_like 'unauthorized access'
   end
-
 end

--- a/spec/services/users/update_service_spec.rb
+++ b/spec/services/users/update_service_spec.rb
@@ -73,6 +73,25 @@ describe Users::UpdateService do
       end
     end
 
+    context 'when valid status' do
+      let(:attributes) { { status: Principal.statuses[:locked] } }
+
+      it 'updates the user' do
+        expect(subject).to be_success
+
+        update_user.reload
+        expect(update_user).to be_locked
+      end
+
+      context 'if current_user is no admin' do
+        let(:current_user) { build_stubbed(:user) }
+
+        it 'is unsuccessful' do
+          expect(subject).not_to be_success
+        end
+      end
+    end
+
     describe 'updating prefs' do
       let(:attributes) { {} }
 


### PR DESCRIPTION
The user contract did not allow setting a status, even if the calling user is admin / has manage_user permissions