### PR TITLE
Remove :stubbed_work_package factory

### DIFF
--- a/modules/backlogs/spec/api/work_packages/work_package_schema_representer_spec.rb
+++ b/modules/backlogs/spec/api/work_packages/work_package_schema_representer_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
   let(:custom_field) { build(:custom_field) }
-  let(:work_package) { build_stubbed(:stubbed_work_package, type: build_stubbed(:type)) }
+  let(:work_package) { build_stubbed(:work_package, type: build_stubbed(:type)) }
   let(:current_user) do
     build_stubbed(:user, member_in_project: work_package.project).tap do |u|
       allow(u)

--- a/modules/backlogs/spec/contracts/work_packages/base_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/work_packages/base_contract_spec.rb
@@ -72,7 +72,7 @@ describe WorkPackages::BaseContract, type: :model do
   end
 
   let(:story) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   subject: 'Story',
                   project:,
                   type: type_feature,
@@ -83,7 +83,7 @@ describe WorkPackages::BaseContract, type: :model do
   end
 
   let(:story2) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   subject: 'Story2',
                   project:,
                   type: type_feature,
@@ -94,7 +94,7 @@ describe WorkPackages::BaseContract, type: :model do
   end
 
   let(:task) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   subject: 'Task',
                   type: type_task,
                   version: version1,
@@ -105,7 +105,7 @@ describe WorkPackages::BaseContract, type: :model do
   end
 
   let(:task2) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   subject: 'Task2',
                   type: type_task,
                   version: version1,
@@ -116,7 +116,7 @@ describe WorkPackages::BaseContract, type: :model do
   end
 
   let(:bug) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   subject: 'Bug',
                   type: type_bug,
                   version: version1,
@@ -127,7 +127,7 @@ describe WorkPackages::BaseContract, type: :model do
   end
 
   let(:bug2) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   subject: 'Bug2',
                   type: type_bug,
                   version: version1,

--- a/modules/bim/spec/api/v3/work_packages/work_package_representer_spec.rb
+++ b/modules/bim/spec/api/v3/work_packages/work_package_representer_spec.rb
@@ -41,7 +41,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
   end
   let(:permissions) { %i[view_linked_issues view_work_packages manage_bcf] }
   let(:work_package) do
-    build_stubbed(:stubbed_work_package, bcf_issue: bcf_topic)
+    build_stubbed(:work_package, bcf_issue: bcf_topic)
   end
   let(:representer) do
     described_class.create(work_package,

--- a/modules/bim/spec/contracts/bcf/issues/shared_contract_examples.rb
+++ b/modules/bim/spec/contracts/bcf/issues/shared_contract_examples.rb
@@ -40,7 +40,7 @@ shared_examples_for 'issues contract' do
   end
   let(:issue_uuid) { 'issue uuid' }
   let(:project) { build_stubbed(:project) }
-  let(:issue_work_package) { build_stubbed(:stubbed_work_package, project:) }
+  let(:issue_work_package) { build_stubbed(:work_package, project:) }
   let(:issue_work_package_id) do
     id = 5
 

--- a/modules/bim/spec/contracts/bcf/issues/update_contract_spec.rb
+++ b/modules/bim/spec/contracts/bcf/issues/update_contract_spec.rb
@@ -44,7 +44,7 @@ describe Bim::Bcf::Issues::UpdateContract do
 
     context 'if work_package is altered' do
       before do
-        issue.work_package = build_stubbed(:stubbed_work_package)
+        issue.work_package = build_stubbed(:work_package)
       end
 
       it 'is invalid' do

--- a/modules/bim/spec/controllers/work_packages_controller_spec.rb
+++ b/modules/bim/spec/controllers/work_packages_controller_spec.rb
@@ -35,7 +35,7 @@ describe WorkPackagesController, type: :controller do
 
   let(:stub_project) { build_stubbed(:project, identifier: 'test_project', public: false) }
   let(:current_user) { build_stubbed(:user) }
-  let(:work_packages) { [build_stubbed(:stubbed_work_package)] }
+  let(:work_packages) { [build_stubbed(:work_package)] }
 
   describe 'index' do
     let(:query) do

--- a/modules/bim/spec/representers/bcf/api/v2_1/project_extensions/representer_spec.rb
+++ b/modules/bim/spec/representers/bcf/api/v2_1/project_extensions/representer_spec.rb
@@ -37,7 +37,7 @@ describe Bim::Bcf::API::V2_1::ProjectExtensions::Representer, 'rendering' do
   let(:project) do
     build_stubbed(:project)
   end
-  let(:work_package) { build_stubbed(:stubbed_work_package, project:) }
+  let(:work_package) { build_stubbed(:work_package, project:) }
   let(:priority) { build_stubbed(:priority) }
   let(:user) { build_stubbed(:user) }
   let(:contract) do

--- a/modules/bim/spec/representers/bcf/api/v2_1/topics/single_representer_rendering_spec.rb
+++ b/modules/bim/spec/representers/bcf/api/v2_1/topics/single_representer_rendering_spec.rb
@@ -43,7 +43,7 @@ describe Bim::Bcf::API::V2_1::Topics::SingleRepresenter, 'rendering' do
   let(:status) { build_stubbed(:status) }
   let(:priority) { build_stubbed(:priority) }
   let(:work_package) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   assigned_to: assignee,
                   due_date: Date.today,
                   status:,

--- a/modules/costs/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/modules/costs/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
   let(:custom_field) { build(:custom_field) }
-  let(:work_package) { build_stubbed(:stubbed_work_package) }
+  let(:work_package) { build_stubbed(:work_package) }
   let(:current_user) do
     build_stubbed(:user).tap do |u|
       allow(u)

--- a/modules/xls_export/spec/patches/work_packages_controller_patch_spec.rb
+++ b/modules/xls_export/spec/patches/work_packages_controller_patch_spec.rb
@@ -37,7 +37,7 @@ describe WorkPackagesController, type: :controller do
   let(:stub_project) { build_stubbed(:project, identifier: 'test_project', public: false) }
   let(:type) { build_stubbed(:type) }
   let(:stub_work_package) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   id: 1337,
                   type:,
                   project: stub_project)

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -31,7 +31,7 @@ require 'contracts/shared/model_contract_shared_context'
 
 describe WorkPackages::BaseContract do
   let(:work_package) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   type:,
                   done_ratio: 50,
                   estimated_hours: 6.0,
@@ -638,7 +638,7 @@ describe WorkPackages::BaseContract do
   end
 
   describe 'parent' do
-    let(:parent) { build_stubbed(:stubbed_work_package) }
+    let(:parent) { build_stubbed(:work_package) }
 
     before do
       work_package.parent = parent

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -37,7 +37,7 @@ describe WorkPackagesController, type: :controller do
   let(:stub_project) { build_stubbed(:project, identifier: 'test_project', public: false) }
   let(:type) { build_stubbed(:type) }
   let(:stub_work_package) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   id: 1337,
                   type:,
                   project: stub_project)

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -65,9 +65,5 @@ FactoryBot.define do
     callback(:after_stub) do |wp, arguments|
       wp.type = wp.project.types.first unless wp.type_id || arguments.instance_variable_get(:@overrides).has_key?(:type)
     end
-
-    factory :stubbed_work_package do
-      "this factory is not necessary anymore and should be removed"
-    end
   end
 end

--- a/spec/lib/api/v3/attachments/attachment_representer_spec.rb
+++ b/spec/lib/api/v3/attachments/attachment_representer_spec.rb
@@ -37,7 +37,7 @@ describe ::API::V3::Attachments::AttachmentRepresenter do
   let(:all_permissions) { %i[view_work_packages edit_work_packages] }
   let(:permissions) { all_permissions }
 
-  let(:container) { build_stubbed(:stubbed_work_package) }
+  let(:container) { build_stubbed(:work_package) }
   let(:author) { current_user }
   let(:attachment) do
     build_stubbed(:attachment,

--- a/spec/lib/api/v3/custom_actions/custom_action_execute_representer_parsing_spec.rb
+++ b/spec/lib/api/v3/custom_actions/custom_action_execute_representer_parsing_spec.rb
@@ -33,7 +33,7 @@ describe ::API::V3::CustomActions::CustomActionExecuteRepresenter, 'parsing' do
 
   let(:struct) { OpenStruct.new }
   let(:user) { build_stubbed(:user) }
-  let(:work_package) { build_stubbed(:stubbed_work_package) }
+  let(:work_package) { build_stubbed(:work_package) }
 
   let(:representer) do
     described_class.new(struct, current_user: user)

--- a/spec/lib/api/v3/relations/relation_representer_spec.rb
+++ b/spec/lib/api/v3/relations/relation_representer_spec.rb
@@ -31,8 +31,8 @@ require 'spec_helper'
 describe ::API::V3::Relations::RelationRepresenter do
   let(:user) { build_stubbed(:admin) }
 
-  let(:from) { build_stubbed(:stubbed_work_package) }
-  let(:to) { build_stubbed :stubbed_work_package }
+  let(:from) { build_stubbed(:work_package) }
+  let(:to) { build_stubbed(:work_package) }
 
   let(:type) { "follows" }
   let(:description) { "This first" }

--- a/spec/lib/api/v3/work_packages/create_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_form_representer_spec.rb
@@ -36,7 +36,7 @@ describe ::API::V3::WorkPackages::CreateFormRepresenter do
     build_stubbed(:project)
   end
   let(:work_package) do
-    build_stubbed(:stubbed_work_package, project:).tap do |wp|
+    build_stubbed(:work_package, project:).tap do |wp|
       allow(wp).to receive(:assignable_versions).and_return []
     end
   end

--- a/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/create_project_form_representer_spec.rb
@@ -36,7 +36,7 @@ describe ::API::V3::WorkPackages::CreateProjectFormRepresenter do
   let(:permissions) { %i(edit_work_packages) }
   let(:type) { build_stubbed(:type) }
   let(:work_package) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   type:)
   end
   let(:representer) do

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -35,7 +35,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
   let(:wp_type) { project.types.first }
   let(:custom_field) { build_stubbed(:custom_field) }
   let(:work_package) do
-    build_stubbed(:stubbed_work_package, project:, type: wp_type) do |wp|
+    build_stubbed(:work_package, project:, type: wp_type) do |wp|
       allow(wp)
         .to receive(:available_custom_fields)
         .and_return(available_custom_fields)
@@ -684,7 +684,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
       context 'when creating (new_record)' do
         let(:work_package) do
-          build(:stubbed_work_package, project:, type: wp_type) do |wp|
+          build(:work_package, project:, type: wp_type) do |wp|
             allow(wp)
               .to receive(:available_custom_fields)
               .and_return(available_custom_fields)
@@ -699,7 +699,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
       context 'when creating (new_record with empty type)' do
         let(:work_package) do
-          build(:stubbed_work_package, project:, type: nil) do |wp|
+          build(:work_package, project:, type: nil) do |wp|
             allow(wp)
               .to receive(:available_custom_fields)
                     .and_return(available_custom_fields)

--- a/spec/lib/api/v3/work_packages/update_form_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/update_form_representer_spec.rb
@@ -38,7 +38,7 @@ describe ::API::V3::WorkPackages::UpdateFormRepresenter do
   let(:project) { work_package.project }
   let(:permissions) { %i(edit_work_packages) }
   let(:work_package) do
-    build_stubbed(:stubbed_work_package)
+    build_stubbed(:work_package)
   end
 
   include_context 'user with stubbed permissions'

--- a/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_payload_representer_spec.rb
@@ -32,7 +32,7 @@ describe ::API::V3::WorkPackages::WorkPackagePayloadRepresenter do
   include API::V3::Utilities::PathHelper
 
   let(:work_package) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   start_date: Date.today.to_datetime,
                   due_date: Date.today.to_datetime,
                   created_at: DateTime.now,

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -53,7 +53,7 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
   let(:derived_due_date) { Time.zone.today - 5.days }
   let(:budget) { build_stubbed(:budget, project:) }
   let(:work_package) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   schedule_manually:,
                   start_date:,
                   due_date:,
@@ -903,14 +903,14 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
 
         describe 'parent' do
           let(:visible_parent) do
-            build_stubbed(:stubbed_work_package) do |wp|
+            build_stubbed(:work_package) do |wp|
               allow(wp)
                 .to receive(:visible?)
                 .and_return(true)
             end
           end
           let(:invisible_parent) do
-            build_stubbed(:stubbed_work_package) do |wp|
+            build_stubbed(:work_package) do |wp|
               allow(wp)
                 .to receive(:visible?)
                       .and_return(false)

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -32,7 +32,7 @@ describe Attachment, type: :model do
   let(:author) { create :user }
   let(:long_description) { 'a' * 300 }
   let(:work_package) { create :work_package }
-  let(:stubbed_work_package) { build_stubbed :stubbed_work_package }
+  let(:stubbed_work_package) { build_stubbed :work_package }
   let(:file) { create :uploaded_jpg, name: 'test.jpg' }
   let(:second_file) { create :uploaded_jpg, name: 'test2.jpg' }
   let(:container) { stubbed_work_package }

--- a/spec/models/custom_actions/actions/date_spec.rb
+++ b/spec/models/custom_actions/actions/date_spec.rb
@@ -36,7 +36,7 @@ describe CustomActions::Actions::Date, type: :model do
 
   it_behaves_like 'base custom action' do
     describe '#apply' do
-      let(:work_package) { build_stubbed(:stubbed_work_package) }
+      let(:work_package) { build_stubbed(:work_package) }
 
       it 'sets both start and finish date to the action\'s value' do
         instance.values = [Date.today + 5]

--- a/spec/models/custom_actions/actions/done_ratio_spec.rb
+++ b/spec/models/custom_actions/actions/done_ratio_spec.rb
@@ -35,7 +35,7 @@ describe CustomActions::Actions::DoneRatio, type: :model do
 
   it_behaves_like 'base custom action' do
     describe '#apply' do
-      let(:work_package) { build_stubbed(:stubbed_work_package) }
+      let(:work_package) { build_stubbed(:work_package) }
 
       it 'sets the done_ratio to the action\'s value' do
         instance.values = [95]

--- a/spec/models/custom_actions/actions/estimated_hours_spec.rb
+++ b/spec/models/custom_actions/actions/estimated_hours_spec.rb
@@ -36,7 +36,7 @@ describe CustomActions::Actions::EstimatedHours, type: :model do
 
   it_behaves_like 'base custom action' do
     describe '#apply' do
-      let(:work_package) { build_stubbed(:stubbed_work_package) }
+      let(:work_package) { build_stubbed(:work_package) }
 
       it 'sets the done_ratio to the action\'s value' do
         instance.values = [95.56]

--- a/spec/models/custom_actions/actions/notify_spec.rb
+++ b/spec/models/custom_actions/actions/notify_spec.rb
@@ -57,7 +57,7 @@ describe CustomActions::Actions::Notify, type: :model do
     it_behaves_like 'associated custom action validations'
 
     describe '#apply' do
-      let(:work_package) { build_stubbed(:stubbed_work_package) }
+      let(:work_package) { build_stubbed(:work_package) }
 
       it 'adds a note with all values distinguised by type' do
         principals = [build_stubbed(:user),

--- a/spec/models/custom_actions/shared_expectations.rb
+++ b/spec/models/custom_actions/shared_expectations.rb
@@ -125,7 +125,7 @@ end
 shared_examples_for 'associated custom action' do
   include_context 'custom actions action' do
     describe '#apply' do
-      let(:work_package) { build_stubbed(:stubbed_work_package) }
+      let(:work_package) { build_stubbed(:work_package) }
 
       it 'sets the associated_id in the work package to the action\'s value' do
         expect(work_package)
@@ -510,7 +510,7 @@ end
 
 shared_examples_for 'date custom action apply' do
   describe '#apply' do
-    let(:work_package) { build_stubbed(:stubbed_work_package) }
+    let(:work_package) { build_stubbed(:work_package) }
 
     it 'sets the daate to the action\'s value' do
       instance.values = [Date.today + 5.days]

--- a/spec/models/work_package/work_package_custom_actions_spec.rb
+++ b/spec/models/work_package/work_package_custom_actions_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe WorkPackage, 'custom_actions', type: :model do
   let(:work_package) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   project:)
   end
   let(:project) { create(:project) }

--- a/spec/services/custom_actions/update_work_package_service_spec.rb
+++ b/spec/services/custom_actions/update_work_package_service_spec.rb
@@ -82,7 +82,7 @@ describe CustomActions::UpdateWorkPackageService do
 
     wp_service_instance
   end
-  let(:work_package) { build_stubbed(:stubbed_work_package) }
+  let(:work_package) { build_stubbed(:work_package) }
   let(:result) do
     ServiceResult.new(result: work_package, success: true)
   end

--- a/spec/services/relations/update_service_spec.rb
+++ b/spec/services/relations/update_service_spec.rb
@@ -38,12 +38,12 @@ describe Relations::UpdateService do
   let(:delay) { 3 }
 
   let(:work_package1) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   due_date: work_package1_due_date,
                   start_date: work_package1_start_date)
   end
   let(:work_package2) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   due_date: work_package2_due_date,
                   start_date: work_package2_start_date)
   end

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -304,7 +304,7 @@ describe WorkPackages::SetAttributesService, type: :model do
       let(:attributes) { {} }
       let(:work_package) { new_work_package }
       let(:parent) do
-        build_stubbed(:stubbed_work_package,
+        build_stubbed(:work_package,
                       start_date: parent_start_date,
                       due_date: parent_due_date)
       end
@@ -639,7 +639,7 @@ describe WorkPackages::SetAttributesService, type: :model do
     end
 
     context 'with start date changed' do
-      let(:work_package) { build_stubbed(:stubbed_work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
+      let(:work_package) { build_stubbed(:work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
       let(:call_attributes) { { start_date: Time.zone.today + 1.day } }
       let(:attributes) { {} }
 
@@ -668,7 +668,7 @@ describe WorkPackages::SetAttributesService, type: :model do
     end
 
     context 'with due date changed' do
-      let(:work_package) { build_stubbed(:stubbed_work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
+      let(:work_package) { build_stubbed(:work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
       let(:call_attributes) { { due_date: Time.zone.today + 1.day } }
       let(:attributes) { {} }
 
@@ -697,7 +697,7 @@ describe WorkPackages::SetAttributesService, type: :model do
     end
 
     context 'with start date nilled' do
-      let(:work_package) { build_stubbed(:stubbed_work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
+      let(:work_package) { build_stubbed(:work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
       let(:call_attributes) { { start_date: nil } }
       let(:attributes) { {} }
 
@@ -726,7 +726,7 @@ describe WorkPackages::SetAttributesService, type: :model do
     end
 
     context 'with due date nilled' do
-      let(:work_package) { build_stubbed(:stubbed_work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
+      let(:work_package) { build_stubbed(:work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
       let(:call_attributes) { { due_date: nil } }
       let(:attributes) { {} }
 
@@ -755,7 +755,7 @@ describe WorkPackages::SetAttributesService, type: :model do
     end
 
     context 'with duration explicitly set' do
-      let(:work_package) { build_stubbed(:stubbed_work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
+      let(:work_package) { build_stubbed(:work_package, start_date: Time.zone.today, due_date: Time.zone.today + 5.days) }
       let(:call_attributes) { { due_date: Time.zone.today + 2.days, duration: 8 } }
       let(:attributes) { {} }
 
@@ -840,7 +840,7 @@ describe WorkPackages::SetAttributesService, type: :model do
   context 'when switching the type' do
     let(:target_type) { build_stubbed(:type) }
     let(:work_package) do
-      build_stubbed(:stubbed_work_package, start_date: Time.zone.today - 6.days, due_date: Time.zone.today)
+      build_stubbed(:work_package, start_date: Time.zone.today - 6.days, due_date: Time.zone.today)
     end
 
     context 'with a type that is no milestone' do
@@ -899,7 +899,7 @@ describe WorkPackages::SetAttributesService, type: :model do
 
     context 'with a type that is a milestone and with only the start date set' do
       let(:work_package) do
-        build_stubbed(:stubbed_work_package, start_date: Time.zone.today - 6.days)
+        build_stubbed(:work_package, start_date: Time.zone.today - 6.days)
       end
 
       before do
@@ -1198,7 +1198,7 @@ describe WorkPackages::SetAttributesService, type: :model do
 
     context 'when the work package also has a child' do
       let(:child) do
-        build_stubbed(:stubbed_work_package,
+        build_stubbed(:work_package,
                       start_date: child_start_date,
                       due_date: child_due_date)
       end

--- a/spec/services/work_packages/set_schedule_service_spec.rb
+++ b/spec/services/work_packages/set_schedule_service_spec.rb
@@ -30,7 +30,7 @@ require 'spec_helper'
 
 describe WorkPackages::SetScheduleService do
   let(:work_package) do
-    build_stubbed(:stubbed_work_package,
+    build_stubbed(:work_package,
                   start_date: work_package_start_date,
                   due_date: work_package_due_date)
   end
@@ -91,7 +91,7 @@ describe WorkPackages::SetScheduleService do
   let(:attributes) { [:start_date] }
 
   def stub_follower(start_date, due_date, predecessors, parent: nil)
-    work_package = build_stubbed(:stubbed_work_package,
+    work_package = build_stubbed(:work_package,
                                  type:,
                                  start_date:,
                                  due_date:,
@@ -306,7 +306,7 @@ describe WorkPackages::SetScheduleService do
 
     context 'when moving backwards with the follower having another relation limiting movement' do
       let(:other_work_package) do
-        build_stubbed(:stubbed_work_package,
+        build_stubbed(:work_package,
                       type:,
                       start_date: follower1_start_date - 8.days,
                       due_date: follower1_start_date - 5.days)
@@ -441,7 +441,7 @@ describe WorkPackages::SetScheduleService do
                         another_successor => 0 })
       end
       let(:another_successor) do
-        build_stubbed(:stubbed_work_package,
+        build_stubbed(:work_package,
                       start_date: nil,
                       due_date: nil)
       end
@@ -474,7 +474,7 @@ describe WorkPackages::SetScheduleService do
 
   context 'with only a parent' do
     let(:parent_work_package) do
-      build_stubbed(:stubbed_work_package)
+      build_stubbed(:work_package)
     end
     let(:work_package_start_date) { Time.zone.today - 5.days }
     let!(:following) do
@@ -555,7 +555,7 @@ describe WorkPackages::SetScheduleService do
 
     context 'when moving backwards with the parent having another relation limiting movement' do
       let(:other_work_package) do
-        build_stubbed(:stubbed_work_package,
+        build_stubbed(:work_package,
                       type:,
                       start_date: Time.zone.today - 8.days,
                       due_date: Time.zone.today - 4.days)
@@ -590,7 +590,7 @@ describe WorkPackages::SetScheduleService do
 
     context 'when moving backwards with the parent having another relation not limiting movement' do
       let(:other_work_package) do
-        build_stubbed(:stubbed_work_package,
+        build_stubbed(:work_package,
                       type:,
                       start_date: Time.zone.today - 10.days,
                       due_date: Time.zone.today - 9.days)
@@ -895,7 +895,7 @@ describe WorkPackages::SetScheduleService do
   end
 
   context 'when setting the parent' do
-    let(:new_parent_work_package) { build_stubbed(:stubbed_work_package) }
+    let(:new_parent_work_package) { build_stubbed(:work_package) }
     let(:attributes) { [:parent] }
 
     before do


### PR DESCRIPTION
Using `build_stubbed(:work_package)` instead of `build_stubbed(:stubbed_work_package)` works equally well.

Relates to commit e1607a6116