### PR TITLE
reduce count calls in collection representer

### DIFF
--- a/lib/api/decorators/offset_paginated_collection.rb
+++ b/lib/api/decorators/offset_paginated_collection.rb
@@ -107,9 +107,20 @@ module API
       end
 
       def paged_models(models)
-        # FIXME: calling :to_a is a hack to circumvent a counting error in will_paginate
-        # see https://github.com/mislav/will_paginate/issues/449
-        models.page(@page).per_page(@per_page).to_a
+        if @per_page == 0
+          # Optimization. If we are not interested in the model, we can
+          # save the round trip to the database.
+          models.none
+        else
+          # Using WillPaginate as we have used it before but avoid the builtin
+          # page(@page).per_page(@per_page) way of fetching
+          # as it will, on top of fetching the values, also do a count of all elements matching the query
+          # which we do not need at this place.
+          page_number = ::WillPaginate::PageNumber(@page.nil? ? 1 : @page)
+          models
+            .offset(page_number.to_offset(@per_page).to_i)
+            .limit(@per_page)
+        end
       end
     end
   end

--- a/lib/api/v3/work_packages/work_package_collection_representer.rb
+++ b/lib/api/v3/work_packages/work_package_collection_representer.rb
@@ -191,12 +191,11 @@ module API
         def all_cfs_of_project
           @all_cfs_of_project ||= represented
                                   .group_by(&:project_id)
-                                  .map { |id, wps| [id, wps.map(&:available_custom_fields).flatten.uniq] }
-                                  .to_h
+                                  .transform_values { |wps| wps.map(&:available_custom_fields).flatten.uniq }
         end
 
         def paged_models(models)
-          models.page(@page).per_page(@per_page).pluck(:id)
+          super.pluck(:id)
         end
 
         def _type

--- a/spec/lib/api/v3/groups/group_collection_representer_spec.rb
+++ b/spec/lib/api/v3/groups/group_collection_representer_spec.rb
@@ -33,13 +33,13 @@ describe ::API::V3::Groups::GroupCollectionRepresenter do
   let(:groups) do
     build_stubbed_list(:group, 3).tap do |groups|
       allow(groups)
-        .to receive(:per_page)
-        .with(page_size)
+        .to receive(:offset)
+        .with(page - 1)
         .and_return(groups)
 
       allow(groups)
-        .to receive(:page)
-        .with(page)
+        .to receive(:limit)
+        .with(page_size)
         .and_return(groups)
 
       allow(groups)

--- a/spec/lib/api/v3/memberships/membership_collection_representer_spec.rb
+++ b/spec/lib/api/v3/memberships/membership_collection_representer_spec.rb
@@ -33,13 +33,13 @@ describe ::API::V3::Memberships::MembershipCollectionRepresenter do
   let(:members) do
     build_stubbed_list(:member, 3).tap do |members|
       allow(members)
-        .to receive(:per_page)
+        .to receive(:limit)
         .with(page_size)
         .and_return(members)
 
       allow(members)
-        .to receive(:page)
-        .with(page)
+        .to receive(:offset)
+        .with(page - 1)
         .and_return(members)
 
       allow(members)

--- a/spec/lib/api/v3/notifications/notification_collection_representer_spec.rb
+++ b/spec/lib/api/v3/notifications/notification_collection_representer_spec.rb
@@ -35,13 +35,13 @@ describe ::API::V3::Notifications::NotificationCollectionRepresenter do
     build_stubbed_list(:notification,
                        3).tap do |items|
       allow(items)
-        .to receive(:per_page)
+        .to receive(:limit)
               .with(page_size)
               .and_return(items)
 
       allow(items)
-        .to receive(:page)
-              .with(page)
+        .to receive(:offset)
+              .with(page - 1)
               .and_return(items)
 
       allow(items)

--- a/spec/lib/api/v3/placeholder_users/placeholder_user_collection_representer_spec.rb
+++ b/spec/lib/api/v3/placeholder_users/placeholder_user_collection_representer_spec.rb
@@ -41,13 +41,13 @@ describe ::API::V3::PlaceholderUsers::PlaceholderUserCollectionRepresenter do
     placeholders = build_stubbed_list(:placeholder_user,
                                       actual_count)
     allow(placeholders)
-      .to receive(:per_page)
+      .to receive(:limit)
       .with(page_size)
       .and_return(placeholders)
 
     allow(placeholders)
-      .to receive(:page)
-      .with(page)
+      .to receive(:offset)
+      .with(page - 1)
       .and_return(placeholders)
 
     allow(placeholders)

--- a/spec/lib/api/v3/relations/relation_paginated_collection_representer_spec.rb
+++ b/spec/lib/api/v3/relations/relation_paginated_collection_representer_spec.rb
@@ -36,13 +36,13 @@ describe ::API::V3::Relations::RelationPaginatedCollectionRepresenter do
   let(:relations) do
     build_stubbed_list(:relation, total).tap do |relations|
       allow(relations)
-        .to receive(:per_page)
+        .to receive(:limit)
               .with(page_size)
               .and_return(relations)
 
       allow(relations)
-        .to receive(:page)
-              .with(page)
+        .to receive(:offset)
+              .with(page - 1)
               .and_return(relations)
 
       allow(relations)

--- a/spec/lib/api/v3/users/user_collection_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_collection_representer_spec.rb
@@ -40,13 +40,13 @@ describe ::API::V3::Users::UserCollectionRepresenter do
     users = build_stubbed_list(:user,
                                actual_count)
     allow(users)
-      .to receive(:per_page)
+      .to receive(:limit)
       .with(page_size)
       .and_return(users)
 
     allow(users)
-      .to receive(:page)
-      .with(page)
+      .to receive(:offset)
+      .with(page - 1)
       .and_return(users)
 
     allow(users)


### PR DESCRIPTION
will_paginated, when actually fetching the records will do an SQL count on top of the fetching. We don't need that
in our offset paginated representers since those implement their own counts.

And if the per_page is 0, we don't even have to try to fetch any objects so we can use `none` to avoid the database
roundtrip.

A good example for the later is the pulling of notifications which happens with a page size of 0. With the change in place, only one single SQL statement  is necessary, the one fetching the count. Before, three SQL statements were issued: the count was fetched twice and the notifications where selected but nothing was returned because of a limit of 0.