### PR TITLE
[42252] Export modal opens when clicking on "introduction video"

### DIFF
--- a/app/views/onboarding/_menu_item.html.erb
+++ b/app/views/onboarding/_menu_item.html.erb
@@ -29,12 +29,13 @@ See COPYRIGHT and LICENSE files for more details.
 <li
   class="op-menu--item"
   data-augmented-model-wrapper
+  data-activation-selector=".onboarding-modal--activation-link"
   data-modal-iframe-url="<%= OpenProject::Configuration.onboarding_video_url %>"
   data-modal-class-name="onboarding-modal op-modal_autoheight -highlight"
 >
   <%= link_to t(:label_introduction_video),
               '',
               title: t(:label_introduction_video),
-              class: 'op-menu--item-action modal-delivery-element--activation-link' %>
+              class: 'op-menu--item-action onboarding-modal--activation-link' %>
   <%= render partial: '/onboarding/onboarding_video_modal' %>
 </li>


### PR DESCRIPTION
Give the onboarding video activation link a different class to avoid conflicts with the export modals on certain pages (e.g. wiki or project list). Before, when clicking on "introduction video" in the global help menu, the export modal was opened.

This issue was raised by these two bugs:  
https://community.openproject.org/projects/openproject/work_packages/42252/activity
https://community.openproject.org/projects/openproject/work_packages/41924/activity

Although the video did never auto-start for me, it is now also not requested in the network tab when opening the export modal. So that should fix these issues as well.