### PR TITLE
Add on_destroy paper_trail audits

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -159,6 +159,8 @@ gem 'cells-rails', '~> 0.1.4'
 
 gem 'meta-tags', '~> 2.16.0'
 
+gem "paper_trail", "~> 12.3"
+
 group :production do
   # we use dalli as standard memcache client
   # requires memcached 1.4+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -683,6 +683,9 @@ GEM
       webfinger (>= 1.0.1)
     openproject-token (2.2.0)
       activemodel
+    paper_trail (12.3.0)
+      activerecord (>= 5.2)
+      request_store (~> 1.1)
     parallel (1.22.1)
     parallel_tests (3.11.1)
       parallel
@@ -1111,6 +1114,7 @@ DEPENDENCIES
   openproject-webhooks!
   openproject-xls_export!
   overviews!
+  paper_trail (~> 12.3)
   parallel_tests (~> 3.1)
   pg (~> 1.4.0)
   plaintext (~> 0.3.2)

--- a/app/models/application_version.rb
+++ b/app/models/application_version.rb
@@ -1,0 +1,3 @@
+class ApplicationVersion < ApplicationRecord
+  include PaperTrail::VersionConcern
+end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -39,6 +39,8 @@ class Attachment < ApplicationRecord
            if: -> { !internal_container? }
   validate :container_changed_more_than_once
 
+  has_paper_trail
+
   # Those columns are currently not displayed in the application and are rarely used
   # at all.
   # Their purpose currently is limited to full text search where the results are not highlighted.

--- a/app/models/paper_trail_audit.rb
+++ b/app/models/paper_trail_audit.rb
@@ -1,0 +1,4 @@
+class PaperTrailAudit < ::ApplicationVersion
+  self.table_name = :paper_trail_audits
+  self.sequence_name = :paper_trail_audits_id_seq
+end

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -59,6 +59,8 @@ class Principal < ApplicationRecord
   has_many :projects, through: :memberships
   has_many :categories, foreign_key: 'assigned_to_id', dependent: :nullify
 
+  has_paper_trail
+
   scopes :like,
          :human,
          :not_builtin,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -102,6 +102,8 @@ class Project < ApplicationRecord
                 author: nil,
                 datetime: :created_at
 
+  has_paper_trail
+
   validates :name,
             presence: true,
             length: { maximum: 255 }

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -159,6 +159,9 @@ class WorkPackage < ApplicationRecord
   # makes virtual modal WorkPackageHierarchy available
   has_closure_tree
 
+  # Add on_destroy paper trail
+  has_paper_trail
+
   ##################### WARNING #####################
   # Do not change the order of acts_as_attachable   #
   # and acts_as_journalized!                        #

--- a/app/workers/paper_trail_audits/cleanup_job.rb
+++ b/app/workers/paper_trail_audits/cleanup_job.rb
@@ -1,0 +1,41 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module PaperTrailAudits
+  class CleanupJob < ::Cron::CronJob
+    # runs at 4:03 on Saturday
+    self.cron_expression = '3 4 * * 6'
+
+    # Clean any paper trails older than 60 days
+    def perform
+      ::PaperTrailAudit
+        .where('created_at < ?', 60.days.ago)
+        .delete_all
+    end
+  end
+end

--- a/config/initializers/cronjobs.rb
+++ b/config/initializers/cronjobs.rb
@@ -6,6 +6,7 @@ OpenProject::Application.configure do |application|
                               ::Cron::ClearTmpCacheJob,
                               ::Cron::ClearUploadedFilesJob,
                               ::OAuth::CleanupJob,
+                              ::PaperTrailAudits::CleanupJob,
                               ::Attachments::CleanupUncontaineredJob,
                               ::Notifications::ScheduleReminderMailsJob,
                               ::Ldap::SynchronizationJob

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -6,7 +6,11 @@ PaperTrail.config.has_paper_trail_defaults = {
   },
   version: :paper_trail_audit,
   meta: {
-    whodunnit: ->(*) { User.current.id }
+    whodunnit: ->(*) { User.current.id },
+    stack: ->(*) {
+      backtrace = Rails.backtrace_cleaner.clean caller
+      backtrace.join("\n")
+    }
   },
   on: %i[destroy]
 }

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,0 +1,12 @@
+PaperTrail.config.enabled = true # PT will be disabled by rspec
+PaperTrail.config.has_paper_trail_defaults = {
+  versions: {
+    class_name: '::PaperTrailAudit',
+    name: :paper_trail_audits
+  },
+  version: :paper_trail_audit,
+  meta: {
+    whodunnit: ->(*) { User.current.id }
+  },
+  on: %i[destroy]
+}

--- a/db/migrate/20220629061540_add_paper_trail.rb
+++ b/db/migrate/20220629061540_add_paper_trail.rb
@@ -1,0 +1,15 @@
+class AddPaperTrail < ActiveRecord::Migration[7.0]
+  def change
+    create_table :paper_trail_audits do |t|
+      t.string :item_type, null: false
+      t.bigint :item_id, null: false
+      t.string :event, null: false
+      t.string :whodunnit
+      t.jsonb :object
+      t.jsonb :object_changes
+
+      t.datetime :created_at
+    end
+    add_index :paper_trail_audits, %i(item_type item_id)
+  end
+end

--- a/db/migrate/20220629061540_add_paper_trail.rb
+++ b/db/migrate/20220629061540_add_paper_trail.rb
@@ -5,6 +5,7 @@ class AddPaperTrail < ActiveRecord::Migration[7.0]
       t.bigint :item_id, null: false
       t.string :event, null: false
       t.string :whodunnit
+      t.text :stack
       t.jsonb :object
       t.jsonb :object_changes
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -204,6 +204,10 @@ describe Attachment, type: :model do
     end
   end
 
+  include_examples 'creates an audit trail on destroy' do
+    subject { create(:attachment) }
+  end
+
   # We just use with_direct_uploads here to make sure the
   # FogAttachment class is defined and Fog is mocked.
   describe "#external_url", with_direct_uploads: true do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -137,4 +137,8 @@ describe Group, type: :model do
     it { expect(group).to validate_presence_of :name }
     it { expect(group).to validate_uniqueness_of :name }
   end
+
+  include_examples 'creates an audit trail on destroy' do
+    subject { create(:attachment) }
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -191,4 +191,8 @@ describe Project, type: :model do
       expect { view.reload }.to raise_error ActiveRecord::RecordNotFound
     end
   end
+
+  include_examples 'creates an audit trail on destroy' do
+    subject { create(:attachment) }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -595,4 +595,8 @@ describe User, type: :model do
       end
     end
   end
+
+  include_examples 'creates an audit trail on destroy' do
+    subject { create(:attachment) }
+  end
 end

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -289,6 +289,10 @@ describe WorkPackage, type: :model do
     end
   end
 
+  include_examples 'creates an audit trail on destroy' do
+    subject { create(:work_package) }
+  end
+
   describe '#done_ratio' do
     let(:status_new) do
       create(:status,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,10 @@ require 'test_prof/recipes/rspec/before_all'
 require 'test_prof/recipes/rspec/let_it_be'
 require "test_prof/recipes/rspec/factory_default"
 
+# Add PaperTrail integration so that it is disabled by default
+# https://github.com/paper-trail-gem/paper_trail#7b-rspec
+require 'paper_trail/frameworks/rspec'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/support/shared/audits.rb
+++ b/spec/support/shared/audits.rb
@@ -1,0 +1,45 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+shared_examples_for 'creates an audit trail on destroy' do
+  with_versioning do
+    let(:whodunnit) { build_stubbed(:user) }
+
+    it 'adds an audit trail on destroy' do
+      User.execute_as(whodunnit) do
+        subject.destroy!
+      end
+
+      expect { subject.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+      expect(subject.paper_trail_audits.count).to eq 1
+      expect(subject.paper_trail_audits.first.event).to eq 'destroy'
+      expect(subject.paper_trail_audits.first.whodunnit).to eq whodunnit.id.to_s
+    end
+  end
+end

--- a/spec/support/shared/audits.rb
+++ b/spec/support/shared/audits.rb
@@ -40,6 +40,7 @@ shared_examples_for 'creates an audit trail on destroy' do
       expect(subject.paper_trail_audits.count).to eq 1
       expect(subject.paper_trail_audits.first.event).to eq 'destroy'
       expect(subject.paper_trail_audits.first.whodunnit).to eq whodunnit.id.to_s
+      expect(subject.paper_trail_audits.first.stack).to include 'app/models'
     end
   end
 end


### PR DESCRIPTION
Adds a paper trail for on_destroy hooks and enable it for the following models: WorkPackage, Attachment, Project, Principal

Paper trail is disabled for testing by default, and only enabled explicity with the `with_versioning` helper.