### PR TITLE
Duration as an explicit work package column

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -131,9 +131,13 @@ module WorkPackages
     validate :validate_assigned_to_exists
 
     validates :duration,
-              comparison: { greater_than: 0 },
+              # only_integer: true, cannot be used as that will not compare with the value
+              # before the type cast. So even a float value will pass the validation as it is silently
+              # floored.
+              numericality: { greater_than: 0 },
               allow_nil: true
 
+    validate :validate_duration_integer
     validate :validate_duration_matches_dates
 
     def initialize(work_package, user, options: {})
@@ -311,6 +315,10 @@ module WorkPackages
                    I18n.t('api_v3.errors.validation.invalid_user_assigned_to_work_package',
                           property: I18n.t("attributes.#{attribute}"))
       end
+    end
+
+    def validate_duration_integer
+      errors.add :duration, :only_integer if model.duration_before_type_cast != model.duration
     end
 
     def validate_duration_matches_dates

--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -205,7 +205,7 @@ module WorkPackages
 
     def validate_enabled_type
       # Checks that the issue can not be added/moved to a disabled type
-      if type_context_changed? && !model.project.types.include?(model.type)
+      if type_context_changed? && model.project.types.exclude?(model.type)
         errors.add :type_id, :inclusion
       end
     end
@@ -313,9 +313,7 @@ module WorkPackages
     end
 
     def validate_duration_matches_dates
-      return unless model.start_date && model.due_date && model.duration
-
-      calculated_duration = model.due_date - model.start_date + 1
+      return unless calculated_duration && model.duration
 
       if calculated_duration > model.duration
         errors.add :duration, :smaller_than_dates
@@ -343,7 +341,7 @@ module WorkPackages
     end
 
     def principal_visible?(id, list)
-      list.exists?(id: id)
+      list.exists?(id:)
     end
 
     def start_before_soonest_start?
@@ -364,7 +362,7 @@ module WorkPackages
     end
 
     def category_not_of_project?
-      model.category && !model.project.categories.include?(model.category)
+      model.category && model.project.categories.exclude?(model.category)
     end
 
     def status_changed?
@@ -433,6 +431,12 @@ module WorkPackages
     # We're in a readonly status and did not move into that status right now.
     def already_in_readonly_status?
       model.readonly_status? && !model.status_id_change
+    end
+
+    def calculated_duration
+      return nil unless model.due_date && model.start_date
+
+      model.due_date - model.start_date + 1
     end
   end
 end

--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -318,7 +318,7 @@ module WorkPackages
     end
 
     def validate_duration_integer
-      errors.add :duration, :only_integer if model.duration_before_type_cast != model.duration
+      errors.add :duration, :not_an_integer if model.duration_before_type_cast != model.duration
     end
 
     def validate_duration_matches_dates

--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -131,7 +131,8 @@ module WorkPackages
     validate :validate_assigned_to_exists
 
     validates :duration,
-              comparison: { greater_than: 0 }
+              comparison: { greater_than: 0 },
+              allow_nil: true
 
     validate :validate_duration_matches_dates
 

--- a/app/models/work_package/scheduling_rules.rb
+++ b/app/models/work_package/scheduling_rules.rb
@@ -62,19 +62,4 @@ module WorkPackage::SchedulingRules
         .compact
         .max
   end
-
-  # Returns the time scheduled for this work package.
-  #
-  # Example:
-  #   Start Date: 2/26/09, Finish Date: 3/04/09,  duration => 7
-  #   Start Date: 2/26/09, Finish Date: 2/26/09,  duration => 1
-  #   Start Date: 2/26/09, Finish Date: -      ,  duration => 1
-  #   Start Date: -      , Finish Date: 2/26/09,  duration => 1
-  def duration
-    if start_date && due_date
-      due_date - start_date + 1
-    else
-      1
-    end
-  end
 end

--- a/app/services/work_packages/copy_service.rb
+++ b/app/services/work_packages/copy_service.rb
@@ -65,22 +65,32 @@ class WorkPackages::CopyService
 
   def create(attributes, send_notifications)
     WorkPackages::CreateService
-      .new(user: user,
-           contract_class: contract_class)
-      .call(**attributes.merge(send_notifications: send_notifications).symbolize_keys)
+      .new(user:,
+           contract_class:)
+      .call(**attributes.merge(send_notifications:).symbolize_keys)
   end
 
-  def copied_attributes(wp, override)
-    wp
-      .attributes
-      .slice(*writable_work_package_attributes(wp))
-      .merge('parent_id' => wp.parent_id,
-             'custom_field_values' => wp.custom_value_attributes)
-      .merge(override)
+  def copied_attributes(work_package, override)
+    overwritten_attributes = override.stringify_keys
+
+    attributes = work_package
+                   .attributes
+                   .slice(*writable_work_package_attributes(work_package))
+                   .merge('parent_id' => work_package.parent_id,
+                          'custom_field_values' => work_package.custom_value_attributes)
+                   .merge(overwritten_attributes)
+
+    if overwritten_attributes.has_key?('start_date') &&
+      overwritten_attributes.has_key?('due_date') &&
+      !overwritten_attributes.has_key?('duration')
+      attributes.delete('duration')
+    end
+
+    attributes
   end
 
-  def writable_work_package_attributes(wp)
-    instantiate_contract(wp, user).writable_attributes
+  def writable_work_package_attributes(work_package)
+    instantiate_contract(work_package, user).writable_attributes
   end
 
   def remove_author_watcher(copied)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -578,6 +578,7 @@ en:
         begin_deletion: "Begin of the deletion"
         children: "Subelements"
         done_ratio: "Progress (%)"
+        duration: "Duration"
         end_insertion: "End of the insertion"
         end_deletion: "End of the deletion"
         version: "Version"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -793,6 +793,9 @@ en:
           attributes:
             due_date:
               not_start_date: "is not on start date, although this is required for milestones."
+            duration:
+              larger_than_dates: "is larger than the interval between the start and the finish date."
+              smaller_than_dates: "is smaller than the interval between the start and the finish date."
             parent:
               cannot_be_milestone: "cannot be a milestone."
               cannot_be_self_assigned: "cannot be assigned to itself."

--- a/db/migrate/20220505154549_add_duration_to_work_packages.rb
+++ b/db/migrate/20220505154549_add_duration_to_work_packages.rb
@@ -1,0 +1,5 @@
+class AddDurationToWorkPackages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :work_packages, :duration, :integer
+  end
+end

--- a/db/migrate/20220525154549_add_duration_to_work_packages.rb
+++ b/db/migrate/20220525154549_add_duration_to_work_packages.rb
@@ -1,5 +1,7 @@
 class AddDurationToWorkPackages < ActiveRecord::Migration[6.1]
   def change
     add_column :work_packages, :duration, :integer
+
+    add_column :work_package_journals, :duration, :integer
   end
 end

--- a/db/migrate/20220525154549_add_duration_to_work_packages.rb
+++ b/db/migrate/20220525154549_add_duration_to_work_packages.rb
@@ -3,5 +3,28 @@ class AddDurationToWorkPackages < ActiveRecord::Migration[6.1]
     add_column :work_packages, :duration, :integer
 
     add_column :work_package_journals, :duration, :integer
+
+    reversible do |dir|
+      dir.up do
+        set_duration(:work_packages)
+        set_duration(:work_package_journals)
+      end
+    end
+  end
+
+  private
+
+  def set_duration(table)
+    execute <<~SQL.squish
+      UPDATE
+        #{table}
+      SET
+        duration = CASE
+                   WHEN start_date IS NULL OR due_date IS NULL
+                   THEN 1
+                   ELSE
+                     due_date - start_date + 1
+                   END
+    SQL
   end
 end

--- a/lib/api/v3/activities/activity_property_formatters.rb
+++ b/lib/api/v3/activities/activity_property_formatters.rb
@@ -39,15 +39,19 @@ module API
         def formatted_details(journal)
           details = render_details(journal, no_html: true)
           html_details = render_details(journal)
-          formattables = details.zip(html_details)
 
-          formattables.map { |d| { format: 'custom', raw: d[0], html: d[1] } }
+          details
+            .zip(html_details)
+            .map { |d| { format: 'custom', raw: d[0], html: d[1] } }
         end
 
         private
 
         def render_details(journal, no_html: false)
-          journal.details.map { |d| journal.render_detail(d, no_html: no_html) }
+          journal
+            .details
+            .map { |d| journal.render_detail(d, no_html:) }
+            .compact
         end
 
         def journal_note(journal)

--- a/lib/api/v3/activities/activity_representer.rb
+++ b/lib/api/v3/activities/activity_representer.rb
@@ -26,8 +26,6 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-API::V3::Utilities::DateTimeFormatter
-
 module API
   module V3
     module Activities
@@ -38,7 +36,7 @@ module API
         include ActivityPropertyFormatters
 
         self_link path: :activity,
-                  title_getter: ->(*) { nil }
+                  title_getter: ->(*) {}
 
         link :workPackage do
           {
@@ -90,10 +88,6 @@ module API
 
         def current_user_allowed_to_edit?
           represented.editable_by?(current_user)
-        end
-
-        def render_details(journal, no_html: false)
-          journal.details.map { |d| journal.render_detail(d, no_html: no_html) }
         end
       end
     end

--- a/modules/backlogs/spec/contracts/work_packages/create_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/work_packages/create_contract_spec.rb
@@ -29,12 +29,9 @@
 require 'spec_helper'
 
 describe WorkPackages::CreateContract do
-  let(:work_package) do
-    WorkPackage.new attributes_for(:stubbed_work_package, author: other_user, project: project)
-  end
+  let(:work_package) { build(:work_package, author: other_user, project:) }
   let(:other_user) { build_stubbed(:user) }
-  include_context 'user with stubbed permissions'
-  let (:project) { build_stubbed(:project) }
+  let(:project) { build_stubbed(:project) }
   let(:permissions) do
     %i[
       view_work_packages
@@ -45,6 +42,8 @@ describe WorkPackages::CreateContract do
 
   subject(:contract) { described_class.new(work_package, user) }
 
+  include_context 'user with stubbed permissions'
+
   before do
     allow(work_package).to receive(:changed).and_return(changed_values)
   end
@@ -54,11 +53,11 @@ describe WorkPackages::CreateContract do
       contract.validate
     end
 
-    context 'has not changed' do
+    context 'when not changed' do
       it('is valid') { expect(contract.errors.symbols_for(:story_points)).to be_empty }
     end
 
-    context 'has changed' do
+    context 'when changed' do
       let(:changed_values) { ['story_points'] }
 
       it('is valid') { expect(contract.errors.symbols_for(:story_points)).to be_empty }
@@ -66,20 +65,18 @@ describe WorkPackages::CreateContract do
   end
 
   describe 'remaining hours' do
-    context 'is no parent' do
-      before do
-        contract.validate
-      end
+    before do
+      contract.validate
+    end
 
-      context 'has not changed' do
-        it('is valid') { expect(contract.errors.symbols_for(:remaining_hours)).to be_empty }
-      end
+    context 'when not changed' do
+      it('is valid') { expect(contract.errors.symbols_for(:remaining_hours)).to be_empty }
+    end
 
-      context 'has changed' do
-        let(:changed_values) { ['remaining_hours'] }
+    context 'when changed' do
+      let(:changed_values) { ['remaining_hours'] }
 
-        it('is valid') { expect(contract.errors.symbols_for(:remaining_hours)).to be_empty }
-      end
+      it('is valid') { expect(contract.errors.symbols_for(:remaining_hours)).to be_empty }
     end
   end
 end

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -498,7 +498,7 @@ describe WorkPackages::BaseContract do
         work_package.duration = 4.5
       end
 
-      it_behaves_like 'contract is invalid', duration: :only_integer
+      it_behaves_like 'contract is invalid', duration: :not_an_integer
     end
 
     context 'when setting the duration to a negative value' do

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -27,6 +27,7 @@
 #++
 
 require 'spec_helper'
+require 'contracts/shared/model_contract_shared_context'
 
 describe WorkPackages::BaseContract do
   let(:work_package) do
@@ -79,6 +80,8 @@ describe WorkPackages::BaseContract do
   let(:changed_values) { [] }
 
   subject(:contract) { described_class.new(work_package, current_user) }
+
+  include_context 'ModelContract shared context'
 
   shared_examples_for 'invalid if changed' do |attribute|
     before do
@@ -426,7 +429,9 @@ describe WorkPackages::BaseContract do
 
       before do
         work_package.schedule_manually = schedule_manually
-        work_package.parent = build_stubbed(:work_package)
+        allow(work_package)
+          .to receive(:parent)
+          .and_return(build_stubbed(:work_package))
         allow(work_package)
           .to receive(:soonest_start)
           .and_return(Date.today + 4.days)
@@ -434,7 +439,7 @@ describe WorkPackages::BaseContract do
         work_package.start_date = Date.today + 2.days
       end
 
-      context 'scheduled automatically' do
+      context 'when scheduled automatically' do
         it 'notes the error' do
           contract.validate
 
@@ -446,20 +451,15 @@ describe WorkPackages::BaseContract do
         end
       end
 
-      context 'scheduled manually' do
+      context 'when scheduled manually' do
         let(:schedule_manually) { true }
 
-        it 'is valid' do
-          contract.validate
-
-          expect(contract.errors[:start_date])
-            .to be_empty
-        end
+        it_behaves_like 'contract is valid'
       end
     end
   end
 
-  describe 'finish date' do
+  describe 'due date' do
     it_behaves_like 'a parent unwritable property', :due_date, schedule_sensitive: true
     it_behaves_like 'a date attribute', :due_date
 
@@ -473,6 +473,72 @@ describe WorkPackages::BaseContract do
 
       expect(contract.errors[:due_date])
         .to include message
+    end
+  end
+
+  describe 'duration' do
+    context 'when setting the duration' do
+      before do
+        work_package.duration = 5
+      end
+
+      it_behaves_like 'contract is valid'
+    end
+
+    context 'when setting the duration to 0' do
+      before do
+        work_package.duration = 0
+      end
+
+      it_behaves_like 'contract is invalid', duration: :greater_than
+    end
+
+    context 'when setting the duration to a negative value' do
+      before do
+        work_package.duration = -5
+      end
+
+      it_behaves_like 'contract is invalid', duration: :greater_than
+    end
+
+    context 'when setting duration as well as the dates' do
+      before do
+        work_package.duration = 6
+        work_package.start_date = Time.zone.today - 4.days
+        work_package.due_date = Time.zone.today + 1.day
+      end
+
+      it_behaves_like 'contract is valid'
+    end
+
+    context 'when setting duration as well as the dates and the duration is too small' do
+      before do
+        work_package.duration = 5
+        work_package.start_date = Time.zone.today - 4.days
+        work_package.due_date = Time.zone.today + 1.day
+      end
+
+      it_behaves_like 'contract is invalid', duration: :smaller_than_dates
+    end
+
+    context 'when setting duration as well as the dates and the duration is too big' do
+      before do
+        work_package.duration = 7
+        work_package.start_date = Time.zone.today - 4.days
+        work_package.due_date = Time.zone.today + 1.day
+      end
+
+      it_behaves_like 'contract is invalid', duration: :larger_than_dates
+    end
+
+    context 'when setting duration as well as the dates to the same date' do
+      before do
+        work_package.duration = 1
+        work_package.start_date = Time.zone.today
+        work_package.due_date = Time.zone.today
+      end
+
+      it_behaves_like 'contract is valid'
     end
   end
 

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -493,6 +493,14 @@ describe WorkPackages::BaseContract do
       it_behaves_like 'contract is invalid', duration: :greater_than
     end
 
+    context 'when setting the duration to a floating point' do
+      before do
+        work_package.duration = 4.5
+      end
+
+      it_behaves_like 'contract is invalid', duration: :only_integer
+    end
+
     context 'when setting the duration to a negative value' do
       before do
         work_package.duration = -5

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -27,6 +27,14 @@
 #++
 
 FactoryBot.define do
+  duration_calculation = -> do
+    if start_date && due_date
+      due_date - start_date + 1
+    else
+      1
+    end
+  end
+
   factory :work_package do
     transient do
       custom_values { nil }
@@ -38,8 +46,9 @@ FactoryBot.define do
     sequence(:subject) { |n| "WorkPackage No. #{n}" }
     description { |i| "Description for '#{i.subject}'" }
     author factory: :user
-    created_at { Time.now }
-    updated_at { Time.now }
+    created_at { Time.zone.now }
+    updated_at { Time.zone.now }
+    duration &duration_calculation
 
     callback(:after_build) do |work_package, evaluator|
       work_package.type = work_package.project.types.first unless work_package.type
@@ -56,7 +65,7 @@ FactoryBot.define do
     end
   end
 
-  factory :stubbed_work_package, class: WorkPackage do
+  factory :stubbed_work_package, class: 'WorkPackage' do
     transient do
       custom_values { nil }
     end
@@ -67,8 +76,9 @@ FactoryBot.define do
     sequence(:subject) { |n| "WorkPackage No. #{n}" }
     description { |i| "Description for '#{i.subject}'" }
     author factory: :user
-    created_at { Time.now }
-    updated_at { Time.now }
+    created_at { Time.zone.now }
+    updated_at { Time.zone.now }
+    duration &duration_calculation
 
     callback(:after_stub) do |wp, arguments|
       wp.type = wp.project.types.first unless wp.type_id || arguments.instance_variable_get(:@overrides).has_key?(:type)

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -27,61 +27,65 @@
 #++
 
 FactoryBot.define do
-  duration_calculation = -> do
-    if start_date && due_date
-      due_date - start_date + 1
-    else
-      1
-    end
-  end
-
-  factory :work_package do
+  factory :abstract_work_package_factory, class: 'WorkPackage' do
     transient do
       custom_values { nil }
+      abstract_factory { raise "You can't instantiate this abstract factory." }
     end
 
     priority
-    project factory: :project_with_types
-    status factory: :status
-    sequence(:subject) { |n| "WorkPackage No. #{n}" }
-    description { |i| "Description for '#{i.subject}'" }
-    author factory: :user
-    created_at { Time.zone.now }
-    updated_at { Time.zone.now }
-    duration &duration_calculation
-
-    callback(:after_build) do |work_package, evaluator|
-      work_package.type = work_package.project.types.first unless work_package.type
-
-      custom_values = evaluator.custom_values || {}
-
-      if custom_values.is_a? Hash
-        custom_values.each_pair do |custom_field_id, value|
-          work_package.custom_values.build custom_field_id: custom_field_id, value: value
-        end
-      else
-        custom_values.each { |cv| work_package.custom_values << cv }
-      end
-    end
-  end
-
-  factory :stubbed_work_package, class: 'WorkPackage' do
-    transient do
-      custom_values { nil }
-    end
-
-    priority
-    project { build_stubbed(:project_with_types) }
     status
     sequence(:subject) { |n| "WorkPackage No. #{n}" }
     description { |i| "Description for '#{i.subject}'" }
     author factory: :user
-    created_at { Time.zone.now }
-    updated_at { Time.zone.now }
-    duration &duration_calculation
+    duration do
+      if start_date && due_date
+        due_date - start_date + 1
+      else
+        1
+      end
+    end
 
-    callback(:after_stub) do |wp, arguments|
-      wp.type = wp.project.types.first unless wp.type_id || arguments.instance_variable_get(:@overrides).has_key?(:type)
+    after(:build) do |_, evaluator|
+      evaluator.abstract_factory
+    end
+
+    after(:stub) do |_, evaluator|
+      evaluator.abstract_factory
+    end
+
+    factory :work_package do
+      transient do
+        abstract_factory { false }
+      end
+
+      project factory: :project_with_types
+
+      callback(:after_build) do |work_package, evaluator|
+        work_package.type = work_package.project.types.first unless work_package.type
+
+        custom_values = evaluator.custom_values || {}
+
+        if custom_values.is_a? Hash
+          custom_values.each_pair do |custom_field_id, value|
+            work_package.custom_values.build custom_field_id: custom_field_id, value: value
+          end
+        else
+          custom_values.each { |cv| work_package.custom_values << cv }
+        end
+      end
+    end
+
+    factory :stubbed_work_package, parent: :abstract_work_package_factory do
+      transient do
+        abstract_factory { false }
+      end
+
+      project { build_stubbed(:project_with_types) }
+
+      callback(:after_stub) do |wp, arguments|
+        wp.type = wp.project.types.first unless wp.type_id || arguments.instance_variable_get(:@overrides).has_key?(:type)
+      end
     end
   end
 end

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -68,7 +68,7 @@ FactoryBot.define do
 
         if custom_values.is_a? Hash
           custom_values.each_pair do |custom_field_id, value|
-            work_package.custom_values.build custom_field_id: custom_field_id, value: value
+            work_package.custom_values.build custom_field_id:, value:
           end
         else
           custom_values.each { |cv| work_package.custom_values << cv }

--- a/spec/features/projects/template_spec.rb
+++ b/spec/features/projects/template_spec.rb
@@ -146,7 +146,7 @@ describe 'Project templates', type: :feature, js: true do
 
       wp_source = template.work_packages.first.attributes.except(*%w[id author_id project_id updated_at created_at])
       wp_target = project.work_packages.first.attributes.except(*%w[id author_id project_id updated_at created_at])
-      expect(wp_source).to eq(wp_target)
+      expect(wp_target).to eq(wp_source)
 
       wiki_source = template.wiki.pages.first
       wiki_target = project.wiki.pages.first

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -37,7 +37,7 @@ describe 'date inplace editor',
          with_settings: { date_format: '%Y-%m-%d' },
          js: true, selenium: true do
   let(:project) { create :project_with_types, public: true }
-  let(:work_package) { create :work_package, project: project, start_date: Date.parse('2016-01-02') }
+  let(:work_package) { create :work_package, project:, start_date: Date.parse('2016-01-02') }
   let(:user) { create :admin }
   let(:work_packages_page) { Pages::FullWorkPackage.new(work_package, project) }
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
@@ -95,7 +95,7 @@ describe 'date inplace editor',
   context 'with start and end date set' do
     let(:work_package) do
       create :work_package,
-             project: project,
+             project:,
              start_date: Date.parse('2016-01-02'),
              due_date: Date.parse('2016-01-25')
     end
@@ -161,7 +161,7 @@ describe 'date inplace editor',
   end
 
   context 'with the start date empty' do
-    let(:work_package) { create :work_package, project: project, start_date: nil }
+    let(:work_package) { create :work_package, project:, start_date: nil }
 
     it 'can set "today" as a date via the provided link' do
       start_date.activate!
@@ -245,7 +245,7 @@ describe 'date inplace editor',
 
     let(:cf_field) { EditField.new page, :"customField#{date_cf.id}" }
     let(:datepicker) { ::Components::Datepicker.new }
-    let(:create_page) { ::Pages::FullWorkPackageCreate.new(project: project) }
+    let(:create_page) { ::Pages::FullWorkPackageCreate.new(project:) }
 
     it 'can handle creating a CF date' do
       create_page.visit!

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -37,7 +37,7 @@ describe 'date inplace editor',
          with_settings: { date_format: '%Y-%m-%d' },
          js: true, selenium: true do
   let(:project) { create :project_with_types, public: true }
-  let(:work_package) { create :work_package, project: project, start_date: '2016-01-02' }
+  let(:work_package) { create :work_package, project: project, start_date: Date.parse('2016-01-02') }
   let(:user) { create :admin }
   let(:work_packages_page) { Pages::FullWorkPackage.new(work_package, project) }
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
@@ -93,7 +93,12 @@ describe 'date inplace editor',
   end
 
   context 'with start and end date set' do
-    let(:work_package) { create :work_package, project: project, start_date: '2016-01-02', due_date: '2016-01-25' }
+    let(:work_package) do
+      create :work_package,
+             project: project,
+             start_date: Date.parse('2016-01-02'),
+             due_date: Date.parse('2016-01-25')
+    end
 
     it 'selecting a date before the current start date will change the start date' do
       start_date.activate!

--- a/spec/features/work_packages/scheduling/scheduling_mode_spec.rb
+++ b/spec/features/work_packages/scheduling/scheduling_mode_spec.rb
@@ -50,28 +50,55 @@ describe 'scheduling mode',
   #                       v               v
   #                     wp_child      wp_suc_child
   #
-  let!(:wp) { create :work_package, project: project, start_date: '2016-01-01', due_date: '2016-01-05', parent: wp_parent }
+  let!(:wp) do
+    create :work_package,
+           project: project,
+           start_date: Date.parse('2016-01-01'),
+           due_date: Date.parse('2016-01-05'),
+           parent: wp_parent
+  end
   let!(:wp_parent) do
-    create(:work_package, project: project, start_date: '2016-01-01', due_date: '2016-01-05')
+    create(:work_package,
+           project: project,
+           start_date: Date.parse('2016-01-01'),
+           due_date: Date.parse('2016-01-05'))
   end
   let!(:wp_child) do
-    create(:work_package, project: project, start_date: '2016-01-01', due_date: '2016-01-05', parent: wp)
+    create(:work_package,
+           project: project,
+           start_date: Date.parse('2016-01-01'),
+           due_date: Date.parse('2016-01-05'),
+           parent: wp)
   end
   let!(:wp_pre) do
-    create(:work_package, project: project, start_date: '2015-12-15', due_date: '2015-12-31').tap do |pre|
+    create(:work_package,
+           project: project,
+           start_date: Date.parse('2015-12-15'),
+           due_date: Date.parse('2015-12-31')).tap do |pre|
       create(:follows_relation, from: wp, to: pre)
     end
   end
   let!(:wp_suc) do
-    create(:work_package, project: project, start_date: '2016-01-06', due_date: '2016-01-10', parent: wp_suc_parent).tap do |suc|
+    create(:work_package,
+           project: project,
+           start_date: Date.parse('2016-01-06'),
+           due_date: Date.parse('2016-01-10'),
+           parent: wp_suc_parent).tap do |suc|
       create(:follows_relation, from: suc, to: wp)
     end
   end
   let!(:wp_suc_parent) do
-    create(:work_package, project: project, start_date: '2016-01-06', due_date: '2016-01-10')
+    create(:work_package,
+           project: project,
+           start_date: Date.parse('2016-01-06'),
+           due_date: Date.parse('2016-01-10'))
   end
   let!(:wp_suc_child) do
-    create(:work_package, project: project, start_date: '2016-01-06', due_date: '2016-01-10', parent: wp_suc)
+    create(:work_package,
+           project: project,
+           start_date: Date.parse('2016-01-06'),
+           due_date: Date.parse('2016-01-10'),
+           parent: wp_suc)
   end
   let(:work_packages_page) { Pages::SplitWorkPackage.new(wp, project) }
 

--- a/spec/features/work_packages/scheduling/scheduling_mode_spec.rb
+++ b/spec/features/work_packages/scheduling/scheduling_mode_spec.rb
@@ -52,27 +52,27 @@ describe 'scheduling mode',
   #
   let!(:wp) do
     create :work_package,
-           project: project,
+           project:,
            start_date: Date.parse('2016-01-01'),
            due_date: Date.parse('2016-01-05'),
            parent: wp_parent
   end
   let!(:wp_parent) do
     create(:work_package,
-           project: project,
+           project:,
            start_date: Date.parse('2016-01-01'),
            due_date: Date.parse('2016-01-05'))
   end
   let!(:wp_child) do
     create(:work_package,
-           project: project,
+           project:,
            start_date: Date.parse('2016-01-01'),
            due_date: Date.parse('2016-01-05'),
            parent: wp)
   end
   let!(:wp_pre) do
     create(:work_package,
-           project: project,
+           project:,
            start_date: Date.parse('2015-12-15'),
            due_date: Date.parse('2015-12-31')).tap do |pre|
       create(:follows_relation, from: wp, to: pre)
@@ -80,7 +80,7 @@ describe 'scheduling mode',
   end
   let!(:wp_suc) do
     create(:work_package,
-           project: project,
+           project:,
            start_date: Date.parse('2016-01-06'),
            due_date: Date.parse('2016-01-10'),
            parent: wp_suc_parent).tap do |suc|
@@ -89,13 +89,13 @@ describe 'scheduling mode',
   end
   let!(:wp_suc_parent) do
     create(:work_package,
-           project: project,
+           project:,
            start_date: Date.parse('2016-01-06'),
            due_date: Date.parse('2016-01-10'))
   end
   let!(:wp_suc_child) do
     create(:work_package,
-           project: project,
+           project:,
            start_date: Date.parse('2016-01-06'),
            due_date: Date.parse('2016-01-10'),
            parent: wp_suc)

--- a/spec/features/work_packages/timeline/timeline_dates_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_dates_spec.rb
@@ -28,10 +28,10 @@
 
 require 'spec_helper'
 
-RSpec.feature 'Work package timeline date formatting',
-              with_settings: { date_format: '%Y-%m-%d' },
-              js: true,
-              selenium: true do
+RSpec.describe 'Work package timeline date formatting',
+               with_settings: { date_format: '%Y-%m-%d' },
+               js: true,
+               selenium: true do
   shared_let(:type) { create(:type_bug) }
   shared_let(:project) { create(:project, types: [type]) }
 
@@ -39,8 +39,8 @@ RSpec.feature 'Work package timeline date formatting',
     create :work_package,
            project: project,
            type: type,
-           start_date: '2020-12-31',
-           due_date: '2021-01-01',
+           start_date: Date.parse('2020-12-31'),
+           due_date: Date.parse('2021-01-01'),
            subject: 'My subject'
   end
 
@@ -73,7 +73,6 @@ RSpec.feature 'Work package timeline date formatting',
 
   describe 'with default settings',
            with_settings: { start_of_week: '', first_week_of_year: '' } do
-
     context 'with english locale user' do
       let(:current_user) { create :admin, language: 'en' }
 
@@ -104,7 +103,6 @@ RSpec.feature 'Work package timeline date formatting',
 
   describe 'with US/CA settings',
            with_settings: { start_of_week: '7', first_week_of_year: '1' } do
-
     let(:current_user) { create :admin }
 
     it 'shows english ISO dates' do

--- a/spec/features/work_packages/timeline/timeline_labels_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_labels_spec.rb
@@ -28,10 +28,10 @@
 
 require 'spec_helper'
 
-RSpec.feature 'Work package timeline labels',
-              with_settings: { date_format: '%Y-%m-%d' },
-              js: true,
-              selenium: true do
+RSpec.describe 'Work package timeline labels',
+               with_settings: { date_format: '%Y-%m-%d' },
+               js: true,
+               selenium: true do
   let(:user) { create(:admin) }
   let(:type) { create(:type_bug) }
   let(:milestone_type) { create(:type, is_milestone: true) }
@@ -52,13 +52,9 @@ RSpec.feature 'Work package timeline labels',
     )
   end
 
-  def custom_value_for(str)
-    custom_field.custom_options.find { |co| co.value == str }.try(:id)
-  end
-
-  let(:today) { Date.today.iso8601 }
-  let(:tomorrow) { Date.tomorrow.iso8601 }
-  let(:future) { (Date.today + 5).iso8601 }
+  let(:today) { Time.zone.today }
+  let(:tomorrow) { Time.zone.tomorrow }
+  let(:future) { Time.zone.today + 5.days }
 
   let(:work_package) do
     create :work_package,
@@ -78,6 +74,10 @@ RSpec.feature 'Work package timeline labels',
            start_date: future,
            due_date: future,
            subject: 'My milestone'
+  end
+
+  def custom_value_for(str)
+    custom_field.custom_options.find { |co| co.value == str }.try(:id)
   end
 
   before do

--- a/spec/features/wysiwyg/macros/quicklink_macros_spec.rb
+++ b/spec/features/wysiwyg/macros/quicklink_macros_spec.rb
@@ -33,7 +33,11 @@ describe 'Wysiwyg work package quicklink macros', type: :feature, js: true do
   let(:user) { admin }
   let!(:project) { create(:project, identifier: 'some-project', enabled_module_names: %w[wiki work_package_tracking]) }
   let!(:work_package) do
-    create(:work_package, subject: "Foo Bar", project: project, start_date: '2020-01-01', due_date: '2020-02-01')
+    create(:work_package,
+           subject: "Foo Bar",
+           project: project,
+           start_date: Date.parse('2020-01-01'),
+           due_date: Date.parse('2020-02-01'))
   end
   let(:editor) { ::Components::WysiwygEditor.new }
 

--- a/spec/features/wysiwyg/macros/quicklink_macros_spec.rb
+++ b/spec/features/wysiwyg/macros/quicklink_macros_spec.rb
@@ -35,7 +35,7 @@ describe 'Wysiwyg work package quicklink macros', type: :feature, js: true do
   let!(:work_package) do
     create(:work_package,
            subject: "Foo Bar",
-           project: project,
+           project:,
            start_date: Date.parse('2020-01-01'),
            due_date: Date.parse('2020-02-01'))
   end

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -603,6 +603,7 @@ describe MailHandler, type: :model do
               "status_id" => [original_status.id, resolved_status.id],
               "assigned_to_id" => [nil, other_user.id],
               "start_date" => [nil, Date.parse("Fri, 01 Jan 2010")],
+              "duration" => [1, 365],
               "custom_fields_#{float_cf.id}" => [nil, "52.6"]
             )
         end

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -648,53 +648,19 @@ describe WorkPackage, type: :model do
   end
 
   describe '#duration' do
-    let(:instance) { send(subclass) }
-
-    describe "w/ today as start date
-              w/ tomorrow as finish date" do
-      before do
-        work_package.start_date = Date.today
-        work_package.due_date = Date.today + 1.day
-      end
-
-      it 'should have a duration of two' do
-        expect(work_package.duration).to eq(2)
+    context "when not setting a value" do
+      it 'is nil' do
+        expect(work_package.duration).to be_nil
       end
     end
 
-    describe "w/ today as start date
-              w/ today as finish date" do
+    context "when setting the value" do
       before do
-        work_package.start_date = Date.today
-        work_package.due_date = Date.today
+        work_package.duration = 5
       end
 
-      it 'should have a duration of one' do
-        expect(work_package.duration).to eq(1)
-      end
-    end
-
-    describe "w/ today as start date
-              w/o a finish date" do
-      before do
-        work_package.start_date = Date.today
-        work_package.due_date = nil
-      end
-
-      it 'should have a duration of one' do
-        expect(work_package.duration).to eq(1)
-      end
-    end
-
-    describe "w/o a start date
-              w today as finish date" do
-      before do
-        work_package.start_date = nil
-        work_package.due_date = Date.today
-      end
-
-      it 'should have a duration of one' do
-        expect(work_package.duration).to eq(1)
+      it 'is the value' do
+        expect(work_package.duration).to eq(5)
       end
     end
   end

--- a/spec/services/work_packages/copy_service_integration_spec.rb
+++ b/spec/services/work_packages/copy_service_integration_spec.rb
@@ -79,9 +79,10 @@ describe WorkPackages::CopyService, 'integration', type: :model do
 
   describe '#call' do
     shared_examples_for 'copied work package' do
-      subject { copy.id }
+      subject { copy }
 
-      it { is_expected.not_to eq(work_package.id) }
+      it { expect(subject.id).not_to eq(work_package.id) }
+      it { is_expected.to be_persisted }
     end
 
     context 'with the same project' do
@@ -121,7 +122,7 @@ describe WorkPackages::CopyService, 'integration', type: :model do
         create(:member,
                project: p,
                roles: [target_role],
-               user: user)
+               user:)
 
         p
       end
@@ -171,15 +172,19 @@ describe WorkPackages::CopyService, 'integration', type: :model do
       end
 
       describe '#attributes' do
+        before do
+          target_project.types << work_package.type
+        end
+
         context 'assigned_to' do
           let(:target_user) { create(:user) }
           let(:target_project_member) do
             create(:member,
                    project: target_project,
                    principal: target_user,
-                   roles: [create(:role)])
+                   roles: [create(:role, permissions: [:work_package_assigned])])
           end
-          let(:attributes) { { assigned_to_id: target_user.id } }
+          let(:attributes) { { project: target_project, assigned_to_id: target_user.id } }
 
           before do
             target_project_member
@@ -194,7 +199,7 @@ describe WorkPackages::CopyService, 'integration', type: :model do
 
         context 'status' do
           let(:target_status) { create(:status) }
-          let(:attributes) { { status_id: target_status.id } }
+          let(:attributes) { { project: target_project, status_id: target_status.id } }
 
           it_behaves_like 'copied work package'
 
@@ -207,7 +212,7 @@ describe WorkPackages::CopyService, 'integration', type: :model do
           let(:target_date) { Date.today + 14 }
 
           context 'start' do
-            let(:attributes) { { start_date: target_date } }
+            let(:attributes) { { project: target_project, start_date: target_date } }
 
             it_behaves_like 'copied work package'
 
@@ -217,7 +222,7 @@ describe WorkPackages::CopyService, 'integration', type: :model do
           end
 
           context 'end' do
-            let(:attributes) { { due_date: target_date } }
+            let(:attributes) { { project: target_project, due_date: target_date } }
 
             it_behaves_like 'copied work package'
 
@@ -289,6 +294,12 @@ describe WorkPackages::CopyService, 'integration', type: :model do
           end
         end
       end
+    end
+
+    describe 'with start and due dates overwritten but not duration' do
+      let(:attributes) { { start_date: Time.zone.today - 5.days, due_date: Time.zone.today + 5.days } }
+
+      it_behaves_like 'copied work package'
     end
   end
 end

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -37,7 +37,7 @@ describe WorkPackages::SetAttributesService, type: :model do
     p
   end
   let(:work_package) do
-    wp = build_stubbed(:work_package, project: project)
+    wp = build_stubbed(:work_package, project:)
     wp.type = initial_type
     wp.send(:clear_changes_information)
 
@@ -64,7 +64,7 @@ describe WorkPackages::SetAttributesService, type: :model do
     instance_double(ActiveModel::Errors)
   end
   let(:instance) do
-    described_class.new(user: user,
+    described_class.new(user:,
                         model: work_package,
                         contract_class: mock_contract)
   end
@@ -280,9 +280,9 @@ describe WorkPackages::SetAttributesService, type: :model do
     end
     let(:user) { build_stubbed(:admin) }
     let(:instance) do
-      described_class.new(user: user,
+      described_class.new(user:,
                           model: invalid_wp,
-                          contract_class: contract_class)
+                          contract_class:)
     end
 
     context 'with a current invalid start date' do
@@ -312,7 +312,7 @@ describe WorkPackages::SetAttributesService, type: :model do
       let(:parent_due_date) { Time.zone.today + 10.days }
 
       context 'with the parent having dates and not providing own dates' do
-        let(:call_attributes) { { parent: parent } }
+        let(:call_attributes) { { parent: } }
 
         it_behaves_like 'service call' do
           it "sets the start_date to the parent`s start_date" do
@@ -332,7 +332,7 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
 
       context 'with the parent having start date (no due) and not providing own dates' do
-        let(:call_attributes) { { parent: parent } }
+        let(:call_attributes) { { parent: } }
         let(:parent_due_date) { nil }
 
         it_behaves_like 'service call' do
@@ -353,7 +353,7 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
 
       context 'with the parent having due date (no start) and not providing own dates' do
-        let(:call_attributes) { { parent: parent } }
+        let(:call_attributes) { { parent: } }
         let(:parent_start_date) { nil }
 
         it_behaves_like 'service call' do
@@ -374,7 +374,7 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
 
       context 'with the parent having dates but providing own dates' do
-        let(:call_attributes) { { parent: parent, start_date: Time.zone.today, due_date: Time.zone.today + 1.day } }
+        let(:call_attributes) { { parent:, start_date: Time.zone.today, due_date: Time.zone.today + 1.day } }
 
         it_behaves_like 'service call' do
           it "sets the start_date to the provided date" do
@@ -394,7 +394,7 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
 
       context 'with the parent having dates but providing own start_date' do
-        let(:call_attributes) { { parent: parent, start_date: Time.zone.today } }
+        let(:call_attributes) { { parent:, start_date: Time.zone.today } }
 
         it_behaves_like 'service call' do
           it "sets the start_date to the provided date" do
@@ -414,7 +414,7 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
 
       context 'with the parent having dates but providing own due_date' do
-        let(:call_attributes) { { parent: parent, due_date: Time.zone.today + 4.days } }
+        let(:call_attributes) { { parent:, due_date: Time.zone.today + 4.days } }
 
         it_behaves_like 'service call' do
           it "sets the start_date to the parent's start date" do
@@ -434,7 +434,7 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
 
       context 'with the parent having dates but providing own empty start_date' do
-        let(:call_attributes) { { parent: parent, start_date: nil } }
+        let(:call_attributes) { { parent:, start_date: nil } }
 
         it_behaves_like 'service call' do
           it "sets the start_date to nil" do
@@ -454,7 +454,7 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
 
       context 'with the parent having dates but providing own empty due_date' do
-        let(:call_attributes) { { parent: parent, due_date: nil } }
+        let(:call_attributes) { { parent:, due_date: nil } }
 
         it_behaves_like 'service call' do
           it "sets the start_date to the parent's start date" do
@@ -474,7 +474,7 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
 
       context 'with the parent having dates but providing a start date that is before parent`s due date`' do
-        let(:call_attributes) { { parent: parent, start_date: parent_due_date - 4.days } }
+        let(:call_attributes) { { parent:, start_date: parent_due_date - 4.days } }
 
         it_behaves_like 'service call' do
           it "sets the start_date to the provided date" do
@@ -494,7 +494,7 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
 
       context 'with the parent having dates but providing a start date that is after the parent`s due date`' do
-        let(:call_attributes) { { parent: parent, start_date: parent_due_date + 1.day } }
+        let(:call_attributes) { { parent:, start_date: parent_due_date + 1.day } }
 
         it_behaves_like 'service call' do
           it "sets the start_date to the provided date" do
@@ -514,7 +514,7 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
 
       context 'with the parent having dates but providing a due date that is before the parent`s start date`' do
-        let(:call_attributes) { { parent: parent, due_date: parent_start_date - 3.days } }
+        let(:call_attributes) { { parent:, due_date: parent_start_date - 3.days } }
 
         it_behaves_like 'service call' do
           it "leaves the start date empty" do
@@ -928,7 +928,6 @@ describe WorkPackages::SetAttributesService, type: :model do
     end
   end
 
-  # rubocop:disable RSpec/MultipleMemoizedHelpers
   context 'when switching the project' do
     let(:new_project) { build_stubbed(:project) }
     let(:version) { build_stubbed(:version) }
@@ -1121,7 +1120,6 @@ describe WorkPackages::SetAttributesService, type: :model do
       end
     end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
 
   context 'for custom fields' do
     subject { instance.call(call_attributes) }
@@ -1142,7 +1140,7 @@ describe WorkPackages::SetAttributesService, type: :model do
   context 'when switching back to automatic scheduling' do
     let(:work_package) do
       wp = build_stubbed(:work_package,
-                         project: project,
+                         project:,
                          schedule_manually: true,
                          start_date: Time.zone.today,
                          due_date: Time.zone.today + 5.days)

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -69,57 +69,122 @@ describe WorkPackages::SetAttributesService, type: :model do
                         contract_class: mock_contract)
   end
 
-  describe 'call' do
-    shared_examples_for 'service call' do
-      subject { instance.call(call_attributes) }
+  shared_examples_for 'service call' do
+    subject { instance.call(call_attributes) }
 
-      it 'is successful' do
-        expect(subject.success?).to be_truthy
+    it 'is successful' do
+      expect(subject).to be_success
+    end
+
+    it 'sets the value' do
+      subject
+
+      attributes.each do |attribute, key|
+        expect(work_package.send(attribute)).to eql key
+      end
+    end
+
+    it 'does not persist the work_package' do
+      expect(work_package)
+        .not_to receive(:save)
+
+      subject
+    end
+
+    it 'has no errors' do
+      expect(subject.errors).to be_empty
+    end
+
+    context 'when the contract does not validate' do
+      let(:contract_valid) { false }
+
+      it 'is unsuccessful' do
+        expect(subject).not_to be_success
       end
 
-      it 'sets the value' do
+      it 'does not persist the changes' do
         subject
 
-        attributes.each do |attribute, key|
-          expect(work_package.send(attribute)).to eql key
-        end
+        expect(work_package).not_to receive(:save)
       end
 
-      it 'does not persist the work_package' do
-        expect(work_package)
-          .not_to receive(:save)
-
+      it "exposes the contract's errors" do
         subject
+
+        expect(subject.errors).to eql mock_contract_instance.errors
+      end
+    end
+  end
+
+  context 'when updating subject before calling the service' do
+    let(:call_attributes) { {} }
+    let(:attributes) { { subject: 'blubs blubs' } }
+
+    before do
+      work_package.attributes = attributes
+    end
+
+    it_behaves_like 'service call'
+  end
+
+  context 'when updating subject via attributes' do
+    let(:call_attributes) { attributes }
+    let(:attributes) { { subject: 'blubs blubs' } }
+
+    it_behaves_like 'service call'
+  end
+
+  context 'for status' do
+    let(:default_status) { build_stubbed(:default_status) }
+    let(:other_status) { build_stubbed(:status) }
+    let(:new_statuses) { [other_status, default_status] }
+
+    before do
+      allow(Status)
+        .to receive(:default)
+              .and_return(default_status)
+    end
+
+    context 'with no value set before for a new work package' do
+      let(:call_attributes) { {} }
+      let(:attributes) { {} }
+      let(:work_package) { new_work_package }
+
+      before do
+        work_package.status = nil
       end
 
-      it 'has no errors' do
-        expect(subject.errors).to be_empty
-      end
-
-      context 'when the contract does not validate' do
-        let(:contract_valid) { false }
-
-        it 'is unsuccessful' do
-          expect(subject.success?).to be_falsey
-        end
-
-        it 'does not persist the changes' do
+      it_behaves_like 'service call' do
+        it 'sets the default status' do
           subject
 
-          expect(work_package).to_not receive(:save)
-        end
-
-        it "exposes the contract's errors" do
-          subject
-
-          expect(subject.errors).to eql mock_contract_instance.errors
+          expect(work_package.status)
+            .to eql default_status
         end
       end
     end
 
-    context 'update subject before calling the service' do
+    context 'with no value set on existing work package' do
       let(:call_attributes) { {} }
-      let(:attributes) { { subject: 'blubs blubs' } }
+      let(:attributes) { {} }
+
+      before do
+        work_package.status = nil
+      end
+
+      it_behaves_like 'service call' do
+        it 'stays nil' do
+          subject
+
+          expect(work_package.status)
+            .to be_nil
+        end
+      end
+    end
+
+    context 'when updating status before calling the service' do
+      let(:call_attributes) { {} }
+      let(:attributes) { { status: other_status } }
 
       before do
         work_package.attributes = attributes
@@ -128,839 +193,1036 @@ describe WorkPackages::SetAttributesService, type: :model do
       it_behaves_like 'service call'
     end
 
-    context 'updating subject via attributes' do
+    context 'when updating status via attributes' do
       let(:call_attributes) { attributes }
-      let(:attributes) { { subject: 'blubs blubs' } }
+      let(:attributes) { { status: other_status } }
+
+      it_behaves_like 'service call'
+    end
+  end
+
+  context 'for author' do
+    let(:other_user) { build_stubbed(:user) }
+
+    context 'with no value set before for a new work package' do
+      let(:call_attributes) { {} }
+      let(:attributes) { {} }
+      let(:work_package) { new_work_package }
+
+      it_behaves_like 'service call' do
+        it "sets the service's author" do
+          subject
+
+          expect(work_package.author)
+            .to eql user
+        end
+
+        it 'notes the author to be system changed' do
+          subject
+
+          expect(work_package.changed_by_system['author_id'])
+            .to eql [0, user.id]
+        end
+      end
+    end
+
+    context 'with no value set on existing work package' do
+      let(:call_attributes) { {} }
+      let(:attributes) { {} }
+
+      before do
+        work_package.author = nil
+      end
+
+      it_behaves_like 'service call' do
+        it 'stays nil' do
+          subject
+
+          expect(work_package.author)
+            .to be_nil
+        end
+      end
+    end
+
+    context 'when updating author before calling the service' do
+      let(:call_attributes) { {} }
+      let(:attributes) { { author: other_user } }
+
+      before do
+        work_package.attributes = attributes
+      end
 
       it_behaves_like 'service call'
     end
 
-    context 'status' do
-      let(:default_status) { build_stubbed(:default_status) }
-      let(:other_status) { build_stubbed(:status) }
-      let(:new_statuses) { [other_status, default_status] }
+    context 'updating author via attributes' do
+      let(:call_attributes) { attributes }
+      let(:attributes) { { author: other_user } }
 
-      before do
-        allow(Status)
-          .to receive(:default)
-          .and_return(default_status)
-      end
+      it_behaves_like 'service call'
+    end
+  end
 
-      context 'no value set before for a new work package' do
-        let(:call_attributes) { {} }
-        let(:attributes) { {} }
-        let(:work_package) { new_work_package }
+  context 'with the actual contract' do
+    let(:invalid_wp) do
+      wp = create(:work_package)
+      wp.start_date = Time.zone.today + 5.days
+      wp.due_date = Time.zone.today
+      wp.save!(validate: false)
 
-        before do
-          work_package.status = nil
-        end
-
-        it_behaves_like 'service call' do
-          it 'sets the default status' do
-            subject
-
-            expect(work_package.status)
-              .to eql default_status
-          end
-        end
-      end
-
-      context 'no value set on existing work package' do
-        let(:call_attributes) { {} }
-        let(:attributes) { {} }
-
-        before do
-          work_package.status = nil
-        end
-
-        it_behaves_like 'service call' do
-          it 'stays nil' do
-            subject
-
-            expect(work_package.status)
-              .to be_nil
-          end
-        end
-      end
-
-      context 'update status before calling the service' do
-        let(:call_attributes) { {} }
-        let(:attributes) { { status: other_status } }
-
-        before do
-          work_package.attributes = attributes
-        end
-
-        it_behaves_like 'service call'
-      end
-
-      context 'updating status via attributes' do
-        let(:call_attributes) { attributes }
-        let(:attributes) { { status: other_status } }
-
-        it_behaves_like 'service call'
-      end
+      wp
+    end
+    let(:user) { build_stubbed(:admin) }
+    let(:instance) do
+      described_class.new(user: user,
+                          model: invalid_wp,
+                          contract_class: contract_class)
     end
 
-    context 'author' do
-      let(:other_user) { build_stubbed(:user) }
+    context 'with a current invalid start date' do
+      let(:call_attributes) { attributes }
+      let(:attributes) { { start_date: Time.zone.today - 5.days } }
+      let(:contract_valid) { true }
 
-      context 'no value set before for a new work package' do
-        let(:call_attributes) { {} }
-        let(:attributes) { {} }
-        let(:work_package) { new_work_package }
+      subject { instance.call(call_attributes) }
 
-        it_behaves_like 'service call' do
-          it "sets the service's author" do
-            subject
-
-            expect(work_package.author)
-              .to eql user
-          end
-
-          it 'notes the author to be system changed' do
-            subject
-
-            expect(work_package.changed_by_system['author_id'])
-              .to eql [0, user.id]
-          end
-        end
-      end
-
-      context 'no value set on existing work package' do
-        let(:call_attributes) { {} }
-        let(:attributes) { {} }
-
-        before do
-          work_package.author = nil
-        end
-
-        it_behaves_like 'service call' do
-          it 'stays nil' do
-            subject
-
-            expect(work_package.author)
-              .to be_nil
-          end
-        end
-      end
-
-      context 'update author before calling the service' do
-        let(:call_attributes) { {} }
-        let(:attributes) { { author: other_user } }
-
-        before do
-          work_package.attributes = attributes
-        end
-
-        it_behaves_like 'service call'
-      end
-
-      context 'updating author via attributes' do
-        let(:call_attributes) { attributes }
-        let(:attributes) { { author: other_user } }
-
-        it_behaves_like 'service call'
+      it 'is successful' do
+        expect(subject).to be_success
+        expect(subject.errors).to be_empty
       end
     end
+  end
 
-    context 'with the actual contract' do
-      let(:invalid_wp) do
-        wp = create(:work_package)
-        wp.start_date = Date.today + 5.days
-        wp.due_date = Date.today
-        wp.save!(validate: false)
-
-        wp
-      end
-      let(:user) { build_stubbed(:admin) }
-      let(:instance) do
-        described_class.new(user: user,
-                            model: invalid_wp,
-                            contract_class: contract_class)
-      end
-
-      context 'with a current invalid start date' do
-        let(:call_attributes) { attributes }
-        let(:attributes) { { start_date: Date.today - 5.days } }
-        let(:contract_valid) { true }
-        subject { instance.call(call_attributes) }
-
-        it 'is successful' do
-          expect(subject.success?).to be_truthy
-          expect(subject.errors).to be_empty
-        end
-      end
-    end
-
-    context 'start_date & due_date' do
+  context 'for start_date & due_date & duration' do
+    context 'with a parent' do
+      let(:attributes) { {} }
+      let(:work_package) { new_work_package }
       let(:parent) do
         build_stubbed(:stubbed_work_package,
                       start_date: parent_start_date,
                       due_date: parent_due_date)
       end
-      let(:parent_start_date) { Date.today - 5.days }
-      let(:parent_due_date) { Date.today + 10.days }
-
-      context 'with a parent' do
-        let(:attributes) { {} }
-        let(:work_package) { new_work_package }
-
-        context 'with the parent having dates and not providing own dates' do
-          let(:call_attributes) { { parent: parent } }
-
-          it_behaves_like 'service call' do
-            it "sets the start_date to the parent`s start_date" do
-              subject
-
-              expect(work_package.start_date)
-                .to eql parent_start_date
-            end
-
-            it "sets the due_date to the parent`s due_date" do
-              subject
-
-              expect(work_package.due_date)
-                .to eql parent_due_date
-            end
-          end
-        end
-
-        context 'with the parent having start date (no due) and not providing own dates' do
-          let(:call_attributes) { { parent: parent } }
-          let(:parent_due_date) { nil }
-
-          it_behaves_like 'service call' do
-            it "sets the start_date to the parent`s start_date" do
-              subject
-
-              expect(work_package.start_date)
-                .to eql parent_start_date
-            end
-
-            it "sets the due_date to nil" do
-              subject
-
-              expect(work_package.due_date)
-                .to be_nil
-            end
-          end
-        end
-
-        context 'with the parent having due date (no start) and not providing own dates' do
-          let(:call_attributes) { { parent: parent } }
-          let(:parent_start_date) { nil }
-
-          it_behaves_like 'service call' do
-            it "sets the start_date to nil" do
-              subject
-
-              expect(work_package.start_date)
-                .to be_nil
-            end
-
-            it "sets the due_date to the parent`s due_date" do
-              subject
-
-              expect(work_package.due_date)
-                .to eql parent_due_date
-            end
-          end
-        end
-
-        context 'with the parent having dates but providing own dates' do
-          let(:call_attributes) { { parent: parent, start_date: Date.today, due_date: Date.today + 1.day } }
-
-          it_behaves_like 'service call' do
-            it "sets the start_date to the provided date" do
-              subject
-
-              expect(work_package.start_date)
-                .to eql Date.today
-            end
-
-            it "sets the due_date to the provided date" do
-              subject
-
-              expect(work_package.due_date)
-                .to eql Date.today + 1.day
-            end
-          end
-        end
-
-        context 'with the parent having dates but providing own start_date' do
-          let(:call_attributes) { { parent: parent, start_date: Date.today } }
-
-          it_behaves_like 'service call' do
-            it "sets the start_date to the provided date" do
-              subject
-
-              expect(work_package.start_date)
-                .to eql Date.today
-            end
-
-            it "sets the due_date to the parent's due_date" do
-              subject
-
-              expect(work_package.due_date)
-                .to eql parent_due_date
-            end
-          end
-        end
-
-        context 'with the parent having dates but providing own due_date' do
-          let(:call_attributes) { { parent: parent, due_date: Date.today + 4.days } }
-
-          it_behaves_like 'service call' do
-            it "sets the start_date to the parent's start date" do
-              subject
-
-              expect(work_package.start_date)
-                .to eql parent_start_date
-            end
-
-            it "sets the due_date to the provided date" do
-              subject
-
-              expect(work_package.due_date)
-                .to eql Date.today + 4.days
-            end
-          end
-        end
-
-        context 'with the parent having dates but providing own empty start_date' do
-          let(:call_attributes) { { parent: parent, start_date: nil } }
-
-          it_behaves_like 'service call' do
-            it "sets the start_date to nil" do
-              subject
-
-              expect(work_package.start_date)
-                .to be_nil
-            end
-
-            it "sets the due_date to the parent's due_date" do
-              subject
-
-              expect(work_package.due_date)
-                .to eql parent_due_date
-            end
-          end
-        end
-
-        context 'with the parent having dates but providing own empty due_date' do
-          let(:call_attributes) { { parent: parent, due_date: nil } }
-
-          it_behaves_like 'service call' do
-            it "sets the start_date to the parent's start date" do
-              subject
-
-              expect(work_package.start_date)
-                .to eql parent_start_date
-            end
-
-            it "sets the due_date to nil" do
-              subject
-
-              expect(work_package.due_date)
-                .to be_nil
-            end
-          end
-        end
-
-        context 'with the parent having dates but providing a start date that is before parent`s due date`' do
-          let(:call_attributes) { { parent: parent, start_date: parent_due_date - 4.days } }
-
-          it_behaves_like 'service call' do
-            it "sets the start_date to the provided date" do
-              subject
-
-              expect(work_package.start_date)
-                .to eql parent_due_date - 4.days
-            end
-
-            it "sets the due_date to the parent's due_date" do
-              subject
-
-              expect(work_package.due_date)
-                .to eql parent_due_date
-            end
-          end
-        end
-
-        context 'with the parent having dates but providing a start date that is after the parent`s due date`' do
-          let(:call_attributes) { { parent: parent, start_date: parent_due_date + 1.day } }
-
-          it_behaves_like 'service call' do
-            it "sets the start_date to the provided date" do
-              subject
-
-              expect(work_package.start_date)
-                .to eql parent_due_date + 1.day
-            end
-
-            it "leaves the due date empty" do
-              subject
-
-              expect(work_package.due_date)
-                .to be_nil
-            end
-          end
-        end
-
-        context 'with the parent having dates but providing a due date that is before the parent`s start date`' do
-          let(:call_attributes) { { parent: parent, due_date: parent_start_date - 3.day } }
-
-          it_behaves_like 'service call' do
-            it "leaves the start date empty" do
-              subject
-
-              expect(work_package.start_date)
-                .to be_nil
-            end
-
-            it "set the due date to the provided date" do
-              subject
-
-              expect(work_package.due_date)
-                .to eql parent_start_date - 3.day
-            end
-          end
-        end
-      end
-
-      context 'with default setting', with_settings: { work_package_startdate_is_adddate: true } do
-        context 'no value set before for a new work package' do
-          let(:call_attributes) { {} }
-          let(:attributes) { {} }
-          let(:work_package) { new_work_package }
-
-          it_behaves_like 'service call' do
-            it "sets the default priority" do
-              subject
-
-              expect(work_package.start_date)
-                .to eql Date.today
-            end
-          end
-        end
-
-        context 'value set on new work package' do
-          let(:call_attributes) { { start_date: Date.today + 1.day } }
-          let(:attributes) { {} }
-          let(:work_package) { new_work_package }
-
-          it_behaves_like 'service call' do
-            it 'stays that value' do
-              subject
-
-              expect(work_package.start_date)
-                .to eq(Date.today + 1.day)
-            end
-          end
-        end
-      end
-    end
-
-    context 'priority' do
-      let(:default_priority) { build_stubbed(:priority) }
-      let(:other_priority) { build_stubbed(:priority) }
-
-      before do
-        allow(IssuePriority)
-          .to receive_message_chain(:active, :default)
-          .and_return(default_priority)
-      end
-
-      context 'no value set before for a new work package' do
-        let(:call_attributes) { {} }
-        let(:attributes) { {} }
-        let(:work_package) { new_work_package }
-
-        before do
-          work_package.priority = nil
-        end
+      let(:parent_start_date) { Time.zone.today - 5.days }
+      let(:parent_due_date) { Time.zone.today + 10.days }
+
+      context 'with the parent having dates and not providing own dates' do
+        let(:call_attributes) { { parent: parent } }
 
         it_behaves_like 'service call' do
-          it "sets the default priority" do
+          it "sets the start_date to the parent`s start_date" do
             subject
 
-            expect(work_package.priority)
-              .to eql default_priority
+            expect(work_package.start_date)
+              .to eql parent_start_date
+          end
+
+          it "sets the due_date to the parent`s due_date" do
+            subject
+
+            expect(work_package.due_date)
+              .to eql parent_due_date
           end
         end
       end
 
-      context 'update priority before calling the service' do
-        let(:call_attributes) { {} }
-        let(:attributes) { { priority: other_priority } }
+      context 'with the parent having start date (no due) and not providing own dates' do
+        let(:call_attributes) { { parent: parent } }
+        let(:parent_due_date) { nil }
 
-        before do
-          work_package.attributes = attributes
+        it_behaves_like 'service call' do
+          it "sets the start_date to the parent`s start_date" do
+            subject
+
+            expect(work_package.start_date)
+              .to eql parent_start_date
+          end
+
+          it "sets the due_date to nil" do
+            subject
+
+            expect(work_package.due_date)
+              .to be_nil
+          end
         end
-
-        it_behaves_like 'service call'
       end
 
-      context 'updating priority via attributes' do
-        let(:call_attributes) { attributes }
-        let(:attributes) { { priority: other_priority } }
+      context 'with the parent having due date (no start) and not providing own dates' do
+        let(:call_attributes) { { parent: parent } }
+        let(:parent_start_date) { nil }
 
-        it_behaves_like 'service call'
+        it_behaves_like 'service call' do
+          it "sets the start_date to nil" do
+            subject
+
+            expect(work_package.start_date)
+              .to be_nil
+          end
+
+          it "sets the due_date to the parent`s due_date" do
+            subject
+
+            expect(work_package.due_date)
+              .to eql parent_due_date
+          end
+        end
+      end
+
+      context 'with the parent having dates but providing own dates' do
+        let(:call_attributes) { { parent: parent, start_date: Time.zone.today, due_date: Time.zone.today + 1.day } }
+
+        it_behaves_like 'service call' do
+          it "sets the start_date to the provided date" do
+            subject
+
+            expect(work_package.start_date)
+              .to eql Time.zone.today
+          end
+
+          it "sets the due_date to the provided date" do
+            subject
+
+            expect(work_package.due_date)
+              .to eql Time.zone.today + 1.day
+          end
+        end
+      end
+
+      context 'with the parent having dates but providing own start_date' do
+        let(:call_attributes) { { parent: parent, start_date: Time.zone.today } }
+
+        it_behaves_like 'service call' do
+          it "sets the start_date to the provided date" do
+            subject
+
+            expect(work_package.start_date)
+              .to eql Time.zone.today
+          end
+
+          it "sets the due_date to the parent's due_date" do
+            subject
+
+            expect(work_package.due_date)
+              .to eql parent_due_date
+          end
+        end
+      end
+
+      context 'with the parent having dates but providing own due_date' do
+        let(:call_attributes) { { parent: parent, due_date: Time.zone.today + 4.days } }
+
+        it_behaves_like 'service call' do
+          it "sets the start_date to the parent's start date" do
+            subject
+
+            expect(work_package.start_date)
+              .to eql parent_start_date
+          end
+
+          it "sets the due_date to the provided date" do
+            subject
+
+            expect(work_package.due_date)
+              .to eql Time.zone.today + 4.days
+          end
+        end
+      end
+
+      context 'with the parent having dates but providing own empty start_date' do
+        let(:call_attributes) { { parent: parent, start_date: nil } }
+
+        it_behaves_like 'service call' do
+          it "sets the start_date to nil" do
+            subject
+
+            expect(work_package.start_date)
+              .to be_nil
+          end
+
+          it "sets the due_date to the parent's due_date" do
+            subject
+
+            expect(work_package.due_date)
+              .to eql parent_due_date
+          end
+        end
+      end
+
+      context 'with the parent having dates but providing own empty due_date' do
+        let(:call_attributes) { { parent: parent, due_date: nil } }
+
+        it_behaves_like 'service call' do
+          it "sets the start_date to the parent's start date" do
+            subject
+
+            expect(work_package.start_date)
+              .to eql parent_start_date
+          end
+
+          it "sets the due_date to nil" do
+            subject
+
+            expect(work_package.due_date)
+              .to be_nil
+          end
+        end
+      end
+
+      context 'with the parent having dates but providing a start date that is before parent`s due date`' do
+        let(:call_attributes) { { parent: parent, start_date: parent_due_date - 4.days } }
+
+        it_behaves_like 'service call' do
+          it "sets the start_date to the provided date" do
+            subject
+
+            expect(work_package.start_date)
+              .to eql parent_due_date - 4.days
+          end
+
+          it "sets the due_date to the parent's due_date" do
+            subject
+
+            expect(work_package.due_date)
+              .to eql parent_due_date
+          end
+        end
+      end
+
+      context 'with the parent having dates but providing a start date that is after the parent`s due date`' do
+        let(:call_attributes) { { parent: parent, start_date: parent_due_date + 1.day } }
+
+        it_behaves_like 'service call' do
+          it "sets the start_date to the provided date" do
+            subject
+
+            expect(work_package.start_date)
+              .to eql parent_due_date + 1.day
+          end
+
+          it "leaves the due date empty" do
+            subject
+
+            expect(work_package.due_date)
+              .to be_nil
+          end
+        end
+      end
+
+      context 'with the parent having dates but providing a due date that is before the parent`s start date`' do
+        let(:call_attributes) { { parent: parent, due_date: parent_start_date - 3.days } }
+
+        it_behaves_like 'service call' do
+          it "leaves the start date empty" do
+            subject
+
+            expect(work_package.start_date)
+              .to be_nil
+          end
+
+          it "set the due date to the provided date" do
+            subject
+
+            expect(work_package.due_date)
+              .to eql parent_start_date - 3.days
+          end
+        end
       end
     end
 
-    context 'when switching the type' do
-      let(:target_type) { build_stubbed(:type) }
-
-      context 'with a type that is no milestone' do
-        before do
-          allow(target_type)
-            .to receive(:is_milestone?)
-            .and_return(false)
-        end
-
-        it 'sets the start date to the due date' do
-          work_package.due_date = Date.today
-
-          instance.call(type: target_type)
-
-          expect(work_package.start_date).to be_nil
-        end
-      end
-
-      context 'with a type that is a milestone' do
-        before do
-          allow(target_type)
-            .to receive(:is_milestone?)
-            .and_return(true)
-        end
-
-        it 'sets the start date to the due date' do
-          date = Date.today
-          work_package.due_date = date
-
-          instance.call(type: target_type)
-
-          expect(work_package.start_date).to eql date
-        end
-
-        it 'set the due date to the start date if the due date is nil' do
-          date = Date.today
-          work_package.start_date = date
-
-          instance.call(type: target_type)
-
-          expect(work_package.due_date).to eql date
-        end
-      end
-    end
-
-    context 'when switching the project' do
-      let(:new_project) { build_stubbed(:project) }
-      let(:version) { build_stubbed(:version) }
-      let(:category) { build_stubbed(:category) }
-      let(:new_category) { build_stubbed(:category, name: category.name) }
-      let(:new_statuses) { [work_package.status] }
-      let(:new_versions) { [] }
-      let(:type) { work_package.type }
-      let(:new_types) { [type] }
-      let(:default_type) { build_stubbed(:type_standard) }
-      let(:other_type) { build_stubbed(:type) }
-      let(:yet_another_type) { build_stubbed(:type) }
-
+    context 'with no value set for a new work package and with default setting active',
+            with_settings: { work_package_startdate_is_adddate: true } do
       let(:call_attributes) { {} }
-      let(:new_project_categories) do
-        categories_stub = double('categories')
-        allow(new_project)
-          .to receive(:categories)
-          .and_return(categories_stub)
+      let(:attributes) { {} }
+      let(:work_package) { new_work_package }
 
-        categories_stub
+      it_behaves_like 'service call' do
+        it "sets the start date to today" do
+          subject
+
+          expect(work_package.start_date)
+            .to eql Time.zone.today
+        end
+
+        it "sets the duration to 1" do
+          subject
+
+          expect(work_package.duration)
+            .to eq 1
+        end
+      end
+    end
+
+    context 'with a value set for a new work package and with default setting active',
+            with_settings: { work_package_startdate_is_adddate: true } do
+      let(:call_attributes) { { start_date: Time.zone.today + 1.day } }
+      let(:attributes) { {} }
+      let(:work_package) { new_work_package }
+
+      it_behaves_like 'service call' do
+        it 'stays that value' do
+          subject
+
+          expect(work_package.start_date)
+            .to eq(Time.zone.today + 1.day)
+        end
+
+        it "sets the duration to 1" do
+          subject
+
+          expect(work_package.duration)
+            .to eq 1
+        end
+      end
+    end
+
+    context 'with date values set to the same date on a new work package' do
+      let(:call_attributes) { { start_date: Time.zone.today, due_date: Time.zone.today } }
+      let(:attributes) { {} }
+      let(:work_package) { new_work_package }
+
+      it_behaves_like 'service call' do
+        it 'sets the start date value' do
+          subject
+
+          expect(work_package.start_date)
+            .to eq(Time.zone.today)
+        end
+
+        it 'sets the due date value' do
+          subject
+
+          expect(work_package.due_date)
+            .to eq(Time.zone.today)
+        end
+
+        it "sets the duration to 1" do
+          subject
+
+          expect(work_package.duration)
+            .to eq 1
+        end
+      end
+    end
+
+    context 'with date values set on a new work package' do
+      let(:call_attributes) { { start_date: Time.zone.today, due_date: Time.zone.today + 5.days } }
+      let(:attributes) { {} }
+      let(:work_package) { new_work_package }
+
+      it_behaves_like 'service call' do
+        it 'sets the start date value' do
+          subject
+
+          expect(work_package.start_date)
+            .to eq(Time.zone.today)
+        end
+
+        it 'sets the due date value' do
+          subject
+
+          expect(work_package.due_date)
+            .to eq(Time.zone.today + 5.days)
+        end
+
+        it "sets the duration to 6" do
+          subject
+
+          expect(work_package.duration)
+            .to eq 6
+        end
+      end
+    end
+
+    context 'with start date changed' do
+      let(:work_package) { build_stubbed(:stubbed_work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
+      let(:call_attributes) { { start_date: Time.zone.today + 1.day } }
+      let(:attributes) { {} }
+
+      it_behaves_like 'service call' do
+        it 'sets the start date value' do
+          subject
+
+          expect(work_package.start_date)
+            .to eq(Time.zone.today + 1.day)
+        end
+
+        it 'keeps the due date value' do
+          subject
+
+          expect(work_package.due_date)
+            .to eq(Time.zone.today + 5.days)
+        end
+
+        it "updates the duration" do
+          subject
+
+          expect(work_package.duration)
+            .to eq 5
+        end
+      end
+    end
+
+    context 'with due date changed' do
+      let(:work_package) { build_stubbed(:stubbed_work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
+      let(:call_attributes) { { due_date: Time.zone.today + 1.day } }
+      let(:attributes) { {} }
+
+      it_behaves_like 'service call' do
+        it 'keeps the start date value' do
+          subject
+
+          expect(work_package.start_date)
+            .to eq(Time.zone.today)
+        end
+
+        it 'sets the due date value' do
+          subject
+
+          expect(work_package.due_date)
+            .to eq(Time.zone.today + 1.day)
+        end
+
+        it "updates the duration" do
+          subject
+
+          expect(work_package.duration)
+            .to eq 2
+        end
+      end
+    end
+
+    context 'with start date nilled' do
+      let(:work_package) { build_stubbed(:stubbed_work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
+      let(:call_attributes) { { start_date: nil } }
+      let(:attributes) { {} }
+
+      it_behaves_like 'service call' do
+        it 'sets the start date to nil' do
+          subject
+
+          expect(work_package.start_date)
+            .to be_nil
+        end
+
+        it 'keeps the due date value' do
+          subject
+
+          expect(work_package.due_date)
+            .to eq(Time.zone.today + 5.days)
+        end
+
+        it "sets the duration to 1" do
+          subject
+
+          expect(work_package.duration)
+            .to eq 1
+        end
+      end
+    end
+
+    context 'with due date nilled' do
+      let(:work_package) { build_stubbed(:stubbed_work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
+      let(:call_attributes) { { due_date: nil } }
+      let(:attributes) { {} }
+
+      it_behaves_like 'service call' do
+        it 'keeps the start date' do
+          subject
+
+          expect(work_package.start_date)
+            .to eq(Time.zone.today)
+        end
+
+        it 'nils the due date' do
+          subject
+
+          expect(work_package.due_date)
+            .to be_nil
+        end
+
+        it "sets the duration to 1" do
+          subject
+
+          expect(work_package.duration)
+            .to eq 1
+        end
+      end
+    end
+
+    context 'with duration explicitly set' do
+      let(:work_package) { build_stubbed(:stubbed_work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
+      let(:call_attributes) { { due_date: Time.zone.today + 2.days, duration: 8 } }
+      let(:attributes) { {} }
+
+      it_behaves_like 'service call' do
+        it 'keeps the start date' do
+          subject
+
+          expect(work_package.start_date)
+            .to eq(Time.zone.today)
+        end
+
+        it 'sets the due date' do
+          subject
+
+          expect(work_package.due_date)
+            .to eq(Time.zone.today + 2.days)
+        end
+
+        it "sets the faulty duration (for error reporting)" do
+          subject
+
+          expect(work_package.duration)
+            .to eq 8
+        end
+      end
+    end
+  end
+
+  context 'for priority' do
+    let(:default_priority) { build_stubbed(:priority) }
+    let(:other_priority) { build_stubbed(:priority) }
+
+    before do
+      allow(IssuePriority)
+        .to receive_message_chain(:active, :default)
+              .and_return(default_priority)
+    end
+
+    context 'with no value set before for a new work package' do
+      let(:call_attributes) { {} }
+      let(:attributes) { {} }
+      let(:work_package) { new_work_package }
+
+      before do
+        work_package.priority = nil
+      end
+
+      it_behaves_like 'service call' do
+        it "sets the default priority" do
+          subject
+
+          expect(work_package.priority)
+            .to eql default_priority
+        end
+      end
+    end
+
+    context 'when updating priority before calling the service' do
+      let(:call_attributes) { {} }
+      let(:attributes) { { priority: other_priority } }
+
+      before do
+        work_package.attributes = attributes
+      end
+
+      it_behaves_like 'service call'
+    end
+
+    context 'when updating priority via attributes' do
+      let(:call_attributes) { attributes }
+      let(:attributes) { { priority: other_priority } }
+
+      it_behaves_like 'service call'
+    end
+  end
+
+  context 'when switching the type' do
+    let(:target_type) { build_stubbed(:type) }
+    let(:work_package) do
+      build_stubbed(:stubbed_work_package, start_date: Time.zone.today - 6.days, due_date: Time.zone.today)
+    end
+
+    context 'with a type that is no milestone' do
+      before do
+        allow(target_type)
+          .to receive(:is_milestone?)
+                .and_return(false)
+      end
+
+      it 'keeps the start date' do
+        instance.call(type: target_type)
+
+        expect(work_package.start_date)
+          .to eql Time.zone.today - 6.days
+      end
+
+      it 'keeps the due date' do
+        instance.call(type: target_type)
+
+        expect(work_package.due_date)
+          .to eql Time.zone.today
+      end
+
+      it 'keeps duration' do
+        instance.call(type: target_type)
+
+        expect(work_package.duration).to be 7
+      end
+    end
+
+    context 'with a type that is a milestone and with both dates set' do
+      before do
+        allow(target_type)
+          .to receive(:is_milestone?)
+                .and_return(true)
+      end
+
+      it 'sets the start date to the due date' do
+        instance.call(type: target_type)
+
+        expect(work_package.start_date).to eql Time.zone.today
+      end
+
+      it 'keeps the due date' do
+        instance.call(type: target_type)
+
+        expect(work_package.due_date).to eql Time.zone.today
+      end
+
+      it 'sets the duration to 1 (to be changed to 0 later on)' do
+        instance.call(type: target_type)
+
+        expect(work_package.duration).to eq 1
+      end
+    end
+
+    context 'with a type that is a milestone and with only the start date set' do
+      let(:work_package) do
+        build_stubbed(:stubbed_work_package, start_date: Time.zone.today - 6.days)
       end
 
       before do
-        allow(new_project)
-          .to receive(:shared_versions)
-          .and_return(new_versions)
-        allow(new_project_categories)
-          .to receive(:find_by)
-          .with(name: category.name)
-          .and_return nil
-        allow(new_project)
-          .to receive(:types)
-          .and_return(new_types)
-        allow(new_types)
-          .to receive(:order)
-          .with(:position)
-          .and_return(new_types)
+        allow(target_type)
+          .to receive(:is_milestone?)
+                .and_return(true)
       end
 
-      shared_examples_for 'updating the project' do
-        context 'version' do
-          before do
-            work_package.version = version
-          end
+      it 'keeps the start date' do
+        instance.call(type: target_type)
 
-          context 'not shared in new project' do
-            it 'sets to nil' do
-              subject
-
-              expect(work_package.version)
-                .to be_nil
-            end
-          end
-
-          context 'shared in the new project' do
-            let(:new_versions) { [version] }
-
-            it 'keeps the version' do
-              subject
-
-              expect(work_package.version)
-                .to eql version
-            end
-          end
-        end
-
-        context 'category' do
-          before do
-            work_package.category = category
-          end
-
-          context 'no category of same name in new project' do
-            it 'sets to nil' do
-              subject
-
-              expect(work_package.category)
-                .to be_nil
-            end
-          end
-
-          context 'category of same name in new project' do
-            before do
-              allow(new_project_categories)
-                .to receive(:find_by)
-                .with(name: category.name)
-                .and_return new_category
-            end
-
-            it 'uses the equally named category' do
-              subject
-
-              expect(work_package.category)
-                .to eql new_category
-            end
-
-            it 'adds change to system changes' do
-              subject
-
-              expect(work_package.changed_by_system['category_id'])
-                .to eql [nil, new_category.id]
-            end
-          end
-        end
-
-        context 'type' do
-          context 'current type exists in new project' do
-            it 'leaves the type' do
-              subject
-
-              expect(work_package.type)
-                .to eql type
-            end
-          end
-
-          context 'a default type exists in new project' do
-            let(:new_types) { [other_type, default_type] }
-
-            it 'uses the first type (by position)' do
-              subject
-
-              expect(work_package.type)
-                .to eql other_type
-            end
-
-            it 'adds change to system changes' do
-              subject
-
-              expect(work_package.changed_by_system['type_id'])
-                .to eql [initial_type.id, other_type.id]
-            end
-          end
-
-          context 'no default type exists in new project' do
-            let(:new_types) { [other_type, yet_another_type] }
-
-            it 'uses the first type (by position)' do
-              subject
-
-              expect(work_package.type)
-                .to eql other_type
-            end
-
-            it 'adds change to system changes' do
-              subject
-
-              expect(work_package.changed_by_system['type_id'])
-                .to eql [initial_type.id, other_type.id]
-            end
-          end
-
-          context 'when also setting a new type via attributes' do
-            let(:attributes) { { project: new_project, type: yet_another_type } }
-
-            it 'sets the desired type' do
-              subject
-
-              expect(work_package.type)
-                .to eql yet_another_type
-            end
-
-            it 'does not set the change to system changes' do
-              subject
-
-              expect(work_package.changed_by_system)
-                .not_to include('type_id')
-            end
-          end
-        end
+        expect(work_package.start_date).to eql Time.zone.today - 6.days
       end
 
-      context 'update project before calling the service' do
-        let(:call_attributes) { {} }
-        let(:attributes) { { project: new_project } }
+      it 'set the due date to the start date' do
+        instance.call(type: target_type)
 
+        expect(work_package.due_date).to eql Time.zone.today - 6.days
+      end
+
+      it 'keeps the duration at 1 (to be changed to 0 later on)' do
+        instance.call(type: target_type)
+
+        expect(work_package.duration).to eq 1
+      end
+    end
+  end
+
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
+  context 'when switching the project' do
+    let(:new_project) { build_stubbed(:project) }
+    let(:version) { build_stubbed(:version) }
+    let(:category) { build_stubbed(:category) }
+    let(:new_category) { build_stubbed(:category, name: category.name) }
+    let(:new_statuses) { [work_package.status] }
+    let(:new_versions) { [] }
+    let(:type) { work_package.type }
+    let(:new_types) { [type] }
+    let(:default_type) { build_stubbed(:type_standard) }
+    let(:other_type) { build_stubbed(:type) }
+    let(:yet_another_type) { build_stubbed(:type) }
+
+    let(:call_attributes) { {} }
+    let(:new_project_categories) do
+      categories_stub = double('categories')
+      allow(new_project)
+        .to receive(:categories)
+              .and_return(categories_stub)
+
+      categories_stub
+    end
+
+    before do
+      allow(new_project)
+        .to receive(:shared_versions)
+              .and_return(new_versions)
+      allow(new_project_categories)
+        .to receive(:find_by)
+              .with(name: category.name)
+              .and_return nil
+      allow(new_project)
+        .to receive(:types)
+              .and_return(new_types)
+      allow(new_types)
+        .to receive(:order)
+              .with(:position)
+              .and_return(new_types)
+    end
+
+    shared_examples_for 'updating the project' do
+      context 'for version' do
         before do
-          work_package.attributes = attributes
+          work_package.version = version
         end
 
-        it_behaves_like 'service call' do
-          it_behaves_like 'updating the project'
+        context 'when not shared in new project' do
+          it 'sets to nil' do
+            subject
+
+            expect(work_package.version)
+              .to be_nil
+          end
+        end
+
+        context 'when shared in the new project' do
+          let(:new_versions) { [version] }
+
+          it 'keeps the version' do
+            subject
+
+            expect(work_package.version)
+              .to eql version
+          end
         end
       end
 
-      context 'updating project via attributes' do
-        let(:call_attributes) { attributes }
-        let(:attributes) { { project: new_project } }
+      context 'for category' do
+        before do
+          work_package.category = category
+        end
 
-        it_behaves_like 'service call' do
-          it_behaves_like 'updating the project'
+        context 'when no category of same name in new project' do
+          it 'sets to nil' do
+            subject
+
+            expect(work_package.category)
+              .to be_nil
+          end
+        end
+
+        context 'when category of same name in new project' do
+          before do
+            allow(new_project_categories)
+              .to receive(:find_by)
+                    .with(name: category.name)
+                    .and_return new_category
+          end
+
+          it 'uses the equally named category' do
+            subject
+
+            expect(work_package.category)
+              .to eql new_category
+          end
+
+          it 'adds change to system changes' do
+            subject
+
+            expect(work_package.changed_by_system['category_id'])
+              .to eql [nil, new_category.id]
+          end
+        end
+      end
+
+      context 'for type' do
+        context 'when current type exists in new project' do
+          it 'leaves the type' do
+            subject
+
+            expect(work_package.type)
+              .to eql type
+          end
+        end
+
+        context 'when a default type exists in new project' do
+          let(:new_types) { [other_type, default_type] }
+
+          it 'uses the first type (by position)' do
+            subject
+
+            expect(work_package.type)
+              .to eql other_type
+          end
+
+          it 'adds change to system changes' do
+            subject
+
+            expect(work_package.changed_by_system['type_id'])
+              .to eql [initial_type.id, other_type.id]
+          end
+        end
+
+        context 'when no default type exists in new project' do
+          let(:new_types) { [other_type, yet_another_type] }
+
+          it 'uses the first type (by position)' do
+            subject
+
+            expect(work_package.type)
+              .to eql other_type
+          end
+
+          it 'adds change to system changes' do
+            subject
+
+            expect(work_package.changed_by_system['type_id'])
+              .to eql [initial_type.id, other_type.id]
+          end
+        end
+
+        context 'when also setting a new type via attributes' do
+          let(:attributes) { { project: new_project, type: yet_another_type } }
+
+          it 'sets the desired type' do
+            subject
+
+            expect(work_package.type)
+              .to eql yet_another_type
+          end
+
+          it 'does not set the change to system changes' do
+            subject
+
+            expect(work_package.changed_by_system)
+              .not_to include('type_id')
+          end
         end
       end
     end
 
-    context 'custom fields' do
-      subject { instance.call(call_attributes) }
+    context 'when updating project before calling the service' do
+      let(:call_attributes) { {} }
+      let(:attributes) { { project: new_project } }
 
-      context 'non existing fields' do
-        let(:call_attributes) { { custom_field_891: '1' } }
+      before do
+        work_package.attributes = attributes
+      end
 
-        before do
+      it_behaves_like 'service call' do
+        it_behaves_like 'updating the project'
+      end
+    end
+
+    context 'when updating project via attributes' do
+      let(:call_attributes) { attributes }
+      let(:attributes) { { project: new_project } }
+
+      it_behaves_like 'service call' do
+        it_behaves_like 'updating the project'
+      end
+    end
+  end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
+
+  context 'for custom fields' do
+    subject { instance.call(call_attributes) }
+
+    context 'non existing fields' do
+      let(:call_attributes) { { custom_field_891: '1' } }
+
+      before do
+        subject
+      end
+
+      it 'is successful' do
+        expect(subject).to be_success
+      end
+    end
+  end
+
+  context 'when switching back to automatic scheduling' do
+    let(:work_package) do
+      wp = build_stubbed(:work_package,
+                         project: project,
+                         schedule_manually: true,
+                         start_date: Time.zone.today,
+                         due_date: Time.zone.today + 5.days)
+      wp.type = build_stubbed(:type)
+      wp.send(:clear_changes_information)
+
+      allow(wp)
+        .to receive(:soonest_start)
+              .and_return(soonest_start)
+
+      wp
+    end
+    let(:call_attributes) { { schedule_manually: false } }
+    let(:attributes) { {} }
+    let(:soonest_start) { Time.zone.today + 1.day }
+
+    context 'when the soonest start date is later than the current start date' do
+      let(:soonest_start) { Time.zone.today + 3.days }
+
+      it_behaves_like 'service call' do
+        it 'sets the start date to the soonest possible start date' do
           subject
-        end
 
-        it 'is successful' do
-          expect(subject).to be_success
+          expect(work_package.start_date).to eql(Time.zone.today + 3.days)
+          expect(work_package.due_date).to eql(Time.zone.today + 8.days)
         end
       end
     end
 
-    context 'when switching back to automatic scheduling' do
-      let(:work_package) do
-        wp = build_stubbed(:work_package,
-                           project: project,
-                           schedule_manually: true,
-                           start_date: Date.today,
-                           due_date: Date.today + 5.days)
-        wp.type = build_stubbed(:type)
-        wp.send(:clear_changes_information)
+    context 'when the soonest start date is before the current start date' do
+      let(:soonest_start) { Time.zone.today - 3.days }
 
-        allow(wp)
-          .to receive(:soonest_start)
-          .and_return(soonest_start)
+      it_behaves_like 'service call' do
+        it 'sets the start date to the soonest possible start date' do
+          subject
 
-        wp
+          expect(work_package.start_date).to eql(soonest_start)
+          expect(work_package.due_date).to eql(Time.zone.today + 2.days)
+        end
       end
-      let(:call_attributes) { { schedule_manually: false } }
-      let(:attributes) { {} }
-      let(:soonest_start) { Date.today + 1.day }
+    end
 
-      context 'when the soonest start date is later than the current start date' do
-        let(:soonest_start) { Date.today + 3.days }
+    context 'when the soonest start date is nil' do
+      let(:soonest_start) { nil }
 
+      it_behaves_like 'service call' do
+        it 'sets the start date to the soonest possible start date' do
+          subject
+
+          expect(work_package.start_date).to eql(Time.zone.today)
+          expect(work_package.due_date).to eql(Time.zone.today + 5.days)
+        end
+      end
+    end
+
+    context 'when the work package also has a child' do
+      let(:child) do
+        build_stubbed(:stubbed_work_package,
+                      start_date: child_start_date,
+                      due_date: child_due_date)
+      end
+      let(:child_start_date) { Time.zone.today + 2.days }
+      let(:child_due_date) { Time.zone.today + 10.days }
+
+      before do
+        allow(work_package)
+          .to receive(:children)
+                .and_return([child])
+      end
+
+      context 'when the child`s start date is after soonest_start' do
         it_behaves_like 'service call' do
-          it 'sets the start date to the soonest possible start date' do
+          it 'sets the dates to the child dates' do
             subject
 
-            expect(work_package.start_date).to eql(Date.today + 3.days)
-            expect(work_package.due_date).to eql(Date.today + 8.days)
+            expect(work_package.start_date).to eql(Time.zone.today + 2.days)
+            expect(work_package.due_date).to eql(Time.zone.today + 10.days)
           end
         end
       end
 
-      context 'when the soonest start date is before the current start date' do
-        let(:soonest_start) { Date.today - 3.days }
+      context 'when the child`s start date is before soonest_start' do
+        let(:soonest_start) { Time.zone.today + 3.days }
 
         it_behaves_like 'service call' do
-          it 'sets the start date to the soonest possible start date' do
+          it 'sets the dates to soonest date and to the duration of the child' do
             subject
 
-            expect(work_package.start_date).to eql(soonest_start)
-            expect(work_package.due_date).to eql(Date.today + 2.days)
-          end
-        end
-      end
-
-      context 'when the soonest start date is nil' do
-        let(:soonest_start) { nil }
-
-        it_behaves_like 'service call' do
-          it 'sets the start date to the soonest possible start date' do
-            subject
-
-            expect(work_package.start_date).to eql(Date.today)
-            expect(work_package.due_date).to eql(Date.today + 5.days)
-          end
-        end
-      end
-
-      context 'when the work package also has a child' do
-        let(:child) do
-          build_stubbed(:stubbed_work_package,
-                        start_date: child_start_date,
-                        due_date: child_due_date)
-        end
-        let(:child_start_date) { Date.today + 2.days }
-        let(:child_due_date) { Date.today + 10.days }
-
-        before do
-          allow(work_package)
-            .to receive(:children)
-            .and_return([child])
-        end
-
-        context 'when the child`s start date is after soonest_start' do
-          it_behaves_like 'service call' do
-            it 'sets the dates to the child dates' do
-              subject
-
-              expect(work_package.start_date).to eql(Date.today + 2.days)
-              expect(work_package.due_date).to eql(Date.today + 10.days)
-            end
-          end
-        end
-
-        context 'when the child`s start date is before soonest_start' do
-          let(:soonest_start) { Date.today + 3.days }
-
-          it_behaves_like 'service call' do
-            it 'sets the dates to soonest date and to the duration of the child' do
-              subject
-
-              expect(work_package.start_date).to eql(Date.today + 3.days)
-              expect(work_package.due_date).to eql(Date.today + 11.days)
-            end
+            expect(work_package.start_date).to eql(Time.zone.today + 3.days)
+            expect(work_package.due_date).to eql(Time.zone.today + 11.days)
           end
         end
       end


### PR DESCRIPTION
Adds an explicit `duration` column to `WorkPackage` instead of calculating it implicitly based on `start_date` and `due_date`.


### Todo

* [x] write migration adding duration as a column on `work_packages`
* [x] write migration adding duration as a column to the `work_package_journals`
  * this might lead to the work package activities starting to render duration which is not what is desired before duration becomes a manipulatable attribute. Because of that the rendering needs to result in an empty string or the field to be ignored for now. 
* [x] write migration setting values for existing work packages if both start and due date are set
  * if either date is nil, duration is to be set to 1
* [x] write migration setting values for existing work package journals if both start and due date are set
  * if either date is nil, duration is to be set to 1
* [x] add duration handling to contract
  * will for now be set to 1 in case either start_date or due_date are nil (or both). This is to be [changed later](https://community.openproject.org/projects/openproject/work_packages/31992) on but if it is done now, all work packages need to be rescheduled because of the change. 
* [x] add duration handling to `WorkPackages::SetAttributesService`
  * set duration if both start and due date are set
  * set duration to 1 if date is unset
  * update duration on changes to start or due date
* [x] update specs relying on automatically calculated duration
  * ideally by automatically calculating the duration in factories

### Work packages

https://community.openproject.org/wp/31992
https://community.openproject.org/wp/40906
https://community.openproject.org/wp/40912