### PR TITLE
Implementation/41816 Add non-working days to the api/v3/days

### DIFF
--- a/app/models/concerns/tableless.rb
+++ b/app/models/concerns/tableless.rb
@@ -33,6 +33,10 @@ module Tableless
     false
   end
 
+  def readonly?
+    true
+  end
+
   class_methods do
     def attribute_names
       @attribute_names ||= attribute_types.keys

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -39,10 +39,12 @@ class Day < ApplicationRecord
            inverse_of: false,
            class_name: 'NonWorkingDay',
            foreign_key: :date,
-           primary_key: :date
+           primary_key: :date,
+           dependent: nil
 
   attribute :date, :date, default: nil
   attribute :day_of_week, :integer, default: nil
+  attribute :working, :boolean, default: 't'
 
   delegate :name, to: :week_day, allow_nil: true
 
@@ -50,11 +52,11 @@ class Day < ApplicationRecord
     today = Time.zone.today
     from = today.at_beginning_of_month
     to = today.next_month.at_end_of_month
+    from_range(from:, to:).includes(:week_day).includes(:non_working_days).order(:date)
+  end
 
+  def self.from_range(from:, to:)
     from(Arel.sql(from_sql(from:, to:)))
-    .includes(:week_day)
-    .includes(:non_working_days)
-    .order(:date)
   end
 
   def self.from_sql(from:, to:)
@@ -62,23 +64,17 @@ class Day < ApplicationRecord
       (SELECT
         to_char(dd, 'YYYYMMDD')::integer id,
         date_trunc('day', dd)::date date,
-        extract(isodow from dd) day_of_week
+        extract(isodow from dd) day_of_week,
+        (COALESCE(week_days.working, TRUE) AND non_working_days.id IS NULL)::bool working
       FROM
       generate_series( '#{from}'::timestamp,
             '#{to}'::timestamp,
             '1 day'::interval) dd
+      LEFT JOIN week_days
+           ON extract(isodow from dd) = week_days.day
+      LEFT JOIN non_working_days
+           ON date = non_working_days.date
       ) days
     SQL
-  end
-
-  def working
-    week_day&.working && non_working_days.empty?
-  end
-
-  ##
-  # Since the base table is a generated series of dates that cannot be modified
-  # we should mark the records readonly.
-  def readonly?
-    true
   end
 end

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -52,7 +52,10 @@ class Day < ApplicationRecord
     today = Time.zone.today
     from = today.at_beginning_of_month
     to = today.next_month.at_end_of_month
-    from_range(from:, to:).includes(:week_day).includes(:non_working_days).order(:date)
+    from_range(from:, to:)
+    .includes(:week_day)
+    .includes(:non_working_days)
+    .order("days.id")
   end
 
   def self.from_range(from:, to:)
@@ -73,7 +76,7 @@ class Day < ApplicationRecord
       LEFT JOIN week_days
            ON extract(isodow from dd) = week_days.day
       LEFT JOIN non_working_days
-           ON date = non_working_days.date
+           ON dd = non_working_days.date
       ) days
     SQL
   end

--- a/app/models/queries/days/day_query.rb
+++ b/app/models/queries/days/day_query.rb
@@ -32,7 +32,7 @@ class Queries::Days::DayQuery < Queries::BaseQuery
   end
 
   def default_scope
-    Day.default
+    Day.default_scope
   end
 
   ##

--- a/lib/api/v3/days/day_representer.rb
+++ b/lib/api/v3/days/day_representer.rb
@@ -34,6 +34,13 @@ module API::V3::Days
 
     self_link path: :day, id_attribute: :date
 
+    link :weekday do
+      {
+        href: api_v3_paths.days_week_day(represented.day_of_week),
+        title: represented.name
+      }
+    end
+
     links :nonWorkingReasons do
       next if represented.working
 

--- a/lib/api/v3/days/day_representer.rb
+++ b/lib/api/v3/days/day_representer.rb
@@ -34,6 +34,23 @@ module API::V3::Days
 
     self_link path: :day, id_attribute: :date
 
+    links :nonWorkingReasons do
+      next if represented.working
+
+      links = []
+      unless represented.week_day.working
+        links << {
+          title: represented.name,
+          href: api_v3_paths.days_week_day(represented.week_day.day)
+        }
+      end
+
+      represented.non_working_days.each do |day|
+        links << { title: day.name, href: api_v3_paths.days_non_working_day(day.date) }
+      end
+      links
+    end
+
     def _type
       'Day'
     end

--- a/spec/factories/day_factory.rb
+++ b/spec/factories/day_factory.rb
@@ -32,6 +32,5 @@ FactoryBot.define do
       (1.year.ago + n.days).to_date
     end
     day_of_week { date.wday }
-    working { date.wday < 6 }
   end
 end

--- a/spec/lib/api/v3/days/day_representer_spec.rb
+++ b/spec/lib/api/v3/days/day_representer_spec.rb
@@ -29,46 +29,94 @@
 require 'spec_helper'
 
 describe ::API::V3::Days::DayRepresenter do
+  let(:working) { true }
   let(:day) do
-    build(:day, date: Date.new(2022, 12, 27), week_day: create(:week_day, :tuesday), working: true)
+    build(:day, date: Date.new(2022, 12, 27), week_day: create(:week_day, :tuesday, working:))
   end
   let(:current_user) { instance_double(User, name: 'current_user') }
   let(:representer) { described_class.new(day, current_user:) }
 
-  describe '#to_json' do
-    subject(:generated) { representer.to_json }
+  subject(:generated) { representer.to_json }
 
-    it 'has _type: Day' do
-      expect(subject).to be_json_eql('Day'.to_json).at_path('_type')
+  it 'has _type: Day' do
+    expect(subject).to be_json_eql('Day'.to_json).at_path('_type')
+  end
+
+  it 'has date property' do
+    expect(subject).to have_json_type(String).at_path('date')
+    expect(subject).to be_json_eql('2022-12-27'.to_json).at_path('date')
+  end
+
+  it 'has name string property' do
+    expect(subject).to have_json_type(String).at_path('name')
+    expect(subject).to be_json_eql(day.name.to_json).at_path('name')
+  end
+
+  it 'has working boolean property' do
+    expect(subject).to have_json_type(TrueClass).at_path('working')
+    expect(subject).to be_json_eql(day.working.to_json).at_path('working')
+  end
+
+  describe '_links' do
+    it 'is present' do
+      expect(subject).to have_json_type(Object).at_path('_links')
     end
 
-    it 'has date property' do
-      expect(subject).to have_json_type(String).at_path('date')
-      expect(subject).to be_json_eql('2022-12-27'.to_json).at_path('date')
+    describe 'self' do
+      it 'links to this resource' do
+        expected_json = {
+          href: '/api/v3/days/2022-12-27',
+          title: 'Tuesday'
+        }.to_json
+        expect(subject).to be_json_eql(expected_json).at_path('_links/self')
+      end
     end
 
-    it 'has name string property' do
-      expect(subject).to have_json_type(String).at_path('name')
-      expect(subject).to be_json_eql(day.name.to_json).at_path('name')
-    end
-
-    it 'has working boolean property' do
-      expect(subject).to have_json_type(TrueClass).at_path('working')
-      expect(subject).to be_json_eql(day.working.to_json).at_path('working')
-    end
-
-    describe '_links' do
-      it 'is present' do
-        expect(subject).to have_json_type(Object).at_path('_links')
+    describe 'nonWorkingReasons' do
+      context 'when the day has working true' do
+        it { is_expected.not_to have_json_path('_links/nonWorkingReasons') }
       end
 
-      describe 'self' do
-        it 'links to this resource' do
-          expected_json = {
-            href: '/api/v3/days/2022-12-27',
+      context 'when day has working false' do
+        let(:working) { false }
+
+        it 'links to the day resource' do
+          expected_json = [{
+            href: '/api/v3/days/week/2',
             title: 'Tuesday'
-          }.to_json
-          expect(subject).to be_json_eql(expected_json).at_path('_links/self')
+          }].to_json
+
+          expect(subject).to be_json_eql(expected_json).at_path('_links/nonWorkingReasons')
+        end
+      end
+
+      context 'when a non-working day is present' do
+        let!(:non_working_day) { create(:non_working_day, date: day.date) }
+
+        it 'links to the non-working day resource' do
+          expected_json = [{
+            href: "/api/v3/days/non_working/2022-12-27",
+            title: non_working_day.name
+          }].to_json
+
+          expect(subject).to be_json_eql(expected_json).at_path('_links/nonWorkingReasons')
+        end
+      end
+
+      context 'when the day has working false and a non-working day is present' do
+        let(:working) { false }
+        let!(:non_working_day) { create(:non_working_day, date: day.date) }
+
+        it 'links to the day resource and to the non-working day resource' do
+          expected_json = [{
+            href: '/api/v3/days/week/2',
+            title: 'Tuesday'
+          }, {
+            href: "/api/v3/days/non_working/2022-12-27",
+            title: non_working_day.name
+          }].to_json
+
+          expect(subject).to be_json_eql(expected_json).at_path('_links/nonWorkingReasons')
         end
       end
     end

--- a/spec/lib/api/v3/days/day_representer_spec.rb
+++ b/spec/lib/api/v3/days/day_representer_spec.rb
@@ -120,5 +120,16 @@ describe ::API::V3::Days::DayRepresenter do
         end
       end
     end
+
+    describe 'weekday' do
+      it 'links to the weekday resource' do
+        expected_json = {
+          href: '/api/v3/days/week/2',
+          title: 'Tuesday'
+        }.to_json
+
+        expect(subject).to be_json_eql(expected_json).at_path('_links/weekday')
+      end
+    end
   end
 end

--- a/spec/lib/api/v3/days/day_representer_spec.rb
+++ b/spec/lib/api/v3/days/day_representer_spec.rb
@@ -30,13 +30,19 @@ require 'spec_helper'
 
 describe ::API::V3::Days::DayRepresenter do
   let(:working) { true }
+  let(:date) { Date.new(2022, 12, 27) }
   let(:day) do
-    build(:day, date: Date.new(2022, 12, 27), week_day: create(:week_day, :tuesday, working:))
+    Day.from_range(from: Date.new(2022, 12, 1), to: Date.new(2022, 12, 31))
+       .find(date.strftime("%Y%m%d").to_i)
   end
   let(:current_user) { instance_double(User, name: 'current_user') }
   let(:representer) { described_class.new(day, current_user:) }
 
   subject(:generated) { representer.to_json }
+
+  before do
+    create(:week_day, :tuesday, working:)
+  end
 
   it 'has _type: Day' do
     expect(subject).to be_json_eql('Day'.to_json).at_path('_type')
@@ -91,7 +97,7 @@ describe ::API::V3::Days::DayRepresenter do
       end
 
       context 'when a non-working day is present' do
-        let!(:non_working_day) { create(:non_working_day, date: day.date) }
+        let!(:non_working_day) { create(:non_working_day, date:) }
 
         it 'links to the non-working day resource' do
           expected_json = [{
@@ -105,7 +111,7 @@ describe ::API::V3::Days::DayRepresenter do
 
       context 'when the day has working false and a non-working day is present' do
         let(:working) { false }
-        let!(:non_working_day) { create(:non_working_day, date: day.date) }
+        let!(:non_working_day) { create(:non_working_day, date:) }
 
         it 'links to the day resource and to the non-working day resource' do
           expected_json = [{

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -2,8 +2,13 @@ require 'spec_helper'
 
 describe Day, type: :model do
   let(:today) { Date.current }
+  let(:first_of_year) { Date.new(2022, 1, 1) }
 
-  subject { described_class.new(date: Date.new(2022, 1, 1), day_of_week: 6) }
+  subject do
+    described_class
+    .from_range(from: Date.new(2022, 1, 1), to: Date.new(2022, 2, 1))
+    .find(first_of_year.strftime("%Y%m%d").to_i)
+  end
 
   it { is_expected.to be_readonly }
   it { is_expected.to respond_to :id }
@@ -67,7 +72,7 @@ describe Day, type: :model do
 
       context 'with a non-working day' do
         before do
-          create(:non_working_day, date: subject.date)
+          create(:non_working_day, date: first_of_year)
         end
 
         it 'is false' do
@@ -87,7 +92,7 @@ describe Day, type: :model do
 
       context 'with a non working day' do
         before do
-          create(:non_working_day, date: subject.date)
+          create(:non_working_day, date: first_of_year)
         end
 
         it 'is false' do

--- a/spec/models/day_spec.rb
+++ b/spec/models/day_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+describe Day, type: :model do
+  let(:today) { Date.current }
+
+  subject { described_class.new(date: Date.new(2022, 1, 1), day_of_week: 6) }
+
+  it { is_expected.to be_readonly }
+  it { is_expected.to respond_to :id }
+  it { is_expected.to respond_to :date }
+  it { is_expected.to respond_to :day_of_week }
+  it { is_expected.to respond_to :name }
+
+  context 'with a collection' do
+    let(:days) { described_class.default_scope }
+
+    it 'returns a default date range' do
+      expect(days.minmax.pluck(:date)).to eq(
+        [today.at_beginning_of_month, today.next_month.at_end_of_month]
+      )
+    end
+
+    it 'eager loads week_day relation' do
+      expect(days).to(be_all { |d| d.association(:week_day).loaded? })
+    end
+
+    it 'eager loads non_working_days relation' do
+      expect(days).to(be_all { |d| d.association(:non_working_days).loaded? })
+    end
+
+    it 'loads the id attribute' do
+      expect(days.first.id).to eq(today.at_beginning_of_month.strftime('%Y%m%d').to_i)
+    end
+
+    it 'loads the date attribute' do
+      expect(days.first.date).to eq(today.at_beginning_of_month)
+    end
+
+    it 'loads the day_of_week attribute' do
+      expect(days.first.day_of_week % 7).to eq(today.at_beginning_of_month.wday) # wday is from 0-6
+    end
+
+    it 'does not have a name' do
+      expect(days.first.name).to be_nil
+    end
+  end
+
+  context 'with the weekday present' do
+    before do
+      create(:week_day, day: 6)
+    end
+
+    it 'loads the name attribute' do
+      expect(subject.name).to eq('Saturday')
+    end
+  end
+
+  describe '#working' do
+    context 'when the week day is non-working' do
+      before do
+        create(:week_day, day: 6, working: false)
+      end
+
+      it 'is false' do
+        expect(subject.working).to be_falsy
+      end
+
+      context 'with a non-working day' do
+        before do
+          create(:non_working_day, date: subject.date)
+        end
+
+        it 'is false' do
+          expect(subject.working).to be_falsy
+        end
+      end
+    end
+
+    context 'when the week day is working' do
+      before do
+        create(:week_day, day: 6, working: true)
+      end
+
+      it 'is true' do
+        expect(subject.working).to be_truthy
+      end
+
+      context 'with a non working day' do
+        before do
+          create(:non_working_day, date: subject.date)
+        end
+
+        it 'is false' do
+          expect(subject.working).to be_falsy
+        end
+      end
+    end
+  end
+end

--- a/spec/models/queries/days/day_query_spec.rb
+++ b/spec/models/queries/days/day_query_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe Queries::Days::DayQuery, type: :model do
   let(:instance) { described_class.new }
-  let(:base_scope) { Day.default.order(date: :asc) }
+  let(:base_scope) { Day.order(date: :asc) }
   let(:current_user) { build_stubbed(:admin) }
 
   before do
@@ -63,7 +63,7 @@ describe Queries::Days::DayQuery, type: :model do
     context 'with dates within the default range' do
       let(:from) { Time.zone.today }
       let(:to) { 5.days.from_now.to_date }
-      let(:base_scope) { Day.default.from(Day.from_sql(from:, to:)).order(date: :asc) }
+      let(:base_scope) { Day.from(Day.from_sql(from:, to:)).order(date: :asc) }
 
       it 'is the same as handwriting the query' do
         # Expectation has to be weirdly specific to the logic of Queries::Operators::DateRangeClauses

--- a/spec/models/queries/days/day_query_spec.rb
+++ b/spec/models/queries/days/day_query_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe Queries::Days::DayQuery, type: :model do
   let(:instance) { described_class.new }
-  let(:base_scope) { Day.order(date: :asc) }
+  let(:base_scope) { Day.reorder(date: :asc) }
   let(:current_user) { build_stubbed(:admin) }
 
   before do
@@ -63,13 +63,14 @@ describe Queries::Days::DayQuery, type: :model do
     context 'with dates within the default range' do
       let(:from) { Time.zone.today }
       let(:to) { 5.days.from_now.to_date }
-      let(:base_scope) { Day.from(Day.from_sql(from:, to:)).order(date: :asc) }
+      let(:base_scope) { Day.from_range(from:, to:).reorder(date: :asc) }
 
       it 'is the same as handwriting the query' do
         # Expectation has to be weirdly specific to the logic of Queries::Operators::DateRangeClauses
         expected = base_scope.where("days.date > ? AND days.date <= ?",
                                     (from - 1.day).end_of_day,
                                     to.end_of_day)
+
         expect(instance.results.to_sql).to eql expected.to_sql
       end
     end

--- a/spec/requests/api/v3/days/day_spec.rb
+++ b/spec/requests/api/v3/days/day_spec.rb
@@ -56,5 +56,16 @@ describe ::API::V3::Days::DaysAPI,
 
       it_behaves_like 'API V3 collection response', 6, 6, 'Day'
     end
+
+    context 'when filtering by working' do
+      let(:filters) do
+        [{ working: { operator: '=',
+                      values: ['t'] } }]
+      end
+
+      nb_days = (Time.zone.today.at_beginning_of_month..Time.zone.today.next_month.at_end_of_month)
+                .count { |d| !(d.saturday? || d.sunday?) }
+      it_behaves_like 'API V3 collection response', nb_days, nb_days, 'Day'
+    end
   end
 end


### PR DESCRIPTION
See OP#41816

This is the continuation of #10671. It consists of:

- join the non_working_days table to refine the working status
- adding _links in the DayRepresenter