### PR TITLE
prevent setting dates twice for new work packages

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -36,18 +36,10 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
     set_static_attributes(attributes)
 
     model.change_by_system do
-      set_default_attributes(attributes)
-      update_project_dependent_attributes
+      set_calculated_attributes(attributes)
     end
 
     set_custom_attributes(attributes)
-
-    model.change_by_system do
-      update_dates
-      update_duration
-      reassign_invalid_status_if_type_changed
-      set_templated_description
-    end
   end
 
   def set_static_attributes(attributes)
@@ -58,9 +50,19 @@ class WorkPackages::SetAttributesService < ::BaseServices::SetAttributes
     work_package.attributes = assignable_attributes
   end
 
-  def set_default_attributes(attributes)
-    return unless work_package.new_record?
+  def set_calculated_attributes(attributes)
+    if work_package.new_record?
+      set_default_attributes(attributes)
+    else
+      update_dates
+    end
+    update_duration
+    update_project_dependent_attributes
+    reassign_invalid_status_if_type_changed
+    set_templated_description
+  end
 
+  def set_default_attributes(attributes)
     set_default_priority
     set_default_author
     set_default_status

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -331,6 +331,33 @@ describe WorkPackages::SetAttributesService, type: :model do
         end
       end
 
+      context 'with the parent having dates and not providing own dates and with the parent`s' \
+              'soonest_start being before the start_date (e.g. because the parent is manually scheduled)' do
+        let(:call_attributes) { { parent: } }
+
+        before do
+          allow(parent)
+            .to receive(:soonest_start)
+                  .and_return(parent_start_date + 3.days)
+        end
+
+        it_behaves_like 'service call' do
+          it "sets the start_date to the parent`s start_date" do
+            subject
+
+            expect(work_package.start_date)
+              .to eql parent_start_date
+          end
+
+          it "sets the due_date to the parent`s due_date" do
+            subject
+
+            expect(work_package.due_date)
+              .to eql parent_due_date
+          end
+        end
+      end
+
       context 'with the parent having start date (no due) and not providing own dates' do
         let(:call_attributes) { { parent: } }
         let(:parent_due_date) { nil }


### PR DESCRIPTION
The distinction into the behaviour for new work packages and that when updating a work package makes it easier to reason about. This is supported by concentrating the automatically calculated values into a single method.

By avoiding the dates to be set twice, the bug https://community.openproject.org/wp/42988 is fixed, which was caused by attempting to recalculated the due_date based on the duration which wasn't set at this point in time.