### PR TITLE
Account for padding in scroll height

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/lazyloaded/lazyloaded-autocompleter.ts
+++ b/frontend/src/app/shared/components/autocompleter/lazyloaded/lazyloaded-autocompleter.ts
@@ -161,7 +161,7 @@ export namespace LazyLoadedAutocompleter {
     const height = container.outerHeight()!;
     const { scrollHeight } = container[0];
     const scrollTop = container.scrollTop()!;
-    return scrollTop >= (scrollHeight - height);
+    return scrollTop >= (scrollHeight - height - 6);
   }
 
   export function register<T>(name:string, ctrl:ILazyAutocompleterBridge<T>) {


### PR DESCRIPTION
The projects dropdown is lazily rendered. A new page is added whenever the scrollbar reaches the bottom of the scrollable area.

A padding of 6px was introduced, which results in the scrollable area never reaching the true bottom of the page. This in turn results in only the first 250 pages being rendered.

https://community.openproject.org/work_packages/42058