### PR TITLE
[41698] Global search: Text input dissapears if you tab to the search icon

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -169,7 +169,7 @@ RSpec/MultipleExpectations:
     - 'modules/*/spec/features/**/*.rb'
 
 RSpec/MultipleMemoizedHelpers:
-  Max: 15
+  Max: 20
   AllowSubject: true
 
 RSpec/NestedGroups:

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -27,7 +27,7 @@
     (blur)="onFocusOut()"
     (search)="search($event)"
     (open)="openCloseMenu(currentValue)"
-    (close)="select.searchTerm = currentValue"
+    (close)="onClose()"
     (change)="followItem($event)"
     (keydown.enter)="onEnterBeforeResultsLoaded()"
     (keydown.escape)="blur()"

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -8,7 +8,7 @@
   >
     <i class="icon-arrow-left1" aria-hidden="true"></i>
   </button>
-
+  
   <op-autocompleter
     #select
     [defaultData]="false"

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -8,7 +8,7 @@
   >
     <i class="icon-arrow-left1" aria-hidden="true"></i>
   </button>
-  
+
   <op-autocompleter
     #select
     [defaultData]="false"

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -58,7 +58,7 @@ import { ApiV3Service } from '../../apiv3/api-v3.service';
 export const globalSearchSelector = 'global-search-input';
 
 interface SearchResultItems {
-  items:SearchResultItem|SearchOptionItem[];
+  items:SearchResultItem[]|SearchOptionItem[];
   term:string;
 }
 

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -57,6 +57,11 @@ import { ApiV3Service } from '../../apiv3/api-v3.service';
 
 export const globalSearchSelector = 'global-search-input';
 
+interface SearchResultItems {
+  items:[];
+  term:string;
+}
+
 interface SearchResultItem {
   id:string;
   subject:string;
@@ -138,7 +143,8 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
 
   ngAfterViewInit():void {
     // check searchterm on init, expand / collapse search bar and set correct classes
-    this.ngSelectComponent.ngSelectInstance.searchTerm = this.currentValue = this.globalSearchService.searchTerm;
+    this.ngSelectComponent.ngSelectInstance.searchTerm = this.globalSearchService.searchTerm;
+    this.currentValue = this.globalSearchService.searchTerm;
     this.expanded = (this.ngSelectComponent.ngSelectInstance.searchTerm.length > 0);
     this.toggleTopMenuClass();
   }
@@ -192,7 +198,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     return Highlighting.inlineClass(property, id);
   }
 
-  public search($event:any) {
+  public search($event:SearchResultItems) {
     this.currentValue = this.ngSelectComponent.ngSelectInstance.searchTerm;
     this.openCloseMenu($event.term);
   }
@@ -217,8 +223,13 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     }
   }
 
+  public onClose() {
+    this.ngSelectComponent.ngSelectInstance.searchTerm = this.currentValue;
+  }
+
   public clearSearch() {
-    this.currentValue = this.ngSelectComponent.ngSelectInstance.searchTerm = '';
+    this.currentValue = '';
+    this.ngSelectComponent.ngSelectInstance.searchTerm = '';
     this.openCloseMenu(this.currentValue);
   }
 
@@ -235,10 +246,6 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
 
   public statusHighlighting(statusId:string) {
     return Highlighting.inlineClass('status', statusId);
-  }
-
-  private get isDirectHit() {
-    return this.selectedItem && this.selectedItem.hasOwnProperty('id');
   }
 
   public followItem(item:WorkPackageResource|SearchOptionItem) {
@@ -259,7 +266,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
   }
 
   // return all project scope items and all items which contain the search term
-  public customSearchFn(term:string, item:any):boolean {
+  public customSearchFn(term:string, item:SearchResultItem):boolean {
     return item.id === undefined || item.subject.toLowerCase().indexOf(term.toLowerCase()) !== -1;
   }
 

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -58,7 +58,7 @@ import { ApiV3Service } from '../../apiv3/api-v3.service';
 export const globalSearchSelector = 'global-search-input';
 
 interface SearchResultItems {
-  items:[];
+  items:SearchResultItem|SearchOptionItem[];
   term:string;
 }
 
@@ -143,14 +143,21 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
 
   ngAfterViewInit():void {
     // check searchterm on init, expand / collapse search bar and set correct classes
-    this.ngSelectComponent.ngSelectInstance.searchTerm = this.globalSearchService.searchTerm;
-    this.currentValue = this.globalSearchService.searchTerm;
-    this.expanded = (this.ngSelectComponent.ngSelectInstance.searchTerm.length > 0);
+    this.searchTerm = this.globalSearchService.searchTerm;
+    this.currentValue = '';
     this.toggleTopMenuClass();
   }
 
   ngOnDestroy():void {
     this.unregister();
+  }
+
+  public set searchTerm(searchTerm:string) {
+    this.ngSelectComponent.ngSelectInstance.searchTerm = searchTerm;
+  }
+
+  public get searchTerm():string {
+    return this.ngSelectComponent.ngSelectInstance.searchTerm;
   }
 
   // detect if click is outside or inside the element
@@ -165,7 +172,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
         this.toggleMobileSearch();
         // open ng-select menu on default
         jQuery('.ng-input input').focus();
-      } else if (this.ngSelectComponent.ngSelectInstance.searchTerm?.length === 0) {
+      } else if (this.searchTerm?.length === 0) {
         this.ngSelectComponent.ngSelectInstance.focus();
       } else {
         this.submitNonEmptySearch();
@@ -198,8 +205,8 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     return Highlighting.inlineClass(property, id);
   }
 
-  public search($event:SearchResultItems) {
-    this.currentValue = this.ngSelectComponent.ngSelectInstance.searchTerm;
+  public search($event:SearchResultItems):void {
+    this.currentValue = this.searchTerm;
     this.openCloseMenu($event.term);
   }
 
@@ -216,20 +223,20 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
 
   public onFocusOut() {
     if (!this.deviceService.isMobile) {
-      this.expanded = (this.ngSelectComponent.ngSelectInstance.searchTerm !== null && this.ngSelectComponent.ngSelectInstance.searchTerm.length > 0);
+      this.expanded = (this.searchTerm !== null && this.searchTerm.length > 0);
       this.ngSelectComponent.ngSelectInstance.isOpen = false;
       this.selectedItem = null;
       this.toggleTopMenuClass();
     }
   }
 
-  public onClose() {
-    this.ngSelectComponent.ngSelectInstance.searchTerm = this.currentValue;
+  public onClose():void {
+    this.searchTerm = this.currentValue;
   }
 
   public clearSearch() {
     this.currentValue = '';
-    this.ngSelectComponent.ngSelectInstance.searchTerm = '';
+    this.searchTerm = '';
     this.openCloseMenu(this.currentValue);
   }
 
@@ -407,7 +414,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
         && this.globalSearchService.currentTab === 'work_packages') {
         window.history
           .replaceState({},
-            `${I18n.t('global_search.search')}: ${this.ngSelectComponent.ngSelectInstance.searchTerm}`,
+            `${I18n.t('global_search.search')}: ${this.searchTerm}`,
             this.globalSearchService.searchPath());
 
         return;

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -28,7 +28,6 @@
 
 require 'spec_helper'
 
-# rubocop:disable RSpec:MultipleMemoizedHelpers
 describe 'Search', type: :feature, js: true, with_settings: { per_page_options: '5' }, with_mail: false do
   include ::Components::NgSelectAutocompleteHelpers
 
@@ -504,4 +503,3 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
     end
   end
 end
-# rubocop:enable RSpec:MultipleMemoizedHelpers

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -215,7 +215,6 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
       end
     end
 
-    # rubocop:disable RSpec/MultipleMemoizedHelpers
     context 'for project search' do
       let(:subproject) { create :project, parent: project }
       let!(:other_work_package) do
@@ -383,7 +382,6 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
       end
     end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
 
   describe 'search for projects' do
     let!(:searched_for_project) { create(:project, name: 'Searched for project') }
@@ -416,11 +414,11 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
 
         click_on 'Next', match: :first
         expect_range 1, 2
-        expect(current_path).to match "/projects/#{project.identifier}/search"
+        expect(page).to have_current_path /\/projects\/#{project.identifier}\/search/
 
         click_on 'Previous', match: :first
         expect_range 3, 12
-        expect(current_path).to match "/projects/#{project.identifier}/search"
+        expect(page).to have_current_path /\/projects\/#{project.identifier}\/search/
       end
     end
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -28,6 +28,7 @@
 
 require 'spec_helper'
 
+# rubocop:disable RSpec:MultipleMemoizedHelpers
 describe 'Search', type: :feature, js: true, with_settings: { per_page_options: '5' }, with_mail: false do
   include ::Components::NgSelectAutocompleteHelpers
 
@@ -85,8 +86,8 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
 
   let(:run_visit) { true }
 
-  def expect_range(a, b)
-    (a..b).each do |n|
+  def expect_range(param_a, param_b)
+    (param_a..param_b).each do |n|
       expect(page).to have_content("No. #{n} WP")
       expect(page).to have_selector("a[href*='#{work_package_path(work_packages[n - 1].id)}']")
     end
@@ -132,7 +133,8 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
       expect(page)
         .to have_selector('.subject', text: target_work_package.subject)
 
-      expect(current_path).to eql project_work_package_path(target_work_package.project, target_work_package, state: 'activity')
+      expect(page)
+        .to have_current_path project_work_package_path(target_work_package.project, target_work_package, state: 'activity')
 
       search_target = work_packages.last
 
@@ -148,7 +150,8 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
       expect(page)
         .to have_selector('.subject', text: search_target.subject)
 
-      expect(current_path).to eql project_work_package_path(search_target.project, search_target, state: 'activity')
+      expect(page)
+        .to have_current_path project_work_package_path(search_target.project, search_target, state: 'activity')
 
       # Typing a hash sign before an ID shall only suggest that work package and (no hits within the subject)
       global_search.search("##{search_target.id}", submit: false)
@@ -162,46 +165,50 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
 
       # Selection project scope 'In all projects' redirects away from current project.
       global_search.submit_in_global_scope
-      expect(current_path).to match(/\/search/)
+      expect(page)
+      .to have_current_path (/\/search/)
       expect(current_url).to match(/\/search\?q=#{"%23#{search_target.id}"}&work_packages=1&scope=all$/)
     end
   end
 
   describe 'search for work packages' do
-    context 'search in all projects' do
+    context 'when search in all projects' do
       let(:params) { [project, { q: query, work_packages: 1 }] }
 
-      context 'custom fields not searchable' do
+      context 'as custom fields not searchable' do
         let(:searchable) { false }
 
         it "does not find WP via custom fields" do
           select_autocomplete(page.find('.top-menu-search--input'),
                               query: "text",
-                              select_text: "In all projects ↵")
+                              select_text: "In all projects ↵",
+                              wait_dropdown_open: false)
           table = Pages::EmbeddedWorkPackagesTable.new(find('.work-packages-embedded-view--container'))
           table.ensure_work_package_not_listed!(work_packages[0])
           table.ensure_work_package_not_listed!(work_packages[1])
         end
       end
 
-      context 'custom fields are no filters' do
+      context 'as custom fields are no filters' do
         let(:is_filter) { false }
 
         it "does not find WP via custom fields" do
           select_autocomplete(page.find('.top-menu-search--input'),
                               query: "text",
-                              select_text: "In all projects ↵")
+                              select_text: "In all projects ↵",
+                              wait_dropdown_open: false)
           table = Pages::EmbeddedWorkPackagesTable.new(find('.work-packages-embedded-view--container'))
           table.ensure_work_package_not_listed!(work_packages[0])
           table.ensure_work_package_not_listed!(work_packages[1])
         end
       end
 
-      context 'custom fields searchable' do
+      context 'as custom fields are searchable' do
         it "finds WP global custom fields" do
           select_autocomplete(page.find('.top-menu-search--input'),
                               query: "string",
-                              select_text: "In all projects ↵")
+                              select_text: "In all projects ↵",
+                              wait_dropdown_open: false)
           table = Pages::EmbeddedWorkPackagesTable.new(find('.work-packages-embedded-view--container'))
           table.ensure_work_package_not_listed!(work_packages[0])
           table.expect_work_package_subject(work_packages[1].subject)
@@ -210,7 +217,7 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
     end
 
     # rubocop:disable RSpec/MultipleMemoizedHelpers
-    context 'project search' do
+    context 'for project search' do
       let(:subproject) { create :project, parent: project }
       let!(:other_work_package) do
         create(:work_package, subject: 'Other work package', project: subproject)
@@ -293,7 +300,8 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
         # and expect that subproject's work packages will not be found
         table.ensure_work_package_not_listed! other_work_package
 
-        expect(current_url).to match(/\/#{project.identifier}\/search\?q=Other%20work%20package&work_packages=1&scope=current_project$/)
+        expect(current_url)
+          .to match(/\/#{project.identifier}\/search\?q=Other%20work%20package&work_packages=1&scope=current_project$/)
 
         # Expect to find custom field values
         # ...for type: text
@@ -382,11 +390,12 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
     let!(:searched_for_project) { create(:project, name: 'Searched for project') }
     let!(:other_project) { create(:project, name: 'Other project') }
 
-    context 'globally' do
+    context 'when globally' do
       it 'finds the project' do
         select_autocomplete(page.find('.top-menu-search--input'),
                             query: "Searched",
-                            select_text: "In all projects ↵")
+                            select_text: "In all projects ↵",
+                            wait_dropdown_open: false)
 
         within '.global-search--tabs' do
           click_on 'Projects'
@@ -402,7 +411,7 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
   end
 
   describe 'pagination' do
-    context 'project wide search' do
+    context 'for project wide search' do
       it 'works' do
         expect_range 3, 12
 
@@ -416,7 +425,7 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
       end
     end
 
-    context 'global "All" search' do
+    context 'for global "All" search' do
       before do
         login_as user
 
@@ -435,12 +444,12 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
     end
   end
 
-  describe 'params escaping' do
-    let(:wp_1) { create :work_package, subject: "Foo && Bar", project: project }
-    let(:wp_2) { create :work_package, subject: "Foo # Bar", project: project }
-    let(:wp_3) { create :work_package, subject: "Foo &# Bar", project: project }
-    let(:wp_4) { create :work_package, subject: %(Foo '' "" \(\) Bar), project: project }
-    let!(:work_packages) { [wp_1, wp_2, wp_3, wp_4] }
+  describe 'when params escaping' do
+    let(:wp1) { create :work_package, subject: "Foo && Bar", project: project }
+    let(:wp2) { create :work_package, subject: "Foo # Bar", project: project }
+    let(:wp3) { create :work_package, subject: "Foo &# Bar", project: project }
+    let(:wp4) { create :work_package, subject: %(Foo '' "" \(\) Bar), project: project }
+    let!(:work_packages) { [wp1, wp2, wp3, wp4] }
     let(:table) { Pages::EmbeddedWorkPackagesTable.new(find('.work-packages-embedded-view--container')) }
 
     let(:run_visit) { false }
@@ -457,33 +466,33 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
       global_search.expect_global_scope_marked
       global_search.submit_in_global_scope
 
-      table.expect_work_package_listed(wp_1, wp_3)
-      table.ensure_work_package_not_listed! wp_2
+      table.expect_work_package_listed(wp1, wp3)
+      table.ensure_work_package_not_listed! wp2
 
       global_search.search "# Bar"
       global_search.find_option "Foo # Bar"
       global_search.find_option "Foo &# Bar"
       global_search.submit_in_global_scope
-      table.expect_work_package_listed(wp_2)
-      table.ensure_work_package_not_listed! wp_1
+      table.expect_work_package_listed(wp2)
+      table.ensure_work_package_not_listed! wp1
 
       global_search.search "&"
       # Bug in ng-select causes highlights to break up entities
       global_search.find_option "Foo && Bar"
       global_search.find_option "Foo &# Bar"
       global_search.submit_in_global_scope
-      table.expect_work_package_listed(wp_1, wp_3)
-      table.ensure_work_package_not_listed! wp_2
+      table.expect_work_package_listed(wp1, wp3)
+      table.ensure_work_package_not_listed! wp2
 
       global_search.search '""'
-      global_search.find_option wp_4.subject
+      global_search.find_option wp4.subject
       global_search.submit_in_global_scope
-      table.expect_work_package_listed(wp_4)
+      table.expect_work_package_listed(wp4)
 
       global_search.search "'"
-      global_search.find_option wp_4.subject
+      global_search.find_option wp4.subject
       global_search.submit_in_global_scope
-      table.expect_work_package_listed(wp_4)
+      table.expect_work_package_listed(wp4)
     end
   end
 
@@ -495,3 +504,4 @@ describe 'Search', type: :feature, js: true, with_settings: { per_page_options: 
     end
   end
 end
+# rubocop:enable RSpec:MultipleMemoizedHelpers


### PR DESCRIPTION
Bind a method to the close event and move what was written in the one-line statement to the function. When assigning currentValue to select.searchTerm in the html file, searchTerm value was not set correctly (It is null). In the onClose method, by assigning currentvalue to  the searchTerm property of ng-select instance, It works correctly. select and ng-select instance are different?

https://community.openproject.org/projects/openproject/work_packages/41698/activity