### PR TITLE
Fix parent link not being reachable due to missing tabIdentifier

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb-parent.html
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb-parent.html
@@ -1,8 +1,8 @@
 <ng-container *ngIf="!active">
   <a *ngIf="parent"
     [attr.title]="parent.name"
-    uiSref="work-packages.show.tabs"
-    [uiParams]="{workPackageId: parent.id}"
+    uiSref="work-packages.show"
+    [uiParams]="{ workPackageId: parent.id }"
     class="op-wp-breadcrumb-parent nocut"
     data-qa-selector="op-wp-breadcrumb-parent">
     <span [textContent]="parent.name"></span>

--- a/frontend/src/app/features/work-packages/routing/work-packages-routes.ts
+++ b/frontend/src/app/features/work-packages/routing/work-packages-routes.ts
@@ -36,6 +36,7 @@ import { WorkPackageListViewComponent } from 'core-app/features/work-packages/ro
 import { WorkPackageViewPageComponent } from 'core-app/features/work-packages/routing/wp-view-page/wp-view-page.component';
 import { makeSplitViewRoutes } from 'core-app/features/work-packages/routing/split-view-routes.template';
 import { WorkPackageCopyFullViewComponent } from 'core-app/features/work-packages/components/wp-copy/wp-copy-full-view.component';
+import { KeepTabService } from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
 
 export const menuItemClass = 'work-packages-menu-item';
 
@@ -96,9 +97,11 @@ export const WORK_PACKAGES_ROUTES:Ng2StateDeclaration[] = [
     // Redirect to 'activity' by default.
     redirectTo: (trans) => {
       const params = trans.params('to');
+      const keepTab = trans.injector().get(KeepTabService) as KeepTabService;
+      const tabIdentifier = keepTab.currentShowTab;
       return {
         state: 'work-packages.show.tabs',
-        params: { ...params, tabIdentifier: 'activity' },
+        params: { ...params, tabIdentifier: tabIdentifier || 'activity' },
       };
     },
     component: WorkPackagesFullViewComponent,


### PR DESCRIPTION
ui-router couldn't create the route from notifications as `tabIdentifier` was not set. Instead, use the entry route `work_packages.show` which redirects already, and have it select the current tab, if any.

https://community.openproject.org/wp/42984