### PR TITLE
[42047] Handle special cases for relations in datepicker modal

### DIFF
--- a/frontend/src/app/shared/components/datepicker/banner/datepicker-banner.component.html
+++ b/frontend/src/app/shared/components/datepicker/banner/datepicker-banner.component.html
@@ -20,7 +20,7 @@
 </op-modal-banner>
 <ng-container *ngIf="!scheduleManually && !isParent">
   <op-modal-banner
-    *ngIf="(hasPrecedingRelations$ | async) === true && (hasFollowingRelations$ | async) === false"
+    *ngIf="(hasPrecedingRelations$ | async) === true && (hasFollowingRelations$ | async) === false && !isChild"
     type="info"
     [title]="text.start_date_limited_by_relations"
     [subtitle]="text.click_on_show_relations_to_open_gantt"

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.service.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.service.ts
@@ -55,12 +55,16 @@ export class DatepickerModalService {
 
   private changeset:WorkPackageChangeset = this.locals.changeset as WorkPackageChangeset;
 
-  precedingWorkPackages$:Observable<{ id:string }[]> = this
+  precedingWorkPackages$:Observable<{ id:string, dueDate?:string, date?:string }[]> = this
     .apiV3Service
     .work_packages
     .signalled(
       ApiV3Filter('precedes', '=', [this.changeset.id]),
-      ['elements/id'],
+      [
+        'elements/id',
+        'elements/dueDate',
+        'elements/date',
+      ],
     )
     .pipe(
       map((collection:IHALCollection<{ id:string }>) => collection._embedded.elements || []),

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
@@ -55,10 +55,8 @@ import {
 } from 'flatpickr/dist/types/instance';
 import flatpickr from 'flatpickr';
 import { DatepickerModalService } from 'core-app/shared/components/datepicker/datepicker.modal.service';
-import {
-  map,
-  take,
-} from 'rxjs/operators';
+import { take } from 'rxjs/operators';
+import { activeFieldContainerClassName } from 'core-app/shared/components/fields/edit/edit-form/edit-form';
 
 export type DateKeys = 'date'|'start'|'end';
 
@@ -247,6 +245,7 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
         inline: true,
         onReady: (selectedDates, dateStr, instance) => {
           this.toggleDisabledState(instance);
+          this.reposition(jQuery(this.modalContainer.nativeElement), jQuery(`.${activeFieldContainerClassName}`));
         },
         onChange: (dates:Date[]) => {
           this.handleDatePickerChange(dates);

--- a/frontend/src/global_styles/content/_datepicker.sass
+++ b/frontend/src/global_styles/content/_datepicker.sass
@@ -28,6 +28,17 @@
 
 $datepicker--border-radius: 5px
 
+@mixin disabled-day
+  background: $spot-color-basic-white
+  color: $spot-color-basic-gray-4 !important
+  border-radius: 0
+  background: $spot-color-basic-white
+  pointer-events: none
+  cursor: not-allowed
+
+  &:hover
+    border-color: transparent
+
 .flatpickr-current-month
   display: flex !important
 
@@ -37,7 +48,8 @@ $datepicker--border-radius: 5px
 
 
 .flatpickr-day
-  &.flatpickr-disabled,
+  &.flatpickr-disabled
+    @include disabled-day
   &.flatpickr-non-working-day
     background: $spot-color-basic-gray-6
     border-radius: 0
@@ -132,13 +144,7 @@ $datepicker--border-radius: 5px
   &.disabled
     .flatpickr-days
       .flatpickr-day
-        color: $spot-color-basic-gray-4
-        background: $spot-color-basic-white
-        pointer-events: none
-        cursor: not-allowed
-
-        &:hover
-          border-color: transparent
+        @include disabled-day
 
         &.selected,
         &.startRange,

--- a/spec/features/work_packages/table/scheduling/manual_scheduling_spec.rb
+++ b/spec/features/work_packages/table/scheduling/manual_scheduling_spec.rb
@@ -98,6 +98,7 @@ describe 'Manual scheduling', js: true do
 
       start_date.toggle_scheduling_mode
       start_date.expect_scheduling_mode manually: true
+      start_date.expect_calendar
 
       # Expect not editable
       start_date.within_modal do

--- a/spec/support/edit_fields/date_edit_field.rb
+++ b/spec/support/edit_fields/date_edit_field.rb
@@ -89,6 +89,12 @@ class DateEditField < EditField
     expect(page).to have_no_selector("#{modal_selector} #{input_selector}")
   end
 
+  def expect_calendar
+    within_modal do
+      expect(page).to have_selector(".flatpickr-calendar")
+    end
+  end
+
   def update(value, save: true, expect_failure: false)
     # Retry to set attributes due to reloading the page after setting
     # an attribute, which may cause an input not to open properly.


### PR DESCRIPTION
- [x] Avoid that two banners are shown in case a Wp is a child AND follows another Wp. In that case only the warning should be shown.
- [x] If a Wp X follows another Wp Y, all dates before the finished date of Y should be disabled in the datepicker of X as they are blocked by the relation
  - [x] The changes for this resulted in a short delay of rendering the actual calendar (since the relations needed to be loaded first). Thus the modal could become misplaced in the end. This was already reported before, but become more apparent due to this fix.


Fixes https://community.openproject.org/projects/openproject/work_packages/42047#activity-36 in https://community.openproject.org/projects/openproject/work_packages/42047/activity
**and**
https://community.openproject.org/projects/openproject/work_packages/42748


