### PR TITLE
[42250] Search field does not open on mobile

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -172,6 +172,9 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
         this.toggleMobileSearch();
         // open ng-select menu on default
         jQuery('.ng-input input').focus();
+        // only for mobile and not for all devices!
+        // See https://github.com/opf/openproject/commit/a2eb0cd6025f2ecaca00f4ed81c4eb8e9399bd86
+        event.stopPropagation();
       } else if (this.searchTerm?.length === 0) {
         this.ngSelectComponent.ngSelectInstance.focus();
       } else {


### PR DESCRIPTION
Stop event propagation on mobile to avoid a quick open and direct close of the search. That is fine, as on mobile no other modal could wait for this event as the modals span full height. 
The issue was introduced by [this commit](https://github.com/opf/openproject/commit/a2eb0cd6025f2ecaca00f4ed81c4eb8e9399bd86).


https://community.openproject.org/projects/openproject/work_packages/42250/activity