### PR TITLE
[#41728] Wiki updated notification: "Updated by" is shown to always b…

### DIFF
--- a/app/services/wiki_pages/update_service.rb
+++ b/app/services/wiki_pages/update_service.rb
@@ -36,7 +36,6 @@ class WikiPages::UpdateService < ::BaseServices::Update
 
     page = service_result.result
     content = page.content
-    content.author_id = user.id
 
     unless page.save && content.save
       service_result.errors = page.errors

--- a/app/views/user_mailer/wiki_content_updated.html.erb
+++ b/app/views/user_mailer/wiki_content_updated.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 <p>
   <%=raw t(:mail_body_wiki_content_updated,
                id: link_to(@wiki_content.page.title, project_wiki_url(@wiki_content.page.project, @wiki_content.page)),
-               author: @wiki_content.author) %><br />
+               author: @wiki_content.journals.last.user) %><br />
   <em><%= @wiki_content.journals.last.notes %></em>
 </p>
 

--- a/app/views/user_mailer/wiki_content_updated.text.erb
+++ b/app/views/user_mailer/wiki_content_updated.text.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= t(:mail_body_wiki_content_updated,
           id: @wiki_content.page.title,
-          author: @wiki_content.author) %>
+          author: @wiki_content.journals.last.user) %>
 <%= @wiki_content.journals.last.notes %>
 
 <%= project_wiki_url(@wiki_content.page.project, @wiki_content.page) %>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -130,15 +130,21 @@ describe UserMailer, type: :mailer do
 
   describe '#wiki_content_updated' do
     let(:wiki_content) { create(:wiki_content) }
+    let(:wiki_content_journal) { build_stubbed(:wiki_content_journal) }
 
     before do
+      allow(wiki_content).to receive(:journals).and_return([wiki_content_journal])
       described_class.wiki_content_updated(recipient, wiki_content).deliver_now
     end
 
     it_behaves_like 'mail is sent'
 
     it 'links to the latest version diff page' do
-      expect(deliveries.first.body.encoded).to include 'diff/1'
+      expect(deliveries.first.body.encoded).to include "diff/#{wiki_content.version}"
+    end
+
+    it 'uses the author from the journal' do
+      expect(deliveries.first.body.encoded).to include wiki_content_journal.user.name
     end
   end
 


### PR DESCRIPTION
…e the "author"

https://community.openproject.org/work_packages/41728

- No longer overwrite Wiki page author with last editor
- Use user from Wiki page journal as author for mail notification