### PR TITLE
rubocop autofix for cops added in 2.15

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -192,18 +192,16 @@ class UsersController < ApplicationController
     was_activated = (@user.status_change == %w[registered active])
 
     if params[:activate] && @user.missing_authentication_method?
-      flash[:error] = I18n.t(:error_status_change_failed,
-                             errors: I18n.t(:notice_user_missing_authentication_method),
-                             scope: :user)
+      flash[:error] = I18n.t('user.error_status_change_failed',
+                             errors: I18n.t(:notice_user_missing_authentication_method))
     elsif @user.save
       flash[:notice] = I18n.t(:notice_successful_update)
       if was_activated
         UserMailer.account_activated(@user).deliver_later
       end
     else
-      flash[:error] = I18n.t(:error_status_change_failed,
-                             errors: @user.errors.full_messages.join(', '),
-                             scope: :user)
+      flash[:error] = I18n.t('user.error_status_change_failed',
+                             errors: @user.errors.full_messages.join(', '))
     end
     redirect_back_or_default(action: 'edit', id: @user)
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -63,10 +63,9 @@ module UsersHelper
 
     both_statuses = user_status + brute_force_status
     if user_status.present? and brute_force_status.present?
-      I18n.t(:status_user_and_brute_force,
+      I18n.t('user.status_user_and_brute_force',
              user: user_status,
-             brute_force: brute_force_status,
-             scope: :user)
+             brute_force: brute_force_status)
     elsif not both_statuses.empty?
       both_statuses
     else

--- a/app/models/queries/relations/filters/involved_filter.rb
+++ b/app/models/queries/relations/filters/involved_filter.rb
@@ -54,7 +54,7 @@ module Queries
                             "AND"
                           end
 
-          sql = <<~SQL
+          sql = <<~SQL.squish
             (from_id #{operator_string} (?) AND to_id IN (#{visible_sql}))
              #{concatenation} (to_id #{operator_string} (?) AND from_id IN (#{visible_sql}))
           SQL

--- a/app/models/queries/relations/filters/involved_filter.rb
+++ b/app/models/queries/relations/filters/involved_filter.rb
@@ -54,7 +54,7 @@ module Queries
                             "AND"
                           end
 
-          sql = <<-SQL.strip_heredoc
+          sql = <<~SQL
             (from_id #{operator_string} (?) AND to_id IN (#{visible_sql}))
              #{concatenation} (to_id #{operator_string} (?) AND from_id IN (#{visible_sql}))
           SQL

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -626,14 +626,8 @@ class User < Principal
 
       if former_passwords_include?(password)
         errors.add(:password,
-                   I18n.t(:reused,
-                          count: Setting[:password_count_former_banned].to_i,
-                          scope: %i[activerecord
-                                    errors
-                                    models
-                                    user
-                                    attributes
-                                    password]))
+                   I18n.t('activerecord.errors.models.user.attributes.password.reused',
+                          count: Setting[:password_count_former_banned].to_i))
       end
     end
   end

--- a/app/models/work_package/pdf_export/view.rb
+++ b/app/models/work_package/pdf_export/view.rb
@@ -59,7 +59,7 @@ class WorkPackage::PDFExport::View
   end
 
   def register_fonts!(document)
-    font_path = Rails.root.join('public/fonts')
+    font_path = Rails.public_path.join('fonts')
 
     document.font_families['NotoSans'] = {
       normal: {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -125,7 +125,7 @@ OpenProject::Application.configure do
       'Access-Control-Allow-Origin' => '*',
       'Access-Control-Allow-Methods' => 'GET, OPTIONS, HEAD',
       'Cache-Control' => 'public, s-maxage=31536000, max-age=15552000',
-      'Expires' => 1.year.from_now.to_formatted_s(:rfc822).to_s
+      'Expires' => 1.year.from_now.to_fs(:rfc822).to_s
     }
   end
 end

--- a/lib/open_project/assets.rb
+++ b/lib/open_project/assets.rb
@@ -43,7 +43,7 @@ module OpenProject
       end
 
       def frontend_asset_path
-        Rails.root.join('public/assets/frontend/')
+        Rails.public_path.join('assets/frontend/')
       end
 
       def manifest_path

--- a/lib/open_project/passwords.rb
+++ b/lib/open_project/passwords.rb
@@ -55,8 +55,7 @@ module OpenProject
           errors << rules_description
         end
         unless password_long_enough(password)
-          errors << I18n.t(:too_short,
-                           scope: %i[activerecord errors messages],
+          errors << I18n.t('activerecord.errors.messages.too_short',
                            count: OpenProject::Passwords::Evaluator.min_length)
         end
         errors
@@ -128,8 +127,7 @@ module OpenProject
       end
 
       def self.rules_description_locale(rules)
-        I18n.t(:weak,
-               scope: %i[activerecord errors models user attributes password],
+        I18n.t('activerecord.errors.models.user.attributes.password.weak',
                rules:,
                min_count: min_adhered_rules,
                all_count: active_rules.size)

--- a/modules/backlogs/lib/open_project/backlogs/work_package_filter.rb
+++ b/modules/backlogs/lib/open_project/backlogs/work_package_filter.rb
@@ -32,10 +32,10 @@ require 'task'
 module OpenProject::Backlogs
   class WorkPackageFilter < ::Queries::WorkPackages::Filter::WorkPackageFilter
     def allowed_values
-      [[I18n.t(:story, scope: [:backlogs]), 'story'],
-       [I18n.t(:task, scope: [:backlogs]), 'task'],
-       [I18n.t(:impediment, scope: [:backlogs]), 'impediment'],
-       [I18n.t(:any, scope: [:backlogs]), 'any']]
+      [[I18n.t('backlogs.story'), 'story'],
+       [I18n.t('backlogs.task'), 'task'],
+       [I18n.t('backlogs.impediment'), 'impediment'],
+       [I18n.t('backlogs.any'), 'any']]
     end
 
     def available?

--- a/modules/backlogs/spec/services/impediments/create_services_spec.rb
+++ b/modules/backlogs/spec/services/impediments/create_services_spec.rb
@@ -137,9 +137,7 @@ describe Impediments::CreateService do
       it { expect(subject).to be_new_record }
 
       it {
-        expect(subject.errors[:blocks_ids]).to include I18n.t(:can_only_contain_work_packages_of_current_sprint,
-                                                              scope: %i[activerecord errors models work_package attributes
-                                                                        blocks_ids])
+        expect(subject.errors[:blocks_ids]).to include I18n.t('activerecord.errors.models.work_package.attributes.blocks_ids.can_only_contain_work_packages_of_current_sprint')
       }
     end
 
@@ -159,9 +157,7 @@ describe Impediments::CreateService do
       it { expect(subject).to be_new_record }
 
       it {
-        expect(subject.errors[:blocks_ids]).to include I18n.t(:can_only_contain_work_packages_of_current_sprint,
-                                                              scope: %i[activerecord errors models work_package attributes
-                                                                        blocks_ids])
+        expect(subject.errors[:blocks_ids]).to include I18n.t('activerecord.errors.models.work_package.attributes.blocks_ids.can_only_contain_work_packages_of_current_sprint')
       }
     end
   end
@@ -182,9 +178,7 @@ describe Impediments::CreateService do
     it { expect(subject).to be_new_record }
 
     it {
-      expect(subject.errors[:blocks_ids]).to include I18n.t(:must_block_at_least_one_work_package,
-                                                            scope: %i[activerecord errors models work_package attributes
-                                                                      blocks_ids])
+      expect(subject.errors[:blocks_ids]).to include I18n.t('activerecord.errors.models.work_package.attributes.blocks_ids.must_block_at_least_one_work_package')
     }
   end
 end

--- a/modules/backlogs/spec/services/impediments/create_services_spec.rb
+++ b/modules/backlogs/spec/services/impediments/create_services_spec.rb
@@ -26,7 +26,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+require 'spec_helper'
 
 describe Impediments::CreateService do
   let(:instance) { described_class.new(user:) }
@@ -137,7 +137,8 @@ describe Impediments::CreateService do
       it { expect(subject).to be_new_record }
 
       it {
-        expect(subject.errors[:blocks_ids]).to include I18n.t('activerecord.errors.models.work_package.attributes.blocks_ids.can_only_contain_work_packages_of_current_sprint')
+        expect(subject.errors.symbols_for(:blocks_ids))
+          .to eq [:can_only_contain_work_packages_of_current_sprint]
       }
     end
 
@@ -157,7 +158,8 @@ describe Impediments::CreateService do
       it { expect(subject).to be_new_record }
 
       it {
-        expect(subject.errors[:blocks_ids]).to include I18n.t('activerecord.errors.models.work_package.attributes.blocks_ids.can_only_contain_work_packages_of_current_sprint')
+        expect(subject.errors.symbols_for(:blocks_ids))
+          .to eq [:can_only_contain_work_packages_of_current_sprint]
       }
     end
   end
@@ -178,7 +180,8 @@ describe Impediments::CreateService do
     it { expect(subject).to be_new_record }
 
     it {
-      expect(subject.errors[:blocks_ids]).to include I18n.t('activerecord.errors.models.work_package.attributes.blocks_ids.must_block_at_least_one_work_package')
+      expect(subject.errors.symbols_for(:blocks_ids))
+        .to eq [:must_block_at_least_one_work_package]
     }
   end
 end

--- a/modules/backlogs/spec/services/impediments/update_service_spec.rb
+++ b/modules/backlogs/spec/services/impediments/update_service_spec.rb
@@ -164,9 +164,8 @@ describe Impediments::UpdateService, type: :model do
       end
 
       it {
-        expect(subject.errors[:blocks_ids]).to include I18n.t(:can_only_contain_work_packages_of_current_sprint,
-                                                              scope: %i[activerecord errors models work_package attributes
-                                                                        blocks_ids])
+        expect(subject.errors.symbols_for(:blocks_ids))
+          .to eq [:can_only_contain_work_packages_of_current_sprint]
       }
     end
 
@@ -179,9 +178,8 @@ describe Impediments::UpdateService, type: :model do
       end
 
       it {
-        expect(subject.errors[:blocks_ids]).to include I18n.t(:can_only_contain_work_packages_of_current_sprint,
-                                                              scope: %i[activerecord errors models work_package attributes
-                                                                        blocks_ids])
+        expect(subject.errors.symbols_for(:blocks_ids))
+          .to eq [:can_only_contain_work_packages_of_current_sprint]
       }
     end
   end
@@ -195,9 +193,8 @@ describe Impediments::UpdateService, type: :model do
     end
 
     it {
-      expect(subject.errors[:blocks_ids]).to include I18n.t(:must_block_at_least_one_work_package,
-                                                            scope: %i[activerecord errors models work_package attributes
-                                                                      blocks_ids])
+      expect(subject.errors.symbols_for(:blocks_ids))
+        .to eq [:must_block_at_least_one_work_package]
     }
   end
 end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -29,8 +29,6 @@
 require 'spec_helper'
 
 describe UsersHelper, type: :helper do
-  include UsersHelper
-
   def build_user(status, blocked)
     build_stubbed(:user,
                   status:,
@@ -60,13 +58,14 @@ describe UsersHelper, type: :helper do
 
     test_cases.each do |(status, blocked), expectation|
       describe "with status #{status} and blocked #{blocked}" do
-        before do
-          user = build_user(status, blocked)
-          @status = full_user_status(user, true)
+        let(:user) { build_user(status, blocked) }
+
+        subject(:user_status) do
+          full_user_status(user, true)
         end
 
         it "returns #{expectation}" do
-          expect(@status).to eq(expectation)
+          expect(user_status).to eq(expectation)
         end
       end
     end
@@ -84,34 +83,34 @@ describe UsersHelper, type: :helper do
     test_cases.each do |(status, blocked), expectation_symbol|
       describe "with status #{status} and blocked #{blocked}" do
         expectation = I18n.t(expectation_symbol, scope: :user)
-        before do
+        subject(:buttons) do
           user = build_user(status, blocked)
-          @buttons = change_user_status_buttons(user)
+          change_user_status_buttons(user)
         end
 
         it "contains '#{expectation}'" do
-          expect(@buttons).to include(expectation)
+          expect(buttons).to include(expectation)
         end
 
         it 'contains a single button' do
-          expect(@buttons.scan('<input').count).to eq(1)
+          expect(buttons.scan('<input').count).to eq(1)
         end
       end
     end
 
     describe 'with status active and blocked True' do
-      before do
+      subject(:buttons) do
         user = build_user(:active, true)
-        @buttons = change_user_status_buttons(user)
+        change_user_status_buttons(user)
       end
 
       it 'returns inputs (buttons)' do
-        expect(@buttons.scan('<input').count).to eq(2)
+        expect(buttons.scan('<input').count).to eq(2)
       end
 
       it "contains 'Lock' and 'Reset Failed logins'" do
-        expect(@buttons).to include(I18n.t('user.lock'))
-        expect(@buttons).to include(I18n.t('user.reset_failed_logins'))
+        expect(buttons).to include(I18n.t('user.lock'))
+        expect(buttons).to include(I18n.t('user.reset_failed_logins'))
       end
     end
   end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -43,24 +43,19 @@ describe UsersHelper, type: :helper do
 
   describe 'full_user_status' do
     test_cases = {
-      [:active, false] => I18n.t(:active, scope: :user),
-      [:active, true] => I18n.t(:blocked_num_failed_logins,
-                                count: 3,
-                                scope: :user),
-      [:locked, false] => I18n.t(:locked, scope: :user),
-      [:locked, true] => I18n.t(:status_user_and_brute_force,
-                                user: I18n.t(:locked, scope: :user),
-                                brute_force: I18n.t(:blocked_num_failed_logins,
-                                                    count: 3,
-                                                    scope: :user),
-                                scope: :user),
-      [:registered, false] => I18n.t(:registered, scope: :user),
-      [:registered, true] => I18n.t(:status_user_and_brute_force,
-                                    user: I18n.t(:registered, scope: :user),
-                                    brute_force: I18n.t(:blocked_num_failed_logins,
-                                                        count: 3,
-                                                        scope: :user),
-                                    scope: :user)
+      [:active, false] => I18n.t('user.active'),
+      [:active, true] => I18n.t('user.blocked_num_failed_logins',
+                                count: 3),
+      [:locked, false] => I18n.t('user.locked'),
+      [:locked, true] => I18n.t('user.status_user_and_brute_force',
+                                user: I18n.t('user.locked'),
+                                brute_force: I18n.t('user.blocked_num_failed_logins',
+                                                    count: 3)),
+      [:registered, false] => I18n.t('user.registered'),
+      [:registered, true] => I18n.t('user.status_user_and_brute_force',
+                                    user: I18n.t('user.registered'),
+                                    brute_force: I18n.t('user.blocked_num_failed_logins',
+                                                        count: 3))
     }
 
     test_cases.each do |(status, blocked), expectation|
@@ -115,8 +110,8 @@ describe UsersHelper, type: :helper do
       end
 
       it "contains 'Lock' and 'Reset Failed logins'" do
-        expect(@buttons).to include(I18n.t(:lock, scope: :user))
-        expect(@buttons).to include(I18n.t(:reset_failed_logins, scope: :user))
+        expect(@buttons).to include(I18n.t('user.lock'))
+        expect(@buttons).to include(I18n.t('user.reset_failed_logins'))
       end
     end
   end

--- a/spec/lib/open_project/scm/adapters/git_adapter_spec.rb
+++ b/spec/lib/open_project/scm/adapters/git_adapter_spec.rb
@@ -517,7 +517,7 @@ describe OpenProject::SCM::Adapters::Git do
 
           it 'provides the selected diff for the given range' do
             diff = adapter.diff('README', '61b685f', '2f9c009').map(&:chomp)
-            expect(diff).to eq(<<-DIFF.strip_heredoc.split("\n"))
+            expect(diff).to eq(<<~DIFF.split("\n"))
               diff --git a/README b/README
               index 6cbd30c..b94e68e 100644
               --- a/README

--- a/spec/lib/open_project/scm/adapters/subversion_adapter_spec.rb
+++ b/spec/lib/open_project/scm/adapters/subversion_adapter_spec.rb
@@ -79,7 +79,7 @@ describe OpenProject::SCM::Adapters::Subversion do
       end
 
       it 'raises a meaningful error if shell output fails' do
-        error_string = <<-ERR.strip_heredoc
+        error_string = <<~ERR
           svn: E215004: Authentication failed and interactive prompting is disabled; see the --force-interactive option
           svn: E215004: Unable to connect to a repository at URL 'file:///tmp/bar.svn'
           svn: E215004: No more credentials or we tried too many times.
@@ -387,7 +387,7 @@ describe OpenProject::SCM::Adapters::Subversion do
 
         it 'provides the selected diff for the given range' do
           diff = adapter.diff('subversion_test/helloworld.c', 8, 6).map(&:chomp)
-          expect(diff).to eq(<<-DIFF.strip_heredoc.split("\n"))
+          expect(diff).to eq(<<~DIFF.split("\n"))
             Index: helloworld.c
             ===================================================================
             --- helloworld.c	(revision 6)

--- a/spec/lib/open_project/text_formatting/markdown/headings_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/headings_spec.rb
@@ -112,7 +112,7 @@ describe OpenProject::TextFormatting,
         end
 
         let(:expected) do
-          <<~EXPECTED.strip_heredoc
+          <<~EXPECTED
             <h1 class="op-uc-h1" id="20090209">
               2009\\02\\09
               <a class="op-uc-link_permalink icon-link op-uc-link" href="#20090209" aria-hidden="true"></a>

--- a/spec/support/rspec_retry.rb
+++ b/spec/support/rspec_retry.rb
@@ -42,9 +42,9 @@ def retry_block(args: {}, screenshot: false, &block)
   end
 
   log_errors = Proc.new do |exception, try, elapsed_time, next_interval|
-    warn <<-EOS.strip_heredoc
-    #{exception.class}: '#{exception.message}'
-    #{try} tries in #{elapsed_time} seconds and #{next_interval} seconds until the next try.
+    warn <<~EOS
+      #{exception.class}: '#{exception.message}'
+      #{try} tries in #{elapsed_time} seconds and #{next_interval} seconds until the next try.
     EOS
 
     if screenshot

--- a/spec/views/admin/settings/authentication/show.html.erb_spec.rb
+++ b/spec/views/admin/settings/authentication/show.html.erb_spec.rb
@@ -40,7 +40,7 @@ describe 'admin/settings/authentication_settings/show', type: :view do
     end
 
     it 'shows automated user blocking options' do
-      expect(rendered).to have_text I18n.t(:brute_force_prevention, scope: [:settings])
+      expect(rendered).to have_text I18n.t('settings.brute_force_prevention')
     end
   end
 
@@ -55,7 +55,7 @@ describe 'admin/settings/authentication_settings/show', type: :view do
     end
 
     it 'does not show automated user blocking options' do
-      expect(rendered).not_to have_text I18n.t(:brute_force_prevention, scope: [:settings])
+      expect(rendered).not_to have_text I18n.t('settings.brute_force_prevention')
     end
   end
 


### PR DESCRIPTION
Result of running

```
rubocop -A --only Rails/DotSeparatedKeys,Rails/StripHeredoc,Rails/ToFormattedS,Rails/RootPublicPath,Rails/DeprecatedActiveModelErrorsMethods .
```