### PR TITLE
[41718] Allow ng-select internal filter when no backend API involved

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -4,7 +4,7 @@
     [(ngModel)]="model"
     [items]="results$ | async"
     [ngClass]="classes"
-    [typeahead]="typeahead"
+    [typeahead]="boundTypeahead"
     [clearOnBackspace]="clearOnBackspace"
     [clearSearchOnAdd]="clearSearchOnAdd"
     [hideSelected]="hideSelected"

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -11,6 +11,7 @@ import {
   Input,
   NgZone,
   OnChanges,
+  OnInit,
   Output,
   SimpleChanges,
   TemplateRef,
@@ -60,7 +61,7 @@ import { OpAutocompleterOptionTemplateDirective } from './directives/op-autocomp
 // it has all inputs and outputs of ng-select
 // in order to use it, you only need to pass the data type and its filters
 // you also can change the value of ng-select default options by changing @inputs and @outputs
-export class OpAutocompleterComponent extends UntilDestroyedMixin implements AfterViewInit, OnChanges {
+export class OpAutocompleterComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit, OnChanges {
   @HostBinding('class.op-autocompleter') className = true;
 
   @Input() public filters?:IAPIFilter[] = [];
@@ -177,6 +178,9 @@ export class OpAutocompleterComponent extends UntilDestroyedMixin implements Aft
 
   @Input() public typeahead:BehaviorSubject<string|null> = new BehaviorSubject(null);
 
+  // We only bind the typeahead to ng-select if we filter values from the backend
+  public boundTypeahead:Subject<string|null>;
+
   // a function for setting the options of ng-select
   @Input() public getOptionsFn:(searchTerm:string) => Observable<unknown>;
 
@@ -233,6 +237,12 @@ export class OpAutocompleterComponent extends UntilDestroyedMixin implements Aft
     private readonly I18n:I18nService,
   ) {
     super();
+  }
+
+  ngOnInit() {
+    if (!!this.getOptionsFn || this.defaultData) {
+      this.boundTypeahead = this.typeahead;
+    }
   }
 
   ngOnChanges(changes:SimpleChanges):void {


### PR DESCRIPTION
When ng-select gets a [typeahead] input, it rightfully assumes we are filtering on the backend. However, in our case we always input a typeahead and just replay the items again.

I think this is a flaw of op-autocompleter, but it's not easily fixable. For 12.1 I suggest to avoid passing in a typeahead in this case and refectoring op-autocompleter afterwards (already discussed the refactoring with Ben).

https://community.openproject.org/wp/41718