### PR TITLE
[#42414] Enable feature flags by default in the development and test environment

### DIFF
--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -402,7 +402,7 @@ Settings::Definition.define do
       writable: false
 
   add :feature_storages_module_active,
-      default: false,
+      default: Rails.env.development? || Rails.env.test?,
       format: :boolean
 
   add :feeds_enabled,

--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -402,7 +402,7 @@ Settings::Definition.define do
       writable: false
 
   add :feature_storages_module_active,
-      default: Rails.env.development? || Rails.env.test?,
+      default: Rails.env.development?,
       format: :boolean
 
   add :feeds_enabled,


### PR DESCRIPTION
https://community.openproject.org/work_packages/42414

This PR simply sets the default for the setting `:feature_storages_module_active` to `Rails.env.development?`.

I didn't add any test, as I don't really know how to test that. All tests run in the test environment. Maybe it is not necessary to test it?

