### PR TITLE
quickfix for principal filter performance

### DIFF
--- a/app/models/queries/work_packages/filter/principal_loader.rb
+++ b/app/models/queries/work_packages/filter/principal_loader.rb
@@ -34,36 +34,36 @@ class Queries::WorkPackages::Filter::PrincipalLoader
   end
 
   def user_values
-    @user_values ||= if principals_by_class[User].present?
-                       principals_by_class[User].map { |s| [s.name, s.id.to_s] }.sort
+    @user_values ||= if principals_by_class['User'].present?
+                       principals_by_class['User'].map { |_, id| [nil, id.to_s] }
                      else
                        []
                      end
   end
 
   def group_values
-    @group_values ||= if principals_by_class[Group].present?
-                        principals_by_class[Group].map { |s| [s.name, s.id.to_s] }.sort
+    @group_values ||= if principals_by_class['Group'].present?
+                        principals_by_class['Group'].map { |_, id| [nil, id.to_s] }
                       else
                         []
                       end
   end
 
   def principal_values
-    @options ||= principals.map { |s| [s.name, s.id.to_s] }.sort
+    @principal_values ||= principals.map { |_, id| [nil, id.to_s] }
   end
 
   private
 
   def principals
     if project
-      project.principals.sort
+      project.principals
     else
-      Principal.visible.sort
-    end
+      Principal.visible.not_builtin
+    end.pluck(:type, :id)
   end
 
   def principals_by_class
-    @principals_by_class ||= principals.group_by(&:class)
+    @principals_by_class ||= principals.group_by(&:first)
   end
 end

--- a/spec/features/work_packages/bulk/copy_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/copy_work_package_spec.rb
@@ -63,6 +63,7 @@ describe 'Copy work packages through Rails view', js: true do
   describe 'copying work packages' do
     context 'with permission' do
       let(:current_user) { mover }
+      let(:wp_table_target) { ::Pages::WorkPackagesTable.new(project2) }
 
       before do
         wp_table.expect_work_package_count 2
@@ -83,7 +84,8 @@ describe 'Copy work packages through Rails view', js: true do
         notes.set_markdown 'A note on copy'
         click_on 'Copy and follow'
 
-        wp_table.expect_work_package_count 2
+        wp_table_target.expect_current_path
+        wp_table_target.expect_work_package_count 2
         expect(page).to have_selector('#projects-menu', text: 'Target')
 
         # Should not move the sources
@@ -109,8 +111,8 @@ describe 'Copy work packages through Rails view', js: true do
         it 'moves parent and child wp to a new project with the hierarchy amended' do
           click_on 'Copy and follow'
 
-          expect_angular_frontend_initialized
-          wp_table.expect_work_package_count 3
+          wp_table_target.expect_current_path
+          wp_table_target.expect_work_package_count 3
           expect(page).to have_selector('#projects-menu', text: 'Target')
 
           # Should not move the sources

--- a/spec/models/queries/work_packages/filter/assigned_to_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/assigned_to_filter_spec.rb
@@ -113,7 +113,7 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
         objects = instance.value_objects
 
         # As no order is defined in the filter, we use the same method of fetching the values
-        # from the DB as the object under text expecting it to return the values in the same order
+        # from the DB as the object under test expecting it to return the values in the same order
         expect(objects.map(&:id)).to eql ['me'] + Principal.where(id: [assignee.id, assignee2.id]).pluck(:id)
       end
     end
@@ -194,7 +194,7 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
     let(:principal_values) { [] }
 
     describe '#valid_values!' do
-      let(:principal_values) { [[user.name, user.id.to_s]] }
+      let(:principal_values) { [[nil, user.id.to_s]] }
 
       before do
         instance.values = [user.id.to_s, '99999']
@@ -233,7 +233,7 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
         end
 
         context 'if a user is available' do
-          let(:principal_values) { [[user.name, user.id.to_s]] }
+          let(:principal_values) { [[nil, user.id.to_s]] }
 
           it 'is true' do
             expect(instance).to be_available
@@ -241,7 +241,7 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
         end
 
         context 'if a placeholder user is available' do
-          let(:principal_values) { [[placeholder_user.name, placeholder_user.id.to_s]] }
+          let(:principal_values) { [[nil, placeholder_user.id.to_s]] }
 
           it 'is true' do
             expect(instance).to be_available
@@ -249,7 +249,7 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
         end
 
         context 'if another group selectable' do
-          let(:principal_values) { [[group.name, group.id.to_s]] }
+          let(:principal_values) { [[nil, group.id.to_s]] }
 
           it 'is true' do
             expect(instance).to be_available
@@ -269,7 +269,7 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
         end
 
         context 'if a user is available' do
-          let(:principal_values) { [[user.name, user.id.to_s]] }
+          let(:principal_values) { [[nil, user.id.to_s]] }
 
           it 'is true' do
             expect(instance).to be_available
@@ -277,7 +277,7 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
         end
 
         context 'if a placeholder user is available' do
-          let(:principal_values) { [[placeholder_user.name, placeholder_user.id.to_s]] }
+          let(:principal_values) { [[nil, placeholder_user.id.to_s]] }
 
           it 'is true' do
             expect(instance).to be_available
@@ -285,7 +285,7 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
         end
 
         context 'if another group selectable' do
-          let(:principal_values) { [[group.name, group.id.to_s]] }
+          let(:principal_values) { [[nil, group.id.to_s]] }
 
           it 'is true' do
             expect(instance).to be_available
@@ -304,15 +304,15 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
 
         allow(principal_loader)
           .to receive(:principal_values)
-          .and_return([[user.name, user.id.to_s], [group.name, group.id.to_s]])
+          .and_return([[nil, user.id.to_s], [nil, group.id.to_s]])
       end
 
       context 'when being logged in' do
         it 'returns the me value and the available users and groups' do
           expect(instance.allowed_values)
             .to match_array([[I18n.t(:label_me), 'me'],
-                             [user.name, user.id.to_s],
-                             [group.name, group.id.to_s]])
+                             [nil, user.id.to_s],
+                             [nil, group.id.to_s]])
         end
       end
 
@@ -321,8 +321,8 @@ describe Queries::WorkPackages::Filter::AssignedToFilter, type: :model do
 
         it 'returns the available users' do
           expect(instance.allowed_values)
-            .to match_array([[user.name, user.id.to_s],
-                             [group.name, group.id.to_s]])
+            .to match_array([[nil, user.id.to_s],
+                             [nil, group.id.to_s]])
         end
       end
     end

--- a/spec/models/queries/work_packages/filter/assignee_or_group_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/assignee_or_group_filter_spec.rb
@@ -160,7 +160,7 @@ describe Queries::WorkPackages::Filter::AssigneeOrGroupFilter, type: :model do
 
         allow(loader)
           .to receive(:user_values)
-          .and_return([[user.name, user.id.to_s]])
+          .and_return([[nil, user.id.to_s]])
         allow(loader)
           .to receive(:group_values)
           .and_return([])

--- a/spec/models/queries/work_packages/filter/author_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/author_filter_spec.rb
@@ -68,7 +68,7 @@ describe Queries::WorkPackages::Filter::AuthorFilter, type: :model do
         it 'is true if there is another user selectable' do
           allow(principal_loader)
             .to receive(:user_values)
-            .and_return([[user_1.name, user_1.id.to_s]])
+            .and_return([[nil, user_1.id.to_s]])
 
           expect(instance).to be_available
         end
@@ -84,7 +84,7 @@ describe Queries::WorkPackages::Filter::AuthorFilter, type: :model do
         it 'is true if there is another user selectable' do
           allow(principal_loader)
             .to receive(:user_values)
-            .and_return([[user_1.name, user_1.id.to_s]])
+            .and_return([[nil, user_1.id.to_s]])
 
           expect(instance).to be_available
         end
@@ -104,11 +104,11 @@ describe Queries::WorkPackages::Filter::AuthorFilter, type: :model do
         it 'returns the me value and the available users' do
           allow(principal_loader)
             .to receive(:user_values)
-            .and_return([[user_1.name, user_1.id.to_s]])
+            .and_return([[nil, user_1.id.to_s]])
 
           expect(instance.allowed_values)
             .to match_array([[I18n.t(:label_me), 'me'],
-                             [user_1.name, user_1.id.to_s]])
+                             [nil, user_1.id.to_s]])
         end
       end
 
@@ -118,10 +118,10 @@ describe Queries::WorkPackages::Filter::AuthorFilter, type: :model do
         it 'returns the available users' do
           allow(principal_loader)
             .to receive(:user_values)
-            .and_return([[user_1.name, user_1.id.to_s]])
+            .and_return([[nil, user_1.id.to_s]])
 
           expect(instance.allowed_values)
-            .to match_array([[user_1.name, user_1.id.to_s]])
+            .to match_array([[nil, user_1.id.to_s]])
         end
       end
     end

--- a/spec/models/queries/work_packages/filter/principal_loader_spec.rb
+++ b/spec/models/queries/work_packages/filter/principal_loader_spec.rb
@@ -44,7 +44,7 @@ describe Queries::WorkPackages::Filter::PrincipalLoader, type: :model do
 
     describe '#user_values' do
       it 'returns a user array' do
-        expect(instance.user_values).to match_array([[user.name, user.id.to_s]])
+        expect(instance.user_values).to match_array([[nil, user.id.to_s]])
       end
 
       it 'is empty if no user exists' do
@@ -58,7 +58,7 @@ describe Queries::WorkPackages::Filter::PrincipalLoader, type: :model do
 
     describe '#group_values' do
       it 'returns a group array' do
-        expect(instance.group_values).to match_array([[group.name, group.id.to_s]])
+        expect(instance.group_values).to match_array([[nil, group.id.to_s]])
       end
 
       it 'is empty if no group exists' do
@@ -73,9 +73,9 @@ describe Queries::WorkPackages::Filter::PrincipalLoader, type: :model do
     describe '#principal_values' do
       it 'returns an array of principals as [name, id]' do
         expect(instance.principal_values)
-          .to match_array([[group.name, group.id.to_s],
-                           [user.name, user.id.to_s],
-                           [placeholder_user.name, placeholder_user.id.to_s]])
+          .to match_array([[nil, group.id.to_s],
+                           [nil, user.id.to_s],
+                           [nil, placeholder_user.id.to_s]])
       end
 
       it 'is empty if no principal exists' do
@@ -97,11 +97,15 @@ describe Queries::WorkPackages::Filter::PrincipalLoader, type: :model do
       allow(Principal)
         .to receive(:visible)
         .and_return(matching_principals)
+
+      allow(matching_principals)
+        .to receive(:not_builtin)
+              .and_return(matching_principals)
     end
 
     describe '#user_values' do
       it 'returns a user array' do
-        expect(instance.user_values).to match_array([[user.name, user.id.to_s]])
+        expect(instance.user_values).to match_array([[nil, user.id.to_s]])
       end
 
       context 'if no user exists' do
@@ -115,7 +119,7 @@ describe Queries::WorkPackages::Filter::PrincipalLoader, type: :model do
 
     describe '#group_values' do
       it 'returns a group array' do
-        expect(instance.group_values).to match_array([[group.name, group.id.to_s]])
+        expect(instance.group_values).to match_array([[nil, group.id.to_s]])
       end
 
       context 'if no group exists' do
@@ -130,9 +134,9 @@ describe Queries::WorkPackages::Filter::PrincipalLoader, type: :model do
     describe '#principal_values' do
       it 'returns an array of principals as [name, id]' do
         expect(instance.principal_values)
-          .to match_array([[group.name, group.id.to_s],
-                           [user.name, user.id.to_s],
-                           [placeholder_user.name, placeholder_user.id.to_s]])
+          .to match_array([[nil, group.id.to_s],
+                           [nil, user.id.to_s],
+                           [nil, placeholder_user.id.to_s]])
       end
 
       context 'if no principals exist' do

--- a/spec/models/queries/work_packages/filter/responsible_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/responsible_filter_spec.rb
@@ -222,7 +222,7 @@ describe Queries::WorkPackages::Filter::ResponsibleFilter, type: :model do
         it 'is true if there is another user selectable' do
           allow(principal_loader)
             .to receive(:principal_values)
-            .and_return([user_1.name, user_1.id.to_s])
+            .and_return([nil, user_1.id.to_s])
 
           expect(instance).to be_available
         end
@@ -238,7 +238,7 @@ describe Queries::WorkPackages::Filter::ResponsibleFilter, type: :model do
         it 'is true if there is another user selectable' do
           allow(principal_loader)
             .to receive(:principal_values)
-            .and_return([[user_1.name, user_1.id.to_s]])
+            .and_return([[nil, user_1.id.to_s]])
 
           expect(instance).to be_available
         end
@@ -256,16 +256,16 @@ describe Queries::WorkPackages::Filter::ResponsibleFilter, type: :model do
 
         allow(principal_loader)
           .to receive(:principal_values)
-          .and_return([[user_1.name, user_1.id.to_s],
-                       [group.name, group.id.to_s]])
+          .and_return([[nil, user_1.id.to_s],
+                       [nil, group.id.to_s]])
       end
 
       context 'when being logged in' do
         it 'returns the me value, the available users, and groups' do
           expect(instance.allowed_values)
             .to match_array([[I18n.t(:label_me), 'me'],
-                             [user_1.name, user_1.id.to_s],
-                             [group.name, group.id.to_s]])
+                             [nil, user_1.id.to_s],
+                             [nil, group.id.to_s]])
         end
       end
 
@@ -274,8 +274,8 @@ describe Queries::WorkPackages::Filter::ResponsibleFilter, type: :model do
 
         it 'returns the available users' do
           expect(instance.allowed_values)
-            .to match_array([[user_1.name, user_1.id.to_s],
-                             [group.name, group.id.to_s]])
+            .to match_array([[nil, user_1.id.to_s],
+                             [nil, group.id.to_s]])
         end
       end
     end

--- a/spec/models/queries/work_packages/filter/watcher_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/watcher_filter_spec.rb
@@ -71,7 +71,7 @@ describe Queries::WorkPackages::Filter::WatcherFilter, type: :model do
 
         allow(principal_loader)
           .to receive(:user_values)
-          .and_return([user])
+          .and_return([nil, user.id.to_s])
 
         expect(instance).to be_available
       end
@@ -103,7 +103,7 @@ describe Queries::WorkPackages::Filter::WatcherFilter, type: :model do
 
         allow(principal_loader)
           .to receive(:user_values)
-          .and_return([user])
+          .and_return([nil, user.id.to_s])
 
         expect(instance).not_to be_available
       end
@@ -133,11 +133,11 @@ describe Queries::WorkPackages::Filter::WatcherFilter, type: :model do
 
           allow(principal_loader)
             .to receive(:user_values)
-            .and_return([user])
+            .and_return([nil, user.id.to_s])
 
           expect(instance.allowed_values)
             .to match_array [[I18n.t(:label_me), 'me'],
-                             [user.name, user.id.to_s]]
+                             [nil, user.id.to_s]]
         end
       end
     end


### PR DESCRIPTION
Instead of instantiating the users only to then get the name and the id for the available values of principal based filters,
only pluck the id directly as that is the only part of the allowed_values that is used nowadays.

Sorting is not necessary at all any more since the allowed_values are no longer displayed within the application.

This drops the time necessary to evaluate the validity of a filter from about a minute on user heavy installations like community to subseconds. 