### PR TITLE
Prevent toasts on loading errors from notifications

### DIFF
--- a/frontend/src/app/core/state/in-app-notifications/in-app-notifications.service.ts
+++ b/frontend/src/app/core/state/in-app-notifications/in-app-notifications.service.ts
@@ -60,10 +60,6 @@ export class InAppNotificationsResourceService {
       .get<IHALCollection<InAppNotification>>(this.notificationsPath + collectionURL)
       .pipe(
         tap((collection) => insertCollectionIntoState(this.store, collection, collectionURL)),
-        catchError((error) => {
-          this.toastService.addError(error);
-          throw error;
-        }),
       );
   }
 

--- a/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.html
+++ b/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.html
@@ -6,10 +6,10 @@
   <op-icon icon-classes="icon-bell"></op-icon>
   <ng-container *ngIf="(unreadCount$ | async) as unreadCount">
     <span
-      *ngIf="unreadCount > 0"
+      *ngIf="unreadCount !== 0"
       class="op-ian-bell--indicator"
       data-qa-selector="op-ian-notifications-count"
-      [textContent]="unreadCount > 99 ? '' : unreadCount"
+      [textContent]="(unreadCount === -1 || unreadCount > 99) ? '' : unreadCount"
     ></span>
   </ng-container>
 </a>

--- a/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.html
+++ b/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.html
@@ -9,7 +9,7 @@
       *ngIf="unreadCount !== 0"
       class="op-ian-bell--indicator"
       data-qa-selector="op-ian-notifications-count"
-      [textContent]="(unreadCount === -1 || unreadCount > 99) ? '' : unreadCount"
+      [textContent]="unreadCountText$ | async"
     ></span>
   </ng-container>
 </a>

--- a/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.ts
+++ b/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.ts
@@ -10,6 +10,7 @@ import {
 import {
   filter,
   map,
+  shareReplay,
   switchMap,
   throttleTime,
 } from 'rxjs/operators';
@@ -41,7 +42,10 @@ export class InAppNotificationBellComponent {
   unreadCount$ = combineLatest([
     this.storeService.unread$,
     this.polling$,
-  ]).pipe(map(([count]) => count));
+  ]).pipe(
+    map(([count]) => count),
+    shareReplay(1),
+  );
 
   unreadCountText$ = this
     .unreadCount$

--- a/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.ts
+++ b/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.ts
@@ -43,6 +43,22 @@ export class InAppNotificationBellComponent {
     this.polling$,
   ]).pipe(map(([count]) => count));
 
+  unreadCountText$ = this
+    .unreadCount$
+    .pipe(
+      map((count) => {
+        if (count > 99) {
+          return '99+';
+        }
+
+        if (count <= 0) {
+          return '';
+        }
+
+        return count;
+      }),
+    );
+
   constructor(
     readonly storeService:IanBellService,
     readonly apiV3Service:ApiV3Service,

--- a/frontend/src/app/features/in-app-notifications/bell/state/ian-bell.service.ts
+++ b/frontend/src/app/features/in-app-notifications/bell/state/ian-bell.service.ts
@@ -6,8 +6,12 @@ import {
   map,
   tap,
   skip,
+  catchError,
 } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import {
+  EMPTY,
+  Observable,
+} from 'rxjs';
 import { IanBellQuery } from 'core-app/features/in-app-notifications/bell/state/ian-bell.query';
 import {
   EffectCallback,
@@ -46,9 +50,16 @@ export class IanBellService {
       .fetchNotifications({ filters: IAN_FACET_FILTERS.unread, pageSize: 0 })
       .pipe(
         map((result) => result.total),
-        tap((count) => {
-          this.store.update({ totalUnread: count });
-        }),
+        tap(
+          (count) => {
+            this.store.update({ totalUnread: count });
+          },
+          (error) => {
+            console.error('Failed to load notifications: %O', error);
+            this.store.update({ totalUnread: -1 });
+          },
+        ),
+        catchError(() => EMPTY),
       );
   }
 


### PR DESCRIPTION
https://community.openproject.org/wp/40506

The error message is non-critical and does not provide any useful information to the user.

- [x] Do not show error message in this case.
- [x] Continue showing a red badge on the notification bell, but remove the number displayed (since that number may no longer be accurate).

I tried to add a feature spec, but couldn't get an appropriate error response without triggering a backend error, which fails the test