### PR TITLE
[42397] Project filter is not applied in embedded table

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-new/wp-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-create.service.ts
@@ -59,7 +59,6 @@ import { SchemaResource } from 'core-app/features/hal/resources/schema-resource'
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/resource-changeset';
-import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 
 export const newWorkPackageHref = '/api/v3/work_packages/new';
 
@@ -80,7 +79,6 @@ export class WorkPackageCreateService extends UntilDestroyedMixin {
     protected halEditing:HalResourceEditingService,
     protected schemaCache:SchemaCacheService,
     protected halEvents:HalEventsService,
-    protected currentProject:CurrentProjectService,
   ) {
     super();
 
@@ -193,18 +191,9 @@ export class WorkPackageCreateService extends UntilDestroyedMixin {
 
   public createOrContinueWorkPackage(projectIdentifier:string|null|undefined, type?:number, defaults?:HalSource):Promise<WorkPackageChangeset> {
     let changePromise = this.continueExistingEdit(type);
-    const extendedDefaults:HalSource = defaults || { _links: {} };
-    const projectId = this.currentProject.id;
-
-    // Special case due to the introduction of the project include dropdown
-    // If we are in a project, we want the create wp to be part of that project.
-    // Only on the global WP page, the filters should be applied.
-    if (projectId) {
-      extendedDefaults._links.project = { href: this.apiV3Service.projects.id(projectId).path };
-    }
 
     if (!changePromise) {
-      changePromise = this.createNewWithDefaults(projectIdentifier, extendedDefaults);
+      changePromise = this.createNewWithDefaults(projectIdentifier, defaults);
     }
 
     return changePromise.then((change:WorkPackageChangeset) => {

--- a/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
+++ b/spec/features/work_packages/details/query_groups/relation_query_group_spec.rb
@@ -148,7 +148,6 @@ describe 'Work package with relation query group', js: true, selenium: true do
       end
 
       it 'can load the query and inline create' do
-        pending("needs to be fixed in 12.2 as it is only a temporary accepted failure")
         full_wp.visit!
         full_wp.ensure_page_loaded
 


### PR DESCRIPTION
Always use the current project if it is part of the filters. Only if it is not included (e.g in the embedded table), use the first filter value.

This supersedes #10648 and undoes some of the changes made there.

https://community.openproject.org/projects/openproject/work_packages/42397/activity