### PR TITLE
Introduce ServiceResult factory methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rails
   - rubocop-rspec
+  - ./lib_static/rubocop/cop/open_project/use_service_result_factory_methods.rb
 
 AllCops:
   TargetRubyVersion: 3.1

--- a/Gemfile
+++ b/Gemfile
@@ -265,10 +265,6 @@ group :development do
   gem 'spring'
   gem 'spring-commands-rspec'
 
-  gem 'rubocop'
-  gem 'rubocop-rails'
-  gem 'rubocop-rspec'
-
   # Gems for living styleguide
   gem 'livingstyleguide', '~> 2.1.0'
   gem 'sassc-rails'
@@ -291,6 +287,11 @@ group :development, :test do
   gem 'pry-rails', '~> 0.3.6'
   gem 'pry-rescue', '~> 1.5.2'
   gem 'pry-stack_explorer', '~> 0.6.0'
+
+  # ruby linting
+  gem 'rubocop'
+  gem 'rubocop-rails'
+  gem 'rubocop-rspec'
 
   # git hooks manager
   gem 'lefthook'

--- a/app/services/api/parse_resource_params_service.rb
+++ b/app/services/api/parse_resource_params_service.rb
@@ -52,8 +52,7 @@ module API
                  {}
                end
 
-      ServiceResult.new(success: true,
-                        result: parsed)
+      ServiceResult.success(result: parsed)
     end
 
     private

--- a/app/services/api/v3/parse_query_params_service.rb
+++ b/app/services/api/v3/parse_query_params_service.rb
@@ -40,7 +40,7 @@ module API
 
         result = without_empty(parsed.merge(json_parsed.result), determine_allowed_empty(params))
 
-        ServiceResult.new(success: true, result:)
+        ServiceResult.success(result:)
       end
 
       private
@@ -52,9 +52,9 @@ module API
           timeline_labels: timeline_labels_from_params(params)
         }
 
-        ServiceResult.new success: true, result: parsed
+        ServiceResult.success result: parsed
       rescue ::JSON::ParserError => e
-        result = ServiceResult.new success: false
+        result = ServiceResult.failure
         result.errors.add(:base, e.message)
         result
       end

--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -46,7 +46,7 @@ module API
         if update.success?
           representer = results_to_representer(params)
 
-          ServiceResult.new(success: true, result: representer)
+          ServiceResult.success(result: representer)
         else
           update
         end

--- a/app/services/attachments/prepare_upload_service.rb
+++ b/app/services/attachments/prepare_upload_service.rb
@@ -33,9 +33,9 @@ module Attachments
 
       if attachment.save
         attachment.reload # necessary so that the fog file uploader path is correct
-        ServiceResult.new success: true, result: attachment
+        ServiceResult.success result: attachment
       else
-        ServiceResult.new success: false, result: attachment
+        ServiceResult.failure result: attachment
       end
     end
 

--- a/app/services/authentication/omniauth_service.rb
+++ b/app/services/authentication/omniauth_service.rb
@@ -51,7 +51,7 @@ module Authentication
       inspect_response(Logger::DEBUG)
 
       unless contract.validate
-        result = ServiceResult.new(success: false, errors: contract.errors)
+        result = ServiceResult.failure(errors: contract.errors)
         Rails.logger.error do
           "[OmniAuth strategy #{strategy.name}] Failed to process omniauth response for #{auth_uid}: #{result.message}"
         end
@@ -194,7 +194,7 @@ module Authentication
           .new(user)
           .call
       else
-        ServiceResult.new(success: true, result: user)
+        ServiceResult.success(result: user)
       end
     end
 

--- a/app/services/authorization/user_allowed_service.rb
+++ b/app/services/authorization/user_allowed_service.rb
@@ -45,11 +45,9 @@ class Authorization::UserAllowedService
   #   or falls back to Non Member / Anonymous permissions depending if the user is logged
   def call(action, context, global: false)
     if supported_context?(context, global:)
-      ServiceResult.new(success: true,
-                        result: allowed_to?(action, context, global:))
+      ServiceResult.success(result: allowed_to?(action, context, global:))
     else
-      ServiceResult.new(success: false,
-                        result: false)
+      ServiceResult.failure(result: false)
     end
   end
 

--- a/app/services/base_services/base_contracted.rb
+++ b/app/services/base_services/base_contracted.rb
@@ -68,11 +68,11 @@ module BaseServices
     end
 
     def validate_params(_params)
-      ServiceResult.new(success: true, result: model)
+      ServiceResult.success(result: model)
     end
 
     def before_perform(*)
-      ServiceResult.new(success: true, result: model)
+      ServiceResult.success(result: model)
     end
 
     def after_validate(_params, contract_call)

--- a/app/services/base_services/copy.rb
+++ b/app/services/base_services/copy.rb
@@ -77,7 +77,7 @@ module BaseServices
       # Try to save the result or return its errors
       copy_instance = call.result
       unless copy_instance.save
-        return ServiceResult.new(success: false, result: copy_instance, errors: copy_instance.errors)
+        return ServiceResult.failure(result: copy_instance, errors: copy_instance.errors)
       end
 
       self.class.copy_dependencies.each do |service_cls|

--- a/app/services/base_type_service.rb
+++ b/app/services/base_type_service.rb
@@ -73,7 +73,7 @@ class BaseTypeService
                       errors:,
                       result: type)
   rescue StandardError => e
-    ServiceResult.new(success: false).tap do |result|
+    ServiceResult.failure.tap do |result|
       result.errors.add(:base, e.message)
     end
   end

--- a/app/services/copy/dependency.rb
+++ b/app/services/copy/dependency.rb
@@ -53,7 +53,7 @@ module Copy
       @user = user
       # Create a result with an empty error set
       # that we can merge! so that not the target.errors object is reused.
-      @result = ServiceResult.new(result: target, success: true, errors: ActiveModel::Errors.new(target))
+      @result = ServiceResult.success(result: target, errors: ActiveModel::Errors.new(target))
     end
 
     protected

--- a/app/services/custom_fields/create_service.rb
+++ b/app/services/custom_fields/create_service.rb
@@ -41,7 +41,7 @@ module CustomFields
     def perform(params)
       super
     rescue StandardError => e
-      ServiceResult.new(success: false, message: e.message)
+      ServiceResult.failure(message: e.message)
     end
 
     def instance(params)

--- a/app/services/design/update_design_service.rb
+++ b/app/services/design/update_design_service.rb
@@ -42,10 +42,10 @@ module Design
 
         custom_style.save!
 
-        ServiceResult.new success: true, result: custom_style
+        ServiceResult.success result: custom_style
       end
     rescue StandardError => e
-      ServiceResult.new success: false, message: e.message
+      ServiceResult.failure message: e.message
     end
 
     private

--- a/app/services/grids/copy/widgets_dependent_service.rb
+++ b/app/services/grids/copy/widgets_dependent_service.rb
@@ -78,7 +78,7 @@ module Grids::Copy
       if mapper
         mapper.call(value, params).map { |id| [option, id] }
       else
-        ServiceResult.new success: true, result: [option, value]
+        ServiceResult.success result: [option, value]
       end
     end
 
@@ -101,7 +101,7 @@ module Grids::Copy
       existing_query_id = state.query_id_lookup[query_id.to_i] if state.query_id_lookup
 
       if existing_query_id
-        ServiceResult.new(result: existing_query_id, success: true)
+        ServiceResult.success(result: existing_query_id)
       else
         duplicate_query(query_id, params).map(&:id)
       end
@@ -112,7 +112,7 @@ module Grids::Copy
         .new(state, filters)
         .map_filters!
 
-      ServiceResult.new success: true, result: filters
+      ServiceResult.success result: filters
     end
 
     def duplicate_query(query_id, params)

--- a/app/services/groups/concerns/membership_manipulation.rb
+++ b/app/services/groups/concerns/membership_manipulation.rb
@@ -44,11 +44,10 @@ module Groups::Concerns
 
     def with_error_handled
       yield
-      ServiceResult.new success: true, result: model
+      ServiceResult.success result: model
     rescue StandardError => e
       Rails.logger.error { "Failed to modify members and associated roles of group #{model.id}: #{e} #{e.message}" }
-      ServiceResult.new(success: false,
-                        message: I18n.t(:notice_internal_server_error, app_title: Setting.app_title))
+      ServiceResult.failure(message: I18n.t(:notice_internal_server_error, app_title: Setting.app_title))
     end
 
     def exec_query!(params, send_notifications, message)

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -51,13 +51,13 @@ module Journals
       Journal.transaction do
         journal = create_journal(notes)
 
-        return ServiceResult.new success: true unless journal
+        return ServiceResult.success unless journal
 
         destroy_predecessor(journal)
         reload_journals
         touch_journable(journal)
 
-        ServiceResult.new success: true, result: journal
+        ServiceResult.success result: journal
       end
     end
 

--- a/app/services/members/cleanup_service.rb
+++ b/app/services/members/cleanup_service.rb
@@ -41,7 +41,7 @@ module Members
       prune_watchers
       unassign_categories
 
-      ServiceResult.new(success: true)
+      ServiceResult.success
     end
 
     attr_accessor :users,

--- a/app/services/oauth_clients/redirect_uri_from_state_service.rb
+++ b/app/services/oauth_clients/redirect_uri_from_state_service.rb
@@ -40,9 +40,9 @@ module OAuthClients
       redirect_uri = oauth_state_cookie
 
       if redirect_uri.present? && ::API::V3::Utilities::PathHelper::ApiV3Path::same_origin?(redirect_uri)
-        ServiceResult.new(success: true, result: redirect_uri)
+        ServiceResult.success(result: redirect_uri)
       else
-        ServiceResult.new(success: false)
+        ServiceResult.failure
       end
     end
 

--- a/app/services/parse_schema_filter_params_service.rb
+++ b/app/services/parse_schema_filter_params_service.rb
@@ -75,11 +75,11 @@ class ParseSchemaFilterParamsService
   def error(message)
     errors = ActiveModel::Errors.new(self)
     errors.add(:base, message)
-    ServiceResult.new(errors:)
+    ServiceResult.failure(errors:)
   end
 
   def success(result)
-    ServiceResult.new(success: true, result:)
+    ServiceResult.success(result:)
   end
 
   def valid_project_type_pairs(filter)

--- a/app/services/principals/replace_references_service.rb
+++ b/app/services/principals/replace_references_service.rb
@@ -36,7 +36,7 @@ module Principals
       rewrite_default_journals(from, to)
       rewrite_customizable_journals(from, to)
 
-      ServiceResult.new success: true
+      ServiceResult.success
     end
 
     private

--- a/app/services/projects/enqueue_copy_service.rb
+++ b/app/services/projects/enqueue_copy_service.rb
@@ -41,7 +41,7 @@ module Projects
       call = test_copy(params)
 
       if call.success?
-        ServiceResult.new success: true, result: schedule_copy_job(params)
+        ServiceResult.success result: schedule_copy_job(params)
       else
         call
       end

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -33,6 +33,38 @@ class ServiceResult
                 :state,
                 :dependent_results
 
+  # Creates a successful ServiceResult.
+  def self.success(errors: nil,
+                   message: nil,
+                   message_type: nil,
+                   state: ::Shared::ServiceState.new,
+                   dependent_results: [],
+                   result: nil)
+    new(success: true,
+        errors:,
+        message:,
+        message_type:,
+        state:,
+        dependent_results:,
+        result:)
+  end
+
+  # Creates a failed ServiceResult.
+  def self.failure(errors: nil,
+                   message: nil,
+                   message_type: nil,
+                   state: ::Shared::ServiceState.new,
+                   dependent_results: [],
+                   result: nil)
+    new(success: false,
+        errors:,
+        message:,
+        message_type:,
+        state:,
+        dependent_results:,
+        result:)
+  end
+
   def initialize(success: false,
                  errors: nil,
                  message: nil,

--- a/app/services/sessions/initialize_session_service.rb
+++ b/app/services/sessions/initialize_session_service.rb
@@ -43,7 +43,7 @@ module Sessions
           ::Sessions::UserSession.for_user(user).delete_all
         end
 
-        ServiceResult.new(success: true, result: session)
+        ServiceResult.success(result: session)
       end
 
       private

--- a/app/services/update_query_from_params_service.rb
+++ b/app/services/update_query_from_params_service.rb
@@ -60,10 +60,9 @@ class UpdateQueryFromParamsService
     end
 
     if query.valid?
-      ServiceResult.new(success: true,
-                        result: query)
+      ServiceResult.success(result: query)
     else
-      ServiceResult.new(errors: query.errors)
+      ServiceResult.failure(errors: query.errors)
     end
   end
 

--- a/app/services/users/create_service.rb
+++ b/app/services/users/create_service.rb
@@ -46,7 +46,7 @@ module Users
     end
 
     def fail_with_missing_email(new_user)
-      ServiceResult.new(success: false, result: new_user).tap do |result|
+      ServiceResult.failure(result: new_user).tap do |result|
         result.errors.add :mail, :blank
       end
     end

--- a/app/services/users/login_service.rb
+++ b/app/services/users/login_service.rb
@@ -53,7 +53,7 @@ module Users
 
       user.log_successful_login
 
-      ServiceResult.new(result: user)
+      ServiceResult.failure(result: user)
     end
 
     def retain_sso_session_values!(user)

--- a/app/services/users/logout_service.rb
+++ b/app/services/users/logout_service.rb
@@ -43,7 +43,7 @@ module Users
       end
 
       User.current = User.anonymous
-      ServiceResult.new(result: User.anonymous)
+      ServiceResult.failure(result: User.anonymous)
     end
 
     private

--- a/app/services/users/register_user_service.rb
+++ b/app/services/users/register_user_service.rb
@@ -50,7 +50,7 @@ module Users
       end
     rescue StandardError => e
       Rails.logger.error { "User #{user.login} failed to activate #{e}." }
-      ServiceResult.new(success: false, result: user, message: I18n.t(:notice_activation_failed))
+      ServiceResult.failure(result: user, message: I18n.t(:notice_activation_failed))
     end
 
     private
@@ -60,7 +60,7 @@ module Users
     # for non-invited users
     def ensure_registration_allowed!
       if Setting::SelfRegistration.disabled?
-        ServiceResult.new(success: false, result: user, message: I18n.t('account.error_self_registration_disabled'))
+        ServiceResult.failure(result: user, message: I18n.t('account.error_self_registration_disabled'))
       end
     end
 
@@ -69,7 +69,7 @@ module Users
     def ensure_user_limit_not_reached!
       if OpenProject::Enterprise.user_limit_reached?
         OpenProject::Enterprise.send_activation_limit_notification_about user
-        ServiceResult.new(success: false, result: user, message: I18n.t(:error_enterprise_activation_user_limit))
+        ServiceResult.failure(result: user, message: I18n.t(:error_enterprise_activation_user_limit))
       end
     end
 
@@ -140,7 +140,7 @@ module Users
 
     def fail_activation
       Rails.logger.error { "User #{user.login} could not be activated, all options were exhausted." }
-      ServiceResult.new(success: false, message: I18n.t(:notice_activation_failed))
+      ServiceResult.failure(message: I18n.t(:notice_activation_failed))
     end
 
     ##
@@ -149,10 +149,10 @@ module Users
     def with_saved_user_result(success_message: I18n.t(:notice_account_activated))
       if user.save
         yield if block_given?
-        return ServiceResult.new(success: true, result: user, message: success_message)
+        return ServiceResult.success(result: user, message: success_message)
       end
 
-      ServiceResult.new(success: false).tap do |call|
+      ServiceResult.failure.tap do |call|
         # Avoid using the errors from the user
         call.result = user
         call.errors.add(:base, I18n.t(:notice_activation_failed), error: :failed_to_activate)

--- a/app/services/work_packages/bulk/bulked_service.rb
+++ b/app/services/work_packages/bulk/bulked_service.rb
@@ -51,7 +51,7 @@ module WorkPackages
       private
 
       def bulk(params)
-        result = ServiceResult.new success: true, result: true
+        result = ServiceResult.success result: true
 
         work_packages.each do |work_package|
           # As updating one work package might have already saved another one,

--- a/app/services/work_packages/exports/schedule_service.rb
+++ b/app/services/work_packages/exports/schedule_service.rb
@@ -37,7 +37,7 @@ class WorkPackages::Exports::ScheduleService
     export_storage = WorkPackages::Export.create
     job = schedule_export(export_storage, mime_type, params, query)
 
-    ServiceResult.new success: true, result: job.job_id
+    ServiceResult.success result: job.job_id
   end
 
   private

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -45,12 +45,10 @@ class WorkPackages::SetScheduleService
       altered += schedule_following
     end
 
-    result = ServiceResult.new(success: true,
-                               result: work_packages.first)
+    result = ServiceResult.success(result: work_packages.first)
 
     altered.each do |wp|
-      result.add_dependent!(ServiceResult.new(success: true,
-                                              result: wp))
+      result.add_dependent!(ServiceResult.success(result: wp))
     end
 
     result

--- a/lib_static/rubocop/cop/open_project/use_service_result_factory_methods.rb
+++ b/lib_static/rubocop/cop/open_project/use_service_result_factory_methods.rb
@@ -1,0 +1,145 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module RuboCop::Cop::OpenProject
+  # # bad
+  # ServiceResult.new(success: true, result: 'result')
+  # ServiceResult.new(success: false, errors: ['error'])
+  #
+  # # good
+  # ServiceResult.success(result: 'result')
+  # ServiceResult.failure(errors: ['error'])
+  # ServiceResult.new(success: some_value)
+  # ServiceResult.new(**kwargs)
+  class UseServiceResultFactoryMethods < RuboCop::Cop::Base
+    extend RuboCop::Cop::AutoCorrector
+
+    MSG = 'Use ServiceResult.%<factory_method>s(...) instead of ServiceResult.new(success: %<success_value>s, ...).'.freeze
+    MSG_IMPLICIT_FAILURE = 'Use ServiceResult.failure instead of ServiceResult.new.'.freeze
+
+    def_node_matcher :service_result_constructor?, <<~PATTERN
+      (send
+        $(const nil? :ServiceResult) :new
+        ...
+      )
+    PATTERN
+
+    def_node_matcher :constructor_with_explicit_success_arg, <<~PATTERN
+      (send
+        (const nil? :ServiceResult) :new
+        (hash
+          <
+            $(pair (sym :success) ({true | false}))
+            ...
+          >
+        )
+      )
+    PATTERN
+
+    def on_send(node)
+      return unless service_result_constructor?(node)
+
+      if success_argument_present?(node)
+        add_offense_if_explicit_success_argument(node)
+      elsif success_argument_possibly_present?(node)
+        return # rubocop:disable Style/RedundantReturn
+      else
+        add_offense_for_implicit_failure(node)
+      end
+    end
+
+    private
+
+    def success_argument_present?(node)
+      hash_argument = node.arguments.find(&:hash_type?)
+      return false unless hash_argument
+
+      hash_argument.keys.any? { |key| key.sym_type? && key.value == :success }
+    end
+
+    def success_argument_possibly_present?(node)
+      return true if node.arguments.find(&:forwarded_args_type?)
+
+      hash_argument = node.arguments.find(&:hash_type?)
+      return false unless hash_argument
+
+      hash_argument.children.any?(&:kwsplat_type?)
+    end
+
+    def add_offense_if_explicit_success_argument(node)
+      constructor_with_explicit_success_arg(node) do |success_argument|
+        message = format(MSG, success_value: success_value(success_argument),
+                              factory_method: factory_method(success_argument))
+        add_offense(success_argument, message:) do |corrector|
+          corrector.replace(node.loc.selector, factory_method(success_argument))
+          corrector.remove(removal_range(node, success_argument))
+        end
+      end
+    end
+
+    def add_offense_for_implicit_failure(node)
+      add_offense(node.loc.selector, message: MSG_IMPLICIT_FAILURE) do |corrector|
+        corrector.replace(node.loc.selector, 'failure')
+      end
+    end
+
+    def success_value(success_argument)
+      success_argument.value.source
+    end
+
+    def factory_method(success_argument)
+      success_argument.value.source == 'true' ? 'success' : 'failure'
+    end
+
+    def removal_range(node, success_argument)
+      if sole_argument?(success_argument)
+        all_parameters_range(node)
+      else
+        success_parameter_range(success_argument)
+      end
+    end
+
+    def sole_argument?(arg)
+      arg.parent.loc.expression == arg.loc.expression
+    end
+
+    def all_parameters_range(node)
+      node.loc.selector.end.join(node.loc.expression.end)
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    def success_parameter_range(success_argument)
+      if success_argument.left_sibling
+        success_argument.left_sibling.loc.expression.end.join(success_argument.loc.expression.end)
+      else
+        success_argument.loc.expression.begin.join(success_argument.right_sibling.loc.expression.begin)
+      end
+    end
+    # rubocop:enable Metrics/AbcSize
+  end
+end

--- a/modules/avatars/app/services/avatars/update_service.rb
+++ b/modules/avatars/app/services/avatars/update_service.rb
@@ -10,7 +10,7 @@ module ::Avatars
 
     def replace(avatar)
       if avatar.nil?
-        return ServiceResult.new(success: false).tap do |_result|
+        return ServiceResult.failure.tap do |_result|
           return error_result(I18n.t(:empty_file_error))
         end
       end
@@ -33,7 +33,7 @@ module ::Avatars
       end
 
       @user.local_avatar_attachment = avatar
-      ServiceResult.new(success: true, result: I18n.t(:message_avatar_uploaded))
+      ServiceResult.success(result: I18n.t(:message_avatar_uploaded))
     rescue StandardError => e
       Rails.logger.error "Failed to update avatar of user##{user.id}: #{e}"
       error_result(I18n.t(:error_image_upload))
@@ -43,7 +43,7 @@ module ::Avatars
       current_attachment = @user.local_avatar_attachment
       if current_attachment && current_attachment.destroy
         @user.reload
-        ServiceResult.new(success: true, result: I18n.t(:avatar_deleted))
+        ServiceResult.success(result: I18n.t(:avatar_deleted))
       else
         error_result(I18n.t(:unable_to_delete_avatar))
       end
@@ -55,7 +55,7 @@ module ::Avatars
     private
 
     def error_result(message)
-      ServiceResult.new(success: false).tap do |result|
+      ServiceResult.failure.tap do |result|
         result.errors.add(:base, message)
       end
     end

--- a/modules/avatars/spec/controllers/avatars/my_controller_spec.rb
+++ b/modules/avatars/spec/controllers/avatars/my_controller_spec.rb
@@ -50,7 +50,7 @@ describe ::Avatars::MyAvatarController, type: :controller do
     it 'calls the service for put' do
       expect_any_instance_of(::Avatars::UpdateService)
         .to receive(:replace)
-        .and_return(ServiceResult.new(success: true))
+        .and_return(ServiceResult.success)
 
       put :update
       expect(response).to be_successful
@@ -60,7 +60,7 @@ describe ::Avatars::MyAvatarController, type: :controller do
     it 'calls the service for put' do
       expect_any_instance_of(::Avatars::UpdateService)
         .to receive(:replace)
-        .and_return(ServiceResult.new(success: false))
+        .and_return(ServiceResult.failure)
 
       put :update
       expect(response).not_to be_successful
@@ -78,7 +78,7 @@ describe ::Avatars::MyAvatarController, type: :controller do
     it 'calls the service for delete' do
       expect_any_instance_of(::Avatars::UpdateService)
         .to receive(:destroy)
-        .and_return(ServiceResult.new(success: true, result: 'message'))
+        .and_return(ServiceResult.success(result: 'message'))
 
       delete :destroy
       expect(flash[:notice]).to include 'message'
@@ -87,7 +87,7 @@ describe ::Avatars::MyAvatarController, type: :controller do
     end
 
     it 'calls the service for delete' do
-      result = ServiceResult.new(success: false)
+      result = ServiceResult.failure
       result.errors.add :base, 'error'
 
       expect_any_instance_of(::Avatars::UpdateService)

--- a/modules/avatars/spec/controllers/avatars/users_controller_spec.rb
+++ b/modules/avatars/spec/controllers/avatars/users_controller_spec.rb
@@ -68,7 +68,7 @@ describe ::Avatars::UsersController, type: :controller do
     it 'calls the service for put' do
       expect_any_instance_of(::Avatars::UpdateService)
         .to receive(:replace)
-              .and_return(ServiceResult.new(success: true))
+              .and_return(ServiceResult.success)
 
       put :update, params: { id: target_user.id }
       expect(response).to be_successful
@@ -78,7 +78,7 @@ describe ::Avatars::UsersController, type: :controller do
     it 'calls the service for put' do
       expect_any_instance_of(::Avatars::UpdateService)
         .to receive(:replace)
-              .and_return(ServiceResult.new(success: false))
+              .and_return(ServiceResult.failure)
 
       put :update, params: { id: target_user.id }
       expect(response).not_to be_successful
@@ -107,7 +107,7 @@ describe ::Avatars::UsersController, type: :controller do
     it 'calls the service for delete' do
       expect_any_instance_of(::Avatars::UpdateService)
         .to receive(:destroy)
-              .and_return(ServiceResult.new(success: true, result: 'message'))
+              .and_return(ServiceResult.success(result: 'message'))
 
       delete :destroy, params: { id: target_user.id }
       expect(flash[:notice]).to include 'message'
@@ -116,7 +116,7 @@ describe ::Avatars::UsersController, type: :controller do
     end
 
     it 'calls the service for delete' do
-      result = ServiceResult.new(success: false)
+      result = ServiceResult.failure
       result.errors.add :base, 'error'
 
       expect_any_instance_of(::Avatars::UpdateService)

--- a/modules/bim/app/services/bim/bcf/issues/create_service.rb
+++ b/modules/bim/app/services/bim/bcf/issues/create_service.rb
@@ -87,7 +87,7 @@ module Bim::Bcf
       end
 
       def work_package_not_found_result
-        ServiceResult.new(errors: Bim::Bcf::Issue.new.errors).tap do |r|
+        ServiceResult.failure(errors: Bim::Bcf::Issue.new.errors).tap do |r|
           r.errors.add :work_package, :does_not_exist
         end
       end

--- a/modules/bim/app/services/bim/bcf/issues/transform_attributes_service.rb
+++ b/modules/bim/app/services/bim/bcf/issues/transform_attributes_service.rb
@@ -34,8 +34,7 @@ module Bim::Bcf
       end
 
       def call(attributes)
-        ServiceResult.new success: true,
-                          result: work_package_attributes(attributes)
+        ServiceResult.success result: work_package_attributes(attributes)
       end
 
       private

--- a/modules/bim/app/services/bim/ifc_models/view_converter_service.rb
+++ b/modules/bim/app/services/bim/ifc_models/view_converter_service.rb
@@ -74,7 +74,7 @@ module Bim
         ifc_model.conversion_error_message = e.message
         ifc_model.save
 
-        ServiceResult.new(success: false).tap { |r| r.errors.add(:base, e.message) }
+        ServiceResult.failure.tap { |r| r.errors.add(:base, e.message) }
       ensure
         self.working_directory = nil
       end

--- a/modules/bim/lib/open_project/bim/bcf_xml/issue_reader.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/issue_reader.rb
@@ -318,7 +318,7 @@ module OpenProject::Bim::BcfXml
                  message: I18n.t('bcf.bcf_xml.import.work_package_has_newer_changes',
                                  bcf_uuid: issue.uuid)
 
-      ServiceResult.new(success: false, errors:)
+      ServiceResult.failure(errors:)
     end
   end
 end

--- a/modules/bim/spec/controllers/work_packages_controller_spec.rb
+++ b/modules/bim/spec/controllers/work_packages_controller_spec.rb
@@ -62,7 +62,7 @@ describe WorkPackagesController, type: :controller do
         allow(service_instance)
           .to receive(:call)
           .with(query:, mime_type: mime_type.to_sym, params: anything)
-          .and_return(ServiceResult.new(result: 'uuid of the export job'))
+          .and_return(ServiceResult.failure(result: 'uuid of the export job'))
       end
 
       it 'redirects to the export' do

--- a/modules/bim/spec/services/bcf/issues/create_service_spec.rb
+++ b/modules/bim/spec/services/bcf/issues/create_service_spec.rb
@@ -34,7 +34,7 @@ describe Bim::Bcf::Issues::CreateService, type: :model do
     let(:model_class) { ::Bim::Bcf::Issue }
     let(:factory) { :bcf_issue }
     let(:work_package) { build_stubbed :work_package }
-    let(:wp_call) { ServiceResult.new(success: true, result: work_package) }
+    let(:wp_call) { ServiceResult.success(result: work_package) }
 
     before do
       allow(instance)
@@ -43,7 +43,7 @@ describe Bim::Bcf::Issues::CreateService, type: :model do
     end
 
     context 'when WP service call fails' do
-      let(:wp_call) { ServiceResult.new(success: false, result: work_package) }
+      let(:wp_call) { ServiceResult.failure(result: work_package) }
 
       it 'returns with that call immediately' do
         expect(subject).to eq wp_call

--- a/modules/bim/spec/workers/ifc_conversion_job_spec.rb
+++ b/modules/bim/spec/workers/ifc_conversion_job_spec.rb
@@ -8,7 +8,7 @@ describe Bim::IfcModels::IfcConversionJob, type: :job do
   it 'calls the conversion service' do
     expect(::Bim::IfcModels::ViewConverterService)
       .to receive_message_chain(:new, :call)
-      .and_return ServiceResult.new success: true
+      .and_return ServiceResult.success
 
     expect { subject }.not_to raise_error
   end

--- a/modules/bim/spec/workers/work_packages/exports/export_job_spec.rb
+++ b/modules/bim/spec/workers/work_packages/exports/export_job_spec.rb
@@ -76,7 +76,7 @@ describe WorkPackages::ExportJob do
 
         expect(service)
           .to(receive(:call))
-          .and_return(ServiceResult.new(result: attachment, success: true))
+          .and_return(ServiceResult.success(result: attachment))
 
         allow(exporter).to receive(:new).and_return(exporter_instance)
         allow(exporter_instance).to receive(:export!).and_return(result)

--- a/modules/ldap_groups/app/services/ldap_groups/synchronize_filter_service.rb
+++ b/modules/ldap_groups/app/services/ldap_groups/synchronize_filter_service.rb
@@ -8,11 +8,11 @@ module LdapGroups
 
     def call
       count = synchronize!
-      ServiceResult.new(success: true, result: count)
+      ServiceResult.success(result: count)
     rescue StandardError => e
       error = "[LDAP groups] Failed to extract LDAP groups from filter #{filter.name}: #{e.class}: #{e.message}"
       Rails.logger.error(error)
-      ServiceResult.new(success: false, message: error)
+      ServiceResult.failure(message: error)
     end
 
     ##

--- a/modules/ldap_groups/app/services/ldap_groups/synchronize_groups_service.rb
+++ b/modules/ldap_groups/app/services/ldap_groups/synchronize_groups_service.rb
@@ -11,11 +11,11 @@ module LdapGroups
 
     def call
       synchronize!
-      ServiceResult.new(success: true)
+      ServiceResult.success
     rescue StandardError => e
       error = "[LDAP groups] Failed to perform LDAP group synchronization: #{e.class}: #{e.message}"
       Rails.logger.error(error)
-      ServiceResult.new(message: error, success: false)
+      ServiceResult.failure(message: error)
     end
 
     def synchronize!

--- a/modules/storages/lib/api/v3/file_links/create_endpoint.rb
+++ b/modules/storages/lib/api/v3/file_links/create_endpoint.rb
@@ -46,7 +46,7 @@ module API::V3::FileLinks
     # call is done by calling the `super` method. Results are aggregated in
     # global_result using the `add_dependent!` method.
     def process(request, params_elements)
-      global_result = ServiceResult.new(success: true)
+      global_result = ServiceResult.success
 
       Storages::FileLink.transaction do
         params_elements.each do |params|

--- a/modules/two_factor_authentication/app/services/two_factor_authentication/token_service.rb
+++ b/modules/two_factor_authentication/app/services/two_factor_authentication/token_service.rb
@@ -45,11 +45,11 @@ module TwoFactorAuthentication
       # Produce the token with the given strategy (e.g., sending an sms)
       strategy.transmit
 
-      ServiceResult.new(success: true, result: strategy.transmit_success_message)
+      ServiceResult.success(result: strategy.transmit_success_message)
     rescue StandardError => e
       Rails.logger.error "[2FA plugin] Error during token request to user##{user.id}: #{e}"
 
-      result = ServiceResult.new(success: false)
+      result = ServiceResult.failure
       result.errors.add(:base, e.message)
 
       result
@@ -69,7 +69,7 @@ module TwoFactorAuthentication
     rescue StandardError => e
       Rails.logger.error "[2FA plugin] Error during token validation for user##{user.id}: #{e}"
 
-      result = ServiceResult.new(success: false)
+      result = ServiceResult.failure
       result.errors.add(:base, e.message)
 
       result

--- a/modules/two_factor_authentication/app/services/two_factor_authentication/use_backup_code_service.rb
+++ b/modules/two_factor_authentication/app/services/two_factor_authentication/use_backup_code_service.rb
@@ -19,7 +19,7 @@ module TwoFactorAuthentication
     rescue StandardError => e
       Rails.logger.error "[2FA plugin] Error during backup code validation for user##{user.id}: #{e}"
 
-      result = ServiceResult.new(success: false)
+      result = ServiceResult.failure
       result.errors.add(:base, e.message)
 
       result
@@ -31,7 +31,7 @@ module TwoFactorAuthentication
       token.destroy!
 
       Rails.logger.info { "[2FA plugin] User ##{user.id} has used backup code." }
-      ServiceResult.new(success: true, result: token)
+      ServiceResult.success(result: token)
     end
   end
 end

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/forced_registration/two_factor_devices_controller_spec.rb
@@ -150,7 +150,7 @@ describe ::TwoFactorAuthentication::ForcedRegistration::TwoFactorDevicesControll
           it 'redirects to failure path if token request failed' do
             allow_any_instance_of(::TwoFactorAuthentication::TokenService)
               .to receive(:request)
-              .and_return(ServiceResult.new(success: false))
+              .and_return(ServiceResult.failure)
 
             get :confirm, params: { device_id: device.id }
             expect(response).to redirect_to stage_failure_path(stage: :two_factor_authentication)
@@ -189,7 +189,7 @@ describe ::TwoFactorAuthentication::ForcedRegistration::TwoFactorDevicesControll
             allow_any_instance_of(::TwoFactorAuthentication::TokenService)
               .to receive(:verify)
               .with('1234')
-              .and_return(ServiceResult.new(success: true))
+              .and_return(ServiceResult.success)
 
             post :confirm, params: { device_id: device.id, otp: '1234' }
             expect(response).to redirect_to stage_success_path(stage: :two_factor_authentication, secret: 'asdf')

--- a/modules/two_factor_authentication/spec/controllers/two_factor_authentication/my/two_factor_devices_controller_spec.rb
+++ b/modules/two_factor_authentication/spec/controllers/two_factor_authentication/my/two_factor_devices_controller_spec.rb
@@ -144,7 +144,7 @@ describe ::TwoFactorAuthentication::My::TwoFactorDevicesController, with_2fa_ee:
           it 'redirects to index if token request failed' do
             allow_any_instance_of(::TwoFactorAuthentication::TokenService)
               .to receive(:request)
-              .and_return(ServiceResult.new(success: false))
+              .and_return(ServiceResult.failure)
 
             get :confirm, params: { device_id: device.id }
             expect(response).to redirect_to action: :index
@@ -183,7 +183,7 @@ describe ::TwoFactorAuthentication::My::TwoFactorDevicesController, with_2fa_ee:
             allow_any_instance_of(::TwoFactorAuthentication::TokenService)
               .to receive(:verify)
               .with('1234')
-              .and_return(ServiceResult.new(success: true))
+              .and_return(ServiceResult.success)
 
             post :confirm, params: { device_id: device.id, otp: '1234' }
             expect(response).to redirect_to action: :index
@@ -200,7 +200,7 @@ describe ::TwoFactorAuthentication::My::TwoFactorDevicesController, with_2fa_ee:
               allow_any_instance_of(::TwoFactorAuthentication::TokenService)
                   .to receive(:verify)
                           .with('1234')
-                          .and_return(ServiceResult.new(success: true))
+                          .and_return(ServiceResult.success)
 
               post :confirm, params: { device_id: device.id, otp: '1234' }
               expect(response).to redirect_to action: :index

--- a/modules/xls_export/spec/patches/work_packages_controller_patch_spec.rb
+++ b/modules/xls_export/spec/patches/work_packages_controller_patch_spec.rb
@@ -133,7 +133,7 @@ describe WorkPackagesController, type: :controller do
             allow(service_instance)
               .to receive(:call)
               .with(query:, mime_type: mime_type.to_sym, params: anything)
-              .and_return(ServiceResult.new(result: export_result))
+              .and_return(ServiceResult.failure(result: export_result))
           end
 
           it 'fulfills the defined should_receives' do

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -49,7 +49,7 @@ describe RolesController, type: :controller do
 
   describe '#create' do
     let(:new_role) { double('role double') }
-    let(:service_call) { ServiceResult.new(success: true, result: new_role) }
+    let(:service_call) { ServiceResult.success(result: new_role) }
     let(:create_params) do
       cp = ActionController::Parameters.new(params[:role])
                  .merge(global_role: nil, copy_workflow_from: '5')
@@ -123,7 +123,7 @@ describe RolesController, type: :controller do
     end
 
     context 'failure' do
-      let(:service_call) { ServiceResult.new(success: false, result: new_role) }
+      let(:service_call) { ServiceResult.failure(result: new_role) }
 
       it 'returns a 200 OK' do
         expect(response.status)
@@ -166,7 +166,7 @@ describe RolesController, type: :controller do
           .and_return(d)
       end
     end
-    let(:service_call) { ServiceResult.new(success: true, result: role) }
+    let(:service_call) { ServiceResult.success(result: role) }
     let(:update_params) do
       cp = ActionController::Parameters.new(params[:role])
       cp.permit!
@@ -206,7 +206,7 @@ describe RolesController, type: :controller do
     end
 
     context 'failure' do
-      let(:service_call) { ServiceResult.new(success: false, result: role) }
+      let(:service_call) { ServiceResult.failure(result: role) }
 
       it 'returns a 200 OK' do
         expect(response.status)
@@ -258,10 +258,10 @@ describe RolesController, type: :controller do
         .and_return(roles)
     end
 
-    let(:service_call0) { ServiceResult.new(success: true, result: role0) }
-    let(:service_call1) { ServiceResult.new(success: true, result: role1) }
-    let(:service_call2) { ServiceResult.new(success: true, result: role2) }
-    let(:service_call3) { ServiceResult.new(success: true, result: role3) }
+    let(:service_call0) { ServiceResult.success(result: role0) }
+    let(:service_call1) { ServiceResult.success(result: role1) }
+    let(:service_call2) { ServiceResult.success(result: role2) }
+    let(:service_call3) { ServiceResult.success(result: role3) }
     let(:update_params0) do
       { permissions: [] }
     end
@@ -349,7 +349,7 @@ describe RolesController, type: :controller do
     end
 
     context 'failure' do
-      let(:service_call2) { ServiceResult.new(success: false, result: role2) }
+      let(:service_call2) { ServiceResult.failure(result: role2) }
 
       it 'returns a 200 OK' do
         expect(response.status)

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -175,7 +175,7 @@ describe WorkPackagesController, type: :controller do
             allow(service_instance)
               .to receive(:call)
               .with(query:, mime_type: mime_type.to_sym, params: anything)
-              .and_return(ServiceResult.new(result: 'uuid of the export job'))
+              .and_return(ServiceResult.failure(result: 'uuid of the export job'))
           end
 
           it 'redirects to the job status' do

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -91,7 +91,7 @@ describe WorkflowsController, type: :controller do
         .with(status_params)
         .and_return(call_result)
     end
-    let(:call_result) { ServiceResult.new success: true }
+    let(:call_result) { ServiceResult.success }
     let(:params) do
       {
         role_id: role.id,

--- a/spec/lib/rubocop/cop/open_project/use_service_result_factory_methods_spec.rb
+++ b/spec/lib/rubocop/cop/open_project/use_service_result_factory_methods_spec.rb
@@ -1,0 +1,149 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'rubocop/rspec/shared_contexts'
+require 'spec_helper'
+require 'rubocop'
+require 'rubocop/rspec/support'
+require 'rubocop/cop/open_project/use_service_result_factory_methods'
+
+RSpec.describe RuboCop::Cop::OpenProject::UseServiceResultFactoryMethods do
+  include RuboCop::RSpec::ExpectOffense
+  include_context 'config'
+
+  it 'registers an offense for ServiceResult.new without any success: argument' do
+    expect_offense(<<~RUBY)
+      ServiceResult.new
+                    ^^^ Use ServiceResult.failure instead of ServiceResult.new.
+      ServiceResult.new(errors: ['error'])
+                    ^^^ Use ServiceResult.failure instead of ServiceResult.new.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ServiceResult.failure
+      ServiceResult.failure(errors: ['error'])
+    RUBY
+  end
+
+  it 'allows ServiceResult.new(success: some_value) (no explicit true/false value)' do
+    expect_no_offenses('ServiceResult.new(success: some_value)')
+    expect_no_offenses('ServiceResult.new(foo: "bar", success: some_value, bar: "baz")')
+  end
+
+  it 'allows ServiceResult.new(**kw) (no explicit true/false value)' do
+    expect_no_offenses('ServiceResult.new(**kw)')
+    expect_no_offenses('ServiceResult.new(foo: "bar", **kw)')
+    expect_no_offenses('ServiceResult.new(**kw, foo: "bar")')
+  end
+
+  include_context 'ruby 3.1' do
+    it 'allows ServiceResult.new(success:) (no explicit true/false value)' do
+      expect_no_offenses('ServiceResult.new(success:)')
+      expect_no_offenses('ServiceResult.new(foo: "bar", success:, bar: "baz")')
+    end
+
+    it 'allows ServiceResult.new(...) (no explicit true/false value)' do
+      expect_no_offenses(<<~RUBY)
+        def call(...)
+          ServiceResult.new(...)
+        end
+      RUBY
+    end
+  end
+
+  it 'registers an offense for ServiceResult.new(success: true) with no additional args' do
+    expect_offense(<<~RUBY)
+      ServiceResult.new(success: true)
+                        ^^^^^^^^^^^^^ Use ServiceResult.success(...) instead of ServiceResult.new(success: true, ...).
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ServiceResult.success
+    RUBY
+  end
+
+  it 'registers an offense for ServiceResult.new(success: true) with additional args' do
+    expect_offense(<<~RUBY)
+      ServiceResult.new(success: true,
+                        ^^^^^^^^^^^^^ Use ServiceResult.success(...) instead of ServiceResult.new(success: true, ...).
+                        message: 'Great!')
+      ServiceResult.new(message: 'Great!',
+                        success: true)
+                        ^^^^^^^^^^^^^ Use ServiceResult.success(...) instead of ServiceResult.new(success: true, ...).
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ServiceResult.success(message: 'Great!')
+      ServiceResult.success(message: 'Great!')
+    RUBY
+  end
+
+  it 'registers an offense for ServiceResult.new(success: false) with no additional args' do
+    expect_offense(<<~RUBY)
+      ServiceResult.new(success: false)
+                        ^^^^^^^^^^^^^^ Use ServiceResult.failure(...) instead of ServiceResult.new(success: false, ...).
+      ServiceResult.new success: false
+                        ^^^^^^^^^^^^^^ Use ServiceResult.failure(...) instead of ServiceResult.new(success: false, ...).
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ServiceResult.failure
+      ServiceResult.failure
+    RUBY
+  end
+
+  it 'registers an offense for ServiceResult.new(success: false) with additional args' do
+    expect_offense(<<~RUBY)
+      ServiceResult.new(success: false,
+                        ^^^^^^^^^^^^^^ Use ServiceResult.failure(...) instead of ServiceResult.new(success: false, ...).
+                        errors: ['error'])
+      ServiceResult.new(errors: ['error'],
+                        success: false)
+                        ^^^^^^^^^^^^^^ Use ServiceResult.failure(...) instead of ServiceResult.new(success: false, ...).
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ServiceResult.failure(errors: ['error'])
+      ServiceResult.failure(errors: ['error'])
+    RUBY
+  end
+
+  it 'registers an offense for ServiceResult.new(success: true/false) with splat kwargs' do
+    expect_offense(<<~RUBY)
+      ServiceResult.new(success: true, **kw)
+                        ^^^^^^^^^^^^^ Use ServiceResult.success(...) instead of ServiceResult.new(success: true, ...).
+      ServiceResult.new(success: false, **kw)
+                        ^^^^^^^^^^^^^^ Use ServiceResult.failure(...) instead of ServiceResult.new(success: false, ...).
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ServiceResult.success(**kw)
+      ServiceResult.failure(**kw)
+    RUBY
+  end
+end

--- a/spec/requests/oauth_clients/callback_flow_spec.rb
+++ b/spec/requests/oauth_clients/callback_flow_spec.rb
@@ -131,7 +131,7 @@ describe 'OAuthClient callback endpoint', with_flag: { storages_module_active: t
         allow(::OAuthClients::ConnectionManager)
           .to receive(:new).and_return(connection_manager)
         allow(connection_manager)
-          .to receive(:code_to_token).with(code).and_return(ServiceResult.new(success: false))
+          .to receive(:code_to_token).with(code).and_return(ServiceResult.failure)
 
         uri.query = URI.encode_www_form([['code', code], ['state', state]])
         get uri.to_s

--- a/spec/services/base/base_callable_spec.rb
+++ b/spec/services/base/base_callable_spec.rb
@@ -33,7 +33,7 @@ describe ::BaseServices::BaseCallable, type: :model do
     Class.new(::BaseServices::BaseCallable) do
       def perform(*)
         state.test = 'foo'
-        ServiceResult.new(success: true, result: 'something')
+        ServiceResult.success(result: 'something')
       end
 
       def rollback
@@ -46,7 +46,7 @@ describe ::BaseServices::BaseCallable, type: :model do
     Class.new(::BaseServices::BaseCallable) do
       def perform(*)
         state.test2 = 'foo'
-        ServiceResult.new(success: true, result: 'something')
+        ServiceResult.success(result: 'something')
       end
 
       def rollback

--- a/spec/services/custom_actions/update_work_package_service_spec.rb
+++ b/spec/services/custom_actions/update_work_package_service_spec.rb
@@ -84,7 +84,7 @@ describe CustomActions::UpdateWorkPackageService do
   end
   let(:work_package) { build_stubbed(:work_package) }
   let(:result) do
-    ServiceResult.new(result: work_package, success: true)
+    ServiceResult.success(result: work_package)
   end
   let(:validation_result) { true }
   let!(:contract) do
@@ -194,7 +194,7 @@ describe CustomActions::UpdateWorkPackageService do
 
     context 'on unfixable validation error' do
       let(:result) do
-        ServiceResult.new(result: work_package, success: false)
+        ServiceResult.failure(result: work_package)
       end
       let(:update_service_call_implementation) do
         -> do

--- a/spec/services/groups/update_service_spec.rb
+++ b/spec/services/groups/update_service_spec.rb
@@ -32,7 +32,7 @@ require 'services/base_services/behaves_like_update_service'
 describe Groups::UpdateService, type: :model do
   it_behaves_like 'BaseServices update service' do
     let(:add_service_result) do
-      ServiceResult.new success: true
+      ServiceResult.success
     end
     let!(:add_users_service) do
       add_service = instance_double(Groups::AddUsersService)
@@ -82,7 +82,7 @@ describe Groups::UpdateService, type: :model do
 
       context 'with the AddUsersService being unsuccessful' do
         let(:add_service_result) do
-          ServiceResult.new success: false
+          ServiceResult.failure
         end
 
         it 'is failure' do

--- a/spec/services/notifications/create_from_journal_job_shared.rb
+++ b/spec/services/notifications/create_from_journal_job_shared.rb
@@ -85,7 +85,7 @@ shared_context 'with CreateFromJournalJob context' do
               .and_return(notifications_service)
       allow(notifications_service)
         .to receive(:call)
-              .and_return(ServiceResult.new(success: true, result: notification))
+              .and_return(ServiceResult.success(result: notification))
 
       expect(call.all_results)
         .to match_array([notification])

--- a/spec/services/relations/create_service_spec.rb
+++ b/spec/services/relations/create_service_spec.rb
@@ -99,10 +99,10 @@ describe Relations::CreateService do
   context 'if all valid and it is a follows relation' do
     let(:set_schedule_service) { double('set schedule service') }
     let(:set_schedule_work_package2_result) do
-      ServiceResult.new success: true, result: work_package2, errors: work_package2.errors
+      ServiceResult.success result: work_package2, errors: work_package2.errors
     end
     let(:set_schedule_result) do
-      sr = ServiceResult.new success: true, result: work_package2, errors: work_package2.errors
+      sr = ServiceResult.success result: work_package2, errors: work_package2.errors
       sr.dependent_results << set_schedule_work_package2_result
       sr
     end

--- a/spec/services/relations/update_service_spec.rb
+++ b/spec/services/relations/update_service_spec.rb
@@ -94,10 +94,10 @@ describe Relations::UpdateService do
   context 'when all valid and it is a follows relation' do
     let(:set_schedule_service) { double('set schedule service') }
     let(:set_schedule_work_package2_result) do
-      ServiceResult.new success: true, result: work_package2, errors: work_package2.errors
+      ServiceResult.success result: work_package2, errors: work_package2.errors
     end
     let(:set_schedule_result) do
-      sr = ServiceResult.new success: true, result: work_package2, errors: work_package2.errors
+      sr = ServiceResult.success result: work_package2, errors: work_package2.errors
       sr.dependent_results << set_schedule_work_package2_result
       sr
     end

--- a/spec/services/service_result_spec.rb
+++ b/spec/services/service_result_spec.rb
@@ -29,36 +29,98 @@
 require 'spec_helper'
 
 describe ServiceResult, type: :model do
-  let(:instance) { ServiceResult.new }
+  let(:instance) { described_class.new }
 
   describe 'success' do
     it 'is what the service is initialized with' do
-      instance = ServiceResult.new success: true
+      instance = described_class.new success: true
 
       expect(instance.success).to be_truthy
-      expect(instance.success?).to be_truthy
+      expect(instance.success?).to be(true)
 
-      instance = ServiceResult.new success: false
+      instance = described_class.new success: false
 
       expect(instance.success).to be_falsey
-      expect(instance.success?).to be_falsey
+      expect(instance.success?).to be(false)
     end
 
     it 'returns what is provided' do
       instance.success = true
 
       expect(instance.success).to be_truthy
-      expect(instance.success?).to be_truthy
+      expect(instance.success?).to be(true)
 
       instance.success = false
 
       expect(instance.success).to be_falsey
-      expect(instance.success?).to be_falsey
+      expect(instance.success?).to be(false)
     end
 
     it 'is false by default' do
       expect(instance.success).to be_falsey
-      expect(instance.success?).to be_falsey
+      expect(instance.success?).to be(false)
+    end
+  end
+
+  describe '.success' do
+    it 'creates a ServiceResult with success: true' do
+      instance = described_class.success
+      expect(instance.success).to be_truthy
+    end
+
+    it 'accepts the same set of parameters as the initializer' do
+      errors = ['errors']
+      message = 'message'
+      message_type = :message_type
+      state = instance_double(::Shared::ServiceState)
+      dependent_results = ['dependent_results']
+      result = instance_double(Object, 'result')
+
+      instance = described_class.success(
+        errors:,
+        message:,
+        message_type:,
+        state:,
+        dependent_results:,
+        result:
+      )
+
+      expect(instance.errors).to be(errors)
+      expect(instance.message).to be(message)
+      expect(instance.state).to be(state)
+      expect(instance.dependent_results).to be(dependent_results)
+      expect(instance.result).to be(result)
+    end
+  end
+
+  describe '.failure' do
+    it 'creates a ServiceResult with success: false' do
+      instance = described_class.failure
+      expect(instance.success).to be_falsy
+    end
+
+    it 'accepts the same set of parameters as the initializer' do
+      errors = ['errors']
+      message = 'message'
+      message_type = :message_type
+      state = instance_double(::Shared::ServiceState)
+      dependent_results = ['dependent_results']
+      result = instance_double(Object, 'result')
+
+      instance = described_class.failure(
+        errors:,
+        message:,
+        message_type:,
+        state:,
+        dependent_results:,
+        result:
+      )
+
+      expect(instance.errors).to be(errors)
+      expect(instance.message).to be(message)
+      expect(instance.state).to be(state)
+      expect(instance.dependent_results).to be(dependent_results)
+      expect(instance.result).to be(result)
     end
   end
 
@@ -72,7 +134,7 @@ describe ServiceResult, type: :model do
     end
 
     it 'is what the object is initialized with' do
-      instance = ServiceResult.new errors: errors
+      instance = described_class.new errors: errors
 
       expect(instance.errors).to eql errors
     end
@@ -81,21 +143,21 @@ describe ServiceResult, type: :model do
       expect(instance.errors).to be_a ActiveModel::Errors
     end
 
-    context 'providing errors from user' do
+    context 'when providing errors from user' do
       let(:result) { build :work_package }
 
       it 'creates a new errors instance' do
-        instance = ServiceResult.new result: result
+        instance = described_class.new result: result
         expect(instance.errors).not_to eq result.errors
       end
     end
   end
 
   describe 'result' do
-    let(:result) { double('result') }
+    let(:result) { instance_double(Object, 'result') }
 
     it 'is what the object is initialized with' do
-      instance = ServiceResult.new result: result
+      instance = described_class.new result: result
 
       expect(instance.result).to eql result
     end
@@ -107,15 +169,13 @@ describe ServiceResult, type: :model do
     end
 
     it 'is nil by default' do
-      instance = ServiceResult.new
+      instance = described_class.new
 
       expect(instance.result).to be_nil
     end
   end
 
   describe 'apply_flash_message!' do
-    let(:service_result) { described_class.new(message:, **params) }
-    let(:params) { {} }
     let(:message) { 'some message' }
 
     subject(:flash) do
@@ -123,19 +183,19 @@ describe ServiceResult, type: :model do
     end
 
     context 'when successful' do
-      let(:params) { { success: true } }
+      let(:service_result) { described_class.success(message:) }
 
       it { is_expected.to include(notice: message) }
     end
 
     context 'when failure' do
-      let(:params) { { success: false } }
+      let(:service_result) { described_class.failure(message:) }
 
       it { is_expected.to include(error: message) }
     end
 
     context 'when setting message_type to :info' do
-      let(:params) { { message_type: :info } }
+      let(:service_result) { described_class.success(message:, message_type: :info) }
 
       it { is_expected.to include(info: message) }
     end

--- a/spec/services/shared/service_context_integration_spec.rb
+++ b/spec/services/shared/service_context_integration_spec.rb
@@ -48,7 +48,7 @@ describe Shared::ServiceContext, 'integration', type: :model do
             VALUES ('test_setting', 'abc')
           SQL
 
-          ServiceResult.new success: false
+          ServiceResult.failure
         end
       end
 
@@ -59,7 +59,7 @@ describe Shared::ServiceContext, 'integration', type: :model do
             VALUES ('test_setting', 'abc')
           SQL
 
-          ServiceResult.new success: true
+          ServiceResult.success
         end
       end
     end.new(user)

--- a/spec/services/shared_type_service.rb
+++ b/spec/services/shared_type_service.rb
@@ -133,7 +133,7 @@ shared_examples_for 'type service' do
       end
       let(:params) { { attribute_groups: [query_group_params] } }
       let(:query) { create(:query, user_id: 0) }
-      let(:service_result) { ServiceResult.new(success: true, result: query) }
+      let(:service_result) { ServiceResult.success(result: query) }
 
       before do
         allow(Query)
@@ -168,7 +168,7 @@ shared_examples_for 'type service' do
 
       context 'when the query service reports an error' do
         let(:success) { false }
-        let(:service_result) { ServiceResult.new(success: false, result: nil) }
+        let(:service_result) { ServiceResult.failure(result: nil) }
 
         it 'reports the error' do
           expect(service_call).to be_failure

--- a/spec/services/users/register_user_service_spec.rb
+++ b/spec/services/users/register_user_service_spec.rb
@@ -100,7 +100,7 @@ describe Users::RegisterUserService do
         # Assuming the next returns a result
         expect(instance)
           .to(receive(:ensure_user_limit_not_reached!))
-          .and_return(ServiceResult.new(success: false, result: user, message: 'test stop'))
+          .and_return(ServiceResult.failure(result: user, message: 'test stop'))
 
         expect(user).not_to receive(:activate)
         expect(user).not_to receive(:save)
@@ -137,7 +137,7 @@ describe Users::RegisterUserService do
         # Assuming the next returns a result
         expect(instance)
           .to(receive(:register_by_email_activation))
-          .and_return(ServiceResult.new(success: false, result: user, message: 'test stop'))
+          .and_return(ServiceResult.failure(result: user, message: 'test stop'))
 
         call = instance.call
         expect(call.result).to eq user
@@ -173,7 +173,7 @@ describe Users::RegisterUserService do
         # Assuming the next returns a result
         expect(instance)
           .to(receive(:register_automatically))
-          .and_return(ServiceResult.new(success: false, result: user, message: 'test stop'))
+          .and_return(ServiceResult.failure(result: user, message: 'test stop'))
 
         expect(user).not_to receive(:activate)
         expect(user).not_to receive(:save)
@@ -211,7 +211,7 @@ describe Users::RegisterUserService do
       # Assuming the next returns a result
       expect(instance)
         .to(receive(:register_manually))
-        .and_return(ServiceResult.new(success: false, result: user, message: 'test stop'))
+        .and_return(ServiceResult.failure(result: user, message: 'test stop'))
 
       expect(user).not_to receive(:activate)
       expect(user).not_to receive(:save)

--- a/spec/services/work_packages/delete_service_spec.rb
+++ b/spec/services/work_packages/delete_service_spec.rb
@@ -102,13 +102,10 @@ describe WorkPackages::DeleteService do
     let(:expect_inherited_attributes_service_calls) do
       inherited_service_instance = double(WorkPackages::UpdateAncestorsService)
 
-      service_result = ServiceResult.new(success: true,
-                                         result: work_package)
+      service_result = ServiceResult.success(result: work_package)
 
-      service_result.dependent_results += [ServiceResult.new(success: true,
-                                                             result: parent),
-                                           ServiceResult.new(success: true,
-                                                             result: grandparent)]
+      service_result.dependent_results += [ServiceResult.success(result: parent),
+                                           ServiceResult.success(result: grandparent)]
 
       expect(WorkPackages::UpdateAncestorsService)
         .to receive(:new)

--- a/spec/workers/work_packages/exports/export_job_spec.rb
+++ b/spec/workers/work_packages/exports/export_job_spec.rb
@@ -82,7 +82,7 @@ describe WorkPackages::ExportJob do
         expect(File.basename(file))
           .to end_with ".#{mime_type}"
 
-        ServiceResult.new(result: attachment, success: true)
+        ServiceResult.success(result: attachment)
       end
 
       allow(exporter).to receive(:new).and_return exporter_instance


### PR DESCRIPTION
Use `ServiceResult.success(result: obj)` instead of `ServiceResult.new(success: true, result: obj)` to have a code easier to read and more explicit.

Same for `ServiceResult.failure(errors: [])` instead of `ServiceResult.new(errors: [])` or `ServiceResult.new(success: false, errors: [])`.

A rubocop cop `OpenProject/UseServiceResultFactoryMethods` was written to enforce the usage of the factory methods, and was used to autocorrect the existing code.