### PR TITLE
fix flickering storages feature spec

### DIFF
--- a/modules/storages/spec/features/show_file_links_spec.rb
+++ b/modules/storages/spec/features/show_file_links_spec.rb
@@ -41,6 +41,7 @@ describe 'Showing of file links in work package', :enable_storages, type: :featu
   let(:wp_page) { ::Pages::FullWorkPackage.new(work_package, project) }
 
   before do
+    project_storage
     file_link
 
     login_as current_user
@@ -48,10 +49,6 @@ describe 'Showing of file links in work package', :enable_storages, type: :featu
   end
 
   context 'if work package has associated file links' do
-    before do
-      project_storage
-    end
-
     it "must show associated file links" do
       expect(page).to have_selector('[data-qa-selector="op-tab-content--tab-section"]', count: 2)
       expect(page.find('[data-qa-selector="op-files-tab--file-link-list"]'))
@@ -62,16 +59,14 @@ describe 'Showing of file links in work package', :enable_storages, type: :featu
   context 'if user has no permission to see file links' do
     let(:permissions) { %i(view_work_packages edit_work_packages) }
 
-    before do
-      project_storage
-    end
-
     it 'must not show a file links section' do
       expect(page).to have_selector('[data-qa-selector="op-tab-content--tab-section"]', count: 1)
     end
   end
 
   context 'if project has no storage' do
+    let(:project_storage) { {} }
+
     it 'must not show a file links section' do
       expect(page).to have_selector('[data-qa-selector="op-tab-content--tab-section"]', count: 1)
     end


### PR DESCRIPTION
- removed race condition, that caused database to be updated AFTER view
  was initialized sometimes