### PR TITLE
Fix team planner scroll behaviour

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -362,6 +362,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
       .then(() => {
         this.calendarOptions$.next(
           this.calendar.calendarOptions({
+            height: '100%',
             schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
             selectable: true,
             plugins: [resourceTimelinePlugin, interactionPlugin],

--- a/frontend/src/global_styles/vendor/_full_calendar.sass
+++ b/frontend/src/global_styles/vendor/_full_calendar.sass
@@ -177,9 +177,6 @@
 
     thead .fc-scroller
       @include no-visible-scroll-bar
-
-    .fc-scroller-liquid-absolute
-      @include styled-scroll-bar
   // ------------------------ END: Calendar toolbar ------------------------
   // -------
   // ------------------------ END: Full calendar overwrite ------------------------

--- a/frontend/src/global_styles/vendor/_full_calendar.sass
+++ b/frontend/src/global_styles/vendor/_full_calendar.sass
@@ -178,6 +178,8 @@
     thead .fc-scroller
       @include no-visible-scroll-bar
 
+    .fc-scroller-liquid-absolute
+      @include styled-scroll-bar
   // ------------------------ END: Calendar toolbar ------------------------
   // -------
   // ------------------------ END: Full calendar overwrite ------------------------


### PR DESCRIPTION
This makes the team planner [age scroll internally along the assignee list only, keeping the rest of the page static

Closes https://community.openproject.org/work_packages/41711/activity

