### PR TITLE
[41853] Missing hover effect on links

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/link.sass
+++ b/frontend/src/app/spot/styles/sass/components/link.sass
@@ -1,7 +1,7 @@
 .spot-link
   @include unset-button-styles
   display: inline
-  color: var(--content-link-color)
+  color: $spot-color-main
   text-decoration: none
   cursor: pointer
 
@@ -11,7 +11,7 @@
   &:hover,
   &:active,
   &:focus
-    color: var(--content-link-hover-active-color)
+    color: $spot-color-main-dark
     text-decoration: none
 
   &_danger


### PR DESCRIPTION
Use spot colours again to match Design system styles and avoid missing hover effect with standard theme

https://community.openproject.org/projects/openproject/work_packages/41853/activity