### PR TITLE
optimize db after upgrade to prevent performance issues

### DIFF
--- a/docker/prod/postgres-db-upgrade
+++ b/docker/prod/postgres-db-upgrade
@@ -31,3 +31,4 @@ fi
 
 cd /var/lib/postgresql
 su -m postgres -c "$PGBINNEW/pg_upgrade"
+su -m postgres -c "./analyze_new_cluster.sh"


### PR DESCRIPTION
analyze_new_cluster.sh is generated in the working directory by pg_upgrade which recommends to call it, and for good reason