### PR TITLE
allows selecting items to copy from a template project

### DIFF
--- a/frontend/src/app/features/projects/components/copy-project/copy-project.component.ts
+++ b/frontend/src/app/features/projects/components/copy-project/copy-project.component.ts
@@ -84,6 +84,6 @@ export class CopyProjectComponent extends UntilDestroyedMixin implements OnInit 
   }
 
   private isMeta(property:string|undefined):boolean {
-    return !!property && (property.startsWith('copy') || property == 'sendNotifications');
+    return !!property && (property.startsWith('copy') || property === 'sendNotifications');
   }
 }

--- a/frontend/src/app/features/projects/components/new-project/new-project.component.ts
+++ b/frontend/src/app/features/projects/components/new-project/new-project.component.ts
@@ -39,6 +39,7 @@ export class NewProjectComponent extends UntilDestroyedMixin implements OnInit {
     use_template: this.I18n.t('js.project.use_template'),
     no_template_selected: this.I18n.t('js.project.no_template_selected'),
     advancedSettingsLabel: this.I18n.t('js.forms.advanced_settings'),
+    copySettingsLabel: this.I18n.t('js.project.copy.copy_options'),
   };
 
   hiddenFields:string[] = [
@@ -88,10 +89,15 @@ export class NewProjectComponent extends UntilDestroyedMixin implements OnInit {
     this.resourcePath = this.apiV3Service.projects.path;
     this.fieldGroups = [{
       name: this.text.advancedSettingsLabel,
-      fieldsFilter: (field) => !['name', 'parent', 'sendNotifications'].includes(field.templateOptions?.property as string)
+      fieldsFilter: (field) => !['name', 'parent'].includes(field.templateOptions?.property as string)
+        && !this.isMeta(field.templateOptions?.property)
         && !(field.templateOptions?.required
         && !field.templateOptions.hasDefault
         && field.templateOptions.payloadValue == null),
+    },
+    {
+      name: this.text.copySettingsLabel,
+      fieldsFilter: (field:IOPFormlyFieldSettings) => this.isMeta(field.templateOptions?.property),
     }];
 
     if (this.uIRouterGlobals.params.parent_id) {
@@ -128,8 +134,8 @@ export class NewProjectComponent extends UntilDestroyedMixin implements OnInit {
     return !!key && (this.hiddenFields.includes(key) || this.isMeta(key));
   }
 
-  private isMeta(key:string):boolean {
-    return key.startsWith('_meta.');
+  private isMeta(property:string|undefined):boolean {
+    return !!property && (property.startsWith('copy') || property === 'sendNotifications');
   }
 
   private setParentAsPayload(parentId:string) {


### PR DESCRIPTION
Displays the same options as when copying a project upon creating a project based on a template. That way, people can i.e. exclude members from being copied upon instantiating a template which helps to avoid adding people as members that simply are members so that they can see the template.

https://community.openproject.org/work_packages/40918