### PR TITLE
avoid Hashie::Mash for parsing

### DIFF
--- a/app/services/api/parse_resource_params_service.rb
+++ b/app/services/api/parse_resource_params_service.rb
@@ -82,7 +82,7 @@ module API
     def deep_to_h(value)
       # Does not yet factor in Arrays. There hasn't been the need to do that, yet.
       case value
-      when Hashie::Mash, Hash
+      when Hash, ParserStruct
         value.to_h.transform_values do |sub_value|
           deep_to_h(sub_value)
         end

--- a/app/services/api/parser_struct.rb
+++ b/app/services/api/parser_struct.rb
@@ -29,14 +29,11 @@
 module API
   class ParserStruct < ::Hashie::Mash
     ##
-    # TODO: Hashie::Mash extends from Hash and
-    # does not allow overriding any enumerable methods.
+    # Hashie::Mash extends from Hash
+    # and by default does not allow overriding any enumerable methods.
     #
-    # This clashed with moving the queries services to BaseContracted,
-    # as we now use a +group_by+ attribute clashing with +Enumerable#group_by#.
-    # This redefines the method to ensure it works with queries, but does not solve the underlying issue.
-    def group_by
-      self[:group_by]
-    end
+    # This clashes with names (e.g. +group_by+) occurring when parsing in the API.
+    # Undefining the method allows to set and get the parsed value without conflicts.
+    undef_method :group_by
   end
 end

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -127,7 +127,7 @@ module API
       end
 
       def format_query_sums(sums)
-        Hashie::Mash.new(format_column_keys(sums).merge(available_custom_fields: WorkPackageCustomField.summable.to_a))
+        API::ParserStruct.new(format_column_keys(sums).merge(available_custom_fields: WorkPackageCustomField.summable.to_a))
       end
 
       def format_column_keys(hash_by_column)

--- a/app/services/queries/set_attributes_service.rb
+++ b/app/services/queries/set_attributes_service.rb
@@ -47,14 +47,14 @@ class Queries::SetAttributesService < ::BaseServices::SetAttributes
   end
 
   def set_ordered_work_packages(ordered_hash)
-    return if ordered_hash.nil?
+    return if ordered_hash.nil? || model.persisted?
 
     available = WorkPackage.where(id: ordered_hash.keys.map(&:to_s)).pluck(:id).to_set
 
     ordered_hash.each do |key, position|
       # input keys are symbols due to hashie::mash, and AR doesn't like that
       wp_id = key.to_s.to_i
-      next unless available.include?(wp_id.to_s.to_i)
+      next unless available.include?(wp_id)
 
       model.ordered_work_packages.build(work_package_id: wp_id, position: position)
     end

--- a/lib/api/utilities/meta_property.rb
+++ b/lib/api/utilities/meta_property.rb
@@ -56,7 +56,7 @@ module API
       protected
 
       def meta_representer
-        meta_representer_class.create(meta || Hashie::Mash.new, current_user: current_user)
+        meta_representer_class.create(meta || API::ParserStruct.new, current_user: current_user)
       end
 
       def meta_representer_class

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -214,13 +214,13 @@ module API
                    end
                  },
                  setter: ->(fragment:, represented:, **) {
-                   represented.status_attributes ||= Hashie::Mash.new
+                   represented.status_attributes ||= API::ParserStruct.new
 
                    link = ::API::Decorators::LinkObject.new(represented.status_attributes,
                                                             path: :project_status,
                                                             property_name: :status,
                                                             getter: :code,
-                                                            setter: :"code=")
+                                                            setter: :'code=')
 
                    link.from_hash(fragment)
                  }
@@ -233,7 +233,7 @@ module API
                                                       plain: false)
                  },
                  setter: ->(fragment:, represented:, **) {
-                   represented.status_attributes ||= Hashie::Mash.new
+                   represented.status_attributes ||= API::ParserStruct.new
                    represented.status_attributes[:explanation] = fragment["raw"]
                  }
 

--- a/lib/api/v3/queries/query_representer.rb
+++ b/lib/api/v3/queries/query_representer.rb
@@ -46,7 +46,7 @@ module API
                               # start with numbers, the id needs to be looked up
                               # in the DB.
                               id = if id.to_i.to_s == id
-                                     id # return numerical ID
+                                     id.to_i # return numerical ID
                                    else
                                      Project.where(identifier: id).pick(:id) # lookup Project by identifier
                                    end
@@ -255,14 +255,7 @@ module API
                   }
 
         property :ordered_work_packages,
-                 skip_render: true,
-                 exec_context: :decorator,
-                 getter: nil,
-                 setter: ->(fragment:, **) {
-                   next if represented.persisted?
-
-                   represented.ordered_work_packages = fragment
-                 }
+                 skip_render: true
 
         property :starred,
                  writeable: true

--- a/lib/api/v3/work_packages/watchers_api.rb
+++ b/lib/api/v3/work_packages/watchers_api.rb
@@ -76,7 +76,7 @@ module API
               fail ::API::Errors::InvalidRequestBody.new(I18n.t('api_v3.errors.missing_request_body'))
             end
 
-            representer = ::API::V3::Watchers::WatcherRepresenter.create(::Hashie::Mash.new, current_user: current_user)
+            representer = ::API::V3::Watchers::WatcherRepresenter.create(API::ParserStruct.new, current_user: current_user)
             representer.from_hash(request_body)
             user_id = representer.represented.user_id.to_i
 

--- a/spec/lib/api/decorators/link_object_spec.rb
+++ b/spec/lib/api/decorators/link_object_spec.rb
@@ -31,7 +31,7 @@ require 'spec_helper'
 describe ::API::Decorators::LinkObject do
   include ::API::V3::Utilities::PathHelper
 
-  let(:represented) { Hashie::Mash.new }
+  let(:represented) { API::ParserStruct.new }
 
   context 'minimal constructor call' do
     let(:representer) { described_class.new(represented, property_name: :foo) }

--- a/spec/lib/api/v3/attachments/attachment_metadata_representer_spec.rb
+++ b/spec/lib/api/v3/attachments/attachment_metadata_representer_spec.rb
@@ -33,7 +33,7 @@ describe ::API::V3::Attachments::AttachmentParsingRepresenter do
   include API::V3::Utilities::PathHelper
 
   let(:metadata) do
-    data = Hashie::Mash.new
+    data = API::ParserStruct.new
     data.filename = original_file_name
     data.description = original_description
     data.content_type = original_content_type

--- a/spec/lib/api/v3/projects/project_payload_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/projects/project_payload_representer_parsing_spec.rb
@@ -32,7 +32,7 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
   include ::API::V3::Utilities::PathHelper
 
   let(:object) do
-    Hashie::Mash.new available_custom_fields: []
+    API::ParserStruct.new available_custom_fields: []
   end
   let(:user) { build_stubbed(:user) }
   let(:representer) do
@@ -40,7 +40,7 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
   end
 
   describe 'properties' do
-    context 'status' do
+    context 'for status' do
       let(:hash) do
         {
           'statusExplanation' => { 'raw' => 'status code explanation' },
@@ -130,7 +130,7 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
             .not_to have_key(:explanation)
 
           expect(status[:code])
-            .to eq nil
+            .to be_nil
         end
       end
     end
@@ -175,7 +175,7 @@ describe ::API::V3::Projects::ProjectPayloadRepresenter, 'parsing' do
             .to have_key(:parent_id)
 
           expect(project[:parent_id])
-            .to eq nil
+            .to be_nil
         end
       end
 

--- a/spec/lib/api/v3/queries/query_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/queries/query_representer_parsing_spec.rb
@@ -66,7 +66,7 @@ describe ::API::V3::Queries::QueryRepresenter, 'parsing' do
     policy
   end
 
-  subject { representer.from_hash request_body }
+  subject { representer.from_hash(request_body) }
 
   describe 'empty group_by (Regression #25606)' do
     before do
@@ -82,7 +82,7 @@ describe ::API::V3::Queries::QueryRepresenter, 'parsing' do
     end
 
     it 'unsets group_by' do
-      expect(query.group_by).to eq('project')
+      expect(subject.group_by).to be_nil
     end
   end
 
@@ -111,37 +111,13 @@ describe ::API::V3::Queries::QueryRepresenter, 'parsing' do
       }
     end
 
-    before do
-      allow(query).to receive(:persisted?).and_return(persisted)
-    end
-
-    context 'if query is new' do
-      let(:persisted) { nil }
-
-      it 'sets ordered_work_packages' do
-        order = subject.ordered_work_packages
-        expect(order).to eq({ '50' => 0, '38' => 1234, '102' => 81234123 })
-      end
-    end
-
-    context 'if query is not new' do
-      let(:persisted) { true }
-
-      it 'sets ordered_work_packages' do
-        allow(query)
-          .to receive(:ordered_work_packages)
-
-        subject
-
-        expect(query)
-          .not_to have_received(:ordered_work_packages)
-      end
+    it 'sets ordered_work_packages' do
+      expect(subject.ordered_work_packages)
+        .to eq({ "50" => 0, "38" => 1234, "102" => 81234123 })
     end
   end
 
   describe 'project' do
-    let(:query) { build_stubbed(:query, project: nil) }
-
     let(:request_body) do
       {
         '_links' => {

--- a/spec/lib/open_project/configuration_spec.rb
+++ b/spec/lib/open_project/configuration_spec.rb
@@ -247,7 +247,7 @@ describe OpenProject::Configuration do
       { 'email_delivery_method' => 'smtp',
         'smtp_address' => 'smtp.example.net',
         'smtp_port' => '25' }.map do |name, value|
-        Hashie::Mash.new name: name, value: value
+        API::ParserStruct.new name: name, value: value
       end
     end
 

--- a/spec/services/api/parser_struct_spec.rb
+++ b/spec/services/api/parser_struct_spec.rb
@@ -1,0 +1,102 @@
+#  OpenProject is an open source project management software.
+#  Copyright (C) 2010-2022 the OpenProject GmbH
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License version 3.
+#
+#  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+#  Copyright (C) 2006-2013 Jean-Philippe Lang
+#  Copyright (C) 2010-2013 the ChiliProject Team
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#  See COPYRIGHT and LICENSE files for more details.
+
+require 'spec_helper'
+
+describe ::API::ParserStruct do
+  let(:instance) { described_class.new }
+
+  describe 'assigning a value and method creation' do
+    # Dynamically creating a method can be misused when allowing
+    # those method are generated based on client input.
+    # See "Symbol denial of service" at
+    # https://ruby-doc.org/stdlib-3.0.0/libdoc/ostruct/rdoc/OpenStruct.html#class-OpenStruct-label-Caveats.
+    it 'does not dynamically create a method' do
+      instance.some_method = 'string'
+
+      expect(instance.methods.grep(/some_method/))
+        .to be_empty
+    end
+  end
+
+  describe 'assigning an value and getting a hash' do
+    it 'works for [value]=' do
+      instance.some_value = 'string'
+
+      expect(instance.to_h)
+        .to eql('some_value' => 'string')
+    end
+
+    it 'works for [value]_id=' do
+      instance.some_value_id = 5
+
+      expect(instance.to_h)
+        .to eql('some_value_id' => 5)
+    end
+
+    it 'works for group_by=' do
+      instance.group_by = 8
+
+      expect(instance.to_h)
+        .to eql('group_by' => 8)
+    end
+  end
+
+  describe 'assigning an value and getting by hash key' do
+    it 'works for [value]=' do
+      instance.some_value = 'string'
+
+      expect(instance[:some_value])
+        .to eq('string')
+    end
+
+    it 'works for [value]_id=' do
+      instance.some_value_id = 5
+
+      expect(instance[:some_value_id])
+        .to eq(5)
+    end
+
+    it 'works for group_by=' do
+      instance.group_by = 8
+
+      expect(instance[:group_by])
+        .to eq(8)
+    end
+  end
+
+  describe 'instantiating with a hash and fetching the value' do
+    let(:instance) do
+      described_class
+        .new({ 'some_value' => 'string', 'some_value_id' => 5, 'group_by' => 8 })
+    end
+
+    it 'allows fetching the value' do
+      expect(instance.to_h)
+        .to eql({ 'some_value' => 'string', 'some_value_id' => 5, 'group_by' => 8 })
+    end
+  end
+end

--- a/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
+++ b/spec/services/api/v3/work_package_collection_from_query_service_spec.rb
@@ -250,7 +250,7 @@ describe ::API::V3::WorkPackageCollectionFromQueryService,
               .to receive(:summable)
               .and_return(custom_fields)
 
-            expected = Hashie::Mash.new(estimated_hours: 0.0, available_custom_fields: custom_fields)
+            expected = API::ParserStruct.new(estimated_hours: 0.0, available_custom_fields: custom_fields)
 
             expect(subject.total_sums)
               .to eq(expected)


### PR DESCRIPTION
Replaces the direct use of Hashie::Mash for API parsing by the introduced `API::ParserStruct` subclass. That class is speced to ensure that no method is generated upon setting a property.

Since we are using parsing object, that is not the object we assign the values to later on, we cannot rely on the state of the resource. Because of this, the PR also removes one occurrence of this where `model.persisted?` was queried.