### PR TITLE
[42013] Calendar widget on overview page not useful

### DIFF
--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -155,8 +155,17 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
       eventResize: (resizeInfo:EventResizeDoneArg) => this.updateEvent(resizeInfo),
       eventDrop: (dropInfo:EventDropArg) => this.updateEvent(dropInfo),
       eventClick: (evt:EventClickArg) => {
-        const workPackage = evt.event.extendedProps.workPackage as WorkPackageResource;
-        this.calendar.openSplitView(workPackage.id as string);
+        const workPackageId = (evt.event.extendedProps.workPackage as WorkPackageResource).id as string;
+        // Currently the calendar widget is shown on multiple pages,
+        // but only the calendar module itself is a partitioned query space which can deal with a split screen request
+        if (this.$state.includes('calendar')) {
+          this.calendar.openSplitView(workPackageId);
+        } else {
+          void this.$state.go(
+            'work-packages.show',
+            { workPackageId },
+          );
+        }
       },
     };
 

--- a/frontend/src/global_styles/content/modules/_team_planner.sass
+++ b/frontend/src/global_styles/content/modules/_team_planner.sass
@@ -55,6 +55,10 @@
     .op-wp-single-card--content-inline-date
       visibility: hidden
 
+  // Avoid pointer cursor on hover
+  .fc-event-draggable:hover
+    cursor: default
+
   .op-team-planner--wp-loading-skeleton
     svg
       height: 80px

--- a/frontend/src/global_styles/vendor/_full_calendar.sass
+++ b/frontend/src/global_styles/vendor/_full_calendar.sass
@@ -90,10 +90,6 @@
     .fc-event-main
       color: unset
 
-    // Avoid pointer cursor on hover
-    .fc-event-draggable:hover
-      cursor: default
-
     .fc-event:hover
       .fc-event-resizer
         display: flex

--- a/modules/calendar/spec/features/calendar_widget_spec.rb
+++ b/modules/calendar/spec/features/calendar_widget_spec.rb
@@ -1,0 +1,75 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require_relative './shared_context'
+require_relative '../../../overviews/spec/support/pages/overview'
+
+describe 'Calendar drag&dop and resizing', type: :feature, js: true do
+  include_context 'with calendar full access'
+
+  let!(:other_user) do
+    create :user,
+           firstname: 'Bernd',
+           member_in_project: project,
+           member_with_permissions: %w[
+             view_work_packages view_calendar
+           ]
+  end
+
+  let!(:work_package) do
+    create :work_package,
+           project: project,
+           start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
+           due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
+  end
+  let(:overview_page) do
+    Pages::Overview.new(project)
+  end
+  let(:wp_full_view) { Pages::FullWorkPackage.new(work_package, project) }
+
+  before do
+    login_as current_user
+    overview_page.visit!
+  end
+
+  it 'opens the work package full view when clicking a calendar entry' do
+    # within top-left area, add an additional widget
+    overview_page.add_widget(1, 1, :row, 'Calendar')
+
+    sleep(1)
+    overview_page.expect_and_dismiss_toaster message: I18n.t('js.notice_successful_update')
+
+    # Clicking the calendar entry goes to work package full screen
+    page.find('.fc-event-title', text: work_package.subject).click
+    wp_full_view.ensure_page_loaded
+
+    wp_full_view.go_back
+    expect(page).to have_text('Overview')
+  end
+end


### PR DESCRIPTION
Redirect to full screen page if the split screen is not supported yet

https://community.openproject.org/projects/openproject/work_packages/42013/activity