### PR TITLE
Parameterize module name for use in checkAll function

### DIFF
--- a/app/views/roles/_permissions.html.erb
+++ b/app/views/roles/_permissions.html.erb
@@ -30,7 +30,8 @@ See COPYRIGHT and LICENSE files for more details.
 <% permissions.each do |mod, mod_permissions| %>
   <% global_prefix = show_global_role ? 'fieldset--global--' : 'fieldset--' %>
   <% module_name = mod.blank? ? 'fieldset--global--' + Project.model_name.human.downcase.gsub(' ', '_') : global_prefix + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_') %>
-  <fieldset class="form--fieldset -collapsible" id="<%= module_name %>">
+  <% module_id = module_name.parameterize  %>
+  <fieldset class="form--fieldset -collapsible" id="<%= module_id %>">
     <legend class="form--fieldset-legend">
       <% if mod.blank? %>
         <%= show_global_role ? t(:label_global) : Project.model_name.human %>
@@ -40,7 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
     </legend>
     <div class="form--toolbar">
       <span class="form--toolbar-item">
-        (<%= check_all_links module_name %>)
+        (<%= check_all_links module_id %>)
       </span>
     </div>
     <div class="-columns-2">


### PR DESCRIPTION
Otherwise, the french module name `planificateur d'équipe` will fail to be used as a param due to lack of escaping

https://community.openproject.org/wp/42246