### PR TITLE
Fix/avoid settings leak between tests

### DIFF
--- a/modules/budgets/spec/lib/api/v3/queries/schemas/cost_object_dependency_representer_spec.rb
+++ b/modules/budgets/spec/lib/api/v3/queries/schemas/cost_object_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::BudgetFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::BudgetFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/modules/xls_export/spec/models/xls_export/project/exporter/xls_integration_spec.rb
+++ b/modules/xls_export/spec/models/xls_export/project/exporter/xls_integration_spec.rb
@@ -32,12 +32,8 @@ describe XlsExport::Project::Exporter::XLS do
   end
 
   context 'with status_explanation enabled' do
-    around do |example|
-      enabled_columns_value = Setting.enabled_projects_columns.dup
+    before do
       Setting.enabled_projects_columns += ["status_explanation"]
-      example.run
-    ensure
-      Setting.enabled_projects_columns = enabled_columns_value
     end
 
     it 'performs a successful export' do
@@ -49,12 +45,8 @@ describe XlsExport::Project::Exporter::XLS do
   end
 
   describe 'custom field columns selected' do
-    around do |example|
-      enabled_columns_value = Setting.enabled_projects_columns.dup
+    before do
       Setting.enabled_projects_columns += custom_fields.map { |cf| "cf_#{cf.id}" }
-      example.run
-    ensure
-      Setting.enabled_projects_columns = enabled_columns_value
     end
 
     context 'when ee enabled', with_ee: %i[custom_fields_in_projects_list] do

--- a/spec/features/auth/auth_source_sso_login_spec.rb
+++ b/spec/features/auth/auth_source_sso_login_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe 'Login with auth source SSO', type: :feature, clear_cache: true do
+describe 'Login with auth source SSO', type: :feature do
   before do
     if sso_config
       allow(OpenProject::Configuration)

--- a/spec/features/auth/login_spec.rb
+++ b/spec/features/auth/login_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe 'Login', type: :feature, clear_cache: true do
+describe 'Login', type: :feature do
   before do
     @capybara_ignore_elements = Capybara.ignore_hidden_elements
     Capybara.ignore_hidden_elements = true

--- a/spec/features/custom_fields/multi_value_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_value_custom_field_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "support/pages/work_packages/abstract_work_package"
 
-describe "multi select custom values", clear_cache: true, js: true do
+describe "multi select custom values", js: true do
   let(:type) { create :type }
   let(:project) { create :project, types: [type] }
   let(:multi_value) { true }

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -30,7 +30,6 @@ require 'spec_helper'
 
 describe 'Projects index page',
          type: :feature,
-         clear_cache: true,
          js: true,
          with_settings: { login_required?: false } do
   shared_let(:admin) { create :admin }

--- a/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
+++ b/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
@@ -108,7 +108,7 @@ describe 'Work package with relation query group', js: true, selenium: true do
     end
   end
 
-  describe 'follower table with project filters', clear_cache: true do
+  describe 'follower table with project filters' do
     let(:visit) { false }
     let!(:project2) { create(:project, types: [type]) }
     let!(:project3) { create(:project, types: [type]) }

--- a/spec/lib/api/v3/queries/columns/query_property_column_representer_spec.rb
+++ b/spec/lib/api/v3/queries/columns/query_property_column_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Columns::QueryPropertyColumnRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Columns::QueryPropertyColumnRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:column) { Query.available_columns.detect { |column| column.name == :status } }

--- a/spec/lib/api/v3/queries/columns/query_relation_of_type_column_representer_spec.rb
+++ b/spec/lib/api/v3/queries/columns/query_relation_of_type_column_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Columns::QueryRelationOfTypeColumnRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Columns::QueryRelationOfTypeColumnRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:type) { { name: :label_relates_to, sym_name: :label_relates_to, order: 1, sym: :relation1 } }

--- a/spec/lib/api/v3/queries/columns/query_relation_to_type_column_representer_spec.rb
+++ b/spec/lib/api/v3/queries/columns/query_relation_to_type_column_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Columns::QueryRelationToTypeColumnRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Columns::QueryRelationToTypeColumnRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:type) { build_stubbed(:type) }

--- a/spec/lib/api/v3/queries/group_bys/query_group_by_representer_spec.rb
+++ b/spec/lib/api/v3/queries/group_bys/query_group_by_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::GroupBys::QueryGroupByRepresenter, clear_cache: true do
+describe ::API::V3::Queries::GroupBys::QueryGroupByRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:column) { Query.available_columns.detect { |column| column.name == :status } }

--- a/spec/lib/api/v3/queries/schemas/all_principals_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/all_principals_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::AllPrincipalsFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::AllPrincipalsFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/blocks_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/blocks_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 5
-describe ::API::V3::Queries::Schemas::BlocksFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::BlocksFilterDependencyRepresenter do
   it_behaves_like 'relation filter dependency' do
     let(:filter) { Queries::WorkPackages::Filter::BlocksFilter.create!(context: query) }
   end

--- a/spec/lib/api/v3/queries/schemas/boolean_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/boolean_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::BooleanFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::BooleanFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/category_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/category_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::CategoryFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::CategoryFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/custom_option_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/custom_option_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::CustomOptionFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::CustomOptionFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/date_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/date_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::DateFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::DateFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/date_time_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/date_time_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::DateTimeFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::DateTimeFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/duplicated_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/duplicated_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 5
-describe ::API::V3::Queries::Schemas::DuplicatedFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::DuplicatedFilterDependencyRepresenter do
   it_behaves_like 'relation filter dependency' do
     let(:filter) { Queries::WorkPackages::Filter::DuplicatedFilter.create!(context: query) }
   end

--- a/spec/lib/api/v3/queries/schemas/duplicates_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/duplicates_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 5
-describe ::API::V3::Queries::Schemas::DuplicatesFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::DuplicatesFilterDependencyRepresenter do
   it_behaves_like 'relation filter dependency' do
     let(:filter) { Queries::WorkPackages::Filter::DuplicatesFilter.create!(context: query) }
   end

--- a/spec/lib/api/v3/queries/schemas/float_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/float_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::FloatFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::FloatFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/follows_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/follows_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::FollowsFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::FollowsFilterDependencyRepresenter do
   it_behaves_like 'relation filter dependency' do
     let(:filter) { Queries::WorkPackages::Filter::FollowsFilter.create!(context: query) }
   end

--- a/spec/lib/api/v3/queries/schemas/group_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/group_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::GroupFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::GroupFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/id_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/id_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::IdFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::IdFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/includes_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/includes_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 5
-describe ::API::V3::Queries::Schemas::IncludesFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::IncludesFilterDependencyRepresenter do
   it_behaves_like 'relation filter dependency' do
     let(:filter) { Queries::WorkPackages::Filter::IncludesFilter.create!(context: query) }
   end

--- a/spec/lib/api/v3/queries/schemas/integer_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/integer_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::IntegerFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::IntegerFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/parent_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/parent_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::ParentFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::ParentFilterDependencyRepresenter do
   it_behaves_like 'relation filter dependency' do
     let(:filter) { Queries::WorkPackages::Filter::ParentFilter.create!(context: query) }
   end

--- a/spec/lib/api/v3/queries/schemas/partof_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/partof_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 5
-describe ::API::V3::Queries::Schemas::PartofFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::PartofFilterDependencyRepresenter do
   it_behaves_like 'relation filter dependency' do
     let(:filter) { Queries::WorkPackages::Filter::PartofFilter.create!(context: query) }
   end

--- a/spec/lib/api/v3/queries/schemas/precedes_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/precedes_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 5
-describe ::API::V3::Queries::Schemas::PrecedesFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::PrecedesFilterDependencyRepresenter do
   it_behaves_like 'relation filter dependency' do
     let(:filter) { Queries::WorkPackages::Filter::PrecedesFilter.create!(context: query) }
   end

--- a/spec/lib/api/v3/queries/schemas/priority_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/priority_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::PriorityFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::PriorityFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/project_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/project_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::ProjectFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::ProjectFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:filter) { Queries::WorkPackages::Filter::ProjectFilter.create! }

--- a/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/query_filter_instance_schema_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::QueryFilterInstanceSchemaRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:filter) { Queries::WorkPackages::Filter::StatusFilter.create! }

--- a/spec/lib/api/v3/queries/schemas/relates_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/relates_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 5
-describe ::API::V3::Queries::Schemas::RelatesFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::RelatesFilterDependencyRepresenter do
   it_behaves_like 'relation filter dependency' do
     let(:filter) { Queries::WorkPackages::Filter::RelatesFilter.create!(context: query) }
   end

--- a/spec/lib/api/v3/queries/schemas/required_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/required_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 5
-describe ::API::V3::Queries::Schemas::RequiredFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::RequiredFilterDependencyRepresenter do
   it_behaves_like 'relation filter dependency' do
     let(:filter) { Queries::WorkPackages::Filter::RequiredFilter.create!(context: query) }
   end

--- a/spec/lib/api/v3/queries/schemas/requires_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/requires_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 5
-describe ::API::V3::Queries::Schemas::RequiresFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::RequiresFilterDependencyRepresenter do
   it_behaves_like 'relation filter dependency' do
     let(:filter) { Queries::WorkPackages::Filter::RequiresFilter.create!(context: query) }
   end

--- a/spec/lib/api/v3/queries/schemas/role_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/role_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::RoleFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::RoleFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:filter) { Queries::WorkPackages::Filter::RoleFilter.create! }

--- a/spec/lib/api/v3/queries/schemas/status_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/status_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::StatusFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::StatusFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:filter) { Queries::WorkPackages::Filter::StatusFilter.create! }

--- a/spec/lib/api/v3/queries/schemas/subproject_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/subproject_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::SubprojectFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::SubprojectFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/text_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/text_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::TextFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::TextFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/type_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/type_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::TypeFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::TypeFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/user_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::UserFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::UserFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed :project }

--- a/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/version_filter_dependency_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::Schemas::VersionFilterDependencyRepresenter, clear_cache: true do
+describe ::API::V3::Queries::Schemas::VersionFilterDependencyRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:project) { build_stubbed(:project) }

--- a/spec/lib/api/v3/queries/sort_bys/query_sort_by_representer_spec.rb
+++ b/spec/lib/api/v3/queries/sort_bys/query_sort_by_representer_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Queries::SortBys::QuerySortByRepresenter, clear_cache: true do
+describe ::API::V3::Queries::SortBys::QuerySortByRepresenter do
   include ::API::V3::Utilities::PathHelper
 
   let(:column_name) { 'status' }

--- a/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
+++ b/spec/lib/api/v3/utilities/custom_field_injector_spec.rb
@@ -28,7 +28,7 @@
 
 require 'spec_helper'
 
-describe ::API::V3::Utilities::CustomFieldInjector, clear_cache: true do
+describe ::API::V3::Utilities::CustomFieldInjector do
   include API::V3::Utilities::PathHelper
 
   let(:cf_path) { "customField#{custom_field.id}" }

--- a/spec/lib/open_project/configuration_spec.rb
+++ b/spec/lib/open_project/configuration_spec.rb
@@ -38,7 +38,6 @@ describe OpenProject::Configuration do
   after do
     Settings::Definition.send(:reset)
     Settings::Definition.instance_variable_set(:@all, definitions_before)
-    Setting.clear_cache
   end
 
   describe '.[setting]' do

--- a/spec/models/projects/exporter/csv_integration_spec.rb
+++ b/spec/models/projects/exporter/csv_integration_spec.rb
@@ -70,7 +70,7 @@ describe Projects::Exports::CSV, 'integration', type: :model do
         expect(parsed.size).to eq 2
 
         cf_names = custom_fields.map(&:name)
-        expect(header).to eq ['id', 'Identifier', 'Name', 'Description', 'Status', 'Status description', 'Public', *cf_names]
+        expect(header).to eq ['id', 'Identifier', 'Name', 'Description', 'Status', 'Public', *cf_names]
 
         custom_values = custom_fields.map do |cf|
           case cf
@@ -84,13 +84,13 @@ describe Projects::Exports::CSV, 'integration', type: :model do
         end
         expect(rows.first)
           .to eq [project.id.to_s, project.identifier, project.name,
-                  project.description, 'Off track', '', 'false', *custom_values]
+                  project.description, 'Off track', 'false', *custom_values]
       end
     end
 
     context 'when ee not enabled' do
       it 'renders only the default columns' do
-        expect(header).to eq %w[id Identifier Name Description Status Status\ description Public]
+        expect(header).to eq %w[id Identifier Name Description Status Public]
       end
     end
   end

--- a/spec/support/shared/clear_cache.rb
+++ b/spec/support/shared/clear_cache.rb
@@ -27,12 +27,7 @@
 #++
 
 RSpec.configure do |config|
-  config.around(:each) do |example|
-    clear_cache = example.metadata[:clear_cache]
-    OpenProject::Cache.clear if clear_cache
-
-    example.run
-
-    OpenProject::Cache.clear if clear_cache
+  config.before do
+    OpenProject::Cache.clear
   end
 end


### PR DESCRIPTION
Settings are cached in `Rails.cache` with a key having the timestamp of the latest updated setting. When no settings are saved, current time is used instead.

For fast tests occurring in the same second, the settings state is kept as they share the same cache key. That leads to non-isolated tests and possibly failures. Clearing the Rails cache before each test avoids it.