### PR TITLE
[41719] Fix 2FA using form_authenticity_token without ruby 3 kwargs

### DIFF
--- a/app/cells/rails_cell.rb
+++ b/app/cells/rails_cell.rb
@@ -65,8 +65,8 @@ class RailsCell < Cell::ViewModel
     context[:action_view] || controller.view_context
   end
 
-  def form_authenticity_token(*args)
-    controller.send(:form_authenticity_token, *args)
+  def form_authenticity_token(**args)
+    controller.send(:form_authenticity_token, **args)
   end
 
   def protect_against_forgery?

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -56,8 +56,8 @@ OpenProject::Application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 
-  # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  # Enable request forgery protection in test environment.
+  config.action_controller.allow_forgery_protection = true
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/modules/two_factor_authentication/spec/features/my_two_factor_devices_spec.rb
+++ b/modules/two_factor_authentication/spec/features/my_two_factor_devices_spec.rb
@@ -135,4 +135,14 @@ describe 'My Account 2FA configuration', with_2fa_ee: true,
     expect(page).to have_selector('.on-off-status.-disabled')
     expect(user.otp_devices.count).to eq 0
   end
+
+  context 'when a device has been registered already' do
+    let!(:device) { create :two_factor_authentication_device_totp, user: user }
+
+    it 'loads the page correctly (Regression #41719)' do
+      visit my_2fa_devices_path
+
+      expect(page).to have_content device.identifier
+    end
+  end
 end

--- a/spec/features/admin/test_mail_notification_spec.rb
+++ b/spec/features/admin/test_mail_notification_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe 'Test mail notification', type: :feature do
+describe 'Test mail notification', type: :feature, js: true do
   shared_let(:admin) { create :admin }
 
   before do

--- a/spec/features/categories/delete_spec.rb
+++ b/spec/features/categories/delete_spec.rb
@@ -29,7 +29,7 @@
 require 'spec_helper'
 require 'features/categories/categories_page'
 
-describe 'Deletion', type: :feature do
+describe 'Deletion', type: :feature, js: true do
   let(:current_user) do
     create :user,
            member_in_project: category.project,
@@ -46,9 +46,9 @@ describe 'Deletion', type: :feature do
     before do
       categories_page.visit_settings
 
-      expect(page).to have_selector(delete_button)
-
       find(delete_button).click
+
+      page.driver.browser.switch_to.alert.accept
     end
   end
 

--- a/spec/features/groups/groups_spec.rb
+++ b/spec/features/groups/groups_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-feature 'group memberships through groups page', type: :feature do
+describe 'group memberships through groups page', type: :feature, js: true do
   shared_let(:admin) { create :admin }
   let!(:group) { create :group, lastname: "Bob's Team" }
 

--- a/spec/features/groups/membership_spec.rb
+++ b/spec/features/groups/membership_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-feature 'group memberships through project members page', type: :feature do
+describe 'group memberships through project members page', type: :feature, js: true do
   shared_let(:admin) { create :admin }
   let(:project) { create :project, name: 'Project 1', identifier: 'project1', members: project_member }
 
@@ -51,7 +51,7 @@ feature 'group memberships through project members page', type: :feature do
     let!(:group) { create :group, lastname: 'group1', members: alice }
     current_user { bob }
 
-    scenario 'adding group1 as a member with the beta role', js: true do
+    it 'adding group1 as a member with the beta role' do
       members_page.visit!
       members_page.add_user! 'group1', as: 'beta'
 
@@ -63,7 +63,7 @@ feature 'group memberships through project members page', type: :feature do
       let(:project_member) { { group => beta } }
 
       context 'with the members having no roles of their own' do
-        scenario 'removing the group removes its members too' do
+        it 'removing the group removes its members too' do
           members_page.visit!
           expect(members_page).to have_user('Alice Wonderland')
 
@@ -82,7 +82,7 @@ feature 'group memberships through project members page', type: :feature do
             .each   { |m| m.roles << alpha }
         end
 
-        scenario 'removing the group leaves the user without their group roles' do
+        it 'removing the group leaves the user without their group roles' do
           members_page.visit!
           expect(members_page).to have_user('Alice Wonderland', roles: ['alpha', 'beta'])
 
@@ -106,7 +106,7 @@ feature 'group memberships through project members page', type: :feature do
       alice # create alice
     end
 
-    scenario 'adding members to that group adds them to the project too', js: true do
+    it 'adding members to that group adds them to the project too' do
       members_page.visit!
 
       expect(members_page).not_to have_user('Alice Wonderland') # Alice not in the project yet

--- a/spec/features/types/crud_spec.rb
+++ b/spec/features/types/crud_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-feature 'Types', type: :feature do
+describe 'Types', type: :feature, js: true do
   shared_let(:admin) { create :admin }
 
   let!(:existing_role) { create(:role) }

--- a/spec/features/users/index_spec.rb
+++ b/spec/features/users/index_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe 'index users', type: :feature do
+describe 'index users', type: :feature, js: true do
   shared_let(:current_user) { create :admin, firstname: 'admin', lastname: 'admin', created_at: 1.hour.ago }
   let(:index_page) { Pages::Admin::Users::Index.new }
 

--- a/spec/support/pages/admin/users/index.rb
+++ b/spec/support/pages/admin/users/index.rb
@@ -37,12 +37,12 @@ module Pages
         end
 
         def expect_listed(*users)
-          rows = page.all 'td.username'
+          rows = page.all 'td.username a'
           expect(rows.map(&:text)).to include(*users.map(&:login))
         end
 
         def expect_order(*users)
-          rows = page.all 'td.username'
+          rows = page.all 'td.username a'
           expect(rows.map(&:text)).to eq(users.map(&:login))
         end
 

--- a/spec/support/pages/members.rb
+++ b/spec/support/pages/members.rb
@@ -69,13 +69,14 @@ module Pages
     # @param user_name [String] The full name of the user.
     # @param as [String] The role as which the user should be added.
     def add_user!(user_name, as:)
-      click_on 'Add member'
-      SeleniumHubWaiter.wait
+      retry_block do
+        click_on 'Add member'
 
-      select_principal! user_name if user_name
-      select_role! as if as
+        select_principal! user_name if user_name
+        select_role! as if as
 
-      click_on 'Add'
+        click_on 'Add'
+      end
     end
 
     def remove_user!(user_name)


### PR DESCRIPTION
The form_authenticity_token did not work with ruby 3 style kwargs.

To ensure we catch these errors, I enabled form authenticity in test mode, to more closely match the other environments. This in turn meant some tests needed to be migrated from Rack::Test

[OP#41719](https://community.openproject.com/wp/41719)