### PR TITLE
Install newer version of postgresql-devel for centos7

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -26,6 +26,10 @@ targets:
   ubuntu-20.04:
     <<: *debian9
   centos-7: &centos7
+    env:
+      - BUNDLE_BUILD__PG="--with-pg-config=/usr/pgsql-13/bin/pg_config"
+      - NODE_ENV=production
+      - NPM_CONFIG_PRODUCTION=false
     dependencies:
       - epel-release
       - ImageMagick
@@ -33,6 +37,9 @@ targets:
       - poppler-utils
   centos-8:
     <<: *centos7
+    env:
+      - NODE_ENV=production
+      - NPM_CONFIG_PRODUCTION=false
   sles-12:
     build_dependencies:
       - sqlite3-devel

--- a/packaging/setup
+++ b/packaging/setup
@@ -14,3 +14,12 @@ cp -f packaging/.npmrc .npmrc
 
 # replace every occurrence of _APP_NAME_ with the corresponding application name we're packaging
 find packaging/ -type f -print0 | xargs -0 sed -i "s|_APP_NAME_|${APP_NAME}|"
+
+# Install newer version of postgresql libs for centos7
+if [ "$TARGET" = 'el:7' ]; then
+  sudo yum remove -y postgresql-devel
+
+  sudo yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+  sudo yum install -y centos-release-scl-rh
+  sudo yum install -y postgresql13-devel
+fi


### PR DESCRIPTION
Fix centos7 builds by providing a newer version of postgresql-devel