### PR TITLE
[chore] added error handling for broken oauth data

### DIFF
--- a/app/services/oauth_clients/connection_manager.rb
+++ b/app/services/oauth_clients/connection_manager.rb
@@ -37,6 +37,9 @@ module OAuthClients
     attr_reader :user, :oauth_client
 
     def initialize(user:, oauth_client:)
+      raise ArgumentError, 'Missing user' if user.blank?
+      raise ArgumentError, 'Missing oauth_client' if oauth_client.blank?
+
       @user = user
       @oauth_client = oauth_client
     end
@@ -112,7 +115,7 @@ module OAuthClients
     # other options.
     def authorization_state
       oauth_client_token = get_existing_token
-      return :failed_authorization unless oauth_client_token
+      return :failed_authorization if oauth_client_token.blank?
 
       # Check for user information. This is the cheapest Nextcloud call that requires
       # valid authentication, so we use it for testing the validity of the Bearer token.
@@ -172,7 +175,7 @@ module OAuthClients
     # Don't handle the case of an expired token.
     def get_existing_token
       # Check if we've got a token in the database and return nil otherwise.
-      OAuthClientToken.find_by(user_id: @user, oauth_client_id: @oauth_client.id)
+      OAuthClientToken.find_by(user: @user, oauth_client: @oauth_client)
     end
 
     # Calls client.access_token!

--- a/modules/storages/lib/api/v3/file_links/work_packages_file_links_api.rb
+++ b/modules/storages/lib/api/v3/file_links/work_packages_file_links_api.rb
@@ -65,23 +65,17 @@ module API
                                         .where(container_id: @work_package.id, container_type: 'WorkPackage'))
                            .all
 
-            begin
-              # Synchronize with Nextcloud. StorageAPI has handled OAuth2 for us before.
-              # We ignore the result, because partial errors (storage network issues) are written to each FileLink
-              service_result = ::Storages::FileLinkSyncService
-                                 .new(user: current_user)
-                                 .call(file_links)
+            # Synchronize with Nextcloud. StorageAPI has handled OAuth2 for us before.
+            # We ignore the result, because partial errors (storage network issues) are written to each FileLink
+            service_result = ::Storages::FileLinkSyncService
+                               .new(user: current_user)
+                               .call(file_links)
 
-              ::API::V3::FileLinks::FileLinkCollectionRepresenter.new(
-                service_result.result,
-                self_link: api_v3_paths.file_links(@work_package.id),
-                current_user:
-              )
-            rescue StandardError => e
-              # Example case: invalid oauth_client for storage raises invalid operation => 500
-              message = "#{I18n.t('api_v3.errors.code_500')}: #{e.message}"
-              raise ::API::Errors::InternalError.new(message)
-            end
+            ::API::V3::FileLinks::FileLinkCollectionRepresenter.new(
+              service_result.result,
+              self_link: api_v3_paths.file_links(@work_package.id),
+              current_user:
+            )
           end
 
           post &CreateEndpoint


### PR DESCRIPTION
- suggestion to fail loudly in constructor of connection manager
- open question: should we handle this exception and raise API errors? or is it fine to return the rails rendered error pages?