### PR TITLE
[42031] Too much white space on left side in WP full view on mobile

### DIFF
--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -63,6 +63,9 @@
   #content-wrapper
     padding: 15px
 
+  #content
+    padding: 0
+
   #main
     grid-template-columns: auto
 


### PR DESCRIPTION
Since the content-wrapper already has a padding, the content doesn't  need an additional one for mobile. Otherwise there would be too much wasted space.

https://community.openproject.org/projects/openproject/work_packages/42031/activity

This also fixes 
https://community.openproject.org/projects/openproject/work_packages/41942/activity