### PR TITLE
[42237] Add project settings looks broken in notification settings

### DIFF
--- a/frontend/src/app/features/user-preferences/notifications-settings/inline-create/notification-setting-inline-create.component.html
+++ b/frontend/src/app/features/user-preferences/notifications-settings/inline-create/notification-setting-inline-create.component.html
@@ -2,10 +2,10 @@
   <button
       *ngIf="!active"
       (click)="active = true"
-      class="wp-inline-create--add-link"
+      class="spot-link"
       type="button"
   >
-    <op-icon icon-classes="icon-context icon-add"></op-icon>
+    <span class="spot-icon spot-icon_add"></span>
     <span [textContent]="text.add_setting"></span>
   </button>
 


### PR DESCRIPTION
Replace inline create button with spot-link for correct styling

https://community.openproject.org/projects/openproject/work_packages/42237/activity