### PR TITLE
 [41442] Attribute help text opens when clicking ng-select dropdown

### DIFF
--- a/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.component.html
+++ b/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.component.html
@@ -1,11 +1,14 @@
-<button
-    type="button"
+<div
     *ngIf="exists"
     class="op-link help-text--entry"
     [attr.data-qa-help-text-for]="attribute"
     [title]="text.open_dialog"
     (click)="handleClick($event)"
+    (keydown.enter)="handleClick($event)"
+    (keydown.space)="handleClick($event)"
+    role="button"
+    tabindex="0"
 >
   <span *ngIf="additionalLabel" [textContent]="additionalLabel"></span>
   <op-icon icon-classes="icon icon-no-color icon-help1"></op-icon>
-</button>
+</div>


### PR DESCRIPTION
The label wrapping the attribute help text and form-field was associated with the input button, so it caused opening the modal by clicking on the wrapping label. 

https://community.openproject.org/work_packages/41442/activity