### PR TITLE
Add dotenv-rails to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -265,6 +265,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'dotenv-rails'
   # Require factory_bot for usage with openproject plugins testing
   gem 'factory_bot', '~> 6.2.0'
   # require factory_bot_rails for convenience in core development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,6 +411,10 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     doorkeeper (5.5.4)
       railties (>= 5)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     dry-configurable (0.15.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.6)
@@ -1012,6 +1016,7 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.1.5)
   disposable (~> 0.6.2)
   doorkeeper (~> 5.5.0)
+  dotenv-rails
   email_validator (~> 2.2.3)
   equivalent-xml (~> 0.6)
   escape_utils (~> 1.0)

--- a/docs/development/development-environment-osx/README.md
+++ b/docs/development/development-environment-osx/README.md
@@ -167,6 +167,8 @@ test:
   database: openproject_test
 ```
 
+To configure the environment variables such as the number of web server threads `OPENPROJECT_WEB_WORKERS`, copy the `.env.example` to `.env` and add the environment variables you want to configure. The variables will be automatically loaded to the application's environment.
+
 ## Finish the Installation of OpenProject
 
 Install code dependencies, link plugin modules and export translation files.

--- a/docs/development/development-environment-ubuntu/README.md
+++ b/docs/development/development-environment-ubuntu/README.md
@@ -218,6 +218,8 @@ test:
   database: openproject_test
 ```
 
+To configure the environment variables such as the number of web server threads `OPENPROJECT_WEB_WORKERS`, copy the `.env.example` to `.env` and add the environment variables you want to configure. The variables will be automatically loaded to the application's environment.
+
 ## Finish the Installation of OpenProject
 
 Install code dependencies, link plugin modules and export translation files.

--- a/docs/installation-and-operations/installation/manual/README.md
+++ b/docs/installation-and-operations/installation/manual/README.md
@@ -219,6 +219,7 @@ file are sensitive to whitespace. It is pretty easy to write
 invalid `yml` files without seeing the error. Validating those files
 prevents you from such errors.
 
+To configure the environment variables such as the number of web server threads `OPENPROJECT_WEB_WORKERS`, copy the `.env.example` to `.env` and add the environment variables you want to configure. The variables will be automatically loaded to the application's environment.
 
 ## Finish the installation of OpenProject
 


### PR DESCRIPTION
I wanted to use the `.env` file for local configuration, but the file is not being used without the dotenv-rails gem.