### PR TITLE
[41817] Non working days in single date pickers

### DIFF
--- a/frontend/src/app/shared/components/op-date-picker/datepicker.ts
+++ b/frontend/src/app/shared/components/op-date-picker/datepicker.ts
@@ -172,7 +172,7 @@ export class DatePicker {
       },
       onDayCreate: (dObj:Date[], dStr:string, fp:flatpickr.Instance, dayElem:DayElement) => {
         if (this.weekdaysService.isDateDisabled(dayElem.dateObj)) {
-          dayElem.classList.add('flatpickr-grey-out');
+          dayElem.classList.add('flatpickr-non-working-day');
         }
       },
       dateFormat: this.datepickerFormat,

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -35,6 +35,13 @@ $datepicker--border-radius: 5px
   position: fixed
   left: 65%
 
+
+.flatpickr-day
+  &.flatpickr-disabled,
+  &.flatpickr-non-working-day
+    background: $spot-color-basic-gray-6
+    border-radius: 0
+
 .flatpickr-calendar.inline
   box-shadow: none !important
   @include spot-caption
@@ -90,11 +97,6 @@ $datepicker--border-radius: 5px
         box-shadow: none !important
 
         &:hover
-          border-radius: 0
-
-        &.flatpickr-disabled,
-        &.flatpickr-non-working-day
-          background: $spot-color-basic-gray-6
           border-radius: 0
 
         &.today


### PR DESCRIPTION
In order to show the non-working days in single date pickers as well, two changes have been made:
* Use correct class name
* Move the style block so that it is not only applied for inline calendars but for all flatpickr instances

Fixes [this commit](https://community.openproject.org/projects/openproject/work_packages/41817?query_id=3115#activity-12) in https://community.openproject.org/projects/openproject/work_packages/41817/activity