### PR TITLE
[42217] Layout of spent time widget is broken

### DIFF
--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.sass
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.sass
@@ -111,7 +111,7 @@ te-calendar
           display: none
 
       .fc-event-title-container
-        margin: 4px !important
+        margin: 0 4px !important
         line-height: 14px !important
 
     .fc-duration


### PR DESCRIPTION
Remove top and bottom margin as it crashes the layout for small time entries (e.g. 0.25h)

https://community.openproject.org/projects/openproject/work_packages/42217/activity