### PR TITLE
Fix/improve scheduling performance

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -156,6 +156,7 @@ class WorkPackage < ApplicationRecord
                      # sort by id so that limited eager loading doesn't break with postgresql
                      order_column: "#{table_name}.id"
 
+  # makes virtual modal WorkPackageHierarchy available
   has_closure_tree
 
   ##################### WARNING #####################

--- a/app/models/work_package/scheduling_rules.rb
+++ b/app/models/work_package/scheduling_rules.rb
@@ -35,18 +35,18 @@ module WorkPackage::SchedulingRules
 
   # TODO: move into work package contract (possibly a module included into the contract)
   # Calculates the minimum date that
-  # will not violate the precedes relations (max(finish date, start date) + delay)
+  # will not violate the precedes relations (max(finish date, start date) + relation delay)
   # of this work package or its ancestors
   # e.g.
-  # AP(due_date: 2017/07/24, delay: 1)-precedes-A
+  # AP(due_date: 2017/07/24)-precedes(delay: 1)-A
   #                                             |
   #                                           parent
   #                                             |
-  # BP(due_date: 2017/07/22, delay: 2)-precedes-B
+  # BP(due_date: 2017/07/22)-precedes(delay: 2)-B
   #                                             |
   #                                           parent
   #                                             |
-  # CP(due_date: 2017/07/25, delay: 2)-precedes-C
+  # CP(due_date: 2017/07/25)-precedes(delay: 2)-C
   #
   # Then soonest_start for:
   #   C is 2017/07/27

--- a/app/models/work_packages/scopes/for_scheduling.rb
+++ b/app/models/work_packages/scopes/for_scheduling.rb
@@ -32,49 +32,77 @@ module WorkPackages::Scopes
     extend ActiveSupport::Concern
 
     class_methods do
-      # Fetches all work packages that need to be evaluated for eventual rescheduling after a related (i.e. follows/precedes
-      # and hierarchy) work package is modified or created.
+      # Fetches all work packages that need to be evaluated for eventual
+      # rescheduling after a related (i.e. follows/precedes and hierarchy) work
+      # package is modified or created.
       #
-      # The SQL relies on a recursive CTE which will fetch all work packages that are connected to the rescheduled work package
-      # via relations (follows/precedes and/or hierarchy) either directly or transitively. It will do so by increasing the
-      # relation path length one at a time and will stop on that path if the work package evaluated to be added is either:
-      # * itself scheduled manually
-      # * having all of it's children scheduled manually
+      # The SQL relies on a recursive CTE which will fetch all work packages
+      # that are connected to the rescheduled work packages via relations
+      # (follows/precedes and/or hierarchy) either directly or transitively. It
+      # will do so by increasing the relation path length one at a time and will
+      # stop on that path if the work package evaluated to be added is either:
       #
-      # The children themselves are scheduled manually if all of their children are scheduled manually which repeats itself down
-      # to the leaf work packages. So another way of putting it, and that is how the sql statement works, is that a work package
-      # is considered to be scheduled manually if *all* of its descendants are scheduled manually.
+      #   * itself scheduled manually
+      #   * having all of it's children scheduled manually
+      #
+      # The children themselves are scheduled manually if all of their children
+      # are scheduled manually which repeats itself down to the leaf work
+      # packages. So another way of putting it, and that is how the sql
+      # statement works, is that a work package is considered to be scheduled
+      # manually if *all* of its descendants are scheduled manually.
+      #
       # For example in case of the hierarchy:
-      # A and B <- hierarchy (C is parent of both A and B) - C <- hierarchy - D
-      # if A and B are both scheduled manually, C is also scheduled manually and so is D. But if only A is scheduled manually,
-      # B, C and D are scheduled automatically. If only C is scheduled manually, then D is still scheduled automatically since
-      # A and B are scheduled manually.
+      #   A and B <- hierarchy (C is parent of both A and B) - C <- hierarchy - D
+      # * A and B are work packages
+      # * C is parent of A and B
+      # * D is parent of C
       #
-      # The recursion will of course also stop if no more work packages can be added.
+      # * If A and B are both scheduled manually, then C is also scheduled
+      #   manually and so is D.
+      # * If only A is scheduled manually, then B, C and D are scheduled
+      #   automatically.
+      # * If only C is scheduled manually, then D is still scheduled
+      #   automatically since A and B are scheduled automatically.
       #
-      # The work packages can either be connected via a follows relationship, a hierarchy relationship
-      # or a combination of both.
+      # The recursion will of course also stop if no more work packages can be
+      # added.
+      #
+      # The work packages can either be connected via a follows relationship, a
+      # hierarchy relationship or a combination of both.
+      #
       # E.g. in a graph of
       #   A  <- follows - B <- hierarchy (C is parent of B) - C <- follows D
+      # * B is a successor of A
+      # * C is parent of B
+      # * D is successor of C
       #
-      # D would also be subject to reschedule.
+      # When considering A, D would also be subject to reschedule.
       #
-      # At least for hierarchical relationships, we need to follow the relationship in both directions.
+      # At least for hierarchical relationships, we need to follow the
+      # relationship in both directions.
+      #
       # E.g. in a graph of
       #   A  <- follows - B - hierarchy (B is parent of C) -> C <- follows D
+      # * B is successor of A
+      # * B is parent of C
+      # * D is successor of C
       #
-      # D would also be subject to reschedule.
+      # When considering A, D would also be subject to reschedule.
       #
-      # That possible switch in direction means that we cannot simply get all possibly affected work packages by one
-      # SQL query which the DAG implementation would have allowed us to do otherwise.
+      # That possible switch in direction means that we cannot simply get all
+      # possibly affected work packages by one SQL query which the DAG
+      # implementation would have allowed us to do otherwise.
       #
-      # Currently, we do not rely on DAG for increasing the path length at all. We are still employing it in the check
-      # for whether all paths to the leaf have a manually scheduled work package.
+      # Currently, we do not rely on DAG for increasing the path length at all.
+      # We are still employing it in the check for whether all paths to the leaf
+      # have a manually scheduled work package.
       #
-      # A further improvement in performance might be reachable by also employing DAG mechanisms to increase the path length.
+      # A further improvement in performance might be reachable by also
+      # employing DAG mechanisms to increase the path length.
       #
-      # @param work_packages WorkPackage[] A set of work packages for which the set of related work packages that might
-      # be subject to reschedule is fetched.
+      # @param work_packages WorkPackage[] A set of work packages for which the
+      #   set of related work packages that might be subject to reschedule is
+      #   fetched.
       def for_scheduling(work_packages)
         return none if work_packages.empty?
 
@@ -95,26 +123,37 @@ module WorkPackages::Scopes
 
       private
 
-      # This recursive CTE fetches all work packages that are in a direct or transitive follows and/or hierarchy
-      # relationship with the provided work package.
+      # This recursive CTE fetches all work packages that are in a direct or
+      # transitive follows and/or hierarchy relationship with the provided work
+      # package.
       #
-      # Hierarchy relationships are followed up as well as down (from and to) but follows relations are only followed
-      # from the predecessor to the successor (from_id to to_id).
+      # Hierarchy relationships are followed up as well as down (from and to)
+      # but follows relations are only followed from the predecessor to the
+      # successor (from_id to to_id).
       #
-      # The CTE starts from the provided work package and for that returns:
-      #   * the id of the work package
-      #   * the information, that the starting work package is not manually scheduled.
-      # Whether the starting work package is manually scheduled or in fact automatically scheduled does make no
-      # difference but we need those four columns later on.
+      # The CTE starts from the provided work packages and returns for each of
+      # them:
       #
-      # For each recursive step, we return all work packages that are directly related to our current set of work
-      # packages by a hierarchy (up or down) or follows relationship (only successors). For each such work package
+      #   * id: the id of the work package
+      #   * manually: the information that the starting work package is not
+      #     manually scheduled.
+      #
+      # Whether the starting work package is manually scheduled or in fact
+      # automatically scheduled does make no difference but we need this
+      # information later on.
+      #
+      # For each recursive step, we return all work packages that are directly
+      # related to our current set of work packages by a hierarchy (up or down)
+      # or follows relationship (only successors). For each such work package
       # the statement returns:
-      #   * id of the work package that is currently at the end of a path.
-      #   * the flag indicating whether the added work package is automatically or manually scheduled. This also includes
-      #     whether *all* of the added work package's descendants are automatically or manually scheduled.
       #
-      # Paths whose ending work package is marked to be manually scheduled are not joined with any more.
+      #   * id of the work package that is currently at the end of a path.
+      #   * the flag indicating whether the added work package is automatically
+      #     or manually scheduled. This also includes whether *all* of the added
+      #     work package's descendants are automatically or manually scheduled.
+      #
+      # Paths whose ending work package is marked to be manually scheduled are
+      # not joined with any more.
       def scheduling_paths_sql(work_packages)
         values = work_packages.map do |wp|
           ::OpenProject::SqlSanitization

--- a/app/services/work_packages/schedule_dependency.rb
+++ b/app/services/work_packages/schedule_dependency.rb
@@ -35,15 +35,15 @@ class WorkPackages::ScheduleDependency
     # Those variables are pure optimizations.
     # We want to reuse the already loaded work packages as much as possible
     # and we want to have them readily available as hashes.
-    self.known_work_packages_by_id = (self.work_packages + following).group_by(&:id).transform_values(&:first)
+    self.known_work_packages_by_id = (self.work_packages + following).index_by(&:id)
     self.known_work_packages_by_parent_id = fetch_descendants.group_by(&:parent_id)
 
     self.dependencies = create_dependencies(following)
   end
 
   # Returns each dependency in the order necessary for scheduling:
-  # * successors after predecessors
-  # * ancestors after descendants
+  #   * successors after predecessors
+  #   * ancestors after descendants
   def in_schedule_order
     schedule_order = []
 
@@ -87,11 +87,15 @@ class WorkPackages::ScheduleDependency
     dependent_work_packages.index_with { |work_package| Dependency.new(work_package, self) }
   end
 
-  # Use a mixture of work packages that are already loaded to be scheduled themselves but also load
-  # all the rest of the descendants. There are two cases in which descendants are not loaded for scheduling:
-  # * manual scheduling: A descendant is either scheduled manually itself or all of its descendants are scheduled manually.
-  # * sibling: the descendant is not below a work package to be scheduled (e.g. one following another) but below an ancestor of
-  #            a schedule work package.
+  # Use a mixture of work packages that are already loaded to be scheduled
+  # themselves but also load all the rest of the descendants.
+  #
+  # There are two cases in which descendants are not loaded for scheduling:
+  #   * manual scheduling: A descendant is either scheduled manually itself or
+  #     all of its descendants are scheduled manually.
+  #   * sibling: the descendant is not below a work package to be scheduled
+  #     (e.g. one following another) but below an ancestor of a schedule work
+  #     package.
   def fetch_descendants
     descendants = known_work_packages_by_id.values
 

--- a/app/services/work_packages/schedule_dependency.rb
+++ b/app/services/work_packages/schedule_dependency.rb
@@ -29,26 +29,45 @@
 class WorkPackages::ScheduleDependency
   def initialize(work_packages)
     self.work_packages = Array(work_packages)
-    self.dependencies = {}
-    self.known_work_packages = self.work_packages
 
-    build_dependencies
+    following = load_following
+
+    # Those variables are pure optimizations.
+    # We want to reuse the already loaded work packages as much as possible
+    # and we want to have them readily available as hashes.
+    self.known_work_packages_by_id = (self.work_packages + following).group_by(&:id).transform_values(&:first)
+    self.known_work_packages_by_parent_id = fetch_descendants.group_by(&:parent_id)
+
+    self.dependencies = create_dependencies(following)
   end
 
-  def each
-    each_while_unhandled do |unhandled_by_id, scheduled, dependency|
-      next unless unhandled_by_id[scheduled.id]
-      next unless dependency.met?(unhandled_by_id.keys)
+  # Returns each dependency in the order necessary for scheduling:
+  # * successors after predecessors
+  # * ancestors after descendants
+  def in_schedule_order
+    schedule_order = []
 
-      yield scheduled, dependency
+    dependencies
+      .each_value do |dependency|
+      # Find the index of the last dependency the dependency needs to come after.
+      index = schedule_order.rindex do |inserted_dependency|
+        dependency.dependent_ids.include?(inserted_dependency.work_package.id)
+      end
 
-      unhandled_by_id.except!(scheduled.id)
+      if index
+        schedule_order.insert(index + 1, dependency)
+      else
+        schedule_order.unshift(dependency)
+      end
+    end
+
+    schedule_order.each do |dependency|
+      yield dependency.work_package, dependency
     end
   end
 
   attr_accessor :work_packages,
                 :dependencies,
-                :known_work_packages,
                 :known_work_packages_by_id,
                 :known_work_packages_by_parent_id
 
@@ -58,71 +77,16 @@ class WorkPackages::ScheduleDependency
 
   private
 
-  def build_dependencies
-    following = load_following
-
-    # Those variables are pure optimizations.
-    # We want to reuse the already loaded work packages as much as possible
-    # and we want to have them readily available as hashes.
-    self.known_work_packages += following
-    known_work_packages.uniq!
-    self.known_work_packages_by_id = known_work_packages.group_by(&:id).transform_values(&:first)
-    self.known_work_packages_by_parent_id = fetch_descendants.group_by(&:parent_id)
-
-    add_dependencies(following)
-  end
-
   def load_following
     WorkPackage
       .for_scheduling(work_packages)
       .includes(follows_relations: :to)
   end
 
-  def add_dependencies(dependent_work_packages)
-    added = dependent_work_packages.inject({}) do |new_dependencies, dependent_work_package|
-      dependency = Dependency.new dependent_work_package, self
-
-      new_dependencies[dependent_work_package] = dependency
-
+  def create_dependencies(dependent_work_packages)
+    dependent_work_packages.inject({}) do |new_dependencies, dependent_work_package|
+      new_dependencies[dependent_work_package] = Dependency.new dependent_work_package, self
       new_dependencies
-    end
-
-    moved = find_moved(added)
-
-    moved.except(*dependencies.keys)
-
-    dependencies.merge!(moved)
-  end
-
-  def find_moved(candidates)
-    candidates.select do |following, dependency|
-      dependency.ancestors.any? { |ancestor| included_in_follows?(ancestor, candidates) } ||
-        dependency.descendants.any? { |descendant| included_in_follows?(descendant, candidates) } ||
-        dependency.descendants.any? { |descendant| work_packages.include?(descendant) } ||
-        included_in_follows?(following, candidates)
-    end
-  end
-
-  def included_in_follows?(wp, candidates)
-    tos = wp.follows_relations.map(&:to)
-
-    dependencies.slice(*tos).any? ||
-      candidates.slice(*tos).any? ||
-      (tos & work_packages).any?
-  end
-
-  def each_while_unhandled
-    unhandled_by_id = dependencies.keys.group_by(&:id).transform_values(&:last)
-
-    while unhandled_by_id.any?
-      unhandled_by_id_count_before = unhandled_by_id_count_after = unhandled_by_id.count
-      dependencies.each do |scheduled, dependency|
-        yield unhandled_by_id, scheduled, dependency
-
-        unhandled_by_id_count_after = unhandled_by_id.count
-      end
-
-      raise "Circular dependency" unless unhandled_by_id_count_after < unhandled_by_id_count_before
     end
   end
 
@@ -158,27 +122,27 @@ class WorkPackages::ScheduleDependency
     end
 
     def follows_moved
-      tree = ancestors + descendants
-
-      @follows_moved ||= moved_predecessors_from_preloaded(work_package, tree)
+      @follows_moved ||= moved_predecessors_from_preloaded(work_package)
     end
 
     def follows_unmoved
-      tree = ancestors + descendants
-
-      @follows_unmoved ||= unmoved_predecessors_from_preloaded(work_package, tree)
+      @follows_unmoved ||= unmoved_predecessors_from_preloaded(work_package)
     end
 
-    def follows_moved_to_ids
-      @follows_moved_to_ids ||= follows_moved.map(&:to).map(&:id)
+    def follows_moved_ids
+      @follows_moved_ids ||= follows_moved.map(&:to).map(&:id)
     end
 
     attr_accessor :work_package,
                   :schedule_dependency
 
+    def dependent_ids
+      @dependent_ids ||= descendants_ids + follows_moved_ids
+    end
+
     def met?(unhandled_ids)
       (descendants_ids & unhandled_ids).empty? &&
-        (follows_moved_to_ids & unhandled_ids).empty?
+        (follows_moved_ids & unhandled_ids).empty?
     end
 
     def max_date_of_followed
@@ -209,7 +173,9 @@ class WorkPackages::ScheduleDependency
         if parent
           [parent] + ancestors_from_preloaded(parent)
         end
-      end || []
+      else
+        []
+      end
     end
 
     def descendants_from_preloaded(work_package)
@@ -218,8 +184,7 @@ class WorkPackages::ScheduleDependency
       children + children.map { |child| descendants_from_preloaded(child) }.flatten
     end
 
-    delegate :known_work_packages,
-             :known_work_packages_by_id,
+    delegate :known_work_packages_by_id,
              :known_work_packages_by_parent_id,
              :scheduled_work_packages_by_id, to: :schedule_dependency
 
@@ -227,8 +192,8 @@ class WorkPackages::ScheduleDependency
       schedule_dependency.work_packages + schedule_dependency.dependencies.keys
     end
 
-    def moved_predecessors_from_preloaded(work_package, tree)
-      ([work_package] + tree)
+    def moved_predecessors_from_preloaded(work_package)
+      ([work_package] + ancestors + descendants)
         .map(&:follows_relations)
         .flatten
         .map do |relation|
@@ -242,8 +207,8 @@ class WorkPackages::ScheduleDependency
         .compact
     end
 
-    def unmoved_predecessors_from_preloaded(work_package, tree)
-      ([work_package] + tree)
+    def unmoved_predecessors_from_preloaded(work_package)
+      ([work_package] + ancestors + descendants)
         .map(&:follows_relations)
         .flatten
         .reject do |relation|

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -77,7 +77,7 @@ class WorkPackages::SetScheduleService
   def schedule_following
     altered = []
 
-    WorkPackages::ScheduleDependency.new(work_packages).each do |scheduled, dependency|
+    WorkPackages::ScheduleDependency.new(work_packages).in_schedule_order do |scheduled, dependency|
       reschedule(scheduled, dependency)
 
       altered << scheduled if scheduled.changed?

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -44,6 +44,7 @@ FactoryBot.define do
       if start_date && due_date
         due_date - start_date + 1
       else
+        # This needs to change to nil once duration can be set
         1
       end
     end

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -29,10 +29,15 @@
 require 'spec_helper'
 
 describe WorkPackages::SetScheduleService do
+  shared_let(:project) { create(:project) }
+  shared_let(:user) { create(:user) }
+  shared_let(:type) { create(:type) }
+
   let(:work_package) do
-    build_stubbed(:work_package,
-                  start_date: work_package_start_date,
-                  due_date: work_package_due_date)
+    create(:work_package,
+           project:,
+           start_date: work_package_start_date,
+           due_date: work_package_due_date)
   end
   let(:work_package_due_date) { Time.zone.today }
   let(:work_package_start_date) { nil }
@@ -40,96 +45,82 @@ describe WorkPackages::SetScheduleService do
     described_class.new(user:, work_package:)
   end
   let!(:following) { [] }
-  let(:user) { build_stubbed(:user) }
-  let(:type) { build_stubbed(:type) }
 
   let(:follower1_start_date) { Time.zone.today + 1.day }
   let(:follower1_due_date) { Time.zone.today + 3.days }
   let(:follower1_delay) { 0 }
   let(:following_work_package1) do
-    stub_follower(follower1_start_date,
-                  follower1_due_date,
-                  { work_package => follower1_delay })
+    create_follower(follower1_start_date,
+                    follower1_due_date,
+                    { work_package => follower1_delay })
   end
   let(:follower2_start_date) { Time.zone.today + 4.days }
   let(:follower2_due_date) { Time.zone.today + 8.days }
   let(:follower2_delay) { 0 }
   let(:following_work_package2) do
-    stub_follower(follower2_start_date,
-                  follower2_due_date,
-                  { following_work_package1 => follower2_delay })
+    create_follower(follower2_start_date,
+                    follower2_due_date,
+                    { following_work_package1 => follower2_delay })
   end
   let(:follower3_start_date) { Time.zone.today + 9.days }
   let(:follower3_due_date) { Time.zone.today + 10.days }
   let(:follower3_delay) { 0 }
   let(:following_work_package3) do
-    stub_follower(follower3_start_date,
-                  follower3_due_date,
-                  { following_work_package2 => follower3_delay })
+    create_follower(follower3_start_date,
+                    follower3_due_date,
+                    { following_work_package2 => follower3_delay })
   end
 
   let(:parent_follower1_start_date) { follower1_start_date }
   let(:parent_follower1_due_date) { follower1_due_date }
 
   let(:parent_following_work_package1) do
-    work_package = stub_follower(parent_follower1_start_date,
-                                 parent_follower1_due_date,
-                                 {})
+    work_package = create_follower(parent_follower1_start_date,
+                                   parent_follower1_due_date,
+                                   {})
 
     following_work_package1.parent = work_package
+    following_work_package1.save
 
     work_package
   end
 
   let(:follower_sibling_work_package) do
-    stub_follower(follower1_due_date + 2.days,
-                  follower1_due_date + 4.days,
-                  {},
-                  parent: parent_following_work_package1)
+    create_follower(follower1_due_date + 2.days,
+                    follower1_due_date + 4.days,
+                    {},
+                    parent: parent_following_work_package1)
   end
 
   let(:attributes) { [:start_date] }
 
-  def stub_follower(start_date, due_date, predecessors, parent: nil)
-    work_package = build_stubbed(:work_package,
-                                 type:,
-                                 start_date:,
-                                 due_date:,
-                                 parent:)
+  def create_follower(start_date, due_date, predecessors, parent: nil)
+    work_package = create(:work_package,
+                          type:,
+                          start_date:,
+                          due_date:,
+                          parent:,
+                          project:,
+                          author: user)
 
-    relations = predecessors.map do |predecessor, delay|
-      build_stubbed(:follows_relation,
-                    delay:,
-                    from: work_package,
-                    to: predecessor)
+    predecessors.map do |predecessor, delay|
+      create(:follows_relation,
+             delay:,
+             from: work_package,
+             to: predecessor)
     end
-
-    allow(work_package)
-      .to receive(:follows_relations)
-            .and_return relations
 
     work_package
   end
 
-  def stub_follower_child(parent, start, due)
-    stub_follower(start,
-                  due,
-                  {},
-                  parent:)
+  def create_follower_child(parent, start, due)
+    create_follower(start,
+                    due,
+                    {},
+                    parent:)
   end
 
   subject { instance.call(attributes) }
-
-  before do
-    allow(WorkPackage)
-      .to receive(:for_scheduling)
-      .with([work_package])
-      .and_return(following)
-
-    allow(following)
-      .to receive(:includes)
-      .and_return(following)
-  end
 
   shared_examples_for 'reschedules' do
     before do
@@ -143,24 +134,20 @@ describe WorkPackages::SetScheduleService do
 
     it 'updates the following work packages' do
       expected.each do |wp, (start_date, due_date)|
-        expect(wp.start_date)
+        result = subject.all_results.find { |result_wp| result_wp.id == wp.id }
+        expect(result)
+          .to be_present
+
+        expect(result.start_date)
           .to eql start_date
-        expect(wp.due_date)
+        expect(result.due_date)
           .to eql due_date
       end
     end
 
     it 'returns only the original and the changed work packages' do
-      expected_to_change = if defined?(unchanged)
-                             expected.keys - unchanged
-                           else
-                             expected.keys
-                           end
-
-      expected_to_change << work_package
-
       expect(subject.all_results)
-        .to match_array expected_to_change
+        .to match_array expected.keys + [work_package]
     end
   end
 
@@ -186,26 +173,32 @@ describe WorkPackages::SetScheduleService do
           { following_work_package1 => [Time.zone.today + 6.days, Time.zone.today + 8.days] }
         end
       end
+    end
 
-      context 'when the follower has no due date' do
-        before do
-          following_work_package1.due_date = nil
-        end
+    context 'when moving forward with the follower having no due date' do
+      let(:follower1_due_date) { nil }
 
-        it_behaves_like 'reschedules' do
-          let(:expected) do
-            { following_work_package1 => [Time.zone.today + 6.days, nil] }
-          end
-        end
+      before do
+        work_package.due_date = Time.zone.today + 5.days
       end
 
-      context 'when the follower has no start date' do
-        let(:follower1_start_date) { nil }
+      it_behaves_like 'reschedules' do
+        let(:expected) do
+          { following_work_package1 => [Time.zone.today + 6.days, nil] }
+        end
+      end
+    end
 
-        it_behaves_like 'reschedules' do
-          let(:expected) do
-            { following_work_package1 => [Time.zone.today + 6.days, Time.zone.today + 7.days] }
-          end
+    context 'when moving forward with the follower having no start date' do
+      let(:follower1_start_date) { nil }
+
+      before do
+        work_package.due_date = Time.zone.today + 5.days
+      end
+
+      it_behaves_like 'reschedules' do
+        let(:expected) do
+          { following_work_package1 => [Time.zone.today + 6.days, Time.zone.today + 6.days] }
         end
       end
     end
@@ -235,10 +228,7 @@ describe WorkPackages::SetScheduleService do
 
       it_behaves_like 'reschedules' do
         let(:expected) do
-          { following_work_package1 => [follower1_start_date, follower1_due_date] }
-        end
-        let(:unchanged) do
-          [following_work_package1]
+          {}
         end
       end
     end
@@ -268,11 +258,9 @@ describe WorkPackages::SetScheduleService do
       end
 
       it_behaves_like 'reschedules' do
+        # Nothing should be rescheduled
         let(:expected) do
-          { following_work_package1 => [Time.zone.today + 6.days, Time.zone.today + 8.days] }
-        end
-        let(:unchanged) do
-          [following_work_package1]
+          {}
         end
       end
     end
@@ -305,46 +293,31 @@ describe WorkPackages::SetScheduleService do
     end
 
     context 'when moving backwards with the follower having another relation limiting movement' do
-      let(:other_work_package) do
-        build_stubbed(:work_package,
-                      type:,
-                      start_date: follower1_start_date - 8.days,
-                      due_date: follower1_start_date - 5.days)
-      end
-
-      let(:follow_relation) do
-        build_stubbed(:follows_relation,
-                      to: work_package,
-                      from: following_work_package1)
-      end
-
-      let(:other_follow_relation) do
-        build_stubbed(:follows_relation,
-                      delay: 3,
-                      to: other_work_package,
-                      from: following_work_package1)
+      let!(:other_work_package) do
+        create(:work_package,
+               type:,
+               start_date: follower1_start_date - 8.days,
+               due_date: follower1_start_date - 5.days).tap do |wp|
+          create(:follows_relation,
+                 delay: 3,
+                 to: wp,
+                 from: following_work_package1)
+        end
       end
 
       before do
-        allow(following_work_package1)
-          .to receive(:follows_relations)
-                .and_return [other_follow_relation, follow_relation]
-
         work_package.due_date = Time.zone.today - 5.days
       end
 
       it_behaves_like 'reschedules' do
         let(:expected) do
-          { following_work_package1 => [Time.zone.today, Time.zone.today + 2.days],
-            other_work_package => [follower1_start_date - 8.days, follower1_start_date - 5.days] }
-        end
-        let(:unchanged) do
-          [other_work_package]
+          { following_work_package1 => [Time.zone.today, Time.zone.today + 2.days] }
         end
       end
     end
 
-    context 'when moving backwards with the follower having no start date (which should not happen)' do
+    context 'when moving backwards with the follower having no start date (which should not happen) \
+             and the due date after the scheduled to date' do
       let(:follower1_start_date) { nil }
 
       before do
@@ -358,17 +331,30 @@ describe WorkPackages::SetScheduleService do
       end
     end
 
+    context 'when moving forward with the follower having no start date (which should not happen) \
+             and the due date before the scheduled to date' do
+      let(:follower1_start_date) { nil }
+
+      before do
+        work_package.due_date = follower1_due_date + 5.days
+      end
+
+      it_behaves_like 'reschedules' do
+        let(:expected) do
+          { following_work_package1 => [follower1_due_date + 6.days, follower1_due_date + 6.days] }
+        end
+      end
+    end
+
     context 'when removing the dates on the predecessor' do
       before do
         work_package.start_date = work_package.due_date = nil
       end
 
       it_behaves_like 'reschedules' do
+        # The follower will keep its dates
         let(:expected) do
-          { following_work_package1 => [follower1_start_date, follower1_due_date] }
-        end
-        let(:unchanged) do
-          [following_work_package1]
+          {}
         end
       end
 
@@ -391,6 +377,17 @@ describe WorkPackages::SetScheduleService do
 
       it_behaves_like 'reschedules' do
         let(:expected) do
+          { following_work_package1 => [work_package.due_date + 1.day, nil] }
+        end
+      end
+    end
+
+    context 'when not moving and the successor having due before predecessor due date (e.g. creating relation)' do
+      let(:follower1_start_date) { nil }
+      let(:follower1_due_date) { work_package_due_date - 5.days }
+
+      it_behaves_like 'reschedules' do
+        let(:expected) do
           { following_work_package1 => [work_package.due_date + 1.day, work_package.due_date + 1.day] }
         end
       end
@@ -402,7 +399,7 @@ describe WorkPackages::SetScheduleService do
 
       it_behaves_like 'reschedules' do
         let(:expected) do
-          { following_work_package1 => [work_package.due_date + 1.day, work_package.due_date + 1.day] }
+          { following_work_package1 => [work_package.due_date + 1.day, nil] }
         end
       end
     end
@@ -425,25 +422,22 @@ describe WorkPackages::SetScheduleService do
 
       it_behaves_like 'reschedules' do
         let(:expected) do
-          { following_work_package1 => [nil, nil] }
-        end
-        let(:unchanged) do
-          [following_work_package1]
+          {}
         end
       end
     end
 
     context 'with the successor having another predecessor which has no dates' do
       let(:following_work_package1) do
-        stub_follower(follower1_start_date,
-                      follower1_due_date,
-                      { work_package => follower1_delay,
-                        another_successor => 0 })
+        create_follower(follower1_start_date,
+                        follower1_due_date,
+                        { work_package => follower1_delay,
+                          another_successor => 0 })
       end
       let(:another_successor) do
-        build_stubbed(:work_package,
-                      start_date: nil,
-                      due_date: nil)
+        create(:work_package,
+               start_date: nil,
+               due_date: nil)
       end
 
       context 'when moving forward' do
@@ -473,20 +467,13 @@ describe WorkPackages::SetScheduleService do
   end
 
   context 'with only a parent' do
-    let(:parent_work_package) do
-      build_stubbed(:work_package)
+    let!(:parent_work_package) do
+      create(:work_package).tap do |parent|
+        work_package.parent = parent
+        work_package.save
+      end
     end
     let(:work_package_start_date) { Time.zone.today - 5.days }
-    let!(:following) do
-      [parent_work_package]
-    end
-
-    before do
-      work_package.parent = parent_work_package
-      allow(parent_work_package)
-        .to receive(:descendants)
-              .and_return([work_package])
-    end
 
     it_behaves_like 'reschedules' do
       let(:expected) do
@@ -531,11 +518,7 @@ describe WorkPackages::SetScheduleService do
       it_behaves_like 'reschedules' do
         let(:expected) do
           { following_work_package1 => [Time.zone.today + 6.days, Time.zone.today + 8.days],
-            parent_following_work_package1 => [Time.zone.today + 5.days, Time.zone.today + 8.days],
-            follower_sibling_work_package => [follower1_due_date + 2.days, follower1_due_date + 4.days] }
-        end
-        let(:unchanged) do
-          [follower_sibling_work_package]
+            parent_following_work_package1 => [Time.zone.today + 5.days, Time.zone.today + 8.days] }
         end
       end
     end
@@ -554,71 +537,55 @@ describe WorkPackages::SetScheduleService do
     end
 
     context 'when moving backwards with the parent having another relation limiting movement' do
-      let(:other_work_package) do
-        build_stubbed(:work_package,
-                      type:,
-                      start_date: Time.zone.today - 8.days,
-                      due_date: Time.zone.today - 4.days)
-      end
-
-      let(:other_follow_relation) do
-        build_stubbed(:follows_relation,
-                      delay: 2,
-                      to: other_work_package,
-                      from: parent_following_work_package1)
+      let!(:other_work_package) do
+        create(:work_package,
+               type:,
+               project:,
+               author: user,
+               start_date: Time.zone.today - 8.days,
+               due_date: Time.zone.today - 4.days).tap do |wp|
+          create(:follows_relation,
+                 delay: 2,
+                 to: wp,
+                 from: parent_following_work_package1)
+        end
       end
 
       before do
-        allow(parent_following_work_package1)
-          .to receive(:follows_relations)
-                .and_return [other_follow_relation]
-
         work_package.due_date = Time.zone.today - 5.days
       end
 
       it_behaves_like 'reschedules' do
         let(:expected) do
           { following_work_package1 => [Time.zone.today - 1.day, Time.zone.today + 1.day],
-            parent_following_work_package1 => [Time.zone.today - 1.day, Time.zone.today + 1.day],
-            other_work_package => [Time.zone.today - 8.days, Time.zone.today - 4.days] }
-        end
-        let(:unchanged) do
-          [other_work_package]
+            parent_following_work_package1 => [Time.zone.today - 1.day, Time.zone.today + 1.day] }
         end
       end
     end
 
     context 'when moving backwards with the parent having another relation not limiting movement' do
       let(:other_work_package) do
-        build_stubbed(:work_package,
-                      type:,
-                      start_date: Time.zone.today - 10.days,
-                      due_date: Time.zone.today - 9.days)
+        create(:work_package,
+               type:,
+               start_date: Time.zone.today - 10.days,
+               due_date: Time.zone.today - 9.days)
       end
 
       let(:other_follow_relation) do
-        build_stubbed(:follows_relation,
-                      delay: 2,
-                      to: other_work_package,
-                      from: parent_following_work_package1)
+        create(:follows_relation,
+               delay: 2,
+               to: other_work_package,
+               from: parent_following_work_package1)
       end
 
       before do
-        allow(parent_following_work_package1)
-          .to receive(:follows_relations)
-                .and_return [other_follow_relation]
-
         work_package.due_date = Time.zone.today - 5.days
       end
 
       it_behaves_like 'reschedules' do
         let(:expected) do
           { following_work_package1 => [Time.zone.today - 4.days, Time.zone.today - 2.days],
-            parent_following_work_package1 => [Time.zone.today - 4.days, Time.zone.today - 2.days],
-            other_work_package => [Time.zone.today - 10.days, Time.zone.today - 9.days] }
-        end
-        let(:unchanged) do
-          [other_work_package]
+            parent_following_work_package1 => [Time.zone.today - 4.days, Time.zone.today - 2.days] }
         end
       end
     end
@@ -640,11 +607,7 @@ describe WorkPackages::SetScheduleService do
       it_behaves_like 'reschedules' do
         let(:expected) do
           { following_work_package1 => [Time.zone.today - 4.days, Time.zone.today - 2.days],
-            parent_following_work_package1 => [Time.zone.today - 4.days, Time.zone.today + 7.days],
-            follower_sibling_work_package => [follower1_due_date + 2.days, follower1_due_date + 4.days] }
-        end
-        let(:unchanged) do
-          [follower_sibling_work_package]
+            parent_following_work_package1 => [Time.zone.today - 4.days, Time.zone.today + 7.days] }
         end
       end
     end
@@ -654,7 +617,7 @@ describe WorkPackages::SetScheduleService do
     let(:child_start_date) { follower1_start_date }
     let(:child_due_date) { follower1_due_date }
 
-    let(:child_work_package) { stub_follower_child(following_work_package1, child_start_date, child_due_date) }
+    let(:child_work_package) { create_follower_child(following_work_package1, child_start_date, child_due_date) }
 
     let!(:following) do
       [following_work_package1,
@@ -683,8 +646,8 @@ describe WorkPackages::SetScheduleService do
     let(:child2_start_date) { follower1_start_date + 8.days }
     let(:child2_due_date) { follower1_due_date }
 
-    let(:child1_work_package) { stub_follower_child(following_work_package1, child1_start_date, child1_due_date) }
-    let(:child2_work_package) { stub_follower_child(following_work_package1, child2_start_date, child2_due_date) }
+    let(:child1_work_package) { create_follower_child(following_work_package1, child1_start_date, child1_due_date) }
+    let(:child2_work_package) { create_follower_child(following_work_package1, child2_start_date, child2_due_date) }
 
     let!(:following) do
       [following_work_package1,
@@ -692,21 +655,10 @@ describe WorkPackages::SetScheduleService do
        child2_work_package]
     end
 
-    before do
-      following_work_package1
-      child1_work_package
-      child2_work_package
-    end
-
     context 'with unchanged dates (e.g. when creating a follows relation) and successor starting 1 day after scheduled' do
       it_behaves_like 'reschedules' do
         let(:expected) do
-          { following_work_package1 => [follower1_start_date, follower1_due_date],
-            child1_work_package => [child1_start_date, child1_due_date],
-            child2_work_package => [child2_start_date, child2_due_date] }
-        end
-        let(:unchanged) do
-          [following_work_package1, child1_work_package, child2_work_package]
+          {}
         end
       end
     end
@@ -721,12 +673,7 @@ describe WorkPackages::SetScheduleService do
 
       it_behaves_like 'reschedules' do
         let(:expected) do
-          { following_work_package1 => [follower1_start_date, follower1_due_date],
-            child1_work_package => [child1_start_date, child1_due_date],
-            child2_work_package => [child2_start_date, child2_due_date] }
-        end
-        let(:unchanged) do
-          [following_work_package1, child1_work_package, child2_work_package]
+          {}
         end
       end
     end
@@ -743,11 +690,7 @@ describe WorkPackages::SetScheduleService do
       it_behaves_like 'reschedules' do
         let(:expected) do
           { following_work_package1 => [work_package_due_date + 1.day, follower1_due_date],
-            child1_work_package => [work_package_due_date + 1.day, follower1_start_date + 10.days],
-            child2_work_package => [child2_start_date, child2_due_date] }
-        end
-        let(:unchanged) do
-          [child2_work_package]
+            child1_work_package => [work_package_due_date + 1.day, follower1_start_date + 10.days] }
         end
       end
     end
@@ -814,11 +757,7 @@ describe WorkPackages::SetScheduleService do
       it_behaves_like 'reschedules' do
         let(:expected) do
           { following_work_package1 => [Time.zone.today + 6.days, Time.zone.today + 8.days],
-            following_work_package2 => [Time.zone.today + 9.days, Time.zone.today + 12.days],
-            following_work_package3 => [Time.zone.today + 17.days, Time.zone.today + 18.days] }
-        end
-        let(:unchanged) do
-          [following_work_package3]
+            following_work_package2 => [Time.zone.today + 9.days, Time.zone.today + 12.days] }
         end
       end
     end
@@ -843,18 +782,18 @@ describe WorkPackages::SetScheduleService do
     let(:follower3_due_date) { Time.zone.today + 7.days }
     let(:follower3_delay) { 0 }
     let(:following_work_package3) do
-      stub_follower(follower3_start_date,
-                    follower3_due_date,
-                    { work_package => follower3_delay })
+      create_follower(follower3_start_date,
+                      follower3_due_date,
+                      { work_package => follower3_delay })
     end
     let(:follower4_start_date) { Time.zone.today + 9.days }
     let(:follower4_due_date) { Time.zone.today + 10.days }
     let(:follower4_delay2) { 0 }
     let(:follower4_delay3) { 0 }
     let(:following_work_package4) do
-      stub_follower(follower4_start_date,
-                    follower4_due_date,
-                    { following_work_package2 => follower4_delay2, following_work_package3 => follower4_delay3 })
+      create_follower(follower4_start_date,
+                      follower4_due_date,
+                      { following_work_package2 => follower4_delay2, following_work_package3 => follower4_delay3 })
     end
     let!(:following) do
       [following_work_package1,
@@ -895,7 +834,7 @@ describe WorkPackages::SetScheduleService do
   end
 
   context 'when setting the parent' do
-    let(:new_parent_work_package) { build_stubbed(:work_package) }
+    let(:new_parent_work_package) { create(:work_package) }
     let(:attributes) { [:parent] }
 
     before do

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -142,6 +142,16 @@ describe WorkPackages::SetScheduleService do
           .to eql start_date
         expect(result.due_date)
           .to eql due_date
+
+        duration = if start_date && due_date
+                     (due_date - start_date + 1).to_i
+                   else
+                     # This needs to change to nil once duration can be set
+                     1
+                   end
+
+        expect(result.duration)
+          .to eql duration
       end
     end
 


### PR DESCRIPTION
Initially the branch started of as an attempt to introduce duration and non working days into the scheduling calculations. While working on that, a couple of topics were extracted that now make up this PR:

* The duration column is not recalculated in the `SetAttributesService`. Because of that, a parent whose start & due date get recalculated might end up with two wrong value in its duration column. In a subsequent rescheduling that wrong duration might then lead to succeeding work packages ending up with the wrong dates.
* The behaviour between a work package having had no date values at all before being rescheduled and a work package having no start date before being rescheduled was different. In the former case, only the start date was set while in the later the due date was set to be one day after the start date. This happened regardless of whether a due date was already set or not. Now, only the start date is set in both cases.
* The calculation of the order in which the scheduling was performed was done over and over again. For more complex relationships, this lead to less than optimal performance. Now, the order is only calculated once.

The code was also simplified.

https://community.openproject.org/work_packages/40906 