### PR TITLE
[40930] Sort siblings of saved project on all levels

### DIFF
--- a/app/models/queries/projects/orders/typeahead_order.rb
+++ b/app/models/queries/projects/orders/typeahead_order.rb
@@ -34,6 +34,6 @@ class Queries::Projects::Orders::TypeaheadOrder < Queries::Projects::Orders::Def
   end
 
   def order
-    model.order(lft: :asc, name: :asc)
+    model.order(lft: :asc)
   end
 end

--- a/db/migrate/20220202140507_reorder_project_children.rb
+++ b/db/migrate/20220202140507_reorder_project_children.rb
@@ -1,5 +1,5 @@
 class ReorderProjectChildren < ActiveRecord::Migration[6.1]
   def up
-    ::Projects::ReorderChildrenJob.perform_later
+    ::Projects::ReorderHierarchyJob.perform_later
   end
 end

--- a/docs/api/apiv3/paths/projects.yml
+++ b/docs/api/apiv3/paths/projects.yml
@@ -43,6 +43,8 @@ get:
 
       + name
 
+      + typeahead (sorting by hierarchy and name)
+
       + created_at
 
       + public

--- a/frontend/src/app/core/augmenting/dynamic-scripts/project.js
+++ b/frontend/src/app/core/augmenting/dynamic-scripts/project.js
@@ -134,7 +134,7 @@ jQuery(function ($) {
   function sendForm() {
     $('#ajax-indicator').show();
     let filters = parseFilters();
-    let orderParam = getUrlParameter('sort');
+    let orderParam = getUrlParameter('sortBy');
 
 
     let query = '?filters=' + encodeURIComponent(JSON.stringify(filters));

--- a/spec/features/projects/projects_index_spec.rb
+++ b/spec/features/projects/projects_index_spec.rb
@@ -291,6 +291,7 @@ describe 'Projects index page',
       expect(page).to have_no_text(project.name)        # Filtered away
       expect(page).to have_no_text('Next')              # Filters kept active, so there is no third page.
       expect(page).to have_no_text(public_project.name) # That one should be on page 1
+      expect(page).to have_selector('.sort.desc', text: 'NAME')
 
       # Sending the filter form again what implies to compose the request freshly
       SeleniumHubWaiter.wait
@@ -302,6 +303,7 @@ describe 'Projects index page',
       expect(page).to have_no_text(development_project.name) # as it is on the second page
       expect(page).to have_no_text(project.name)             # as it filtered away
       expect(page).to have_text('Next') # as the result set is larger than 1
+      expect(page).to have_selector('.sort.desc', text: 'NAME')
     end
   end
 

--- a/spec/models/queries/projects/project_query_spec.rb
+++ b/spec/models/queries/projects/project_query_spec.rb
@@ -149,7 +149,7 @@ describe Queries::Projects::ProjectQuery, type: :model do
     describe '#results' do
       it 'returns all visible projects ordered by lft asc' do
         expect(instance.results.to_sql)
-          .to eql base_scope.except(:order).order(lft: :asc, name: :asc, id: :desc).to_sql
+          .to eql base_scope.except(:order).order(lft: :asc, id: :desc).to_sql
       end
     end
   end


### PR DESCRIPTION
We access `parent.children.first` (https://github.com/opf/openproject/pull/10562/files#diff-e2e1298a0f8bd99c6abc1094c8b7f9f43ab11a68d9caf693b9b4c47b46b70befR47) to decide whether we need to resort a new child. But as the `order_column` was still set to `name`, `parent.children` is explicitly sorted by that column, skeweing the actual LFT order.

As the whole ordeal of the feature was to keep the LFT correctly, we can drop the name order. A spec is added to catch the missing behavior. It shows whenever a newly added child is lexicographically sorted to the beginning. On dev, this incorrectly causes the LFT to remain higher than the last child of the parent.

Additionally, Atilla noticed that the root projects were never ever sorted in the first place. The reorder job has been altered to reorder all projects according to case-insensitive name comparison. Whenever a project is saved, it is reordered appropriately into its `siblings`. This works on any level, including roots.


https://community.openproject.org/work_packages/40930