### PR TITLE
[42152] Add assignee buttons moves to the bottom when the split screen is opened

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_table.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table.sass
@@ -40,6 +40,11 @@
   @include extended-content--bottom
   @include extended-content--right
 
+  // Since only the split screen on the right should touch the bottom,
+  // we need to add it manually to the left to avoid a jump there
+  .work-packages-partitioned-page--content-left
+    padding-bottom: 10px
+
 // Ensure correct height applied to child elements.
 // The dom looks like this:
 // flash (generated from rails - if it was generated when rendering the page)


### PR DESCRIPTION
Avoid that the left side of the partitioned query space also jumps to the bottom when the split screen is opened

https://community.openproject.org/projects/openproject/work_packages/42152/activity