### PR TITLE
skip 12.0 update mail on newly created instance

### DIFF
--- a/db/migrate/20211105142202_queue_notification_update_mail.rb
+++ b/db/migrate/20211105142202_queue_notification_update_mail.rb
@@ -1,5 +1,9 @@
 class QueueNotificationUpdateMail < ActiveRecord::Migration[6.1]
   def up
+    # On a newly created database, we don't want the update mail to be sent.
+    # Users are only created upon seeding.
+    return unless User.exists?
+
     ::Announcements::SchedulerJob
       .perform_later subject: :'notifications.update_info_mail.subject',
                      body: :'notifications.update_info_mail.body',

--- a/db/migrate/20211105142202_queue_notification_update_mail.rb
+++ b/db/migrate/20211105142202_queue_notification_update_mail.rb
@@ -2,7 +2,7 @@ class QueueNotificationUpdateMail < ActiveRecord::Migration[6.1]
   def up
     # On a newly created database, we don't want the update mail to be sent.
     # Users are only created upon seeding.
-    return unless User.exists?
+    return unless User.not_builtin.exists?
 
     ::Announcements::SchedulerJob
       .perform_later subject: :'notifications.update_info_mail.subject',


### PR DESCRIPTION
Skips the 12.0 update mail on newly created instances.

It would also be an option to remove the functionality now that 12.1 will be out but I deemed that to be premature. There typically are some installations that migrate from 11.x to a 12.x skipping 12.0. I would recommend removing that notification mail sending altogether in 13.0.

https://community.openproject.org/wp/42094