### PR TITLE
Add 406 and 415 responses to API and clean up into components

### DIFF
--- a/docs/api/apiv3/components/responses/invalid_request_body.yml
+++ b/docs/api/apiv3/components/responses/invalid_request_body.yml
@@ -1,0 +1,15 @@
+# Response: InvalidRequestBody
+---
+content:
+  application/hal+json:
+    schema:
+      $ref: "../schemas/error_response.yml"
+    examples:
+      response:
+        value:
+          _type: Error
+          errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
+          message: The request body was not a single JSON object.
+description: Occurs when the client did not send a valid JSON object in the
+  request body.
+headers: {}

--- a/docs/api/apiv3/components/responses/missing_content_type.yml
+++ b/docs/api/apiv3/components/responses/missing_content_type.yml
@@ -1,0 +1,8 @@
+# Response: MissingContentType
+---
+content:
+  text/plain:
+    schema:
+      type: string
+description: Occurs when the client did not send a Content-Type header
+headers: {}

--- a/docs/api/apiv3/components/responses/unsupported_media_type.yml
+++ b/docs/api/apiv3/components/responses/unsupported_media_type.yml
@@ -1,0 +1,14 @@
+# Response: UnsupportedMediaType
+---
+content:
+  application/hal+json:
+    schema:
+      $ref: "../schemas/error_response.yml"
+    examples:
+      response:
+        value:
+          _type: Error
+          errorIdentifier: urn:openproject-org:api:v3:errors:TypeNotSupported
+          message: Expected CONTENT-TYPE to be (expected value) but got (actual value).
+description: Occurs when the client sends an unsupported Content-Type header.
+headers: {}

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -454,6 +454,14 @@ components:
       "$ref": "./components/examples/view_work_packages_table.yml"
     ViewTeamPlanner:
       "$ref": "./components/examples/view_team_planner.yml"
+      
+  responses:
+    InvalidRequestBody:
+      "$ref": "./components/responses/invalid_request_body.yml"
+    MissingContentType:
+      "$ref": "./components/responses/missing_content_type.yml"
+    UnsupportedMediaType:
+      "$ref": "./components/responses/unsupported_media_type.yml"
 
   schemas:
     ActivityModel:

--- a/docs/api/apiv3/paths/activity.yml
+++ b/docs/api/apiv3/paths/activity.yml
@@ -92,19 +92,7 @@ patch:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -121,6 +109,10 @@ patch:
 
         **Required permission:** edit journals
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/attachment.yml
+++ b/docs/api/apiv3/paths/attachment.yml
@@ -55,6 +55,10 @@ delete:
         *Note: A client without sufficient permissions shall not be able to test for the existence of an attachment.
         That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Attachments
   description: Permanently deletes the specified attachment.

--- a/docs/api/apiv3/paths/attachments.yml
+++ b/docs/api/apiv3/paths/attachments.yml
@@ -70,6 +70,10 @@ post:
 
         **Required permission:** At least one permission in any project: edit work package, add work package, edit messages, edit wiki pages (plugins might extend this list)
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/custom_action_execute.yml
+++ b/docs/api/apiv3/paths/custom_action_execute.yml
@@ -14,19 +14,7 @@ post:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -56,6 +44,8 @@ post:
                 message: The requested resource could not be found.
       description: Returned if the custom action does not exist.
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
     '409':
       content:
         application/hal+json:
@@ -70,6 +60,8 @@ post:
       description: Returned if the client provided an outdated lockVersion or no lockVersion
         at all.
       headers: {}
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/days.yml
+++ b/docs/api/apiv3/paths/days.yml
@@ -45,13 +45,8 @@ get:
           schema:
             $ref: '../components/schemas/day_collection_model.yml'
     '400':
-      description: |-
-        Returned if the client sends invalid request parameters.
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The request body was not a single JSON object.
+      $ref: "../components/responses/invalid_request_body.yml"
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"

--- a/docs/api/apiv3/paths/days_date.yml
+++ b/docs/api/apiv3/paths/days_date.yml
@@ -26,13 +26,4 @@ get:
           schema:
             $ref: '../components/schemas/day_model.yml'
     '400':
-      description: |-
-        Returned if the client sends invalid request parameters.
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The date is invalid.
+      $ref: "../components/responses/invalid_request_body.yml"

--- a/docs/api/apiv3/paths/days_non_working.yml
+++ b/docs/api/apiv3/paths/days_non_working.yml
@@ -29,16 +29,7 @@ post:
           schema:
             $ref: '../components/schemas/non_working_day_model.yml'
     '400':
-      description: |-
-        Returned if the client sends invalid request parameters.
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The request body was not a single JSON object.
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       description: |-
         Returned if the client does not have sufficient permissions.
@@ -50,3 +41,7 @@ post:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
             message: You are not authorized to access this resource.
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"

--- a/docs/api/apiv3/paths/days_non_working_date.yml
+++ b/docs/api/apiv3/paths/days_non_working_date.yml
@@ -26,12 +26,7 @@ get:
           schema:
             $ref: '../components/schemas/non_working_day_model.yml'
     '400':
-      description: |-
-        Returned if the client sends invalid request parameters.
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
+      $ref: "../components/responses/invalid_request_body.yml"
     '404':
       description: |-
         Returned if the given date is not a non-working day.
@@ -81,12 +76,7 @@ patch:
           schema:
             $ref: '../components/schemas/non_working_day_model.yml'
     '400':
-      description: |-
-        Returned if the client sends invalid request parameters.
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
+      $ref: "../components/responses/invalid_request_body.yml"
     '404':
       description: |-
         Returned if the given date is not a non-working day.
@@ -98,6 +88,10 @@ patch:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
             message: The requested resource could not be found.
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
 
 delete:
   summary: Removes a non-working day (NOT IMPLEMENTED)
@@ -127,16 +121,7 @@ delete:
 
         The operation succeeded.
     '400':
-      description: |-
-        Returned if the client sends invalid request parameters.
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The date is not valid.
+      $ref: "../components/responses/invalid_request_body.yml"
     '404':
       description: |-
         Returned if the given date is not a non-working day.
@@ -148,3 +133,7 @@ delete:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
             message: The requested resource could not be found.
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"

--- a/docs/api/apiv3/paths/days_week.yml
+++ b/docs/api/apiv3/paths/days_week.yml
@@ -16,16 +16,7 @@ get:
           schema:
             $ref: '../components/schemas/week_day_collection_model.yml'
     '400':
-      description: |-
-        Returned if the client sends invalid request parameters
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The request body was not a single JSON object.
+      $ref: "../components/responses/invalid_request_body.yml"
 
 patch:
   summary: Update week days (NOT IMPLEMENTED)
@@ -50,16 +41,7 @@ patch:
           schema:
             $ref: '../components/schemas/week_day_collection_model.yml'
     '400':
-      description: |-
-        Returned if the client sends invalid request parameters
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The request body was not a single JSON object.
+      $ref: "../components/responses/invalid_request_body.yml"
     '404':
       description: |-
         Returned if a week day resource can not be found.
@@ -71,3 +53,7 @@ patch:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
             message: The requested resource could not be found.
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"

--- a/docs/api/apiv3/paths/days_week_day.yml
+++ b/docs/api/apiv3/paths/days_week_day.yml
@@ -26,16 +26,7 @@ get:
           schema:
             $ref: '../components/schemas/week_day_model.yml'
     '400':
-      description: |-
-        Occurs if the client sends an invalid request.
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The request body was not a single JSON object.
+      $ref: "../components/responses/invalid_request_body.yml"
     '404':
       description: |-
         Returned if the day is out of the 1-7 range.
@@ -88,16 +79,7 @@ patch:
           schema:
             $ref: '../components/schemas/week_day_model.yml'
     '400':
-      description: |-
-        Occurs if the client sends an invalid request.
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The request body was not a single JSON object.
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       description: |-
         Returned if the client does not have sufficient permissions.
@@ -120,3 +102,7 @@ patch:
             _type: Error
             errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
             message: The requested resource could not be found.
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"

--- a/docs/api/apiv3/paths/example_form.yml
+++ b/docs/api/apiv3/paths/example_form.yml
@@ -119,6 +119,8 @@ post:
       description: Returned if the client does not have sufficient permissions to
         modify the associated resource.
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
     '409':
       content:
         application/hal+json:
@@ -133,6 +135,8 @@ post:
       description: Returned if underlying resource was changed since the client requested
         the form. This is determined using the `lockVersion` property.
       headers: {}
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Forms
   description: This is an example of how a form might look like. Note that this endpoint

--- a/docs/api/apiv3/paths/grid_form.yml
+++ b/docs/api/apiv3/paths/grid_form.yml
@@ -151,6 +151,10 @@ post:
 
         **Required permission:** view work package
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Grids
   description: ''

--- a/docs/api/apiv3/paths/grids.yml
+++ b/docs/api/apiv3/paths/grids.yml
@@ -120,19 +120,7 @@ patch:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -149,6 +137,10 @@ patch:
 
         **Required permission:** The permission depends on the page the grid is placed in.
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       description: |-
         Returned if:
@@ -173,19 +165,7 @@ post:
       description: Created
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -202,6 +182,10 @@ post:
 
         **Required permission:** Depends on the page the grid is defined for.
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       description: |-
         Returned if:

--- a/docs/api/apiv3/paths/group.yml
+++ b/docs/api/apiv3/paths/group.yml
@@ -53,6 +53,10 @@ delete:
         *Note: A client without sufficient permissions shall not be able to test for the existence of
         a version. That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Groups
   description: Deletes the group.
@@ -167,19 +171,7 @@ patch:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -217,6 +209,10 @@ patch:
         *Note: A client without sufficient permissions shall not be able to test for the existence of
         a version. That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/groups.yml
+++ b/docs/api/apiv3/paths/groups.yml
@@ -113,19 +113,7 @@ post:
       description: Created
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -142,6 +130,10 @@ post:
 
         **Required permission:** Administrator
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/membership.yml
+++ b/docs/api/apiv3/paths/membership.yml
@@ -49,6 +49,10 @@ delete:
         *Note: A client without sufficient permissions shall not be able to test for the existence of
         a version. That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Memberships
   description: Deletes the membership.
@@ -148,19 +152,7 @@ patch:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -197,6 +189,10 @@ patch:
         *Note: A client without sufficient permissions shall not be able to test for the existence of
         a version. That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/membership_form.yml
+++ b/docs/api/apiv3/paths/membership_form.yml
@@ -94,19 +94,7 @@ post:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -123,6 +111,10 @@ post:
 
         **Required permission:** manage versions in the version's project
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Memberships
   description: ''

--- a/docs/api/apiv3/paths/memberships.yml
+++ b/docs/api/apiv3/paths/memberships.yml
@@ -133,19 +133,7 @@ post:
       description: Created
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -162,6 +150,10 @@ post:
 
         **Required permission:** Manage members
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/memberships_form.yml
+++ b/docs/api/apiv3/paths/memberships_form.yml
@@ -6,19 +6,7 @@ post:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -35,6 +23,10 @@ post:
 
         **Required permission:** manage memberships in any project
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Memberships
   description: ''

--- a/docs/api/apiv3/paths/my_preferences.yml
+++ b/docs/api/apiv3/paths/my_preferences.yml
@@ -109,19 +109,7 @@ patch:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '401':
       content:
         application/hal+json:
@@ -135,6 +123,10 @@ patch:
                 message: You need to be authenticated to access this resource.
       description: Returned if no user is currently authenticated
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/news.yml
+++ b/docs/api/apiv3/paths/news.yml
@@ -128,19 +128,7 @@ get:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
-                message:
-                - Filters Invalid filter does not exist.
-      description: Returned if the client sends invalid request parameters e.g. filters
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/notifications_read.yml
+++ b/docs/api/apiv3/paths/notifications_read.yml
@@ -45,3 +45,7 @@ post:
             errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
             message: 
               - Filters Invalid filter does not exist.
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"

--- a/docs/api/apiv3/paths/notifications_unread.yml
+++ b/docs/api/apiv3/paths/notifications_unread.yml
@@ -35,13 +35,8 @@ post:
     '204':
       description: OK
     '400':
-      description: Returned if the request is not properly formatted.
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
-            message:
-              - Filters Invalid filter does not exist.
+      $ref: "../components/responses/invalid_request_body.yml"
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"

--- a/docs/api/apiv3/paths/post_attachments.yml
+++ b/docs/api/apiv3/paths/post_attachments.yml
@@ -228,6 +228,10 @@ post:
         *Note: A client without sufficient permissions shall not be able to test for the existence of a post.
         That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/project.yml
+++ b/docs/api/apiv3/paths/project.yml
@@ -51,6 +51,10 @@ delete:
         *Note: A client without sufficient permissions shall not be able to test for the existence of
         a version. That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:
@@ -152,19 +156,7 @@ patch:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -201,6 +193,10 @@ patch:
         *Note: A client without sufficient permissions shall not be able to test for the existence of
         a version. That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/project_copy.yml
+++ b/docs/api/apiv3/paths/project_copy.yml
@@ -16,19 +16,7 @@ post:
         endpoint to check the status of the copy, and eventually get the created project.
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -45,6 +33,10 @@ post:
 
         **Required permission:** copy projects in the source project
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/project_copy_form.yml
+++ b/docs/api/apiv3/paths/project_copy_form.yml
@@ -14,19 +14,7 @@ post:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -43,6 +31,10 @@ post:
 
         **Required permission:** copy projects in the source project
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Projects
   description: ''

--- a/docs/api/apiv3/paths/project_form.yml
+++ b/docs/api/apiv3/paths/project_form.yml
@@ -25,19 +25,7 @@ post:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -54,6 +42,10 @@ post:
 
         **Required permission:** edit projects in the project
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Projects
   description: ''

--- a/docs/api/apiv3/paths/project_work_packages.yml
+++ b/docs/api/apiv3/paths/project_work_packages.yml
@@ -81,17 +81,7 @@ get:
             $ref: '../components/schemas/work_packages_model.yml'
       description: OK
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
-            message: Operator can't be blank.
-      description: |-
-        Returned if the client sends a query parameter, that the server knows, but does not understand.
-        E.g. by providing a syntactically incorrect `filters` parameter.
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -157,16 +147,7 @@ post:
             $ref: '../components/schemas/work_package_model.yml'
       description: OK
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -199,6 +180,10 @@ post:
 
         *Note: A client without sufficient permissions shall not be able to test for the existence of a project.
         That's why a 404 is returned here, even if a 403 might be more appropriate.*
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/projects.yml
+++ b/docs/api/apiv3/paths/projects.yml
@@ -187,19 +187,7 @@ post:
       description: Created
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -216,6 +204,10 @@ post:
 
         **Required permission:** add project which is a global permission
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/projects_form.yml
+++ b/docs/api/apiv3/paths/projects_form.yml
@@ -245,19 +245,7 @@ post:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -274,6 +262,10 @@ post:
 
         **Required permission:** add project which is a global permission
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Projects
   description: ''

--- a/docs/api/apiv3/paths/queries.yml
+++ b/docs/api/apiv3/paths/queries.yml
@@ -65,19 +65,11 @@ post:
       description: Created
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/query.yml
+++ b/docs/api/apiv3/paths/query.yml
@@ -320,19 +320,7 @@ patch:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -365,6 +353,10 @@ patch:
 
         **Required permission:** view work packages in the query's project (unless global)
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/query_star.yml
+++ b/docs/api/apiv3/paths/query_star.yml
@@ -113,18 +113,7 @@ patch:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not empty.
-      description: Occurs when the client did not send an empty request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/query_unstar.yml
+++ b/docs/api/apiv3/paths/query_unstar.yml
@@ -113,18 +113,7 @@ patch:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not empty.
-      description: Occurs when the client did not send an empty request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -161,6 +150,10 @@ patch:
 
         **Required permission:** view work package in queries project
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Queries
   description: ''

--- a/docs/api/apiv3/paths/relation.yml
+++ b/docs/api/apiv3/paths/relation.yml
@@ -47,6 +47,10 @@ delete:
 
         **Required permission:** manage work package relations
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Relations
   description: Deletes the relation.
@@ -164,19 +168,7 @@ patch:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '404':
       content:
         application/hal+json:
@@ -193,6 +185,10 @@ patch:
 
         **Required permission:** manage work package relations
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/time_entries.yml
+++ b/docs/api/apiv3/paths/time_entries.yml
@@ -153,19 +153,7 @@ get:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
-                message:
-                - Filters Invalid filter does not exist.
-      description: Returned if the client sends invalid request parameters e.g. filters
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -195,19 +183,7 @@ post:
       description: Created
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -224,6 +200,10 @@ post:
 
         **Required permission:** Log time
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/time_entries_form.yml
+++ b/docs/api/apiv3/paths/time_entries_form.yml
@@ -6,19 +6,7 @@ post:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -35,6 +23,10 @@ post:
 
         **Required permission:** *log time* in any project
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Time Entries
   description: ''

--- a/docs/api/apiv3/paths/time_entries_id_form.yml
+++ b/docs/api/apiv3/paths/time_entries_id_form.yml
@@ -14,19 +14,7 @@ post:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -59,6 +47,10 @@ post:
 
         **Required permission** `view time entries` in the project the time entry is assigned to or `view own time entries` for time entries belonging to the user
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Time Entries
   description: ''

--- a/docs/api/apiv3/paths/time_entry.yml
+++ b/docs/api/apiv3/paths/time_entry.yml
@@ -42,6 +42,10 @@ delete:
 
         **Required permission** `view time entries` in the project the time entry is assigned to or `view own time entries` for time entries belonging to the user
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Time Entries
   description: Permanently deletes the specified time entry.
@@ -146,19 +150,7 @@ patch:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -175,6 +167,10 @@ patch:
 
         **Required permission:** Edit (own) time entries, depending on what time entry is being modified.
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/user.yml
+++ b/docs/api/apiv3/paths/user.yml
@@ -109,16 +109,7 @@ patch:
             $ref: '../components/schemas/user_model.yml'
       description: OK
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -145,6 +136,10 @@ patch:
         Returned if the user does not exist or if the API user does not have the necessary permissions to update it.
 
         **Required permission:** Administrators only (exception: users may update their own accounts)
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/user_form.yml
+++ b/docs/api/apiv3/paths/user_form.yml
@@ -14,19 +14,7 @@ post:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -60,6 +48,10 @@ post:
         *Note: A client without sufficient permissions shall not be able to test for the existence of
         a membership. That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Users
   description: ''

--- a/docs/api/apiv3/paths/user_lock.yml
+++ b/docs/api/apiv3/paths/user_lock.yml
@@ -56,6 +56,10 @@ delete:
             errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
             message: The specified user does not exist.
       description: Returned if the user does not exist.
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
 
 post:
   summary: Lock user
@@ -113,3 +117,7 @@ post:
             errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
             message: The specified user does not exist.
       description: Returned if the user does not exist.
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"

--- a/docs/api/apiv3/paths/users.yml
+++ b/docs/api/apiv3/paths/users.yml
@@ -67,15 +67,7 @@ get:
             $ref: '../components/schemas/user_collection_model.yml'
       description: OK
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
-            message: Unknown sort column.
-      description: Returned if the client sends an unknown sort column.
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -117,15 +109,7 @@ post:
             $ref: '../components/schemas/user_model.yml'
       description: Created
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the request body.
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -139,6 +123,10 @@ post:
         Returned if the client does not have sufficient permissions.
 
         **Required permission:** Administrator
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/version.yml
+++ b/docs/api/apiv3/paths/version.yml
@@ -49,6 +49,10 @@ delete:
         *Note: A client without sufficient permissions shall not be able to test for the existence of
         a version. That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Versions
   description: Deletes the version. Work packages associated to the version will no
@@ -146,19 +150,7 @@ patch:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -195,6 +187,10 @@ patch:
         *Note: A client without sufficient permissions shall not be able to test for the existence of
         a version. That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       description: |-
         Returned if:

--- a/docs/api/apiv3/paths/version_form.yml
+++ b/docs/api/apiv3/paths/version_form.yml
@@ -14,19 +14,7 @@ post:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -43,6 +31,10 @@ post:
 
         **Required permission:** manage versions in the version's project
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Versions
   description: ''

--- a/docs/api/apiv3/paths/versions.yml
+++ b/docs/api/apiv3/paths/versions.yml
@@ -102,19 +102,7 @@ post:
       description: Created
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -131,6 +119,10 @@ post:
 
         **Required permission:** Manage versions
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       description: |-
         Returned if:

--- a/docs/api/apiv3/paths/versions_form.yml
+++ b/docs/api/apiv3/paths/versions_form.yml
@@ -6,19 +6,7 @@ post:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -35,6 +23,10 @@ post:
 
         **Required permission:** manage versions in any project
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Versions
   description: ''

--- a/docs/api/apiv3/paths/view.yml
+++ b/docs/api/apiv3/paths/view.yml
@@ -20,19 +20,7 @@ get:
               "$ref": "../components/examples/view_team_planner.yml"
       description: Returns the result of a single view, dependent of the view type.
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: { }
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -121,19 +109,11 @@ post:
       description: Created
       headers: { }
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: { }
+      $ref: "../components/responses/invalid_request_body.yml"
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/wiki_page_attachments.yml
+++ b/docs/api/apiv3/paths/wiki_page_attachments.yml
@@ -228,6 +228,10 @@ post:
         *Note: A client without sufficient permissions shall not be able to test for the existence of a wiki page
         That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/work_package.yml
+++ b/docs/api/apiv3/paths/work_package.yml
@@ -45,6 +45,10 @@ delete:
 
         **Required permission:** view work package
       headers: { }
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
     - Work Packages
   description: |-
@@ -398,17 +402,7 @@ patch:
       description: OK
       headers: { }
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: { }
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -437,6 +431,8 @@ patch:
 
         **Required permission:** view work package
       headers: { }
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
     '409':
       content:
         application/hal+json:
@@ -450,6 +446,8 @@ patch:
       description: Returned if the resource was changed since the client requested
         it. This is determined using the `lockVersion` property.
       headers: { }
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/work_package_activities.yml
+++ b/docs/api/apiv3/paths/work_package_activities.yml
@@ -106,19 +106,7 @@ post:
       description: Created
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/work_package_attachments.yml
+++ b/docs/api/apiv3/paths/work_package_attachments.yml
@@ -142,6 +142,10 @@ post:
         *Note: A client without sufficient permissions shall not be able to test for the existence of a work package.
         That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/work_package_file_links.yml
+++ b/docs/api/apiv3/paths/work_package_file_links.yml
@@ -60,15 +60,7 @@ post:
           schema:
             $ref: '../components/schemas/file_link_collection_read_model.yml'
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-            message: The request body was invalid.
-      description: Occurs when the client did not send a valid JSON object in the request body.
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -97,6 +89,10 @@ post:
         Returned if the work package does not exist or the client does not have sufficient permissions to see it.
 
         **Required permission:** view work package, view file links
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/work_package_form.yml
+++ b/docs/api/apiv3/paths/work_package_form.yml
@@ -47,6 +47,10 @@ post:
 
         **Required permission:** view work package
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Work Packages
   description: ''

--- a/docs/api/apiv3/paths/work_package_relations.yml
+++ b/docs/api/apiv3/paths/work_package_relations.yml
@@ -42,19 +42,7 @@ post:
       description: Created
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -86,6 +74,10 @@ post:
         Returned if there already exists a relation between the given work packages of **any** type
         or if the relation is not allowed.
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/work_package_watcher.yml
+++ b/docs/api/apiv3/paths/work_package_watcher.yml
@@ -60,6 +60,10 @@ delete:
 
         *Note that you will effectively not be able to change the watchers of a work package without being able to see the work package.*
       headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
   tags:
   - Work Packages
   description: |-

--- a/docs/api/apiv3/paths/work_package_watchers.yml
+++ b/docs/api/apiv3/paths/work_package_watchers.yml
@@ -182,6 +182,10 @@ post:
 
         *Note that you will effectively not be able to change the watchers of a work package without being able to see the work package.*
       headers: { }
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       description: |-
         Returned if:

--- a/docs/api/apiv3/paths/work_packages.yml
+++ b/docs/api/apiv3/paths/work_packages.yml
@@ -133,17 +133,7 @@ get:
             $ref: '../components/schemas/work_packages_model.yml'
       description: OK
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: '../components/schemas/error_response.yml'
-          example:
-            _type: Error
-            errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
-            message: Operator can't be blank.
-      description: |-
-        Returned if the client sends a query parameter, that the server knows, but does not understand.
-        E.g. by providing a syntactically incorrect `filters` parameter.
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -321,19 +311,7 @@ post:
       description: OK
       headers: { }
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidRequestBody
-                message: The request body was not a single JSON object.
-      description: Occurs when the client did not send a valid JSON object in the
-        request body.
-      headers: { }
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:
@@ -372,6 +350,10 @@ post:
         *Note: A client without sufficient permissions shall not be able to test for the existence of a project.
         That's why a 404 is returned here, even if a 403 might be more appropriate.*
       headers: { }
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
     '422':
       content:
         application/hal+json:

--- a/docs/api/apiv3/paths/work_packages_schemas.yml
+++ b/docs/api/apiv3/paths/work_packages_schemas.yml
@@ -43,18 +43,7 @@ get:
       description: OK
       headers: {}
     '400':
-      content:
-        application/hal+json:
-          schema:
-            $ref: "../components/schemas/error_response.yml"
-          examples:
-            response:
-              value:
-                _type: Error
-                errorIdentifier: urn:openproject-org:api:v3:errors:InvalidQuery
-                message: Unknown filter.
-      description: Returned if the client sends invalid request.
-      headers: {}
+      $ref: "../components/responses/invalid_request_body.yml"
     '403':
       content:
         application/hal+json:

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -92,7 +92,7 @@ module API
 
         # Raise if missing header
         content_type = request.content_type
-        error!('Missing content-type header', 406) unless content_type.present?
+        error!('Missing content-type header', 406, { 'Content-Type' => 'text/plain' }) if content_type.blank?
 
         # Allow JSON and JSON+HAL per default
         # and anything that each endpoint may optionally add to that


### PR DESCRIPTION
The documentation for content type errors (406, 415) is missing from the API spec.

- [x] Add response components so that they can be reused without copypasta
- [x] Remove duplication of the 400 error along the way

https://community.openproject.org/wp/42925