### PR TITLE
[41680] Include projects number is wrong moving from projects page to gantt view

### DIFF
--- a/frontend/src/app/shared/components/project-include/project-include.component.ts
+++ b/frontend/src/app/shared/components/project-include/project-include.component.ts
@@ -114,11 +114,11 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin {
         if (selectedProjectHrefs.includes(currentProjectHref)) {
           return selectedProjectHrefs;
         }
-
-        return [
-          ...selectedProjectHrefs,
-          currentProjectHref,
-        ];
+        const selectedPrjects = [...selectedProjectHrefs];
+        if (currentProjectHref) {
+          selectedPrjects.push(currentProjectHref);
+        }
+        return selectedPrjects;
       }),
     );
 


### PR DESCRIPTION
Current project path is null when we didn't select any project in projects page. Check if the current project is not null, then add it to the list of projects.

https://community.openproject.org/projects/openproject/work_packages/41680/activity