### PR TITLE
improve api documentation about versions and wp schemas

### DIFF
--- a/docs/api/apiv3/components/schemas/type_model.yml
+++ b/docs/api/apiv3/components/schemas/type_model.yml
@@ -22,10 +22,11 @@ properties:
     readOnly: true
   isDefault:
     type: boolean
+    description: Is this type active by default in new projects?
     readOnly: true
   isMilestone:
     type: boolean
-    description: Do tickets of this type represent a milestone?
+    description: Do work packages of this type represent a milestone?
     readOnly: true
   createdAt:
     type: string

--- a/docs/api/apiv3/paths/version.yml
+++ b/docs/api/apiv3/paths/version.yml
@@ -54,7 +54,7 @@ delete:
   description: Deletes the version. Work packages associated to the version will no
     longer be assigned to it.
   operationId: Delete_Version
-  summary: Delete Version
+  summary: Delete version
 get:
   parameters:
   - description: Version id
@@ -93,7 +93,7 @@ get:
                   format: plain
                   html: This version has a description
                   raw: This version has a description
-                endDate: 
+                endDate:
                 id: 11
                 name: v3.0 Alpha
                 sharing: system
@@ -206,5 +206,5 @@ patch:
   description: Updates the given version by applying the attributes provided in the
     body. Please note that while there is a fixed set of attributes, custom fields
     can extend a version's attributes and are accepted by the endpoint.
-  operationId: Update_Versions
-  summary: Update Versions
+  operationId: Update_Version
+  summary: Update Version

--- a/docs/api/apiv3/paths/versions.yml
+++ b/docs/api/apiv3/paths/versions.yml
@@ -35,7 +35,7 @@ get:
                       format: plain
                       html: This version has a description
                       raw: This version has a description
-                    endDate: 
+                    endDate:
                     id: 11
                     name: v3.0 Alpha
                     startDate: '2014-11-20'
@@ -52,10 +52,10 @@ get:
                       format: plain
                       html: ''
                       raw: ''
-                    endDate: 
+                    endDate:
                     id: 12
                     name: v2.0
-                    startDate: 
+                    startDate:
                     status: Closed
                   - _links:
                       availableInProjects:
@@ -69,10 +69,10 @@ get:
                       format: plain
                       html: ''
                       raw: ''
-                    endDate: 
+                    endDate:
                     id: 10
                     name: v1.0
-                    startDate: 
+                    startDate:
                     status: Open
                 _links:
                   self:
@@ -143,5 +143,5 @@ post:
     Creates a new version applying the attributes provided in the body. Please note that while there is a fixed set of attributes, custom fields can extend a version's attributes and are accepted by the endpoint.
 
     You can use the form and schema to be retrieve the valid attribute values and by that be guided towards successful creation.
-  operationId: Create_versions
-  summary: Create versions
+  operationId: Create_version
+  summary: Create version

--- a/docs/api/apiv3/paths/work_packages_schemas.yml
+++ b/docs/api/apiv3/paths/work_packages_schemas.yml
@@ -7,6 +7,8 @@ get:
       Accepts the same format as returned by the [queries](https://www.openproject.org/docs/api/endpoints/queries/) endpoint. Currently supported filters are:
 
       + id: The schema's id
+
+      Schema id has the form `project_id-work_package_type_id`.
     example: '[{ "id": { "operator": "=", "values": ["12-1", "14-2"] } }]'
     in: query
     name: filters

--- a/docs/api/apiv3/tags/types.yml
+++ b/docs/api/apiv3/tags/types.yml
@@ -1,5 +1,9 @@
 ---
 description: |-
+  Work package types represented in the system.
+
+  Types exist globally and are then activated for projects.
+
   ## Linked Properties
 
   |  Link         | Description               | Type          | Constraints | Supported operations |
@@ -8,14 +12,14 @@ description: |-
 
   ## Local Properties
 
-  | Property         | Description                                    | Type     | Constraints | Supported operations |
-  |:----------------:| ---------------------------------------------- | -------- | ----------- | -------------------- |
-  | id               | Type id                                        | Integer  | x > 0       | READ                 |
-  | name             | Type name                                      | String   |             | READ                 |
-  | color            | The color used to represent this type          | Color    |             | READ                 |
-  | position         | Sort index of the type                         | Integer  |             | READ                 |
-  | isDefault        |                                                | Boolean  |             | READ                 |
-  | isMilestone      | Do tickets of this type represent a milestone? | Boolean  |             | READ                 |
-  | createdAt        | Time of creation                               | DateTime |             | READ                 |
-  | updatedAt        | Time of the most recent change to the user     | DateTime |             | READ                 |
+  | Property         | Description                                          | Type     | Constraints | Supported operations |
+  |:----------------:| ---------------------------------------------------- | -------- | ----------- | -------------------- |
+  | id               | Type id                                              | Integer  | x > 0       | READ                 |
+  | name             | Type name                                            | String   |             | READ                 |
+  | color            | The color used to represent this type                | Color    |             | READ                 |
+  | position         | Sort index of the type                               | Integer  |             | READ                 |
+  | isDefault        | Is this type active by default in new projects?      | Boolean  |             | READ                 |
+  | isMilestone      | Do work packages of this type represent a milestone? | Boolean  |             | READ                 |
+  | createdAt        | Time of creation                                     | DateTime |             | READ                 |
+  | updatedAt        | Time of the most recent change to the user           | DateTime |             | READ                 |
 name: Types


### PR DESCRIPTION
I got some hard time understanding what the id of work package schema meant, so I updated the documentation. I added some other minor stuff I noticed as well.