### PR TITLE
[42039] Text for some widgets in administration not centered

### DIFF
--- a/frontend/src/global_styles/content/menus/_menu_blocks.sass
+++ b/frontend/src/global_styles/content/menus/_menu_blocks.sass
@@ -8,8 +8,9 @@
   .menu-block
     border-radius: 3px
     display: grid
-    grid-template: 110px 1fr / 1fr
+    grid-template: 94px 1fr / 1fr
     grid-row-gap: 5px
+    padding: 1rem
     justify-items: center
     text-align: center
     background: #cccccc30


### PR DESCRIPTION
Add padding to menu blocks
Refers to this comment https://community.openproject.org/projects/openproject/work_packages/42039/activity?query_id=3154#activity-3 in
https://community.openproject.org/projects/openproject/work_packages/42039/activity