### PR TITLE
Chore/add file tab migration section

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -291,9 +291,6 @@ ij_javascript_while_on_new_line = false
 ij_javascript_wrap_comments = false
 
 [{*.sht,*.html,*.shtm,*.shtml,*.htm,*.ng}]
-indent_size = 2
-tab_width = 2
-ij_continuation_indent_size = 2
 ij_html_add_new_line_before_tags = body,div,p,form,h1,h2,h3
 ij_html_align_attributes = true
 ij_html_align_text = false

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1073,6 +1073,7 @@ en:
         relations: Relations
         watchers: Watchers
         files: Files
+        files_tab_migration_help: 'You can now attach files to work packages via the new tab:'
       time_relative:
         days: "days"
         weeks: "weeks"

--- a/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.ts
@@ -35,6 +35,7 @@ import {
   Input,
   OnInit,
 } from '@angular/core';
+import { StateService } from '@uirouter/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { distinctUntilChanged, map } from 'rxjs/operators';
@@ -114,6 +115,10 @@ export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implemen
     attachments: {
       label: this.I18n.t('js.label_attachments'),
     },
+    files: {
+      label: this.I18n.t('js.work_packages.tabs.files'),
+      migration_help: this.I18n.t('js.work_packages.tabs.files_tab_migration_help'),
+    },
     project: {
       required: this.I18n.t('js.project.required_outside_context'),
       context: this.I18n.t('js.project.context'),
@@ -131,6 +136,8 @@ export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implemen
 
   public isNewResource:boolean;
 
+  public uiSelfRef:string;
+
   protected firstTimeFocused = false;
 
   $element:JQuery;
@@ -138,6 +145,7 @@ export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implemen
   constructor(readonly I18n:I18nService,
     protected currentProject:CurrentProjectService,
     protected PathHelper:PathHelperService,
+    protected $state:StateService,
     protected states:States,
     protected halEditing:HalResourceEditingService,
     protected halResourceService:HalResourceService,
@@ -151,10 +159,12 @@ export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implemen
     super();
   }
 
-  public ngOnInit() {
+  public ngOnInit():void {
     this.$element = jQuery(this.elementRef.nativeElement as HTMLElement);
 
     this.isNewResource = isNewResource(this.workPackage);
+
+    this.uiSelfRef = this.$state.$current.name;
 
     const change = this.halEditing.changeFor<WorkPackageResource, WorkPackageChangeset>(this.workPackage);
     this.resourceContextChange.next(this.contextFrom(change.projectedResource));
@@ -368,7 +378,7 @@ export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implemen
   private contextFrom(workPackage:WorkPackageResource):ResourceContextChange {
     const schema = this.schema(workPackage);
 
-    let schemaHref:string|null = null;
+    let schemaHref:string|null;
     const projectHref:string|null = workPackage.project && workPackage.project.href;
 
     if (schema.baseSchema) {

--- a/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.html
@@ -5,8 +5,8 @@
   <div class="wp-new--subject-wrapper"
        *ngIf="isNewResource">
     <editable-attribute-field [resource]="workPackage"
-                   [wrapperClasses]="'-no-label'"
-                   [fieldName]="'subject'"></editable-attribute-field>
+                              [wrapperClasses]="'-no-label'"
+                              [fieldName]="'subject'"></editable-attribute-field>
   </div>
 
   <div class="wp-info-wrapper">
@@ -25,11 +25,13 @@
       because otherwise the browser would add a second space after it -->
       <span>&nbsp;</span>
       <op-user-link class="user-link"
-                 [user]="workPackage.author"></op-user-link>.
+                    [user]="workPackage.author"></op-user-link>
+      .
       <span [textContent]="text.infoRow.lastUpdatedOn"></span>
       <span>&nbsp;</span>
-      <op-date-time [dateTimeValue]="workPackage.updatedAt"></op-date-time>.
-     </div>
+      <op-date-time [dateTimeValue]="workPackage.updatedAt"></op-date-time>
+      .
+    </div>
 
     <wp-custom-actions [workPackage]="workPackage" class="custom-actions"></wp-custom-actions>
   </div>
@@ -53,7 +55,7 @@
         </div>
         <div class="attributes-key-value--value-container">
           <editable-attribute-field [resource]="workPackage"
-                         [fieldName]="descriptor.name"></editable-attribute-field>
+                                    [fieldName]="descriptor.name"></editable-attribute-field>
         </div>
       </div>
     </div>
@@ -84,9 +86,9 @@
   <div class="attributes-group description-group">
     <div class="single-attribute work-packages--details--description">
       <editable-attribute-field [fieldName]="'description'"
-                     [resource]="workPackage"
-                     [isDropTarget]="true"
-                     [wrapperClasses]="'-no-label'">
+                                [resource]="workPackage"
+                                [isDropTarget]="true"
+                                [wrapperClasses]="'-no-label'">
       </editable-attribute-field>
     </div>
   </div>
@@ -102,7 +104,7 @@
       <ndc-dynamic [ndcDynamicComponent]="attributeGroupComponent(group)"
                    [ndcDynamicInputs]="{ workPackage: workPackage,
                                          group: group,
-                                         query: group.query }" >
+                                         query: group.query }">
       </ndc-dynamic>
     </ng-container>
 
@@ -138,5 +140,25 @@
                  [ndcDynamicInputs]="{ resource: workPackage }"
                  *ngIf="workPackage.canAddAttachments">
     </ndc-dynamic>
+  </div>
+</div>
+
+<div class="work-packages--files attributes-group" *ngIf="!isNewResource">
+  <div class="work-packages--files-container">
+    <div class="attributes-group--header">
+      <div class="attributes-group--header-container">
+        <h3 class="attributes-group--header-text" [textContent]="text.files.label"></h3>
+      </div>
+    </div>
+
+    <div class="attributes-group--icon-indented-text">
+      <op-icon icon-classes="icon-info1"></op-icon>
+      <span [textContent]="text.files.migration_help"></span>
+      <a
+        [textContent]="text.files.label"
+        [uiSref]="uiSelfRef"
+        [uiParams]="{ workPackageId: workPackage.id, tabIdentifier: 'files' }"
+      ></a>
+    </div>
   </div>
 </div>

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
@@ -29,7 +29,7 @@
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { StateService } from '@uirouter/core';
 import { Component, Injector, OnInit } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 import { WorkPackageViewSelectionService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
 import { WorkPackageSingleViewBase } from 'core-app/features/work-packages/routing/wp-view-base/work-package-single-view.base';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -3,78 +3,78 @@
      *ngIf="workPackage"
      class="work-packages--show-view">
 
-    <wp-breadcrumb [workPackage]="workPackage"></wp-breadcrumb>
+  <wp-breadcrumb [workPackage]="workPackage"></wp-breadcrumb>
 
-    <div class="toolbar-container">
-      <div id="toolbar">
-        <div class="wp-show--header-container">
+  <div class="toolbar-container">
+    <div id="toolbar">
+      <div class="wp-show--header-container">
 
-          <op-back-button
-            linkClass="work-packages-back-button op-back-button_mobile-full-width"
-          >
-          </op-back-button>
+        <op-back-button
+          linkClass="work-packages-back-button op-back-button_mobile-full-width"
+        >
+        </op-back-button>
 
-          <div class="subject-header">
-            <wp-subject></wp-subject>
-          </div>
+        <div class="subject-header">
+          <wp-subject></wp-subject>
         </div>
-        <ul id="toolbar-items" class="toolbar-items hide-when-print">
-          <li class="toolbar-item hidden-for-mobile">
-            <wp-create-button
-              [allowed]="['work_package.addChild', 'work_package.copy']"
-              [stateName$]="stateName$">
-            </wp-create-button>
-          </li>
-          <li class="toolbar-item" *ngIf="displayWatchButton">
-            <wp-watcher-button [workPackage]="workPackage"
-                               [showText]="false">
-            </wp-watcher-button>
-          </li>
-          <li class="toolbar-item hidden-for-mobile">
-            <zen-mode-toggle-button>
-            </zen-mode-toggle-button>
-          </li>
-          <li class="toolbar-item action_menu_main" id="action-show-more-dropdown-menu">
-            <button class="button dropdown-relative toolbar-icon"
-                    [attr.title]="text.full_view.button_more"
-                    wpSingleContextMenu
-                    [wpSingleContextMenu-workPackage]="workPackage">
-              <op-icon icon-classes="button--icon icon-show-more"></op-icon>
-            </button>
-          </li>
-        </ul>
+      </div>
+      <ul id="toolbar-items" class="toolbar-items hide-when-print">
+        <li class="toolbar-item hidden-for-mobile">
+          <wp-create-button
+            [allowed]="['work_package.addChild', 'work_package.copy']"
+            [stateName$]="stateName$">
+          </wp-create-button>
+        </li>
+        <li class="toolbar-item" *ngIf="displayWatchButton">
+          <wp-watcher-button [workPackage]="workPackage"
+                             [showText]="false">
+          </wp-watcher-button>
+        </li>
+        <li class="toolbar-item hidden-for-mobile">
+          <zen-mode-toggle-button>
+          </zen-mode-toggle-button>
+        </li>
+        <li class="toolbar-item action_menu_main" id="action-show-more-dropdown-menu">
+          <button class="button dropdown-relative toolbar-icon"
+                  [attr.title]="text.full_view.button_more"
+                  wpSingleContextMenu
+                  [wpSingleContextMenu-workPackage]="workPackage">
+            <op-icon icon-classes="button--icon icon-show-more"></op-icon>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="work-packages-full-view--split-container">
+    <div class="work-packages-full-view--split-left">
+      <div class="work-packages--panel-inner">
+        <wp-single-view [workPackage]="workPackage"></wp-single-view>
       </div>
     </div>
-
-    <div class="work-packages-full-view--split-container">
-      <div class="work-packages-full-view--split-left">
-        <div class="work-packages--panel-inner">
-          <wp-single-view [workPackage]="workPackage"></wp-single-view>
+    <div class="work-packages-full-view--split-right work-packages-tab-view--overflow">
+      <div class="work-packages--panel-inner">
+        <span class="hidden-for-sighted" tabindex="-1" opAutofocus [textContent]="focusAnchorLabel"></span>
+        <op-wp-tabs [workPackage]="workPackage" [view]="'full'"></op-wp-tabs>
+        <div class="work-packages-full-view--tab-breadcrumb">
+          <op-work-package-mark-notification-button
+            *ngIf="(displayNotificationsButton$ | async) && keepTab.currentTabIdentifier === 'activity'"
+            class="work-package--details-button"
+            [workPackage]="workPackage"
+            buttonClasses="-round button_no-margin"
+            data-qa-selector="mark-notification-read-button"
+          ></op-work-package-mark-notification-button>
+        </div>
+        <div class="tabcontent"
+             data-notification-selector='notification-scroll-container'
+             ui-view>
         </div>
       </div>
-      <div class="work-packages-full-view--split-right work-packages-tab-view--overflow">
-        <div class="work-packages--panel-inner">
-          <span class="hidden-for-sighted" tabindex="-1" opAutofocus [textContent]="focusAnchorLabel"></span>
-          <op-wp-tabs [workPackage]="workPackage" view="full"></op-wp-tabs>
-          <div class="work-packages-full-view--tab-breadcrumb">
-            <op-work-package-mark-notification-button
-                    *ngIf="(displayNotificationsButton$ | async) && keepTab.currentTabIdentifier === 'activity'"
-                    class="work-package--details-button"
-                    [workPackage]="workPackage"
-                    buttonClasses="-round button_no-margin"
-                    data-qa-selector="mark-notification-read-button"
-            ></op-work-package-mark-notification-button>
-          </div>
-          <div class="tabcontent"
-               data-notification-selector='notification-scroll-container'
-               ui-view>
-          </div>
-        </div>
 
-        <div class="work-packages-full-view--resizer hidden-for-mobile hide-when-print">
-          <wp-resizer [elementClass]="'work-packages-full-view--split-right'"
-                      [localStorageKey]="'openProject-fullViewFlexBasis'"></wp-resizer>
-        </div>
+      <div class="work-packages-full-view--resizer hidden-for-mobile hide-when-print">
+        <wp-resizer [elementClass]="'work-packages-full-view--split-right'"
+                    [localStorageKey]="'openProject-fullViewFlexBasis'"></wp-resizer>
       </div>
     </div>
+  </div>
 </div>

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.html
@@ -3,8 +3,8 @@
   data-indicator-name="wpDetails"
   *ngIf="workPackage"
 >
-    <op-wp-tabs [workPackage]="workPackage" view="split"></op-wp-tabs>
-    <div class="work-packages--details-content work-packages-tab-view--overflow" *ngIf="workPackage">
+  <op-wp-tabs [workPackage]="workPackage" [view]="'split'"></op-wp-tabs>
+  <div class="work-packages--details-content work-packages-tab-view--overflow" *ngIf="workPackage">
       <span
         class="hidden-for-sighted"
         tabindex="-1"
@@ -12,51 +12,51 @@
         [textContent]="focusAnchorLabel"
       ></span>
 
-      <edit-form
-        [resource]="workPackage"
-        class="work-packages--details-form"
-      >
-        <div class="work-packages--details-header">
-          <div class="work-packages--details-header-left">
-            <wp-breadcrumb
-              [workPackage]="workPackage"
-              class="work-packages--breadcrumb"
-            ></wp-breadcrumb>
-
-            <div class="wp-show--header-container">
-              <op-back-button
-                *ngIf="showBackButton()"
-                linkClass="work-packages-back-button"
-                [customBackMethod]="backToList.bind(this)"
-              ></op-back-button>
-
-              <wp-subject class="subject-header"></wp-subject>
-            </div>
-          </div>
-
-          <op-work-package-mark-notification-button
-            *ngIf="(displayNotificationsButton$ | async) && keepTab.currentTabIdentifier === 'activity'"
-            class="work-packages--details-button"
+    <edit-form
+      [resource]="workPackage"
+      class="work-packages--details-form"
+    >
+      <div class="work-packages--details-header">
+        <div class="work-packages--details-header-left">
+          <wp-breadcrumb
             [workPackage]="workPackage"
-            buttonClasses="-round"
-            data-qa-selector="mark-notification-read-button"
-          ></op-work-package-mark-notification-button>
+            class="work-packages--breadcrumb"
+          ></wp-breadcrumb>
+
+          <div class="wp-show--header-container">
+            <op-back-button
+              *ngIf="showBackButton()"
+              linkClass="work-packages-back-button"
+              [customBackMethod]="backToList.bind(this)"
+            ></op-back-button>
+
+            <wp-subject class="subject-header"></wp-subject>
+          </div>
         </div>
 
-        <div
-          class="work-package-details-tab"
-          data-notification-selector='notification-scroll-container'
-          ui-view
-        ></div>
-      </edit-form>
-    </div>
+        <op-work-package-mark-notification-button
+          *ngIf="(displayNotificationsButton$ | async) && keepTab.currentTabIdentifier === 'activity'"
+          class="work-packages--details-button"
+          [workPackage]="workPackage"
+          buttonClasses="-round"
+          data-qa-selector="mark-notification-read-button"
+        ></op-work-package-mark-notification-button>
+      </div>
 
-    <div class="work-packages--details-toolbar-container" *ngIf="workPackage">
-      <wp-details-toolbar [workPackage]="workPackage"></wp-details-toolbar>
-    </div>
+      <div
+        class="work-package-details-tab"
+        data-notification-selector='notification-scroll-container'
+        ui-view
+      ></div>
+    </edit-form>
+  </div>
 
-    <div class="work-packages--details--resizer hidden-for-mobile hide-when-print">
-      <wp-resizer [elementClass]="'work-packages-partitioned-page--content-right'"
-                  [localStorageKey]="'openProject-splitViewFlexBasis'"></wp-resizer>
-    </div>
+  <div class="work-packages--details-toolbar-container" *ngIf="workPackage">
+    <wp-details-toolbar [workPackage]="workPackage"></wp-details-toolbar>
+  </div>
+
+  <div class="work-packages--details--resizer hidden-for-mobile hide-when-print">
+    <wp-resizer [elementClass]="'work-packages-partitioned-page--content-right'"
+                [localStorageKey]="'openProject-splitViewFlexBasis'"></wp-resizer>
+  </div>
 </div>

--- a/frontend/src/global_styles/content/_attributes_group.sass
+++ b/frontend/src/global_styles/content/_attributes_group.sass
@@ -33,7 +33,7 @@
 
 .attributes-group--header
   @include grid-block
-  margin:  0 0 0.5rem 0
+  margin: 0 0 0.5rem 0
   border-bottom: 1px solid #ddd
   align-items: flex-end
 
@@ -60,6 +60,13 @@
 
   .button
     margin: 0 0 8px 0
+
+.attributes-group--icon-indented-text
+  display: grid
+  margin-top: 1rem
+  grid-template-columns: auto auto 1fr
+  column-gap: 8px
+
 
 // HACK. TODO: Remove H3 element rules in various places.
 .attributes-group--header-text,

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -118,7 +118,7 @@ describe 'form configuration', type: :feature, js: true do
         wp_page.expect_hidden_field(:done_ratio)
 
         groups = page.all('.attributes-group--header-text').map(&:text)
-        expect(groups).to eq []
+        expect(groups).to eq ['FILES']
         expect(page)
           .to have_selector('.work-packages--details--description', text: work_package.description)
       end

--- a/spec/features/work_packages/tabs/activity_tab_spec.rb
+++ b/spec/features/work_packages/tabs/activity_tab_spec.rb
@@ -1,3 +1,31 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 require 'spec_helper'
 
 require 'features/work_packages/work_packages_page'
@@ -34,7 +62,7 @@ describe 'Activity tab', js: true, selenium: true do
     work_package.journals[0]
   end
 
-  let!(:note_1) do
+  let!(:note1) do
     attributes = { subject: 'New subject', description: 'Some not so long description.' }
 
     alter_work_package_at(work_package,
@@ -45,12 +73,12 @@ describe 'Activity tab', js: true, selenium: true do
     work_package.journals.last
   end
 
-  let!(:note_2) do
+  let!(:note2) do
     attributes = { journal_notes: 'Another comment by a different user' }
 
     alter_work_package_at(work_package,
                           attributes: attributes,
-                          at: 1.days.ago.to_date.to_s(:db),
+                          at: 1.day.ago.to_date.to_s(:db),
                           user: create(:admin))
 
     work_package.journals.last
@@ -65,7 +93,7 @@ describe 'Activity tab', js: true, selenium: true do
 
   shared_examples 'shows activities in order' do
     let(:journals) do
-      journals = [initial_note, note_1, note_2]
+      journals = [initial_note, note1, note2]
 
       journals
     end
@@ -87,12 +115,12 @@ describe 'Activity tab', js: true, selenium: true do
 
         activity = page.find("#activity-#{idx + 1}")
 
-        if journal.id != note_1.id
+        if journal.id != note1.id
           expect(activity).to have_selector('.op-user-activity--user-line', text: journal.user.name)
           expect(activity).to have_selector('.user-comment > .message', text: journal.notes, visible: :all)
         end
 
-        if activity == note_1
+        if activity == note1
           expect(activity).to have_selector('.work-package-details-activities-messages .message',
                                             count: 2)
           expect(activity).to have_selector('.message',
@@ -113,8 +141,7 @@ describe 'Activity tab', js: true, selenium: true do
 
     context 'with permission' do
       let(:role) do
-        create(:role, permissions: %i[view_work_packages
-                                                 add_work_package_notes])
+        create(:role, permissions: %i[view_work_packages add_work_package_notes])
       end
       let(:user) do
         create(:user,
@@ -124,27 +151,29 @@ describe 'Activity tab', js: true, selenium: true do
 
       context 'with ascending comments' do
         let(:comments_in_reverse) { false }
+
         it_behaves_like 'shows activities in order'
       end
 
       context 'with reversed comments' do
         let(:comments_in_reverse) { true }
+
         it_behaves_like 'shows activities in order'
       end
 
       it 'can deep link to an activity' do
-        visit "/work_packages/#{work_package.id}/activity#activity-#{note_2.id}"
+        visit "/work_packages/#{work_package.id}/activity#activity-#{note2.id}"
 
         work_package_page.ensure_page_loaded
         expect(page).to have_selector('.user-comment > .message',
                                       text: initial_comment)
 
-        expect(page.current_url).to match /\/work_packages\/#{work_package.id}\/activity#activity-#{note_2.id}/
+        expect(page.current_url).to match /\/work_packages\/#{work_package.id}\/activity#activity-#{note2.id}/
       end
 
       it 'can toggle between activities and comments-only' do
         expect(page).to have_selector('.work-package-details-activities-activity-contents', count: 3)
-        expect(page).to have_selector('.user-comment > .message', text: note_2.notes)
+        expect(page).to have_selector('.user-comment > .message', text: note2.notes)
 
         # Show only comments
         find('.activity-comments--toggler').click
@@ -152,7 +181,7 @@ describe 'Activity tab', js: true, selenium: true do
         # It should remove the middle
         expect(page).to have_selector('.work-package-details-activities-activity-contents', count: 2)
         expect(page).to have_selector('.user-comment > .message', text: initial_comment)
-        expect(page).to have_selector('.user-comment > .message', text: note_2.notes)
+        expect(page).to have_selector('.user-comment > .message', text: note2.notes)
 
         # Show all again
         find('.activity-comments--toggler').click
@@ -190,18 +219,20 @@ describe 'Activity tab', js: true, selenium: true do
       end
 
       it 'shows the activities, but does not allow commenting' do
-        expect(page).not_to have_selector('.work-packages--activity--add-comment', visible: true)
+        expect(page).not_to have_selector('.work-packages--activity--add-comment', visible: :visible)
       end
     end
   end
 
-  context 'split screen' do
+  context 'if on split screen' do
     let(:work_package_page) { Pages::SplitWorkPackage.new(work_package, project) }
+
     it_behaves_like 'activity tab'
   end
 
-  context 'full screen' do
+  context 'if on full screen' do
     let(:work_package_page) { Pages::FullWorkPackage.new(work_package) }
+
     it_behaves_like 'activity tab'
   end
 end

--- a/spec/features/work_packages/tabs/files_tab_spec.rb
+++ b/spec/features/work_packages/tabs/files_tab_spec.rb
@@ -1,0 +1,75 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe 'Files tab', js: true do
+  let(:role) { create(:role, permissions: %i[view_work_packages edit_work_packages]) }
+  let(:user) { create(:user, member_in_project: project, member_through_role: role) }
+  let(:project) { create :project }
+  let(:work_package) { create(:work_package, project: project) }
+  let(:wp_page) { ::Pages::FullWorkPackage.new(work_package, project) }
+
+  before do
+    login_as(user)
+  end
+
+  describe 'navigation to new files tab from work package view' do
+    before do
+      wp_page.visit!
+    end
+
+    context 'if on work packages full view' do
+      it 'must open files tab' do
+        wp_page.switch_to_tab tab: 'activity'
+        expect(page).not_to have_selector '.work-package--attachments--drop-box'
+
+        files_link = wp_page.find('.work-packages--files-container .attributes-group--icon-indented-text a')
+        files_link.click
+
+        expect(page).to have_current_path project_work_package_path(project, work_package, 'files')
+        expect(page).to have_selector '.work-package--attachments--drop-box'
+      end
+    end
+
+    context 'if on work packages split view' do
+      let(:wp_page) { ::Pages::SplitWorkPackage.new(work_package, project) }
+
+      it 'must open files tab' do
+        wp_page.switch_to_tab tab: 'overview'
+        expect(page).not_to have_selector '.work-package--attachments--drop-box'
+
+        files_link = wp_page.find('.work-packages--files-container .attributes-group--icon-indented-text a')
+        files_link.click
+
+        expect(page).to have_current_path project_work_packages_path(project) + "/details/#{work_package.id}/files"
+        expect(page).to have_selector '.work-package--attachments--drop-box'
+      end
+    end
+  end
+end


### PR DESCRIPTION
- added new attribute group to work package single view
  - is displayed, if NOT the files section of the "new resource" is displayed
  - contains informational text and a hyper link to the files tab
- added test cases for wp split and full view