### PR TITLE
[41932] Use filter ID instead of _type which are always available

### DIFF
--- a/frontend/src/app/features/team-planner/team-planner/assignee/add-assignee.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/assignee/add-assignee.component.ts
@@ -81,7 +81,7 @@ export class AddAssigneeComponent {
       .pipe(
         take(1),
         map((queryFilters) => {
-          const projectFilter = queryFilters.find((queryFilter) => queryFilter._type === 'ProjectQueryFilter');
+          const projectFilter = queryFilters.find((queryFilter) => queryFilter.id === 'project');
 
           const selectedProjectIds = (() => {
             const baseList = ((projectFilter?.values || []) as HalResource[]).map((p) => p.id);

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -168,7 +168,7 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
     .pipe(
       this.untilDestroyed(),
       map((queryFilters) => {
-        const assigneeFilter = queryFilters.find((queryFilter) => queryFilter._type === 'AssigneeQueryFilter');
+        const assigneeFilter = queryFilters.find((queryFilter) => queryFilter.id === 'assignee');
         return ((assigneeFilter?.values || []) as HalResource[]).map((p) => p.id);
       }),
     );
@@ -181,13 +181,13 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
         const filters:ApiV3ListFilter[] = [
           ['action', '=', ['work_packages/assigned']],
         ];
-        const assigneeFilter = queryFilters.find((queryFilter) => queryFilter._type === 'AssigneeQueryFilter');
+        const assigneeFilter = queryFilters.find((queryFilter) => queryFilter.id === 'assignee');
         if (assigneeFilter) {
           const values = (assigneeFilter.values as HalResource[]).map((el:HalResource) => el.id as string);
           filters.push(['principal', '=', values]);
         }
 
-        const projectFilter = queryFilters.find((queryFilter) => queryFilter._type === 'ProjectQueryFilter');
+        const projectFilter = queryFilters.find((queryFilter) => queryFilter.id === 'project');
         if (projectFilter) {
           const values = (projectFilter.values as HalResource[]).map((el:HalResource) => `p${el.id as string}`);
           filters.push(['context', '=', values]);


### PR DESCRIPTION
When creating a new query filter instance from the frontend, the `_type` is not set. The same is true for when filters are parsed from a form request.

However, for identifying which filter is being used, we can simply use the `id` property which contains a unique filter ID such as `assignee` and `project`.

This prevents flickering in the team planner while we already have an assignee filter, but one that does not have a _type yet.

https://community.openproject.org/wp/41932