### PR TITLE
Bump lefthook to 1.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -593,7 +593,7 @@ GEM
       open4 (~> 1.0)
     launchy (2.5.0)
       addressable (~> 2.7)
-    lefthook (1.0.0)
+    lefthook (1.0.1)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
     listen (3.7.1)


### PR DESCRIPTION
lefthook 1.0.0 seems to be no longer present on rubygems.