### PR TITLE
[42046] Drop zone is too small in team planner

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.sass
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.sass
@@ -52,12 +52,13 @@ $op-team-planner-resource-width: 180px
     flex: 1
     border: 1px dashed #1A67A3
     box-sizing: border-box
+    height: 2.25rem
 
     display: flex
     align-items: center
     justify-content: center
 
-    margin-left: $op-team-planner-resource-width
+    font-size: 14px
 
     &_active
       background: #D1E5F5


### PR DESCRIPTION
Fix expected height of team planner drop zone

https://community.openproject.org/projects/openproject/work_packages/42046/activity