### PR TITLE
Fix event propagation for context menus

### DIFF
--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive.ts
@@ -11,8 +11,10 @@ export class OpContextMenuTrigger extends OpContextMenuHandler implements AfterV
 
   protected items:OpContextMenuItem[] = [];
 
-  constructor(readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService) {
+  constructor(
+    readonly elementRef:ElementRef,
+    readonly opContextMenu:OPContextMenuService,
+  ) {
     super(opContextMenu);
   }
 
@@ -22,16 +24,13 @@ export class OpContextMenuTrigger extends OpContextMenuHandler implements AfterV
     // Open by clicking the element
     this.$element.on('click', (evt:JQuery.TriggeredEvent) => {
       evt.preventDefault();
-      evt.stopPropagation();
 
       // When clicking the same trigger twice, close the element instead.
       if (this.opContextMenu.isActive(this)) {
         this.opContextMenu.close();
-        return false;
+      } else {
+        this.open(evt);
       }
-
-      this.open(evt);
-      return false;
     });
 
     // Open with keyboard combination as well


### PR DESCRIPTION
Currently all click events on context menu triggers are stopped from
propagating. This breaks functionality like `spot-drop-modal`, since
that expects events to bubble up the DOM. This commit changes that
behavior, allowing all events to bubble up the DOM as usual.

Closes https://community.openproject.org/work_packages/42380/activity