### PR TITLE
Fix copying symbolized filters in widgets

### DIFF
--- a/app/services/queries/copy/filters_mapper.rb
+++ b/app/services/queries/copy/filters_mapper.rb
@@ -40,15 +40,15 @@ module Queries::Copy
     # Returns the mapped filter array for either
     # hash-based APIv3 filters or filter clasess
     def map_filters!
-      filters.each do |filter|
-        if filter.is_a?(Hash)
-          map_api_filter_hash(filter)
+      filters.map do |input|
+        if input.is_a?(Hash)
+          filter = input.dup.with_indifferent_access
+          filter.tap(&method(:map_api_filter_hash))
         else
-          map_filter_class(filter)
+          map_filter_class(input)
+          input
         end
       end
-
-      filters
     end
 
     protected

--- a/spec/services/queries/filter_mappper_spec.rb
+++ b/spec/services/queries/filter_mappper_spec.rb
@@ -98,4 +98,24 @@ describe Queries::Copy::FiltersMapper do
       end
     end
   end
+
+  describe 'with a symbolized filter hash array' do
+    let(:filters) do
+      [
+        { parent: { operator: '=', values: ['1'] } }
+      ]
+    end
+
+    context 'when mapping state exists' do
+      before do
+        state.work_package_id_lookup = { 1 => 11 }
+        state.category_id_lookup = { 2 => 22 }
+        state.version_id_lookup = { 3 => 33 }
+      end
+
+      it 'maps the filters' do
+        expect(subject[0]['parent']['values']).to eq(['11'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Widgets created by the backend such as the demo projects have symbolized
filter keys and raise and error when trying to copy them.