### PR TITLE
[42757] Non working days in Gantt charts

### DIFF
--- a/frontend/src/app/core/days/weekday.service.ts
+++ b/frontend/src/app/core/days/weekday.service.ts
@@ -1,0 +1,69 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2022 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  Injectable,
+  Injector,
+} from '@angular/core';
+import * as moment from 'moment';
+import {
+  take,
+  tap,
+} from 'rxjs/operators';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
+import { WeekdayResourceService } from 'core-app/core/state/days/weekday.service';
+import { IWeekday } from 'core-app/core/state/days/weekday.model';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class WeekdayService {
+  @InjectField() weekdaysService:WeekdayResourceService;
+
+  private weekdays:IWeekday[] = [];
+
+  constructor(
+    readonly injector:Injector,
+  ) {}
+
+  public isDateDisabled(date:Date):boolean {
+    const dayOfWeek = moment(date).isoWeekday();
+    return !!this.weekdays.find((wd) => wd.day === dayOfWeek && !wd.working);
+  }
+
+  loadWeekdays():Observable<IWeekday[]> {
+    return this
+      .weekdaysService
+      .require()
+      .pipe(
+        take(1),
+        tap((weekdays) => {
+          this.weekdays = weekdays;
+        }),
+      );
+  }
+}

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/container/wp-timeline-container.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/container/wp-timeline-container.directive.ts
@@ -66,6 +66,7 @@ import {
   TimelineViewParameters,
   zoomLevelOrder,
 } from '../wp-timeline';
+import { WeekdayService } from 'core-app/core/days/weekday.service';
 
 @Component({
   selector: 'wp-timeline-container',
@@ -120,7 +121,8 @@ export class WorkPackageTimelineTableController extends UntilDestroyedMixin impl
     return workPackagesWithGroupHeaderCell;
   }
 
-  constructor(public readonly injector:Injector,
+  constructor(
+    public readonly injector:Injector,
     private elementRef:ElementRef,
     private states:States,
     public wpTableComponent:WorkPackagesTableComponent,
@@ -132,7 +134,9 @@ export class WorkPackageTimelineTableController extends UntilDestroyedMixin impl
     private halEvents:HalEventsService,
     private querySpace:IsolatedQuerySpace,
     readonly I18n:I18nService,
-    private workPackageViewCollapsedGroupsService:WorkPackageViewCollapsedGroupsService) {
+    private workPackageViewCollapsedGroupsService:WorkPackageViewCollapsedGroupsService,
+    private weekdaysService:WeekdayService,
+  ) {
     super();
   }
 
@@ -157,10 +161,11 @@ export class WorkPackageTimelineTableController extends UntilDestroyedMixin impl
       this.querySpace.tableRendered.values$(),
       this.refreshRequest.changes$(),
       this.wpTableTimeline.live$(),
+      this.weekdaysService.loadWeekdays(),
     ]).pipe(
       this.commonPipes,
     )
-      .subscribe(([orderedRows, changes, timelineState]) => {
+      .subscribe(([orderedRows]) => {
       // Remember all visible rows in their order of appearance.
         this.workPackageIdOrder = orderedRows.filter((row:RenderedWorkPackage) => !row.hidden);
         this.orderedRows = orderedRows;

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/grid/wp-timeline-grid.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/grid/wp-timeline-grid.directive.ts
@@ -38,13 +38,13 @@ import {
 } from '../wp-timeline';
 import Moment = moment.Moment;
 
-function checkForWeekendHighlight(date:Moment, cell:HTMLElement) {
+function checkForNonWorkingDayHighlight(date:Moment, cell:HTMLElement) {
   const day = date.day();
 
   // Sunday = 0
   // Monday = 6
   if (day === 0 || day === 6) {
-    cell.classList.add('grid-weekend');
+    cell.classList.add('wp-timeline--non-working-day');
   }
 }
 
@@ -61,17 +61,17 @@ export class WorkPackageTableTimelineGrid implements AfterViewInit {
     public wpTimeline:WorkPackageTimelineTableController) {
   }
 
-  ngAfterViewInit() {
+  ngAfterViewInit():void {
     const $element = jQuery(this.elementRef.nativeElement);
     this.gridContainer = $element.find('.wp-table-timeline--grid');
     this.wpTimeline.onRefreshRequested('grid', (vp:TimelineViewParameters) => this.refreshView(vp));
   }
 
-  refreshView(vp:TimelineViewParameters) {
+  refreshView(vp:TimelineViewParameters):void {
     this.renderLabels(vp);
   }
 
-  private renderLabels(vp:TimelineViewParameters) {
+  private renderLabels(vp:TimelineViewParameters):void {
     if (this.activeZoomLevel === vp.settings.zoomLevel) {
       return;
     }
@@ -80,81 +80,88 @@ export class WorkPackageTableTimelineGrid implements AfterViewInit {
 
     switch (vp.settings.zoomLevel) {
       case 'days':
-        return this.renderLabelsDays(vp);
+        this.renderLabelsDays(vp);
+        break;
       case 'weeks':
-        return this.renderLabelsWeeks(vp);
+        this.renderLabelsWeeks(vp);
+        break;
       case 'months':
-        return this.renderLabelsMonths(vp);
+        this.renderLabelsMonths(vp);
+        break;
       case 'quarters':
-        return this.renderLabelsQuarters(vp);
+        this.renderLabelsQuarters(vp);
+        break;
       case 'years':
-        return this.renderLabelsYears(vp);
+        this.renderLabelsYears(vp);
+        break;
+      default:
+        return;
     }
 
     this.activeZoomLevel = vp.settings.zoomLevel;
   }
 
-  private renderLabelsDays(vp:TimelineViewParameters) {
+  private renderLabelsDays(vp:TimelineViewParameters):void {
     this.renderTimeSlices(vp, 'day', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
       cell.style.paddingTop = '1px';
-      checkForWeekendHighlight(start, cell);
+      checkForNonWorkingDayHighlight(start, cell);
     });
 
     this.renderTimeSlices(vp, 'year', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      cell.classList.add('-grid-highlight');
+      cell.classList.add('wp-timeline--grid-element_highlight');
       cell.style.zIndex = '2';
     });
   }
 
-  private renderLabelsWeeks(vp:TimelineViewParameters) {
+  private renderLabelsWeeks(vp:TimelineViewParameters):void {
     this.renderTimeSlices(vp, 'day', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      checkForWeekendHighlight(start, cell);
+      checkForNonWorkingDayHighlight(start, cell);
     });
 
     this.renderTimeSlices(vp, 'week', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      cell.classList.add('-grid-highlight');
+      cell.classList.add('wp-timeline--grid-element_highlight');
     });
 
     this.renderTimeSlices(vp, 'year', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      cell.classList.add('-grid-highlight');
+      cell.classList.add('wp-timeline--grid-element_highlight');
       cell.style.zIndex = '2';
     });
   }
 
-  private renderLabelsMonths(vp:TimelineViewParameters) {
-    this.renderTimeSlices(vp, 'week', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
+  private renderLabelsMonths(vp:TimelineViewParameters):void {
+    this.renderTimeSlices(vp, 'week', vp.dateDisplayStart, vp.dateDisplayEnd, () => {
     });
 
     this.renderTimeSlices(vp, 'month', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      cell.classList.add('-grid-highlight');
+      cell.classList.add('wp-timeline--grid-element_highlight');
     });
 
     this.renderTimeSlices(vp, 'year', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      cell.classList.add('-grid-highlight');
+      cell.classList.add('wp-timeline--grid-element_highlight');
       cell.style.zIndex = '2';
     });
   }
 
-  private renderLabelsQuarters(vp:TimelineViewParameters) {
-    this.renderTimeSlices(vp, 'month', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
+  private renderLabelsQuarters(vp:TimelineViewParameters):void {
+    this.renderTimeSlices(vp, 'month', vp.dateDisplayStart, vp.dateDisplayEnd, () => {
     });
 
     this.renderTimeSlices(vp, 'quarter', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      cell.classList.add('-grid-highlight');
+      cell.classList.add('wp-timeline--grid-element_highlight');
     });
 
     this.renderTimeSlices(vp, 'year', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      cell.classList.add('-grid-highlight');
+      cell.classList.add('wp-timeline--grid-element_highlight');
       cell.style.zIndex = '2';
     });
   }
 
-  private renderLabelsYears(vp:TimelineViewParameters) {
-    this.renderTimeSlices(vp, 'month', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
+  private renderLabelsYears(vp:TimelineViewParameters):void {
+    this.renderTimeSlices(vp, 'month', vp.dateDisplayStart, vp.dateDisplayEnd, () => {
     });
 
     this.renderTimeSlices(vp, 'year', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      cell.classList.add('-grid-highlight');
+      cell.classList.add('wp-timeline--grid-element_highlight');
     });
   }
 
@@ -162,7 +169,7 @@ export class WorkPackageTableTimelineGrid implements AfterViewInit {
     unit:moment.unitOfTime.DurationConstructor,
     startView:Moment,
     endView:Moment,
-    cellCallback:(start:Moment, cell:HTMLElement) => void) {
+    cellCallback:(start:Moment, cell:HTMLElement) => void):void {
     const { inViewportAndBoundaries, rest } = getTimeSlicesForHeader(vp, unit, startView, endView);
 
     for (const [start, end] of inViewportAndBoundaries) {

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/grid/wp-timeline-grid.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/grid/wp-timeline-grid.directive.ts
@@ -194,6 +194,7 @@ export class WorkPackageTableTimelineGrid implements AfterViewInit {
 
     if (this.weekdaysService.isDateDisabled(day)) {
       cell.classList.add('wp-timeline--non-working-day');
+      cell.dataset.qaSelector = `wp-timeline--non-working-day_${day.getDate()}-${day.getMonth() + 1}-${day.getFullYear()}`;
     }
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/grid/wp-timeline-grid.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/grid/wp-timeline-grid.directive.ts
@@ -25,7 +25,11 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 //++
-import { AfterViewInit, Component, ElementRef } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+} from '@angular/core';
 import * as moment from 'moment';
 import { TimelineZoomLevel } from 'core-app/features/hal/resources/query-resource';
 import { WorkPackageTimelineTableController } from '../container/wp-timeline-container.directive';
@@ -36,17 +40,8 @@ import {
   timelineGridElementCssClass,
   TimelineViewParameters,
 } from '../wp-timeline';
+import { WeekdayService } from 'core-app/core/days/weekday.service';
 import Moment = moment.Moment;
-
-function checkForNonWorkingDayHighlight(date:Moment, cell:HTMLElement) {
-  const day = date.day();
-
-  // Sunday = 0
-  // Monday = 6
-  if (day === 0 || day === 6) {
-    cell.classList.add('wp-timeline--non-working-day');
-  }
-}
 
 @Component({
   selector: 'wp-timeline-grid',
@@ -57,9 +52,11 @@ export class WorkPackageTableTimelineGrid implements AfterViewInit {
 
   private gridContainer:JQuery;
 
-  constructor(private elementRef:ElementRef,
-    public wpTimeline:WorkPackageTimelineTableController) {
-  }
+  constructor(
+    private elementRef:ElementRef,
+    public wpTimeline:WorkPackageTimelineTableController,
+    private weekdaysService:WeekdayService,
+  ) {}
 
   ngAfterViewInit():void {
     const $element = jQuery(this.elementRef.nativeElement);
@@ -104,7 +101,7 @@ export class WorkPackageTableTimelineGrid implements AfterViewInit {
   private renderLabelsDays(vp:TimelineViewParameters):void {
     this.renderTimeSlices(vp, 'day', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
       cell.style.paddingTop = '1px';
-      checkForNonWorkingDayHighlight(start, cell);
+      this.checkForNonWorkingDayHighlight(start, cell);
     });
 
     this.renderTimeSlices(vp, 'year', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
@@ -115,7 +112,7 @@ export class WorkPackageTableTimelineGrid implements AfterViewInit {
 
   private renderLabelsWeeks(vp:TimelineViewParameters):void {
     this.renderTimeSlices(vp, 'day', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
-      checkForNonWorkingDayHighlight(start, cell);
+      this.checkForNonWorkingDayHighlight(start, cell);
     });
 
     this.renderTimeSlices(vp, 'week', vp.dateDisplayStart, vp.dateDisplayEnd, (start, cell) => {
@@ -190,5 +187,13 @@ export class WorkPackageTableTimelineGrid implements AfterViewInit {
         cellCallback(start, cell);
       }
     }, 0);
+  }
+
+  private checkForNonWorkingDayHighlight(date:Moment, cell:HTMLElement) {
+    const day = date.toDate();
+
+    if (this.weekdaysService.isDateDisabled(day)) {
+      cell.classList.add('wp-timeline--non-working-day');
+    }
   }
 }

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
@@ -244,7 +244,7 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
           this.onDataChange();
         },
         onDayCreate: (dObj:Date[], dStr:string, fp:flatpickr.Instance, dayElem:DayElement) => {
-          if (this.datePickerInstance?.isDateDisabled(dayElem.dateObj)) {
+          if (this.datePickerInstance?.weekdaysService.isDateDisabled(dayElem.dateObj)) {
             dayElem.classList.add('flatpickr-non-working-day');
           }
 

--- a/frontend/src/app/shared/components/op-date-picker/datepicker.ts
+++ b/frontend/src/app/shared/components/op-date-picker/datepicker.ts
@@ -34,11 +34,9 @@ import {
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { rangeSeparator } from 'core-app/shared/components/op-date-picker/op-range-date-picker/op-range-date-picker.component';
-import { WeekdayResourceService } from 'core-app/core/state/days/weekday.service';
-import { IWeekday } from 'core-app/core/state/days/weekday.model';
 import { Injector } from '@angular/core';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
-import { take } from 'rxjs/operators';
+import { WeekdayService } from 'core-app/core/days/weekday.service';
 import DateOption = flatpickr.Options.DateOption;
 
 export class DatePicker {
@@ -50,11 +48,9 @@ export class DatePicker {
 
   private reshowTimeout:ReturnType<typeof setTimeout>;
 
-  private weekdays:IWeekday[] = [];
-
   @InjectField() configurationService:ConfigurationService;
 
-  @InjectField() weekdaysService:WeekdayResourceService;
+  @InjectField() weekdaysService:WeekdayService;
 
   @InjectField() I18n:I18nService;
 
@@ -69,7 +65,14 @@ export class DatePicker {
   }
 
   private initialize(options:flatpickr.Options.Options) {
-    this.loadWeekdays();
+    this
+      .weekdaysService
+      .loadWeekdays()
+      .subscribe(() => {
+        if (this.datepickerInstance) {
+          this.datepickerInstance.redraw();
+        }
+      });
 
     const mergedOptions = _.extend({}, this.defaultOptions, options);
 
@@ -159,27 +162,6 @@ export class DatePicker {
     );
   }
 
-  public isDateDisabled(date:Date):boolean {
-    const dayOfWeek = moment(date).isoWeekday();
-    return !!this.weekdays.find((wd) => wd.day === dayOfWeek && !wd.working);
-  }
-
-  private loadWeekdays() {
-    this
-      .weekdaysService
-      .require()
-      .pipe(
-        take(1),
-      )
-      .subscribe((weekdays) => {
-        this.weekdays = weekdays;
-
-        if (this.datepickerInstance) {
-          this.datepickerInstance.redraw();
-        }
-      });
-  }
-
   private get defaultOptions() {
     const firstDayOfWeek = this.configurationService.startOfWeek();
 
@@ -189,7 +171,7 @@ export class DatePicker {
         return moment(dateObj).format('W');
       },
       onDayCreate: (dObj:Date[], dStr:string, fp:flatpickr.Instance, dayElem:DayElement) => {
-        if (this.isDateDisabled(dayElem.dateObj)) {
+        if (this.weekdaysService.isDateDisabled(dayElem.dateObj)) {
           dayElem.classList.add('flatpickr-grey-out');
         }
       },

--- a/frontend/src/global_styles/content/work_packages/timelines/_grid.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/_grid.sass
@@ -1,12 +1,13 @@
-.wp-timeline--grid-element
-  position: absolute
-  top: 0
-  padding-top: 5px
-  height: 100%
-  border-right: 1px solid var(--timeline--grid-color)
+.wp-timeline
+  &--grid-element
+    position: absolute
+    top: 0
+    padding-top: 5px
+    height: 100%
+    border-right: 1px solid var(--timeline--grid-color)
 
-  &.-grid-highlight
-    border-right: 1px solid var(--timeline--header-border-color)
+    &_highlight
+      border-right: 1px solid var(--timeline--header-border-color)
 
-  &.grid-weekend
+  &--non-working-day
     background-color: #f5f5f5

--- a/spec/features/work_packages/timeline/timeline_dates_spec.rb
+++ b/spec/features/work_packages/timeline/timeline_dates_spec.rb
@@ -99,6 +99,24 @@ RSpec.describe 'Work package timeline date formatting',
         expect_date_week '2021-01-04', '01'
       end
     end
+
+    context 'with weekdays defined' do
+      let(:current_user) { create :admin, language: 'en' }
+      let!(:week_days) { create :week_days }
+
+      it 'shows them as disabled' do
+        expect_date_week work_package.start_date.iso8601, '01'
+
+        expect(page).to have_selector('[data-qa-selector="wp-timeline--non-working-day_27-12-2020"]')
+        expect(page).to have_selector('[data-qa-selector="wp-timeline--non-working-day_2-1-2021"]')
+
+        expect(page).to have_no_selector('[data-qa-selector="wp-timeline--non-working-day_28-12-2020"]')
+        expect(page).to have_no_selector('[data-qa-selector="wp-timeline--non-working-day_29-12-2020"]')
+        expect(page).to have_no_selector('[data-qa-selector="wp-timeline--non-working-day_30-12-2020"]')
+        expect(page).to have_no_selector('[data-qa-selector="wp-timeline--non-working-day_31-12-2020"]')
+        expect(page).to have_no_selector('[data-qa-selector="wp-timeline--non-working-day_1-1-2021"]')
+      end
+    end
   end
 
   describe 'with US/CA settings',


### PR DESCRIPTION
Instead of always showing Saturday and Sunday as non-working days, the Gantt chart should use the new API data.

https://community.openproject.org/projects/openproject/work_packages/42757/activity