### PR TITLE
[41667] Cannot inline-create a work package on views that filter by WP ID

### DIFF
--- a/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
@@ -120,7 +120,7 @@ export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMix
   matchingItems(elements:HalResource[], matching:string):Observable<HalResource[]> {
     let filtered:HalResource[];
 
-    if (matching === '') {
+    if (matching === '' || !matching) {
       filtered = elements;
     } else {
       const lowered = matching.toLowerCase();

--- a/frontend/src/app/features/work-packages/components/wp-edit-form/work-package-filter-values.ts
+++ b/frontend/src/app/features/work-packages/components/wp-edit-form/work-package-filter-values.ts
@@ -21,13 +21,13 @@ export class WorkPackageFilterValues {
     '!*': this.setToNull.bind(this),
   };
 
-  constructor(public injector:Injector,
+  constructor(
+    public injector:Injector,
     private filters:QueryFilterInstanceResource[],
-    private excluded:string[] = []) {
+    private excluded:string[] = [],
+  ) {}
 
-  }
-
-  public applyDefaultsFromFilters(change:WorkPackageChangeset|Object) {
+  applyDefaultsFromFilters(change:WorkPackageChangeset|Object):void {
     _.each(this.filters, (filter) => {
       // Exclude filters specified in constructor
       if (this.excluded.indexOf(filter.id) !== -1) {
@@ -43,6 +43,11 @@ export class WorkPackageFilterValues {
         });
         this.setValue(change, 'project', projectFilter || filter.values[0]);
 
+        return;
+      }
+
+      // ID filters should never be taken over
+      if (filter.id === 'id') {
         return;
       }
 
@@ -90,7 +95,7 @@ export class WorkPackageFilterValues {
     this.setValue(change, attributeName, { href: null });
   }
 
-  private setValueFor(change:WorkPackageChangeset|Object, field:string, value:string|HalResource) {
+  private setValueFor(change:WorkPackageChangeset|Object, field:string, value:string|HalResource):void {
     const newValue = this.findSpecialValue(value, field) || value;
 
     if (newValue) {
@@ -98,7 +103,7 @@ export class WorkPackageFilterValues {
     }
   }
 
-  private setValue(change:WorkPackageChangeset|{ [id:string]:any }, field:string, value:any) {
+  private setValue(change:WorkPackageChangeset|{ [id:string]:any }, field:string, value:any):void {
     if (change instanceof WorkPackageChangeset) {
       change.setValue(field, value);
     } else {

--- a/spec/features/work_packages/table/queries/id_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/id_filter_spec.rb
@@ -32,7 +32,7 @@ describe 'Work package filtering by id', js: true do
   let(:project) { create :project }
   let(:wp_table) { ::Pages::WorkPackagesTable.new(project) }
   let(:filters) { ::Components::WorkPackages::Filters.new }
-  let(:role) { create(:role, permissions: %i[view_work_packages save_queries]) }
+  let(:role) { create(:role, permissions: %i[view_work_packages add_work_packages edit_work_packages save_queries]) }
 
   let!(:work_package) do
     create :work_package,
@@ -49,13 +49,15 @@ describe 'Work package filtering by id', js: true do
            member_through_role: role
   end
 
-  it 'shows the work package matching the id filter' do
+  before do
     wp_table.visit!
     wp_table.expect_work_package_listed(work_package, other_work_package)
 
     filters.open
     filters.add_filter_by('ID', 'is', [work_package.subject])
+  end
 
+  it 'shows the work package matching the id filter' do
     wp_table.ensure_work_package_not_listed!(other_work_package)
     wp_table.expect_work_package_listed(work_package)
 
@@ -80,5 +82,12 @@ describe 'Work package filtering by id', js: true do
     filters.expect_filter_by('ID', 'is', ["##{work_package.id} #{work_package.subject}"])
 
     wp_table.expect_work_package_listed(work_package)
+  end
+
+  it 'can still inline create a new work package (regression #41667)' do
+    wp_table.click_inline_create
+    expect(page).to have_selector('.wp--row', count: 2)
+
+    expect(page).to have_selector('.wp-inline-create-row')
   end
 end


### PR DESCRIPTION
Don't use ID as a default value for newly created work packages from the filter

https://community.openproject.org/projects/openproject/work_packages/41667/activity