### PR TITLE
[#42326] do not escape values for autocomplete again

### DIFF
--- a/app/controllers/work_packages/auto_completes_controller.rb
+++ b/app/controllers/work_packages/auto_completes_controller.rb
@@ -63,8 +63,8 @@ class WorkPackages::AutoCompletesController < ::ApplicationController
   def wp_hashes_with_string(work_packages)
     work_packages.map do |work_package|
       wp_hash = Hash.new
-      work_package.attributes.each { |key, value| wp_hash[key] = Rack::Utils.escape_html(value) }
-      wp_hash['to_s'] = Rack::Utils.escape_html(work_package.to_s)
+      work_package.attributes.each { |key, value| wp_hash[key] = value }
+      wp_hash['to_s'] = work_package.to_s
       wp_hash
     end
   end


### PR DESCRIPTION
I wonder if we need the extra escaping here is needed
the JSON encoder seems to encode it already using UTF codes

before this change the response for a WP with the subject `test with ampersand & and some text` is:
```
[{
"id":"40",
.....
"subject":"test with ampersand \u0026amp; and some text",
......
"to_s":"Task #40: test with ampersand \u0026amp; and some text"
}]
```


after
```
[{
"id":40,
.....
"subject":"test with ampersan \u0026 and some text",
.....
"to_s":"Task #40: test with ampersand \u0026 and some text"
}]
```

and that lets the editor to render it correctly (fixes: https://community.openproject.org/projects/openproject/work_packages/42326)

old:
![image](https://user-images.githubusercontent.com/2425577/178257206-270f619b-2ef4-44b4-a7a8-d084deb027e1.png)

new
![image](https://user-images.githubusercontent.com/2425577/178256522-c87e990d-a75a-4409-99c3-830950669175.png)


seems also to work fine with other bad characters e.g. `<a href=test>test</a>` turns into 
```
[{
"id":41,
....
"subject":"\u003ca href=test\u003etest\u003c/a\u003e",
....
"to_s":"Task #41: \u003ca href=test\u003etest\u003c/a\u003e"
}]
```
