### PR TITLE
[#41944] fixed parsing of error messages of hal errors

### DIFF
--- a/docker/dev/backend/Dockerfile
+++ b/docker/dev/backend/Dockerfile
@@ -7,7 +7,7 @@ ARG DEV_GID=1001
 ENV USER=dev
 ENV RAILS_ENV=development
 
-ENV BUNDLER_VERSION "2.0.2"
+ENV BUNDLER_VERSION "2.2.32"
 
 # `--no-log-init` is required as a workaround to avoid disk exhaustion.
 #

--- a/frontend/src/app/features/hal/resources/error-resource.ts
+++ b/frontend/src/app/features/hal/resources/error-resource.ts
@@ -38,6 +38,11 @@ export interface IHalErrorBase {
   errorIdentifier:string;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/no-explicit-any
+export function isHalError(err:any):err is IHalErrorBase {
+  return '_type' in err && 'message' in err && 'errorIdentifier' in err;
+}
+
 export interface IHalSingleError extends IHalErrorBase {
   _embedded:{
     details:{
@@ -70,7 +75,7 @@ export class ErrorResource extends HalResource {
    * Override toString to ensure the resource can
    * be printed nicely on console and in errors
    */
-  public toString() {
+  public toString():string {
     return `[ErrorResource ${this.message}]`;
   }
 
@@ -82,7 +87,7 @@ export class ErrorResource extends HalResource {
     return [this.message];
   }
 
-  public isMultiErrorMessage() {
+  public isMultiErrorMessage():boolean {
     return this.errorIdentifier === v3ErrorIdentifierMultipleErrors;
   }
 

--- a/frontend/src/app/shared/components/toaster/toast.service.ts
+++ b/frontend/src/app/shared/components/toaster/toast.service.ts
@@ -161,8 +161,15 @@ export class ToastService {
     this.stack.putValue([]);
   }
 
-  private createToast(message:IToast|string, type:ToastType):IToast {
-    return (typeof message === 'string') ? { message, type } : { message: message.message, type };
+  private createToast(toast:IToast|string, type:ToastType):IToast {
+    return (typeof toast === 'string')
+      ? { message: toast, type }
+      : {
+        message: toast.message,
+        type,
+        link: toast.link,
+        data: toast.data,
+      };
   }
 
   private createAttachmentUploadToast(message:IToast|string, uploads:UploadInProgress[]) {

--- a/frontend/src/app/shared/components/toaster/toast.service.ts
+++ b/frontend/src/app/shared/components/toaster/toast.service.ts
@@ -36,12 +36,13 @@ import { UploadInProgress } from 'core-app/core/file-upload/op-file-upload.servi
 import {
   IHalErrorBase,
   IHalMultipleError,
+  isHalError,
 } from 'core-app/features/hal/resources/error-resource';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
-export function removeSuccessFlashMessages() {
+export function removeSuccessFlashMessages():void {
   jQuery('.flash.notice').remove();
 }
 
@@ -50,7 +51,7 @@ export const OPToastEvent = 'op:toasters:add';
 
 export interface IToast {
   message:string;
-  link?:{ text:string, target:Function };
+  link?:{ text:string, target:() => void };
   type:ToastType;
   data?:unknown;
 }
@@ -110,14 +111,17 @@ export class ToastService {
       errors = [...additionalErrors] as string[];
     }
 
-    if (obj instanceof HttpErrorResponse && (obj.error as IHalMultipleError)?._embedded?.errors) {
-      errors = [
-        ...errors,
-        ...(obj.error as IHalMultipleError)._embedded.errors.map((el:IHalErrorBase) => el.message),
-      ];
-      message = obj.message;
+    if (obj instanceof HttpErrorResponse) {
+      message = isHalError(obj.error) ? obj.error.message : obj.message;
+
+      if ((obj.error as IHalMultipleError)?._embedded?.errors) {
+        errors = [
+          ...errors,
+          ...(obj.error as IHalMultipleError)._embedded.errors.map((el:IHalErrorBase) => el.message),
+        ];
+      }
     } else {
-      message = obj as IToast|string;
+      message = obj;
     }
 
     const toast:IToast = this.createToast(message, 'error');
@@ -158,12 +162,7 @@ export class ToastService {
   }
 
   private createToast(message:IToast|string, type:ToastType):IToast {
-    if (typeof message === 'string') {
-      return { message, type };
-    }
-    message.type = type;
-
-    return message;
+    return (typeof message === 'string') ? { message, type } : { message: message.message, type };
   }
 
   private createAttachmentUploadToast(message:IToast|string, uploads:UploadInProgress[]) {


### PR DESCRIPTION
- https://community.openproject.org/work_packages/41944

toast service returns messages from hal errors instead of the status text message rendered by the http lib. Should fall back to previous behaviour if no hal error is returned.