### PR TITLE
Add styled scrollbar to project include

### DIFF
--- a/frontend/src/app/shared/components/project-include/project-include.component.sass
+++ b/frontend/src/app/shared/components/project-include/project-include.component.sass
@@ -1,4 +1,5 @@
 @import '../../../spot/styles/sass/variables'
+@import 'helpers'
 
 \::ng-deep .spot-drop-modal--body
 
@@ -26,6 +27,7 @@
       max-height: 70vh
 
   &--list
+    @include styled-scroll-bar
     overflow-y: auto
     flex-shrink: 1
     flex-basis: 100%


### PR DESCRIPTION
This was forgotten because the default browser scrollbars from everyone
that tested looks and feels close to our override. This commit adds the
scrollbar to this specific section. In the future, a global override
could be added to prevent this from happening.

Closes https://community.openproject.org/work_packages/42225/activity