### PR TITLE
Avoid "undefined" as value for text fields

### DIFF
--- a/frontend/src/app/spot/components/text-field/text-field.component.ts
+++ b/frontend/src/app/spot/components/text-field/text-field.component.ts
@@ -50,7 +50,7 @@ export class SpotTextFieldComponent implements ControlValueAccessor {
   }
 
   writeValue(value:string) {
-    this.value = value;
+    this.value = value || '';
   }
 
   onChange = (_:string):void => {};


### PR DESCRIPTION
Avoid `undefined` as a value being set because Angular sometimes fires this method on initialisation