### PR TITLE
Reduce the number of SQL requests for scheduling

### DIFF
--- a/app/services/work_packages/schedule_dependency/dependency_graph.rb
+++ b/app/services/work_packages/schedule_dependency/dependency_graph.rb
@@ -31,7 +31,6 @@ class WorkPackages::ScheduleDependency::DependencyGraph
 
   def initialize(dependencies)
     @dependencies = dependencies
-    @dependent_ids = dependencies.to_h { |dep| [dep.work_package.id, dep.dependent_ids] }
   end
 
   def schedule_order
@@ -54,16 +53,22 @@ class WorkPackages::ScheduleDependency::DependencyGraph
   # Returns true if the given work package depends on the work package of the
   # dependency, either directly or transitively.
   def depends_on?(work_package, dependency)
-    to_process_ids = [work_package.id]
-    processed_ids = Set.new
-    while id = to_process_ids.shift
-      processed_ids.add(id)
-      dependent_ids = @dependent_ids[id]
-      next if dependent_ids.nil?
-      return true if dependent_ids.include?(dependency.work_package.id)
+    full_dependencies_of(work_package.id).include?(dependency.work_package.id)
+  end
 
-      to_process_ids.concat(dependent_ids.without(processed_ids))
+  private
+
+  def full_dependencies_of(work_package_id)
+    @full_dependent_ids ||= {}
+    @full_dependent_ids[work_package_id] ||= begin
+      ids = dependent_ids_for_work_package_id(work_package_id)
+      ids += ids.flat_map { full_dependencies_of(_1) }
+      ids.uniq
     end
-    false
+  end
+
+  def dependent_ids_for_work_package_id(id)
+    @dependent_ids ||= dependencies.to_h { |dep| [dep.work_package.id, dep.dependent_ids] }
+    @dependent_ids[id] || []
   end
 end

--- a/app/services/work_packages/schedule_dependency/dependency_graph.rb
+++ b/app/services/work_packages/schedule_dependency/dependency_graph.rb
@@ -31,7 +31,7 @@ class WorkPackages::ScheduleDependency::DependencyGraph
 
   def initialize(dependencies)
     @dependencies = dependencies
-    @dependent_ids = dependencies.to_h { |dep| [dep.work_package.id, dep.dependent_ids.uniq] }
+    @dependent_ids = dependencies.to_h { |dep| [dep.work_package.id, dep.dependent_ids] }
   end
 
   def schedule_order

--- a/spec/factories/week_day_factory.rb
+++ b/spec/factories/week_day_factory.rb
@@ -42,7 +42,7 @@ FactoryBot.define do
     end
   end
 
-  # Factory to create all 7 week days at once
+  # Factory to create all 7 week days at once, Saturday and Sunday being weekend days
   factory :week_days, class: 'Array' do
     # Skip the create callback to be able to use non-AR models. Otherwise FactoryBot will
     # try to call #save! on any created object.

--- a/spec/features/work_packages/bulk/copy_work_package_spec.rb
+++ b/spec/features/work_packages/bulk/copy_work_package_spec.rb
@@ -76,6 +76,7 @@ describe 'Copy work packages through Rails view', js: true do
                               select_text: project2.name,
                               results_selector: 'body'
         end
+        sleep(1) # wait for the change of target project to finish updating the page
       end
 
       it 'sets the version on copy and leaves a note' do

--- a/spec/services/work_packages/schedule_dependency/dependency_spec.rb
+++ b/spec/services/work_packages/schedule_dependency/dependency_spec.rb
@@ -72,12 +72,6 @@ RSpec.describe WorkPackages::ScheduleDependency::Dependency do
     create(:work_package, subject: "child of #{work_package.subject}", parent: work_package)
   end
 
-  shared_examples 'returns empty array' do
-    it 'returns empty array' do
-      expect(subject.dependent_ids).to eq([])
-    end
-  end
-
   describe '#dependent_ids' do
     context 'when the work_package has a follower' do
       let!(:follower) { create_follower_of(work_package) }
@@ -214,14 +208,14 @@ RSpec.describe WorkPackages::ScheduleDependency::Dependency do
     end
   end
 
-  describe '#max_date_of_followed' do
+  describe '#soonest_start_date' do
     let(:work_package_used_in_dependency) { work_package }
     let(:work_package) { create(:work_package, subject: 'moved', due_date: Time.zone.today) }
 
     context 'with a moved predecessor' do
       it 'returns the soonest start date from the predecessors' do
         follower = create_follower_of(work_package)
-        expect(dependency_for(follower).max_date_of_followed).to eq(work_package.due_date + 1.day)
+        expect(dependency_for(follower).soonest_start_date).to eq(work_package.due_date + 1.day)
       end
     end
 
@@ -229,7 +223,7 @@ RSpec.describe WorkPackages::ScheduleDependency::Dependency do
       it 'returns the soonest start date from the predecessors' do
         follower = create_follower_of(work_package)
         unmoved_follower_predecessor = create_predecessor_of(follower, due_date: Time.zone.today + 4.days)
-        expect(dependency_for(follower).max_date_of_followed).to eq(unmoved_follower_predecessor.due_date + 1.day)
+        expect(dependency_for(follower).soonest_start_date).to eq(unmoved_follower_predecessor.due_date + 1.day)
       end
     end
   end

--- a/spec/services/work_packages/schedule_dependency/dependency_spec.rb
+++ b/spec/services/work_packages/schedule_dependency/dependency_spec.rb
@@ -28,132 +28,208 @@
 
 require 'rails_helper'
 
+# Scenario: a work package has been moved on the calendar. The moved work
+# package has children, parents, followers, and/or predecessors. The
+# +ScheduleDependency+ created for the moved work package will have one
+# +Dependency+ instance per work package that may need to change due to the
+# move. These dependencies are the subjects under test.
 RSpec.describe WorkPackages::ScheduleDependency::Dependency do
-  subject { described_class.new(work_package, schedule_dependency) }
+  subject(:dependency) { dependency_for(work_package_used_in_dependency) }
 
-  let(:work_package) { create(:work_package, subject: 'subject') }
-  let(:schedule_dependency) { instance_double(WorkPackages::ScheduleDependency) }
-  let(:known_work_packages_by_parent_id) { Hash.new { |h, k| h[k] = [] } }
-  let(:known_work_packages_by_id) { { work_package.id => work_package } }
+  let(:work_package) { create(:work_package, subject: 'moved') }
+  let(:schedule_dependency) { WorkPackages::ScheduleDependency.new(work_package) }
 
-  before do
-    allow(schedule_dependency)
-      .to receive(:known_work_packages_by_parent_id)
-      .and_return(known_work_packages_by_parent_id)
-    allow(schedule_dependency)
-      .to receive(:known_work_packages_by_id)
-      .and_return(known_work_packages_by_id)
-    allow(schedule_dependency)
-      .to receive(:scheduled_work_packages_by_id)
-      .and_return(known_work_packages_by_id)
+  def dependency_for(work_package)
+    dependency = schedule_dependency.dependencies[work_package]
+    if dependency.nil?
+      available = schedule_dependency.dependencies.keys.map(&:subject).map(&:inspect).to_sentence
+      raise ArgumentError, "Unable to find dependency for work package #{work_package.subject.inspect}; " \
+                           "ScheduleDependency instance has dependencies for work packages #{available}"
+    end
+
+    dependency
   end
 
-  def create_predecessor_of(work_package)
-    create(:work_package, subject: "predecessor of #{work_package.subject}").tap do |predecessor|
+  def create_predecessor_of(work_package, **attributes)
+    create(:work_package, subject: "predecessor of #{work_package.subject}", **attributes).tap do |predecessor|
       create(:follows_relation, from: work_package, to: predecessor)
-      known_work_packages_by_id[predecessor.id] = predecessor
     end
   end
 
   def create_follower_of(work_package)
     create(:work_package, subject: "follower of #{work_package.subject}").tap do |follower|
       create(:follows_relation, from: follower, to: work_package)
-      known_work_packages_by_id[follower.id] = follower
     end
   end
 
   def create_parent_of(work_package)
-    create(:work_package, subject: "parent of #{work_package.subject}", parent: work_package).tap do |parent|
-      known_work_packages_by_id[parent.id] = parent
-      known_work_packages_by_parent_id[work_package.parent_id] << parent
+    create(:work_package, subject: "parent of #{work_package.subject}").tap do |parent|
+      work_package.update(parent:)
     end
   end
 
   def create_child_of(work_package)
-    create(:work_package, subject: "child of #{work_package.subject}", parent: work_package).tap do |child|
-      known_work_packages_by_id[child.id] = child
-      known_work_packages_by_parent_id[child.parent_id] << child
+    create(:work_package, subject: "child of #{work_package.subject}", parent: work_package)
+  end
+
+  shared_examples 'returns empty array' do
+    it 'returns empty array' do
+      expect(subject.dependent_ids).to eq([])
     end
   end
 
   describe '#dependent_ids' do
-    context 'when the work_package is not related to anything' do
-      it 'returns empty array' do
-        expect(subject.dependent_ids).to eq([])
-      end
-    end
-
-    context 'when the work_package has a predecessor' do
-      let!(:predecessor) { create_predecessor_of(work_package) }
-
-      it 'returns an array with the predecessor id' do
-        expect(subject.dependent_ids).to eq([predecessor.id])
-      end
-    end
-
     context 'when the work_package has a follower' do
       let!(:follower) { create_follower_of(work_package) }
 
-      it 'returns empty array' do
-        expect(subject.dependent_ids).to eq([])
+      context 'for dependency of the follower' do
+        let(:work_package_used_in_dependency) { follower }
+
+        it 'returns an array with the work package id' do
+          expect(subject.dependent_ids).to eq([work_package.id])
+        end
       end
     end
 
     context 'when the work_package has a parent' do
       let!(:parent) { create_parent_of(work_package) }
 
-      it 'returns empty array' do
-        expect(subject.dependent_ids).to eq([])
+      context 'for dependency of the parent' do
+        let(:work_package_used_in_dependency) { parent }
+
+        it 'returns an array with the work package id' do
+          expect(subject.dependent_ids).to eq([work_package.id])
+        end
       end
     end
 
-    context 'when the work_package has a child' do
-      let!(:child) { create_child_of(work_package) }
+    context 'when the work_package has a follower which has a child' do
+      let!(:follower) { create_follower_of(work_package) }
+      let!(:follower_child) { create_child_of(follower) }
 
-      it 'returns an array with the child id' do
-        expect(subject.dependent_ids).to eq([child.id])
+      context 'for dependency of the child' do
+        let(:work_package_used_in_dependency) { follower_child }
+
+        it 'returns an array with the work_package id' do
+          expect(subject.dependent_ids).to eq([work_package.id])
+        end
+      end
+
+      context 'for dependency of the follower' do
+        let(:work_package_used_in_dependency) { follower }
+
+        it 'returns an array with the work_package id and the follower child id' do
+          expect(subject.dependent_ids).to contain_exactly(work_package.id, follower_child.id)
+        end
       end
     end
 
-    context 'when the work_package has multiple children and predecessors' do
-      let!(:child1) { create_child_of(work_package) }
-      let!(:child2) { create_child_of(work_package) }
-      let!(:predecessor1) { create_predecessor_of(work_package) }
-      let!(:predecessor2) { create_predecessor_of(work_package) }
+    context 'when the work_package has multiple parents and followers' do
+      let!(:first_follower) { create_follower_of(work_package) }
+      let!(:second_follower) { create_follower_of(work_package) }
+      let!(:first_follower_parent) { create_parent_of(first_follower) }
+      let!(:first_follower_grandparent) { create_parent_of(first_follower_parent) }
 
-      it 'returns an array with the children and the predecessors ids' do
-        expect(subject.dependent_ids).to contain_exactly(child1.id, child2.id, predecessor1.id, predecessor2.id)
+      context 'for dependency of the first follower parent' do
+        let(:work_package_used_in_dependency) { first_follower_parent }
+
+        it 'returns an array with the work_package and the first follower ids' do
+          expect(subject.dependent_ids).to contain_exactly(work_package.id, first_follower.id)
+        end
+      end
+
+      context 'for dependency of the first follower grandparent' do
+        let(:work_package_used_in_dependency) { first_follower_grandparent }
+
+        it 'returns an array with the work_package, the first follower, and the first follower parent ids' do
+          expect(subject.dependent_ids).to contain_exactly(work_package.id, first_follower.id, first_follower_parent.id)
+        end
+      end
+
+      context 'for dependency of the second follower' do
+        let(:work_package_used_in_dependency) { second_follower }
+
+        it 'returns an array with the work_package id' do
+          expect(subject.dependent_ids).to contain_exactly(work_package.id)
+        end
       end
     end
 
     context 'with more complex relations' do
-      context 'when has a child which has a child' do
-        let!(:child) { create_child_of(work_package) }
-        let!(:child_child) { create_child_of(child) }
+      context 'when has two consecutive followers' do
+        let!(:follower) { create_follower_of(work_package) }
+        let!(:follower_follower) { create_follower_of(follower) }
 
-        it 'returns an array with both children ids' do
-          expect(subject.dependent_ids).to contain_exactly(child.id, child_child.id)
+        context 'for dependency of the first follower' do
+          let(:work_package_used_in_dependency) { follower }
+
+          it 'returns an array with the work_package id' do
+            expect(subject.dependent_ids).to contain_exactly(work_package.id)
+          end
+        end
+
+        context 'for dependency of the second follower' do
+          let(:work_package_used_in_dependency) { follower_follower }
+
+          it 'returns an array with only the first follower id' do
+            expect(subject.dependent_ids).to contain_exactly(follower.id)
+          end
         end
       end
 
-      context 'when has a predecessor which has a predecessor and a follower' do
-        let!(:predecessor) { create_predecessor_of(work_package) }
-        let!(:predecessor_predecessor) { create_predecessor_of(predecessor) }
-        let!(:predecessor_follower) { create_follower_of(predecessor) }
+      context 'when has a follower which has a predecessor' do
+        let!(:follower) { create_follower_of(work_package) }
+        let!(:follower_predecessor) { create_predecessor_of(follower) }
 
-        it 'returns an array with the first predecessor only (not transient)' do
-          expect(subject.dependent_ids).to contain_exactly(predecessor.id)
+        context 'for dependency of the follower' do
+          let(:work_package_used_in_dependency) { follower }
+
+          it 'returns an array with the work_package id' do
+            expect(subject.dependent_ids).to contain_exactly(work_package.id)
+          end
         end
       end
 
       context 'when has a predecessor which has a parent and a child' do
-        let!(:predecessor) { create_predecessor_of(work_package) }
-        let!(:predecessor_parent) { create_parent_of(predecessor) }
-        let!(:predecessor_child) { create_child_of(predecessor) }
+        let!(:follower) { create_follower_of(work_package) }
+        let!(:follower_parent) { create_parent_of(follower) }
+        let!(:follower_child) { create_child_of(follower) }
 
-        it 'returns an array with the predecessor only (not transient)' do
-          expect(subject.dependent_ids).to contain_exactly(predecessor.id)
+        context 'for dependency of the follower child' do
+          let(:work_package_used_in_dependency) { follower_child }
+
+          it 'returns an array with the work_package id' do
+            expect(subject.dependent_ids).to contain_exactly(work_package.id)
+          end
         end
+
+        context 'for dependency of the follower parent' do
+          let(:work_package_used_in_dependency) { follower_parent }
+
+          it 'returns an array with the work_package, the follower, and the follower child ids' do
+            expect(subject.dependent_ids).to contain_exactly(work_package.id, follower.id, follower_child.id)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#max_date_of_followed' do
+    let(:work_package_used_in_dependency) { work_package }
+    let(:work_package) { create(:work_package, subject: 'moved', due_date: Time.zone.today) }
+
+    context 'with a moved predecessor' do
+      it 'returns the soonest start date from the predecessors' do
+        follower = create_follower_of(work_package)
+        expect(dependency_for(follower).max_date_of_followed).to eq(work_package.due_date + 1.day)
+      end
+    end
+
+    context 'with an unmoved predecessor' do
+      it 'returns the soonest start date from the predecessors' do
+        follower = create_follower_of(work_package)
+        unmoved_follower_predecessor = create_predecessor_of(follower, due_date: Time.zone.today + 4.days)
+        expect(dependency_for(follower).max_date_of_followed).to eq(unmoved_follower_predecessor.due_date + 1.day)
       end
     end
   end


### PR DESCRIPTION
4 SQL requests are done:

  1. load the work packages that need to be rescheduled
  2. load the descendants
  3. load the precedes relations
  4. load the predecessors

Once done, only the preloaded data is used to determine the order of scheduling and the computation of rescheduling dates.

The terminology has also been updated to be more consistent:

  * moved work packages are the ones just rescheduled
  * moving work packages are the ones to be rescheduled
  * unmoving work packages are the ones not to be rescheduled but necessary to determine start and due dates of moving work packages
