### PR TITLE
join status explicitly triggered by status filter

### DIFF
--- a/app/models/queries/work_packages/filter/status_filter.rb
+++ b/app/models/queries/work_packages/filter/status_filter.rb
@@ -65,6 +65,10 @@ class Queries::WorkPackages::Filter::StatusFilter < Queries::WorkPackages::Filte
     true
   end
 
+  def joins
+    :status
+  end
+
   private
 
   def all_statuses

--- a/app/models/query/results.rb
+++ b/app/models/query/results.rb
@@ -41,9 +41,9 @@ class ::Query::Results
   def work_package_count
     work_package_scope
       .joins(all_filter_joins)
-      .includes(:status, :project)
+      .includes(:project)
       .where(query.statement)
-      .references(:statuses, :projects)
+      .references(:projects)
       .count
   rescue ::ActiveRecord::StatementInvalid => e
     raise ::Query::StatementInvalid.new(e.message)
@@ -79,7 +79,7 @@ class ::Query::Results
   end
 
   def all_includes
-    (%i(status project) +
+    (%i(project) +
       includes_for_columns(include_columns)).uniq
   end
 


### PR DESCRIPTION
The status filter as of now had always been depending on the eager loading provided by the `query/results`. It now joins the `status` on its own. Because it is an explicit join (as opposed to an `includes`) the join is also applied on [`to_sql`](https://github.com/opf/openproject/blob/dev/lib/api/decorators/sql_collection_representer.rb#L37)

https://community.openproject.org/wp/41653