### PR TITLE
Add Appsignal configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -202,6 +202,9 @@ gem "sentry-delayed_job", '~> 5.3.0'
 gem "sentry-rails", '~> 5.3.0'
 gem "sentry-ruby", '~> 5.3.0'
 
+# Appsignal integration
+gem "appsignal", "~> 3.0", require: false
+
 group :test do
   gem 'launchy', '~> 2.5.0'
   gem 'rack-test', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,8 @@ GEM
       airbrake-ruby (~> 6.0)
     airbrake-ruby (6.1.0)
       rbtree3 (~> 0.5)
+    appsignal (3.0.27)
+      rack
     ast (2.4.2)
     attr_required (1.0.1)
     auto_strip_attributes (2.6.0)
@@ -1015,6 +1017,7 @@ DEPENDENCIES
   acts_as_tree (~> 2.9.0)
   addressable (~> 2.8.0)
   airbrake (~> 13.0.0)
+  appsignal (~> 3.0)
   auto_strip_attributes (~> 2.5)
   awesome_nested_set (~> 3.5.0)
   aws-sdk-core (~> 3.107)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -132,6 +132,7 @@ class ApplicationController < ActionController::Base
 
   before_action :user_setup,
                 :set_localization,
+                :tag_request,
                 :check_if_login_required,
                 :log_requesting_user,
                 :reset_i18n_fallbacks,
@@ -165,6 +166,10 @@ class ApplicationController < ActionController::Base
         must_revalidate: true
       )
     end
+  end
+
+  def tag_request
+    ::OpenProject::Appsignal.tag_request(controller: self, request:)
   end
 
   def reload_mailer_settings!

--- a/config/initializers/appsignal.rb
+++ b/config/initializers/appsignal.rb
@@ -1,0 +1,33 @@
+require 'open_project/version'
+
+if ENV['APPSIGNAL_ENABLED'] == 'true'
+  require 'appsignal'
+  OpenProject::Application.configure do |app|
+    config = {
+      active: true,
+      name: ENV.fetch('APPSIGNAL_NAME'),
+      push_api_key: ENV.fetch('APPSIGNAL_KEY'),
+      revision: OpenProject::VERSION.to_s,
+      ignore_actions: %w[OkComputerController#index OkComputerController#show]
+    }
+
+    if Rails.env.development?
+      config[:log] = 'stdout'
+      config[:debug] = true
+      config[:log_level] = 'debug'
+    end
+
+    Appsignal.config = Appsignal::Config.new(
+      Rails.root,
+      Rails.env,
+      config
+    )
+
+    app.middleware.insert_after(
+      ActionDispatch::DebugExceptions,
+      Appsignal::Rack::RailsInstrumentation
+    )
+
+    Appsignal.start
+  end
+end

--- a/config/initializers/appsignal.rb
+++ b/config/initializers/appsignal.rb
@@ -29,6 +29,10 @@ if OpenProject::Appsignal.enabled?
       Appsignal::Rack::RailsInstrumentation
     )
 
+    # Extend the core log delegator
+    handler = ::OpenProject::Appsignal.method(:exception_handler)
+    ::OpenProject::Logging::LogDelegator.register(:appsignal, handler)
+
     Appsignal.start
   end
 end

--- a/config/initializers/appsignal.rb
+++ b/config/initializers/appsignal.rb
@@ -12,7 +12,7 @@ if OpenProject::Appsignal.enabled?
       ignore_actions: %w[OkComputerController#index OkComputerController#show]
     }
 
-    if Rails.env.development?
+    if ENV['APPSIGNAL_DEBUG'] == 'true'
       config[:log] = 'stdout'
       config[:debug] = true
       config[:log_level] = 'debug'

--- a/config/initializers/appsignal.rb
+++ b/config/initializers/appsignal.rb
@@ -1,6 +1,7 @@
 require 'open_project/version'
+require_relative '../../lib_static/open_project/appsignal'
 
-if ENV['APPSIGNAL_ENABLED'] == 'true'
+if OpenProject::Appsignal.enabled?
   require 'appsignal'
   OpenProject::Application.configure do |app|
     config = {

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -33,6 +33,8 @@ preload_app! if ENV["RAILS_ENV"] == 'production'
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart unless ENV["RAILS_ENV"] == 'production'
 
+plugin :appsignal if ENV['APPSIGNAL_ENABLED'] == 'true'
+
 # activate statsd plugin only if a host is configured explicitly
 if OpenProject::Configuration.statsd_host.present?
   module ConfigurationViaOpenProject

--- a/lib/api/appsignal_api.rb
+++ b/lib/api/appsignal_api.rb
@@ -25,42 +25,17 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
+require "appsignal"
+require "appsignal/integrations/grape"
 
 module API
-  class OpenProjectAPI < ::Grape::API
-    include ::API::AppsignalAPI
-
-    class << self
-      def inherited(api, *)
-        super
-
-        # run unscoped patches (i.e. patches that are on the class root, not in a namespace)
-        api.apply_patches(nil)
+  module AppsignalAPI
+    def self.included(base)
+      base.class_eval do
+        if Appsignal.active?
+          insert_before Grape::Middleware::Error, Appsignal::Grape::Middleware
+        end
       end
     end
-  end
-end
-
-Grape::DSL::Routing::ClassMethods.module_eval do
-  # Be reload safe. otherwise, an infinite loop occurs on reload.
-  unless instance_methods.include?(:orig_namespace)
-    alias :orig_namespace :namespace
-  end
-
-  def namespace(space = nil, options = {}, &)
-    orig_namespace(space, options) do
-      instance_eval(&)
-      apply_patches(space)
-    end
-  end
-
-  def apply_patches(path)
-    (patches[path] || []).each do |patch|
-      instance_eval(&patch)
-    end
-  end
-
-  def patches
-    ::Constants::APIPatchRegistry.patches_for(base)
   end
 end

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -25,9 +25,9 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-
 module API
   class Root < ::API::RootAPI
+    include ::API::AppsignalAPI
     content_type 'hal+json', 'application/hal+json; charset=utf-8'
     format 'hal+json'
     formatter 'hal+json', API::Formatter.new

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -35,6 +35,7 @@ require 'open_project/authentication'
 module API
   class RootAPI < Grape::API
     include OpenProject::Authentication::Scope
+    include ::API::AppsignalAPI
     extend API::Utilities::GrapeHelper
 
     insert_before Grape::Middleware::Error,

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -258,6 +258,7 @@ module API
       authenticate
       set_localization
       enforce_content_type
+      ::OpenProject::Appsignal.tag_request(request:)
     end
   end
 end


### PR DESCRIPTION
Add Appsignal as an optional integration that gets bootstrapped when the appropriate envs are presented:

```
APPSIGNAL_ENABLED=true
APPSIGNAL_KEY=<push key>
APPSIGNAL_NAME=<name of the app>
```