### PR TITLE
Fix/41844 changing host name option in system settings leads to exception

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -56,7 +56,7 @@ module SettingsHelper
       },
       {
         name: 'repositories',
-        controller:'/admin/settings/repositories_settings',
+        controller: '/admin/settings/repositories_settings',
         label: :label_repository_plural
       }
     ]
@@ -85,7 +85,7 @@ module SettingsHelper
         hidden +
           choices.map do |choice|
             setting_multiselect_choice(setting, choice, options)
-          end.join.html_safe
+          end.join.html_safe # rubocop:disable Rails/OutputSafety
       end
   end
 
@@ -194,10 +194,10 @@ module SettingsHelper
   private
 
   def wrap_field_outer(options, &block)
-    if options[:label] != false
-      content_tag(:span, class: 'form--field-container', &block)
-    else
+    if options[:label] == false
       block.call
+    else
+      content_tag(:span, class: 'form--field-container', &block)
     end
   end
 
@@ -210,7 +210,7 @@ module SettingsHelper
             hidden_field_tag("settings[#{setting}][]", '') +
               I18n.t("setting_#{setting}")
           end
-        end.join.html_safe
+        end.join.html_safe # rubocop:disable Rails/OutputSafety
     end
   end
 
@@ -221,17 +221,21 @@ module SettingsHelper
       exceptions = Array(choice[:except]).compact
       content_tag(:tr, class: 'form--matrix-row') do
         content_tag(:td, caption, class: 'form--matrix-cell') +
-          settings.map do |setting|
-            content_tag(:td, class: 'form--matrix-checkbox-cell') do
-              unless exceptions.include?(setting)
-                styled_check_box_tag("settings[#{setting}][]", value,
-                                     Setting.send(setting).include?(value),
-                                     disabled_setting_option(setting).merge(id: "#{setting}_#{value}"))
-              end
-            end
-          end.join.html_safe
+          settings_matrix_tds(settings, exceptions, value)
       end
-    end.join.html_safe
+    end.join.html_safe # rubocop:disable Rails/OutputSafety
+  end
+
+  def settings_matrix_tds(settings, exceptions, value)
+    settings.map do |setting|
+      content_tag(:td, class: 'form--matrix-checkbox-cell') do
+        unless exceptions.include?(setting)
+          styled_check_box_tag("settings[#{setting}][]", value,
+                               Setting.send(setting).include?(value),
+                               disabled_setting_option(setting).merge(id: "#{setting}_#{value}"))
+        end
+      end
+    end.join.html_safe # rubocop:disable Rails/OutputSafety
   end
 
   def setting_multiselect_choice(setting, choice, options)
@@ -244,7 +248,6 @@ module SettingsHelper
     content_tag(:label, class: 'form--label-with-check-box') do
       styled_check_box_tag("settings[#{setting}][]", value,
                            Setting.send(setting).include?(value), choice_options) + text.to_s
-
     end
   end
 

--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -707,8 +707,7 @@ Settings::Definition.define do
 
   # Display update / security badge, enabled by default
   add :security_badge_displayed,
-      value: true,
-      writable: false
+      value: true
 
   add :security_badge_url,
       value: "https://releases.openproject.com/v1/check.svg",

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -114,7 +114,8 @@ describe SettingsHelper, type: :helper do
                 .and_return false
       end
 
-      it 'is disabled' do
+      it 'is disabled and has no hidden field' do
+        expect(output).not_to have_selector 'input[type="hidden"][value="''"]', visible: :all
         expect(output).to have_selector 'input[type="checkbox"][disabled="disabled"].form--check-box', count: 3
       end
     end
@@ -275,8 +276,21 @@ important text</textarea>
       it_behaves_like 'field disabled if non writable'
 
       it 'outputs element' do
+        expect(output).to have_selector 'input[type="hidden"][value=0]', visible: :hidden
         expect(output).to have_selector 'input[type="checkbox"].custom-class.form--check-box'
         expect(output).to have_checked_field 'settings_field'
+      end
+
+      context 'when the setting isn`t writable' do
+        before do
+          allow(Setting)
+            .to receive(:field_writable?)
+                  .and_return false
+        end
+
+        it 'does not output a hidden field' do
+          expect(output).not_to have_selector 'input[type="hidden"][value=0]', visible: :hidden
+        end
       end
     end
 
@@ -291,8 +305,21 @@ important text</textarea>
       it_behaves_like 'field disabled if non writable'
 
       it 'outputs element' do
+        expect(output).to have_selector 'input[type="hidden"][value=0]', visible: :hidden
         expect(output).to have_selector 'input[type="checkbox"].custom-class.form--check-box'
         expect(output).to have_unchecked_field 'settings_field'
+      end
+
+      context 'when the setting isn`t writable' do
+        before do
+          allow(Setting)
+            .to receive(:field_writable?)
+                  .and_return false
+        end
+
+        it 'does not output a hidden field' do
+          expect(output).not_to have_selector 'input[type="hidden"][value=0]', visible: :hidden
+        end
       end
     end
   end

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -115,7 +115,7 @@ describe SettingsHelper, type: :helper do
       end
 
       it 'is disabled and has no hidden field' do
-        expect(output).not_to have_selector 'input[type="hidden"][value="''"]', visible: :all
+        expect(output).not_to have_selector 'input[type="hidden"][value=""]', visible: :all
         expect(output).to have_selector 'input[type="checkbox"][disabled="disabled"].form--check-box', count: 3
       end
     end


### PR DESCRIPTION
Non writable settings, e.g. because they have been defined within the configuration.yml, cannot be changed in the UI so an error is thrown if that is attempted. Because of that, the frontend should not send a value for those fields at all. In the case of  checkboxes there normally is a hidden field so that the unchecked case if covered. That field needs to not be there if the field is non writable.

Additionally, the setting governing whether a security badge is displayed does have a UI so it should be writable.

https://community.openproject.org/wp/41844