### PR TITLE
[41845] Distances in work package details tabs inconsistent

### DIFF
--- a/frontend/src/app/features/work-packages/components/work-package-comment/work-package-comment.component.html
+++ b/frontend/src/app/features/work-packages/components/work-package-comment/work-package-comment.component.html
@@ -5,6 +5,7 @@
 
     <div
         class="work-package--details--long-field work-packages--activity--add-comment hide-when-print"
+        [ngClass]="{'work-packages--activity--add-comment_top': showAbove} "
         #commentContainer
         *ngIf="canAddComment"
     >

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-mark-notification-button/work-package-mark-notification-button.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-mark-notification-button/work-package-mark-notification-button.component.html
@@ -1,8 +1,13 @@
 <button
   (click)="markAllBelongingNotificationsAsRead()"
   [attr.title]="text.mark_as_read"
-  [ngClass]="buttonClasses"
   class="button">
 
   <op-icon icon-classes="button--icon icon-mark-read"></op-icon>
+  <span
+    *ngIf="showWithText"
+    class="button--text"
+    [textContent]="text.mark_as_read"
+  >
+  </span>
 </button>

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-mark-notification-button/work-package-mark-notification-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-mark-notification-button/work-package-mark-notification-button.component.ts
@@ -11,7 +11,7 @@ import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-
 export class WorkPackageMarkNotificationButtonComponent {
   @Input() public workPackage:WorkPackageResource;
 
-  @Input() public buttonClasses:string;
+  @Input() public showWithText:boolean;
 
   text = {
     mark_as_read: this.I18n.t('js.notifications.center.mark_as_read'),

--- a/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.component.ts
@@ -38,6 +38,8 @@ import { WorkPackageResource } from 'core-app/features/hal/resources/work-packag
 export class WorkPackageSplitViewToolbarComponent {
   @Input('workPackage') workPackage:WorkPackageResource;
 
+  @Input() displayNotificationsButton:boolean;
+
   public text = {
     button_more: this.I18n.t('js.button_more'),
   };

--- a/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.html
+++ b/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.html
@@ -3,6 +3,13 @@
                      [showText]="true">
   </wp-watcher-button>
 
+  <op-work-package-mark-notification-button
+    *ngIf="displayNotificationsButton"
+    [workPackage]="workPackage"
+    [showWithText]="true"
+    data-qa-selector="mark-notification-read-button"
+  ></op-work-package-mark-notification-button>
+
   <button class="button dropdown-relative"
           [attr.accesskey]="7"
 

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.template.html
@@ -1,8 +1,7 @@
 <div class="loading-indicator--location"
      data-indicator-name="relation-groups">
 
-  <div class="wp-relations-hierarchy-section"
-       *ngIf="!relationsPresent">
+  <div *ngIf="!relationsPresent">
     <div class="attributes-group--header">
       <div class="attributes-group--header-container">
         <h3 class="attributes-group--header-text"

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -30,6 +30,12 @@
                              [showText]="false">
           </wp-watcher-button>
         </li>
+        <li class="toolbar-item" *ngIf="(displayNotificationsButton$ | async)">
+          <op-work-package-mark-notification-button
+            [workPackage]="workPackage"
+            data-qa-selector="mark-notification-read-button"
+          ></op-work-package-mark-notification-button>
+        </li>
         <li class="toolbar-item hidden-for-mobile">
           <zen-mode-toggle-button>
           </zen-mode-toggle-button>
@@ -56,15 +62,6 @@
       <div class="work-packages--panel-inner">
         <span class="hidden-for-sighted" tabindex="-1" opAutofocus [textContent]="focusAnchorLabel"></span>
         <op-wp-tabs [workPackage]="workPackage" [view]="'full'"></op-wp-tabs>
-        <div class="work-packages-full-view--tab-breadcrumb">
-          <op-work-package-mark-notification-button
-            *ngIf="(displayNotificationsButton$ | async) && keepTab.currentTabIdentifier === 'activity'"
-            class="work-package--details-button"
-            [workPackage]="workPackage"
-            buttonClasses="-round button_no-margin"
-            data-qa-selector="mark-notification-read-button"
-          ></op-work-package-mark-notification-button>
-        </div>
         <div class="tabcontent"
              data-notification-selector='notification-scroll-container'
              ui-view>

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.html
@@ -33,14 +33,6 @@
             <wp-subject class="subject-header"></wp-subject>
           </div>
         </div>
-
-        <op-work-package-mark-notification-button
-          *ngIf="(displayNotificationsButton$ | async) && keepTab.currentTabIdentifier === 'activity'"
-          class="work-packages--details-button"
-          [workPackage]="workPackage"
-          buttonClasses="-round"
-          data-qa-selector="mark-notification-read-button"
-        ></op-work-package-mark-notification-button>
       </div>
 
       <div
@@ -52,7 +44,10 @@
   </div>
 
   <div class="work-packages--details-toolbar-container" *ngIf="workPackage">
-    <wp-details-toolbar [workPackage]="workPackage"></wp-details-toolbar>
+    <wp-details-toolbar
+      [workPackage]="workPackage"
+      [displayNotificationsButton]="(displayNotificationsButton$ | async)"
+    ></wp-details-toolbar>
   </div>
 
   <div class="work-packages--details--resizer hidden-for-mobile hide-when-print">

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.html
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.html
@@ -1,10 +1,12 @@
 <div
-  *ngIf="resource"
+  *ngIf="resource && $attachments | async as attachments"
   class="work-package--attachments--files op-attachments-list"
 >
-  <ul class="spot-list spot-list_compact op-files-tab--file-list">
+  <ul
+    *ngIf="attachments.length > 0"
+    class="spot-list spot-list_compact op-files-tab--file-list">
     <li
-      *ngFor="let attachment of $attachments | async; let i = index;"
+      *ngFor="let attachment of attachments; let i = index;"
       op-attachment-list-item
       class="spot-list--item op-files-tab--file-list-item"
       data-qa-selector="op-attachment-list-item"

--- a/frontend/src/global_styles/content/_scrollable_tabs.sass
+++ b/frontend/src/global_styles/content/_scrollable_tabs.sass
@@ -1,7 +1,7 @@
 .op-scrollable-tabs
   display: flex
   border-bottom: 1px solid #ddd
-  margin-bottom: 1rem
+  margin-bottom: 1.5rem
 
   &--tab-container
     flex: 1

--- a/frontend/src/global_styles/content/work_packages/tabs/_activities.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_activities.sass
@@ -82,7 +82,7 @@ h4.comment
 
 .work-package-details-activities-list
   list-style-type: none
-  margin: 20px 0 0 0
+  margin: 0
 
 // Position first date with comment toggler
 .activity-date.-with-toggler
@@ -137,3 +137,8 @@ ul.work-package-details-activities-messages
   height: 100px
   display: block
   margin-top: 17px
+
+.work-packages--activity
+  &--add-comment
+    &_top
+      margin-bottom: 20px

--- a/frontend/src/global_styles/content/work_packages/tabs/_files.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_files.sass
@@ -29,6 +29,8 @@
 .op-files-tab,
 .op-attachments-list
   .op-files-tab--file-list
+    margin-bottom: 1rem
+
     .op-files-tab--file-list-item
       .op-files-tab--file-list-item-action
         padding-left: 0

--- a/frontend/src/global_styles/layout/work_packages/_details_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_details_view.sass
@@ -135,17 +135,6 @@ body.router--work-packages-partitioned-split-view-new
 .work-packages--breadcrumb
   margin-bottom: 4px
 
-.work-packages--details-button
-  display: flex
-  align-items: center
-  margin-left: 4px
-
-  button
-    margin-bottom: 0
-
-    &:only-child
-      margin-right: 4px
-
 .work-packages--type-selector
   flex-shrink: 0
 

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -136,10 +136,6 @@
       &::before
         left: 0
 
-  &--tab-breadcrumb
-    text-align: right
-    padding-right: 1rem
-
 .nosidebar
   ul.subject-header
     width: 67%

--- a/frontend/src/global_styles/layout/work_packages/_table.sass
+++ b/frontend/src/global_styles/layout/work_packages/_table.sass
@@ -133,38 +133,6 @@
   // Hinter browser that the content of the flex is contained except for size
   contain: strict
 
-
-.work-package--attachments--files
-  margin-bottom: 1rem
-
-  > h4
-    margin-top: 5px
-
-    i
-      display: inline-block
-      &:before
-        vertical-align: middle
-        padding-top: 0
-
-  .work-package--attachments--filename
-    display: inline-block
-    line-height: 1.4
-    // FF & IE
-    word-break: break-all
-    // Chrome & Safari
-    word-break: break-word
-    width: 90%
-    vertical-align: middle
-
-    .work-package--attachments--info
-      display: inline-block
-      margin-left: 5px
-      font-size: 12px
-      color: var(--body-font-color)
-      font-style: italic
-      &:hover
-        text-decoration: none
-
 .router--work-packages-base
   #content
     height: 100%

--- a/modules/github_integration/frontend/module/tab-header/styles/tab-header.sass
+++ b/modules/github_integration/frontend/module/tab-header/styles/tab-header.sass
@@ -33,7 +33,7 @@
 
   border-bottom: 1px solid #ddd
 
-  margin: 1.5rem 0 0.8rem 0
+  margin: 0 0 0.8rem 0
 
   .title
     flex: 1 1 auto


### PR DESCRIPTION
**ToDo**

Unify distance between tab header and content to 24px for all tabs:

- [x] Overview
- [x] Activity
  - [x] The "mark notification as read" button will be moved to the toolbar (full view) respectively the bottom bar (split view)
- [x] Attachments
  - [x] w/o attachments being uploaded
- [x] Relations
- [x] Watchers
- [x] Github 

https://community.openproject.org/projects/openproject/work_packages/41845/activity