### PR TITLE
Fix mailer interceptors rejecting empty to addresses

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -173,36 +173,3 @@ class ApplicationMailer < ActionMailer::Base
     host
   end
 end
-
-##
-# Interceptors
-#
-# These are registered in config/initializers/register_mail_interceptors.rb
-#
-# Unfortunately, this results in changes on the interceptor classes during development mode
-# not being reflected until a server restart.
-
-class DefaultHeadersInterceptor
-  def self.delivering_email(mail)
-    mail.headers(default_headers)
-  end
-
-  def self.default_headers
-    {
-      'X-Mailer' => 'OpenProject',
-      'X-OpenProject-Host' => Setting.host_name,
-      'X-OpenProject-Site' => Setting.app_title,
-      'Precedence' => 'bulk',
-      'Auto-Submitted' => 'auto-generated'
-    }
-  end
-end
-
-class DoNotSendMailsWithoutReceiverInterceptor
-  def self.delivering_email(mail)
-    receivers = [mail.to, mail.cc, mail.bcc]
-    # the above fields might be empty arrays (if entries have been removed
-    # by another interceptor) or nil, therefore checking for blank?
-    mail.perform_deliveries = false if receivers.all?(&:blank?)
-  end
-end

--- a/app/mailers/interceptors/default_headers.rb
+++ b/app/mailers/interceptors/default_headers.rb
@@ -1,0 +1,17 @@
+module Interceptors
+  class DefaultHeaders
+    def self.delivering_email(mail)
+      mail.headers(default_headers)
+    end
+
+    def self.default_headers
+      {
+        'X-Mailer' => 'OpenProject',
+        'X-OpenProject-Host' => Setting.host_name,
+        'X-OpenProject-Site' => Setting.app_title,
+        'Precedence' => 'bulk',
+        'Auto-Submitted' => 'auto-generated'
+      }
+    end
+  end
+end

--- a/app/mailers/interceptors/do_not_send_mails_without_recipient.rb
+++ b/app/mailers/interceptors/do_not_send_mails_without_recipient.rb
@@ -1,0 +1,10 @@
+module Interceptors
+  class DoNotSendMailsWithoutRecipient
+    def self.delivering_email(mail)
+      receivers = [mail.to, mail.cc, mail.bcc]
+      # the above fields might be empty arrays (if entries have been removed
+      # by another interceptor) or nil, therefore checking for blank?
+      mail.perform_deliveries = false if receivers.all?(&:blank?)
+    end
+  end
+end

--- a/config/initializers/register_mail_interceptors.rb
+++ b/config/initializers/register_mail_interceptors.rb
@@ -29,8 +29,6 @@
 # Register interceptors defined in app/mailers/user_mailer.rb
 # Do this here, so they aren't registered multiple times due to reloading in development mode.
 
-Rails.application.config.action_mailer.interceptors = [
-  "DefaultHeadersInterceptor",
-  # following needs to be the last interceptor
-  "DoNotSendMailsWithoutReceiverInterceptor"
-]
+ApplicationMailer.register_interceptor Interceptors::DefaultHeaders
+# following needs to be the last interceptor
+ApplicationMailer.register_interceptor Interceptors::DoNotSendMailsWithoutRecipient

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -116,6 +116,12 @@ describe UserMailer, type: :mailer do
             with_settings: { user_format: :lastname_coma_firstname } do
       it_behaves_like 'mail is sent'
     end
+
+    context 'with the recipient being the system user' do
+      let(:recipient) { User.system }
+
+      it_behaves_like 'mail is not sent'
+    end
   end
 
   describe '#wiki_content_added' do


### PR DESCRIPTION
In case of invalid mails or trying to send mails to builtin users like the system user, there is an interceptor in place trying to reject sending the mail as the to address is empty.

This interceptor however was no longer loaded, as the ActionMailer configuration is loaded before it gets added.

Instead, explictly add the interceptors and add a spec that causes the error reported in

https://community.openproject.org/work_packages/42377