### PR TITLE
[IMPLEMENTATION 41097] When adding a type to a project, add all configured custom fields to that project

### DIFF
--- a/app/controllers/projects/settings/types_controller.rb
+++ b/app/controllers/projects/settings/types_controller.rb
@@ -35,11 +35,20 @@ class Projects::Settings::TypesController < Projects::SettingsController
 
   def update
     if UpdateProjectsTypesService.new(@project).call(permitted_params.projects_type_ids)
-      flash[:notice] = I18n.t('notice_successful_update')
+      flash[:notice] = success_message
     else
       flash[:error] = @project.errors.full_messages
     end
 
     redirect_to project_settings_types_path(@project.identifier)
+  end
+
+  private
+
+  def success_message
+    ApplicationController.helpers.sanitize(
+      t(:notice_successful_update_custom_fields_added_to_project, url: project_settings_custom_fields_path(@project)),
+      attributes: %w(href target)
+    )
   end
 end

--- a/app/controllers/types_controller.rb
+++ b/app/controllers/types_controller.rb
@@ -84,7 +84,7 @@ class TypesController < ApplicationController
       .new(@type, current_user)
       .call(permitted_type_params) do |call|
       call.on_success do
-        redirect_to_type_tab_path(@type, t(:notice_successful_update))
+        redirect_to_type_tab_path(@type, update_success_message)
       end
 
       call.on_failure do |result|
@@ -159,6 +159,14 @@ class TypesController < ApplicationController
     true
   end
 
+  def update_success_message
+    if params[:tab].in?(["form_configuration", "projects"])
+      t(:notice_successful_update_custom_fields_added_to_type)
+    else
+      t(:notice_successful_update)
+    end
+  end
+
   def destroy_error_message
     if @type.is_standard?
       t(:error_can_not_delete_standard_type)
@@ -183,6 +191,6 @@ class TypesController < ApplicationController
   end
 
   def belonging_wps_url(type_id)
-    work_packages_path query_props: '{"f":[{"n":"type","o":"=","v":[' + type_id.to_s + ']}]}'
+    work_packages_path query_props: "{\"f\":[{\"n\":\"type\",\"o\":\"=\",\"v\":[#{type_id}]}]}"
   end
 end

--- a/app/services/projects/set_attributes_service.rb
+++ b/app/services/projects/set_attributes_service.rb
@@ -47,6 +47,7 @@ module Projects
       set_default_public(attribute_keys.include?('public'))
       set_default_module_names(attribute_keys.include?('enabled_module_names'))
       set_default_types(attribute_keys.include?('types') || attribute_keys.include?('type_ids'))
+      set_default_active_work_pacakge_types
     end
 
     def set_default_public(provided)
@@ -59,6 +60,10 @@ module Projects
 
     def set_default_types(provided)
       model.types = ::Type.default if !provided && model.types.empty?
+    end
+
+    def set_default_active_work_pacakge_types
+      model.work_package_custom_fields = WorkPackageCustomField.joins(:types).where(types: { id: model.type_ids })
     end
 
     def update_status(attributes)
@@ -91,7 +96,7 @@ module Projects
     end
 
     def faulty_code?(attributes)
-      attributes && attributes[:code] && !Projects::Status.codes.keys.include?(attributes[:code].to_s)
+      attributes && attributes[:code] && Projects::Status.codes.keys.exclude?(attributes[:code].to_s)
     end
 
     def first_not_set_code

--- a/app/services/projects/set_attributes_service.rb
+++ b/app/services/projects/set_attributes_service.rb
@@ -47,7 +47,7 @@ module Projects
       set_default_public(attribute_keys.include?('public'))
       set_default_module_names(attribute_keys.include?('enabled_module_names'))
       set_default_types(attribute_keys.include?('types') || attribute_keys.include?('type_ids'))
-      set_default_active_work_pacakge_types
+      set_default_active_work_package_custom_fields
     end
 
     def set_default_public(provided)
@@ -62,7 +62,7 @@ module Projects
       model.types = ::Type.default if !provided && model.types.empty?
     end
 
-    def set_default_active_work_pacakge_types
+    def set_default_active_work_package_custom_fields
       model.work_package_custom_fields = WorkPackageCustomField.joins(:types).where(types: { id: model.type_ids })
     end
 

--- a/app/services/update_projects_types_service.rb
+++ b/app/services/update_projects_types_service.rb
@@ -28,7 +28,7 @@
 
 class UpdateProjectsTypesService < BaseProjectService
   def call(type_ids)
-    type_ids = standard_types if type_ids.nil? || type_ids.empty?
+    type_ids = standard_types if type_ids.blank?
 
     if types_missing?(type_ids)
       project.errors.add(:types,
@@ -36,7 +36,7 @@ class UpdateProjectsTypesService < BaseProjectService
                          types: missing_types(type_ids).map(&:name).join(', '))
       false
     else
-      project.type_ids = type_ids
+      update_project_types(type_ids)
 
       true
     end
@@ -58,10 +58,16 @@ class UpdateProjectsTypesService < BaseProjectService
   end
 
   def missing_types(type_ids)
-    types_used_by_work_packages.select { |t| !type_ids.include?(t.id) }
+    types_used_by_work_packages.select { |t| type_ids.exclude?(t.id) }
   end
 
   def types_used_by_work_packages
     @types_used_by_work_packages ||= project.types_used_by_work_packages
+  end
+
+  def update_project_types(type_ids)
+    new_types_to_add = type_ids - project.type_ids
+    project.type_ids = type_ids
+    project.work_package_custom_field_ids |= WorkPackageCustomField.joins(:types).where(types: { id: new_types_to_add }).ids
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2208,6 +2208,12 @@ en:
   notice_successful_create: "Successful creation."
   notice_successful_delete: "Successful deletion."
   notice_successful_update: "Successful update."
+  notice_successful_update_custom_fields_added_to_project: |
+    Successful update. The custom fields of the activated types are automatically activated
+    on the work package form. <a href="%{url}" target="_blank">See more</a>.
+  notice_successful_update_custom_fields_added_to_type: |
+    Successful update. The active custom fields are automatically activated for
+    the associated projects of this type.
   notice_to_many_principals_to_display: "There are too many results.\nNarrow down the search by typing in the name of the new member (or group)."
   notice_user_missing_authentication_method: User has yet to choose a password or another way to sign in.
   notice_user_invitation_resent: An invitation has been sent to %{email}.

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -305,6 +305,20 @@ describe 'form configuration', type: :feature, js: true do
 
       context 'if inactive in project' do
         it 'can be added to the type, but is not shown' do
+          # Disable in project, should be invisible
+          # This step is necessary, since we auto-activate custom fields
+          # when adding them to the form configuration
+          project_settings_page.visit_tab!('custom_fields')
+
+          expect(page).to have_selector(".custom-field-#{custom_field.id} td", text: 'MyNumber')
+          expect(page).to have_selector(".custom-field-#{custom_field.id} td", text: type.name)
+
+          id_checkbox = find("#project_work_package_custom_field_ids_#{custom_field.id}")
+          expect(id_checkbox).to be_checked
+          id_checkbox.set(false)
+
+          click_button 'Save'
+
           # Visit work package with that type
           wp_page.visit!
           wp_page.ensure_page_loaded

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -207,6 +207,7 @@ describe Projects::SetAttributesService, type: :model do
         shared_examples "setting custom field defaults" do
           context 'with custom fields' do
             let!(:custom_field) { create :text_wp_custom_field, types: }
+            let!(:custom_field_with_no_type) { create :text_wp_custom_field }
 
             it 'activates the type\'s custom fields' do
               expect(subject.result.work_package_custom_fields)

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -28,11 +28,10 @@
 
 require 'spec_helper'
 
-# rubocop:disable RSpec/NestedGroups
 describe Projects::SetAttributesService, type: :model do
   let(:user) { build_stubbed(:user) }
   let(:contract_class) do
-    contract = double('contract_class')
+    contract = class_double(Projects::CreateContract)
 
     allow(contract)
       .to receive(:new)
@@ -42,11 +41,11 @@ describe Projects::SetAttributesService, type: :model do
     contract
   end
   let(:contract_instance) do
-    double('contract_instance', validate: contract_valid, errors: contract_errors)
+    instance_double(Projects::CreateContract, validate: contract_valid, errors: contract_errors)
   end
   let(:contract_valid) { true }
   let(:contract_errors) do
-    double('contract_errors')
+    instance_double(ActiveModel::Errors)
   end
   let(:project_valid) { true }
   let(:instance) do
@@ -70,7 +69,7 @@ describe Projects::SetAttributesService, type: :model do
         .to receive(:valid?)
         .and_return(project_valid)
 
-      expect(contract_instance)
+      allow(contract_instance)
         .to receive(:validate)
         .and_return(contract_valid)
     end
@@ -78,7 +77,14 @@ describe Projects::SetAttributesService, type: :model do
     subject { instance.call(call_attributes) }
 
     it 'is successful' do
-      expect(subject.success?).to be_truthy
+      expect(subject).to be_success
+    end
+
+    it 'calls validation' do
+      subject
+
+      expect(contract_instance)
+        .to have_received(:validate)
     end
 
     it 'sets the attributes' do
@@ -89,10 +95,13 @@ describe Projects::SetAttributesService, type: :model do
     end
 
     it 'does not persist the project' do
-      expect(project)
-        .not_to receive(:save)
+      allow(project)
+        .to receive(:save)
 
       subject
+
+      expect(project)
+        .not_to have_received(:save)
     end
 
     context 'for a new record' do
@@ -195,6 +204,17 @@ describe Projects::SetAttributesService, type: :model do
                   .and_return default_types
         end
 
+        shared_examples "setting custom field defaults" do
+          context 'with custom fields' do
+            let!(:custom_field) { create :text_wp_custom_field, types: }
+
+            it 'activates the type\'s custom fields' do
+              expect(subject.result.work_package_custom_fields)
+                .to eq([custom_field])
+            end
+          end
+        end
+
         context 'with a value for types provided' do
           let(:call_attributes) do
             {
@@ -206,6 +226,11 @@ describe Projects::SetAttributesService, type: :model do
             expect(subject.result.types)
               .to match_array other_types
           end
+
+          include_examples "setting custom field defaults" do
+            let(:other_types) { [create(:type)] }
+            let(:types) { other_types }
+          end
         end
 
         context 'with no value for types provided' do
@@ -213,16 +238,27 @@ describe Projects::SetAttributesService, type: :model do
             expect(subject.result.types)
               .to match_array default_types
           end
+
+          include_examples "setting custom field defaults" do
+            let(:default_types) { [create(:type)] }
+            let(:types) { default_types }
+          end
         end
 
         context 'with the types being set before' do
+          let(:types) { [build(:type, name: 'lorem')] }
+
           before do
-            project.types.build(name: 'lorem')
+            project.types = types
           end
 
           it 'does not alter the types modules' do
             expect(subject.result.types.map(&:name))
               .to match_array %w(lorem)
+          end
+
+          include_examples "setting custom field defaults" do
+            let(:types) { [create(:type, name: 'lorem')] }
           end
         end
       end
@@ -350,4 +386,3 @@ describe Projects::SetAttributesService, type: :model do
     end
   end
 end
-# rubocop:enable RSpec/NestedGroups

--- a/spec/services/update_projects_types_service_spec.rb
+++ b/spec/services/update_projects_types_service_spec.rb
@@ -38,16 +38,48 @@ describe UpdateProjectsTypesService do
   end
 
   describe '.call' do
+    subject { instance.call(ids) }
+
     before do
       allow(project).to receive(:type_ids=)
+    end
+
+    shared_examples 'activating custom fields' do
+      let(:project) { create :project, no_types: true }
+      let!(:custom_field) { create :text_wp_custom_field, types: }
+
+      it 'updates the active custom fields' do
+        expect { subject }
+          .to change { project.reload.work_package_custom_field_ids }
+          .from([])
+          .to([custom_field.id])
+      end
+
+      it 'does not activates the same custom field twice' do
+        expect { subject }.to change { project.reload.work_package_custom_field_ids }
+        expect { subject }.not_to change { project.reload.work_package_custom_field_ids }
+      end
+
+      context 'for a project with already existing types' do
+        let(:project) { create :project, types:, work_package_custom_fields: [create(:text_wp_custom_field)] }
+
+        it 'does not change custom fields' do
+          expect { subject }.not_to change { project.reload.work_package_custom_field_ids }
+        end
+      end
     end
 
     context 'with ids provided' do
       let(:ids) { [1, 2, 3] }
 
       it 'returns true and updates the ids' do
-        expect(instance.call(ids)).to be_truthy
+        expect(subject).to be_truthy
         expect(project).to have_received(:type_ids=).with(ids)
+      end
+
+      include_examples 'activating custom fields' do
+        let(:types) { create_list(:type, 2) }
+        let(:ids) { types.collect(&:id) }
       end
     end
 
@@ -55,8 +87,13 @@ describe UpdateProjectsTypesService do
       let(:ids) { [] }
 
       it 'adds the id of the default type and returns true' do
-        expect(instance.call(ids)).to be_truthy
+        expect(subject).to be_truthy
         expect(project).to have_received(:type_ids=).with([standard_type.id])
+      end
+
+      include_examples 'activating custom fields' do
+        let(:standard_type) { create(:type_standard) }
+        let(:types) { [standard_type] }
       end
     end
 
@@ -64,28 +101,34 @@ describe UpdateProjectsTypesService do
       let(:ids) { nil }
 
       it 'adds the id of the default type and returns true' do
-        expect(instance.call(ids)).to be_truthy
+        expect(subject).to be_truthy
         expect(project).to have_received(:type_ids=).with([standard_type.id])
+      end
+
+      include_examples 'activating custom fields' do
+        let(:standard_type) { create(:type_standard) }
+        let(:types) { [standard_type] }
       end
     end
 
     context 'when the id of a type in use is not provided' do
       let(:type) { build_stubbed(:type) }
+      let(:ids) { [1] }
 
       before do
         allow(project).to receive(:types_used_by_work_packages).and_return([type])
+        allow(project).to receive(:work_package_custom_field_ids=).and_return([type])
       end
 
       it 'returns false and sets an error message' do
-        ids = [1]
-
         errors = instance_double(ActiveModel::Errors)
         allow(errors).to receive(:add)
         allow(project).to receive(:errors).and_return(errors)
 
-        expect(instance.call(ids)).to be_falsey
+        expect(subject).to be_falsey
         expect(errors).to have_received(:add).with(:types, :in_use_by_work_packages, types: type.name)
         expect(project).not_to have_received(:type_ids=)
+        expect(project).not_to have_received(:work_package_custom_field_ids=)
       end
     end
   end


### PR DESCRIPTION
[See OP#41097](https://community.openproject.org/wp/41097)

I found 4 different ways to associate a custom field with a project via the types. I covered all 4 in the PR.
Update active custom fields for projects when:

1. Creating a new project (`/projects/new`)
2. Adding a new type with custom fields to the project (`/projects/<id>/settings/types`)
3. Adding a new custom field to the type that is associated with the project (`/types/<id>/edit/form_configuration`)
4. Adding a new project to the type that has custom fields. This is basically the inverse of the # 2 (`/types/<id>/edit/projects`)

All the newly associated custom fields should become active which can be verified on the project settings page, custom fields tab. (`projects/<id>/settings/custom_fields`)

I added test-cases to make sure we do not retroactively activate any custom fields whether we save the project, type or a custom field without introducing the relation between them. It is done this way, to avoid surprising the users on their existing projects.