### PR TITLE
[41822] Long words in formattable columns in project list are not cut off

### DIFF
--- a/frontend/src/global_styles/content/_projects_list.sass
+++ b/frontend/src/global_styles/content/_projects_list.sass
@@ -104,6 +104,7 @@ form.project-filters
           display: none
     td.format-text
       min-width: 160px
+      word-wrap: break-word
     td.format-user
       min-width: 120px
     .buttons


### PR DESCRIPTION
Break very long words in the project table so that they do not overflow the limits of the table

Fixes https://community.openproject.org/projects/openproject/work_packages/41822#activity-3 in 
https://community.openproject.org/projects/openproject/work_packages/41822/activity