### PR TITLE
Remove budget when copying work package

### DIFF
--- a/app/services/projects/copy/work_packages_dependent_service.rb
+++ b/app/services/projects/copy/work_packages_dependent_service.rb
@@ -134,6 +134,9 @@ module Projects::Copy
         assigned_to_id: work_package_assigned_to_id(source_work_package),
         responsible_id: work_package_responsible_id(source_work_package),
         custom_field_values: custom_value_attributes,
+        # We don't support copying budgets right now
+        budget_id: nil,
+
         # We fetch the value from the global registry to persist it in the job which
         # will trigger a delayed job for potentially sending the journal notifications.
         send_notifications: ActionMailer::Base.perform_deliveries

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -254,6 +254,22 @@ describe Projects::CopyService, 'integration', type: :model do
       end
     end
 
+    context 'with work package budgets' do
+      let!(:budget) { create(:budget, project: source) }
+
+      let(:only_args) { %w[work_packages] }
+
+      it 'copies the work package without budgets' do
+        source_wp.update!(budget: budget)
+
+        expect(subject).to be_success
+
+        expect(source.work_packages.count).to eq(project_copy.work_packages.count)
+        copied_wp = project_copy.work_packages.find_by(subject: 'source wp')
+        expect(copied_wp.budget).to be_nil
+      end
+    end
+
     describe '#copy_wiki' do
       it 'will not copy wiki pages without content' do
         source.wiki.pages << create(:wiki_page)


### PR DESCRIPTION
Copying budgets is not supported as of now, but it should not prevent work packages from being copied that have one assigned.

https://community.openproject.org/wp/42227