### PR TITLE
Enable missing notifications cleanup job

### DIFF
--- a/config/initializers/cronjobs.rb
+++ b/config/initializers/cronjobs.rb
@@ -8,6 +8,7 @@ OpenProject::Application.configure do |application|
                               ::OAuth::CleanupJob,
                               ::Attachments::CleanupUncontaineredJob,
                               ::Notifications::ScheduleReminderMailsJob,
+                              ::Notifications::CleanupJob,
                               ::Ldap::SynchronizationJob
   end
 end


### PR DESCRIPTION
It was not registered to be run as a cronjob