### PR TITLE
[#41714] removed enforced scroll on transistions

### DIFF
--- a/frontend/src/app/core/routing/openproject.routes.ts
+++ b/frontend/src/app/core/routing/openproject.routes.ts
@@ -259,9 +259,6 @@ export function initializeUiRouterListeners(injector:Injector) {
     if (transition.from().data && _.get(state, 'data.menuItem') !== transition.from().data.menuItem) {
       updateMenuItem(_.get(state, 'data.menuItem'), 'add');
     }
-
-    // Reset scroll position, mostly relevant for mobile
-    window.scrollTo(0, 0);
   });
 
   $transitions.onExit({}, (transition:Transition, state:StateDeclaration) => {


### PR DESCRIPTION
We need to check, if this enforced scrolling is still needed, especially for iOS Safari.

It was introduced in https://community.openproject.org/projects/openproject/work_packages/31723, but creates unexpected behaviour in https://community.openproject.org/work_packages/41714/activity.