### PR TITLE
Bug/41428 trailing slash in relative url root breaks assets bis

### DIFF
--- a/app/helpers/frontend_asset_helper.rb
+++ b/app/helpers/frontend_asset_helper.rb
@@ -30,7 +30,7 @@ module FrontendAssetHelper
   CLI_DEFAULT_PROXY = 'http://localhost:4200'.freeze
 
   def self.assets_proxied?
-    !ENV['OPENPROJECT_DISABLE_DEV_ASSET_PROXY'].present? && !Rails.env.production? && cli_proxy?
+    ENV['OPENPROJECT_DISABLE_DEV_ASSET_PROXY'].blank? && !Rails.env.production? && cli_proxy?
   end
 
   def self.cli_proxy
@@ -47,10 +47,10 @@ module FrontendAssetHelper
   def include_frontend_assets
     capture do
       %w(vendor.js polyfills.js runtime.js main.js).each do |file|
-        concat javascript_include_tag variable_asset_path(file)
+        concat javascript_include_tag variable_asset_path(file), skip_pipeline: true
       end
 
-      concat stylesheet_link_tag variable_asset_path("styles.css"), media: :all
+      concat stylesheet_link_tag variable_asset_path("styles.css"), media: :all, skip_pipeline: true
     end
   end
 
@@ -60,10 +60,9 @@ module FrontendAssetHelper
     URI.join(FrontendAssetHelper.cli_proxy, "assets/frontend/#{path}")
   end
 
-  def frontend_asset_path(unhashed, options = {})
+  def frontend_asset_path(unhashed)
     file_name = ::OpenProject::Assets.lookup_asset unhashed
-
-    asset_path "assets/frontend/#{file_name}", options.merge(skip_pipeline: true)
+    "/assets/frontend/#{file_name}"
   end
 
   def variable_asset_path(path)

--- a/lib/open_project/assets.rb
+++ b/lib/open_project/assets.rb
@@ -54,7 +54,7 @@ module OpenProject
         @manifest ||= begin
           JSON.parse File.read(manifest_path)
         rescue StandardError => e
-          Rails.logger.error "Failed to read frontend manifest file: #{e} #{e.message}."
+          Rails.logger.error "Failed to read frontend manifest file: #{e}."
           {}
         end
       end

--- a/spec/helpers/frontend_asset_helper_spec.rb
+++ b/spec/helpers/frontend_asset_helper_spec.rb
@@ -1,0 +1,74 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+
+describe FrontendAssetHelper, type: :helper do
+  describe '#include_frontend_assets' do
+    context 'when in development or test' do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(false)
+        stub_const('ENV', 'OPENPROJECT_DISABLE_DEV_ASSET_PROXY' => '')
+      end
+
+      it 'returns the proxied frontend server' do
+        expect(helper.include_frontend_assets).to include('script src="http://localhost:4200/assets/frontend/main.js"')
+      end
+    end
+
+    context 'when in production' do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      it 'returns the path to the asset' do
+        expect(helper.include_frontend_assets).to include('script src="/assets/frontend/main.js"')
+      end
+
+      context 'when using relative_url_root' do
+        before do
+          controller.config.relative_url_root = "/openproject"
+        end
+
+        it 'prepends it to the asset path' do
+          expect(helper.include_frontend_assets).to include('script src="/openproject/assets/frontend/main.js"')
+        end
+      end
+
+      context 'when using relative_url_root ending with a slash' do
+        before do
+          controller.config.relative_url_root = "/openproject/"
+        end
+
+        it 'prepends it to the asset path only once (bug #41428)' do
+          expect(helper.include_frontend_assets).to include('script src="/openproject/assets/frontend/main.js"')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[#41428] Trailing slash in relative_url_root breaks assets

https://community.openproject.org/work_packages/41428

Same as #10742 but against release/12.1
    
The asset_tag helper was called twice, and thus added the relative_url_root twice.

It still worked when the relative_url_root did not end with a slash because `unless source.start_with?("#{relative_url_root}/")` was checked in the helper.

See https://github.com/rails/rails/blob/920fcce54c9e112dc724d587e58182c5603de2d0/actionview/lib/action_view/helpers/asset_url_helper.rb#L207-L210

Calling the asset_tag helper once fixed it.