### PR TITLE
[41071] Ensure project export includes optional column

### DIFF
--- a/app/cells/projects/row_cell.rb
+++ b/app/cells/projects/row_cell.rb
@@ -79,8 +79,8 @@ module Projects
     end
 
     def status_explanation
-      if project.status.try(:explanation)
-        content_tag :div, format_text(project.status.explanation), class: 'wiki'
+      if project.status_explanation
+        content_tag :div, format_text(project.status_explanation), class: 'wiki'
       end
     end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -137,6 +137,8 @@ class Project < ApplicationRecord
 
   friendly_id :identifier, use: :finders
 
+  delegate :explanation, to: :status, allow_nil: true, prefix: true
+
   scope :has_module, ->(mod) {
     where(["#{Project.table_name}.id IN (SELECT em.project_id FROM #{EnabledModule.table_name} em WHERE em.name=?)", mod.to_s])
   }

--- a/modules/xls_export/spec/models/xls_export/project/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/project/exporter/xls_integration_spec.rb
@@ -31,6 +31,19 @@ describe XlsExport::Project::Exporter::XLS do
                                 project.name, project.description, 'Off track', 'false']
   end
 
+  context 'with status_explanation enabled' do
+    before do
+      Setting.enabled_projects_columns += ["status_explanation"]
+    end
+
+    it 'performs a successful export' do
+      expect(rows.count).to eq(1)
+      expect(sheet.row(1)).to eq [project.id.to_s, project.identifier,
+                                  project.name, project.description,
+                                  'Off track', project.status_explanation, 'false']
+    end
+  end
+
   describe 'custom field columns selected' do
     before do
       Setting.enabled_projects_columns += custom_fields.map { |cf| "cf_#{cf.id}" }

--- a/spec/models/projects/exporter/csv_integration_spec.rb
+++ b/spec/models/projects/exporter/csv_integration_spec.rb
@@ -47,6 +47,19 @@ describe Projects::Exports::CSV, 'integration', type: :model do
                                project.name, project.description, 'Off track', 'false']
   end
 
+  context 'with status_explanation enabled' do
+    before do
+      Setting.enabled_projects_columns += ["status_explanation"]
+    end
+
+    it 'performs a successful export' do
+      expect(parsed.size).to eq(2)
+      expect(parsed.last).to eq [project.id.to_s, project.identifier,
+                                 project.name, project.description,
+                                 'Off track', '', 'false']
+    end
+  end
+
   describe 'custom field columns selected' do
     before do
       Setting.enabled_projects_columns += custom_fields.map { |cf| "cf_#{cf.id}" }
@@ -57,7 +70,7 @@ describe Projects::Exports::CSV, 'integration', type: :model do
         expect(parsed.size).to eq 2
 
         cf_names = custom_fields.map(&:name)
-        expect(header).to eq ['id', 'Identifier', 'Name', 'Description', 'Status', 'Public', *cf_names]
+        expect(header).to eq ['id', 'Identifier', 'Name', 'Description', 'Status', 'Status description', 'Public', *cf_names]
 
         custom_values = custom_fields.map do |cf|
           case cf
@@ -70,13 +83,14 @@ describe Projects::Exports::CSV, 'integration', type: :model do
           end
         end
         expect(rows.first)
-          .to eq [project.id.to_s, project.identifier, project.name, project.description, 'Off track', 'false', *custom_values]
+          .to eq [project.id.to_s, project.identifier, project.name,
+                  project.description, 'Off track', '', 'false', *custom_values]
       end
     end
 
     context 'when ee not enabled' do
       it 'renders only the default columns' do
-        expect(header).to eq %w[id Identifier Name Description Status Public]
+        expect(header).to eq %w[id Identifier Name Description Status Status\ description Public]
       end
     end
   end


### PR DESCRIPTION
https://community.openproject.org/wp/41071

The [Default formatter](https://github.com/opf/openproject/blob/a31a77ef878ac5a7d029d16670b449b5f3c90df3/app/models/exports/formatters/default.rb#L51-L53) expects the `status_explanation` method to be present on the project, however we don't have the delegate to the `Status#explanation ` attribute.
I set up a delegate on the `Project` model which will facilitate the `status_explanation` method, so the `Default formatter` will pick up the right attribute.

Perhaps it would be useful to set up an error mechanism in case the called method does not exist on the callee `object` in the [Default formatter](https://github.com/opf/openproject/blob/a31a77ef878ac5a7d029d16670b449b5f3c90df3/app/models/exports/formatters/default.rb#L51-L53), but this should be discussed whether we want to do it.