### PR TITLE
[42397] Project filter is not applied in embedded table

### DIFF
--- a/frontend/src/app/core/apiv3/api-v3.service.ts
+++ b/frontend/src/app/core/apiv3/api-v3.service.ts
@@ -61,6 +61,7 @@ import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { ApiV3NotificationsPaths } from 'core-app/core/apiv3/endpoints/notifications/apiv3-notifications-paths';
 import { ApiV3ViewsPaths } from 'core-app/core/apiv3/endpoints/views/apiv3-views-paths';
 import { Apiv3BackupsPath } from 'core-app/core/apiv3/endpoints/backups/apiv3-backups-path';
+import { ID } from '@datorama/akita';
 
 @Injectable({ providedIn: 'root' })
 export class ApiV3Service {
@@ -162,13 +163,13 @@ export class ApiV3Service {
    *
    *  The available API endpoints are being restricted automatically by typescript.
    *
-   * @param projectIdentifier
+   * @param projectID
    */
-  public withOptionalProject(projectIdentifier:string|number|null|undefined):ApiV3ProjectPaths|this {
-    if (_.isNil(projectIdentifier)) {
+  public withOptionalProject(projectID?:ID|null):ApiV3ProjectPaths|this {
+    if (_.isNil(projectID)) {
       return this;
     }
-    return this.projects.id(projectIdentifier);
+    return this.projects.id(projectID);
   }
 
   public collectionFromString(fullPath:string) {

--- a/frontend/src/app/features/bim/ifc_models/bcf/list/bcf-list.component.html
+++ b/frontend/src/app/features/bim/ifc_models/bcf/list/bcf-list.component.html
@@ -10,7 +10,7 @@
               localStorageKey="openProject-splitViewFlexBasis">
   </wp-resizer>
 
-  <wp-table [projectIdentifier]="CurrentProject.identifier"
+  <wp-table [projectID]="CurrentProject.id"
             [configuration]="wpTableConfiguration"
             (itemClicked)="handleWorkPackageClicked($event)"
             (stateLinkClicked)="openStateLink($event)"

--- a/frontend/src/app/features/work-packages/components/wp-card-view/services/wp-card-drag-and-drop.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/services/wp-card-drag-and-drop.service.ts
@@ -159,7 +159,7 @@ export class WorkPackageCardDragAndDropService {
    */
   public addNewCard() {
     this.wpCreate
-      .createOrContinueWorkPackage(this.currentProject.identifier)
+      .createOrContinueWorkPackage()
       .then((changeset:WorkPackageChangeset) => {
         this.activeInlineCreateWp = changeset.projectedResource;
         this.workPackages = this.workPackages;

--- a/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.component.ts
@@ -59,6 +59,7 @@ import {
 import { WorkPackageCreateService } from '../wp-new/wp-create.service';
 import { WorkPackageTable } from '../wp-fast-table/wp-fast-table';
 import { onClickOrEnter } from '../wp-fast-table/handlers/click-or-enter-handler';
+import { ID } from '@datorama/akita';
 
 @Component({
   selector: '[wpInlineCreate]',
@@ -67,7 +68,7 @@ import { onClickOrEnter } from '../wp-fast-table/handlers/click-or-enter-handler
 export class WorkPackageInlineCreateComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit {
   @Input('wp-inline-create--table') table:WorkPackageTable;
 
-  @Input('wp-inline-create--project-identifier') projectIdentifier:string;
+  @Input('wp-inline-create--project-id') projectID:ID;
 
   @Output('wp-inline-create--showing') showing = new EventEmitter<boolean>();
 
@@ -216,7 +217,7 @@ export class WorkPackageInlineCreateComponent extends UntilDestroyedMixin implem
 
   public addWorkPackageRow() {
     this.wpCreate
-      .createOrContinueWorkPackage(this.projectIdentifier)
+      .createOrContinueWorkPackage(this.projectID)
       .then((change:WorkPackageChangeset) => {
         const wp = this.currentWorkPackage = change.projectedResource;
 

--- a/frontend/src/app/features/work-packages/components/wp-new/wp-create.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-create.component.ts
@@ -190,7 +190,6 @@ export class WorkPackageCreateComponent extends UntilDestroyedMixin implements O
 
     const type = this.stateParams.type ? parseInt(this.stateParams.type) : undefined;
     const parent = this.stateParams.parent_id ? parseInt(this.stateParams.parent_id) : undefined;
-    const project = this.stateParams.projectPath;
 
     if (type) {
       defaults._links.type = { href: this.apiV3Service.types.id(type).path };
@@ -199,7 +198,7 @@ export class WorkPackageCreateComponent extends UntilDestroyedMixin implements O
       defaults._links.parent = { href: this.apiV3Service.work_packages.id(parent).path };
     }
 
-    return this.wpCreate.createOrContinueWorkPackage(project, type, defaults);
+    return this.wpCreate.createOrContinueWorkPackage(undefined, type, defaults);
   }
 
   private closeEditFormWhenNewWorkPackageSaved() {

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/wp-relation-query.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/wp-relation-query.html
@@ -17,7 +17,7 @@
                                         compactTableStyle: true,
                                         columnMenuEnabled: false,
                                         contextMenuEnabled: false,
-                                        projectIdentifier: idFromLink(workPackage.project.href),
+                                        projectID: idFromLink(workPackage.project.href),
                                         projectContext: false }" >
   </wp-embedded-table>
 </ng-container>

--- a/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-base.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-base.component.ts
@@ -70,11 +70,11 @@ export abstract class WorkPackageEmbeddedBaseComponent extends WorkPackagesViewB
     }
   }
 
-  public get projectIdentifier() {
+  public get projectID() {
     if (this.configuration.projectContext) {
-      return this.currentProject.identifier || undefined;
+      return this.currentProject.id || undefined;
     }
-    return this.configuration.projectIdentifier || undefined;
+    return this.configuration.projectID || undefined;
   }
 
   public buildQueryProps() {
@@ -135,7 +135,7 @@ export abstract class WorkPackageEmbeddedBaseComponent extends WorkPackagesViewB
     if (!this.configuration.projectContext) {
       return undefined;
     }
-    return this.projectIdentifier;
+    return this.projectID;
   }
 
   protected initializeStates(query:QueryResource) {

--- a/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table.html
@@ -15,7 +15,7 @@
 
     <!-- TABLE + TIMELINE horizontal split -->
     <wp-table *ngIf="!configuration.isCardView"
-              [projectIdentifier]="projectIdentifier"
+              [projectID]="projectID"
               [configuration]="configuration"
               (itemClicked)="handleWorkPackageClicked($event)"
               (stateLinkClicked)="openStateLink($event)"

--- a/frontend/src/app/features/work-packages/components/wp-table/wp-table-configuration.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/wp-table-configuration.ts
@@ -48,7 +48,7 @@ export class WorkPackageTableConfiguration {
   public projectContext = true;
 
   /** Whether the embedded table should live within a specific project context (e.g., given by its parent) */
-  public projectIdentifier:string|null = null;
+  public projectID:string|null = null;
 
   /** Whether inline create is enabled */
   public inlineCreateEnabled = true;

--- a/frontend/src/app/features/work-packages/components/wp-table/wp-table.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/wp-table.component.ts
@@ -61,6 +61,7 @@ import {
 } from 'core-app/features/work-packages/components/wp-table/wp-table-configuration';
 import { States } from 'core-app/core/states/states.service';
 import { QueryGroupByResource } from 'core-app/features/hal/resources/query-group-by-resource';
+import { ID } from '@datorama/akita';
 
 export interface WorkPackageFocusContext {
   /** Work package that was focused */
@@ -77,7 +78,7 @@ export interface WorkPackageFocusContext {
   selector: 'wp-table',
 })
 export class WorkPackagesTableComponent extends UntilDestroyedMixin implements OnInit, TableEventComponent {
-  @Input() projectIdentifier:string;
+  @Input() projectID:ID;
 
   @Input('configuration') configurationObject:WorkPackageTableConfigurationObject;
 

--- a/frontend/src/app/features/work-packages/components/wp-table/wp-table.directive.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/wp-table.directive.html
@@ -68,7 +68,7 @@
       <tbody *ngIf="tableElement && configuration.inlineCreateEnabled"
              wpInlineCreate
              [wp-inline-create--table]="workPackageTable"
-             [wp-inline-create--project-identifier]="projectIdentifier"
+             [wp-inline-create--project-id]="projectID"
              (wp-inline-create--showing)="inlineCreateVisible = $event"
       >
       </tbody>

--- a/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.html
+++ b/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.html
@@ -3,7 +3,7 @@
 
 <!-- TABLE + TIMELINE horizontal split -->
 <wp-table *ngIf="tableInformationLoaded && showTableView"
-          [projectIdentifier]="CurrentProject.identifier"
+          [projectID]="CurrentProject.id"
           [configuration]="wpTableConfiguration"
           (itemClicked)="handleWorkPackageClicked($event)"
           (stateLinkClicked)="openStateLink($event)"


### PR DESCRIPTION
Use projectID instead of identifier to pass through to the wp-create service. This ID is needed to pass projects as default filters. 

### TODO

- [ ] Revert https://github.com/opf/openproject/pull/10648/commits/d323a4e20737ab53ce78cab70dc4b1456e26aca7 once it is merged to dev

https://community.openproject.org/projects/openproject/work_packages/42397/activity