### PR TITLE
Fix asterisk in csp config

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -38,7 +38,9 @@ Rails.application.config.after_initialize do
 
     # Add proxy configuration for Angular CLI to csp
     if FrontendAssetHelper.assets_proxied?
-      proxied = ['ws://localhost:*', 'http://localhost:*', FrontendAssetHelper.cli_proxy]
+      proxied = ['ws://localhost:3000', 'http://localhost:3000',
+                 'ws://localhost:4200', 'http://localhost:4200',
+                 FrontendAssetHelper.cli_proxy]
       connect_src += proxied
       assets_src += proxied
     end


### PR DESCRIPTION
Fixes:

```
2022-06-29 08:56:52 +0100 Rack app ("GET /" - (::1)): #<URI::InvalidURIError: bad URI(is not URI?): "ws://[localhost](http://localhost/):*">
2022-06-29 08:56:52 +0100 Rack app ("GET /favicon.ico" - (::1)): #<URI::InvalidURIError: bad URI(is not URI?): "ws://[localhost](http://localhost/):*">
```