### PR TITLE
[#41899] Seed (migrate) team planner permissions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,9 @@ Lint/UnderscorePrefixedVariableName:
 Lint/Void:
   Enabled: false
 
+Lint/AmbiguousBlockAssociation:
+  IgnoredMethods: [change]
+
 
 Metrics/ClassLength:
   Enabled: false

--- a/db/migrate/20220414085531_migrate_team_planner_permissions.rb
+++ b/db/migrate/20220414085531_migrate_team_planner_permissions.rb
@@ -1,0 +1,42 @@
+class MigrateTeamPlannerPermissions < ActiveRecord::Migration[6.1]
+  def up
+    # Add view_team_planner role if a role already has the view_work_packages permission
+    execute <<~SQL.squish
+      INSERT INTO
+        role_permissions
+        (role_id, permission, created_at, updated_at)
+      SELECT
+        role_permissions.role_id, 'view_team_planner', NOW(), NOW()
+      FROM
+        role_permissions
+      GROUP BY role_permissions.role_id
+      HAVING
+        ARRAY_AGG(role_permissions.permission)::text[] @> ARRAY['view_work_packages']
+      AND
+        NOT ARRAY_AGG(role_permissions.permission)::text[] @> ARRAY['view_team_planner'];
+    SQL
+
+    # Add manage_team_planner if a role already has
+    # the view_team_planner (which in turn means the view_work_packages permission),
+    # add_work_packages, edit_work_packages, save_queries and manage_public_queries permission
+    execute <<~SQL.squish
+      INSERT INTO
+        role_permissions
+        (role_id, permission, created_at, updated_at)
+      SELECT
+        role_permissions.role_id, 'manage_team_planner', NOW(), NOW()
+      FROM
+        role_permissions
+      GROUP BY role_permissions.role_id
+      HAVING
+        ARRAY_AGG(role_permissions.permission)::text[] @>
+        ARRAY['view_work_packages', 'add_work_packages', 'edit_work_packages', 'save_queries', 'manage_public_queries']
+      AND
+        NOT ARRAY_AGG(role_permissions.permission)::text[] @> ARRAY['manage_team_planner']
+    SQL
+  end
+
+  def down
+    # Nothing to do
+  end
+end

--- a/spec/migrations/migrate_team_planner_permissions_spec.rb
+++ b/spec/migrations/migrate_team_planner_permissions_spec.rb
@@ -43,6 +43,13 @@ describe MigrateTeamPlannerPermissions, type: :model do
     end
   end
 
+  shared_examples_for 'migration is idempotent' do
+    context 'when the migration is ran twice' do
+      before { subject }
+      it_behaves_like 'not changing permissions'
+    end
+  end
+
   shared_examples_for 'adding permissions' do |new_permissions|
     it "adds the #{new_permissions} permissions for the role" do
       expect { subject }.to change { role.reload.permissions }
@@ -59,6 +66,7 @@ describe MigrateTeamPlannerPermissions, type: :model do
     let!(:role) { create(:role, permissions: %i[permission1 permission2]) }
 
     it_behaves_like 'not changing permissions'
+    it_behaves_like 'migration is idempotent'
   end
 
   context 'for a role eligible to view_team_planner' do
@@ -66,6 +74,7 @@ describe MigrateTeamPlannerPermissions, type: :model do
     let!(:role) { create(:role, permissions: permissions) }
 
     it_behaves_like 'adding permissions', %i[view_team_planner]
+    it_behaves_like 'migration is idempotent'
   end
 
   context 'for a role with view_team_planner' do
@@ -73,6 +82,7 @@ describe MigrateTeamPlannerPermissions, type: :model do
     let!(:role) { create(:role, permissions: permissions) }
 
     it_behaves_like 'not changing permissions'
+    it_behaves_like 'migration is idempotent'
   end
 
   context 'for a role eligible to manage_team_planner having view_team_planner' do
@@ -83,6 +93,7 @@ describe MigrateTeamPlannerPermissions, type: :model do
     let!(:role) { create(:role, permissions: permissions) }
 
     it_behaves_like 'adding permissions', %i[manage_team_planner]
+    it_behaves_like 'migration is idempotent'
   end
 
   context 'for a role eligible to manage_team_planner not having view_team_planner' do
@@ -93,6 +104,7 @@ describe MigrateTeamPlannerPermissions, type: :model do
     let!(:role) { create(:role, permissions: permissions) }
 
     it_behaves_like 'adding permissions', %i[manage_team_planner view_team_planner]
+    it_behaves_like 'migration is idempotent'
   end
 
   context 'for a role with manage_team_planner' do
@@ -103,5 +115,6 @@ describe MigrateTeamPlannerPermissions, type: :model do
     let!(:role) { create(:role, permissions: permissions) }
 
     it_behaves_like 'not changing permissions'
+    it_behaves_like 'migration is idempotent'
   end
 end

--- a/spec/migrations/migrate_team_planner_permissions_spec.rb
+++ b/spec/migrations/migrate_team_planner_permissions_spec.rb
@@ -46,6 +46,7 @@ describe MigrateTeamPlannerPermissions, type: :model do
   shared_examples_for 'migration is idempotent' do
     context 'when the migration is ran twice' do
       before { subject }
+
       it_behaves_like 'not changing permissions'
     end
   end
@@ -62,7 +63,7 @@ describe MigrateTeamPlannerPermissions, type: :model do
     end
   end
 
-  context 'for a role with unrelated permissions' do
+  context 'for a role not eligible to view_team_planner' do
     let!(:role) { create(:role, permissions: %i[permission1 permission2]) }
 
     it_behaves_like 'not changing permissions'
@@ -79,6 +80,17 @@ describe MigrateTeamPlannerPermissions, type: :model do
 
   context 'for a role with view_team_planner' do
     let(:permissions) { %i[view_team_planner view_work_packages permission1 permission2] }
+    let!(:role) { create(:role, permissions: permissions) }
+
+    it_behaves_like 'not changing permissions'
+    it_behaves_like 'migration is idempotent'
+  end
+
+  context 'for a role not eligible to manage_team_planner' do
+    let(:permissions) do
+      %i[view_team_planner view_work_packages edit_work_packages
+         save_queries manage_public_queries permission1 permission2]
+    end
     let!(:role) { create(:role, permissions: permissions) }
 
     it_behaves_like 'not changing permissions'

--- a/spec/migrations/migrate_team_planner_permissions_spec.rb
+++ b/spec/migrations/migrate_team_planner_permissions_spec.rb
@@ -54,7 +54,7 @@ describe MigrateTeamPlannerPermissions, type: :model do
   shared_examples_for 'adding permissions' do |new_permissions|
     it "adds the #{new_permissions} permissions for the role" do
       expect { subject }.to change { role.reload.permissions }
-        .from(permissions)
+        .from(match_array(permissions))
         .to match_array(permissions + new_permissions)
     end
 

--- a/spec/migrations/migrate_team_planner_permissions_spec.rb
+++ b/spec/migrations/migrate_team_planner_permissions_spec.rb
@@ -1,0 +1,107 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require Rails.root.join("db/migrate/20220414085531_migrate_team_planner_permissions.rb")
+require 'spec_helper'
+
+describe MigrateTeamPlannerPermissions, type: :model do
+  # Silencing migration logs, since we are not interested in that during testing
+  subject { ActiveRecord::Migration.suppress_messages { described_class.new.up } }
+
+  shared_examples_for 'not changing permissions' do
+    it 'is not changed' do
+      expect { subject }.not_to change { role.reload.permissions }
+    end
+
+    it 'does not adds any new permissions' do
+      expect { subject }.not_to change(RolePermission, :count)
+    end
+  end
+
+  shared_examples_for 'adding permissions' do |new_permissions|
+    it "adds the #{new_permissions} permissions for the role" do
+      expect { subject }.to change { role.reload.permissions }
+        .from(permissions)
+        .to match_array(permissions + new_permissions)
+    end
+
+    it "adds #{new_permissions.size} new permissions" do
+      expect { subject }.to change(RolePermission, :count).by(new_permissions.size)
+    end
+  end
+
+  context 'for a role with unrelated permissions' do
+    let!(:role) { create(:role, permissions: %i[permission1 permission2]) }
+
+    it_behaves_like 'not changing permissions'
+  end
+
+  context 'for a role eligible to view_team_planner' do
+    let(:permissions) { %i[view_work_packages permission1 permission2] }
+    let!(:role) { create(:role, permissions: permissions) }
+
+    it_behaves_like 'adding permissions', %i[view_team_planner]
+  end
+
+  context 'for a role with view_team_planner' do
+    let(:permissions) { %i[view_team_planner view_work_packages permission1 permission2] }
+    let!(:role) { create(:role, permissions: permissions) }
+
+    it_behaves_like 'not changing permissions'
+  end
+
+  context 'for a role eligible to manage_team_planner having view_team_planner' do
+    let(:permissions) do
+      %i[view_team_planner view_work_packages add_work_packages edit_work_packages
+         save_queries manage_public_queries permission1 permission2]
+    end
+    let!(:role) { create(:role, permissions: permissions) }
+
+    it_behaves_like 'adding permissions', %i[manage_team_planner]
+  end
+
+  context 'for a role eligible to manage_team_planner not having view_team_planner' do
+    let(:permissions) do
+      %i[view_work_packages add_work_packages edit_work_packages
+         save_queries manage_public_queries permission1 permission2]
+    end
+    let!(:role) { create(:role, permissions: permissions) }
+
+    it_behaves_like 'adding permissions', %i[manage_team_planner view_team_planner]
+  end
+
+  context 'for a role with manage_team_planner' do
+    let(:permissions) do
+      %i[manage_team_planner view_team_planner view_work_packages add_work_packages
+         edit_work_packages save_queries manage_public_queries permission1 permission2]
+    end
+    let!(:role) { create(:role, permissions: permissions) }
+
+    it_behaves_like 'not changing permissions'
+  end
+end


### PR DESCRIPTION
See OP#41899
I'm using the `array_agg` function from postgresql to query the permissions, it seems to be a lot faster than doing multiple sub-queries.
I also added tests to make sure we have the expected behaviour, however we might not need those tests after we ran the migration.

https://community.openproject.org/wp/41899