### PR TITLE
Fix logging out the user after multiple visits with auth source sso

### DIFF
--- a/app/controllers/concerns/auth_source_sso.rb
+++ b/app/controllers/concerns/auth_source_sso.rb
@@ -29,7 +29,11 @@ module AuthSourceSSO
     logged_user = match_sso_with_logged_user(login, user)
 
     # Return the logged in user if matches
-    return logged_user if logged_user.present?
+    # but remember it came from auth_source_sso
+    if logged_user.present?
+      session[:user_from_auth_header] = true
+      return logged_user
+    end
 
     Rails.logger.debug { "Starting header-based auth source SSO for #{header_name}='#{op_auth_header_value}'" }
 

--- a/spec/features/auth/auth_source_sso_logout_spec.rb
+++ b/spec/features/auth/auth_source_sso_logout_spec.rb
@@ -1,0 +1,67 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+Capybara.register_driver :auth_source_sso do |app|
+  Capybara::RackTest::Driver.new(app, headers: { 'HTTP_X_REMOTE_USER' => 'bob' })
+end
+
+describe 'Login with auth source SSO',
+         type: :feature,
+         driver: :auth_source_sso do
+  before do
+    allow(OpenProject::Configuration)
+      .to receive(:auth_source_sso)
+            .and_return(sso_config)
+  end
+
+  let(:sso_config) do
+    {
+      header: 'X-Remote-User',
+      logout_url: 'http://google.com/'
+    }
+  end
+
+  let(:auth_source) { create :auth_source }
+  let!(:user) { create(:user, login: 'bob', auth_source: auth_source) }
+
+  it 'can log out after multiple visits' do
+    visit home_path
+
+    expect(page).to have_selector('.controller-homescreen')
+
+    visit home_path
+
+    expect(page).to have_selector('.controller-homescreen')
+
+    visit signout_path
+
+    expect(current_url).to eq 'http://google.com/'
+  end
+end


### PR DESCRIPTION
An optimization returned the user early if the logged in user matches the user from the auth header. In this case, the session was not populated with user_from_auth_source marker.

In turn, when logging out, the user was no longer redirected correctly.

https://community.openproject.org/wp/42735