### PR TITLE
Feature/42184/date picker banner

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -924,6 +924,13 @@ en:
       comment_send_failed: "An error has occurred. Could not submit the comment."
       comment_updated: "The comment was successfully updated."
       confirm_edit_cancel: "Are you sure you want to cancel editing the work package?"
+      datepicker_modal:
+        automatically_scheduled_parent: "Automatically scheduled. Dates are derived from relations."
+        manually_scheduled: "Manual scheduling enabled, all relations ignored."
+        start_date_limited_by_relations: "Available start date is limited by relations."
+        changing_dates_affects_follow_relations: "Changing these dates will affect dates of related work packages."
+        click_on_show_relations_to_open_gantt: 'Click on "%{button_name}" for GANTT overview.'
+        show_relations: 'Show relations'
       description_filter: "Filter"
       description_enter_text: "Enter text"
       description_options_hide: "Hide options"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -925,10 +925,10 @@ en:
       comment_updated: "The comment was successfully updated."
       confirm_edit_cancel: "Are you sure you want to cancel editing the work package?"
       datepicker_modal:
-        automatically_scheduled_parent: "Automatically scheduled. Dates are derived from relations."
-        manually_scheduled: "Manual scheduling enabled, all relations ignored."
-        start_date_limited_by_relations: "Available start date is limited by relations."
-        changing_dates_affects_follow_relations: "Changing these dates will affect dates of related work packages."
+        automatically_scheduled_parent: "The dates are automatically derived from relations."
+        manually_scheduled: "Manual scheduling is enabled so all existing work package relations are ignored."
+        start_date_limited_by_relations: "Available start and finish dates are limited by relations."
+        changing_dates_affects_follow_relations: "Changing the dates of this work package will change the dates of related work packages."
         click_on_show_relations_to_open_gantt: 'Click on "%{button_name}" for GANTT overview.'
         show_relations: 'Show relations'
       description_filter: "Filter"

--- a/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
@@ -396,6 +396,7 @@ import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
 import { OpenprojectFileLinksModule } from 'core-app/shared/components/file-links/openproject-file-links.module';
 import { FileLinksResourceService } from 'core-app/core/state/file-links/file-links.service';
 import { StoragesResourceService } from 'core-app/core/state/storages/storages.service';
+import { DatepickerBannerComponent } from 'core-app/shared/components/datepicker/banner/datepicker-banner.component';
 
 @NgModule({
   imports: [
@@ -604,6 +605,7 @@ import { StoragesResourceService } from 'core-app/core/state/storages/storages.s
     SaveQueryModalComponent,
     WpDestroyModalComponent,
     DatePickerModalComponent,
+    DatepickerBannerComponent,
 
     // CustomActions
     WpCustomActionComponent,

--- a/frontend/src/app/shared/components/datepicker/banner/datepicker-banner.component.html
+++ b/frontend/src/app/shared/components/datepicker/banner/datepicker-banner.component.html
@@ -1,0 +1,43 @@
+<op-modal-banner
+  *ngIf="scheduleManually && (hasRelations$ | async)"
+  type="warning"
+  [title]="text.manually_scheduled"
+  [subtitle]="text.click_on_show_relations_to_open_gantt"
+  [actionButton]="text.show_relations_button"
+  actionButtonClasses="icon-view-timeline"
+  (buttonClicked)="openGantt($event)"
+>
+</op-modal-banner>
+<op-modal-banner
+  *ngIf="!scheduleManually && isParent"
+  type="info"
+  [title]="text.automatically_scheduled_parent"
+  [subtitle]="text.click_on_show_relations_to_open_gantt"
+  [actionButton]="text.show_relations_button"
+  actionButtonClasses="icon-view-timeline"
+  (buttonClicked)="openGantt($event)"
+>
+</op-modal-banner>
+<ng-container *ngIf="!scheduleManually && !isParent">
+  <op-modal-banner
+    *ngIf="(hasPrecedingRelations$ | async) === true"
+    type="info"
+    [title]="text.start_date_limited_by_relations"
+    [subtitle]="text.click_on_show_relations_to_open_gantt"
+    [actionButton]="text.show_relations_button"
+    actionButtonClasses="icon-view-timeline"
+    (buttonClicked)="openGantt($event)"
+  >
+  </op-modal-banner>
+
+  <op-modal-banner
+    *ngIf="(hasPrecedingRelations$ | async) === false && (hasFollowingRelations$ | async) === true"
+    type="info"
+    [title]="text.changing_dates_affects_follow_relations"
+    [subtitle]="text.click_on_show_relations_to_open_gantt"
+    [actionButton]="text.show_relations_button"
+    actionButtonClasses="icon-view-timeline"
+    (buttonClicked)="openGantt($event)"
+  >
+  </op-modal-banner>
+</ng-container>

--- a/frontend/src/app/shared/components/datepicker/banner/datepicker-banner.component.html
+++ b/frontend/src/app/shared/components/datepicker/banner/datepicker-banner.component.html
@@ -20,7 +20,7 @@
 </op-modal-banner>
 <ng-container *ngIf="!scheduleManually && !isParent">
   <op-modal-banner
-    *ngIf="(hasPrecedingRelations$ | async) === true"
+    *ngIf="(hasPrecedingRelations$ | async) === true && (hasFollowingRelations$ | async) === false"
     type="info"
     [title]="text.start_date_limited_by_relations"
     [subtitle]="text.click_on_show_relations_to_open_gantt"
@@ -31,8 +31,8 @@
   </op-modal-banner>
 
   <op-modal-banner
-    *ngIf="(hasPrecedingRelations$ | async) === false && (hasFollowingRelations$ | async) === true"
-    type="info"
+    *ngIf="(hasFollowingRelations$ | async) === true || isChild"
+    type="warning"
     [title]="text.changing_dates_affects_follow_relations"
     [subtitle]="text.click_on_show_relations_to_open_gantt"
     [actionButton]="text.show_relations_button"

--- a/frontend/src/app/shared/components/datepicker/banner/datepicker-banner.component.ts
+++ b/frontend/src/app/shared/components/datepicker/banner/datepicker-banner.component.ts
@@ -1,0 +1,117 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2022 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Injector,
+  Input,
+} from '@angular/core';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { DatepickerModalService } from 'core-app/shared/components/datepicker/datepicker.modal.service';
+import {
+  map,
+  take,
+} from 'rxjs/operators';
+import { StateService } from '@uirouter/core';
+
+@Component({
+  selector: 'op-datepicker-banner',
+  templateUrl: './datepicker-banner.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DatepickerBannerComponent {
+  @Input() scheduleManually = false;
+
+  hasRelations$ = this.datepickerService.hasRelations$;
+
+  hasPrecedingRelations$ = this
+    .datepickerService
+    .precedingWorkPackages$
+    .pipe(
+      map((relations) => relations?.length > 0),
+    );
+
+  hasFollowingRelations$ = this
+    .datepickerService
+    .followingWorkPackages$
+    .pipe(
+      map((relations) => relations?.length > 0),
+    );
+
+  isParent = this.datepickerService.isParent;
+
+  text = {
+    automatically_scheduled_parent: this.I18n.t('js.work_packages.datepicker_modal.automatically_scheduled_parent'),
+    manually_scheduled: this.I18n.t('js.work_packages.datepicker_modal.manually_scheduled'),
+    start_date_limited_by_relations: this.I18n.t('js.work_packages.datepicker_modal.start_date_limited_by_relations'),
+    changing_dates_affects_follow_relations: this.I18n.t('js.work_packages.datepicker_modal.changing_dates_affects_follow_relations'),
+    click_on_show_relations_to_open_gantt: this.I18n.t(
+      'js.work_packages.datepicker_modal.click_on_show_relations_to_open_gantt',
+      { button_name: this.I18n.t('js.work_packages.datepicker_modal.show_relations') },
+    ),
+    show_relations_button: this.I18n.t('js.work_packages.datepicker_modal.show_relations'),
+  };
+
+  constructor(
+    readonly datepickerService:DatepickerModalService,
+    readonly injector:Injector,
+    readonly I18n:I18nService,
+    readonly state:StateService,
+  ) {}
+
+  openGantt(evt:MouseEvent):void {
+    evt.preventDefault();
+
+    this
+      .datepickerService
+      .getInvolvedWorkPackageIds()
+      .pipe(
+        take(1),
+      )
+      .subscribe((ids) => {
+        const props = {
+          c: ['id', 'subject', 'type', 'status', 'assignee', 'createdAt'],
+          t: 'createdAt:desc',
+          tv: true,
+          f: [{ n: 'id', o: '=', v: ids }],
+        };
+
+        const href = this.state.href(
+          'work-packages.partitioned.list',
+          {
+            query_id: null,
+            projects: null,
+            projectPath: null,
+            query_props: JSON.stringify(props),
+          },
+        );
+        window.open(href, '_blank');
+      });
+  }
+}

--- a/frontend/src/app/shared/components/datepicker/banner/datepicker-banner.component.ts
+++ b/frontend/src/app/shared/components/datepicker/banner/datepicker-banner.component.ts
@@ -66,6 +66,8 @@ export class DatepickerBannerComponent {
 
   isParent = this.datepickerService.isParent;
 
+  isChild = this.datepickerService.isChild;
+
   text = {
     automatically_scheduled_parent: this.I18n.t('js.work_packages.datepicker_modal.automatically_scheduled_parent'),
     manually_scheduled: this.I18n.t('js.work_packages.datepicker_modal.manually_scheduled'),

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.html
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.html
@@ -6,6 +6,7 @@
   data-indicator-name="modal"
   (submit)="save($event)"
 >
+  <op-datepicker-banner [scheduleManually]="scheduleManually"></op-datepicker-banner>
   <div class="op-modal--body form -vertical">
     <div class="form--field op-datepicker-modal--scheduling-action-container">
       <div class="form--field-container">
@@ -34,11 +35,11 @@
               <spot-text-field
                      name="date"
                      class="op-datepicker-modal--date-field"
-                     [ngClass]="{'op-datepicker-modal--date-field_current' : datepickerHelper.isStateOfCurrentActivatedField('date')}"
+                     [ngClass]="{'op-datepicker-modal--date-field_current' : datepickerService.isStateOfCurrentActivatedField('date')}"
                      [ngModel]="dates.date"
                      (ngModelChange)="updateDate('date', $event)"
-                     [showClearButton]="datepickerHelper.isStateOfCurrentActivatedField('date')"
-                     (click)="datepickerHelper.setCurrentActivatedField('date')"
+                     [showClearButton]="datepickerService.isStateOfCurrentActivatedField('date')"
+                     (click)="datepickerService.setCurrentActivatedField('date')"
               ></spot-text-field>
             </div>
           </div>
@@ -63,12 +64,12 @@
                      name="startDate"
                      data-qa-selector="op-datepicker-modal--start-date-field"
                      class="op-datepicker-modal--date-field"
-                     [ngClass]="{'op-datepicker-modal--date-field_current' : datepickerHelper.isStateOfCurrentActivatedField('start')}"
+                     [ngClass]="{'op-datepicker-modal--date-field_current' : datepickerService.isStateOfCurrentActivatedField('start')}"
                      [ngModel]="dates.start"
                      (ngModelChange)="updateDate('start', $event)"
                      [disabled]="!isSchedulable"
-                     [showClearButton]="datepickerHelper.isStateOfCurrentActivatedField('start')"
-                     (focusin)="datepickerHelper.setCurrentActivatedField('start')"
+                     [showClearButton]="datepickerService.isStateOfCurrentActivatedField('start')"
+                     (focusin)="datepickerService.setCurrentActivatedField('start')"
               ></spot-text-field>
             </div>
           </div>
@@ -91,12 +92,12 @@
                      name="endDate"
                      data-qa-selector="op-datepicker-modal--end-date-field"
                      class="op-datepicker-modal--date-field"
-                     [ngClass]="{'op-datepicker-modal--date-field_current' : datepickerHelper.isStateOfCurrentActivatedField('end')}"
+                     [ngClass]="{'op-datepicker-modal--date-field_current' : datepickerService.isStateOfCurrentActivatedField('end')}"
                      [ngModel]="dates.end"
                      (ngModelChange)="updateDate('end', $event)"
                      [disabled]="!isSchedulable"
-                     [showClearButton]="datepickerHelper.isStateOfCurrentActivatedField('end')"
-                     (focusin)="datepickerHelper.setCurrentActivatedField('end')"
+                     [showClearButton]="datepickerService.isStateOfCurrentActivatedField('end')"
+                     (focusin)="datepickerService.setCurrentActivatedField('end')"
               ></spot-text-field>
             </div>
           </div>

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
@@ -8,6 +8,9 @@
   max-width: 730px
   min-height: 200px
   box-shadow: $spot-shadow-light-mid
+  // Apply a bottom margin before the banners are loaded
+  // to avoid overlapping
+  margin-bottom: 60px
 
   &--dates-container
     display: grid

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
@@ -16,6 +16,8 @@
     display: grid
     grid-template-columns: 1fr 1fr 150px
     grid-column-gap: $spot-spacing-1
+    // avoid a jump when the today link is hidden in disabled mode
+    min-height: 90px
 
   &--date-field
     &_current,

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.service.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.service.ts
@@ -80,13 +80,26 @@ export class DatepickerModalService {
     this.followingWorkPackages$,
   ])
     .pipe(
-      map(([precedes, follows]) => precedes.length > 0 || follows.length > 0 || this.isParent),
+      map(([precedes, follows]) => precedes.length > 0 || follows.length > 0 || this.isParent || this.isChild),
     );
 
   constructor(
     @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
     private apiV3Service:ApiV3Service,
   ) {}
+
+  /**
+   * Determines whether the work package is a child. It does so
+   * by checking the ancestors links.
+   */
+  get isChild():boolean {
+    return this.ancestors.length > 0;
+  }
+
+  get ancestors():HalResource[] {
+    const wp = this.changeset.projectedResource;
+    return wp.ancestors || [];
+  }
 
   /**
    * Determines whether the work package is a parent. It does so
@@ -112,6 +125,7 @@ export class DatepickerModalService {
             ...preceding,
             ...following,
             ...this.children,
+            ...this.ancestors,
           ].map((el) => el.id as string),
         ),
       );

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
@@ -49,7 +49,10 @@ import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/r
 import { BrowserDetector } from 'core-app/core/browser/browser-detector.service';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
-import { DayElement } from 'flatpickr/dist/types/instance';
+import {
+  DayElement,
+  Instance,
+} from 'flatpickr/dist/types/instance';
 import flatpickr from 'flatpickr';
 import { DatepickerModalService } from 'core-app/shared/components/datepicker/datepicker.modal.service';
 
@@ -131,22 +134,15 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
   }
 
   ngAfterViewInit():void {
-    if (this.isSchedulable) {
-      this.initializeDatepicker();
-    }
+    this.initializeDatepicker();
 
     this.onDataChange();
   }
 
   changeSchedulingMode():void {
     this.scheduleManually = !this.scheduleManually;
+    this.toggleDisabledState(this.datePickerInstance.datepickerInstance);
     this.cdRef.detectChanges();
-
-    if (this.scheduleManually) {
-      this.initializeDatepicker();
-    } else if (this.datepickerService.isParent) {
-      this.removeDateSelection();
-    }
   }
 
   save($event:Event):void {
@@ -229,10 +225,6 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
     return !this.scheduleManually && !!this.changeset.value('scheduleManually');
   }
 
-  private removeDateSelection() {
-    this.datePickerInstance.destroy();
-  }
-
   private initializeDatepicker() {
     this.datePickerInstance?.destroy();
     this.datePickerInstance = new DatePicker(
@@ -243,9 +235,7 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
         showMonths: this.browserDetector.isMobile ? 1 : 2,
         inline: true,
         onReady: (selectedDates, dateStr, instance) => {
-          if (!this.isSchedulable) {
-            instance.calendarContainer.classList.add('disabled');
-          }
+          this.toggleDisabledState(instance);
         },
         onChange: (dates:Date[]) => {
           this.handleDatePickerChange(dates);
@@ -346,5 +336,13 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
 
   private initialActivatedField():DateKeys {
     return this.locals.fieldName === 'dueDate' ? 'end' : 'start';
+  }
+
+  private toggleDisabledState(instance:Instance) {
+    if (this.isSchedulable) {
+      instance.calendarContainer.classList.remove('disabled');
+    } else {
+      instance.calendarContainer.classList.add('disabled');
+    }
   }
 }

--- a/frontend/src/app/shared/components/datepicker/datepicker_mobile.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/datepicker_mobile.modal.sass
@@ -3,4 +3,4 @@
     height: initial
     width: calc(100vw - 2rem)
     &--dates-container
-      grid-template-columns: 1fr auto
+      grid-template-columns: 1fr max-content

--- a/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.html
+++ b/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.html
@@ -1,0 +1,37 @@
+<div
+  class="op-modal-banner"
+  ngClass="op-modal-banner_{{ type }}"
+  attr.data-qa-selector="op-modal-banner-{{ type }}"
+>
+  <span
+    *ngIf="type === 'info'"
+    class="op-modal-banner--icon spot-icon spot-icon_info1"
+  ></span>
+  <span
+    *ngIf="type === 'warning'"
+    class="op-modal-banner--icon spot-icon spot-icon_warning hidden-for-mobile"
+  ></span>
+  <p
+    class="op-modal-banner--text"
+  >
+    <span
+      class="op-modal-banner--title"
+      [textContent]="title"
+    ></span>
+    <br/>
+    <span
+      class="op-modal-banner--subtitle hidden-for-mobile"
+      [textContent]="subtitle"
+    ></span>
+  </p>
+
+  <button
+    *ngIf="!!actionButton"
+    class="op-modal-banner--button button"
+    type="button"
+    (click)="buttonClicked.emit($event)"
+  >
+    <op-icon icon-classes="button--icon {{ actionButtonClasses }}"></op-icon>
+    <span class="button--text" [textContent]="actionButton"></span>
+  </button>
+</div>

--- a/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.html
+++ b/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.html
@@ -5,11 +5,11 @@
 >
   <span
     *ngIf="type === 'info'"
-    class="op-modal-banner--icon spot-icon spot-icon_info1 hidden-for-mobile"
+    class="spot-icon spot-icon_info1 hidden-for-mobile"
   ></span>
   <span
     *ngIf="type === 'warning'"
-    class="op-modal-banner--icon spot-icon spot-icon_warning hidden-for-mobile"
+    class="spot-icon spot-icon_warning hidden-for-mobile"
   ></span>
   <p
     class="op-modal-banner--text spot-caption"

--- a/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.html
+++ b/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.html
@@ -12,10 +12,10 @@
     class="op-modal-banner--icon spot-icon spot-icon_warning hidden-for-mobile"
   ></span>
   <p
-    class="op-modal-banner--text"
+    class="op-modal-banner--text spot-caption"
   >
     <span
-      class="op-modal-banner--title"
+      class="op-modal-banner--title spot-caption spot-caption_bold"
       [textContent]="title"
     ></span>
     <br/>

--- a/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.html
+++ b/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.html
@@ -5,7 +5,7 @@
 >
   <span
     *ngIf="type === 'info'"
-    class="op-modal-banner--icon spot-icon spot-icon_info1"
+    class="op-modal-banner--icon spot-icon spot-icon_info1 hidden-for-mobile"
   ></span>
   <span
     *ngIf="type === 'warning'"

--- a/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.sass
+++ b/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.sass
@@ -1,0 +1,30 @@
+@import '~app/spot/styles/sass/variables'
+
+.op-modal-banner
+  display: grid
+  grid-template-columns: 20px auto max-content
+  grid-gap: 20px
+  align-items: center
+  padding: 10px 20px
+
+  @media only screen and (max-width: 679px)
+    grid-template-columns: auto max-content
+
+  &_warning
+    background: $spot-color-feedback-warning-light
+
+  &_info
+    background: $spot-color-feedback-info-light
+
+  &--text
+    margin: 0
+    line-height: 1
+
+  &--icon
+    font-size: 20px
+
+  &--title
+    font-weight: bold
+
+  &--button
+    margin: 0

--- a/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.sass
+++ b/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.sass
@@ -3,9 +3,9 @@
 .op-modal-banner
   display: grid
   grid-template-columns: 20px auto max-content
-  grid-gap: 20px
+  grid-gap: $spot-spacing-1
   align-items: center
-  padding: 10px 20px
+  padding: $spot-spacing-0-75
 
   @media only screen and (max-width: 679px)
     grid-template-columns: auto max-content
@@ -15,16 +15,6 @@
 
   &_info
     background: $spot-color-feedback-info-light
-
-  &--text
-    margin: 0
-    line-height: 1
-
-  &--icon
-    font-size: 20px
-
-  &--title
-    font-weight: bold
 
   &--button
     margin: 0

--- a/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.ts
+++ b/frontend/src/app/shared/components/modal/modal-banner/modal-banner.component.ts
@@ -1,0 +1,55 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2022 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+
+@Component({
+  selector: 'op-modal-banner',
+  templateUrl: './modal-banner.component.html',
+  styleUrls: ['./modal-banner.component.sass'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OpModalBannerComponent {
+  @Input() type:'info'|'warning' = 'info';
+
+  @Input() title:string;
+
+  @Input() subtitle:string;
+
+  @Input() actionButton?:string;
+
+  @Input() actionButtonClasses?:string;
+
+  @Output() buttonClicked = new EventEmitter<MouseEvent>();
+}

--- a/frontend/src/app/shared/components/modal/modal.module.ts
+++ b/frontend/src/app/shared/components/modal/modal.module.ts
@@ -5,6 +5,7 @@ import { IconModule } from 'core-app/shared/components/icon/icon.module';
 import { OpModalService } from './modal.service';
 import { OpModalWrapperAugmentService } from './modal-wrapper-augment.service';
 import { OpModalHeaderComponent } from './modal-header.component';
+import { OpModalBannerComponent } from 'core-app/shared/components/modal/modal-banner/modal-banner.component';
 
 @NgModule({
   imports: [
@@ -12,11 +13,18 @@ import { OpModalHeaderComponent } from './modal-header.component';
     FocusModule,
     IconModule,
   ],
-  exports: [OpModalHeaderComponent],
+  exports: [
+    OpModalHeaderComponent,
+    OpModalBannerComponent,
+  ],
   providers: [
     OpModalService,
     OpModalWrapperAugmentService,
   ],
-  declarations: [OpModalHeaderComponent],
+  declarations: [
+    OpModalHeaderComponent,
+    OpModalBannerComponent,
+
+  ],
 })
 export class OpenprojectModalModule { }

--- a/frontend/src/app/spot/styles/sass/common/typography.sass
+++ b/frontend/src/app/spot/styles/sass/common/typography.sass
@@ -32,3 +32,20 @@
   @include spot-caption
   padding: 0
   margin: 0
+
+.spot-header-big,
+.spot-header-small,
+.spot-subheader-big,
+.spot-subheader-small,
+.spot-body-big,
+.spot-body-small,
+.spot-caption
+  &_bold
+    font-weight: bold
+
+  &_italic
+    font-style: italic
+
+  &_regular
+    font-weight: normal
+    font-style: normal

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -289,7 +289,7 @@ describe 'date inplace editor',
       expect(page).to have_no_selector('[data-qa-selector="op-modal-banner-warning"]')
       expect(page).to have_no_selector('[data-qa-selector="op-modal-banner-info"]')
 
-      # When toggling manuallly scheduled
+      # When toggling manually scheduled
       start_date.expect_scheduling_mode manually: false
       start_date.toggle_scheduling_mode
       start_date.expect_scheduling_mode manually: true
@@ -317,16 +317,16 @@ describe 'date inplace editor',
 
       it 'shows a banner that the relations are ignored' do
         expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
-                                      text: 'Manual scheduling enabled, all relations ignored.')
+                                      text: 'Manual scheduling is enabled so all existing work package relations are ignored.')
 
-        # When toggling manuallly scheduled
+        # When toggling manually scheduled
         start_date.expect_scheduling_mode manually: true
         start_date.toggle_scheduling_mode
         start_date.expect_scheduling_mode manually: false
 
         # Expect banner to switch
         expect(page).to have_selector('[data-qa-selector="op-modal-banner-info"] span',
-                                      text: 'Automatically scheduled. Dates are derived from relations.')
+                                      text: 'The dates are automatically derived from relations.')
 
         new_window = window_opened_by { click_on 'Show relations' }
         switch_to_window new_window
@@ -341,15 +341,15 @@ describe 'date inplace editor',
 
       it 'shows a banner that the dates are not editable' do
         expect(page).to have_selector('[data-qa-selector="op-modal-banner-info"] span',
-                                      text: 'Automatically scheduled. Dates are derived from relations.')
+                                      text: 'The dates are automatically derived from relations.')
 
-        # When toggling manuallly scheduled
+        # When toggling manually scheduled
         start_date.expect_scheduling_mode manually: false
         start_date.toggle_scheduling_mode
         start_date.expect_scheduling_mode manually: true
 
         expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
-                                      text: 'Manual scheduling enabled, all relations ignored.')
+                                      text: 'Manual scheduling is enabled so all existing work package relations are ignored.')
 
         new_window = window_opened_by { click_on 'Show relations' }
         switch_to_window new_window
@@ -381,16 +381,16 @@ describe 'date inplace editor',
 
       it 'shows a banner that the relations are ignored' do
         expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
-                                      text: 'Manual scheduling enabled, all relations ignored.')
+                                      text: 'Manual scheduling is enabled so all existing work package relations are ignored.')
 
-        # When toggling manuallly scheduled
+        # When toggling manually scheduled
         start_date.expect_scheduling_mode manually: true
         start_date.toggle_scheduling_mode
         start_date.expect_scheduling_mode manually: false
 
         # Expect new banner info
         expect(page).to have_selector('[data-qa-selector="op-modal-banner-info"] span',
-                                      text: 'Available start date is limited by relations.')
+                                      text: 'Available start and finish dates are limited by relations.')
 
         new_window = window_opened_by { click_on 'Show relations' }
         switch_to_window new_window
@@ -405,15 +405,15 @@ describe 'date inplace editor',
 
       it 'shows a banner that the start date is limited' do
         expect(page).to have_selector('[data-qa-selector="op-modal-banner-info"] span',
-                                      text: 'Available start date is limited by relations.')
+                                      text: 'Available start and finish dates are limited by relations.')
 
-        # When toggling manuallly scheduled
+        # When toggling manually scheduled
         start_date.expect_scheduling_mode manually: false
         start_date.toggle_scheduling_mode
         start_date.expect_scheduling_mode manually: true
 
         expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
-                                      text: 'Manual scheduling enabled, all relations ignored.')
+                                      text: 'Manual scheduling is enabled so all existing work package relations are ignored.')
       end
     end
   end
@@ -439,15 +439,16 @@ describe 'date inplace editor',
 
       it 'shows a banner that the relations are ignored' do
         expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
-                                      text: 'Manual scheduling enabled, all relations ignored.')
+                                      text: 'Manual scheduling is enabled so all existing work package relations are ignored.')
 
-        # When toggling manuallly scheduled
+        # When toggling manually scheduled
         start_date.expect_scheduling_mode manually: true
         start_date.toggle_scheduling_mode
         start_date.expect_scheduling_mode manually: false
 
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-info"] span',
-                                      text: 'Changing these dates will affect dates of related work packages.')
+        expect(page)
+          .to have_selector('[data-qa-selector="op-modal-banner-info"] span',
+                            text: 'Changing the dates of this work package will change the dates of related work packages.')
 
         new_window = window_opened_by { click_on 'Show relations' }
         switch_to_window new_window
@@ -461,16 +462,17 @@ describe 'date inplace editor',
       let(:schedule_manually) { false }
 
       it 'shows a banner that the start date is limited' do
-        expect(page).to have_selector('[data-qa-selector="op-modal-banner-info"] span',
-                                      text: 'Changing these dates will affect dates of related work packages.')
+        expect(page)
+          .to have_selector('[data-qa-selector="op-modal-banner-info"] span',
+                            text: 'Changing the dates of this work package will change the dates of related work packages.')
 
-        # When toggling manuallly scheduled
+        # When toggling manually scheduled
         start_date.expect_scheduling_mode manually: false
         start_date.toggle_scheduling_mode
         start_date.expect_scheduling_mode manually: true
 
         expect(page).to have_selector('[data-qa-selector="op-modal-banner-warning"] span',
-                                      text: 'Manual scheduling enabled, all relations ignored.')
+                                      text: 'Manual scheduling is enabled so all existing work package relations are ignored.')
       end
     end
   end


### PR DESCRIPTION
**Acceptance criteria**

- [x]   The banner can be in two different colours (or not existent at all)
- [x]   There can be two types of banners:
    - [x]   An **information banner** has a blue background
    - [x]  A **warning banner**  has an orange background
- [x]   There are 4 identified cases in which this banner is displayed:
    - [x]   **Warning:** Manual scheduling is enabled so all existing work package relations are ignored. (This is only visible when the work package in question has relations; a manually scheduled work package with no relations will not show this banner).
    - [x]   **Warning:** Changing the dates of this work package will change the dates of related work packages
    - [x]  **Information:** Available start and finish dates are limited by relations.
    - [x]  **Information:** The dates are automatically derived from relations (and date input is disabled).
- [x]   Structure (may already be done in <mention class="mention" data-id="41814" data-type="work_package" data-text="#41814">#41814</mention> )
    - [x]   an icon
    - [x]   two-line message, the first in bold
    - [x]   a &quot;Show relations&quot; button that, when clicked, opens up a GANTT preview in a new window
        - [x]   This is a filtered work package list (table view + GANTT view) showing only work packages related to the &quot;main&quot; work package (the one for which the GANTT preview was requested).
    - [x]   The mobile date picker displays a simplified version of the banner:
        - [x]   Without the left-side icon
        - [x]   Without the second line of text (only the first line is displayed)
        - [x]  With the usual &quot;Show relations&quot; button.


https://community.openproject.org/wp/42184
