### PR TITLE
add a setting:available_envs rake task to list overridable env var names

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -38,38 +38,27 @@ module Settings
                 :allowed
 
     def initialize(name,
-                   value:,
+                   default:,
                    format: nil,
                    writable: true,
                    allowed: nil,
                    env_alias: nil)
       self.name = name.to_s
+      @default = default.is_a?(Hash) ? default.deep_stringify_keys : default
+      @default.freeze
+      self.value = @default.dup
       self.format = format ? format.to_sym : deduce_format(value)
-      self.value = value.is_a?(Hash) ? value.deep_stringify_keys : value
       self.writable = writable
       self.allowed = allowed
       self.env_alias = env_alias
     end
 
-    def value
-      return nil if @value.nil?
+    def default
+      cast(@default)
+    end
 
-      case format
-      when :integer
-        @value.to_i
-      when :float
-        @value.to_f
-      when :boolean
-        ActiveRecord::Type::Boolean.new.cast(@value)
-      when :symbol
-        @value.to_sym
-      else
-        if @value.respond_to?(:call)
-          @value.call
-        else
-          @value
-        end
-      end
+    def value
+      cast(@value)
     end
 
     def serialized?
@@ -129,7 +118,7 @@ module Settings
       # * a value provided by an ENV var
       #
       # @param [Object] name The name of the definition
-      # @param [Object] value The default value the setting has if not overwritten.
+      # @param [Object] default The default value the setting has if not overridden.
       # @param [nil] format The format the value is in e.g. symbol, array, hash, string. If a value is present,
       #  the format is deferred.
       # @param [TrueClass] writable Whether the value can be set in the UI. In case the value is set via file or ENV var,
@@ -142,7 +131,7 @@ module Settings
       #  `OPENPROJECT_2FA` for a definition with the name `two_factor_authentication`, the value is fetched
       #  from the ENV OPENPROJECT_2FA as well.
       def add(name,
-              value:,
+              default:,
               format: nil,
               writable: true,
               allowed: nil,
@@ -153,7 +142,7 @@ module Settings
 
         definition = new(name,
                          format: format,
-                         value: value,
+                         default: default,
                          writable: writable,
                          allowed: allowed,
                          env_alias: env_alias)
@@ -334,6 +323,7 @@ module Settings
           env_name_alias(definition)
         ].compact
       end
+      public :possible_env_names
 
       def env_name_nested(definition)
         "#{ENV_PREFIX}#{definition.name.upcase.gsub('_', '__')}"
@@ -388,6 +378,27 @@ module Settings
 
     attr_accessor :serialized,
                   :writable
+
+    def cast(value)
+      return nil if value.nil?
+
+      case format
+      when :integer
+        value.to_i
+      when :float
+        value.to_f
+      when :boolean
+        ActiveRecord::Type::Boolean.new.cast(value)
+      when :symbol
+        value.to_sym
+      else
+        if value.respond_to?(:call)
+          value.call
+        else
+          value
+        end
+      end
+    end
 
     def deduce_format(value)
       case value

--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -35,69 +35,69 @@
 
 Settings::Definition.define do
   add :activity_days_default,
-      value: 30
+      default: 30
 
   add :additional_footer_content,
       format: :string,
-      value: nil
+      default: nil
 
   add :after_first_login_redirect_url,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :after_login_default_redirect_url,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :apiv3_cors_enabled,
-      value: false
+      default: false
 
   add :apiv3_cors_origins,
-      value: []
+      default: []
 
   add :apiv3_docs_enabled,
-      value: true
+      default: true
 
   add :apiv3_enable_basic_auth,
-      value: true,
+      default: true,
       writable: false
 
   add :apiv3_max_page_size,
-      value: 1000
+      default: 1000
 
   add :app_title,
-      value: 'OpenProject'
+      default: 'OpenProject'
 
   add :attachment_max_size,
-      value: 5120
+      default: 5120
 
   # Existing setting
   add :attachment_whitelist,
-      value: []
+      default: []
 
   ##
   # Carrierwave storage type. Possible values are, among others, :file and :fog.
   # The latter requires further configuration.
   add :attachments_storage,
-      value: :file,
+      default: :file,
       format: :symbol,
       allowed: %i[file fog],
       writable: false
 
   add :attachments_storage_path,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :attachments_grace_period,
-      value: 180,
+      default: 180,
       writable: false
 
   add :auth_source_sso,
       format: :hash,
-      value: nil,
+      default: nil,
       writable: false
 
   # Configures the authentication capabilities supported by the instance.
@@ -109,158 +109,158 @@ Settings::Definition.define do
   #     password: 123456
   add :authentication,
       format: :hash,
-      value: nil,
+      default: nil,
       writable: false
 
   add :autofetch_changesets,
-      value: true
+      default: true
 
   # autologin duration in days
   # 0 means autologin is disabled
   add :autologin,
-      value: 0
+      default: 0
 
   add :autologin_cookie_name,
-      value: 'autologin',
+      default: 'autologin',
       writable: false
 
   add :autologin_cookie_path,
-      value: '/',
+      default: '/',
       writable: false
 
   add :autologin_cookie_secure,
-      value: false,
+      default: false,
       writable: false
 
   add :available_languages,
       format: :array,
-      value: %w[en de fr es pt pt-BR it zh-CN ko ru].freeze,
+      default: %w[en de fr es pt pt-BR it zh-CN ko ru].freeze,
       allowed: -> { Redmine::I18n.all_languages }
 
   add :avatar_link_expiry_seconds,
-      value: 24.hours.to_i,
+      default: 24.hours.to_i,
       writable: false
 
   # Allow users with the required permissions to create backups via the web interface or API.
   add :backup_enabled,
-      value: true,
+      default: true,
       writable: false
 
   add :backup_daily_limit,
-      value: 3,
+      default: 3,
       writable: false
 
   add :backup_initial_waiting_period,
-      value: 24.hours,
+      default: 24.hours,
       format: :integer,
       writable: false
 
   add :backup_include_attachments,
-      value: true,
+      default: true,
       writable: false
 
   add :backup_attachment_size_max_sum_mb,
-      value: 1024,
+      default: 1024,
       writable: false
 
   add :blacklisted_routes,
-      value: [],
+      default: [],
       writable: false
 
   add :bcc_recipients,
-      value: true
+      default: true
 
   add :boards_demo_data_available,
-      value: false
+      default: false
 
   add :brute_force_block_minutes,
-      value: 30
+      default: 30
 
   add :brute_force_block_after_failed_logins,
-      value: 20
+      default: 20
 
   add :cache_expires_in_seconds,
       format: :integer,
-      value: nil,
+      default: nil,
       writable: false
 
   add :cache_formatted_text,
-      value: true
+      default: true
 
   # use dalli defaults for memcache
   add :cache_memcache_server,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :cache_namespace,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :commit_fix_done_ratio,
-      value: 100
+      default: 100
 
   add :commit_fix_keywords,
-      value: 'fixes,closes'
+      default: 'fixes,closes'
 
   add :commit_fix_status_id,
       format: :integer,
-      value: nil,
+      default: nil,
       allowed: -> { Status.pluck(:id) + [nil] }
 
   # encoding used to convert commit logs to UTF-8
   add :commit_logs_encoding,
-      value: 'UTF-8'
+      default: 'UTF-8'
 
   add :commit_logtime_activity_id,
       format: :integer,
-      value: nil,
+      default: nil,
       allowed: -> { TimeEntryActivity.pluck(:id) + [nil] }
 
   add :commit_logtime_enabled,
-      value: false
+      default: false
 
   add :commit_ref_keywords,
-      value: 'refs,references,IssueID'
+      default: 'refs,references,IssueID'
 
   add :consent_decline_mail,
       format: :string,
-      value: nil
+      default: nil
 
   # Time after which users have to have consented to what ever they need to consent
   # to (depending on other settings) such as a privacy policy.
   add :consent_time,
-      value: nil,
+      default: nil,
       format: :datetime
 
   # Additional info about what the user is consenting to (optional).
   add :consent_info,
-      value: {
+      default: {
         en: "## Consent\n\nYou need to agree to the [privacy and security policy]" +
             "(https://www.openproject.org/data-privacy-and-security/) of this OpenProject instance."
       }
 
   # Indicates whether or not users need to consent to something such as privacy policy.
   add :consent_required,
-      value: false
+      default: false
 
   add :cross_project_work_package_relations,
-      value: true
+      default: true
 
   # Allow in-context translations to be loaded with CSP
   add :crowdin_in_context_translations,
-      value: true,
+      default: true,
       writable: false
 
   add :database_cipher_key,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :date_format,
       format: :string,
-      value: nil,
+      default: nil,
       allowed: [
         '%Y-%m-%d',
         '%d/%m/%Y',
@@ -274,653 +274,653 @@ Settings::Definition.define do
       ].freeze
 
   add :default_auto_hide_popups,
-      value: true
+      default: true
 
   # user configuration
   add :default_comment_sort_order,
-      value: 'asc',
+      default: 'asc',
       writable: false
 
   add :default_language,
-      value: 'en'
+      default: 'en'
 
   add :default_projects_modules,
-      value: %w[calendar board_view work_package_tracking news costs wiki],
+      default: %w[calendar board_view work_package_tracking news costs wiki],
       allowed: -> { OpenProject::AccessControl.available_project_modules.map(&:to_s) }
 
   add :default_projects_public,
-      value: false
+      default: false
 
   add :demo_projects_available,
-      value: false
+      default: false
 
   add :demo_view_of_type_work_packages_table_seeded,
-      value: false
+      default: false
 
   add :demo_view_of_type_team_planner_seeded,
-      value: false
+      default: false
 
   add :diff_max_lines_displayed,
-      value: 1500
+      default: 1500
 
   # only applicable in conjunction with fog (effectively S3) attachments
   # which will be uploaded directly to the cloud storage rather than via OpenProject's
   # server process.
   add :direct_uploads,
-      value: true,
+      default: true,
       writable: false
 
   add :disable_browser_cache,
-      value: true,
+      default: true,
       writable: false
 
   # allow to disable default modules
   add :disabled_modules,
-      value: [],
+      default: [],
       writable: false
 
   add :disable_password_choice,
-      value: false,
+      default: false,
       writable: false
 
   add :disable_password_login,
-      value: false,
+      default: false,
       writable: false
 
   add :display_subprojects_work_packages,
-      value: true
+      default: true
 
   # Destroy all sessions for current_user on logout
   add :drop_old_sessions_on_logout,
-      value: true,
+      default: true,
       writable: false
 
   # Destroy all sessions for current_user on login
   add :drop_old_sessions_on_login,
-      value: false,
+      default: false,
       writable: false
 
   add :edition,
       format: :string,
-      value: 'standard',
+      default: 'standard',
       writable: false,
       allowed: %w[standard bim]
 
   add :ee_manager_visible,
-      value: true,
+      default: true,
       writable: false
 
   # Enable internal asset server
   add :enable_internal_assets_server,
-      value: false,
+      default: false,
       writable: false
 
   # email configuration
   add :email_delivery_configuration,
-      value: 'inapp',
+      default: 'inapp',
       allowed: %w[inapp legacy],
       writable: false,
       env_alias: 'EMAIL_DELIVERY_CONFIGURATION'
 
   add :email_delivery_method,
       format: :symbol,
-      value: nil,
+      default: nil,
       env_alias: 'EMAIL_DELIVERY_METHOD'
 
   add :emails_footer,
-      value: {
+      default: {
         'en' => ''
       }
 
   add :emails_header,
-      value: {
+      default: {
         'en' => ''
       }
 
   # use email address as login, hide login in registration form
   add :email_login,
-      value: false
+      default: false
 
   add :enabled_projects_columns,
-      value: %w[project_status public created_at latest_activity_at required_disk_space],
+      default: %w[project_status public created_at latest_activity_at required_disk_space],
       allowed: -> { Projects::TableCell.new(nil, current_user: User.admin.first).all_columns.map(&:first).map(&:to_s) }
 
   add :enabled_scm,
-      value: %w[subversion git]
+      default: %w[subversion git]
 
   # Allow connections for trial creation and booking
   add :enterprise_trial_creation_host,
-      value: 'https://augur.openproject.com',
+      default: 'https://augur.openproject.com',
       writable: false
 
   add :enterprise_chargebee_site,
-      value: 'openproject-enterprise',
+      default: 'openproject-enterprise',
       writable: false
 
   add :enterprise_plan,
-      value: 'enterprise-on-premises---euro---1-year',
+      default: 'enterprise-on-premises---euro---1-year',
       writable: false
 
   add :feature_storages_module_active,
-      value: false,
+      default: false,
       format: :boolean
 
   add :feeds_enabled,
-      value: true
+      default: true
 
   add :feeds_limit,
-      value: 15
+      default: 15
 
   # Maximum size of files that can be displayed
   # inline through the file viewer (in KB)
   add :file_max_size_displayed,
-      value: 512
+      default: 512
 
   add :first_week_of_year,
-      value: nil,
+      default: nil,
       format: :integer,
       allowed: [1, 4]
 
   # Configure fog, e.g. when using an S3 uploader
   add :fog,
-      value: {}
+      default: {}
 
   add :fog_download_url_expires_in,
-      value: 21600, # 6h by default as 6 hours is max in S3 when using IAM roles
+      default: 21600, # 6h by default as 6 hours is max in S3 when using IAM roles
       writable: false
 
   # Additional / overridden help links
   add :force_help_link,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :force_formatting_help_link,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :forced_single_page_size,
-      value: 250
+      default: 250
 
   add :host_name,
-      value: "localhost:3000"
+      default: "localhost:3000"
 
   # Health check configuration
   add :health_checks_authentication_password,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   # Maximum number of backed up jobs (that are not yet executed)
   # before health check fails
   add :health_checks_jobs_queue_count_threshold,
       format: :integer,
-      value: 50,
+      default: 50,
       writable: false
 
   ## Maximum number of minutes that jobs have not yet run after their designated 'run_at' time
   add :health_checks_jobs_never_ran_minutes_ago,
       format: :integer,
-      value: 5,
+      default: 5,
       writable: false
 
   ## Maximum number of unprocessed requests in puma's backlog.
   add :health_checks_backlog_threshold,
       format: :integer,
-      value: 20,
+      default: 20,
       writable: false
 
   # Default gravatar image, set to something other than 404
   # to ensure a default is returned
   add :gravatar_fallback_image,
-      value: '404',
+      default: '404',
       writable: false
 
   add :hidden_menu_items,
-      value: {},
+      default: {},
       writable: false
 
   # Impressum link to be set, nil by default (= hidden)
   add :impressum_link,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :installation_type,
-      value: 'manual',
+      default: 'manual',
       writable: false
 
   add :installation_uuid,
       format: :string,
-      value: nil
+      default: nil
 
   add :internal_password_confirmation,
-      value: true,
+      default: true,
       writable: false
 
   add :invitation_expiration_days,
-      value: 7
+      default: 7
 
   add :journal_aggregation_time_minutes,
-      value: 5
+      default: 5
 
   # Allow override of LDAP options
   add :ldap_force_no_page,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :ldap_auth_source_tls_options,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   # Allow users to manually sync groups in a different way
   # than the provided job using their own cron
   add :ldap_groups_disable_sync_job,
-      value: false,
+      default: false,
       writable: false
 
   add :ldap_users_disable_sync_job,
-      value: false,
+      default: false,
       writable: false
 
   add :ldap_tls_options,
-      value: {},
+      default: {},
       writable: false
 
   add :log_level,
-      value: 'info',
+      default: 'info',
       writable: false
 
   add :log_requesting_user,
-      value: false
+      default: false
 
   # Use lograge to format logs, off by default
   add :lograge_formatter,
-      value: nil,
+      default: nil,
       format: :string,
       writable: false
 
   add :login_required,
-      value: false
+      default: false
 
   add :lost_password,
-      value: true
+      default: true
 
   add :mail_from,
-      value: 'openproject@example.net'
+      default: 'openproject@example.net'
 
   add :mail_handler_api_key,
       format: :string,
-      value: nil
+      default: nil
 
   add :mail_handler_body_delimiters,
-      value: ''
+      default: ''
 
   add :mail_handler_body_delimiter_regex,
-      value: ''
+      default: ''
 
   add :mail_handler_ignore_filenames,
-      value: 'signature.asc'
+      default: 'signature.asc'
 
   add :mail_suffix_separators,
-      value: '+'
+      default: '+'
 
   add :main_content_language,
-      value: 'english',
+      default: 'english',
       writable: false
 
   # Check for missing migrations in internal errors
   add :migration_check_on_exceptions,
-      value: true,
+      default: true,
       writable: false
 
   # Role given to a non-admin user who creates a project
   add :new_project_user_role_id,
       format: :integer,
-      value: nil,
+      default: nil,
       allowed: -> { Role.pluck(:id) }
 
   add :oauth_allow_remapping_of_existing_users,
-      value: false
+      default: false
 
   add :omniauth_direct_login_provider,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :override_bcrypt_cost_factor,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :notification_retention_period_days,
-      value: 30
+      default: 30
 
   add :notification_email_delay_minutes,
-      value: 15
+      default: 15
 
   add :notification_email_digest_time,
-      value: '08:00'
+      default: '08:00'
 
   add :onboarding_video_url,
-      value: 'https://player.vimeo.com/video/163426858?autoplay=1',
+      default: 'https://player.vimeo.com/video/163426858?autoplay=1',
       writable: false
 
   add :onboarding_enabled,
-      value: true,
+      default: true,
       writable: false
 
   add :password_active_rules,
-      value: %w[lowercase uppercase numeric special],
+      default: %w[lowercase uppercase numeric special],
       allowed: %w[lowercase uppercase numeric special]
 
   add :password_count_former_banned,
-      value: 0
+      default: 0
 
   add :password_days_valid,
-      value: 0
+      default: 0
 
   add :password_min_length,
-      value: 10
+      default: 10
 
   add :password_min_adhered_rules,
-      value: 0
+      default: 0
 
   # TODO: turn into array of ints
   # Requires a migration to be written
   # replace Setting#per_page_options_array
   add :per_page_options,
-      value: '20, 100'
+      default: '20, 100'
 
   add :plain_text_mail,
-      value: false
+      default: false
 
   add :protocol,
-      value: "http",
+      default: "http",
       allowed: %w[http https]
 
   add :project_gantt_query,
-      value: nil,
+      default: nil,
       format: :string
 
   add :rails_asset_host,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :rails_cache_store,
       format: :symbol,
-      value: :file_store,
+      default: :file_store,
       writable: false,
       allowed: %i[file_store memcache]
 
   # url-path prefix
   add :rails_relative_url_root,
-      value: '',
+      default: '',
       writable: false
 
   add :rails_force_ssl,
-      value: false,
+      default: false,
       writable: false
 
   add :registration_footer,
-      value: {
+      default: {
         'en' => ''
       },
       writable: false
 
   add :repositories_automatic_managed_vendor,
-      value: nil,
+      default: nil,
       format: :string,
       allowed: -> { OpenProject::SCM::Manager.registered.keys.map(&:to_s) }
 
   # encodings used to convert repository files content to UTF-8
   # multiple values accepted, comma separated
   add :repositories_encodings,
-      value: nil,
+      default: nil,
       format: :string
 
   add :repository_authentication_caching_enabled,
-      value: true
+      default: true
 
   add :repository_checkout_data,
-      value: {
+      default: {
         "git" => { "enabled" => 0 },
         "subversion" => { "enabled" => 0 }
       }
 
   add :repository_log_display_limit,
-      value: 100
+      default: 100
 
   add :repository_storage_cache_minutes,
-      value: 720
+      default: 720
 
   add :repository_truncate_at,
-      value: 500
+      default: 500
 
   add :rest_api_enabled,
-      value: true
+      default: true
 
   add :scm,
       format: :hash,
-      value: {},
+      default: {},
       writable: false
 
   add :scm_git_command,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :scm_local_checkout_path,
-      value: 'repositories', # relative to OpenProject directory
+      default: 'repositories', # relative to OpenProject directory
       writable: false
 
   add :scm_subversion_command,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   # Display update / security badge, enabled by default
   add :security_badge_displayed,
-      value: true
+      default: true
 
   add :security_badge_url,
-      value: "https://releases.openproject.com/v1/check.svg",
+      default: "https://releases.openproject.com/v1/check.svg",
       writable: false
 
   add :self_registration,
-      value: 2
+      default: 2
 
   add :sendmail_arguments,
       format: :string,
-      value: "-i",
+      default: "-i",
       writable: false
 
   add :sendmail_location,
       format: :string,
-      value: "/usr/sbin/sendmail"
+      default: "/usr/sbin/sendmail"
 
   # Which breadcrumb loggers to enable
   add :sentry_breadcrumb_loggers,
-      value: ['active_support_logger'],
+      default: ['active_support_logger'],
       writable: false
 
   # Log errors to sentry instance
   add :sentry_dsn,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   # Allow separate error reporting for frontend errors
   add :sentry_frontend_dsn,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   add :sentry_host,
       format: :string,
-      value: nil,
+      default: nil,
       writable: false
 
   # Allow sentry to collect tracing samples
   # set to 1 to enable default tracing samples (see sentry initializer)
   # set to n >= 1 to enable n times the default tracing
   add :sentry_trace_factor,
-      value: 0,
+      default: 0,
       writable: false
 
   # Allow sentry to collect tracing samples on frontend
   # set to n >= 1 to enable n times the default tracing
   add :sentry_frontend_trace_factor,
-      value: 0,
+      default: 0,
       writable: false
 
   add :session_cookie_name,
-      value: '_open_project_session',
+      default: '_open_project_session',
       writable: false
 
   # where to store session data
   add :session_store,
-      value: :active_record_store,
+      default: :active_record_store,
       writable: false
 
   add :session_ttl_enabled,
-      value: false
+      default: false
 
   add :session_ttl,
-      value: 120
+      default: 120
 
   add :show_community_links,
-      value: true,
+      default: true,
       writable: false
 
   # Show pending migrations as warning bar
   add :show_pending_migrations_warning,
-      value: true,
+      default: true,
       writable: false
 
   # Show mismatched protocol/hostname warning
   # in settings where they must differ this can be disabled
   add :show_setting_mismatch_warning,
-      value: true,
+      default: true,
       writable: false
 
   # Render storage information
   add :show_storage_information,
-      value: true,
+      default: true,
       writable: false
 
   # Render warning bars (pending migrations, deprecation, unsupported browsers)
   # Set to false to globally disable this for all users!
   add :show_warning_bars,
-      value: true,
+      default: true,
       writable: false
 
   add :smtp_authentication,
       format: :string,
-      value: 'plain',
+      default: 'plain',
       env_alias: 'SMTP_AUTHENTICATION'
 
   add :smtp_enable_starttls_auto,
       format: :boolean,
-      value: false,
+      default: false,
       env_alias: 'SMTP_ENABLE_STARTTLS_AUTO'
 
   add :smtp_openssl_verify_mode,
       format: :string,
-      value: "peer",
+      default: "peer",
       allowed: %w[none peer client_once fail_if_no_peer_cert],
       writable: false
 
   add :smtp_ssl,
       format: :boolean,
-      value: false,
+      default: false,
       env_alias: 'SMTP_SSL'
 
   add :smtp_address,
       format: :string,
-      value: '',
+      default: '',
       env_alias: 'SMTP_ADDRESS'
 
   add :smtp_domain,
       format: :string,
-      value: 'your.domain.com',
+      default: 'your.domain.com',
       env_alias: 'SMTP_DOMAIN'
 
   add :smtp_user_name,
       format: :string,
-      value: '',
+      default: '',
       env_alias: 'SMTP_USER_NAME'
 
   add :smtp_port,
       format: :integer,
-      value: 587,
+      default: 587,
       env_alias: 'SMTP_PORT'
 
   add :smtp_password,
       format: :string,
-      value: '',
+      default: '',
       env_alias: 'SMTP_PASSWORD'
 
   add :software_name,
-      value: 'OpenProject'
+      default: 'OpenProject'
 
   add :software_url,
-      value: 'https://www.openproject.org/'
+      default: 'https://www.openproject.org/'
 
   # Slow query logging threshold in ms
   add :sql_slow_query_threshold,
-      value: 2000,
+      default: 2000,
       writable: false
 
   add :start_of_week,
-      value: nil,
+      default: nil,
       format: :integer,
       allowed: [1, 6, 7]
 
   # enable statsd metrics (currently puma only) by configuring host
   add :statsd,
-      value: {
+      default: {
         'host' => nil,
         'port' => 8125
       },
       writable: false
 
   add :sys_api_enabled,
-      value: false
+      default: false
 
   add :sys_api_key,
-      value: nil,
+      default: nil,
       format: :string
 
   add :time_format,
       format: :string,
-      value: nil,
+      default: nil,
       allowed: [
         '%H:%M',
         '%I:%M %p'
       ].freeze
 
   add :user_default_timezone,
-      value: nil,
+      default: nil,
       format: :string,
       allowed: ActiveSupport::TimeZone.all + [nil]
 
   add :users_deletable_by_admins,
-      value: false
+      default: false
 
   add :users_deletable_by_self,
-      value: false
+      default: false
 
   add :user_format,
-      value: :firstname_lastname,
+      default: :firstname_lastname,
       allowed: -> { User::USER_FORMATS_STRUCTURE.keys }
 
   add :web,
-      value: {
+      default: {
         'workers' => 2,
         'timeout' => 120,
         'wait_timeout' => 10,
@@ -931,42 +931,42 @@ Settings::Definition.define do
 
   add :welcome_text,
       format: :string,
-      value: nil
+      default: nil
 
   add :welcome_title,
       format: :string,
-      value: nil
+      default: nil
 
   add :welcome_on_homescreen,
-      value: false
+      default: false
 
   add :work_package_done_ratio,
-      value: 'field',
+      default: 'field',
       allowed: %w[field status disabled]
 
   add :work_packages_export_limit,
-      value: 500
+      default: 500
 
   add :work_package_list_default_highlighted_attributes,
-      value: [],
+      default: [],
       allowed: -> {
         Query.available_columns(nil).select(&:highlightable).map(&:name).map(&:to_s)
       }
 
   add :work_package_list_default_highlighting_mode,
       format: :string,
-      value: -> { EnterpriseToken.allows_to?(:conditional_highlighting) ? 'inline' : 'none' },
+      default: -> { EnterpriseToken.allows_to?(:conditional_highlighting) ? 'inline' : 'none' },
       allowed: -> { Query::QUERY_HIGHLIGHTING_MODES },
       writable: -> { EnterpriseToken.allows_to?(:conditional_highlighting) }
 
   add :work_package_list_default_columns,
-      value: %w[id subject type status assigned_to priority],
+      default: %w[id subject type status assigned_to priority],
       allowed: -> { Query.new.available_columns.map(&:name).map(&:to_s) }
 
   add :work_package_startdate_is_adddate,
-      value: false
+      default: false
 
   add :youtube_channel,
-      value: 'https://www.youtube.com/c/OpenProjectCommunity',
+      default: 'https://www.youtube.com/c/OpenProjectCommunity',
       writable: false
 end

--- a/lib/redmine/plugin.rb
+++ b/lib/redmine/plugin.rb
@@ -108,7 +108,7 @@ module Redmine #:nodoc:
 
       if p.settings
         Settings::Definition.add("plugin_#{id}",
-                                 value: p.settings[:default],
+                                 default: p.settings[:default],
                                  format: :hash,
                                  env_alias: p.settings[:env_alias])
       end

--- a/lib/tasks/setting.rake
+++ b/lib/tasks/setting.rake
@@ -58,4 +58,11 @@ namespace :setting do
       setting.save!
     end
   end
+
+  desc 'List the supported environment variables to override settings'
+  task available_envs: :environment do
+    Settings::Definition.all.sort_by(&:name).each do |definition|
+      puts "#{Settings::Definition.possible_env_names(definition).first} (default=#{definition.default.inspect})"
+    end
+  end
 end

--- a/modules/auth_saml/lib/open_project/auth_saml/engine.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/engine.rb
@@ -86,7 +86,7 @@ module OpenProject
 
       initializer 'auth_saml.configuration' do
         ::Settings::Definition.add 'saml',
-                                   value: nil,
+                                   default: nil,
                                    format: :hash,
                                    writable: false
       end

--- a/modules/recaptcha/lib/open_project/recaptcha/engine.rb
+++ b/modules/recaptcha/lib/open_project/recaptcha/engine.rb
@@ -23,7 +23,7 @@ module OpenProject::Recaptcha
     end
 
     initializer "openproject.configuration" do
-      ::Settings::Definition.add OpenProject::Recaptcha::Configuration::CONFIG_KEY, value: false
+      ::Settings::Definition.add OpenProject::Recaptcha::Configuration::CONFIG_KEY, default: false
     end
 
     config.after_initialize do

--- a/modules/reporting/lib/open_project/reporting/engine.rb
+++ b/modules/reporting/lib/open_project/reporting/engine.rb
@@ -97,7 +97,7 @@ module OpenProject::Reporting
 
     initializer 'reporting.configuration' do
       ::Settings::Definition.add 'cost_reporting_cache_filter_classes',
-                                 value: true,
+                                 default: true,
                                  format: :boolean
     end
 

--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -367,7 +367,7 @@ describe Settings::Definition do
         all
 
         described_class.add 'bogus',
-                            value: 0
+                            default: 0
 
         expect(all.detect { |d| d.name == 'bogus' }.value)
           .to eq 1
@@ -487,7 +487,7 @@ describe Settings::Definition do
         all
 
         described_class.add 'bogus',
-                            value: 1,
+                            default: 1,
                             format: :integer
 
         expect(all.detect { |d| d.name == 'bogus' }.value)
@@ -502,7 +502,7 @@ describe Settings::Definition do
     context 'with a string' do
       let(:key) { 'smtp_address' }
 
-      it 'returns the value' do
+      it 'returns the definition matching the name' do
         expect(definition.name)
           .to eql key
       end
@@ -511,7 +511,7 @@ describe Settings::Definition do
     context 'with a symbol' do
       let(:key) { :smtp_address }
 
-      it 'returns the value' do
+      it 'returns the definition matching the name' do
         expect(definition.name)
           .to eql key.to_s
       end
@@ -520,7 +520,7 @@ describe Settings::Definition do
     context 'with a non existing key' do
       let(:key) { 'bogus' }
 
-      it 'returns the value' do
+      it 'returns nil' do
         expect(definition)
           .to be_nil
       end
@@ -534,7 +534,7 @@ describe Settings::Definition do
         described_class[key]
 
         described_class.add 'bogus',
-                            value: 1,
+                            default: 1,
                             format: :integer
       end
 
@@ -547,13 +547,13 @@ describe Settings::Definition do
 
   describe '#override_value' do
     let(:format) { :string }
-    let(:value) { 'abc' }
+    let(:default) { 'abc' }
 
     let(:instance) do
       described_class
         .new 'bogus',
              format: format,
-             value: value
+             default: default
     end
 
     context 'with string format' do
@@ -561,9 +561,14 @@ describe Settings::Definition do
         instance.override_value('xyz')
       end
 
-      it 'overwrites' do
+      it 'overwrites the value' do
         expect(instance.value)
           .to eql 'xyz'
+      end
+
+      it 'does not overwrite the default' do
+        expect(instance.default)
+          .to eql 'abc'
       end
 
       it 'turns the definition unwritable' do
@@ -574,7 +579,7 @@ describe Settings::Definition do
 
     context 'with hash format' do
       let(:format) { :hash }
-      let(:value) do
+      let(:default) do
         {
           abc: {
             a: 1,
@@ -600,6 +605,17 @@ describe Settings::Definition do
                   })
       end
 
+      it 'does not overwrite the default' do
+        expect(instance.default)
+          .to eql({
+                    'abc' => {
+                      'a' => 1,
+                      'b' => 2
+                    },
+                    'cde' => 1
+                  })
+      end
+
       it 'turns the definition unwritable' do
         expect(instance)
           .not_to be_writable
@@ -608,15 +624,20 @@ describe Settings::Definition do
 
     context 'with array format' do
       let(:format) { :array }
-      let(:value) { [1, 2, 3] }
+      let(:default) { [1, 2, 3] }
 
       before do
         instance.override_value([4, 5, 6])
       end
 
-      it 'overwrites' do
+      it 'overwrites the value' do
         expect(instance.value)
           .to eql [4, 5, 6]
+      end
+
+      it 'does not overwrite the default' do
+        expect(instance.default)
+          .to eql [1, 2, 3]
       end
 
       it 'turns the definition unwritable' do
@@ -630,7 +651,7 @@ describe Settings::Definition do
         described_class
           .new 'bogus',
                format: format,
-               value: 'foo',
+               default: 'foo',
                allowed: %w[foo bar]
       end
 
@@ -662,7 +683,7 @@ describe Settings::Definition do
       let(:instance) do
         described_class.new 'bogus',
                             format: :integer,
-                            value: 1,
+                            default: 1,
                             writable: false,
                             allowed: [1, 2, 3]
       end
@@ -675,6 +696,11 @@ describe Settings::Definition do
       it 'has the format (in symbol)' do
         expect(instance.format)
           .to eq :integer
+      end
+
+      it 'has the default' do
+        expect(instance.default)
+          .to eq 1
       end
 
       it 'has the value' do
@@ -701,7 +727,7 @@ describe Settings::Definition do
     context 'with the minimal attributes (integer value)' do
       let(:instance) do
         described_class.new 'bogus',
-                            value: 1
+                            default: 1
       end
 
       it 'has the name' do
@@ -712,6 +738,16 @@ describe Settings::Definition do
       it 'has the format (in symbol) deduced' do
         expect(instance.format)
           .to eq :integer
+      end
+
+      it 'has the default' do
+        expect(instance.default)
+          .to eq 1
+      end
+
+      it 'has the default frozen' do
+        expect(instance.default)
+          .to be_frozen
       end
 
       it 'has the value' do
@@ -733,7 +769,7 @@ describe Settings::Definition do
     context 'with the minimal attributes (hash value)' do
       let(:instance) do
         described_class.new 'bogus',
-                            value: { a: 'b', c: { d: 'e' } }
+                            default: { a: 'b', c: { d: 'e' } }
       end
 
       it 'has the format (in symbol) deduced' do
@@ -744,6 +780,11 @@ describe Settings::Definition do
       it 'is serialized' do
         expect(instance)
           .to be_serialized
+      end
+
+      it 'has the default frozen' do
+        expect(instance.default)
+          .to be_frozen
       end
 
       it 'transforms keys to string' do
@@ -758,7 +799,7 @@ describe Settings::Definition do
     context 'with the minimal attributes (array value)' do
       let(:instance) do
         described_class.new 'bogus',
-                            value: %i[a b]
+                            default: %i[a b]
       end
 
       it 'has the format (in symbol) deduced' do
@@ -775,7 +816,7 @@ describe Settings::Definition do
     context 'with the minimal attributes (true value)' do
       let(:instance) do
         described_class.new 'bogus',
-                            value: true
+                            default: true
       end
 
       it 'has the format (in symbol) deduced' do
@@ -787,7 +828,7 @@ describe Settings::Definition do
     context 'with the minimal attributes (false value)' do
       let(:instance) do
         described_class.new 'bogus',
-                            value: false
+                            default: false
       end
 
       it 'has the format (in symbol) deduced' do
@@ -799,7 +840,7 @@ describe Settings::Definition do
     context 'with the minimal attributes (date value)' do
       let(:instance) do
         described_class.new 'bogus',
-                            value: Time.zone.today
+                            default: Time.zone.today
       end
 
       it 'has the format (in symbol) deduced' do
@@ -811,7 +852,7 @@ describe Settings::Definition do
     context 'with the minimal attributes (datetime value)' do
       let(:instance) do
         described_class.new 'bogus',
-                            value: DateTime.now
+                            default: DateTime.now
       end
 
       it 'has the format (in symbol) deduced' do
@@ -823,7 +864,7 @@ describe Settings::Definition do
     context 'with the minimal attributes (string value)' do
       let(:instance) do
         described_class.new 'bogus',
-                            value: 'abc'
+                            default: 'abc'
       end
 
       it 'has the format (in symbol) deduced' do
@@ -836,9 +877,14 @@ describe Settings::Definition do
       let(:instance) do
         described_class.new 'bogus',
                             format: 'string',
-                            value: -> { 'some value' },
+                            default: -> { 'some value' },
                             writable: -> { false },
                             allowed: -> { %w[a b c] }
+      end
+
+      it 'returns the procs return value for default' do
+        expect(instance.default)
+          .to eql 'some value'
       end
 
       it 'returns the procs return value for value' do
@@ -861,7 +907,12 @@ describe Settings::Definition do
       let(:instance) do
         described_class.new 'bogus',
                             format: :integer,
-                            value: '5'
+                            default: '5'
+      end
+
+      it 'returns default as an int' do
+        expect(instance.default)
+          .to eq 5
       end
 
       it 'returns value as an int' do
@@ -874,7 +925,12 @@ describe Settings::Definition do
       let(:instance) do
         described_class.new 'bogus',
                             format: :float,
-                            value: '0.5'
+                            default: '0.5'
+      end
+
+      it 'returns default as a float' do
+        expect(instance.default)
+          .to eq 0.5
       end
 
       it 'returns value as a float' do

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -132,7 +132,7 @@ describe Setting, type: :model do
       before do
         Settings::Definition.add(
           setting_name,
-          value: nil,
+          default: nil,
           format: setting_format
         )
         described_class.create!(name: setting_name, value: '')

--- a/spec/tasks/setting_spec.rb
+++ b/spec/tasks/setting_spec.rb
@@ -98,4 +98,14 @@ RSpec.describe Rake::Task, 'setting', :settings_reset do
       end
     end
   end
+
+  describe 'setting:available_envs' do
+    include_context 'rake'
+
+    it 'displays all environment variables which can override settings values' do
+      # just want to ensure the code does not raise any errors
+      expect { subject.invoke }
+        .to output(/OPENPROJECT_SMTP__ENABLE__STARTTLS__AUTO/).to_stdout
+    end
+  end
 end


### PR DESCRIPTION
Each environment variable name is listed with its default value. 

For instance:
```
OPENPROJECT_ACTIVITY__DAYS__DEFAULT (default=30)
OPENPROJECT_ADDITIONAL__FOOTER__CONTENT (default=nil)
OPENPROJECT_AFTER__FIRST__LOGIN__REDIRECT__URL (default=nil)
OPENPROJECT_AFTER__LOGIN__DEFAULT__REDIRECT__URL (default=nil)
...
```