### PR TITLE
Fixed OAuth2 documentation regarding how to test with Postman

### DIFF
--- a/docs/api/apiv3/example/README.md
+++ b/docs/api/apiv3/example/README.md
@@ -72,9 +72,24 @@ Click the "+ Add" button to add an application:
 
 ![OAuth2 add](./oauth2-add.png)
 
-The "Name" attribute can be freely chosen. But naming reveals a difference between the way the two flows are used. While "Authorization code" flow is less focused on one use case per OAuth2 application, the "Client credentials" flow is more client application specific. This is because the user, and by that the permissions granted, can change for "Authorization code" but is fixed for "Client credentials" as a specific user has to be chosen when configuring the later.
+The "Name" attribute can be freely chosen. But naming reveals a 
+difference between the way the two flows are used. 
+While "Authorization code" flow is less focused on one use 
+case per OAuth2 application, the "Client credentials" 
+flow is more client application specific. 
+This is because the user, and by that the permissions granted, 
+can change for "Authorization code" but is fixed for 
+"Client credentials" as a specific user has to be chosen when 
+configuring the later.
 
-For the guide, we will focus on the "Authorization code" flow. After having selected a name, specify the callback url that the browser is redirected to, after the user has authenticated successfully. It is the end point that the credentials will be send to via POST from the OpenProject instance to the client so it is dependent on the client application. To stress the point, this is an end point within the client application, not within OpenProject.
+For the guide, we will focus on the "Authorization code" flow. 
+After having selected a name, specify the "Redirect URI" that the 
+browser is redirected to, after the user has authenticated successfully.
+So it is dependent on the client application, please see the respective 
+documentation.
+In the case of Postman, the Redirect URI is "https://oauth.pstmn.io/v1/callback". 
+To stress the point, this is an end point within the client application, 
+not within OpenProject.
 
 Next we chose "api_v3" to be the scope of the application. This means, that clients can only access the API v3 and cannot use the same OAuth application to also authenticate for the [BCF api which OpenProject also offers](../bcf-rest-api).
 
@@ -90,23 +105,35 @@ For this guide, we again chose Postman as our client application. Apart from "Ba
 
 ![OAuth2 postman configure](./oauth2-postman-configure.png)
 
-There are a couple of fields in that form but most of the information can simply be copied over:
+Please use the following instructions to set these fields for you:
 
-* Token Name: Freely choosable field
+* Token Name: Freely choosable field, 
+for example "Token Name"
 * Grant Type: Choose "Authorization Code"
-* Callback URL: Copy from OpenProject
-* Auth URL: Copy from OpenProject
-* Access Token URL: Copy from OpenProject
-* Client ID: Copy from OpenProject
-* Client Secret: Copy from OpenProject
-* Scope: Type in "api_v3" as we chose that in OpenProject
+* **Callback URL**: This is the callback URL of the _client_ _application_.
+With Postman 9.6 this is "https://oauth.pstmn.io/v1/callback".
+Postman automatically fills this field with this URL
+when you select "Authorize using browser". However, you have to
+uncheck "Authorize using browser" afterwards again, please see below.
+* Authorize using browser: Please leave unchecked.
+* Auth URL: Copy from OpenProject, for example "http://localhost:3000/oauth/authorize"
+* Access Token URL: Copy from OpenProject, for example "http://localhost:3000/oauth/token"
+* Client ID: Copy from OpenProject, for example "sTx_pT7DU7ixLeUtYQ1UpqOjUVRFilgUleTWV-nyPVA"
+* Client Secret: Copy from OpenProject, for example "DsPlyDgxv5P7yzzRtRclBAI63o-PdpzgwGxfgVLpi_U"
+* Scope: Please use "api_v3" as we chose that in OpenProject
 * State: You can leave this blank
+* Client Authentication: Please use "Send as Basic Auth header"
+
+
 
 After having provided the necessary information, you can press the "Request Token" button which will result in a browser being shown in which the user, not the client as it will impersonate the user, can log in:
 
 ![OAuth2 postman login](./oauth2-postman-login.png) 
 
-Using the UI credentials, be that username and password or any authentication provider e.g. Google, the user now authenticates and is asked whether she/he wants to grant the client application, Postman in this case, access on her/his behalf. 
+Using the UI credentials, be that username and password or any 
+authentication provider e.g. Google, the user now authenticates 
+and is asked whether she/he wants to grant the client application, 
+Postman in this case, access on her/his behalf. 
 
 ![OAuth2 postman grant](./oauth2-postman-grant.png) 
 

--- a/docs/api/apiv3/example/README.md
+++ b/docs/api/apiv3/example/README.md
@@ -90,23 +90,35 @@ For this guide, we again chose Postman as our client application. Apart from "Ba
 
 ![OAuth2 postman configure](./oauth2-postman-configure.png)
 
-There are a couple of fields in that form but most of the information can simply be copied over:
+Please use the following instructions to set these fields for you:
 
-* Token Name: Freely choosable field
+* Token Name: Freely choosable field, 
+for example "Token Name"
 * Grant Type: Choose "Authorization Code"
-* Callback URL: Copy from OpenProject
-* Auth URL: Copy from OpenProject
-* Access Token URL: Copy from OpenProject
-* Client ID: Copy from OpenProject
-* Client Secret: Copy from OpenProject
-* Scope: Type in "api_v3" as we chose that in OpenProject
+* **Callback URL**: This is the callback URL of the _client_ _application_.
+With Postman 9.6 this is "https://oauth.pstmn.io/v1/callback".
+Postman automatically fills this field with this URL
+when you select "Authorize using browser". However, you have to
+uncheck "Authorize using browser" afterwards again, please see below.
+* Authorize using browser: Please leave unchecked.
+* Auth URL: Copy from OpenProject, for example "http://localhost:3000/oauth/authorize"
+* Access Token URL: Copy from OpenProject, for example "http://localhost:3000/oauth/token"
+* Client ID: Copy from OpenProject, for example "sTx_pT7DU7ixLeUtYQ1UpqOjUVRFilgUleTWV-nyPVA"
+* Client Secret: Copy from OpenProject, for example "DsPlyDgxv5P7yzzRtRclBAI63o-PdpzgwGxfgVLpi_U"
+* Scope: Please use "api_v3" as we chose that in OpenProject
 * State: You can leave this blank
+* Client Authentication: Please use "Send as Basic Auth header"
+
+
 
 After having provided the necessary information, you can press the "Request Token" button which will result in a browser being shown in which the user, not the client as it will impersonate the user, can log in:
 
 ![OAuth2 postman login](./oauth2-postman-login.png) 
 
-Using the UI credentials, be that username and password or any authentication provider e.g. Google, the user now authenticates and is asked whether she/he wants to grant the client application, Postman in this case, access on her/his behalf. 
+Using the UI credentials, be that username and password or any 
+authentication provider e.g. Google, the user now authenticates 
+and is asked whether she/he wants to grant the client application, 
+Postman in this case, access on her/his behalf. 
 
 ![OAuth2 postman grant](./oauth2-postman-grant.png) 
 

--- a/docs/api/apiv3/example/README.md
+++ b/docs/api/apiv3/example/README.md
@@ -38,17 +38,34 @@ Regardless of the authentication mechanism used, a client will always authentica
 
 ### Basic auth
 
-Basic auth is simple to setup and understand but should be avoided in the long run due to security reasons but also because it limits a client and is harder to manage within an organization.
+Basic auth is simple to setup and understand but should be avoided in 
+the long run due to security reasons but also because it limits a client 
+and is harder to manage within an organization.
 
-In order to authenticate with basic auth, a user first has to login into OpenProject, generate an api key, and then use the key to authenticate on API calls. A user cannot use the credentials used to login into the UI to also authenticate when communicating with the API.
+In order to authenticate with basic auth, a user first has to login 
+into OpenProject and generate an API key. After that he can use the 
+API key to authenticate API calls. The normal login credentials will 
+not work when communicating via the API.
 
-An API key can be generated on the "Access token" page within the "My account" section by clicking on the "Generate" or "Reset" (depending on whether a key already exists) link within the "API" row. 
+An API key can be generated on the "Access token" page within the 
+"My account" section by clicking on the "Generate" or "Reset" 
+(depending on whether a key already exists) link within the "API" row. 
 
 ![get basic auth key](./basic-auth-key-generation.png)
 
-Only one API key can exist for a user at any given time. Generating a new key will invalidate the former key so make sure to note down the access token. This is one of the limitations that do apply to basic auth but do not apply to OAuth2.
+Only one API key can exist for a user at any given time. 
+Generating a new key will invalidate the former key, so please
+make sure to note down the access token. 
+This is one of the limitations that do apply to basic auth 
+but do not apply to OAuth2.
 
-Postman offers to correctly encode the key and set the correct `Authorization` header via a form. So using Postman, having chosen "Basic Auth" as the authorization type, we can authenticate by pasting in the key into the "Password" field and by setting 'apikey' for "Username". When using basic auth, the user's login is never used. The whole of the information is already encoded in the generated key.
+Postman offers to correctly encode the key and set the 
+correct `Authorization` header via a form. So using Postman, 
+having chosen "Basic Auth" as the authorization type, 
+we can authenticate by pasting in the key into the 
+"Password" field and by setting 'apikey' for "Username". 
+When using basic auth, the user's login is never used. T
+he whole of the information is already encoded in the generated key.
 
 ![basic auth postman form](./basic-auth-postman-form.png)
 
@@ -60,99 +77,45 @@ We could just as well have generated the header ourselves by Base64 encoding the
 
 ### OAuth2
 
-The OAuth2 based authentication requires an administrator to set up but offers significant advantages compared to authentication based on Basic auth. 
+OAuth2 based authentication requires an administrator to create
+and configure an OAuth2 application as described in the 
+[Administration Guide](../../system-admin-guide/authentication/oauth-applications/).
+The guide also explains how to use the Postman application to
+test the OAuth2 flow and to obtain a Bearer token.
 
-OpenProject supports two OAuth flows: "Authorization code" and "Client credentials". In OpenProject terms, the main difference is whether a client wants to impersonate different users or wants to always access OpenProject with the same user account. An example for the former would be an application for logging time. Via the "Authorization code" flow, the logged time would be booked in the name of each user separately. The user would be the user creating the logged time. If the calling user is less important or if that user can always be the same, the "Client credentials" flow is sufficient.
+Once available, we chose to use the resulting Bearer token 
+in Postman by pressing "Use token".
 
-Before the client can authenticate, an administrator sets up the OAuth application within the OpenProject instance. Go to the Administration and select "OAuth applications" within the "Authentication" menu.
-
-![OAuth2 index](./oauth2-index.png)
-
-Click the "+ Add" button to add an application:
-
-![OAuth2 add](./oauth2-add.png)
-
-The "Name" attribute can be freely chosen. But naming reveals a 
-difference between the way the two flows are used. 
-While "Authorization code" flow is less focused on one use 
-case per OAuth2 application, the "Client credentials" 
-flow is more client application specific. 
-This is because the user, and by that the permissions granted, 
-can change for "Authorization code" but is fixed for 
-"Client credentials" as a specific user has to be chosen when 
-configuring the later.
-
-For the guide, we will focus on the "Authorization code" flow. 
-After having selected a name, specify the "Redirect URI" that the 
-browser is redirected to, after the user has authenticated successfully.
-So it is dependent on the client application, please see the respective 
-documentation.
-In the case of Postman, the Redirect URI is "https://oauth.pstmn.io/v1/callback". 
-To stress the point, this is an end point within the client application, 
-not within OpenProject.
-
-Next we chose "api_v3" to be the scope of the application. This means, that clients can only access the API v3 and cannot use the same OAuth application to also authenticate for the [BCF api which OpenProject also offers](../bcf-rest-api).
-
-If we can ensure, that the application can secure the api key, we can check the "Confidential" checkbox. This is typically the case for client applications running on a server or on desktop but requires the client application to ensure it.
-
-After having provided the necessary information we click "Create" to actually create the application and are presented the following screen:
-
-![OAuth2 created](./oauth2-created.png)
-
-It contains information we are going to copy to our client application. Part of the information, the client secret, will be shown never again after the page is left so ensure to write it down. 
-
-For this guide, we again chose Postman as our client application. Apart from "Basic auth" as the "Authorization" type, it also supports "Oauth 2.0" which is what we are going to chose:
-
-![OAuth2 postman configure](./oauth2-postman-configure.png)
-
-Please use the following instructions to set these fields for you:
-
-* Token Name: Freely choosable field, 
-for example "Token Name"
-* Grant Type: Choose "Authorization Code"
-* **Callback URL**: This is the callback URL of the _client_ _application_.
-With Postman 9.6 this is "https://oauth.pstmn.io/v1/callback".
-Postman automatically fills this field with this URL
-when you select "Authorize using browser". However, you have to
-uncheck "Authorize using browser" afterwards again, please see below.
-* Authorize using browser: Please leave unchecked.
-* Auth URL: Copy from OpenProject, for example "http://localhost:3000/oauth/authorize"
-* Access Token URL: Copy from OpenProject, for example "http://localhost:3000/oauth/token"
-* Client ID: Copy from OpenProject, for example "sTx_pT7DU7ixLeUtYQ1UpqOjUVRFilgUleTWV-nyPVA"
-* Client Secret: Copy from OpenProject, for example "DsPlyDgxv5P7yzzRtRclBAI63o-PdpzgwGxfgVLpi_U"
-* Scope: Please use "api_v3" as we chose that in OpenProject
-* State: You can leave this blank
-* Client Authentication: Please use "Send as Basic Auth header"
-
-
-
-After having provided the necessary information, you can press the "Request Token" button which will result in a browser being shown in which the user, not the client as it will impersonate the user, can log in:
-
-![OAuth2 postman login](./oauth2-postman-login.png) 
-
-Using the UI credentials, be that username and password or any 
-authentication provider e.g. Google, the user now authenticates 
-and is asked whether she/he wants to grant the client application, 
-Postman in this case, access on her/his behalf. 
-
-![OAuth2 postman grant](./oauth2-postman-grant.png) 
-
-Choosing "Authorize" will show the granted token:
- 
 ![OAuth2 postman token](./oauth2-postman-token.png) 
 
-which we chose to use by pressing "Use token". Please note that an OAuth token expires in two hours so the client has to request a new token, then. But using the refreshToken, this does not necessarily require user interaction.
+Please note that an OAuth token expires after two hours,
+so the client has to request a new token then. This will require
+another click to the "Get New Access Token" button at the bottom
+of the Postman "Authorization" tab.
 
 ### Being authenticated
 
-Once we gain authenticated access to the OpenProject application, the error, informing the client of a missing `Authorization` header will disappear. But the collection of work packages returned might still not contain the work packages the client is looking for. This might be, because the user in whose name the client accesses the application is lacking permissions. 
+With the Bearer token included in the request, 
+we should see a list of work packages
+in the work packages page above.
+
+However, the collection of work packages returned might still 
+not contain the work packages the client is looking for. 
+This might be, because the user in whose name the client 
+accesses the application is lacking permissions. 
 We need to ensure that the user also has the necessary authorization.
 
 ## Authorization
 
-As the client accesses OpenProject on behalf of a user, that user needs to have authorization to do the desired actions. So while the user might be authenticated, she/he might lack the necessary permissions to do anything.
+As the client accesses OpenProject on behalf of a user, 
+that user needs to have authorization to do the desired actions. 
+So while the user might be authenticated, she/he might lack the 
+necessary permissions to do anything.
 
-In OpenProject, permissions are mostly granted by creating a connection between a user, a project and a role in the form of a membership. So for every project the user is supposed to have access, a role needs to be assigned to him/her.
+In OpenProject, permissions are mostly granted by creating a 
+connection between a user, a project and a role in the form of a 
+membership. So for every project the user is supposed to have access, 
+a role needs to be assigned to him/her.
 
 This can be done in the members administration of each project:
 

--- a/docs/system-admin-guide/authentication/oauth-applications/README.md
+++ b/docs/system-admin-guide/authentication/oauth-applications/README.md
@@ -8,7 +8,8 @@ keywords: OAuth application settings
 ---
 # OAuth applications
 
-To activate and configure OAuth applications, navigate to -> *Administration* -> *Authentication* -> *OAuth applications*.
+To configure OpenProject to act as a server to an
+OAuth client applications, please navigate to -> *Administration* -> *Authentication* -> *OAuth applications*.
 
 ## Add a new authentication application for OAuth
 
@@ -16,24 +17,38 @@ To add a new OAuth application, click the green **+ Add** button.
 
 ![Sys-admin-authentication-OAuth-applications](Sys-admin-authentication-oauth-applications.png)
 
+You can configure the following options to add your OAuth application:
 
-
-You can configure the following options to add your OAuth application.
-
-1. Enter the **name** of your OAuth application.
-2. **Define redirect URLs** where authorized users can be redirected to.
-3. Set the **scope** that the OAuth application will have access to. Choose the API you want to grant access to. Multiple selection is possible. If no scope is checked, per default **api_v3** is assumed.
-4. Check if the application will be used **confidentially**.
-5. (Optional) Choose **client credential flows** and define a user on whose behalf requests will be performed.
-6. Press the blue **Create** button to add your OAuth application.
+1. Enter the **Name** of your OAuth application.
+2. Define a **Redirect URL** where users are redirected to
+   after having authorized OAuth2 access in OpenProject.
+   This URL is provided by your client application. 
+   In the case of locally running Postman you can use the special string:
+   `urn:ietf:wg:oauth:2.0:oob`
+   Postman 9.6 and higher also provides a Web URL that you can use:
+   `https://oauth.pstmn.io/v1/callback`.
+3. Set the **Scopes** that the OAuth clien application will be 
+   able to access. Multiple selection is possible. 
+   If no scope is checked, per default **api_v3** is assumed.
+   api_v3 is the standard OpenProject API, while
+   [bcf_v2_1](../bcf-rest-api) is specific to the BIM edition of 
+   OpenProject.
+4. Check if the application will be **Confidential**.
+   This is typically the case for client applications
+   running on a server or desktop but requires the
+   client application to ensure it.
+5. (Optional) Choose **Client Credentials User** and define a 
+   user on whose behalf requests will be performed.
+6. Press **Create** to add your OAuth application.
 
 ![add-new-oauth-application](add-new-oauth-application.png)
 
-Don't forget to note down your `Client ID` and your `Client secret` in a safe space. You will need it later.
+Don't forget to note down your `Client ID` and your `Client secret` 
+in a safe space. You will need them later.
 
 ## OAuth endpoints
 
-The authentication endpoints are at
+The authentication endpoints of OpenProject OAuth2 server are:
 
 * Auth URL: `https://example.com/oauth/authorize`
 * Access Token URL: `https://example.com/oauth/token`
@@ -42,33 +57,38 @@ The authentication endpoints are at
 
 ### Requesting authorization code
 
-Request an authorization code. Please adopt the following URL replacing 
+Request an authorization code. Please adopt the following URL replacing:
 
- * the `example.com` with the root path of your OpenProject instance,
- * `<Client ID>` with your client ID, and
- * `<Redirect URI>` with the redirect URI just as you configured it above.
+ * `example.com` with the IP/host name of your OpenProject instance,
+ * `<Client ID>` with your OAuth2 client ID, and
+ * `<Redirect URI>` with the redirect URI as configured above.
  * You can leave the `scope` value untouched unless you are running the OpenProject BIM edition and also plan to access to the BCF version 2.1 REST API. Then simply replace `api_v3` with `api_v3%20bcf_v2_1`.
 
 `https://example.com/oauth/authorize?response_type=code&client_id=<Client ID>&redirect_uri=<Redirect URI>&scope=api_v3&prompt=consent`
 
-That requests redirects you to a URL that holds a `code` parameter which is the authentication code.
+This requests redirects you to a URL that holds a `code` parameter 
+which is the authentication code.
 
-Typically the server that was requested with that redirect will save the authorization code and use it
-to obtain an API token, with which the server can then act on behalf of the current user. 
+Typically the server that was requested with that redirect will save 
+the authorization code and use it to obtain API token, with which 
+the server can then act on behalf of the current user. 
 
-In this example we skip that server side implementation and just copy the value of the `code` parameter from the URL that you see in your browser.
+In this example we skip that server side implementation and just 
+copy the value of the `code` parameter from the URL that you see 
+in your browser.
 
 ### Requesting API token
 
-With the authorization code that you obtained above you can now request an API token.
+With the authorization code that you obtained above you can now 
+request an API token.
 
-We do this manually in the command line using cURL. Please replace
+We do this manually in the command line using cURL. Please replace:
 
- * the `example.com` with the root path of your OpenProject instance,
- * `<Client ID>` with your client ID,
- * `<Client secret>` with your client secret,
+ * `example.com` with the IP/host name of your OpenProject instance,
+ * `<Client ID>` with your OAuth2 client ID,
+ * `<Client secret>` with your OAuth2 client secret,
  * `<Authentication code>` with the code you obtained above,
- * and `<Redirect URI>` with the redirect URI just as you configured it above.
+ * and `<Redirect URI>` with the redirect URI as configured above.
 
 ```
 $ curl --request POST \
@@ -81,30 +101,64 @@ $ curl --request POST \
   --data 'redirect_uri=<Redirect URI>'
 ```
 
-The response will contain the token that you need when working with the API. Please copy the token.
+The response will look like this:
+
+```
+{
+  "access_token": "Ize6vvCIeENQ_suzd9kBJ6BxDNpxcumfTfweZQaOoJc",
+  "token_type": "Bearer",
+  "expires_in": 7200,
+  "refresh_token": "kDQ5pxzOE_4kCSKzONZaI1ogcyjcXk97_KhBS0JfCw4",
+  "scope": "api_v3",
+  "created_at": 1652112852
+}
+```
+
+The response contains the bearer token ("access_token") and 
+a refresh token that you will need when working with the API. 
+Please copy the tokens for reference.
+
 
 ### Performing a request to the OpenProject API with OAuth token
 
-With the token that you obtained above you can now make API calls to the OpenProject instance 
-on behalf of the current user.
+With the token that you obtained above you can now make API 
+calls to the OpenProject instance on behalf of the current user.
 
-For example, the following cURL command fetches all projects from the API V3. Please replace
+For example, the following cURL command fetches all projects 
+from the API V3. Please replace:
                                                                   
- * the `example.com` with the root path of your OpenProject instance, and
- * `<Token>` with the code you obtained above.
+ * `example.com` with the IP/host name of your OpenProject instance, and
+ * `<Token>` with the bearer token you obtained above.
 
-`$ curl --request GET 'https://example.com/api/v3/projects' \
+```
+$ curl --request GET 'https://example.com/api/v3/projects' \
   --header 'Authorization: Bearer <Token>'`
+```
 
-## Using Postman with OAuth?
+## Using Postman with OAuth2
 
-Set redirect URLs to `urn:ietf:wg:oauth:2.0:oob` in both, for your application (see step 2 above) and 
-within Postman.
+You can exercise the authentication flow above using Postman. 
+Just create a new request:
 
-In Postman the configuration should look like this (Replace `{{protocolHostPort}}` with your host, 
-i.e. `https://example.com`)
+```
+GET {{protocolHostPort}}/api/v3/projects
+```
+
+with {{protocolHostPort}} corresponding to your server and port,
+for example `http://localhost:3000`. Then go to the
+Authorization tab and select **Type**: OAuth2 2.0. On the right
+side you will see a form similar to the one below.
+Please fill in your specific Client ID and Client Secret from above.
 
 ![Sys-admin-authentication-add-OAuth-application](Sys-admin-authentication-oauth-postman.png)
+
+Clicking on "Request Token" will initiate the same flow as above
+and complete with a success screen. Please click on "Use Token"
+to use this token for authenticating your `/api/v3/projects` request.
+
+Please note that your Bearer token will expire after two hours (default)
+and you will have to click on "Request Token" again. Otherwise your
+API request will return an error message.
 
 ## CORS headers
 


### PR DESCRIPTION
I was trying to follow the documentation to test OAuth2 authentication using Postman 9.6:
https://www.openproject.org/docs/api/example/#oauth2
However, the "Callback URL" was incorrectly specified, and the instructions where misleading on how to find this value, so I fixed this and provided example values in the instructions for each field.

However, I did **not** update the screenshots in the documentation. They don't 100% match Postman 9.6, but they may change with again with the next version of Postman.