### PR TITLE
Correctly skip user admin mapping when syncing users

### DIFF
--- a/app/models/ldap_auth_source.rb
+++ b/app/models/ldap_auth_source.rb
@@ -88,15 +88,23 @@ class LdapAuthSource < AuthSource
   end
 
   def get_user_attributes_from_ldap_entry(entry)
-    {
+    base_attributes = {
       dn: entry.dn,
-      login: LdapAuthSource.get_attr(entry, attr_login),
-      firstname: LdapAuthSource.get_attr(entry, attr_firstname),
-      lastname: LdapAuthSource.get_attr(entry, attr_lastname),
-      mail: LdapAuthSource.get_attr(entry, attr_mail),
-      admin: !!LdapAuthSource.get_attr(entry, attr_admin),
       auth_source_id: id
     }
+
+    base_attributes.merge mapped_attributes(entry)
+  end
+
+  def mapped_attributes(entry)
+    %i[login firstname lastname mail admin].each_with_object({}) do |key, hash|
+      ldap_attribute = send(:"attr_#{key}")
+      next if ldap_attribute.blank?
+
+      val = LdapAuthSource.get_attr(entry, ldap_attribute)
+      val = !!ActiveRecord::Type::Boolean.new.cast(val) if key == :admin
+      hash[key] = val
+    end
   end
 
   # Return the attributes needed for the LDAP search.

--- a/spec/services/ldap/synchronize_users_service_integration_spec.rb
+++ b/spec/services/ldap/synchronize_users_service_integration_spec.rb
@@ -7,6 +7,18 @@ describe Ldap::SynchronizeUsersService do
     described_class.new(auth_source).call
   end
 
+  context 'when updating an admin' do
+    let!(:user_aa729) { create :user, login: 'aa729', firstname: 'Foobar', auth_source: auth_source, admin: true }
+
+    it 'does not update the admin attribute if not defined (Regression #42396)' do
+      expect(user_aa729).to be_admin
+
+      subject
+
+      expect(user_aa729.reload).to be_admin
+    end
+  end
+
   context 'when updating users' do
     let!(:user_aa729) { create :user, login: 'aa729', firstname: 'Foobar', auth_source: auth_source }
     let!(:user_bb459) { create :user, login: 'bb459', firstname: 'Bla', auth_source: auth_source }


### PR DESCRIPTION
The admin flag was returned as false even if the admin attribute was not set.

https://community.openproject.org/wp/42396