### PR TITLE
[#41833] Changing Code Snippet ONLY in Wiki page does not trigger new Version in History

### DIFF
--- a/docs/user-guide/wiki/more-wiki-functions/README.md
+++ b/docs/user-guide/wiki/more-wiki-functions/README.md
@@ -68,6 +68,7 @@ First, you will get an overview on author and date of the latest updates. Potent
 
 <div class="alert alert-info" role="alert">
 **Note**: The more distance between two versions, the more difficult it becomes to compare them, since only the selected versions are compared (ignoring the changes that were made in the meantime). The most comprehensible information is thus provided by comparing two consecutive versions.</div>
+**Note**: The wiki will merge changes, if changes are entered within less then 5 minutes by the same person. This helps to avoid clutter in the wiki history. 
 
 ## Export a wiki page
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/41833

Added a note to Wiki page history documentation about changes being merged:
The Wiki "journal" merges changes within a merge window which is
set to 5 minutes by default. The parameter "journal_aggregation_time_minutes"
is defined in the settings (config/constants/settings/definitions.rb line 487).