### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/brakeman-scan-core.yml
+++ b/.github/workflows/brakeman-scan-core.yml
@@ -10,8 +10,14 @@ on:
   schedule:
     - cron: '10 6 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   brakeman-scan:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     if: github.repository == 'opf/openproject'
     name: Brakeman Scan
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -4,8 +4,13 @@ on:
     branches:
       - dev
       - release/*
+permissions:
+  contents: read
+
 jobs:
   trigger_downstream_workflow:
+    permissions:
+      contents: none
     if: github.repository == 'opf/openproject'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -14,6 +14,9 @@ on:
       - 'docs/**'
       - 'help/**'
 
+permissions:
+  contents: read
+
 jobs:
   units:
     name: Units


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
