### PR TITLE
keep roles inherited from different group on role adding

### DIFF
--- a/db/migrate/20220426132637_refix_inherited_group_member_roles.rb
+++ b/db/migrate/20220426132637_refix_inherited_group_member_roles.rb
@@ -1,0 +1,14 @@
+class RefixInheritedGroupMemberRoles < ActiveRecord::Migration[6.1]
+  def up
+    # When the FixInheritedGroupMemberRoles ran initially, Members
+    # where the MemberRoles were inherited from more than one Group where
+    # applied incorrectly. Only the MemberRoles of the last Group where kept.
+    require Rails.root.join('db/migrate/20200625133727_fix_inherited_group_member_roles.rb')
+
+    # created_on has been renamed to created_at
+    Member.reset_column_information
+    Principal.reset_column_information
+
+    FixInheritedGroupMemberRoles.new.up
+  end
+end


### PR DESCRIPTION
The PR leads to not removing roles inherited from a group upon switching the roles of a different group.

Before, only the roles inherited from the group that was altered were considered. This change now leads to checking whether any group inherits the member_roles to the user and if that is the case, they are kept.

https://community.openproject.org/wp/41255 

## TODO

* [x] fix bug that lead to roles of another group being removed upon changing a group's roles in a project
* [x] write migration recreating all roles to be inherited from groups