### PR TITLE
iCalendar file misses "METHOD:PUBLISH" - Update meeting_mailer.rb

### DIFF
--- a/modules/meeting/app/mailers/meeting_mailer.rb
+++ b/modules/meeting/app/mailers/meeting_mailer.rb
@@ -77,7 +77,10 @@ class MeetingMailer < UserMailer
         e.uid         = "#{@meeting.id}@#{@meeting.project.identifier}"
         e.organizer   = author
       end
-
+      
+      # add needed 'METHOD:PUBLISH' to ics file
+      entry.publish
+      
       attachments['meeting.ics'] = entry.to_ical
       mail(to: user.mail, subject: subject)
     end


### PR DESCRIPTION
When using the METHOD in in multipart mime content-type mail here we need to set the method in the ics file, too. See rfc2445, chapter "4.7.2 Method".
We noticed this problem without this METHOD:PUBLISH ics part in the Horde Groupware.