### PR TITLE
Fix spacing of "Log time" button in the my spent time widget

### DIFF
--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.sass
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.sass
@@ -1,4 +1,22 @@
 te-calendar
+  // The two media queries below make sure the "Log time" button does not overlap
+  // with the dates on mobile. Instead, it will be shown above the full calendar toolbar.
+  // The media queries are the normal mobile/tablet breakpoints.
+  @media screen and (max-width: 679px)
+    .fc-toolbar-chunk:empty
+      display: none
+
+  @media screen and (min-width: 680px)
+    .te-calendar--create-button
+      position: absolute
+      right: 0
+      top: 0
+      margin-right: 0px
+
+    .fc-toolbar-chunk:last-child
+      flex-basis: 165px
+      flex-shrink: 0
+
   full-calendar
     overflow-x: auto
 
@@ -119,9 +137,3 @@ te-calendar
       margin-right: 5px
       padding-right: 5px
       font-weight: bold
-
-  .te-calendar--create-button
-    position: absolute
-    right: 0
-    top: 6px
-    margin-right: 0px


### PR DESCRIPTION
Changes to the way full calendar CSS was being overwritten caused the
date display to overlap the log time button on the right hand side.

This commit changes the behavior entirely by putting the log time button
above the full calendar toolbar on mobile. On desktop, some spacings
are improved so that the date feels more centered.

Closes https://community.openproject.org/work_packages/42085/activity