### PR TITLE
Prevent uncontainered attachments being added due to public permissions

### DIFF
--- a/app/contracts/attachments/create_contract.rb
+++ b/app/contracts/attachments/create_contract.rb
@@ -50,7 +50,7 @@ module Attachments
     def validate_attachments_addable
       return if model.container
 
-      if Redmine::Acts::Attachable.attachables.none?(&:attachments_addable?)
+      if Redmine::Acts::Attachable.attachables.none?(&:uncontainered_attachable?)
         errors.add(:base, :error_unauthorized)
       end
     end

--- a/app/models/projects/export.rb
+++ b/app/models/projects/export.rb
@@ -2,6 +2,7 @@ class Projects::Export < Export
   acts_as_attachable view_permission: :view_project,
                      add_permission: :view_project,
                      delete_permission: :view_project,
+                     allow_uncontainered: false,
                      only_user_allowed: true
 
   def ready?

--- a/lib_static/plugins/acts_as_attachable/lib/acts_as_attachable.rb
+++ b/lib_static/plugins/acts_as_attachable/lib/acts_as_attachable.rb
@@ -65,6 +65,7 @@ module Redmine
             add_on_new_permission: add_on_new_permission(options),
             add_on_persisted_permission: add_on_persisted_permission(options),
             only_user_allowed: only_user_allowed(options),
+            allow_uncontainered: allow_uncontainered(options),
             viewable_by_all_users: viewable_by_all_users(options),
             modification_blocked: options[:modification_blocked],
             extract_tsv: attachable_extract_tsv_option(options)
@@ -80,6 +81,7 @@ module Redmine
                           :add_on_persisted_permission,
                           :add_permission,
                           :only_user_allowed,
+                          :allow_uncontainered,
                           :viewable_by_all_users,
                           :modification_blocked,
                           :extract_tsv)
@@ -109,6 +111,10 @@ module Redmine
           options.fetch(:only_user_allowed, false)
         end
 
+        def allow_uncontainered(options)
+          options.fetch(:allow_uncontainered, true)
+        end
+
         def view_permission_default
           "view_#{name.pluralize.underscore}".to_sym
         end
@@ -134,9 +140,21 @@ module Redmine
         end
 
         class_methods do
+          ##
+          # Can this acts_as_attachable instance accept attachments from the given user
+          # @param user [User]
           def attachments_addable?(user = User.current)
             user.allowed_to_globally?(attachable_options[:add_on_new_permission]) ||
               user.allowed_to_globally?(attachable_options[:add_on_persisted_permission])
+          end
+
+          ##
+          # Can this acts_as_attachable instance accept uncontainered attachments from the given user
+          # @param user [User]
+          def uncontainered_attachable?(user = User.current)
+            return false unless attachable_options[:allow_uncontainered]
+
+            attachments_addable?(user)
           end
 
           def attachment_tsv_extracted?

--- a/modules/grids/app/models/grids/grid.rb
+++ b/modules/grids/app/models/grids/grid.rb
@@ -45,6 +45,6 @@ module Grids
       name.presence || self.class.to_s.demodulize
     end
 
-    acts_as_attachable
+    acts_as_attachable allow_uncontainered: false
   end
 end

--- a/spec/contracts/attachments/create_contract_integration_spec.rb
+++ b/spec/contracts/attachments/create_contract_integration_spec.rb
@@ -1,0 +1,80 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require 'spec_helper'
+require 'contracts/shared/model_contract_shared_context'
+
+describe Attachments::CreateContract, 'integration' do
+  include_context 'ModelContract shared context'
+
+  let(:model) do
+    build :attachment,
+          container:,
+          content_type:,
+          file:,
+          filename:,
+          author: current_user
+  end
+  let(:contract) { described_class.new model, user, options: contract_options }
+  let(:contract_options) { {} }
+
+  let(:user) { current_user }
+  let(:container) { nil }
+  let(:file) do
+    Rack::Test::UploadedFile.new(
+      Rails.root.join("spec/fixtures/files/image.png"),
+      'image/png',
+      true
+    )
+  end
+  let(:content_type) { 'image/png' }
+  let(:filename) { 'image.png' }
+
+  context 'with anonymous user that can export' do
+    current_user do
+      create(:anonymous_role, permissions: %i[view_project])
+      User.anonymous
+    end
+
+    describe 'uncontainered' do
+      it_behaves_like 'contract is invalid', base: :error_unauthorized
+    end
+
+    describe 'invalid container' do
+      let(:container) { build_stubbed :work_package }
+
+      it_behaves_like 'contract is invalid', base: :error_unauthorized
+    end
+
+    describe 'valid container' do
+      let(:container) { build_stubbed :project_export }
+
+      it_behaves_like 'contract is valid'
+    end
+  end
+end

--- a/spec/factories/export_factory.rb
+++ b/spec/factories/export_factory.rb
@@ -26,19 +26,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Grids
-  class MyPage < Grid
-    belongs_to :user
-
-    # The requirement on view_project is more or less arbitrary.
-    # We need a permission here and view_project is a public one so everybody
-    # should have it.
-    # In the long run it would be better to have a global permission to
-    # maintain a my page.
-    set_acts_as_attachable_options view_permission: :view_project,
-                                   delete_permission: :view_project,
-                                   add_permission: :view_project,
-                                   allow_uncontainered: false,
-                                   only_user_allowed: true
+FactoryBot.define do
+  factory :export do
+    factory :project_export, class: '::Projects::Export'
   end
 end


### PR DESCRIPTION
If there is an anonymous role to view_project, there are two attachable instances (Grids::MyPage, Projects::Export) that allow anonymous attaching of uncontainered attachments.

This has the consequence that anon users can upload uncontainered attachments when this role is set.

This PR fixes this by preventing these classes from getting uncontainered attachments, as they are only necessary for resources
created through the frontend (projects, work packages).