### PR TITLE
[#38672] Project members shown repetitively in member page if a group filter is active

### DIFF
--- a/app/models/queries/members/filters/group_filter.rb
+++ b/app/models/queries/members/filters/group_filter.rb
@@ -29,12 +29,12 @@
 class Queries::Members::Filters::GroupFilter < Queries::Members::Filters::MemberFilter
   include Queries::Filters::Shared::GroupFilter
 
-  def joins
-    nil
-  end
-
   def scope
-    scope = model.joins(:principal).merge(User.joins(:groups))
-    scope.where(where)
+    scope = model.joins(:principal)
+    scope = scope.where(where)
+    scope = scope.from(from) if from
+    scope = scope.joins(joins) if joins
+    scope = scope.left_outer_joins(left_outer_joins) if left_outer_joins
+    scope
   end
 end

--- a/app/models/queries/members/member_query.rb
+++ b/app/models/queries/members/member_query.rb
@@ -33,25 +33,7 @@ class Queries::Members::MemberQuery < Queries::BaseQuery
 
   # Convert the Query into an ActiveRecord Relation
   def results
-    # An invalid query reaults in an empty scope
-    if !valid?
-      return empty_scope
-    end
-
-    # Apply filters around a "select * from membership", but
-    # don't yet apply_orders, because the DISTINCT (below...) will break order
-    base_query = apply_filters(default_scope)
-
-    # Add a "select distinct * from (...) members" around the Members base_query,
-    # because users may appear multiple times if member of multiple groups (bug #38672).
-    # Then also load roles and preference for speed-up.
-    # This query is used in the /projects/<id>/member page and the also in the
-    # membership_api, but there only to find the me
-    distinct_query = self.class.model
-        .from(base_query.distinct, :members)
-
-    # Return the ordered query with additional resources eagerly loaded
-    apply_orders(distinct_query)
+    super
       .includes(:roles, { principal: :preference }, :member_roles)
   end
 

--- a/spec/models/queries/members/filters/group_filter_spec.rb
+++ b/spec/models/queries/members/filters/group_filter_spec.rb
@@ -54,7 +54,7 @@ describe Queries::Members::Filters::GroupFilter, type: :model do
   end
 
   it_behaves_like 'list_optional group query filter' do
-    let(:model) { Member.joins(:principal).merge(User.joins(:groups)) }
+    let(:model) { Member.joins(:principal) }
     let(:valid_values) { [group1.id.to_s] }
   end
 end

--- a/spec/models/queries/members/member_query_spec.rb
+++ b/spec/models/queries/members/member_query_spec.rb
@@ -32,7 +32,7 @@ describe Queries::Members::MemberQuery, type: :model do
   let(:admin) { create(:admin) }
   let(:instance) { described_class.new(user: admin) }
   # This is the MemberQuery.default_scope with an admin user
-  let(:base_scope) { Member.from(Member.all.order(id: :desc), :members).distinct }
+  let(:base_scope) { Member.from(Member.all.distinct, :members).order(id: :desc) }
 
   # Objects required for testing with filters
   let(:group1) { create(:group) }

--- a/spec/models/queries/members/member_query_spec.rb
+++ b/spec/models/queries/members/member_query_spec.rb
@@ -31,14 +31,14 @@ require 'spec_helper'
 describe Queries::Members::MemberQuery, type: :model do
   let(:admin) { create(:admin) }
   let(:instance) { described_class.new(user: admin) }
-  let(:manual_reference_scope) { Member.from(Member.all.distinct, :members).order(id: :desc) }
+  let(:manual_reference_scope) { Member.all.order(id: :desc) }
 
   # Objects required for testing with filters
   let(:group1) { create(:group) }
   let(:group2) { create(:group) }
   let(:project) { create(:project) }
   let(:role) { create(:role, permissions: %i[edit_project]) }
-  let(:member) { create(:member, user: admin, project: project, roles: [role]) }
+  let(:member) { create(:member, user: admin, project:, roles: [role]) }
 
   # We need to be admin user to get the simplified default_scope from MemberQuery
   before do

--- a/spec/models/queries/members/member_query_spec.rb
+++ b/spec/models/queries/members/member_query_spec.rb
@@ -1,0 +1,91 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe Queries::Members::MemberQuery, type: :model do
+  let(:admin) { create(:admin) }
+  let(:instance) { described_class.new(user: admin) }
+  # This is the MemberQuery.default_scope with an admin user
+  let(:base_scope) { Member.from(Member.all.order(id: :desc), :members).distinct }
+
+  # Objects required for testing with filters
+  let(:group1) { create(:group) }
+  let(:group2) { create(:group) }
+  let(:project) { create(:project) }
+  let(:role) { create(:role, permissions: %i[edit_project]) }
+  let(:member) { create(:member, user: admin, project: project, roles: [role]) }
+
+  # We need to be admin user to get the simplified default_scope from MemberQuery
+  before do
+    # instance.new uses default_user, and we need an admin to get a default_scope of Member.all
+    login_as(admin)
+  end
+
+  context 'without filter nor data' do
+    describe '#results' do
+      # Check that the query SQL is the same as the manual SQL
+      it 'is the same as getting all the members' do
+        expect(instance.results.to_sql).to eql base_scope.to_sql
+      end
+    end
+  end
+
+  context 'with a user but without filters' do
+    before do
+      # We need to write the membership to the DB to count results
+      member.save
+    end
+
+    describe '#results' do
+      it 'returns the single test user if no filters are specified' do
+        expect(instance.results.count).to eq 1
+      end
+    end
+  end
+
+  # Check for regression of bug #38672 describes a case with group filters
+  # and a user being member in two different groups which leads to the user
+  # appearing twice.
+  context 'with group filter and a user belonging to two groups' do
+    let(:instance) { described_class.new(user: admin).where(:group, '=', group1.id) }
+
+    before do
+      member.save
+      # Add the admin user to the two groups
+      Groups::UpdateService.new(user: admin, model: group1).call(user_ids: Array(admin.id))
+      Groups::UpdateService.new(user: admin, model: group2).call(user_ids: Array(admin.id))
+    end
+
+    describe '#results' do
+      it 'returns a single result despite the test user being member of two groups' do
+        expect(instance.results.count).to eq 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/work_packages/38672

… (and the user is in several groups that have a membership role).

Added a "select distinct * from (...)" around the results of MemberQuery in order to eliminate multiple rows returned by the group filter in MemberQuery if a user belongs to multiple groups.
Also added a brand new spec for MemberQuery testing the happy path and the regression of this bug.