### PR TITLE
[41814] Apply style changes to new date picker

### DIFF
--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.html
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.html
@@ -7,6 +7,22 @@
   (submit)="save($event)"
 >
   <div class="op-modal--body form -vertical">
+    <div class="form--field op-datepicker-modal--scheduling-action-container">
+      <div class="form--field-container">
+        <label class="form--label-with-check-box">
+          <div class="form--check-box-container">
+            <input type="checkbox"
+                   name="scheduling"
+                   class="form--check-box op-datepicker-modal--scheduling-action"
+                   data-qa-selector="op-datepicker-modal--scheduling-action"
+                   [ngModel]="scheduleManually"
+                   (ngModelChange)="changeSchedulingMode()">
+          </div>
+          {{ text.manualScheduling }}
+        </label>
+      </div>
+    </div>
+
     <div class="op-datepicker-modal--dates-container">
       <ng-container *ngIf="singleDate">
         <div class="form--field">
@@ -103,21 +119,6 @@
           </div>
         </div>
       </ng-container>
-      <div class="form--field op-datepicker-modal--scheduling-action-container">
-        <div class="form--field-container">
-          <label class="form--label-with-check-box">
-            <div class="form--check-box-container">
-              <input type="checkbox"
-                     name="scheduling"
-                     class="form--check-box op-datepicker-modal--scheduling-action"
-                     data-qa-selector="op-datepicker-modal--scheduling-action"
-                     [ngModel]="scheduleManually"
-                     (ngModelChange)="changeSchedulingMode()">
-            </div>
-            {{ text.manualScheduling }}
-          </label>
-        </div>
-      </div>
     </div>
 
     <ng-container *ngIf="!isSchedulable">

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.html
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.html
@@ -110,22 +110,8 @@
       </ng-container>
     </div>
 
-    <ng-container *ngIf="!isSchedulable">
-      <div class="op-toast -info">
-        <div class="op-toast--content">
-          <ng-container *ngIf="isParent">
-            <p [textContent]="text.isParent"></p>
-          </ng-container>
-          <ng-container *ngIf="isSwitchedFromManualToAutomatic && !isParent">
-            <p [textContent]="text.isSwitchedFromManualToAutomatic"></p>
-          </ng-container>
-        </div>
-      </div>
-    </ng-container>
-    <ng-container *ngIf="isSchedulable">
-      <input id="flatpickr-input"
-             hidden>
-    </ng-container>
+    <input id="flatpickr-input"
+           hidden>
   </div>
 
   <div class="op-modal--footer">

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.html
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.html
@@ -30,20 +30,17 @@
                  [textContent]="text.date">
           </label>
           <div class="form--field-container">
-            <div class="form--text-field-container -xslim">
-              <input type="text"
+            <div class="form--text-field-container op-datepicker-modal--date-container">
+              <spot-text-field
                      name="date"
-                     class="form--date-field"
-                     [ngClass]="{'-current' : datepickerHelper.isStateOfCurrentActivatedField('date')}"
+                     class="op-datepicker-modal--date-field"
+                     [ngClass]="{'op-datepicker-modal--date-field_current' : datepickerHelper.isStateOfCurrentActivatedField('date')}"
                      [ngModel]="dates.date"
                      (ngModelChange)="updateDate('date', $event)"
-                     (click)="datepickerHelper.setCurrentActivatedField('date')">
+                     [showClearButton]="datepickerHelper.isStateOfCurrentActivatedField('date')"
+                     (click)="datepickerHelper.setCurrentActivatedField('date')"
+              ></spot-text-field>
             </div>
-            <a class="form--field-inline-action"
-               [title]="text.clear"
-               (click)="clear('date')">
-              <span class="icon2 icon-small icon-cancel"></span>
-            </a>
           </div>
           <div class="form--field-extra-actions">
             <a (click)="setToday('date')"
@@ -61,23 +58,19 @@
                  [textContent]="text.startDate">
           </label>
           <div class="form--field-container">
-            <div class="form--text-field-container -xslim">
-              <input type="text"
+            <div class="form--text-field-container op-datepicker-modal--date-container">
+              <spot-text-field
                      name="startDate"
                      data-qa-selector="op-datepicker-modal--start-date-field"
-                     class="form--date-field"
-                     [ngClass]="{'-current' : datepickerHelper.isStateOfCurrentActivatedField('start')}"
+                     class="op-datepicker-modal--date-field"
+                     [ngClass]="{'op-datepicker-modal--date-field_current' : datepickerHelper.isStateOfCurrentActivatedField('start')}"
                      [ngModel]="dates.start"
                      (ngModelChange)="updateDate('start', $event)"
                      [disabled]="!isSchedulable"
-                     (focusin)="datepickerHelper.setCurrentActivatedField('start')">
+                     [showClearButton]="datepickerHelper.isStateOfCurrentActivatedField('start')"
+                     (focusin)="datepickerHelper.setCurrentActivatedField('start')"
+              ></spot-text-field>
             </div>
-            <a class="form--field-inline-action"
-               *ngIf="isSchedulable"
-               [title]="text.clear"
-               (click)="clear('start')">
-              <span class="icon2 icon-small  icon-cancel"></span>
-            </a>
           </div>
           <div class="form--field-extra-actions">
             <a *ngIf="showTodayLink()"
@@ -93,23 +86,19 @@
                  [textContent]="text.endDate">
           </label>
           <div class="form--field-container">
-            <div class="form--text-field-container -xslim">
-              <input type="text"
+            <div class="form--text-field-container op-datepicker-modal--date-container">
+              <spot-text-field
                      name="endDate"
                      data-qa-selector="op-datepicker-modal--end-date-field"
-                     class="form--date-field"
-                     [ngClass]="{'-current' : datepickerHelper.isStateOfCurrentActivatedField('end')}"
+                     class="op-datepicker-modal--date-field"
+                     [ngClass]="{'op-datepicker-modal--date-field_current' : datepickerHelper.isStateOfCurrentActivatedField('end')}"
                      [ngModel]="dates.end"
                      (ngModelChange)="updateDate('end', $event)"
                      [disabled]="!isSchedulable"
-                     (focusin)="datepickerHelper.setCurrentActivatedField('end')">
+                     [showClearButton]="datepickerHelper.isStateOfCurrentActivatedField('end')"
+                     (focusin)="datepickerHelper.setCurrentActivatedField('end')"
+              ></spot-text-field>
             </div>
-            <a class="form--field-inline-action"
-               *ngIf="isSchedulable"
-               [title]="text.clear"
-               (click)="clear('end')">
-              <span class="icon2 icon-small icon-cancel"></span>
-            </a>
           </div>
           <div class="form--field-extra-actions">
             <a *ngIf="showTodayLink()"

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
@@ -1,21 +1,14 @@
 .op-datepicker-modal
-  position: relative
   z-index: 500
   width: auto
   // prevent additional content like notifications to
   // drastically increase the width.
   max-width: 730px
   box-shadow: 0px 0px 5px 2px rgba(0, 0, 0, 0.25)
-  padding: 5px 0 0 0
-
-  .grid-block
-    align-items: center
-
 
   &--dates-container
     display: grid
     grid-template-columns: 170px 1fr auto
-    margin: 0 1.5rem
 
     .form--date-field
       margin: 2px !important
@@ -24,29 +17,8 @@
       &.-current:hover
         outline: 2px solid var(--primary-color)
 
-    .op-datepicker-modal--scheduling-action-container
-      margin-top: 28px
-
-      .form--label-with-check-box
-        padding: 0
-
     .form--field-inline-action
       .icon-small:before
         vertical-align: text-bottom
       &:hover, &:focus
-        text-decoration: none
-
-
-  &--actions-container
-    display: flex
-    justify-content: flex-end
-    padding: 15px 1.5rem 0 1.5rem
-    border-top: 1px solid #DDDDDD
-    background: #F8F8F8
-
-    .op-datepicker-modal--action[disabled]
-      color: var(--gray-dark)
-      cursor: not-allowed
-
-      &:hover
         text-decoration: none

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
@@ -7,7 +7,6 @@
   // drastically increase the width.
   max-width: 730px
   box-shadow: $spot-shadow-light-mid
-  padding: 1rem
 
   &--dates-container
     display: grid

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
@@ -1,24 +1,24 @@
+@import '../../app/spot/styles/sass/variables'
+
 .op-datepicker-modal
   z-index: 500
   width: auto
   // prevent additional content like notifications to
   // drastically increase the width.
   max-width: 730px
-  box-shadow: 0px 0px 5px 2px rgba(0, 0, 0, 0.25)
+  box-shadow: $spot-shadow-light-mid
+  padding: 1rem
 
   &--dates-container
     display: grid
-    grid-template-columns: 170px 1fr auto
+    grid-template-columns: 1fr 1fr 150px
+    grid-column-gap: $spot-spacing-1
 
-    .form--date-field
-      margin: 2px !important
+  &--date-field
+    &_current,
+    &_current:hover
+      outline: 2px solid var(--primary-color)
+      outline-offset: -2px
 
-      &.-current,
-      &.-current:hover
-        outline: 2px solid var(--primary-color)
-
-    .form--field-inline-action
-      .icon-small:before
-        vertical-align: text-bottom
-      &:hover, &:focus
-        text-decoration: none
+  &--date-container
+    display: inline-grid

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
@@ -6,6 +6,7 @@
   // prevent additional content like notifications to
   // drastically increase the width.
   max-width: 730px
+  min-height: 200px
   box-shadow: $spot-shadow-light-mid
 
   &--dates-container

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
@@ -84,8 +84,6 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
     endDate: this.I18n.t('js.work_packages.properties.dueDate'),
     placeholder: this.I18n.t('js.placeholders.default'),
     today: this.I18n.t('js.label_today'),
-    isParent: this.I18n.t('js.work_packages.scheduling.is_parent'),
-    isSwitchedFromManualToAutomatic: this.I18n.t('js.work_packages.scheduling.is_switched_from_manual_to_automatic'),
   };
 
   onDataUpdated = new EventEmitter<string>();
@@ -251,6 +249,11 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
         mode: this.singleDate ? 'single' : 'range',
         showMonths: this.browserDetector.isMobile ? 1 : 2,
         inline: true,
+        onReady: (selectedDates, dateStr, instance) => {
+          if (!this.isSchedulable) {
+            instance.calendarContainer.classList.add('disabled');
+          }
+        },
         onChange: (dates:Date[]) => {
           this.handleDatePickerChange(dates);
 

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
@@ -78,7 +78,6 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
   text = {
     save: this.I18n.t('js.button_save'),
     cancel: this.I18n.t('js.button_cancel'),
-    clear: this.I18n.t('js.work_packages.button_clear'),
     manualScheduling: this.I18n.t('js.scheduling.manual'),
     date: this.I18n.t('js.work_packages.properties.date'),
     startDate: this.I18n.t('js.work_packages.properties.startDate'),
@@ -174,11 +173,6 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
 
   cancel():void {
     this.closeMe();
-  }
-
-  clear(key:DateKeys):void {
-    this.dates[key] = '';
-    this.enforceManualChangesToDatepicker();
   }
 
   updateDate(key:DateKeys, val:string):void {

--- a/frontend/src/app/shared/components/datepicker/datepicker_mobile.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/datepicker_mobile.modal.sass
@@ -1,8 +1,6 @@
 @media screen and (max-width: 679px)
   .op-datepicker-modal
+    height: initial
+    width: calc(100vw - 2rem)
     &--dates-container
-      grid-template-columns: 1fr 1fr
-      grid-template-rows: 75px 40px
-
-    &--scheduling-action-container
-        margin: 10px 0
+      grid-template-columns: 1fr auto

--- a/frontend/src/app/shared/components/modal/modal.sass
+++ b/frontend/src/app/shared/components/modal/modal.sass
@@ -1,6 +1,6 @@
 // TODO: Check out -danger-zone and modal-close-button patterns
 .op-modal
-  --modal-padding: 2rem
+  --modal-padding: 1rem
 
   position: relative
   display: flex
@@ -19,7 +19,6 @@
   @include styled-scroll-bar
 
   @media (max-width: 680px), (max-height: 500px)
-    --modal-padding: 1rem
     height: 100vh
     width: 100vw
     min-height: unset
@@ -70,7 +69,7 @@
       text-align: center
 
   &--title
-    font-size: 1.3rem 
+    font-size: 1.3rem
     padding: 0
     margin: 0
     margin-right: auto
@@ -78,14 +77,14 @@
   &--footer
     display: flex
     justify-content: flex-end
-    padding: calc(0.5 * var(--modal-padding)) var(--modal-padding) var(--modal-padding) var(--modal-padding) 
+    padding: calc(0.5 * var(--modal-padding)) var(--modal-padding) var(--modal-padding) var(--modal-padding)
     width: 100%
 
     .button
       margin-bottom: 0
 
     @media (max-width: 680px), (max-height: 500px)
-      padding: var(--modal-padding) 
+      padding: var(--modal-padding)
 
   &--close-button
     height: 100%

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -66,6 +66,7 @@ $datepicker--border-radius: 5px
         &:nth-child(7n+7),
         &:nth-child(7n+6)
           background: $spot-color-basic-gray-6
+          border-radius: 0
 
         &.today
           background: $spot-color-indication-current-date
@@ -91,3 +92,30 @@ $datepicker--border-radius: 5px
           background: $spot-color-feedback-info-light
           border-color: $spot-color-feedback-info-light
           border-radius: 0
+
+
+  &.disabled
+    .flatpickr-days
+      .flatpickr-day
+        color: $spot-color-basic-gray-4
+        background: $spot-color-basic-white
+        pointer-events: none
+        cursor: not-allowed
+
+        &:hover
+          border-color: transparent
+
+        &.selected,
+        &.startRange,
+        &.endRange
+          background: $spot-color-basic-gray-3
+          border-color: $spot-color-basic-gray-3
+          color: $spot-color-basic-gray-5
+
+        &.inRange
+          background: $spot-color-basic-gray-5
+          border-color: $spot-color-basic-gray-5
+          color: $spot-color-basic-gray-3
+
+        &.today
+          color: $spot-color-basic-gray-4

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -26,9 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-$datepicker--border-radius: 2px
-$datepicker--line-height:   28px
-$datepicker--hover-color:   #DDDDDD
+$datepicker--border-radius: 5px
 
 .flatpickr-current-month
   display: flex !important
@@ -38,84 +36,58 @@ $datepicker--hover-color:   #DDDDDD
   left: 65% !important
 
 .flatpickr-calendar.inline
-  width: initial !important
-  top: 0 !important
-  margin: 0 1.5rem
-  padding-top: 10px !important
-  border-top: 1px solid $datepicker--hover-color !important
-  border-radius: 0 !important
   box-shadow: none !important
+  @include spot-caption
 
   .flatpickr-months
     min-height: 45px
-    .flatpickr-prev-month,
-    .flatpickr-next-month
-      top: unset
-
-  .flatpickr-monthDropdown-months
-    display: inline-block
 
   .flatpickr-weekwrapper
     display: none
 
   .flatpickr-weekday
     color: var(--body-font-color)
-    font-size: var(--body-font-size)
 
   .flatpickr-weekdaycontainer,
   .flatpickr-days .dayContainer
-    padding: 0.75rem 0.75rem 15px 0.75rem
+    padding: 0 1.25rem
 
   .flatpickr-days
     .dayContainer
       box-shadow: none
 
       .flatpickr-day
-        height: $datepicker--line-height
-        line-height: $datepicker--line-height
+        color: $spot-color-basic-black
+        height: 30px
+        line-height: 28px
         border-radius: $datepicker--border-radius
+        box-shadow: none !important
 
         &:nth-child(7n+7),
         &:nth-child(7n+6)
-          background: var(--gray-light)
-          border-radius: 0
-
-        &:nth-child(7n+6)
-          box-shadow: 5px 0 0 var(--gray-light)
+          background: $spot-color-basic-gray-6
 
         &.today
-          border-color: var(--light-gray) !important
-          &:hover:not(.selected)
-            color: var(--body-font-color)
+          background: $spot-color-indication-current-date
+          border-color: $spot-color-indication-current-date
 
-        &.selected
-          background: var(--primary-color)
-          border-color: var(--primary-color)
-          &.startRange
-            border-radius: 2px 0 0 2px
-          // Workaround to close the gap caused by original styles
-          &.endRange
-            border-radius: 0 2px 2px 0
-            box-shadow: none
-          &:hover
-            background: var(--primary-color-dark)
-            border-color: var(--primary-color-dark)
+        &.selected,
+        &.startRange,
+        &.endRange
+          background: $spot-color-main
+          border-color: $spot-color-main
+          color: $spot-color-basic-white
+
+        &.startRange
+          border-radius: $datepicker--border-radius 0 0 $datepicker--border-radius
+
+        &.endRange
+          border-radius: 0 $datepicker--border-radius $datepicker--border-radius 0
+
+        &.endRange.startRange
+          border-radius: $datepicker--border-radius
 
         &.inRange
-          background: $datepicker--hover-color
-          border-color: $datepicker--hover-color
+          background: $spot-color-feedback-info-light
+          border-color: $spot-color-feedback-info-light
           border-radius: 0
-          &:nth-child(7n+7)
-            box-shadow: none
-          &:hover
-            background: var(--light-gray)
-            border-color: var(--light-gray)
-
-        &.inRange:not(:nth-child(7n+7)),
-        &.selected.startRange:not(:nth-child(7n+7))
-          box-shadow: 5px 0 0 $datepicker--hover-color
-
-        &:hover
-          background: $datepicker--hover-color
-          border-color: $datepicker--hover-color
-          border-radius: $datepicker--border-radius

--- a/spec/features/work_packages/scheduling/scheduling_mode_spec.rb
+++ b/spec/features/work_packages/scheduling/scheduling_mode_spec.rb
@@ -98,7 +98,6 @@ describe 'scheduling mode',
     combined_field.activate!(expect_open: false)
     combined_field.expect_active!
     combined_field.expect_scheduling_mode manually: false
-    combined_field.expect_parent_notification
     combined_field.toggle_scheduling_mode
     combined_field.update(%w[2016-01-05 2016-01-10])
 
@@ -132,7 +131,6 @@ describe 'scheduling mode',
     combined_field.expect_active!
     combined_field.expect_scheduling_mode manually: true
     combined_field.toggle_scheduling_mode
-    combined_field.expect_parent_notification
     combined_field.save!
 
     work_packages_page.expect_and_dismiss_toaster message: 'Successful update.'
@@ -162,7 +160,6 @@ describe 'scheduling mode',
     combined_field.activate!(expect_open: false)
     combined_field.expect_active!
     combined_field.expect_scheduling_mode manually: false
-    combined_field.expect_parent_notification
     combined_field.toggle_scheduling_mode
     # Increasing the duration while at it
     combined_field.update(%w[2015-12-20 2015-12-31])
@@ -194,7 +191,6 @@ describe 'scheduling mode',
     combined_field.expect_active!
     combined_field.expect_scheduling_mode manually: true
     combined_field.toggle_scheduling_mode
-    combined_field.expect_parent_notification
     combined_field.save!
 
     work_packages_page.expect_and_dismiss_toaster message: 'Successful update.'

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -44,12 +44,6 @@ class DateEditField < EditField
     end
   end
 
-  def expect_parent_notification
-    within_modal do
-      expect(page).to have_content(I18n.t('js.work_packages.scheduling.is_parent'))
-    end
-  end
-
   def toggle_scheduling_mode
     within_modal do
       find('[data-qa-selector="op-datepicker-modal--scheduling-action"]').click


### PR DESCRIPTION
### ToDo

- [x] The modal has a new structure (scheduling mode - dates - calendar - action bar)

**Scheduling mode**
- [x] The "Manual scheduling" checkbox is now in a new line by itself above the start/finish dates

**Date fields**
- [x] There are two fields that use the new text field components of equal width (Start date & Finish date)
  - [x] There is space left for where duration field will eventually go, but this is not displayed yet.
- [x] Each field has a "today" link underneath it.
- [x] Each field has a "clear" buttons on focus that allow the user to clear that date
- [x] On focus, the field is outlined in the primary colour

**Calendar**
- [x] Each mini calendar will show weekends differently in grey as it does today. 
- [x] The start and finish dates are have rounded corners:
  - [x] Start date on the left edge.
  - [x] Finish date on the right edge.
  - [x] A one-day event will have rounded corners on all edges (when start date == end date).
- [x] Each calendar day can has multiple states depending on what kind of day it is (see ticket for more details)
- [x] A disabled datepicker has different colours
- [x] These colours do not change or adapt to themes or custom colours and are always these colours.

**Action bar**
- [x] There are two buttons at the bottom of the modal (cancel & save)

**The simple date picker**
- [x] For Milestones only a single date field is shown (called "Date")
- [x] The selected date is rounded on all corners.

**Mobile**
- [x] Is displayed in a modal that takes almost the full available screen width.
- [x] There is only one month in the mini calendar
- [x] The simple version of the mobile date picker Has a single date field that takes 100% of the available width


https://community.openproject.org/projects/openproject/work_packages/41814/activity