### PR TITLE
Bug/42194 special characters in comments not translated in activity view

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -110,7 +110,8 @@ module ApplicationHelper
   end
 
   def format_activity_description(text)
-    html_escape_once(truncate(text.to_s, length: 120).gsub(%r{[\r\n]*<(pre|code)>.*$}m, '...'))
+    truncate_lines(strip_tags(format_text(text.to_s)).html_safe, length: 120)
+      .strip
       .gsub(/[\r\n]+/, '<br />')
       .html_safe
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -109,13 +109,6 @@ module ApplicationHelper
     date == User.current.today ? I18n.t(:label_today).titleize : format_date(date)
   end
 
-  def format_activity_description(text)
-    truncate_lines(strip_tags(format_text(text.to_s)).html_safe, length: 120)
-      .strip
-      .gsub(/[\r\n]+/, '<br />')
-      .html_safe
-  end
-
   def due_date_distance_in_words(date)
     if date
       label = date < Date.today ? :label_roadmap_overdue : :label_roadmap_due_in

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -146,6 +146,22 @@ module SearchHelper
   end
 
   def abbreviated_text(words)
-    h(words.length > 100 ? "#{words.slice(0..44)} ... #{words.slice(-45..-1)}" : words)
+    formatted_words = truncate_formatted_text(words, length: nil)
+
+    abbreviated_words = if formatted_words.length > 100
+                          "#{formatted_words.slice(0..44)} ... #{formatted_words.slice(-44..-1)}"
+                        else
+                          formatted_words
+                        end
+
+    if words[0] == ' '
+      abbreviated_words = " #{abbreviated_words}"
+    end
+
+    if words[-1] == ' ' && words.length > 1
+      abbreviated_words = "#{abbreviated_words} "
+    end
+
+    abbreviated_words
   end
 end

--- a/app/helpers/text_formatting_helper.rb
+++ b/app/helpers/text_formatting_helper.rb
@@ -82,7 +82,7 @@ module TextFormattingHelper
     stripped_text = strip_tags(format_text(text.to_s)).html_safe
 
     if length
-      truncate_lines(stripped_text, length: length)
+      truncate_multiline(stripped_text)
     else
       stripped_text
     end
@@ -90,5 +90,13 @@ module TextFormattingHelper
       .gsub(/[\r\n]+/, '<br />')
       .html_safe
     # rubocop:enable Rails/OutputSafety
+  end
+
+  def truncate_multiline(string)
+    if string.to_s =~ /\A(.{120}).*?$/m
+      "#{$1}..."
+    else
+      string
+    end
   end
 end

--- a/app/helpers/text_formatting_helper.rb
+++ b/app/helpers/text_formatting_helper.rb
@@ -27,7 +27,9 @@
 #++
 
 module TextFormattingHelper
+  include OpenProject::TextFormatting
   extend Forwardable
+
   def_delegators :current_formatting_helper,
                  :wikitoolbar_for
 
@@ -73,5 +75,20 @@ module TextFormattingHelper
     else
       project_preview_context(object, project)
     end
+  end
+
+  def truncate_formatted_text(text, length: 120)
+    # rubocop:disable Rails/OutputSafety
+    stripped_text = strip_tags(format_text(text.to_s)).html_safe
+
+    if length
+      truncate_lines(stripped_text, length: length)
+    else
+      stripped_text
+    end
+      .strip
+      .gsub(/[\r\n]+/, '<br />')
+      .html_safe
+    # rubocop:enable Rails/OutputSafety
   end
 end

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -50,7 +50,7 @@ See COPYRIGHT and LICENSE files for more details.
             <% end %>
             <%= link_to format_activity_title(e.event_title), e.event_path%>
           </div>
-          <div class="description"><%= format_activity_description(e.event_description) %></div>
+          <div class="description"><%= truncate_formatted_text(e.event_description) %></div>
           <div class="author">
             <%= avatar(e.event_author, {class: 'avatar-mini'}) if e.respond_to?(:event_author) %>
             <%= link_to_user(e.event_author) if e.respond_to?(:event_author) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -95,7 +95,7 @@ See COPYRIGHT and LICENSE files for more details.
                   <%= link_to format_activity_title(e.event_title), e.event_url %>
                 </div>
                 <div class="description">
-                  <%= format_activity_description(e.event_description) %>
+                  <%= truncate_formatted_text(e.event_description) %>
                 </div>
               </li>
             <% end -%>

--- a/lib/open_project/text_formatting/truncation.rb
+++ b/lib/open_project/text_formatting/truncation.rb
@@ -36,15 +36,6 @@ module OpenProject
       def truncate_single_line(string, *args)
         truncate(string.to_s, *args).gsub(%r{[\r\n]+}m, ' ').html_safe
       end
-
-      # Truncates at line break after 250 characters
-      def truncate_lines(string, length: 250)
-        if string.to_s =~ /\A(.{#{length}}).*?$/m
-          "#{$1}..."
-        else
-          string
-        end
-      end
     end
   end
 end

--- a/lib/open_project/text_formatting/truncation.rb
+++ b/lib/open_project/text_formatting/truncation.rb
@@ -37,10 +37,9 @@ module OpenProject
         truncate(string.to_s, *args).gsub(%r{[\r\n]+}m, ' ').html_safe
       end
 
-      # Truncates at line break after 250 characters or options[:length]
-      def truncate_lines(string, options = {})
-        length = options[:length] || 250
-        if string.to_s =~ /\A(.{#{length}}.*?)$/m
+      # Truncates at line break after 250 characters
+      def truncate_lines(string, length: 250)
+        if string.to_s =~ /\A(.{#{length}}).*?$/m
           "#{$1}..."
         else
           string

--- a/modules/documents/app/views/documents/_document.html.erb
+++ b/modules/documents/app/views/documents/_document.html.erb
@@ -31,5 +31,5 @@ See COPYRIGHT and LICENSE files for more details.
 <p class="document-category-elements--date"><em><%= format_time(document.updated_at) %></em></p>
 
 <div class="wiki op-uc-container">
-	<%= truncate_formatted_text(document.description, length: 250) %>
+	<%= format_text(document.description) %>
 </div>

--- a/modules/documents/app/views/documents/_document.html.erb
+++ b/modules/documents/app/views/documents/_document.html.erb
@@ -31,5 +31,5 @@ See COPYRIGHT and LICENSE files for more details.
 <p class="document-category-elements--date"><em><%= format_time(document.updated_at) %></em></p>
 
 <div class="wiki op-uc-container">
-	<%= format_text(truncate_lines(document.description)) %>
+	<%= truncate_formatted_text(document.description, length: 250) %>
 </div>

--- a/modules/documents/spec/controllers/documents_controller_spec.rb
+++ b/modules/documents/spec/controllers/documents_controller_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.dirname(__FILE__) + '/../spec_helper'
+require "#{File.dirname(__FILE__)}/../spec_helper"
 
 describe DocumentsController do
   render_views
@@ -40,32 +40,14 @@ describe DocumentsController do
     create(:document_category, project: project, name: "Default Category")
   end
 
-  let(:document) do
+  let!(:document) do
     create(:document, title: "Sample Document", project: project, category: default_category)
   end
 
   current_user { admin }
 
   describe "index" do
-    let(:long_description) do
-      <<-LOREM.strip_heredoc
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit.\
-        Ut egestas, mi vehicula varius varius, ipsum massa fermentum orci,\
-        eget tristique ante sem vel mi. Nulla facilisi.\
-        Donec enim libero, luctus ac sagittis sit amet, vehicula sagittis magna.\
-        Duis ultrices molestie ante, eget scelerisque sem iaculis vitae.\
-        Etiam fermentum mauris vitae metus pharetra condimentum fermentum est pretium.\
-        Proin sollicitudin elementum quam quis pharetra.\
-        Aenean facilisis nunc quis elit volutpat mollis.\
-        Aenean eleifend varius euismod. Ut dolor est, congue eget dapibus eget, elementum eu odio.\
-        Integer et lectus neque, nec scelerisque nisi. EndOfLineHere
-
-        Praesent a nunc lorem, ac porttitor eros.
-      LOREM
-    end
-
     before do
-      document.update(description: long_description)
       get :index, params: { project_id: project.identifier }
     end
 
@@ -77,11 +59,6 @@ describe DocumentsController do
     it "group documents by category, if no other sorting is given" do
       expect(assigns(:grouped)).not_to be_nil
       expect(assigns(:grouped).keys.map(&:name)).to eql [default_category.name]
-    end
-
-    it "renders documents with long descriptions properly" do
-      expect(response.body).to have_selector('.wiki', visible: :all)
-      expect(response.body).to have_selector('.wiki', visible: :all, text: "#{document.description[0..249]}...")
     end
   end
 
@@ -149,7 +126,7 @@ describe DocumentsController do
       it "adds an attachment" do
         document = Document.last
 
-        expect(document.attachments.count).to eql 1
+        expect(document.attachments.count).to be 1
         attachment = document.attachments.first
         expect(uncontainered.reload).to eql attachment
       end

--- a/modules/documents/spec/controllers/documents_controller_spec.rb
+++ b/modules/documents/spec/controllers/documents_controller_spec.rb
@@ -80,9 +80,8 @@ describe DocumentsController do
     end
 
     it "renders documents with long descriptions properly" do
-      expect(response.body).to have_selector('.wiki p', visible: :all)
-      expect(response.body).to have_selector('.wiki p', visible: :all, text: (document.description.split("\n").first + '...'))
-      expect(response.body).to have_selector('.wiki p', visible: :all, text: /EndOfLineHere.../)
+      expect(response.body).to have_selector('.wiki', visible: :all)
+      expect(response.body).to have_selector('.wiki', visible: :all, text: "#{document.description[0..249]}...")
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -32,28 +32,6 @@ describe ApplicationHelper, type: :helper do
   include ApplicationHelper
   include WorkPackagesHelper
 
-  describe 'format_activity_description' do
-    it 'truncates given text' do
-      text = 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lore'
-      expect(format_activity_description(text).size).to eq(123)
-    end
-
-    it 'replaces escaped line breaks with html line breaks and should be html_safe' do
-      text = "Lorem ipsum dolor sit \namet, consetetur sadipscing elitr, sed diam nonumy eirmod\n tempor invidunt"
-      text_html = 'Lorem ipsum dolor sit <br /> amet, consetetur sadipscing elitr, sed diam nonumy eirmod <br /> tempor invidunt'
-      expect(format_activity_description(text))
-        .to be_html_eql(text_html)
-      expect(format_activity_description(text))
-        .to be_html_safe
-    end
-
-    it 'escapes potentially harmful code' do
-      text = "Lorem ipsum dolor <script>alert('pwnd');</script> tempor invidunt"
-      expect(format_activity_description(text))
-        .to include('&lt;script&gt;alert(\'pwnd\');&lt;/script&gt;')
-    end
-  end
-
   describe 'footer_content' do
     context 'no additional footer content' do
       before do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -35,19 +35,22 @@ describe ApplicationHelper, type: :helper do
   describe 'format_activity_description' do
     it 'truncates given text' do
       text = 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lore'
-      expect(format_activity_description(text).size).to eq(120)
+      expect(format_activity_description(text).size).to eq(123)
     end
 
     it 'replaces escaped line breaks with html line breaks and should be html_safe' do
-      text = "Lorem ipsum dolor sit \namet, consetetur sadipscing elitr, sed diam nonumy eirmod\r tempor invidunt"
-      text_html = 'Lorem ipsum dolor sit <br />amet, consetetur sadipscing elitr, sed diam nonumy eirmod<br /> tempor invidunt'
-      expect(format_activity_description(text)).to be_html_eql(text_html)
-      expect(format_activity_description(text).html_safe?).to be_truthy
+      text = "Lorem ipsum dolor sit \namet, consetetur sadipscing elitr, sed diam nonumy eirmod\n tempor invidunt"
+      text_html = 'Lorem ipsum dolor sit <br /> amet, consetetur sadipscing elitr, sed diam nonumy eirmod <br /> tempor invidunt'
+      expect(format_activity_description(text))
+        .to be_html_eql(text_html)
+      expect(format_activity_description(text))
+        .to be_html_safe
     end
 
     it 'escapes potentially harmful code' do
       text = "Lorem ipsum dolor <script>alert('pwnd');</script> tempor invidunt"
-      expect(format_activity_description(text).include?('&lt;script&gt;alert(&#39;pwnd&#39;);&lt;/script&gt;')).to be_truthy
+      expect(format_activity_description(text))
+        .to include('&lt;script&gt;alert(\'pwnd\');&lt;/script&gt;')
     end
   end
 

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -44,7 +44,6 @@ describe 'search/index', type: :helper do
   describe '#highlight_tokens' do
     let(:maximum_length) { 1300 }
 
-    subject { helper.highlight_tokens title, tokens }
     subject(:highlighted_title) { helper.highlight_tokens title, tokens }
 
     context 'with single token' do
@@ -59,7 +58,11 @@ describe 'search/index', type: :helper do
       let(:tokens) { %w(token another) }
       let(:title) { 'This is a token and another token.' }
       let(:expected_title) do
-        'This is a <span class="search-highlight token-0">token</span> and <span class="search-highlight token-1">another</span> <span class="search-highlight token-0">token</span>.'
+        <<~TITLE.squish
+          This is a <span class="search-highlight token-0">token</span>
+          and <span class="search-highlight token-1">another</span>
+          <span class="search-highlight token-0">token</span>.
+        TITLE
       end
 
       it { is_expected.to eq expected_title }
@@ -67,7 +70,7 @@ describe 'search/index', type: :helper do
 
     context 'with huge content' do
       let(:tokens) { %w(token) }
-      let(:title) { (('1234567890' * 100) + ' token ') * 100 }
+      let(:title) { "#{'1234567890' * 100} token " * 100 }
       let(:highlighted_token) { '<span class="search-highlight token-0">token</span>' }
 
       it { expect(highlighted_title).to include highlighted_token }
@@ -79,9 +82,9 @@ describe 'search/index', type: :helper do
 
     context 'with multibyte title' do
       let(:tokens) { %w(token) }
-      let(:title) { ('й' * 200) + ' token ' + ('й' * 200) }
+      let(:title) { "#{'й' * 200} token #{'й' * 200}" }
       let(:expected_title) do
-        ('й' * 45) + ' ... ' + ('й' * 44) + ' <span class="search-highlight token-0">token</span> ' + ('й' * 44) + ' ... ' + ('й' * 45)
+        "#{'й' * 45} ... #{'й' * 44} <span class=\"search-highlight token-0\">token</span> #{'й' * 45} ... #{'й' * 44}"
       end
 
       it { is_expected.to eq expected_title }
@@ -95,7 +98,7 @@ describe 'search/index', type: :helper do
     let(:attachment_filename) { "attachment_filename.txt" }
     let(:journal) { build_stubbed(:work_package_journal, notes: journal_notes) }
     let(:event) do
-      instance_double('WorkPackage',
+      instance_double(WorkPackage,
                       last_journal: journal,
                       last_loaded_journal: journal,
                       event_description: event_description,
@@ -125,7 +128,6 @@ describe 'search/index', type: :helper do
       it 'shows the text in the notes' do
         expect(helper.highlight_tokens_in_event(event, tokens))
           .to eql '<span class="search-highlight token-0">Journals</span> notes'
-
       end
     end
 

--- a/spec/helpers/text_formatting_helper_spec.rb
+++ b/spec/helpers/text_formatting_helper_spec.rb
@@ -57,4 +57,33 @@ describe TextFormattingHelper, type: :helper do
       end
     end
   end
+
+  describe 'truncate_formatted_text' do
+    it 'truncates given text' do
+      text = <<~TEXT.squish
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+        nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+        erat, sed diam voluptua. At vero eos et accusam et justo duo dolores
+        et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem
+        ipsum dolor sit amet. Lore
+      TEXT
+
+      expect(truncate_formatted_text(text).size).to eq(123)
+    end
+
+    it 'replaces escaped line breaks with html line breaks and should be html_safe' do
+      text = "Lorem ipsum dolor sit \namet, consetetur sadipscing elitr, sed diam nonumy eirmod\n tempor invidunt"
+      text_html = 'Lorem ipsum dolor sit <br /> amet, consetetur sadipscing elitr, sed diam nonumy eirmod <br /> tempor invidunt'
+      expect(truncate_formatted_text(text))
+        .to be_html_eql(text_html)
+      expect(truncate_formatted_text(text))
+        .to be_html_safe
+    end
+
+    it 'escapes potentially harmful code' do
+      text = "Lorem ipsum dolor <script>alert('pwnd');</script> tempor invidunt"
+      expect(truncate_formatted_text(text))
+        .to include('&lt;script&gt;alert(\'pwnd\');&lt;/script&gt;')
+    end
+  end
 end


### PR DESCRIPTION
Fixes displaying special chars on the activity as well as on the search list. While special chars are allowed, html tags are stripped.

The truncation on the documents page has been removed since it might have lead to html becoming invalid.

https://community.openproject.org/wp/42194