### PR TITLE
[42939] Project autocompleter is too wide in work package table

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/project-edit-field.component.html
+++ b/frontend/src/app/shared/components/fields/edit/field-types/project-edit-field.component.html
@@ -1,6 +1,6 @@
 <op-project-autocompleter
   [ngClass]="'inline-edit--field ' + handler.fieldName"
-
+  [value]="value"
   [url]="url"
   [apiFilters]="APIFilters"
   [focusDirectly]="!(handler.inEditMode || isNew)"

--- a/frontend/src/global_styles/content/work_packages/_table_content.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_content.sass
@@ -74,8 +74,9 @@
   line-height: 24px
 
   // Avoid that the select field gets too small
-  .inline-edit--field.ng-select
-    min-width: 140px
+  .inline-edit--field
+    &.ng-select, ng-select
+      min-width: 140px
 
 // Styles for inline editable attributes
 .work-package-table--container td.-editable


### PR DESCRIPTION
Set min width for the table column including ng-select or an auto completer component, which is a project auto completer in this case.

https://community.openproject.org/projects/openproject/work_packages/42939/activity