### PR TITLE
Fix/42229/autocompleter typeahead

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -4,7 +4,7 @@
     [(ngModel)]="model"
     [items]="results$ | async"
     [ngClass]="classes"
-    [typeahead]="boundTypeahead"
+    [typeahead]="typeahead"
     [clearOnBackspace]="clearOnBackspace"
     [clearSearchOnAdd]="clearSearchOnAdd"
     [hideSelected]="hideSelected"

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -128,6 +128,7 @@
       ></op-principal>
       <span
         class="op-autocompleter--wp-subject"
+        data-qa-selector="op-autocompleter-item-subject"
       >
         <span
           *ngIf="item.type"

--- a/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
+++ b/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
@@ -39,13 +39,15 @@ describe 'My page time entries current user widget spec', type: :feature, js: tr
     create :work_package,
            project: project,
            type: type,
-           author: user
+           author: user,
+           subject: 'First work package'
   end
   let!(:other_work_package) do
     create :work_package,
            project: project,
            type: type,
-           author: user
+           author: user,
+           subject: 'Another task'
   end
   let!(:visible_time_entry) do
     create :time_entry,
@@ -184,6 +186,12 @@ describe 'My page time entries current user widget spec', type: :feature, js: tr
 
     expect(page)
       .not_to have_selector('.ng-spinner-loader')
+
+    # Expect filtering works
+    time_logging_modal.work_package_field.autocomplete work_package.subject, select: false
+
+    expect(page).to have_selector('[data-qa-selector="op-autocompleter-item-subject"]', text: work_package.subject)
+    expect(page).to have_no_selector('[data-qa-selector="op-autocompleter-item-subject"]', text: other_work_package.subject)
 
     time_logging_modal.update_work_package_field other_work_package.subject
 

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -134,16 +134,28 @@ class EditField
   # For fields of type select, will check for an option with that value.
   def set_value(content)
     scroll_to_element(input_element)
-    if field_type.end_with?('-autocompleter')
-      select_autocomplete field_container,
-                          query: content,
-                          results_selector: 'body'
+    if autocompleter_field?
+      autocomplete(content)
     else
       # A normal fill_in would cause the focus loss on the input for empty strings.
       # Thus the form would be submitted.
       # https://github.com/erikras/redux-form/issues/686
       input_element.fill_in with: content, fill_options: { clear: :backspace }
     end
+  end
+
+  def autocomplete(query, select: true)
+    raise ArgumentError.new('Is not an autocompleter field') unless autocompleter_field?
+
+    if select
+      select_autocomplete field_container, query: query, results_selector: 'body'
+    else
+      search_autocomplete field_container, query: query, results_selector: 'body'
+    end
+  end
+
+  def autocompleter_field?
+    field_type.end_with?('-autocompleter')
   end
 
   ##


### PR DESCRIPTION
In the edit fields, we bind `[items]="availableValues"` and update those values from the typeahead emitter.

The typeahead however was no longer being bound in op-autocompleter when neither getOptionsFn nor defaultData was set.

This results in the autocompleter never firing again.

https://github.com/opf/openproject/pull/10559
https://community.openproject.org/wp/42229