### PR TITLE
[42413] Optimisation for closed cards in team planner

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.sass
@@ -155,8 +155,14 @@
 
   &--inline-buttons
     opacity: 0
-    padding-left: 40px
+    padding-left: 30px
     padding-right: 4px
+    white-space: nowrap
+
+    // For selected cards the padding needs to be smaller
+    // Otherwise the left-side color shading can overflow the card (e.g. in small cards in the team planner)
+    .op-wp-single-card_selected &
+      padding-left: 15px
 
     .op-icon--wrapper:not(&_selected)
       background: $spot-color-basic-white


### PR DESCRIPTION
The status in cards is clickable by default. However, there are some special cases to tackle especially for small cards:

- [x] Avoid line-wrap for action icons
- [x] Reduce amount of space for left-side shading so that more parts of the status button are clickable.
  - [x] Exception: Cards that are very small (e.g. one day in a two-week view): We accept that the status is not clickable here.

Fixes https://community.openproject.org/projects/openproject/work_packages/42413/activity#activity-22 in https://community.openproject.org/projects/openproject/work_packages/42413/activity