### PR TITLE
[41649] Allow embedded bootstrap within boostrapped components

### DIFF
--- a/frontend/src/app/core/setup/globals/dynamic-bootstrapper.ts
+++ b/frontend/src/app/core/setup/globals/dynamic-bootstrapper.ts
@@ -116,7 +116,7 @@ export class DynamicBootstrapper {
         for (let i = 0; i < elements.length; i++) {
           const target = elements[i];
 
-          if (target.closest('[op-dynamic-bootstrap]')) {
+          if (!embedded && target.closest('[op-dynamic-bootstrap]')) {
             debugLog(`Skipping nested bootstrap ${el.selector} in %O`, target);
             return;
           }

--- a/spec/features/work_packages/details/markdown/activity_comments_spec.rb
+++ b/spec/features/work_packages/details/markdown/activity_comments_spec.rb
@@ -217,6 +217,32 @@ describe 'activity comments', js: true, with_mail: false do
         wp_page.expect_comment subselector: 'strong', text: 'a bold'
       end
     end
+
+    describe 'referencing another work package' do
+      let!(:work_package2) { create(:work_package, project: project) }
+
+      it 'can reference another work package with all methods' do
+        comment_field.activate!
+
+        # Insert new text, need to do this separately.
+        [
+          "Single ##{work_package2.id}",
+          :return,
+          "Double ###{work_package2.id}",
+          :return,
+          "Triple ####{work_package2.id}",
+          :return
+        ].each do |key|
+          comment_field.input_element.send_keys key
+        end
+
+        comment_field.submit_by_click
+
+        wp_page.expect_comment text: "Single ##{work_package2.id}"
+        expect(page).to have_selector('.user-comment .macro--wp-quickinfo', count: 2)
+        expect(page).to have_selector('.user-comment .work-package--quickinfo.preview-trigger', count: 2)
+      end
+    end
   end
 
   context 'with no permission' do


### PR DESCRIPTION
Embeddable components need to be bootstrapped even if they are within another bootstrapped component.

As the application root component is also dynamically bootstrapped, otherwise no embeddable component would have been bootstrapped.

https://community.openproject.org/wp/41649