### PR TITLE
[41942] Comment numbers are not aligned on mobile

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_mobile.sass
+++ b/frontend/src/global_styles/layout/work_packages/_mobile.sass
@@ -62,7 +62,10 @@
 
           .work-packages--panel-inner
             padding: 0
-            max-width: calc(100vw - 40px)
+            max-width: calc(100vw - 30px)
+
+            .tabcontent
+              padding: 0
 
         .work-packages-full-view--resizer
           display: none


### PR DESCRIPTION
Adjust spacings so that the inner tab content is aligned on the right side on mobile

Fixes https://community.openproject.org/projects/openproject/work_packages/41942/activity#activity-11 in
https://community.openproject.org/projects/openproject/work_packages/41942/activity