### PR TITLE
[42512] Split screen is not tied to the window border in the team planner module

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_table.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table.sass
@@ -35,7 +35,8 @@
       top: 12px
 
 .router--work-packages-partitioned-split-view:not(.router--work-packages-full-create),
-.router--work-packages-partitioned-split-view-details:not(.router--work-packages-full-create)
+.router--work-packages-partitioned-split-view-details:not(.router--work-packages-full-create),
+.router--work-packages-partitioned-split-view-new:not(.router--work-packages-full-create)
   @include extended-content--bottom
   @include extended-content--right
 


### PR DESCRIPTION
Move create split screen to the screen border as well

https://community.openproject.org/projects/openproject/work_packages/42152/activity