### PR TITLE
avoid left joining on roles to avoid multiple projects returned

### DIFF
--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -30,20 +30,10 @@ module API
   module V3
     module Projects
       class ProjectsAPI < ::API::OpenProjectAPI
-        helpers do
-          def visible_project_scope
-            if current_user.admin?
-              Project.all
-            else
-              Project.visible(current_user)
-            end
-          end
-        end
-
         resources :projects do
           get &::API::V3::Utilities::Endpoints::SqlFallbackedIndex.new(model: Project,
                                                                        scope: -> {
-                                                                         visible_project_scope
+                                                                         Project
                                                                            .includes(ProjectRepresenter.to_eager_load)
                                                                        })
                                                                   .mount
@@ -61,7 +51,11 @@ module API
           end
           route_param :id do
             after_validation do
-              @project = visible_project_scope.find(params[:id])
+              @project = if current_user.admin?
+                           Project.all
+                         else
+                           Project.visible(current_user)
+                         end.find(params[:id])
             end
 
             get &::API::V3::Utilities::Endpoints::Show.new(model: Project).mount

--- a/spec/requests/api/v3/projects/index_resource_spec.rb
+++ b/spec/requests/api/v3/projects/index_resource_spec.rb
@@ -43,12 +43,15 @@ describe 'API v3 Project resource index', type: :request, content_type: :json do
     create(:project, public: false)
   end
   let(:parent_project) do
-    create(:project, public: false, members: { current_user => role }).tap do |parent|
+    # Adding two roles in here to guard against regression where projects were returned twice if a user
+    # had multiple roles in the same project.
+    create(:project, public: false, members: { current_user => [role, second_role] }).tap do |parent|
       project.parent = parent
       project.save
     end
   end
   let(:role) { create(:role) }
+  let(:second_role) { create(:role) }
   let(:filters) { [] }
   let(:get_path) do
     api_v3_paths.path_for :projects, filters: filters


### PR DESCRIPTION
As the permission check used to be left joined directly to the list of projects, with a user having multiple roles, this lead to having a project returned multiple times.

The permission check is not necessary at this point at all however since the query will already add a visible scope if necessary.

This is how the central part of the SQL query generated looked like:

```
SELECT projects.*
                    FROM "projects"
                             LEFT OUTER JOIN "members"
                                             ON "projects"."id" = "members"."project_id" AND "members"."user_id" = 3 AND
                                                "projects"."active" = TRUE
                             LEFT OUTER JOIN "member_roles" ON "members"."id" = "member_roles"."member_id"
                             LEFT OUTER JOIN "roles" "assigned_roles" ON 1 = 1 AND "projects"."active" = TRUE AND
                                                                         ("assigned_roles"."id" =
                                                                          "member_roles"."role_id" OR
                                                                          "projects"."public" = TRUE AND
                                                                          "assigned_roles"."builtin" = 1 AND
                                                                          "member_roles"."id" IS NULL)
                    WHERE "assigned_roles"."id" IS NOT NULL
                      AND "projects"."id" IN (SELECT DISTINCT "projects"."id"
                                              FROM "projects"
                                                       LEFT OUTER JOIN "members"
                                                                       ON "projects"."id" = "members"."project_id" AND
                                                                          "members"."user_id" = 3 AND
                                                                          "projects"."active" = TRUE
                                                       LEFT OUTER JOIN "member_roles" ON "members"."id" = "member_roles"."member_id"
                                                       LEFT OUTER JOIN "roles" "assigned_roles"
                                                                       ON 1 = 1 AND "projects"."active" = TRUE AND
                                                                          ("assigned_roles"."id" =
                                                                           "member_roles"."role_id" OR
                                                                           "projects"."public" = TRUE AND
                                                                           "assigned_roles"."builtin" = 1 AND
                                                                           "member_roles"."id" IS NULL)
                                              WHERE "assigned_roles"."id" IS NOT NULL)
                    ORDER BY "projects"."id" DESC
                    LIMIT 20 OFFSET 0
```

The permission checking part existed twice, once as a LEFT JOIN and once as a subquery. The subquery part is left as it is but the LEFT JOIN is removed to avoid the duplication.

```
SELECT projects.*
                    FROM "projects"                             
                    WHERE 
                      "projects"."id" IN (SELECT DISTINCT "projects"."id"
                                              FROM "projects"
                                                       LEFT OUTER JOIN "members"
                                                                       ON "projects"."id" = "members"."project_id" AND
                                                                          "members"."user_id" = 3 AND
                                                                          "projects"."active" = TRUE
                                                       LEFT OUTER JOIN "member_roles" ON "members"."id" = "member_roles"."member_id"
                                                       LEFT OUTER JOIN "roles" "assigned_roles"
                                                                       ON 1 = 1 AND "projects"."active" = TRUE AND
                                                                          ("assigned_roles"."id" =
                                                                           "member_roles"."role_id" OR
                                                                           "projects"."public" = TRUE AND
                                                                           "assigned_roles"."builtin" = 1 AND
                                                                           "member_roles"."id" IS NULL)
                                              WHERE "assigned_roles"."id" IS NOT NULL)
                    ORDER BY "projects"."id" DESC
                    LIMIT 20 OFFSET 0
```

https://community.openproject.org/wp/41673