### PR TITLE
define aliases for smtp/mail definitions

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -138,6 +138,9 @@ module Settings
       #  Will serve to be validated against. A lambda can be provided returning an array in case
       #  the array needs to be evaluated dynamically. In case of e.g. boolean format, setting
       #  an allowed array is not necessary.
+      # @param [nil] env_alias Alternative for the default env name to also look up. E.g. with the alias set to
+      #  `OPENPROJECT_2FA` for a definition with the name `two_factor_authentication`, the value is fetched
+      #  from the ENV OPENPROJECT_2FA as well.
       def add(name,
               value:,
               format: nil,
@@ -345,7 +348,9 @@ module Settings
       end
 
       def env_name_alias(definition)
-        "#{ENV_PREFIX}#{definition.env_alias.upcase}" if definition.env_alias
+        return unless definition.env_alias
+
+        definition.env_alias.upcase
       end
 
       ##

--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -347,11 +347,13 @@ Settings::Definition.define do
   add :email_delivery_configuration,
       value: 'inapp',
       allowed: %w[inapp legacy],
-      writable: false
+      writable: false,
+      env_alias: 'EMAIL_DELIVERY_CONFIGURATION'
 
   add :email_delivery_method,
       format: :symbol,
-      value: nil
+      value: nil,
+      env_alias: 'EMAIL_DELIVERY_METHOD'
 
   add :emails_footer,
       value: {
@@ -802,9 +804,16 @@ Settings::Definition.define do
       value: true,
       writable: false
 
+  add :smtp_authentication,
+      format: :string,
+      value: 'plain',
+      writable: false,
+      env_alias: 'SMTP_AUTHENTICATION'
+
   add :smtp_enable_starttls_auto,
       format: :boolean,
-      value: false
+      value: false,
+      env_alias: 'SMTP_ENABLE_STARTTLS_AUTO'
 
   add :smtp_openssl_verify_mode,
       format: :string,
@@ -814,32 +823,33 @@ Settings::Definition.define do
 
   add :smtp_ssl,
       format: :boolean,
-      value: false
+      value: false,
+      env_alias: 'SMTP_SSL'
 
   add :smtp_address,
       format: :string,
-      value: ''
+      value: '',
+      env_alias: 'SMTP_ADDRESS'
 
   add :smtp_domain,
       format: :string,
-      value: 'your.domain.com'
+      value: 'your.domain.com',
+      env_alias: 'SMTP_DOMAIN'
 
   add :smtp_user_name,
       format: :string,
-      value: ''
+      value: '',
+      env_alias: 'SMTP_USER_NAME'
 
   add :smtp_port,
       format: :integer,
-      value: 587
+      value: 587,
+      env_alias: 'SMTP_PORT'
 
   add :smtp_password,
       format: :string,
-      value: ''
-
-  add :smtp_authentication,
-      format: :string,
-      value: 'plain',
-      writable: false
+      value: '',
+      env_alias: 'SMTP_PASSWORD'
 
   add :software_name,
       value: 'OpenProject'

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/engine.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/engine.rb
@@ -18,7 +18,7 @@ module OpenProject::TwoFactorAuthentication
                  # Don't allow remember cookie
                  allow_remember_for_days: 0
                },
-               env_alias: '2FA' # can override values with OPENPROJECT_2FA env var
+               env_alias: 'OPENPROJECT_2FA'
              },
              bundled: true do
                menu :my_menu,

--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -109,8 +109,34 @@ describe Settings::Definition do
                      'DEFAULT_LANGUAGE' => 'de'
                    })
 
-        expect(value_for('default_language')).not_to eql 'de'
         expect(value_for('default_language')).to eql 'en'
+      end
+
+      it 'allows overriding email/smpt configuration from ENV without OPENPROJECT_ prefix even though setting is writable' do
+        stub_const('ENV',
+                   {
+                     'EMAIL_DELIVERY_CONFIGURATION' => 'legacy',
+                     'EMAIL_DELIVERY_METHOD' => 'smtp',
+                     'SMTP_ADDRESS' => 'smtp.somedomain.org',
+                     'SMTP_AUTHENTICATION' => 'something',
+                     'SMTP_DOMAIN' => 'email.bogus.abc',
+                     'SMTP_ENABLE_STARTTLS_AUTO' => 'true',
+                     'SMTP_PASSWORD' => 'password',
+                     'SMTP_PORT' => '987',
+                     'SMTP_USER_NAME' => 'user',
+                     'SMTP_SSL' => 'true'
+                   })
+
+        expect(value_for('email_delivery_configuration')).to eql 'legacy'
+        expect(value_for('email_delivery_method')).to eq :smtp
+        expect(value_for('smtp_address')).to eql 'smtp.somedomain.org'
+        expect(value_for('smtp_authentication')).to eql 'something'
+        expect(value_for('smtp_domain')).to eql 'email.bogus.abc'
+        expect(value_for('smtp_enable_starttls_auto')).to be true
+        expect(value_for('smtp_password')).to eql 'password'
+        expect(value_for('smtp_port')).to eq 987
+        expect(value_for('smtp_user_name')).to eq 'user'
+        expect(value_for('smtp_ssl')).to be true
       end
 
       it 'logs a deprecation warning when overriding configuration from ENV without OPENPROJECT_ prefix' do


### PR DESCRIPTION
Removes the automatic prefixing of env_alias to allow for a greater flexibility. That way, the email settings can be unprefixed as well as prefixed and the 2FA will always be prefixed.

https://community.openproject.org/wp/42209