### PR TITLE
[#33908] Custom Field User Not available in Filter

### DIFF
--- a/app/models/queries/work_packages/filter/custom_field_context.rb
+++ b/app/models/queries/work_packages/filter/custom_field_context.rb
@@ -47,7 +47,7 @@ module Queries::WorkPackages::Filter::CustomFieldContext
           .filter
           .for_all
           .where
-          .not(field_format: %w(user version))
+          .not(field_format: %w(version))
       end
     end
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/33908

Re-enabled custom fields of type "User" to act as filters in global work_packages report:

Custom fields of type "User" and "Version" were excluded in 2018 by Jens from 
appearing in the global work_packages reports. I guess that's because their values 
are set per-project. 
However, it seems that the current "principal" endpoint now returns the global list of 
users in this case, so that a filter of type "User" works correctly, at least on my dev
installation.