### PR TITLE
[41935] Layout of "My spent time" widget broken

### DIFF
--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.sass
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.sass
@@ -85,9 +85,6 @@ te-calendar
         .te-calendar--add-icon
           display: none
 
-      .fc-event-title-container
-        margin: 0 !important
-
     .te-calendar--time-entry
       .fc-content
         height: 100%
@@ -101,6 +98,12 @@ te-calendar
       &.-no-fadeout
         .fc-fadeout
           display: none
+
+    .te-calendar--add-entry,
+    .te-calendar--time-entry
+      .fc-event-title-container
+        margin: 0 !important
+        line-height: 14px !important
 
     .fc-duration
       border-right: 1px solid white


### PR DESCRIPTION
Overwrite fullCalendar margin and line-heigh not only for the add element but also for exisiting time entries

Fixes https://community.openproject.org/projects/openproject/work_packages/41935#activity-10 in
https://community.openproject.org/projects/openproject/work_packages/41935/activity