### PR TITLE
Add missing include_subprojects property to schema

### DIFF
--- a/lib/api/v3/queries/schemas/query_schema_representer.rb
+++ b/lib/api/v3/queries/schemas/query_schema_representer.rb
@@ -162,6 +162,12 @@ module API
                  writable: true,
                  has_default: true
 
+          schema :include_subprojects,
+                 type: 'Boolean',
+                 required: true,
+                 writable: true,
+                 has_default: true
+
           schema_with_allowed_collection :columns,
                                          type: '[]QueryColumn',
                                          required: false,


### PR DESCRIPTION
The property is otherwise not writable and not sent to the backend on create

[OP#42277](https://community.openproject.org/wp/42277)