### PR TITLE
Prevent trying to upsert an empty collection

### DIFF
--- a/frontend/src/app/core/state/collection-store.ts
+++ b/frontend/src/app/core/state/collection-store.ts
@@ -113,11 +113,17 @@ export function insertCollectionIntoState<T extends { id:ID }>(
   collection:IHALCollection<T>,
   collectionUrl:string,
 ):void {
+  const { elements } = collection._embedded as { elements:undefined|T[] };
+
   // Some JSON endpoints return no elements result if there are no elements
-  const ids = collection._embedded.elements?.map((el) => el.id) || [];
+  const ids = elements?.map((el) => el.id) || [];
 
   applyTransaction(() => {
-    store.upsertMany(collection._embedded.elements);
+    // Avoid inserting when elements is not defined
+    if (elements && elements.length > 0) {
+      store.upsertMany(collection._embedded.elements);
+    }
+
     store.update(({ collections }) => (
       {
         collections: {


### PR DESCRIPTION
in some cases, the capabilites API returns a collection without _embedded.elements.

In this case undefined is passed to upsertMany, which breaks akita and results in a "Entities is not iterable" error.