### PR TITLE
Remove appsignal console plugin due to high volume of logs

### DIFF
--- a/frontend/src/app/core/errors/appsignal/appsignal-dependency.ts
+++ b/frontend/src/app/core/errors/appsignal/appsignal-dependency.ts
@@ -1,11 +1,9 @@
 import Appsignal from '@appsignal/javascript';
 import { Span } from '@appsignal/javascript/dist/esm/span';
 import { plugin as networkPlugin } from '@appsignal/plugin-breadcrumbs-network';
-import { plugin as consolePlugin } from '@appsignal/plugin-breadcrumbs-console';
 
 export {
   Appsignal,
   Span,
   networkPlugin,
-  consolePlugin,
 };

--- a/frontend/src/app/core/errors/appsignal/appsignal-reporter.ts
+++ b/frontend/src/app/core/errors/appsignal/appsignal-reporter.ts
@@ -71,7 +71,6 @@ export class AppsignalReporter extends ErrorReporterBase {
         revision,
       });
 
-      this.client.use(imported.consolePlugin());
       this.client.use(imported.networkPlugin());
     });
   }


### PR DESCRIPTION
I don't think it is adding a lot of value right now