### PR TITLE
[42023] Ensure formattable properties output a string as raw

### DIFF
--- a/lib/api/decorators/formattable.rb
+++ b/lib/api/decorators/formattable.rb
@@ -51,7 +51,7 @@ module API
                render_nil: true
       property :raw,
                exec_context: :decorator,
-               getter: ->(*) { represented },
+               getter: ->(*) { raw_text },
                render_nil: true
       property :html,
                exec_context: :decorator,
@@ -60,10 +60,15 @@ module API
                render_nil: true
 
       def to_html
-        format_text(represented, format: @format, object: @object)
+        format_text(raw_text, format: @format, object: @object)
       end
 
       private
+
+      # Ensure the raw text is always a string
+      def raw_text
+        represented.to_s
+      end
 
       def model_required?
         # the formatted string may also be nil, we are prepared for that

--- a/spec/lib/api/decorators/formattable_spec.rb
+++ b/spec/lib/api/decorators/formattable_spec.rb
@@ -30,43 +30,56 @@ require 'spec_helper'
 
 describe ::API::Decorators::Formattable do
   let(:represented) { 'A **raw** string!' }
+
   subject { described_class.new(represented).to_json }
 
-  it 'should indicate its format' do
-    is_expected.to be_json_eql('markdown'.to_json).at_path('format')
+  it 'indicates its format' do
+    expect(subject).to be_json_eql('markdown'.to_json).at_path('format')
   end
 
-  it 'should contain the raw string' do
-    is_expected.to be_json_eql(represented.to_json).at_path('raw')
+  it 'contains the raw string' do
+    expect(subject).to be_json_eql(represented.to_json).at_path('raw')
   end
 
-  it 'should contain the formatted string' do
-    is_expected.to be_json_eql('<p class="op-uc-p">A <strong>raw</strong> string!</p>'.to_json).at_path('html')
+  it 'contains the formatted string' do
+    expect(subject).to be_json_eql('<p class="op-uc-p">A <strong>raw</strong> string!</p>'.to_json).at_path('html')
   end
 
-  context 'passing an object context' do
+  context 'when passing an object context' do
     let(:object) { build_stubbed :work_package }
+
     subject { described_class.new(represented, object: object) }
 
     it 'passes that to format_text' do
+      # rubocop:disable RSpec/SubjectStub RSpec/MessageSpies
       expect(subject)
         .to receive(:format_text).with(anything, format: :markdown, object: object)
         .and_call_original
+      # rubocop:enable RSpec/SubjectStub RSpec/MessageSpies
 
       expect(subject.to_json)
         .to be_json_eql('<p class="op-uc-p">A <strong>raw</strong> string!</p>'.to_json).at_path('html')
     end
   end
 
-  context 'format specified explicitly' do
+  context 'when format specified explicitly' do
     subject { described_class.new(represented, plain: true).to_json }
 
-    it 'should indicate the explicit format' do
-      is_expected.to be_json_eql('plain'.to_json).at_path('format')
+    it 'indicates the explicit format' do
+      expect(subject).to be_json_eql('plain'.to_json).at_path('format')
     end
 
-    it 'should format using the explicit format' do
-      is_expected.to be_json_eql('<p>A **raw** string!</p>'.to_json).at_path('html')
+    it 'formats using the explicit format' do
+      expect(subject).to be_json_eql('<p>A **raw** string!</p>'.to_json).at_path('html')
+    end
+  end
+
+  context 'when passing a nil object as input' do
+    let(:represented) { nil }
+
+    it 'still outputs a string as per the specification' do
+      expect(subject).to be_json_eql(''.to_json).at_path('raw')
+      expect(subject).to be_json_eql(''.to_json).at_path('html')
     end
   end
 end

--- a/spec/lib/api/v3/support/api_v3_formattable.rb
+++ b/spec/lib/api/v3/support/api_v3_formattable.rb
@@ -33,7 +33,9 @@ shared_examples_for 'API V3 formattable' do |property|
 
   it { is_expected.to be_json_eql(format.to_json).at_path(property + '/format') }
 
-  it { is_expected.to be_json_eql(raw.to_json).at_path(property + '/raw') }
+  it_behaves_like 'formattable property', property do
+    let(:value) { raw }
+  end
 
   it do
     if defined?(html)

--- a/spec/lib/api/v3/support/property_examples.rb
+++ b/spec/lib/api/v3/support/property_examples.rb
@@ -37,7 +37,7 @@ end
 shared_examples_for 'formattable property' do |name|
   it "has the #{name} property" do
     is_expected
-      .to be_json_eql(value.to_json)
+      .to be_json_eql(value.to_s.to_json)
       .at_path("#{name}/raw")
   end
 end


### PR DESCRIPTION
The API specification states that the raw text is always a string.
However when passing `nil` as the represented text, it is output
directly.

https://www.openproject.org/docs/api/basic-objects/#formattable-text

https://community.openproject.org/wp/42023