### PR TITLE
[#41946] Projects created from templates are shown twice in project list

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -143,7 +143,7 @@ class Project < ApplicationRecord
     where(["#{Project.table_name}.id IN (SELECT em.project_id FROM #{EnabledModule.table_name} em WHERE em.name=?)", mod.to_s])
   }
   scope :public_projects, -> { where(public: true) }
-  scope :visible, ->(user = User.current) { merge(Project.visible_by(user)) }
+  scope :visible, ->(user = User.current) { where(id: Project.visible_by(user)) }
   scope :newest, -> { order(created_at: :desc) }
   scope :active, -> { where(active: true) }
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/41946

- Changed a join to sub select to remove duplicates without having to use distinct