### PR TITLE
Add compact version of spot-list

### DIFF
--- a/frontend/src/app/spot/spot-docs.component.html
+++ b/frontend/src/app/spot/spot-docs.component.html
@@ -115,6 +115,8 @@ Currently selected value is {{ toggleValue }}
 
 <h1>Lists</h1>
 
+<h2>Normal list</h2>
+
 <ul class="spot-list">
   <li class="spot-list--item">
     <label class="spot-list--item-action">
@@ -134,6 +136,54 @@ Currently selected value is {{ toggleValue }}
           <div class="spot-list--item-title">Child checkbox item</div>
         </label>
         <ul class="spot-list">
+          <li class="spot-list--item">
+            <label class="spot-list--item-action">
+              <spot-checkbox [(ngModel)]="listCheckboxValue"></spot-checkbox>
+              <div class="spot-list--item-title">Secon level child</div>
+            </label>
+          </li>
+        </ul>
+      </li>
+      <li class="spot-list--item">
+        <label class="spot-list--item-action">
+          <spot-checkbox [(ngModel)]="listCheckboxValue"></spot-checkbox>
+          <div class="spot-list--item-title">Second child checkbox item</div>
+        </label>
+      </li>
+      <li class="spot-list--item">
+        <label class="spot-list--item-action spot-list--item-action_disabled">
+          <spot-checkbox
+            [(ngModel)]="listCheckboxValue"
+            [disabled]="true"
+          ></spot-checkbox>
+          <div class="spot-list--item-title">Disabled item</div>
+        </label>
+      </li>
+    </ul>
+  </li>
+</ul>
+
+<h2>Compact list</h2>
+
+<ul class="spot-list spot-list_compact">
+  <li class="spot-list--item">
+    <label class="spot-list--item-action">
+      <spot-checkbox [(ngModel)]="listCheckboxValue"></spot-checkbox>
+      <div class="spot-list--item-title">Checkbox item</div>
+    </label>
+  </li>
+  <li class="spot-list--item">
+    <label class="spot-list--item-action">
+      <spot-checkbox [(ngModel)]="listCheckboxValue"></spot-checkbox>
+      <div class="spot-list--item-title">Checkbox item with children</div>
+    </label>
+    <ul class="spot-list spot-list_compact">
+      <li class="spot-list--item">
+        <label class="spot-list--item-action">
+          <spot-checkbox [(ngModel)]="listCheckboxValue"></spot-checkbox>
+          <div class="spot-list--item-title">Child checkbox item</div>
+        </label>
+        <ul class="spot-list spot-list_compact">
           <li class="spot-list--item">
             <label class="spot-list--item-action">
               <spot-checkbox [(ngModel)]="listCheckboxValue"></spot-checkbox>

--- a/frontend/src/app/spot/styles/sass/components/list.sass
+++ b/frontend/src/app/spot/styles/sass/components/list.sass
@@ -23,7 +23,7 @@
       cursor: pointer
 
       &:hover
-        background-color: $spot-color-main-light
+        background-color: $spot-color-basic-gray-6
 
       &_disabled
         color: $spot-color-basic-gray-3
@@ -37,7 +37,10 @@
       &:not(:last-child)
         margin-left: $spot-spacing-0_5
 
-  &_compact &--item
+  &_compact &--item:not(:first-child)
+    margin-top: $spot-spacing-0_25
+
+  &--item > &_compact > &--item:first-child
     margin-top: $spot-spacing-0_25
 
   &_compact &--item-action

--- a/frontend/src/app/spot/styles/sass/components/list.sass
+++ b/frontend/src/app/spot/styles/sass/components/list.sass
@@ -16,7 +16,7 @@
       display: flex
       align-items: center
       justify-content: flex-start
-      padding: $spot-spacing-0_5
+      padding: $spot-spacing-0_5 $spot-spacing-1
       background-color: transparent
       margin: 0
       border: 0
@@ -37,9 +37,15 @@
       &:not(:last-child)
         margin-left: $spot-spacing-0_5
 
+  &_compact &--item
+    margin-top: $spot-spacing-0_25
+
+  &_compact &--item-action
+    padding: $spot-spacing-0_25 $spot-spacing-1
+
   $item-list: ""
-  @for $i from 1 through 10
+  @for $i from 0 through 10
     $item-list: list.append($item-list, ".spot-list--item")
 
     #{$item-list} .spot-list--item-action
-      padding-left: $i * $spot-spacing-1
+      padding-left: $spot-spacing-1 + ($i * $spot-spacing-1)


### PR DESCRIPTION
This adds the modifier `spot-list_compact`, which compresses `spot-list`
vertically by reducing paddings. It also increases the padding on the
right hand side of items, since it differed from the left.

This is a small change that will make spot-list look nice within the work package split-screen.

Relates to https://community.openproject.org/projects/openproject/work_packages/40203/activity?query_id=3115