### PR TITLE
[42479] "Project" is not translated in invite user modal

### DIFF
--- a/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.html
+++ b/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.html
@@ -6,7 +6,7 @@
 
   <div class="op-modal--body op-form">
     <op-form-field
-      label="Project"
+      [label]="text.project.label"
       required
     >
       <op-ium-project-search

--- a/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.ts
+++ b/frontend/src/app/features/invite-user-modal/project-selection/project-selection.component.ts
@@ -36,6 +36,7 @@ export class ProjectSelectionComponent implements OnInit {
   public text = {
     title: this.I18n.t('js.invite_user_modal.title.invite'),
     project: {
+      label: this.I18n.t('js.invite_user_modal.project.label'),
       required: this.I18n.t('js.invite_user_modal.project.required'),
       lackingPermission: this.I18n.t('js.invite_user_modal.project.lacking_permission'),
       lackingPermissionInfo: this.I18n.t('js.invite_user_modal.project.lacking_permission_info'),


### PR DESCRIPTION
Use translated string for "project" label in invite user modal

https://community.openproject.org/projects/openproject/work_packages/42479/activity