### PR TITLE
Fix adding principal in work package create

### DIFF
--- a/frontend/src/app/features/boards/add-list-modal/add-list-modal.component.ts
+++ b/frontend/src/app/features/boards/add-list-modal/add-list-modal.component.ts
@@ -101,7 +101,7 @@ export class AddListModalComponent extends OpModalComponent implements OnInit {
   };
 
   public referenceOutputs = {
-    onCreate: (value:HalResource) => this.onNewActionCreated(value),
+    onAddNew: (value:HalResource) => this.onNewActionCreated(value),
     onOpen: () => this.requests.input$.next(''),
     onChange: (value:HalResource) => this.onModelChange(value),
     onAfterViewInit: (component:CreateAutocompleterComponent) => component.focusInputField(),

--- a/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.ts
@@ -59,6 +59,11 @@ export interface CreateAutocompleterValueOption {
   templateUrl: './create-autocompleter.component.html',
   selector: 'create-autocompleter',
   styleUrls: ['./create-autocompleter.component.sass'],
+  providers: [
+    // Provide a new version of the modal invite service,
+    // as otherwise the close event will be shared across all instances
+    OpInviteUserModalService,
+  ]
 })
 export class CreateAutocompleterComponent extends UntilDestroyedMixin implements AfterViewInit {
   @Input() public availableValues:CreateAutocompleterValueOption[];
@@ -95,7 +100,7 @@ export class CreateAutocompleterComponent extends UntilDestroyedMixin implements
 
   @Output() public onAfterViewInit = new EventEmitter<this>();
 
-  @Output() public onAddNew = new EventEmitter<this>();
+  @Output() public onAddNew = new EventEmitter<HalResource>();
 
   @ViewChild(NgSelectComponent) public ngSelectComponent:NgSelectComponent;
 
@@ -132,7 +137,7 @@ export class CreateAutocompleterComponent extends UntilDestroyedMixin implements
           filter((user) => !!user),
         )
         .subscribe((user:HalResource) => {
-          this.onChange.emit(user);
+          this.onAddNew.emit(user);
         });
     }
   }

--- a/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
+++ b/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
@@ -327,6 +327,13 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
     return this.cache[key] = request();
   }
 
+  /**
+   * Invalidate a cache value
+   */
+  public invalidateCache(key:string) {
+    delete this.cache[key];
+  }
+
   protected get minimalPayload() {
     return { lockVersion: this.pristineResource.lockVersion, _links: {} };
   }

--- a/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
+++ b/frontend/src/app/shared/components/fields/changeset/resource-changeset.ts
@@ -108,8 +108,8 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
   /**
    * Returns the cached form or loads it if necessary.
    */
-  public getForm():Promise<FormResource> {
-    if (this.form$.isPristine() && !this.form$.hasActivePromiseRequest()) {
+  public getForm(reload = false):Promise<FormResource> {
+    if ((this.form$.isPristine() || reload) && !this.form$.hasActivePromiseRequest()) {
       return this.updateForm();
     }
 
@@ -325,13 +325,6 @@ export class ResourceChangeset<T extends HalResource = HalResource> {
     }
 
     return this.cache[key] = request();
-  }
-
-  /**
-   * Invalidate a cache value
-   */
-  public invalidateCache(key:string) {
-    delete this.cache[key];
   }
 
   protected get minimalPayload() {

--- a/frontend/src/app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.component.ts
@@ -33,7 +33,7 @@ import {
 } from '@angular/core';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { SelectAutocompleterRegisterService } from 'core-app/shared/components/fields/edit/field-types/select-edit-field/select-autocompleter-register.service';
-import { from } from 'rxjs';
+import { from, Observable } from 'rxjs';
 import {
   map,
   tap,
@@ -75,6 +75,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   public referenceOutputs:{ [key:string]:Function } = {
     onCreate: (newElement:HalResource) => this.onCreate(newElement),
     onChange: (value:HalResource) => this.onChange(value),
+    onAddNew: (value:HalResource) => this.onNewValueAdded(value),
     onKeydown: (event:JQuery.TriggeredEvent) => this.handler.handleUserKeydown(event, true),
     onOpen: () => this.onOpen(),
     onClose: () => this.onClose(),
@@ -87,14 +88,6 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
   }
 
   public set selectedOption(val:ValueOption|HalResource) {
-    // The InviteUserModal gives us a resource that is not in availableOptions yet,
-    // but we also don't want to wait for a refresh of the options every time we want to
-    // select an option, so if we get a HalResource we trust it exists
-    if (val instanceof HalResource) {
-      this.value = val;
-      return;
-    }
-
     const option = _.find(this.availableOptions, (o) => o.href === val.href);
 
     // Special case 'null' value, which angular
@@ -103,7 +96,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
       option.href = null;
     }
 
-    this.value = option;
+    this.value = option || val;
   }
 
   public showAddNewButton:boolean;
@@ -167,7 +160,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
     this.addEmptyOption();
   }
 
-  protected loadValues(query?:string) {
+  protected loadValues(query?:string):Observable<HalResource[]> {
     const { allowedValues } = this.schema;
 
     if (Array.isArray(allowedValues)) {
@@ -251,6 +244,18 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
       this.selectedOption = emptyOption;
       this.handler.handleUserSubmit();
     }
+  }
+
+  private async onNewValueAdded(value:HalResource|undefined|null) {
+    if (!value) {
+      return;
+    }
+
+    const cacheKey = this.schema.allowedValues.$link.href;
+    this.change.invalidateCache(cacheKey);
+    await this.loadValues().toPromise();
+
+    this.onChange(value);
   }
 
   private addEmptyOption() {

--- a/frontend/src/app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.component.ts
@@ -251,9 +251,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
       return;
     }
 
-    const cacheKey = this.schema.allowedValues.$link.href;
-    this.change.invalidateCache(cacheKey);
-    await this.loadValues().toPromise();
+    await this.change.getForm(true);
 
     this.onChange(value);
   }


### PR DESCRIPTION
The close callback was called for all open select edit fields, as the service is bound globally. Reproviding it locally fixes that.

Additionally, this commit also fixes the principal not being available in the list by reloading values from the edit field.

https://community.openproject.org/work_packages/42348