### PR TITLE
[41830] In team planner and calendar, the sidebar should not use the word "views"

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -517,10 +517,10 @@ en:
     label_unwatch: "Unwatch"
     label_unwatch_work_package: "Unwatch work package"
     label_uploaded_by: "Uploaded by"
-    label_default_queries: "Default views"
-    label_starred_queries: "Favorite views"
-    label_global_queries: "Public views"
-    label_custom_queries: "Private views"
+    label_default_queries: "Default"
+    label_starred_queries: "Favorite"
+    label_global_queries: "Public"
+    label_custom_queries: "Private"
     label_columns: "Columns"
     label_attachments: Attachments
     label_nextcloud: Nextcloud
@@ -1128,10 +1128,7 @@ en:
       filter: "Filter"
       unselected_title: "Work package"
       search_query_label: "Search saved views"
-      search_query_title: "Click to search saved views"
-      placeholder_query_title: "Set a title for this view"
     modals:
-      label_settings: "Rename view"
       label_name: "Name"
       label_delete_page: "Delete current page"
       button_apply: "Apply"

--- a/frontend/src/app/shared/components/editable-toolbar-title/editable-toolbar-title.component.ts
+++ b/frontend/src/app/shared/components/editable-toolbar-title/editable-toolbar-title.component.ts
@@ -90,7 +90,6 @@ export class EditableToolbarTitleComponent implements OnInit, OnChanges {
     query_has_changed_click_to_save: this.I18n.t('js.label_view_has_changed'),
     input_title: '',
     input_placeholder: this.I18n.t('js.work_packages.query.rename_query_placeholder'),
-    search_query_title: this.I18n.t('js.toolbar.search_query_title'),
     confirm_edit_cancel: this.I18n.t('js.work_packages.query.confirm_edit_cancel'),
     duplicate_query_title: this.I18n.t('js.work_packages.query.errors.duplicate_query_title'),
   };

--- a/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-view-select.component.ts
@@ -64,14 +64,13 @@ export const opViewSelectSelector = 'op-view-select';
 })
 export class ViewSelectComponent extends UntilDestroyedMixin implements OnInit {
   public text = {
-    search: this.I18n.t('js.toolbar.search_query_label'),
+    search: this.I18n.t('js.global_search.search'),
     label: this.I18n.t('js.toolbar.search_query_label'),
     scope_default: this.I18n.t('js.label_default_queries'),
     scope_starred: this.I18n.t('js.label_starred_queries'),
     scope_global: this.I18n.t('js.label_global_queries'),
     scope_private: this.I18n.t('js.label_custom_queries'),
-    scope_new: this.I18n.t('js.label_create_new_query'),
-    no_results: this.I18n.t('js.work_packages.query.text_no_results'),
+    no_results: this.I18n.t('js.autocompleter.notFoundText'),
   };
 
   public views$:Observable<IOpSidemenuItem[]>;


### PR DESCRIPTION
* Avoid the word "view" in the sidemenu. The only exception is a hidden accessibility label ("Search saved views") where it makes no sense to write only "Search saved"
* Remove some unused strings

https://community.openproject.org/projects/openproject/work_packages/41830/activity