### PR TITLE
Use existing button styles in include projects modal and sidebar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,6 +149,9 @@ gem 'airbrake', '~> 13.0.0', require: false
 gem 'prawn', '~> 2.2'
 gem 'prawn-markup', '~> 0.3.0'
 
+# prawn implictly depends on matrix gem no longer in ruby core with 3.1
+gem 'matrix', '~> 0.4.2'
+
 gem 'cells-erb', '~> 0.1.0'
 gem 'cells-rails', '~> 0.1.4'
 

--- a/Gemfile
+++ b/Gemfile
@@ -149,9 +149,6 @@ gem 'airbrake', '~> 13.0.0', require: false
 gem 'prawn', '~> 2.2'
 gem 'prawn-markup', '~> 0.3.0'
 
-# prawn implictly depends on matrix gem no longer in ruby core with 3.1
-gem 'matrix', '~> 0.4.2'
-
 gem 'cells-erb', '~> 0.1.0'
 gem 'cells-rails', '~> 0.1.4'
 

--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
@@ -11,7 +11,7 @@
 <div class="op-sidebar--footer">
   <button
     *ngIf="canCreateBoards$ | async"
-    class="spot-button spot-button_outlined"
+    class="button -alt-highlight"
     (click)="showNewBoardModal()"
     [title]="text.create_new_board"
   >

--- a/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.html
+++ b/frontend/src/app/features/calendar/sidemenu/calendar-sidemenu.component.html
@@ -11,7 +11,7 @@
 <div class="op-sidebar--footer">
   <button
     *ngIf="(canCreateCalendar$ | async)"
-    class="spot-button spot-button_outlined"
+    class="button -alt-highlight"
     [uiSref]="createButton.uiSref"
     [uiParams]="createButton.uiParams"
     [title]="text.create_new_calendar"

--- a/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/sidemenu/team-planner-sidemenu.component.html
@@ -10,7 +10,7 @@
 <div class="op-sidebar--footer">
   <button
     *ngIf="(canAddTeamPlanner$ | async)"
-    class="spot-button spot-button_outlined"
+    class="button -alt-highlight"
     [uiSref]="createButton.uiSref"
     [uiParams]="createButton.uiParams"
     data-qa-selector="team-planner--create-button"

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -73,7 +73,7 @@
         <div class="spot-action-bar--right">
           <button
             [disabled]="(loading$ | async)"
-            class="spot-button spot-button_outlined spot-button_main"
+            class="button"
             type="button"
             (click)="clearSelection()"
           >
@@ -81,7 +81,7 @@
           </button>
           <button 
             [disabled]="(loading$ | async)"
-            class="spot-button spot-button_main"
+            class="button -highlight"
           >
             {{ text.apply }}
           </button>

--- a/frontend/src/app/spot/components/toggle/toggle.component.html
+++ b/frontend/src/app/spot/components/toggle/toggle.component.html
@@ -1,6 +1,7 @@
 <label
   *ngFor="let option of options"
   [ngClass]="{ 'button': true, 'form--field-inline-button': true, '-active': value === option.value }"
+  data-qa-selector="spot-toggle--option"
 >
   <input
     class="spot-toggle--option-input"

--- a/frontend/src/app/spot/components/toggle/toggle.component.html
+++ b/frontend/src/app/spot/components/toggle/toggle.component.html
@@ -1,6 +1,6 @@
 <label
   *ngFor="let option of options"
-  [ngClass]="{ 'spot-toggle--option': true, 'spot-toggle--option_selected': value === option.value }"
+  [ngClass]="{ 'button': true, 'form--field-inline-button': true, '-active': value === option.value }"
 >
   <input
     class="spot-toggle--option-input"

--- a/frontend/src/app/spot/components/toggle/toggle.component.ts
+++ b/frontend/src/app/spot/components/toggle/toggle.component.ts
@@ -23,6 +23,9 @@ export interface SpotToggleOption<T> {
   }],
 })
 export class SpotToggleComponent<T> implements ControlValueAccessor {
+  // TODO: These old styles will need to be replaced
+  @HostBinding('class.form--field-inline-buttons-container') public classNameOld = true;
+
   @HostBinding('class.spot-toggle') public className = true;
 
   @Output() checkedChange = new EventEmitter<boolean>();

--- a/frontend/src/app/spot/styles/sass/components/link.sass
+++ b/frontend/src/app/spot/styles/sass/components/link.sass
@@ -1,7 +1,7 @@
 .spot-link
   @include unset-button-styles
   display: inline
-  color: $spot-color-main
+  color: var(--content-link-color)
   text-decoration: none
   cursor: pointer
 

--- a/frontend/src/app/spot/styles/sass/components/link.sass
+++ b/frontend/src/app/spot/styles/sass/components/link.sass
@@ -11,8 +11,8 @@
   &:hover,
   &:active,
   &:focus
-    color: $spot-color-main-dark
-    text-decoration: none
+    color: var(--content-link-hover-active-color)
+    text-decoration: underline
 
   &_danger
     color: $spot-color-danger

--- a/frontend/src/global_styles/content/_buttons.sass
+++ b/frontend/src/global_styles/content/_buttons.sass
@@ -120,6 +120,9 @@ a.button
 .button--icon
   @include icon-common
 
+  &::before
+    color: inherit
+
 .button--icon + .button--text,
 .button--text + .button--icon,
 .op-icon--wrapper + .button--text,

--- a/frontend/src/global_styles/content/_editable_toolbar.sass
+++ b/frontend/src/global_styles/content/_editable_toolbar.sass
@@ -9,9 +9,6 @@
     float: none
     margin-left: 1rem
 
-    // Fix up default margins of items in floating toolbar
-    .button
-      margin: 0
 
 .title-container.-small
   .editable-toolbar-title--fixed

--- a/frontend/src/global_styles/content/_sidebar.sass
+++ b/frontend/src/global_styles/content/_sidebar.sass
@@ -16,3 +16,6 @@
     display: grid
     text-align: center
     padding: 1rem
+
+    .button .spot-icon
+      margin-right: 0.5rem

--- a/frontend/src/global_styles/layout/_toolbar.sass
+++ b/frontend/src/global_styles/layout/_toolbar.sass
@@ -105,7 +105,6 @@ $nm-color-success-background: #d8fdd1
       flex-grow: 0
 
     .button
-      width: 100%
       overflow: hidden
       white-space: normal
       // For links the total height adds borders to line-height (== 34px)

--- a/frontend/src/global_styles/layout/_toolbar_mobile.sass
+++ b/frontend/src/global_styles/layout/_toolbar_mobile.sass
@@ -56,5 +56,8 @@
             width: 100%
             white-space: nowrap
 
+          .spot-action-bar .button
+            width: auto
+
         > form input.button
           width: 100%

--- a/spec/support/components/project_include_component.rb
+++ b/spec/support/components/project_include_component.rb
@@ -61,7 +61,7 @@ module Components
 
     def set_filter_selected(filter)
       within_body do
-        page.find("label.spot-toggle--option", text: filter ? 'Only selected' : 'All projects').click
+        page.find("[data-qa-selector='spot-toggle--option']", text: filter ? 'Only selected' : 'All projects').click
       end
     end
 


### PR DESCRIPTION
The buttons in project include were using new styles, which caused
visual inconsistencies when compared to the rest of the application.
This commit changes those spot-buttons to old buttons. It also makes
sure that spot-link uses the theming variables, at least for the
non-danger variant.

Closes https://community.openproject.org/projects/openproject/work_packages/42251/activity
