### PR TITLE
[41718] Filter query filter values in the frontend

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -301,10 +301,8 @@ export class OpAutocompleterComponent extends UntilDestroyedMixin implements Aft
   }
 
   public opened(_:unknown) { // eslint-disable-line no-unused-vars
-    if (this.openDirectly) {
-      this.typeahead.next('');
-    }
-
+    // Re-search for empty value as search value gets removed
+    this.typeahead.next('');
     this.repositionDropdown();
     this.open.emit();
   }


### PR DESCRIPTION
Modify the query filter autocompleters to do the following:

- Load an initial request when opening with pageSize -1. If total == count, filter values in the frontend instead of sending additional requests
- If total > count, request each input to the backend

If we loaded all values in the first run, filter them in the frontend. The backend does not provide queries and typeahead filters for all resources, and we can avoid additional requests if we just filter them here.

:warning:  Note that if more than the max API size items are returned, and the backend does not provide any filtering, this will result in all items being shown at all times.

The backend should still add typahead filters for as many resources as possible to fix this issue, but this will fix the happy case.

https://community.openproject.org/wp/41718