### PR TITLE
Escape single quotes from i18n string in sql query

### DIFF
--- a/lib/api/v3/projects/project_sql_representer.rb
+++ b/lib/api/v3/projects/project_sql_representer.rb
@@ -77,7 +77,8 @@ module API
               <<-SQL.squish
                 CASE
                   WHEN ancestors.id IS NOT NULL
-                    THEN json_build_object('href', format('/api/v3/projects/%s', ancestors.id), 'title', ancestors.name)
+                    THEN json_build_object('href', format('/api/v3/projects/%s', ancestors.id),
+                                           'title', ancestors.name)
                   ELSE NULL
                 END
               SQL
@@ -85,9 +86,11 @@ module API
               <<-SQL.squish
                 CASE
                   WHEN ancestors.id IS NOT NULL AND ancestors.id IN (SELECT id FROM visible_projects)
-                    THEN json_build_object('href', format('/api/v3/projects/%s', ancestors.id), 'title', ancestors.name)
+                    THEN json_build_object('href', format('/api/v3/projects/%s', ancestors.id),
+                                           'title', ancestors.name)
                   WHEN ancestors.id IS NOT NULL AND ancestors.id NOT IN (SELECT id FROM visible_projects)
-                    THEN json_build_object('href', '#{API::V3::URN_UNDISCLOSED}', 'title', '#{I18n.t(:'api_v3.undisclosed.ancestor')}')
+                    THEN json_build_object('href', '#{API::V3::URN_UNDISCLOSED}',
+                                           'title', #{ActiveRecord::Base.connection.quote(I18n.t(:'api_v3.undisclosed.ancestor'))})
                   ELSE NULL
                 END
               SQL

--- a/spec/lib/api/v3/projects/project_sql_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_sql_representer_rendering_spec.rb
@@ -154,6 +154,32 @@ describe ::API::V3::Projects::ProjectSqlRepresenter, 'rendering' do
           }.to_json
         )
     end
+
+    context 'when in a foreign language with single quotes in the translation hint text' do
+      before do
+        I18n.locale = :fr
+      end
+
+      it 'renders as expected' do
+        expect(json)
+          .to be_json_eql(
+            {
+              _links: {
+                ancestors: [
+                  {
+                    href: api_v3_paths.project(grandparent.id),
+                    title: grandparent.name
+                  },
+                  {
+                    href: API::V3::URN_UNDISCLOSED,
+                    title: I18n.t(:'api_v3.undisclosed.ancestor')
+                  }
+                ]
+              }
+            }.to_json
+          )
+      end
+    end
   end
 
   context 'with an archived ancestor but with the user being admin' do


### PR DESCRIPTION
Will fix PG::SyntaxError seen on Sentry SAAS-OPENPROJECT-PROD-111

https://sentry2.openproject.com/organizations/sentry/issues/1799/events/27338691eee84473b79410165e54bd6f/\?project\=6

The error occurs with french and italian locales.