### PR TITLE
[41929] Autofocus for sign in form OpenProject missing

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -449,8 +449,8 @@ module ApplicationHelper
 
   # To avoid the menu flickering, disable it
   # by default unless we're in test mode
-  def initial_menu_styles
-    Rails.env.test? ? '' : 'display:none'
+  def initial_menu_styles(side_displayed)
+    Rails.env.test? || !side_displayed ? '' : 'display:none'
   end
 
   def initial_menu_classes(side_displayed, show_decoration)

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -57,7 +57,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% main_menu = render_main_menu(local_assigns.fetch(:menu_name, nil), @project) %>
 <% side_displayed = content_for?(:sidebar) || content_for?(:main_menu) || !main_menu.blank? %>
 <% initial_classes = initial_menu_classes(side_displayed, show_decoration) %>
-<div id="wrapper" style="<%= initial_menu_styles %>" class="<%= initial_classes %>">
+<div id="wrapper" style="<%= initial_menu_styles(side_displayed) %>" class="<%= initial_classes %>">
   <% if show_decoration %>
     <header class="op-app-header">
       <div class="op-app-header--start">

--- a/frontend/src/app/core/setup/globals/global-listeners/top-menu.ts
+++ b/frontend/src/app/core/setup/globals/global-listeners/top-menu.ts
@@ -199,7 +199,7 @@ export class TopMenu {
 
   slideAndFocus(dropdown:JQuery, callback:any) {
     this.slideDown(dropdown, callback);
-    this.focusFirstInputOrLink(dropdown);
+    setTimeout(() => this.focusFirstInputOrLink(dropdown), ANIMATION_RATE_MS);
   }
 
   slideDown(dropdown:JQuery, callback:any) {
@@ -223,8 +223,8 @@ export class TopMenu {
 
   // If there is ANY input, it will have precedence over links,
   // i.e. links will only get focused, if there is NO input whatsoever
-  focusFirstInputOrLink(dropdown:JQuery) {
-    const focusable = dropdown.find('input:not([disabled]), a[href], area[href], select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]');
+  focusFirstInputOrLink(dropdown:JQuery):void {
+    const focusable = dropdown.find('.op-app-menu--dropdown').find('input:not([disabled]):not([type="hidden"]), a[href], area[href], select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]');
     const toFocus = focusable[0];
     if (!toFocus) {
       return;


### PR DESCRIPTION
Both the global login form, as well as the one toggled via the top menu receive no focus on the first input due to different reasons:

- [x] The `wrapper` element is only displayed delayed to avoid a menu flickering. However, this takes away the `autofocus` from the login form.
- [x] The dropdown has some focus functionality, but is too fast.

https://community.openproject.org/projects/openproject/work_packages/41929/activity