### PR TITLE
[41814] Fix minor style issues in the new datepicker

### DIFF
--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.html
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.html
@@ -26,7 +26,7 @@
 
     <div class="op-datepicker-modal--dates-container">
       <ng-container *ngIf="singleDate">
-        <div class="form--field">
+        <div class="form--field op-datepicker-modal--date-form">
           <label class="form--label"
                  [textContent]="text.date">
           </label>
@@ -52,7 +52,7 @@
       </ng-container>
 
       <ng-container *ngIf="!singleDate">
-        <div class="form--field"
+        <div class="form--field op-datepicker-modal--date-form"
              data-qa-selector="datepicker-start-date"
         >
           <label class="form--label"
@@ -80,7 +80,7 @@
             </a>
           </div>
         </div>
-        <div class="form--field"
+        <div class="form--field op-datepicker-modal--date-form"
              data-qa-selector="datepicker-end-date"
         >
           <label class="form--label"

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
@@ -3,9 +3,8 @@
 .op-datepicker-modal
   z-index: 500
   width: auto
-  // prevent additional content like notifications to
-  // drastically increase the width.
-  max-width: 730px
+  // Basically the width of the two calendars next to each other + spacings
+  max-width: 600px
   min-height: 200px
   box-shadow: $spot-shadow-light-mid
   // Apply a bottom margin before the banners are loaded
@@ -27,3 +26,7 @@
 
   &--date-container
     display: inline-grid
+
+  &--action
+    &:last-of-type
+      margin-right: 0

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.sass
@@ -4,6 +4,7 @@
   z-index: 500
   width: auto
   // Basically the width of the two calendars next to each other + spacings
+  // will be overwritten on mobile
   max-width: 600px
   min-height: 200px
   box-shadow: $spot-shadow-light-mid

--- a/frontend/src/app/shared/components/datepicker/datepicker_mobile.modal.sass
+++ b/frontend/src/app/shared/components/datepicker/datepicker_mobile.modal.sass
@@ -1,6 +1,10 @@
 @media screen and (max-width: 679px)
   .op-datepicker-modal
     height: initial
-    width: calc(100vw - 2rem)
+    max-width: 300px
     &--dates-container
-      grid-template-columns: 1fr max-content
+      grid-template-columns: 1fr 1fr
+
+    &--date-form
+      &:only-child
+        grid-column: 1 / 3

--- a/frontend/src/app/spot/styles/sass/components/text-field.sass
+++ b/frontend/src/app/spot/styles/sass/components/text-field.sass
@@ -23,6 +23,7 @@
     border: 0
     padding: 0
     flex-grow: 1
+    width: 100%
     outline: 0
 
     &:not(:first-child)

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -42,6 +42,14 @@ $datepicker--border-radius: 5px
   .flatpickr-months
     min-height: 45px
 
+    .flatpickr-current-month
+      @include spot-body-small(bold)
+      justify-content: center
+
+    .numInputWrapper
+      position: relative !important
+      left: 0 !important
+
   .flatpickr-weekwrapper
     display: none
 
@@ -50,18 +58,32 @@ $datepicker--border-radius: 5px
 
   .flatpickr-weekdaycontainer,
   .flatpickr-days .dayContainer
-    padding: 0 1.25rem
+
+    &:first-of-type
+      padding: 0 1rem 0 0
+    &:last-of-type
+      padding: 0 0 0 1rem
+
+  .flatpickr-prev-month
+    padding-left: 0
+  .flatpickr-next-month
+    padding-right: 0
 
   .flatpickr-days
     .dayContainer
       box-shadow: none
+      min-width: 283px
 
       .flatpickr-day
         color: $spot-color-basic-black
         height: 30px
         line-height: 28px
+        margin: 0
         border-radius: $datepicker--border-radius
         box-shadow: none !important
+
+        &:hover
+          border-radius: 0
 
         &.flatpickr-disabled,
         &.flatpickr-non-working-day
@@ -71,6 +93,7 @@ $datepicker--border-radius: 5px
         &.today
           background: $spot-color-indication-current-date
           border-color: $spot-color-indication-current-date
+          border-radius: $datepicker--border-radius
 
         &.selected,
         &.startRange,

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -31,9 +31,9 @@ $datepicker--border-radius: 5px
 .flatpickr-current-month
   display: flex !important
 
-.numInputWrapper
-  position: fixed !important
-  left: 65% !important
+.flatpickr-calendar .numInputWrapper
+  position: fixed
+  left: 65%
 
 .flatpickr-calendar.inline
   box-shadow: none !important
@@ -47,8 +47,8 @@ $datepicker--border-radius: 5px
       justify-content: center
 
     .numInputWrapper
-      position: relative !important
-      left: 0 !important
+      position: relative
+      left: 0
 
   .flatpickr-weekwrapper
     display: none

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -63,6 +63,8 @@ $datepicker--border-radius: 5px
       padding: 0 1rem 0 0
     &:last-of-type
       padding: 0 0 0 1rem
+    &:only-of-type
+      padding: 0
 
   .flatpickr-prev-month
     padding-left: 0
@@ -73,6 +75,11 @@ $datepicker--border-radius: 5px
     .dayContainer
       box-shadow: none
       min-width: 283px
+      max-width: 283px
+
+      @media screen and (max-width: 679px)
+        min-width: 267px
+        max-width: 267px
 
       .flatpickr-day
         color: $spot-color-basic-black


### PR DESCRIPTION
### ToDo

- [x] On hover, normal days should have squared hover effect to match the "greyed-out" days hover effect
- [x] The month/year in the mini calendar should be centered, joined together, and the same text size as "Manual scheduling" but in bold.
- [x] There is 1px line vertical padding between each week that we don't need.
- [x] The padding on the right side of the modal a lot more than the padding on the left; they should be equal (16px/1rem).
- [x] The length of the date picker modal should be determined by the length required for the two mini calendars + padding (not the width of the banner text).
- [x] The padding to the left/right of the mini calendars should be the same as the other elements (start date/manual scheduling and so forth). Currently, the mini calendars seem to have additional padding.

**mobile**
- [x] The two date fields need to be resized so that each takes 50% of available horizontal space (+ padding). Right now they overflow..


Fixes [this commit](https://community.openproject.org/projects/openproject/work_packages/41814#activity-18) in https://community.openproject.org/projects/openproject/work_packages/41814/activity