### PR TITLE
[38531] [Navigation] Breadcrumbs changes from "Relations" to "Activity"

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb-parent.html
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb-parent.html
@@ -1,8 +1,8 @@
 <ng-container *ngIf="!active">
   <a *ngIf="parent"
     [attr.title]="parent.name"
-    uiSref="work-packages.show"
-    [uiParams]="{workPackageId: parent.id}"
+    uiSref="work-packages.show.tabs"
+    [uiParams]="{ workPackageId: parent.id }"
     class="op-wp-breadcrumb-parent nocut"
     data-qa-selector="op-wp-breadcrumb-parent">
     <span [textContent]="parent.name"></span>

--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb-parent.html
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb-parent.html
@@ -2,7 +2,7 @@
   <a *ngIf="parent"
     [attr.title]="parent.name"
     uiSref="work-packages.show.tabs"
-    [uiParams]="{ workPackageId: parent.id }"
+    [uiParams]="{workPackageId: parent.id}"
     class="op-wp-breadcrumb-parent nocut"
     data-qa-selector="op-wp-breadcrumb-parent">
     <span [textContent]="parent.name"></span>


### PR DESCRIPTION
Show the current opened tab while clicking on breadcrumb parent and navigating to parent work package.


https://community.openproject.org/work_packages/38531/activity