### PR TITLE
Filter representer caching regression tests

### DIFF
--- a/spec/lib/api/v3/queries/schemas/project_filter_dependency_representer_spec.rb
+++ b/spec/lib/api/v3/queries/schemas/project_filter_dependency_representer_spec.rb
@@ -42,39 +42,37 @@ describe ::API::V3::Queries::Schemas::ProjectFilterDependencyRepresenter do
 
   subject(:generated) { instance.to_json }
 
-  context 'generation' do
-    context 'properties' do
-      describe 'values' do
-        let(:path) { 'values' }
-        let(:type) { '[]Project' }
-        let(:filters) do
-          "?filters=%5B%7B%22active%22%3A%7B%22operator%22%3A%22%3D%22%2C%22values%22%3A%5B%22t%22%5D%7D%7D%5D&pageSize=-1"
-        end
-        let(:href) { api_v3_paths.projects + filters }
+  context 'with generation' do
+    context 'for properties' do
+      let(:path) { 'values' }
+      let(:type) { '[]Project' }
+      let(:filters) do
+        "?filters=%5B%7B%22active%22%3A%7B%22operator%22%3A%22%3D%22%2C%22values%22%3A%5B%22t%22%5D%7D%7D%5D&pageSize=-1"
+      end
+      let(:href) { api_v3_paths.projects + filters }
 
-        context "for operator 'Queries::Operators::Equals'" do
-          let(:operator) { Queries::Operators::Equals }
+      context "for operator 'Queries::Operators::Equals'" do
+        let(:operator) { Queries::Operators::Equals }
 
-          it_behaves_like 'filter dependency with allowed link'
-        end
+        it_behaves_like 'filter dependency with allowed link'
+      end
 
-        context "for operator 'Queries::Operators::NotEquals'" do
-          let(:operator) { Queries::Operators::NotEquals }
+      context "for operator 'Queries::Operators::NotEquals'" do
+        let(:operator) { Queries::Operators::NotEquals }
 
-          it_behaves_like 'filter dependency with allowed link'
-        end
+        it_behaves_like 'filter dependency with allowed link'
+      end
 
-        context "for operator 'Queries::Operators::All'" do
-          let(:operator) { Queries::Operators::All }
+      context "for operator 'Queries::Operators::All'" do
+        let(:operator) { Queries::Operators::All }
 
-          it_behaves_like 'filter dependency empty'
-        end
+        it_behaves_like 'filter dependency empty'
+      end
 
-        context "for operator 'Queries::Operators::None'" do
-          let(:operator) { Queries::Operators::None }
+      context "for operator 'Queries::Operators::None'" do
+        let(:operator) { Queries::Operators::None }
 
-          it_behaves_like 'filter dependency empty'
-        end
+        it_behaves_like 'filter dependency empty'
       end
     end
 
@@ -87,38 +85,79 @@ describe ::API::V3::Queries::Schemas::ProjectFilterDependencyRepresenter do
       end
 
       it 'is cached' do
-        expect(instance)
-          .not_to receive(:to_hash)
+        allow(instance)
+          .to receive(:to_hash)
 
         instance.to_json
+
+        expect(instance)
+          .not_to have_received(:to_hash)
       end
 
       it 'busts the cache on a different operator' do
         instance.send(:operator=, Queries::Operators::NotEquals)
 
-        expect(instance)
+        allow(instance)
           .to receive(:to_hash)
 
         instance.to_json
+
+        expect(instance)
+          .to have_received(:to_hash)
       end
 
       it 'busts the cache on changes to the locale' do
-        expect(instance)
+        allow(instance)
           .to receive(:to_hash)
 
         I18n.with_locale(:de) do
           instance.to_json
         end
+
+        expect(instance)
+          .to have_received(:to_hash)
       end
 
       it 'busts the cache on different form_embedded' do
         embedded_instance = described_class.new(filter,
                                                 operator,
                                                 form_embedded: !form_embedded)
-        expect(embedded_instance)
+        allow(embedded_instance)
           .to receive(:to_hash)
 
         embedded_instance.to_json
+
+        expect(embedded_instance)
+          .to have_received(:to_hash)
+      end
+
+      it 'busts the cache on different OpenProject::VERSION.product_version' do
+        allow(OpenProject::VERSION)
+          .to receive(:instance_variable_get)
+          .with(:@product_version)
+          .and_return(4)
+
+        allow(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+
+        expect(instance)
+          .to have_received(:to_hash)
+      end
+
+      it 'busts the cache on different OpenProject::VERSION::ARRAY' do
+        new_version = OpenProject::VERSION::ARRAY
+        new_version[2] = -1
+        stub_const('OpenProject::VERSION::ARRAY', new_version)
+
+        allow(instance)
+          .to receive(:to_hash)
+
+        instance.to_json
+
+        expect(instance)
+          .to have_received(:to_hash)
       end
     end
   end


### PR DESCRIPTION
Add some regression tests for the filter representer caching, the idea came after investigating the OP#41237.
Some style changes are also included to make rubocop pass.