### PR TITLE
[41943] Wrong capitalization of "Enterprise Edition" on project overview teaser widget

### DIFF
--- a/modules/grids/config/locales/js-en.yml
+++ b/modules/grids/config/locales/js-en.yml
@@ -6,7 +6,7 @@ en:
       configure: 'Configure widget'
       upsale:
         text: "Some widgets, like the work package graph widget, are only available in the "
-        link: 'enterprise edition.'
+        link: 'Enterprise Edition.'
       widgets:
         custom_text:
           title: 'Custom text'


### PR DESCRIPTION
Capitalize "Enterprise Edition" for consistency

https://community.openproject.org/projects/openproject/work_packages/41943/activity