### PR TITLE
Fix boolean values typed as string in open api

### DIFF
--- a/docs/api/apiv3/paths/examples.yml
+++ b/docs/api/apiv3/paths/examples.yml
@@ -13,13 +13,13 @@ get:
     schema:
       type: string
   - description: ''
-    example: 'true'
+    example: true
     in: query
     name: showSums
     required: false
     schema:
-      default: 'false'
-      type: string
+      default: false
+      type: boolean
   responses:
     '200':
       description: OK

--- a/docs/api/apiv3/paths/project_queries_default.yml
+++ b/docs/api/apiv3/paths/project_queries_default.yml
@@ -58,28 +58,28 @@ get:
   - description: Indicates whether properties should be summed up if they support
       it. The showSums parameter is applied to the to the query's result collection
       of work packages overriding the query's persisted sums property.
-    example: 'true'
+    example: true
     in: query
     name: showSums
     required: false
     schema:
-      default: 'false'
+      default: false
       type: boolean
   - description: Indicates whether the timeline should be shown.
-    example: 'true'
+    example: true
     in: query
     name: timelineVisible
     required: false
     schema:
-      default: 'false'
+      default: false
       type: boolean
   - description: Indicates whether the hierarchy mode should be enabled.
-    example: 'true'
+    example: true
     in: query
     name: showHierarchies
     required: false
     schema:
-      default: 'true'
+      default: true
       type: boolean
   responses:
     '200':
@@ -130,8 +130,8 @@ get:
                   - href: "/api/v3/queries/columns/updated_at"
                     title: Updated on
                   groupBy:
-                    href: 
-                    title: 
+                    href:
+                    title:
                   project:
                     href: "/api/v3/projects/42"
                     title: Lorem ipsum project

--- a/docs/api/apiv3/paths/project_work_packages.yml
+++ b/docs/api/apiv3/paths/project_work_packages.yml
@@ -53,12 +53,12 @@ get:
       type: string
   - description: Indicates whether properties should be summed up if they support
       it.
-    example: 'true'
+    example: true
     in: query
     name: showSums
     required: false
     schema:
-      default: 'false'
+      default: false
       type: boolean
   - description: |-
       Comma separated list of properties to include.
@@ -166,12 +166,12 @@ post:
       Indicates whether change notifications (e.g. via E-Mail) should be sent.
       Note that this controls notifications for all users interested in changes to the work package (e.g. watchers, author and assignee),
       not just the current user.
-    example: 'false'
+    example: false
     in: query
     name: notify
     required: false
     schema:
-      default: 'true'
+      default: true
       type: boolean
   responses:
     '200':
@@ -302,19 +302,19 @@ post:
                 createdAt: '2014-08-29T12:40:53Z'
                 customField1: Foo
                 customField2: 42
-                derivedDueDate: 
+                derivedDueDate:
                 derivedEstimatedTime: PT10H
-                derivedStartDate: 
+                derivedStartDate:
                 description:
                   format: markdown
                   html: "<p>Develop super cool OpenProject API.</p>"
                   raw: Develop super cool OpenProject API.
-                dueDate: 
+                dueDate:
                 estimatedTime: PT2H
                 id: 1528
                 percentageDone: 0
                 scheduleManually: false
-                startDate: 
+                startDate:
                 subject: Develop API
                 updatedAt: '2014-08-29T12:44:41Z'
           schema:

--- a/docs/api/apiv3/paths/queries_default.yml
+++ b/docs/api/apiv3/paths/queries_default.yml
@@ -51,20 +51,20 @@ get:
   - description: Indicates whether properties should be summed up if they support
       it. The showSums parameter is applied to the to the query's result collection
       of work packages overriding the query's persisted sums property.
-    example: 'true'
+    example: true
     in: query
     name: showSums
     required: false
     schema:
-      default: 'false'
+      default: false
       type: boolean
   - description: Indicates whether the timeline should be shown.
-    example: 'true'
+    example: true
     in: query
     name: timelineVisible
     required: false
     schema:
-      default: 'false'
+      default: false
       type: boolean
   - description: Indicates in what zoom level the timeline should be shown. Valid
       values are  `days`, `weeks`, `months`, `quarters`, and `years`.
@@ -76,12 +76,12 @@ get:
       default: days
       type: string
   - description: Indicates whether the hierarchy mode should be enabled.
-    example: 'true'
+    example: true
     in: query
     name: showHierarchies
     required: false
     schema:
-      default: 'true'
+      default: true
       type: boolean
   responses:
     '200':
@@ -132,11 +132,11 @@ get:
                   - href: "/api/v3/queries/columns/updated_at"
                     title: Updated on
                   groupBy:
-                    href: 
-                    title: 
+                    href:
+                    title:
                   highlightedAttributes: []
                   project:
-                    href: 
+                    href:
                   results:
                     href: "/api/v3/work_packages?filters=%5B%7B%22status%22%3A%7B%22operator%22%3A%22o%22%2C%22values%22%3A%5B%5D%7D%7D%2C%7B%22dueDate%22%3A%7B%22operator%22%3A%22%3Ct%2B%22%2C%22values%22%3A%5B%221%22%5D%7D%7D%5D&offset=1&pageSize=2&sortBy=%5B%5B%22parent%22%2C%22desc%22%5D%5D"
                   self:

--- a/docs/api/apiv3/paths/query.yml
+++ b/docs/api/apiv3/paths/query.yml
@@ -120,20 +120,20 @@ get:
     - description: Indicates whether properties should be summed up if they support
         it. The showSums parameter is applied to the to the query's result collection
         of work packages overriding the query's persisted sums property.
-      example: 'true'
+      example: true
       in: query
       name: showSums
       required: false
       schema:
-        default: 'false'
+        default: false
         type: boolean
     - description: Indicates whether the timeline should be shown.
-      example: 'true'
+      example: true
       in: query
       name: timelineVisible
       required: false
       schema:
-        default: 'false'
+        default: false
         type: boolean
     - description: Overridden labels in the timeline view
       example: "{}"
@@ -162,12 +162,12 @@ get:
         default: "['type', 'priority']"
         type: string
     - description: Indicates whether the hierarchy mode should be enabled.
-      example: 'true'
+      example: true
       in: query
       name: showHierarchies
       required: false
       schema:
-        default: 'true'
+        default: true
         type: boolean
   responses:
     '200':
@@ -264,8 +264,8 @@ patch:
                   - href: "/api/v3/queries/columns/updated_at"
                     title: Updated on
                   groupBy:
-                    href: 
-                    title: 
+                    href:
+                    title:
                   highlightedAttributes: []
                   project:
                     href: "/api/v3/projects/3"

--- a/docs/api/apiv3/paths/work_package.yml
+++ b/docs/api/apiv3/paths/work_package.yml
@@ -242,12 +242,12 @@ patch:
         Indicates whether change notifications (e.g. via E-Mail) should be sent.
         Note that this controls notifications for all users interested in changes to the work package (e.g. watchers, author and assignee),
         not just the current user.
-      example: 'false'
+      example: false
       in: query
       name: notify
       required: false
       schema:
-        default: 'true'
+        default: true
         type: boolean
   responses:
     '200':

--- a/docs/api/apiv3/paths/work_package_activities.yml
+++ b/docs/api/apiv3/paths/work_package_activities.yml
@@ -94,12 +94,12 @@ post:
       Indicates whether change notifications (e.g. via E-Mail) should be sent.
       Note that this controls notifications for all users interested in changes to the work package (e.g. watchers, author and assignee),
       not just the current user.
-    example: 'false'
+    example: false
     in: query
     name: notify
     required: false
     schema:
-      default: 'true'
+      default: true
       type: boolean
   responses:
     '201':

--- a/docs/api/apiv3/paths/work_packages.yml
+++ b/docs/api/apiv3/paths/work_packages.yml
@@ -22,7 +22,7 @@ get:
         Accepts the same format as returned by the [queries](https://www.openproject.org/docs/api/endpoints/queries/)
         endpoint. If no filter is to be applied, the client should send an empty array (`[]`), otherwise a default
         filter is applied. A Currently supported filters are (there are additional filters added by modules):
-        
+
         - assigned_to
         - assignee_or_group
         - attachment_base
@@ -104,12 +104,12 @@ get:
         type: string
     - description: Indicates whether properties should be summed up if they support
         it.
-      example: 'true'
+      example: true
       in: query
       name: showSums
       required: false
       schema:
-        default: 'false'
+        default: false
         type: boolean
     - description: |-
         Comma separated list of properties to include.
@@ -192,12 +192,12 @@ post:
         Indicates whether change notifications (e.g. via E-Mail) should be sent.
         Note that this controls notifications for all users interested in changes to the work package (e.g. watchers, author and assignee),
         not just the current user.
-      example: 'false'
+      example: false
       in: query
       name: notify
       required: false
       schema:
-        default: 'true'
+        default: true
         type: boolean
   responses:
     '200':


### PR DESCRIPTION
It prevented tools like restish to correctly parse the json of our api.

I can finally use [restish](https://rest.sh/) 🙂