### PR TITLE
[41103] Remove unnecessary tab header in board configuration modal

### DIFF
--- a/frontend/src/app/features/boards/board/configuration-modal/board-configuration.modal.html
+++ b/frontend/src/app/features/boards/board/configuration-modal/board-configuration.modal.html
@@ -5,28 +5,6 @@
   <op-modal-header (close)="closeMe($event)">{{text.title}}</op-modal-header>
 
   <div class="op-modal--body">
-    <div
-        *ngIf="!!tabPortalHost"
-        class="content--tabs scrollable-tabs"
-    >
-      <ul class="op-tab-row">
-        <li
-            *ngFor="let tab of availableTabs"
-            class="op-tab-row--tab"
-        >
-          <a
-              class="op-tab-row--link"
-              role="button"
-              [ngClass]="{ 'op-tab-row--link_selected': currentTab && tab.name === currentTab.name, 'op-tab-row--link_disabled': tab.disable != null  }"
-              [attr.title]="tab.disable || tab.name"
-              [textContent]="tab.name"
-              (click)="switchTo(tab)"
-              href
-          ></a>
-        </li>
-      </ul>
-    </div>
-
     <div class="tab-content" #tabContentOutlet></div>
   </div>
 


### PR DESCRIPTION
Remove unnecessary tab header as it is the only tab in this modal.

https://community.openproject.org/projects/openproject/work_packages/41103/activity