### PR TITLE
Also request notifications from inactive tabs at much larger intervals

### DIFF
--- a/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.ts
+++ b/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.ts
@@ -2,15 +2,16 @@ import {
   ChangeDetectionStrategy,
   Component,
 } from '@angular/core';
-import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import {
   combineLatest,
+  merge,
   timer,
 } from 'rxjs';
 import {
   filter,
   map,
   switchMap,
+  throttleTime,
 } from 'rxjs/operators';
 import { ActiveWindowService } from 'core-app/core/active-window/active-window.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -18,7 +19,8 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { IanBellService } from 'core-app/features/in-app-notifications/bell/state/ian-bell.service';
 
 export const opInAppNotificationBellSelector = 'op-in-app-notification-bell';
-const POLLING_INTERVAL = 10000;
+const ACTIVE_POLLING_INTERVAL = 10000;
+const INACTIVE_POLLING_INTERVAL = 120000;
 
 @Component({
   selector: opInAppNotificationBellSelector,
@@ -27,10 +29,14 @@ const POLLING_INTERVAL = 10000;
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class InAppNotificationBellComponent {
-  polling$ = timer(10, POLLING_INTERVAL).pipe(
-    filter(() => this.activeWindow.isActive),
-    switchMap(() => this.storeService.fetchUnread()),
-  );
+  polling$ = merge(
+    timer(10, ACTIVE_POLLING_INTERVAL).pipe(filter(() => this.activeWindow.isActive)),
+    timer(10, INACTIVE_POLLING_INTERVAL).pipe(filter(() => !this.activeWindow.isActive)),
+  )
+    .pipe(
+      throttleTime(ACTIVE_POLLING_INTERVAL),
+      switchMap(() => this.storeService.fetchUnread()),
+    );
 
   unreadCount$ = combineLatest([
     this.storeService.unread$,
@@ -41,7 +47,6 @@ export class InAppNotificationBellComponent {
     readonly storeService:IanBellService,
     readonly apiV3Service:ApiV3Service,
     readonly activeWindow:ActiveWindowService,
-    readonly modalService:OpModalService,
     readonly pathHelper:PathHelperService,
   ) { }
 


### PR DESCRIPTION
We have seen reports from customers where requests of notifications fail whenever they re-activate the window after leaving it for some time.

This is probably due to some proxy or network timeout in between, but notifications is the first request they see and connect to them.

This PR allows notification requests to be performed every 2 minutes while the tab is inactive. This has the side-effect of a ping request, keeping the session alive as well as preventing a 10s delay between reactivating the tab and seeing new notifications come in.