### PR TITLE
[chore] removed negative margin from icons in spot links

### DIFF
--- a/frontend/src/app/spot/spot-docs.component.html
+++ b/frontend/src/app/spot/spot-docs.component.html
@@ -58,6 +58,10 @@
     <span>Default Link</span>
     <span class="spot-icon spot-icon_bell"></span>
   </a>
+  <a class="spot-link" href="#">
+    <span class="spot-icon spot-icon_bell"></span>
+    <span>Default Link</span>
+  </a>
   <button class="spot-link"><span class="spot-icon spot-icon_bell"></span></button>
 </section>
 
@@ -66,6 +70,10 @@
   <a class="spot-link spot-link_danger" href="#">
     <span>Danger Link</span>
     <span class="spot-icon spot-icon_bell"></span>
+  </a>
+  <a class="spot-link spot-link_danger" href="#">
+    <span class="spot-icon spot-icon_bell"></span>
+    <span>Danger Link</span>
   </a>
   <button class="spot-link spot-link_danger"><span class="spot-icon spot-icon_bell"></span></button>
 </section>

--- a/frontend/src/app/spot/styles/sass/components/link.sass
+++ b/frontend/src/app/spot/styles/sass/components/link.sass
@@ -30,20 +30,11 @@
     width: $spot-spacing-1_5
     height: $spot-spacing-1_5
 
-    &:first-child
-      margin-left: -$spot-spacing-0_25
-
-      &:not(:last-child)
+    &:first-child:not(:last-child)
         margin-right: $spot-spacing-0_25
 
-    &:last-child
-      margin-right: -$spot-spacing-0_25
-
-      &:not(:first-child)
+    &:last-child:not(:first-child)
         margin-left: $spot-spacing-0_25
-
-    &:first-child:last-child
-      margin: 0 -$spot-spacing-0_5
 
   // Ensure op-icon within a link gets inline-block
   // to avoid it receiving any text-decoration on hover


### PR DESCRIPTION
While styling the file link list with partial spot components, I realized those negative marginson `spot-link`. They lead to some strange overwrites I need to do.

Question to @HDinger : Why are those there? Can they be removed?