### PR TITLE
override value from unprefixed env only for used-to-be configuration settings

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -84,6 +84,14 @@ module Settings
       end
     end
 
+    def unprefixed_env_var_name_allowed?
+      # Configuration values could be overridden with unprefixed env var
+      # names before being harmonized (PR#10296). Using unprefixed en var
+      # is deprecated and will be removed in 13.0.
+      # Configuration are recognized by not being writable.
+      !writable
+    end
+
     def override_value(other_value)
       if format == :hash
         self.value = {} if value.nil?
@@ -333,7 +341,7 @@ module Settings
       end
 
       def env_name_unprefixed(definition)
-        definition.name.upcase
+        definition.name.upcase if definition.unprefixed_env_var_name_allowed?
       end
 
       def env_name_alias(definition)

--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -97,22 +97,30 @@ describe Settings::Definition do
       it 'allows overriding configuration from ENV without OPENPROJECT_ prefix' do
         stub_const('ENV',
                    {
-                     'EDITION' => 'bim',
-                     'DEFAULT_LANGUAGE' => 'de'
+                     'EDITION' => 'bim'
                    })
 
         expect(value_for('edition')).to eql 'bim'
-        expect(value_for('default_language')).to eql 'de'
+      end
+
+      it 'does not allows overriding configuration from ENV without OPENPROJECT_ prefix if setting is writable' do
+        stub_const('ENV',
+                   {
+                     'DEFAULT_LANGUAGE' => 'de'
+                   })
+
+        expect(value_for('default_language')).not_to eql 'de'
+        expect(value_for('default_language')).to eql 'en'
       end
 
       it 'logs a deprecation warning when overriding configuration from ENV without OPENPROJECT_ prefix' do
         allow(Rails.logger).to receive(:warn)
-        stub_const('ENV', { 'DEFAULT_LANGUAGE' => 'de' })
+        stub_const('ENV', { 'EDITION' => 'bim' })
 
-        expect(value_for('default_language')).to eql 'de'
+        expect(value_for('edition')).to eql 'bim'
         expect(Rails.logger)
           .to have_received(:warn)
-              .with(a_string_including("use OPENPROJECT_DEFAULT_LANGUAGE instead of DEFAULT_LANGUAGE"))
+              .with(a_string_including("use OPENPROJECT_EDITION instead of EDITION"))
       end
 
       it 'overriding boolean configuration from ENV will cast the value' do


### PR DESCRIPTION
Before [harmonization](https://github.com/opf/openproject/pull/10296), `OpenProject::Configuration` data could be overridden with unprefixed env vars, while `Setting` could not. This PR restores the distinction between both and forbids definitions that were `Setting` before to be overriden with unprefixed env vars.

This should fix the issue of `HOST_NAME` env var being used to set the value of `Settings.host_name`. Now only `OPENPROJECT_HOST_NAME` can be used