### PR TITLE
Update README.md. Changed git:// to https://

### DIFF
--- a/docs/installation-and-operations/installation/manual/README.md
+++ b/docs/installation-and-operations/installation/manual/README.md
@@ -132,7 +132,7 @@ time to finish.
 [openproject@host] echo 'export PATH="$HOME/.nodenv/bin:$PATH"' >> ~/.profile
 [openproject@host] echo 'eval "$(nodenv init -)"' >> ~/.profile
 [openproject@host] source ~/.profile
-[openproject@host] git clone git://github.com/OiNutter/node-build.git ~/.nodenv/plugins/node-build
+[openproject@host] git clone https://github.com/OiNutter/node-build.git ~/.nodenv/plugins/node-build
 
 [openproject@host] nodenv install 14.16.0
 [openproject@host] nodenv rehash


### PR DESCRIPTION
The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.