### PR TITLE
LDAP groups: Rollback transaction on service call failure

### DIFF
--- a/modules/ldap_groups/spec/models/synchronized_group_spec.rb
+++ b/modules/ldap_groups/spec/models/synchronized_group_spec.rb
@@ -105,6 +105,26 @@ describe LdapGroups::SynchronizedGroup, type: :model do
           let(:members) { group.users.pluck(:id) }
         end
       end
+
+      context 'when the service call fails for any reason' do
+        let(:service) { instance_double(::Groups::UpdateService) }
+        let(:failure_result) { ServiceResult.new(success: false, message: 'oh noes') }
+
+        it 'does not commit the changes' do
+          allow(::Groups::UpdateService).to receive(:new).and_return(service)
+          allow(service).to receive(:call).and_return(failure_result)
+
+          user_ids = synchronized_group.users.pluck(:id)
+
+          expect(user_ids.count).to eq 2
+
+          expect { synchronized_group.remove_members! user_ids }.not_to raise_error
+
+          synchronized_group.reload
+
+          expect(synchronized_group.users.pluck(:id)).to match_array(user_ids)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The transaction is not rolled back when users were destroyed from the synchronized group, but the `::Groups::UpdateService` call would fail. Also adds some log output, which results in the methods exceeindg branch condition.

This might not cause the origin of https://community.openproject.org/wp/43022, but should help in removing users from the synced group, without removing it from the upstream group.