### PR TITLE
[43125] Action bar is missing in global project select

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.template.html
+++ b/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.template.html
@@ -49,6 +49,7 @@
           [projects]="projects$ | async"
           [searchText]="searchableProjectListService.searchText"
           [multiSelect]="false"
+          [root]="true"
           data-list-root="true"
           data-qa-selector="op-project-menu-autocomplete--list"
         ></ul>

--- a/frontend/src/app/shared/components/project-include/project-include.component.sass
+++ b/frontend/src/app/shared/components/project-include/project-include.component.sass
@@ -10,6 +10,3 @@
       // A true center aligned text does not look center aligned
       padding-top: 1px
       margin-left: $spot-spacing-0_5
-
-  &--list
-    overflow-y: auto

--- a/frontend/src/app/shared/components/project-list/project-list.component.sass
+++ b/frontend/src/app/shared/components/project-list/project-list.component.sass
@@ -3,9 +3,13 @@
 
 :host,
 .op-project-list
-  @include styled-scroll-bar
   flex-shrink: 1
   flex-basis: 100%
+
+  // Since we are referring to the host element as well we need the complete class name here
+  &.op-project-list--root
+    overflow-y: auto
+    @include styled-scroll-bar
 
   &--item-action
     display: flex

--- a/frontend/src/app/shared/components/project-list/project-list.component.ts
+++ b/frontend/src/app/shared/components/project-list/project-list.component.ts
@@ -32,7 +32,7 @@ export class OpProjectListComponent {
 
   @Output() update = new EventEmitter<string[]>();
 
-  @Input() root = false;
+  @Input() @HostBinding('class.op-project-list--root') root = false;
 
   @Input() projects:IProjectData[] = [];
 


### PR DESCRIPTION
Allow scrolling on all project lists, not only project include. However, the scrolling needs to be handled only on the root list (not all recursive hierarchy lists). Otherwise, the tooltips in project include won't be shown correctly.

https://community.openproject.org/projects/openproject/work_packages/43125/activity