### PR TITLE
Fix project selectors being stuck without results

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.component.ts
@@ -37,6 +37,9 @@ import { combineLatest } from 'rxjs';
 import {
   debounceTime,
   map,
+  filter,
+  take,
+  mergeMap,
   shareReplay,
 } from 'rxjs/operators';
 import { IProject } from 'core-app/core/state/projects/project.model';
@@ -104,11 +107,11 @@ export class ProjectMenuAutocompleteComponent {
     search_placeholder: this.I18n.t('js.include_projects.search_placeholder'),
   };
 
-  public loading$ = combineLatest([
-    this.searchableProjectListService.fetchingProjects$,
-    this.projects$,
-  ]).pipe(
-    map(([isFetching, projects]) => isFetching || projects.length === 0),
+  public loading$ = this.searchableProjectListService.fetchingProjects$.pipe(
+    filter((fetching) => fetching),
+    take(1),
+    mergeMap(() => this.projects$),
+    mergeMap(() => this.searchableProjectListService.fetchingProjects$),
   );
 
   constructor(

--- a/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.component.ts
@@ -107,6 +107,17 @@ export class ProjectMenuAutocompleteComponent {
     search_placeholder: this.I18n.t('js.include_projects.search_placeholder'),
   };
 
+  /* This seems like a way too convoluted loading check, but there's a good reason we need it.
+   * The searchableProjectListService says fetching is "done" when the request returns.
+   * However, this causes flickering on the initial load, since `projects$` still needs
+   * to do the tree calculation. In the template, we show the project-list when `loading$ | async` is false,
+   * but if we would only make this depend on `fetchingProjects$` Angular would still wait with
+   * rendering the project-list until `projects$ | async` has also fired.
+   *
+   * To fix this, we first wait for fetchingProjects$ to be true once,
+   * then switch over to projects$, and after that has pinged once, it switches back to
+   * fetchingProjects$ as the decider for when fetching is done.
+   */
   public loading$ = this.searchableProjectListService.fetchingProjects$.pipe(
     filter((fetching) => fetching),
     take(1),

--- a/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.template.html
+++ b/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.template.html
@@ -31,7 +31,6 @@
       class="op-project-list-modal--body spot-container"
     >
       <spot-text-field
-        [disabled]="(loading$ | async)"
         [placeholder]="text.search_placeholder"
         [(ngModel)]="searchableProjectListService.searchText"
         [ngModelOptions]="{standalone: true}"

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -33,7 +33,6 @@
       class="spot-container op-project-list-modal--body"
     >
       <spot-text-field
-        [disabled]="(loading$ | async)"
         [placeholder]="text.search_placeholder"
         name="project-include-search"
         [(ngModel)]="searchableProjectListService.searchText"

--- a/frontend/src/app/shared/components/project-include/project-include.component.ts
+++ b/frontend/src/app/shared/components/project-include/project-include.component.ts
@@ -185,6 +185,17 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
       shareReplay(),
     );
 
+  /* This seems like a way too convoluted loading check, but there's a good reason we need it.
+   * The searchableProjectListService says fetching is "done" when the request returns.
+   * However, this causes flickering on the initial load, since `projects$` still needs
+   * to do the tree calculation. In the template, we show the project-list when `loading$ | async` is false,
+   * but if we would only make this depend on `fetchingProjects$` Angular would still wait with
+   * rendering the project-list until `projects$ | async` has also fired.
+   *
+   * To fix this, we first wait for fetchingProjects$ to be true once,
+   * then switch over to projects$, and after that has pinged once, it switches back to
+   * fetchingProjects$ as the decider for when fetching is done.
+   */
   public loading$ = this.searchableProjectListService.fetchingProjects$.pipe(
     filter((fetching) => fetching),
     take(1),

--- a/frontend/src/app/shared/components/project-include/project-include.component.ts
+++ b/frontend/src/app/shared/components/project-include/project-include.component.ts
@@ -13,6 +13,7 @@ import {
 import {
   debounceTime,
   distinctUntilChanged,
+  filter,
   map,
   mergeMap,
   shareReplay,
@@ -116,11 +117,11 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
         if (selectedProjectHrefs.includes(currentProjectHref)) {
           return selectedProjectHrefs;
         }
-        const selectedPrjects = [...selectedProjectHrefs];
+        const selectedProjects = [...selectedProjectHrefs];
         if (currentProjectHref) {
-          selectedPrjects.push(currentProjectHref);
+          selectedProjects.push(currentProjectHref);
         }
-        return selectedPrjects;
+        return selectedProjects;
       }),
     );
 
@@ -184,11 +185,11 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
       shareReplay(),
     );
 
-  public loading$ = combineLatest([
-    this.searchableProjectListService.fetchingProjects$,
-    this.projects$,
-  ]).pipe(
-    map(([isFetching, projects]) => isFetching || projects.length === 0)
+  public loading$ = this.searchableProjectListService.fetchingProjects$.pipe(
+    filter((fetching) => fetching),
+    take(1),
+    mergeMap(() => this.projects$),
+    mergeMap(() => this.searchableProjectListService.fetchingProjects$),
   );
 
   constructor(

--- a/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
+++ b/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
@@ -46,7 +46,7 @@ export class SearchableProjectListService {
       },
     )
       .pipe(
-        finalize(() => setTimeout(() => this.fetchingProjects$.next(false))),
+        finalize(() => this.fetchingProjects$.next(false)),
       )
       .subscribe((projects) => {
         this.allProjects$.next(projects);

--- a/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
+++ b/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
@@ -46,7 +46,7 @@ export class SearchableProjectListService {
       },
     )
       .pipe(
-        finalize(() => this.fetchingProjects$.next(false)),
+        finalize(() => setTimeout(() => this.fetchingProjects$.next(false))),
       )
       .subscribe((projects) => {
         this.allProjects$.next(projects);

--- a/spec/features/work_packages/project_include/project_include_shared_examples.rb
+++ b/spec/features/work_packages/project_include/project_include_shared_examples.rb
@@ -436,4 +436,12 @@ shared_examples 'has a project include dropdown', type: :feature, js: true do
       dropdown.expect_checkbox(sub_sub_project.id)
     end
   end
+
+  it 'keeps working even when there are no results (regression #42908)' do
+    dropdown.expect_count 1
+    dropdown.toggle!
+    dropdown.expect_open
+    dropdown.search 'Nonexistent'
+    expect(page).to have_no_selector("[data-qa-selector='op-project-include--loading']")
+  end
 end


### PR DESCRIPTION
Both project-include and the global project menu blocked themselves
into the loading state when no results were returned. This was caused
by a faulty "loaded" check.

Closes https://community.openproject.org/work_packages/42908/activity