### PR TITLE
turn manage_overviews into manageable permission

### DIFF
--- a/modules/calendar/spec/features/calendar_widget_spec.rb
+++ b/modules/calendar/spec/features/calendar_widget_spec.rb
@@ -27,34 +27,33 @@
 #++
 
 require 'spec_helper'
-require_relative './shared_context'
 require_relative '../../../overviews/spec/support/pages/overview'
 
 describe 'Calendar drag&dop and resizing', type: :feature, js: true do
-  include_context 'with calendar full access'
-
-  let!(:other_user) do
-    create :user,
-           firstname: 'Bernd',
-           member_in_project: project,
-           member_with_permissions: %w[
-             view_work_packages view_calendar
-           ]
+  let(:project) do
+    create(:project, enabled_module_names: %w[work_package_tracking calendar_view])
   end
-
   let!(:work_package) do
     create :work_package,
            project: project,
            start_date: Time.zone.today.beginning_of_week.next_occurring(:tuesday),
            due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
   end
+
   let(:overview_page) do
     Pages::Overview.new(project)
   end
   let(:wp_full_view) { Pages::FullWorkPackage.new(work_package, project) }
 
+  current_user do
+    create :user,
+           member_in_project: project,
+           member_with_permissions: %w[
+             view_work_packages view_calendar manage_overview
+           ]
+  end
+
   before do
-    login_as current_user
     overview_page.visit!
   end
 

--- a/modules/overviews/lib/overviews/engine.rb
+++ b/modules/overviews/lib/overviews/engine.rb
@@ -23,7 +23,7 @@ module Overviews
         ac_map.project_module nil do |map|
           map.permission :manage_overview,
                          { 'overviews/overviews': ['show'] },
-                         public: true
+                         require: :member
         end
       end
     end
@@ -31,7 +31,7 @@ module Overviews
     patch_with_namespace :OpenProject, :TextFormatting, :Formats, :Markdown, :TextileConverter
 
     initializer 'overviews.conversion' do
-      require Rails.root.join('config', 'constants', 'ar_to_api_conversions')
+      require Rails.root.join('config/constants/ar_to_api_conversions')
 
       Constants::ARToAPIConversions.add('grids/overview': 'grid')
     end

--- a/modules/overviews/lib/overviews/grid_registration.rb
+++ b/modules/overviews/lib/overviews/grid_registration.rb
@@ -99,7 +99,7 @@ module Overviews
         # of the application prevent a user from saving arbitrary pages.
         # Only the default config is allowed and only one page per project is allowed.
         # That way, a new page can be created on the fly without the user noticing.
-        super || grid.new_record?
+        super || (grid.new_record? && user.allowed_to?(:view_project, grid.project))
       end
     end
   end

--- a/modules/overviews/spec/contracts/grids/create_contract_spec.rb
+++ b/modules/overviews/spec/contracts/grids/create_contract_spec.rb
@@ -91,7 +91,8 @@ describe Grids::CreateContract, 'for Grids::Overview' do
   end
 
   context 'if the user lacks :manage_overview permission' do
-    let(:permissions) { [] }
+    # View project is a public permission so every member will have it but as we stub...
+    let(:permissions) { [:view_project] }
 
     before do
       # Have to remove the widgets (members, work_package_overview) that is not allowed to the user

--- a/modules/overviews/spec/contracts/roles/base_contract_spec.rb
+++ b/modules/overviews/spec/contracts/roles/base_contract_spec.rb
@@ -1,0 +1,64 @@
+#  OpenProject is an open source project management software.
+#  Copyright (C) 2010-2022 the OpenProject GmbH
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License version 3.
+#
+#  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+#  Copyright (C) 2006-2013 Jean-Philippe Lang
+#  Copyright (C) 2010-2013 the ChiliProject Team
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#  See COPYRIGHT and LICENSE files for more details.
+
+require 'spec_helper'
+
+describe Roles::BaseContract do
+  let(:member_role) { build_stubbed(:role) }
+  let(:global_role) { build_stubbed(:global_role) }
+  let(:anonymous_role) { build_stubbed(:anonymous_role) }
+  let(:current_user) { build_stubbed(:admin) }
+  let(:contract) { described_class.new(role, current_user) }
+
+  describe 'assignable_permissions' do
+    context 'for a member role' do
+      let(:role) { member_role }
+
+      it 'includes manage_overview' do
+        expect(contract.assignable_permissions.map(&:name))
+          .to include :manage_overview
+      end
+    end
+
+    context 'for a global role' do
+      let(:role) { global_role }
+
+      it 'does not include manage_overview' do
+        expect(contract.assignable_permissions.map(&:name))
+          .not_to include :manage_overview
+      end
+    end
+
+    context 'for a builtin role' do
+      let(:role) { anonymous_role }
+
+      it 'does not include manage_overview' do
+        expect(contract.assignable_permissions.map(&:name))
+          .not_to include :manage_overview
+      end
+    end
+  end
+end

--- a/modules/overviews/spec/lib/overview/grid_registration_spec.rb
+++ b/modules/overviews/spec/lib/overview/grid_registration_spec.rb
@@ -6,37 +6,38 @@ describe Overviews::GridRegistration do
   let(:grid) { build_stubbed(:overview, project: project) }
 
   describe 'writable?' do
-    let(:allowed) { true }
+    let(:permissions) { %i[manage_overview view_project] }
+
     before do
       allow(user)
-        .to receive(:allowed_to?)
-        .with(:manage_overview, project)
-        .and_return(allowed)
+        .to receive(:allowed_to?) do |queried_permission, queried_project|
+        project == queried_project && permissions.include?(queried_permission)
+      end
     end
 
     context 'if the user has the :manage_overview permission' do
       it 'is truthy' do
-        expect(described_class.writable?(grid, user))
-          .to be_truthy
+        expect(described_class)
+          .to be_writable(grid, user)
       end
     end
 
     context 'if the user lacks the :manage_overview permission and it is a persisted page' do
-      let(:allowed) { false }
+      let(:permissions) { %i[view_project] }
 
       it 'is falsey' do
-        expect(described_class.writable?(grid, user))
-          .to be_falsey
+        expect(described_class)
+          .not_to be_writable(grid, user)
       end
     end
 
     context 'if the user lacks the :manage_overview permission and it is a new record' do
-      let(:allowed) { false }
+      let(:permissions) { %i[view_project] }
       let(:grid) { Grids::Overview.new **attributes_for(:overview).merge(project: project) }
 
       it 'is truthy' do
-        expect(described_class.writable?(grid, user))
-          .to be_truthy
+        expect(described_class)
+          .to be_writable(grid, user)
       end
     end
   end

--- a/modules/overviews/spec/requests/api/v3/grids/grids_resource_spec.rb
+++ b/modules/overviews/spec/requests/api/v3/grids/grids_resource_spec.rb
@@ -113,9 +113,12 @@ describe 'API v3 Grids resource', type: :request, content_type: :json do
       expect(subject.body)
         .to be_json_eql('Grid'.to_json)
               .at_path('_type')
-      expect(subject.body)
-        .to be_json_eql(params['rowCount'].to_json)
-              .at_path('rowCount')
+
+      if params["rowCount"]
+        expect(subject.body)
+          .to be_json_eql(params['rowCount'].to_json)
+                .at_path('rowCount')
+      end
     end
 
     it 'persists the grid' do
@@ -131,11 +134,11 @@ describe 'API v3 Grids resource', type: :request, content_type: :json do
 
     let(:params) do
       {
-        "rowCount": 10,
-        "columnCount": 15,
-        "_links": {
-          "scope": {
-            "href": project_overview_path(project)
+        rowCount: 10,
+        columnCount: 15,
+        _links: {
+          scope: {
+            href: project_overview_path(project)
           }
         }
       }.with_indifferent_access
@@ -147,14 +150,40 @@ describe 'API v3 Grids resource', type: :request, content_type: :json do
 
     it_behaves_like 'creates a grid resource'
 
-    context 'if lacking the manage_overview permission' do
-      # Since manage_overview is a public permission, being a member in the project will grant the permission
-      # which is why this test case is the same as the one above
+    context 'if lacking the manage_overview permission and not changing the default values' do
+      # Creating a grid should be possible for every member in the project to avoid having an empty page for the project
+      # which is why this test case is the same as the one above.
+      # But this is only true if only the scope is provided and no other attribute.
       let(:permissions) { %i[] }
+      let(:params) do
+        {
+          _links: {
+            scope: {
+              href: project_overview_path(project)
+            }
+          }
+        }.with_indifferent_access
+      end
 
       it_behaves_like 'creates a grid resource'
     end
 
+    context 'if lacking the manage_overview permission and changing the default values' do
+      # Creating a grid should be possible for every member in the project to avoid having an empty page for the project
+      # which is why this test case is the same as the one above.
+      # But this is only true if only the scope is provided and no other attribute.
+      # In this test, the rowCount and columnCount is changed
+      let(:permissions) { %i[] }
+
+      it 'responds with 422' do
+        expect(subject.status).to eq(422)
+      end
+
+      it 'persists no grid' do
+        expect(Grids::Grid.count)
+          .to be(0)
+      end
+    end
 
     context 'if not being a member in the project' do
       current_user do


### PR DESCRIPTION
The `manage_overview` permission used to be `public` so that every user having any permission in the project was able to modify the overview page.

This is now changed so that the permission needs to be granted explicitly and can only be granted to members (non member/anonymous role excluded).

https://community.openproject.org/wp/42732