### PR TITLE
[#41712] Redundant heading in file section (files + attachments)

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.html
@@ -1,5 +1,6 @@
 <div class="work-packages--attachments-container">
-  <div class="attributes-group--header">
+  <!-- The condition below will get replaced when implementing #41905. -->
+  <div *ngIf="false" class="attributes-group--header">
     <div class="attributes-group--header-container">
       <h3 class="attributes-group--header-text" [textContent]="text.attachments.label"></h3>
     </div>


### PR DESCRIPTION
https://community.openproject.org/work_packages/41712

Introduced temporary if condition to hide "Attachments" section in WP
file tab.