### PR TITLE
remove level list implementation

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -30,7 +30,7 @@ class ProjectsController < ApplicationController
   menu_item :overview
   menu_item :roadmap, only: :roadmap
 
-  before_action :find_project, except: %i[index level_list new]
+  before_action :find_project, except: %i[index new]
   before_action :authorize, only: %i[copy]
   before_action :authorize_global, only: %i[new]
   before_action :require_admin, only: %i[destroy destroy_info]
@@ -100,14 +100,6 @@ class ProjectsController < ApplicationController
     @project_to_destroy = @project
 
     hide_project_in_layout
-  end
-
-  def level_list
-    projects = Project.project_level_list(Project.visible)
-
-    respond_to do |format|
-      format.json { render json: projects_level_list_json(projects) }
-    end
   end
 
   private

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -169,22 +169,6 @@ module ProjectsHelper
     end
   end
 
-  def projects_level_list_json(projects)
-    projects_list = projects.map do |item|
-      project = item[:project]
-
-      {
-        id: project.id,
-        name: project.name,
-        identifier: project.identifier,
-        has_children: !project.leaf?,
-        level: item[:level]
-      }
-    end
-
-    { projects: projects_list }
-  end
-
   def projects_with_levels_order_sensitive(projects, &)
     if sorted_by_lft?
       project_tree(projects, &)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -395,21 +395,6 @@ class Project < ApplicationRecord
       project_tree_from_hierarchy(projects_hierarchy, 0, &)
     end
 
-    def project_level_list(projects)
-      list = []
-      project_tree(projects) do |project, level|
-        element = {
-          project:,
-          level:
-        }
-
-        element.merge!(yield(project)) if block_given?
-
-        list << element
-      end
-      list
-    end
-
     private
 
     def sort_by_name(project_hashes)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,10 +202,6 @@ OpenProject::Application.routes.draw do
       get :destroy_info, as: 'confirm_destroy'
     end
 
-    collection do
-      get :level_list
-    end
-
     resources :versions, only: %i[new create] do
       collection do
         put :close_completed

--- a/frontend/src/app/core/path-helper/path-helper.service.ts
+++ b/frontend/src/app/core/path-helper/path-helper.service.ts
@@ -252,10 +252,6 @@ export class PathHelperService {
     return `${this.workPackagesPath()}/bulk`;
   }
 
-  public projectLevelListPath() {
-    return `${this.projectsPath()}/level_list.json`;
-  }
-
   public textFormattingHelp() {
     return `${this.staticBase}/help/text_formatting`;
   }

--- a/spec/helpers/projects_helper_spec.rb
+++ b/spec/helpers/projects_helper_spec.rb
@@ -102,48 +102,6 @@ describe ProjectsHelper, type: :helper do
     end
   end
 
-  describe '#projects_level_list_json' do
-    subject { helper.projects_level_list_json(projects).to_json }
-
-    let(:projects) { [] }
-
-    describe 'with no project available' do
-      it 'renders an empty projects document' do
-        expect(subject).to have_json_size(0).at_path('projects')
-      end
-    end
-
-    describe 'with some projects available' do
-      let(:projects) do
-        p1 = build(:project, name: 'P1')
-
-        # a result from Project.project_level_list
-        [{ project: p1,
-           level: 0 },
-         { project: build(:project, name: 'P2', parent: p1),
-           level: 1 },
-         { project: build(:project, name: 'P3'),
-           level: 0 }]
-      end
-
-      it 'renders a projects document with the size of 3 of type array' do
-        expect(subject).to have_json_size(3).at_path('projects')
-      end
-
-      it 'renders all three projects' do
-        expect(subject).to be_json_eql('P1'.to_json).at_path('projects/0/name')
-        expect(subject).to be_json_eql('P2'.to_json).at_path('projects/1/name')
-        expect(subject).to be_json_eql('P3'.to_json).at_path('projects/2/name')
-      end
-
-      it 'renders the project levels' do
-        expect(subject).to be_json_eql(0.to_json).at_path('projects/0/level')
-        expect(subject).to be_json_eql(1.to_json).at_path('projects/1/level')
-        expect(subject).to be_json_eql(0.to_json).at_path('projects/2/level')
-      end
-    end
-  end
-
   describe '#short_project_description' do
     let(:project) { build_stubbed(:project, description: (('Abcd ' * 5) + "\n") * 11) }
 

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -118,12 +118,4 @@ describe ProjectsController, type: :routing do
       )
     end
   end
-
-  describe 'level_list' do
-    it do
-      expect(get('/projects/level_list.json')).to route_to(
-        controller: 'projects', action: 'level_list', format: 'json'
-      )
-    end
-  end
 end


### PR DESCRIPTION
With the project selector now using the API, the rails controller action is no longer necessary