### PR TITLE
Fix/smtp and auth settings definition

### DIFF
--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -100,6 +100,18 @@ Settings::Definition.define do
       value: nil,
       writable: false
 
+  # Configures the authentication capabilities supported by the instance.
+  # Currently this is focused on the configuration for basic auth.
+  # e.g.
+  # authentication:
+  #   global_basic_auth:
+  #     user: admin
+  #     password: 123456
+  add :authentication,
+      format: :hash,
+      value: nil,
+      writable: false
+
   add :autofetch_changesets,
       value: true
 

--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -819,7 +819,6 @@ Settings::Definition.define do
   add :smtp_authentication,
       format: :string,
       value: 'plain',
-      writable: false,
       env_alias: 'SMTP_AUTHENTICATION'
 
   add :smtp_enable_starttls_auto,


### PR DESCRIPTION
Adds the definition for authentication/global_basic_auth and turns the smtp_authentication definition writable via the UI.