### PR TITLE
Implement change duration default to nil

### DIFF
--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -986,10 +986,6 @@ Settings::Definition.define do
   add :work_package_startdate_is_adddate,
       default: false
 
-  add :work_packages_duration_field_active,
-      default: Rails.env.development?,
-      format: :boolean
-
   add :youtube_channel,
       default: 'https://www.youtube.com/c/OpenProjectCommunity',
       writable: false

--- a/db/migrate/20220620132922_change_duration_default_value.rb
+++ b/db/migrate/20220620132922_change_duration_default_value.rb
@@ -1,0 +1,22 @@
+class ChangeDurationDefaultValue < ActiveRecord::Migration[7.0]
+  def up
+    set_duration(:work_packages)
+    set_duration(:work_package_journals)
+  end
+
+  private
+
+  def set_duration(table)
+    execute <<~SQL.squish
+      UPDATE
+        #{table}
+      SET
+        duration = CASE
+                   WHEN start_date IS NULL OR due_date IS NULL
+                   THEN NULL
+                   ELSE
+                     due_date - start_date + 1
+                   END
+    SQL
+  end
+end

--- a/db/migrate/20220817154403_remove_work_packages_duration_field_active_setting.rb
+++ b/db/migrate/20220817154403_remove_work_packages_duration_field_active_setting.rb
@@ -1,0 +1,5 @@
+class RemoveWorkPackagesDurationFieldActiveSetting < ActiveRecord::Migration[7.0]
+  def change
+    Setting.where(name: 'work_packages_duration_field_active').destroy_all
+  end
+end

--- a/db/migrate/20220830092057_change_default_for_non_working_days.rb
+++ b/db/migrate/20220830092057_change_default_for_non_working_days.rb
@@ -1,0 +1,13 @@
+class ChangeDefaultForNonWorkingDays < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :work_packages, :ignore_non_working_days, from: true, to: false
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL.squish
+          UPDATE work_packages SET ignore_non_working_days = TRUE
+        SQL
+      end
+    end
+  end
+end

--- a/lib/open_project/feature_decisions.rb
+++ b/lib/open_project/feature_decisions.rb
@@ -40,8 +40,9 @@ module OpenProject
     #     Setting.feature_your_module_active || Date.today > release_date
     #   end
 
+    # TODO: remove this feature flag
     def self.work_packages_duration_field_active?
-      Setting.work_packages_duration_field_active
+      true
     end
   end
 end

--- a/spec/contracts/work_packages/base_contract_spec.rb
+++ b/spec/contracts/work_packages/base_contract_spec.rb
@@ -694,10 +694,10 @@ describe WorkPackages::BaseContract do
       it_behaves_like 'contract is valid'
     end
 
-    context 'when setting the value to false and with the feature disabled',
+    context 'when setting the value to true and with the feature disabled',
             with_flag: { work_packages_duration_field_active: false } do
       before do
-        work_package.ignore_non_working_days = false
+        work_package.ignore_non_working_days = true
       end
 
       it_behaves_like 'contract is invalid', ignore_non_working_days: :error_readonly

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -699,7 +699,7 @@ describe WorkPackage, type: :model do
     context 'for a new record' do
       it 'is true' do
         expect(described_class.new.ignore_non_working_days)
-          .to be true
+          .to be false
       end
     end
   end

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -697,7 +697,7 @@ describe WorkPackage, type: :model do
 
   describe '#ignore_non_working_days' do
     context 'for a new record' do
-      it 'is true' do
+      it 'is false' do
         expect(described_class.new.ignore_non_working_days)
           .to be false
       end


### PR DESCRIPTION
Follow up on OP#31992
This should be merged only in 12.3.

- [x] Add migration to update duration on work packages, work package journals always ignoring the non working days in case both start/stop dates are present
- [x] Check if duration and ignore_non_working days are not part of the form config
- [x] change_column_default :work_packages, :ignore_non_working_days, from: true, to: false