### PR TITLE
[#43119] Work package following another work package is not deletable

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -227,17 +227,9 @@ class WorkPackage < ApplicationRecord
       .exists?
   end
 
-  def relations
-    Relation.of_work_package(self)
-  end
-
   def visible_relations(user)
     relations
       .visible(user)
-  end
-
-  def relation(id)
-    Relation.of_work_package(self).find(id)
   end
 
   def add_time_entry(attributes = {})

--- a/app/models/work_packages/relations.rb
+++ b/app/models/work_packages/relations.rb
@@ -28,6 +28,17 @@ module WorkPackages::Relations
   extend ActiveSupport::Concern
 
   included do
+    # All relations of the work package in both directions.
+    # Mostly used to have the relations destroyed upon destruction of the work package.
+    # rubocop:disable Rails:InverseOf
+    has_many :relations,
+             ->(work_package) {
+               unscope(:where)
+                 .of_work_package(work_package)
+             },
+             dependent: :destroy
+    # rubocop:enable Rails:InverseOf
+
     # Relations where the current work package follows another one.
     # In this case,
     #   * from is self.id

--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -197,7 +197,7 @@ module DemoData
     end
 
     def create_relation(to:, from:, type:)
-      from.relations.create!(from:, to:, relation_type: type)
+      Relation.create!(from:, to:, relation_type: type)
     end
 
     def calculate_start_date(days_ahead)

--- a/spec/models/work_package/work_package_relations_spec.rb
+++ b/spec/models/work_package/work_package_relations_spec.rb
@@ -100,8 +100,8 @@ describe WorkPackage, type: :model do
         end
 
         it 'only duplicates are closed' do
-          expect(dup_1.closed?).to be_truthy
-          expect(dup_2.closed?).to be_truthy
+          expect(dup_1).to be_closed
+          expect(dup_2).to be_closed
         end
       end
 
@@ -224,6 +224,33 @@ describe WorkPackage, type: :model do
         context 'no start date exists in related work packages' do
           it { expect(successor_grandchild.soonest_start).to be_nil }
         end
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let(:work_package) { create(:work_package) }
+    let(:other_work_package) { create(:work_package) }
+
+    context 'for a work package with a relation as to' do
+      let!(:to_relation) { create(:follows_relation, from: other_work_package, to: work_package) }
+
+      it 'removes the relation as well as the work package' do
+        work_package.destroy
+
+        expect(Relation)
+          .not_to exist(id: to_relation.id)
+      end
+    end
+
+    context 'for a work package with a relation as from' do
+      let!(:from_relation) { create(:follows_relation, to: other_work_package, from: work_package) }
+
+      it 'removes the relation as well as the work package' do
+        work_package.destroy
+
+        expect(Relation)
+          .not_to exist(id: from_relation.id)
       end
     end
   end


### PR DESCRIPTION
By adding a `has_many ... dependent: :destroy` relations of a work package are deleted upon work package destruction.

https://community.openproject.org/work_packages/43119