### PR TITLE
[42873] Manage "OAuth applications" for storages from within storages administration

### DIFF
--- a/app/cells/oauth/applications/row_cell.rb
+++ b/app/cells/oauth/applications/row_cell.rb
@@ -10,7 +10,11 @@ module OAuth
       end
 
       def name
-        link_to application.name, oauth_application_path(application)
+        if application.integration_type == 'Storages::Storage'
+          link_to application.name, admin_settings_storage_path(application.integration)
+        else
+          link_to application.name, oauth_application_path(application)
+        end
       end
 
       def owner
@@ -39,18 +43,28 @@ module OAuth
       delegate :confidential, to: :application
 
       def edit_link
-        link_to(
-          I18n.t(:button_edit),
-          edit_oauth_application_path(application),
-          class: "oauth-application--edit-link icon icon-edit"
-        )
+        if application.integration_type == 'Storages::Storage'
+          link_to(
+            I18n.t(:button_edit),
+            edit_admin_settings_storage_path(application.integration),
+            class: "oauth-application--edit-link icon icon-edit"
+          )
+        else
+          link_to(
+            I18n.t(:button_edit),
+            edit_oauth_application_path(application),
+            class: "oauth-application--edit-link icon icon-edit"
+          )
+        end
       end
 
       def button_links
-        [
-          edit_link,
-          delete_link(oauth_application_path(application))
-        ]
+        buttons = [edit_link]
+        if application.integration.blank?
+          buttons.unshift delete_link(oauth_application_path(application))
+        end
+
+        buttons
       end
     end
   end

--- a/app/cells/oauth/applications/row_cell.rb
+++ b/app/cells/oauth/applications/row_cell.rb
@@ -10,11 +10,7 @@ module OAuth
       end
 
       def name
-        if application.integration_type == 'Storages::Storage'
-          link_to application.name, admin_settings_storage_path(application.integration)
-        else
-          link_to application.name, oauth_application_path(application)
-        end
+        link_to application.name, oauth_application_path(application)
       end
 
       def owner
@@ -43,28 +39,15 @@ module OAuth
       delegate :confidential, to: :application
 
       def edit_link
-        if application.integration_type == 'Storages::Storage'
-          link_to(
-            I18n.t(:button_edit),
-            edit_admin_settings_storage_path(application.integration),
-            class: "oauth-application--edit-link icon icon-edit"
-          )
-        else
-          link_to(
-            I18n.t(:button_edit),
-            edit_oauth_application_path(application),
-            class: "oauth-application--edit-link icon icon-edit"
-          )
-        end
+        link_to(
+          I18n.t(:button_edit),
+          edit_oauth_application_path(application),
+          class: "oauth-application--edit-link icon icon-edit"
+        )
       end
 
       def button_links
-        buttons = [edit_link]
-        if application.integration.blank?
-          buttons.unshift delete_link(oauth_application_path(application))
-        end
-
-        buttons
+        [edit_link, delete_link(oauth_application_path(application))]
       end
     end
   end

--- a/app/contracts/oauth/application_contract.rb
+++ b/app/contracts/oauth/application_contract.rb
@@ -33,6 +33,7 @@ module OAuth
     end
 
     validate :validate_client_credential_user
+    validate :validate_integration
 
     attribute :name
     attribute :redirect_uri
@@ -41,13 +42,22 @@ module OAuth
     attribute :owner_type
     attribute :scopes
     attribute :client_credentials_user_id
+    attribute :integration_id
+    attribute :integration_type
 
     private
 
-    def validate_client_credential_user
-      return unless model.client_credentials_user_id.present?
+    def validate_integration
+      if (model.integration_id.nil? && model.integration_type.present?) ||
+         (model.integration_id.present? && model.integration_type.nil?)
+        errors.add :integration, :invalid
+      end
+    end
 
-      unless User.where(id: model.client_credentials_user_id).exists?
+    def validate_client_credential_user
+      return if model.client_credentials_user_id.blank?
+
+      unless User.exists?(id: model.client_credentials_user_id)
         errors.add :client_credentials_user_id, :invalid
       end
     end

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -36,7 +36,7 @@ module OAuth
     menu_item :oauth_applications
 
     def index
-      @applications = ::Doorkeeper::Application.includes(:owner).all
+      @applications = ::Doorkeeper::Application.without_integration.includes(:owner).all
     end
 
     def new; end

--- a/app/helpers/oauth_helper.rb
+++ b/app/helpers/oauth_helper.rb
@@ -40,6 +40,17 @@ module OAuthHelper
   end
 
   ##
+  # Show first two and last two characters, with **** in the middle
+  def short_secret(secret)
+    result = ""
+    if secret.is_a?(String) && secret.present?
+      result = "#{secret[...2]}****#{secret[-2...]}"
+    end
+
+    result
+  end
+
+  ##
   # Get granted applications for the given user
   def granted_applications(user = current_user)
     tokens = ::Doorkeeper::AccessToken.active_for(user).includes(:application)

--- a/app/helpers/oauth_helper.rb
+++ b/app/helpers/oauth_helper.rb
@@ -44,7 +44,7 @@ module OAuthHelper
   def short_secret(secret)
     result = ""
     if secret.is_a?(String) && secret.present?
-      result = "#{secret[...2]}****#{secret[-2...]}"
+      result = "#{secret[...2]}●●●●#{secret[-2...]}"
     end
 
     result

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2450,6 +2450,7 @@ en:
     storage:
       not_available: "Disk storage consumption is not available for this repository."
       update_timeout: "Keep the last required disk space information for a repository for N minutes.\nAs counting the required disk space of a repository may be costly, increase this value to reduce performance impact."
+      oauth_application_details: "Please copy this values into the Nextcloud OpenProject Integration settings. The client secret value will not be accessible again after you close this window."
     subversion:
       existing_title: "Existing Subversion repository"
       existing_introduction: "If you have an existing Subversion repository, you can link it with OpenProject to access it from within the application."

--- a/db/migrate/20220629073727_add_polymorphic_integration_to_oauth_application.rb
+++ b/db/migrate/20220629073727_add_polymorphic_integration_to_oauth_application.rb
@@ -1,0 +1,5 @@
+class AddPolymorphicIntegrationToOAuthApplication < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :oauth_applications, :integration, polymorphic: true
+  end
+end

--- a/frontend/src/global_styles/content/_buttons.sass
+++ b/frontend/src/global_styles/content/_buttons.sass
@@ -92,6 +92,16 @@ a.button
     &:hover, &:focus, &.-active
       background: var(--button--background-hover-color)
 
+  &.-without-button-styling
+    @include without-link-styling
+    background: transparent
+    border: none
+    margin: 0
+    padding: 0
+
+    &:hover
+      background: transparent
+
   &.-tiny
     @include button-size(tiny)
 

--- a/frontend/src/global_styles/content/_toast.sass
+++ b/frontend/src/global_styles/content/_toast.sass
@@ -173,6 +173,8 @@ $nm-upload-box-padding: rem-calc(15) rem-calc(25)
   & p, & div, & ul>li, & .button
     font-size: $nm-font-size
 
+  &.-with-bottom-spacing
+    margin-bottom: 2rem
 
 [class^="icon-"]
   &.-error

--- a/lib/open_project/patches/doorkeeper_application.rb
+++ b/lib/open_project/patches/doorkeeper_application.rb
@@ -26,27 +26,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# See also: create_service.rb for comments
-module Storages::Storages
-  class UpdateService < ::BaseServices::Update
-    protected
+# This patch adds an optional polymorphic relation to OAuth applications.
 
-    def after_perform(service_call)
-      super(service_call)
-
-      storage = service_call.result
-      if storage.provider_type == 'nextcloud'
-        application = storage.oauth_application
-        persist_service_result = ::OAuth::PersistApplicationService
-         .new(application, user:)
-         .call({
-                 name: "#{storage.name} (#{I18n.t("storages.provider_types.#{storage.provider_type}")})",
-                 redirect_uri: File.join(storage.host, "apps/integration_openproject/oauth-redirect")
-               })
-        service_call.add_dependent!(persist_service_result)
-      end
-
-      service_call
-    end
-  end
+Doorkeeper::Application.class_eval do
+  belongs_to :integration, polymorphic: true
 end

--- a/lib/open_project/patches/doorkeeper_application.rb
+++ b/lib/open_project/patches/doorkeeper_application.rb
@@ -30,4 +30,5 @@
 
 Doorkeeper::Application.class_eval do
   belongs_to :integration, polymorphic: true
+  scope :without_integration, -> { where(integration_type: nil, integration_id: nil) }
 end

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -54,6 +54,7 @@ class Storages::Storage < ApplicationRecord
   # The OAuth client credentials that OpenProject will use to obtain user specific
   # access tokens from the storage server, i.e a Nextcloud serer.
   has_one :oauth_client, as: :integration, dependent: :destroy
+  has_one :oauth_application, class_name: '::Doorkeeper::Application', as: :integration, dependent: :destroy
 
   PROVIDER_TYPES = [
     PROVIDER_TYPE_NEXTCLOUD = 'nextcloud'.freeze

--- a/modules/storages/app/services/storages/oauth_applications/create_service.rb
+++ b/modules/storages/app/services/storages/oauth_applications/create_service.rb
@@ -48,7 +48,7 @@ module Storages::OAuthApplications
         .call({
                 name: "#{storage.name} (#{I18n.t("storages.provider_types.#{storage.provider_type}")})",
                 redirect_uri: File.join(storage.host, "apps/integration_openproject/oauth-redirect"),
-                scopes: '',
+                scopes: 'api_v3',
                 confidential: true,
                 owner: storage.creator,
                 integration: storage

--- a/modules/storages/app/services/storages/storages/create_service.rb
+++ b/modules/storages/app/services/storages/storages/create_service.rb
@@ -35,5 +35,18 @@
 # The comments here are also valid for the other *_service.rb files
 module Storages::Storages
   class CreateService < ::BaseServices::Create
+    protected
+
+    def after_perform(service_call)
+      super(service_call)
+
+      storage = service_call.result
+      if storage.provider_type == 'nextcloud'
+        persist_service_result = ::Storages::OAuthApplications::CreateService.new(storage:, user:).call
+        service_call.add_dependent!(persist_service_result)
+      end
+
+      service_call
+    end
   end
 end

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -14,6 +14,34 @@
   <%= styled_button_tag t(:button_save), class: "-highlight -with-icon icon-checkmark" %>
 <% end %>
 
+<% if @object.oauth_application %>
+  <section class="form--section">
+    <fieldset class="form--fieldset">
+      <legend class="form--fieldset-legend">OpenProject <%= t(:'storages.label_oauth_application_details') %></legend>
+        <div class="attributes-key-value">
+          <div class="attributes-key-value--key">OpenProject <%= t(:'storages.label_oauth_client_id') %></div>
+          <div class="attributes-key-value--value-container">
+            <div class="attributes-key-value--value -text">
+              <span><%= @object.oauth_application.uid %></span>
+            </div>
+          </div>
+          <div class="attributes-key-value--key">OpenProject <%= t(:'storages.label_oauth_client_secret') %></div>
+          <div class="attributes-key-value--value-container">
+            <div class="attributes-key-value--value -text">
+              <span><%= short_secret(@object.oauth_application.secret) %></span>
+            </div>
+          </div>
+        </div>
+
+        <%= link_to(t("storages.buttons.replace_openproject_oauth"),
+                    replace_oauth_application_admin_settings_storage_path(@object),
+                    method: :delete,
+                    data: { confirm: t(:'storages.confirm_replace_oauth_application')},
+                    class: 'button -with-icon icon-reload' ) %>
+    </fieldset>
+  </section>
+<% end %>
+
 <section class="form--section">
   <fieldset class="form--fieldset">
     <legend class="form--fieldset-legend"><%= t("storages.provider_types.#{@object.provider_type}") %> <%= t(:'storages.label_oauth_client_details') %></legend>
@@ -28,11 +56,11 @@
         <div class="attributes-key-value--key"><%= t("storages.provider_types.#{@object.provider_type}") %> <%= t(:'storages.label_oauth_client_secret') %></div>
         <div class="attributes-key-value--value-container">
           <div class="attributes-key-value--value -text">
-            <span><%= @short_secret %></span>
+            <span><%= short_secret(@object.oauth_client.client_secret) %></span>
           </div>
         </div>
       </div>
-      <%= link_to(t("button_replace"),
+      <%= link_to(t("storages.buttons.replace_provider_type_oauth", provider_type: t("storages.provider_types.#{@object.provider_type}")),
                   new_admin_settings_storage_oauth_client_path(@object),
                   data: { confirm: t(:'storages.confirm_replace_oauth_client')},
                   class: 'button -with-icon icon-reload' ) %>

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -28,7 +28,7 @@
           <div class="attributes-key-value--key">OpenProject <%= t(:'storages.label_oauth_client_secret') %></div>
           <div class="attributes-key-value--value-container">
             <div class="attributes-key-value--value -text">
-              <span><%= short_secret(@object.oauth_application.secret) %></span>
+              <span>●●●●●●●●●●●●●●●●</span>
             </div>
           </div>
         </div>
@@ -56,7 +56,7 @@
         <div class="attributes-key-value--key"><%= t("storages.provider_types.#{@object.provider_type}") %> <%= t(:'storages.label_oauth_client_secret') %></div>
         <div class="attributes-key-value--value-container">
           <div class="attributes-key-value--value -text">
-            <span><%= short_secret(@object.oauth_client.client_secret) %></span>
+            <span>●●●●●●●●●●●●●●●●</span>
           </div>
         </div>
       </div>

--- a/modules/storages/app/views/storages/admin/storages/edit.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/edit.html.erb
@@ -56,7 +56,7 @@
         <div class="attributes-key-value--key"><%= t("storages.provider_types.#{@object.provider_type}") %> <%= t(:'storages.label_oauth_client_secret') %></div>
         <div class="attributes-key-value--value-container">
           <div class="attributes-key-value--value -text">
-            <span>●●●●●●●●●●●●●●●●</span>
+            <span><%= short_secret(@object.oauth_client.client_secret) %></span>
           </div>
         </div>
       </div>

--- a/modules/storages/app/views/storages/admin/storages/new_oauth_client.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/new_oauth_client.html.erb
@@ -13,7 +13,7 @@
     <span class="form--field-instructions">
       <%= t("storages.instructions.#{@storage.provider_type}.oauth_client_id") %>
       <%= link_to "#{t("storages.provider_types.#{@storage.provider_type}")} / #{t("storages.instructions.#{@storage.provider_type}.administration")} / #{t("storages.instructions.#{@storage.provider_type}.oauth2_clients")}",
-                  URI::join(@storage.host, "settings/admin/security#oauth2").to_s,
+                  URI::join(@storage.host, "settings/admin/openproject").to_s,
                   target: "blank" %>
     </span>
   </div>
@@ -26,7 +26,7 @@
     <span class="form--field-instructions">
       <%= t("storages.instructions.#{@storage.provider_type}.oauth_client_secret") %>
       <%= link_to "#{t("storages.provider_types.#{@storage.provider_type}")} / #{t("storages.instructions.#{@storage.provider_type}.administration")} / #{t("storages.instructions.#{@storage.provider_type}.oauth2_clients")}",
-                  URI::join(@storage.host, "settings/admin/security#oauth2").to_s,
+                  URI::join(@storage.host, "settings/admin/openproject").to_s,
                   target: "blank" %>
     </span>
   </div>

--- a/modules/storages/app/views/storages/admin/storages/show.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/show.html.erb
@@ -93,6 +93,30 @@ See COPYRIGHT and LICENSE files for more details.
   </div>
 </div>
 
+<% if @object.oauth_application %>
+  <div class="attributes-group">
+    <div class="attributes-group--header">
+      <div class="attributes-group--header-container">
+        <h3 class="attributes-group--header-text">OpenProject <%= t(:'storages.label_oauth_application_details') %></h3>
+      </div>
+    </div>
+      <div class="attributes-key-value">
+        <div class="attributes-key-value--key">OpenProject <%= t(:'storages.label_oauth_client_id') %></div>
+        <div class="attributes-key-value--value-container">
+          <div class="attributes-key-value--value -text">
+            <span><%= @object.oauth_application.uid %></span>
+          </div>
+        </div>
+        <div class="attributes-key-value--key">OpenProject <%= t(:'storages.label_oauth_client_secret') %></div>
+        <div class="attributes-key-value--value-container">
+          <div class="attributes-key-value--value -text">
+            <span><%= short_secret(@object.oauth_application.secret) %></span>
+          </div>
+        </div>
+      </div>
+  </div>
+<% end %>
+
 <div class="attributes-group">
   <div class="attributes-group--header">
     <div class="attributes-group--header-container">
@@ -110,7 +134,7 @@ See COPYRIGHT and LICENSE files for more details.
       <div class="attributes-key-value--key"><%= t("storages.provider_types.#{@object.provider_type}") %> <%= t(:'storages.label_oauth_client_secret') %></div>
       <div class="attributes-key-value--value-container">
         <div class="attributes-key-value--value -text">
-          <span><%= @short_secret %></span>
+          <span><%= short_secret(@object.oauth_client.client_secret) %></span>
         </div>
       </div>
     </div>

--- a/modules/storages/app/views/storages/admin/storages/show.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/show.html.erb
@@ -134,7 +134,7 @@ See COPYRIGHT and LICENSE files for more details.
       <div class="attributes-key-value--key"><%= t("storages.provider_types.#{@object.provider_type}") %> <%= t(:'storages.label_oauth_client_secret') %></div>
       <div class="attributes-key-value--value-container">
         <div class="attributes-key-value--value -text">
-          <span>●●●●●●●●●●●●●●●●</span>
+          <span><%= short_secret(@object.oauth_client.client_secret) %></span>
         </div>
       </div>
     </div>

--- a/modules/storages/app/views/storages/admin/storages/show.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/show.html.erb
@@ -110,7 +110,7 @@ See COPYRIGHT and LICENSE files for more details.
         <div class="attributes-key-value--key">OpenProject <%= t(:'storages.label_oauth_client_secret') %></div>
         <div class="attributes-key-value--value-container">
           <div class="attributes-key-value--value -text">
-            <span><%= short_secret(@object.oauth_application.secret) %></span>
+            <span>●●●●●●●●●●●●●●●●</span>
           </div>
         </div>
       </div>
@@ -134,7 +134,7 @@ See COPYRIGHT and LICENSE files for more details.
       <div class="attributes-key-value--key"><%= t("storages.provider_types.#{@object.provider_type}") %> <%= t(:'storages.label_oauth_client_secret') %></div>
       <div class="attributes-key-value--value-container">
         <div class="attributes-key-value--value -text">
-          <span><%= short_secret(@object.oauth_client.client_secret) %></span>
+          <span>●●●●●●●●●●●●●●●●</span>
         </div>
       </div>
     </div>

--- a/modules/storages/app/views/storages/admin/storages/show_oauth_application.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/show_oauth_application.html.erb
@@ -1,0 +1,46 @@
+<!-- Standard Ruby view, please see the controller for comments -->
+<% html_title t(:label_administration), t("project_module_storages"), @object.name, "#{t("storages.provider_types.#{@object.provider_type}")} #{t("storages.label_oauth_application_details")}" %>
+<% local_assigns[:additional_breadcrumb] = "#{t("storages.provider_types.#{@object.provider_type}")} #{t("storages.label_oauth_application_details")}" %>
+<%= toolbar title: "#{t("storages.provider_types.#{@object.provider_type}")} #{t("storages.label_oauth_application_details")}" %>
+
+<%= labelled_tabular_form_for @oauth_application, url: '/' do |f| -%>
+  <div class="form--field">
+    <%= f.text_field :uid,
+                     label: t('storages.label_oauth_client_id'),
+                     size: 40,
+                     container_class: '-wide',
+                     disabled: true,
+                     id: 'client_id' %>
+    <% csp_onclick('this.focus(); this.select();', '#client_id') %>
+    <copy-to-clipboard click-target=".client-id-copy-button"
+                       clipboard-target="#client_id">
+    </copy-to-clipboard>
+    <button class="client-id-copy-button toolbar-input--affix toolbar-input-group--affix -append"
+            title="<%= t(:label_copy_to_clipboard) %>">
+      <%= op_icon('icon-copy') %>
+      <span class="hidden-for-sighted"><%= t(:label_copy_to_clipboard) %></span>
+    </button>
+  </div>
+  <div class="form--field">
+    <%= f.text_field :plaintext_secret,
+                     label: t('storages.label_oauth_client_secret'),
+                     size: 40,
+                     container_class: '-wide',
+                     disabled: true,
+                     id: 'secret' %>
+    <% csp_onclick('this.focus(); this.select();', '#secret') %>
+    <copy-to-clipboard click-target=".secret-copy-button"
+                       clipboard-target="#secret">
+    </copy-to-clipboard>
+    <button class="secret-copy-button toolbar-input--affix toolbar-input-group--affix -append"
+            title="<%= t(:label_copy_to_clipboard) %>">
+      <%= op_icon('icon-copy') %>
+      <span class="hidden-for-sighted"><%= t(:label_copy_to_clipboard) %></span>
+    </button>
+  </div>
+  <% if @object.oauth_client %>
+    <%= link_to t("storages.buttons.done_continue_setup"), admin_settings_storage_path(@object), class: "-highlight -with-icon icon-checkmark button" %>
+  <% else %>
+    <%= link_to t("storages.buttons.done_continue_setup"), new_admin_settings_storage_oauth_client_path(@object), class: "-highlight -with-icon icon-checkmark button" %>
+  <% end %>
+<% end %>

--- a/modules/storages/app/views/storages/admin/storages/show_oauth_application.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/show_oauth_application.html.erb
@@ -9,7 +9,7 @@
                      label: t('storages.label_oauth_client_id'),
                      size: 40,
                      container_class: '-wide',
-                     disabled: true,
+                     readonly: true,
                      id: 'client_id' %>
     <% csp_onclick('this.focus(); this.select();', '#client_id') %>
     <copy-to-clipboard click-target=".client-id-copy-button"
@@ -26,7 +26,7 @@
                      label: t('storages.label_oauth_client_secret'),
                      size: 40,
                      container_class: '-wide',
-                     disabled: true,
+                     readonly: true,
                      id: 'secret' %>
     <% csp_onclick('this.focus(); this.select();', '#secret') %>
     <copy-to-clipboard click-target=".secret-copy-button"

--- a/modules/storages/app/views/storages/admin/storages/show_oauth_application.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/show_oauth_application.html.erb
@@ -3,10 +3,7 @@
 <% local_assigns[:additional_breadcrumb] = "#{t("storages.provider_types.#{@object.provider_type}")} #{t("storages.label_oauth_application_details")}" %>
 <%= toolbar title: "#{t("storages.provider_types.#{@object.provider_type}")} #{t("storages.label_oauth_application_details")}" %>
 
-<div class="op-toast -warning">
-  <a title="{{ ::I18n.t('js.close_popup_title') }}"
-     class="op-toast--close icon-context icon-close">
-  </a>
+<div class="op-toast -warning -with-bottom-spacing">
   <div class="op-toast--content">
     <p><%= t('repositories.storage.oauth_application_details') %></p>
   </div>
@@ -14,39 +11,63 @@
 
 <%= labelled_tabular_form_for @oauth_application, url: '/' do |f| -%>
   <div class="form--field">
-    <%= f.text_field :uid,
-                     label: t('storages.label_oauth_client_id'),
-                     size: 40,
-                     container_class: '-wide',
-                     readonly: true,
-                     id: 'client_id' %>
-    <% csp_onclick('this.focus(); this.select();', '#client_id') %>
-    <copy-to-clipboard click-target=".client-id-copy-button"
-                       clipboard-target="#client_id">
-    </copy-to-clipboard>
-    <button class="client-id-copy-button toolbar-input--affix toolbar-input-group--affix -append"
-            title="<%= t(:label_copy_to_clipboard) %>">
-      <%= op_icon('icon-copy') %>
-      <span class="hidden-for-sighted"><%= t(:label_copy_to_clipboard) %></span>
-    </button>
+    <label class="form--label"><%= t('storages.label_oauth_client_id') %></label>
+
+    <div class="form--field-container">
+      <div class="form--text-field-container -wide">
+        <%= text_field_tag(
+              :uid,
+              @oauth_application.uid,
+              {
+                size: 40,
+                readonly: true,
+                id: 'client_id'
+              }
+            ) %>
+      </div>
+      <div class="form--field-affix">
+        <% csp_onclick('this.focus(); this.select();', '#client_id') %>
+        <copy-to-clipboard click-target=".client-id-copy-button"
+                           clipboard-target="#client_id">
+        </copy-to-clipboard>
+        <button class="client-id-copy-button button -without-button-styling"
+                title="<%= t(:label_copy_to_clipboard) %>">
+          <%= op_icon('icon-copy') %>
+          <span class="hidden-for-sighted"><%= t(:label_copy_to_clipboard) %></span>
+        </button>
+      </div>
+    </div>
   </div>
+
   <div class="form--field">
-    <%= f.text_field :plaintext_secret,
-                     label: t('storages.label_oauth_client_secret'),
-                     size: 40,
-                     container_class: '-wide',
-                     readonly: true,
-                     id: 'secret' %>
-    <% csp_onclick('this.focus(); this.select();', '#secret') %>
-    <copy-to-clipboard click-target=".secret-copy-button"
-                       clipboard-target="#secret">
-    </copy-to-clipboard>
-    <button class="secret-copy-button toolbar-input--affix toolbar-input-group--affix -append"
-            title="<%= t(:label_copy_to_clipboard) %>">
-      <%= op_icon('icon-copy') %>
-      <span class="hidden-for-sighted"><%= t(:label_copy_to_clipboard) %></span>
-    </button>
+    <label class="form--label"><%= t('storages.label_oauth_client_secret') %></label>
+
+    <div class="form--field-container">
+      <div class="form--text-field-container -wide">
+        <%= text_field_tag(
+              :plaintext_secret,
+              @oauth_application.plaintext_secret,
+              {
+                size: 40,
+                readonly: true,
+                id: 'secret'
+              }
+            ) %>
+      </div>
+      <div class="form--field-affix">
+        <% csp_onclick('this.focus(); this.select();', '#secret') %>
+        <copy-to-clipboard click-target=".secret-copy-button"
+                           clipboard-target="#secret">
+        </copy-to-clipboard>
+        <button class="secret-copy-button button -without-button-styling"
+                title="<%= t(:label_copy_to_clipboard) %>">
+          <%= op_icon('icon-copy') %>
+          <span class="hidden-for-sighted"><%= t(:label_copy_to_clipboard) %></span>
+        </button>
+      </div>
+    </div>
   </div>
+
   <% if @object.oauth_client %>
     <%= link_to t("storages.buttons.done_continue_setup"), admin_settings_storage_path(@object), class: "-highlight -with-icon icon-checkmark button" %>
   <% else %>

--- a/modules/storages/app/views/storages/admin/storages/show_oauth_application.html.erb
+++ b/modules/storages/app/views/storages/admin/storages/show_oauth_application.html.erb
@@ -3,6 +3,15 @@
 <% local_assigns[:additional_breadcrumb] = "#{t("storages.provider_types.#{@object.provider_type}")} #{t("storages.label_oauth_application_details")}" %>
 <%= toolbar title: "#{t("storages.provider_types.#{@object.provider_type}")} #{t("storages.label_oauth_application_details")}" %>
 
+<div class="op-toast -warning">
+  <a title="{{ ::I18n.t('js.close_popup_title') }}"
+     class="op-toast--close icon-context icon-close">
+  </a>
+  <div class="op-toast--content">
+    <p><%= t('repositories.storage.oauth_application_details') %></p>
+  </div>
+</div>
+
 <%= labelled_tabular_form_for @oauth_application, url: '/' do |f| -%>
   <div class="form--field">
     <%= f.text_field :uid,

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -36,6 +36,10 @@ en:
       too_many_elements_created_at_once: "Too many elements created at once. Expected %{max} at most, got %{actual}."
 
   storages:
+    buttons:
+      done_continue_setup: "Done. Continue setup"
+      replace_openproject_oauth: "Replace OpenProject OAuth"
+      replace_provider_type_oauth: "Replace %{provider_type} OAuth"
     page_titles:
       project_settings:
         index: "File storages available in this project"
@@ -66,6 +70,7 @@ en:
     label_file_links: "File links"
     label_name: "Name"
     label_host: "Host"
+    label_oauth_application_details: "OAuth application details"
     label_oauth_client_details: "OAuth client details"
     label_provider_type: "Provider type"
     label_new_storage: "New storage"
@@ -77,5 +82,7 @@ en:
     provider_types:
       label: "Provider type"
       nextcloud: "Nextcloud"
+    confirm_replace_oauth_application: "Are you sure? All users will have to authorize again against OpenProject."
     confirm_replace_oauth_client: "Are you sure? All users will have to authorize again against the storage."
     oauth_client_details_missing: "To complete the setup, please add OAuth client credentials from your storage."
+    notice_oauth_application_replaced: "The OpenProject OAuth application was successfully replaced."

--- a/modules/storages/config/routes.rb
+++ b/modules/storages/config/routes.rb
@@ -31,6 +31,9 @@ OpenProject::Application.routes.draw do
     namespace :settings do
       resources :storages, controller: '/storages/admin/storages' do
         resource :oauth_client, controller: '/storages/admin/oauth_clients', only: %i[new create]
+        member do
+          delete '/replace_oauth_application' => '/storages/admin/storages#replace_oauth_application'
+        end
       end
     end
   end

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -166,7 +166,7 @@ describe 'Admin storages', :storage_server_helpers, with_flag: { storages_module
     page.find('[data-qa-selector="op-menu--item-action"]', text: 'Authentication').click
     page.find('[data-qa-selector="op-menu--item-action"]', text: 'OAuth applications').click
     expect(page).to have_text("Other NC (#{storage_type})")
-    expect(page).not_to have_selector('a', text: 'Delete')
+    expect(page).not_to have_link('Delete')
 
     # Editing oauth app opens storage edit controller
     page.find('a', text: 'Edit').click

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -162,19 +162,8 @@ describe 'Admin storages', :storage_server_helpers, with_flag: { storages_module
     # List of storages
     page.find("ul.op-breadcrumb li", text: "File storages").click
 
-    # Check created OAuth2 Application
-    page.find('[data-qa-selector="op-menu--item-action"]', text: 'Authentication').click
-    page.find('[data-qa-selector="op-menu--item-action"]', text: 'OAuth applications').click
-    expect(page).to have_text("Other NC (#{storage_type})")
-    expect(page).not_to have_link('Delete')
-
-    # Editing oauth app opens storage edit controller
-    page.find('a', text: 'Edit').click
-    expect(page).to have_title("Edit: Other NC")
-    page.find('button[type=submit]', text: "Save").click
-
     # Delete on List page
-    page.find('.button--icon.icon-delete').click
+    page.find('td.buttons .icon-delete').click
 
     alert_text = page.driver.browser.switch_to.alert.text
     expect(alert_text).to eq(I18n.t('storages.delete_warning.storage'))

--- a/modules/storages/spec/features/admin_storages_spec.rb
+++ b/modules/storages/spec/features/admin_storages_spec.rb
@@ -57,6 +57,14 @@ describe 'Admin storages', :storage_server_helpers, with_flag: { storages_module
     page.find('#storages_storage_host').set("https://example.com")
     page.find('button[type=submit]', text: "Continue").click
 
+    # Show created oauth application
+    storage_type = I18n.t('storages.provider_types.nextcloud')
+    expect(page).to have_title("#{storage_type} #{I18n.t('storages.label_oauth_application_details')}")
+    oauth_app_client_id = page.find('#client_id').value
+    expect(oauth_app_client_id.length).to eq 43
+    expect(page.find('#secret').value.length).to eq 43
+    page.find('a.button', text: 'Done. Continue setup').click
+
     # Add OAuthClient - Testing a number of different invalid states
     # However, more detailed checks are performed in the service spec.
     expect(page).to have_title("OAuth client details")
@@ -86,9 +94,9 @@ describe 'Admin storages', :storage_server_helpers, with_flag: { storages_module
     expect(page).to have_text(admin.name)
     expect(page).to have_text('https://example.com')
     expect(page).to have_text(created_storage.created_at.localtime.strftime("%m/%d/%Y %I:%M %p"))
-    # Check for client_id and the shortened client secret
+    # Check for client_id of nextcloud client and oauth application
+    expect(page).to have_text(oauth_app_client_id)
     expect(page).to have_text("0123456789")
-    expect(page).to have_text("12****90")
 
     # Edit storage again
     page.find('.button--icon.icon-edit').click
@@ -97,7 +105,7 @@ describe 'Admin storages', :storage_server_helpers, with_flag: { storages_module
 
     # Edit page - With option to replace the OAuth2 client
     # Check presence of a "Replace" link and follow it
-    page.find('a', text: 'Replace').click
+    page.find('a', text: 'Replace Nextcloud').click
 
     alert_text = page.driver.browser.switch_to.alert.text
     expect(alert_text).to have_text("Are you sure?")
@@ -105,15 +113,13 @@ describe 'Admin storages', :storage_server_helpers, with_flag: { storages_module
 
     # The form the new OAuth client shall be empty as we are creating a new one.
     expect(page).not_to have_text("234567")
-    expect(page).not_to have_text("****")
 
     page.find('#oauth_client_client_id').set("2345678901")
     page.find('#oauth_client_client_secret').set("3456789012")
     page.find('button[type=submit]', text: 'Replace').click
 
-    # Check for client_id and the shortened client secret
+    # Check for client_id
     expect(page).to have_text("2345678901")
-    expect(page).to have_text("34****12")
 
     # Test the behavior of a failed host validation with code 400 (Bad Request)
     # simulating server not running Nextcloud
@@ -156,9 +162,16 @@ describe 'Admin storages', :storage_server_helpers, with_flag: { storages_module
     # List of storages
     page.find("ul.op-breadcrumb li", text: "File storages").click
 
-    # Go to Other NC again
-    page.find("a", text: 'Other NC').click
-    expect(page).to have_current_path admin_settings_storage_path(created_storage)
+    # Check created OAuth2 Application
+    page.find('[data-qa-selector="op-menu--item-action"]', text: 'Authentication').click
+    page.find('[data-qa-selector="op-menu--item-action"]', text: 'OAuth applications').click
+    expect(page).to have_text("Other NC (#{storage_type})")
+    expect(page).not_to have_selector('a', text: 'Delete')
+
+    # Editing oauth app opens storage edit controller
+    page.find('a', text: 'Edit').click
+    expect(page).to have_title("Edit: Other NC")
+    page.find('button[type=submit]', text: "Save").click
 
     # Delete on List page
     page.find('.button--icon.icon-delete').click

--- a/modules/storages/spec/services/storages/oauth_applications/create_service_spec.rb
+++ b/modules/storages/spec/services/storages/oauth_applications/create_service_spec.rb
@@ -1,0 +1,54 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require 'services/base_services/behaves_like_create_service'
+
+describe ::Storages::OAuthApplications::CreateService, type: :model do
+  let(:user) { create :admin }
+  let(:storage) { create :storage, creator: user }
+  let(:instance) { described_class.new(user:, storage:) }
+
+  describe '#call' do
+    subject { instance.call }
+
+    it 'returns a OAuthApplication' do
+      expect(subject).to be_a ServiceResult
+      expect(subject).to be_success
+      expect(subject.result).to be_a ::Doorkeeper::Application
+      expect(subject.result.name).to include storage.name
+      expect(subject.result.name).to include I18n.t("storages.provider_types.#{storage.provider_type}")
+      expect(subject.result.scopes.to_s).to eql "api_v3"
+      expect(subject.result.redirect_uri).to include storage.host
+      expect(subject.result.redirect_uri).to include 'apps/integration_openproject/oauth-redirect'
+      expect(subject.result.integration).to eql storage
+      expect(subject.result.confidential).to be_truthy
+      expect(subject.result.owner).to eql user
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/42873

Done:

- Extend data model with a polymorphic relation between `::Doorkeeper::Application` (aka "OAuth application") and storages called "integration".
  - Migration
  - Patch `::Doorkeeper::Application` with association 
- Extend Storages `CreateService` to also create `::Doorkeeper::Application`
- Extend Storages `UpdateService` to update the `::Doorkeeper::Application` (`name` and `redirect_uri`)
- Extend OAuth application `ApplicationContract` to validate completeness of the "integration" relation

Todo:

- [ ] ~~Reveal correct secret and do not shorten (as it would shorten the hash... non sense)~~
  - [x] Hide secrets (discussed with product team)
- [x] Fixing "copy to clipboard" when showing OpenProject OAuth details.
- [x] Add Info/Warning box when showing OpenProject OAuth details. Check Figma.
- [ ] ~~Generaly, check wording with Figma~~ (moved: https://community.openproject.org/projects/openproject/work_packages/43111/activity)
- [x] Extend feature specs to cover creation of OAuth application