### PR TITLE
Change alignment for editable toolbar titles

### DIFF
--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-partitioned-page.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-partitioned-page.component.ts
@@ -76,7 +76,7 @@ export class BoardPartitionedPageComponent extends UntilDestroyedMixin {
   editable:boolean;
 
   /** Go back to boards using back-button */
-  backButtonCallback = () => this.state.go('boards');
+  backButtonCallback:() => void;
 
   /** Current query title to render */
   selectedTitle?:string;

--- a/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
+++ b/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.sass
@@ -8,6 +8,10 @@
   grid-template-columns: 1fr
   grid-template-rows: auto auto minmax(200px, 1fr)
 
+  margin-left: -10px
+  padding-left: 10px
+  width: calc(100% + 10px)
+
   &.-right-only
     .work-packages-partitioned-page--content-left
       display: none

--- a/frontend/src/app/shared/components/editable-toolbar-title/editable-toolbar-title.component.ts
+++ b/frontend/src/app/shared/components/editable-toolbar-title/editable-toolbar-title.component.ts
@@ -48,7 +48,7 @@ export const selectableTitleIdentifier = 'editable-toolbar-title';
   selector: 'editable-toolbar-title',
   templateUrl: './editable-toolbar-title.html',
   styleUrls: ['./editable-toolbar-title.sass'],
-  host: { class: 'title-container' },
+  host: { class: 'title-container title-container_editable' },
 })
 export class EditableToolbarTitleComponent implements OnInit, OnChanges {
   @Input('title') public inputTitle:string;

--- a/frontend/src/app/shared/components/editable-toolbar-title/editable-toolbar-title.component.ts
+++ b/frontend/src/app/shared/components/editable-toolbar-title/editable-toolbar-title.component.ts
@@ -29,6 +29,7 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  HostBinding,
   Injector,
   Input,
   OnChanges,
@@ -48,7 +49,6 @@ export const selectableTitleIdentifier = 'editable-toolbar-title';
   selector: 'editable-toolbar-title',
   templateUrl: './editable-toolbar-title.html',
   styleUrls: ['./editable-toolbar-title.sass'],
-  host: { class: 'title-container title-container_editable' },
 })
 export class EditableToolbarTitleComponent implements OnInit, OnChanges {
   @Input('title') public inputTitle:string;
@@ -66,6 +66,10 @@ export class EditableToolbarTitleComponent implements OnInit, OnChanges {
   @Output() public onSave = new EventEmitter<string>();
 
   @Output() public onEmptySubmit = new EventEmitter<void>();
+
+  @HostBinding('class.title-container') baseClass = true;
+
+  @HostBinding('class.title-container_editable') editableClass = true;
 
   @ViewChild('editableTitleInput') inputField?:ElementRef;
 

--- a/frontend/src/global_styles/layout/_base.sass
+++ b/frontend/src/global_styles/layout/_base.sass
@@ -48,7 +48,7 @@
   @include default-transition
   @include styled-scroll-bar
   margin: 0 0 0 0
-  padding: 10px 20px
+  padding: 0px
   // Needed for Safari
   height: calc(100vh - var(--header-height))
   overflow-y: auto
@@ -65,6 +65,7 @@
 
 #content
   padding: 0
+  padding: 10px 20px
   margin: 0
   width: 100%
   z-index: 10

--- a/frontend/src/global_styles/layout/_breadcrumb.sass
+++ b/frontend/src/global_styles/layout/_breadcrumb.sass
@@ -29,5 +29,8 @@
 #breadcrumb
   @include global-breadcrumb-styles
   min-height: var(--breadcrumb-height)
+  padding: 10px 20px
+  padding-bottom: 0
+
   li
     white-space: nowrap

--- a/frontend/src/global_styles/layout/_toolbar.sass
+++ b/frontend/src/global_styles/layout/_toolbar.sass
@@ -212,6 +212,9 @@ $nm-color-success-background: #d8fdd1
   &.-no-grow
     flex-grow: 0
 
+  &_editable
+    margin-left: -7px
+
   h2
     @include text-shortener
     padding: 0

--- a/frontend/src/global_styles/vendor/_full_calendar.sass
+++ b/frontend/src/global_styles/vendor/_full_calendar.sass
@@ -145,7 +145,8 @@
 
       // ensure to have higher specificity than above extend
       .fc-button-group
-        margin-left: 8px
+        &:not(:first-child)
+          margin-left: 8px
         .fc-button
           margin-right: 0
           margin-bottom: 0

--- a/modules/boards/spec/features/support/board_page.rb
+++ b/modules/boards/spec/features/support/board_page.rb
@@ -34,6 +34,8 @@ module Pages
     include ::Components::NgSelectAutocompleteHelpers
 
     def initialize(board)
+      super()
+
       @board = board
     end
 
@@ -131,7 +133,9 @@ module Pages
     # Expect the given titled card in the list name to be present (expect=true) or not (expect=false)
     def expect_card(list_name, card_title, present: true)
       within_list(list_name) do
-        expect(page).to have_conditional_selector(present, '[data-qa-selector="op-wp-single-card--content-subject"]', text: card_title)
+        expect(page).to have_conditional_selector(present,
+                                                  '[data-qa-selector="op-wp-single-card--content-subject"]',
+                                                  text: card_title)
       end
     end
 
@@ -152,7 +156,9 @@ module Pages
     def expect_movable(list_name, card_title, movable: true)
       within_list(list_name) do
         expect(page).to have_selector('[data-qa-selector="op-wp-single-card"]', text: card_title)
-        expect(page).to have_conditional_selector(movable, '[data-qa-selector="op-wp-single-card"][data-qa-draggable]', text: card_title)
+        expect(page).to have_conditional_selector(movable,
+                                                  '[data-qa-selector="op-wp-single-card"][data-qa-draggable]',
+                                                  text: card_title)
       end
     end
 
@@ -183,7 +189,7 @@ module Pages
     def add_list_with_new_value(name)
       open_and_fill_add_list_modal name
 
-      page.find('.op-select-footer--label', text: 'Create ' + name).click
+      page.find('.op-select-footer--label', text: "Create #{name}").click
     end
 
     def save
@@ -260,7 +266,9 @@ module Pages
     end
 
     def back_to_index
-      find('[data-qa-selector="op-back-button"]').click
+      within '#main-menu' do
+        click_link 'Boards'
+      end
     end
 
     def expect_editable_board(editable)

--- a/modules/team_planner/spec/support/pages/team_planner.rb
+++ b/modules/team_planner/spec/support/pages/team_planner.rb
@@ -183,9 +183,10 @@ module Pages
     end
 
     def drag_to_remove_dropzone(work_package, expect_removable: true)
-      source = event(work_package)
-
-      start_dragging(source)
+      retry_block do
+        source = event(work_package)
+        start_dragging(source)
+      end
 
       # Move the footer first to signal we're dragging something
       footer = find('[data-qa-selector="op-team-planner-footer"]')


### PR DESCRIPTION
Does three things;

1. Change alignment for editable toolbar titles

This is a rather dirty but workable global change to the CSS that moves editable toolbar titles to be on the same
vertical alignment when compared to the rest of the page. When editing or hovering these titles, a box appears
around them (indicating an input field). This box would now be moved outside the parent, getting cut off because 
of specific scrollbar and padding placements. Since the previous CSS assumed paddings farther up the HTML 
tree and the scrolling to happen inside these paddings, we've had to move the paddings further down the HTML 
tree, slightly complicating how they're applied. However, this makes the change possible with minimal changes.

2. Fix side padding of full calendar button groups
3. Remove back button from boards

See this comment: https://community.openproject.org/work_packages/41710/activity#activity-12
Closes https://community.openproject.org/work_packages/41710/activity