### PR TITLE
Use correct translation key for view_calendar

### DIFF
--- a/modules/calendar/config/locales/en.yml
+++ b/modules/calendar/config/locales/en.yml
@@ -1,6 +1,6 @@
 # English strings go here
 en:
   label_calendar_plural: "Calendars"
-  permission_view_calendars: "View calendars"
+  permission_view_calendar: "View calendars"
   permission_manage_calendars: "Manage calendars"
   project_module_calendar_view: "Calendar"


### PR DESCRIPTION
The permission is called `view_calendar` (singular) , probably from the time before the module got expanded to get multiple views. Changing that would require a migration, so this PR only fixes the translation key instead.