### PR TITLE
Prevent using withCredentials: false by default

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -87,6 +87,8 @@ import { OpenProjectBackupService } from './core/backup/op-backup.service';
 import { OpenProjectDirectFileUploadService } from './core/file-upload/op-direct-file-upload.service';
 import { OpenProjectStateModule } from 'core-app/core/state/openproject-state.module';
 import { OpenprojectContentLoaderModule } from 'core-app/shared/components/op-content-loader/openproject-content-loader.module';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { OpenProjectHeaderInterceptor } from 'core-app/features/hal/http/openproject-header-interceptor';
 
 export function initializeServices(injector:Injector) {
   return () => {
@@ -186,6 +188,7 @@ export function initializeServices(injector:Injector) {
   ],
   providers: [
     { provide: States, useValue: new States() },
+    { provide: HTTP_INTERCEPTORS, useClass: OpenProjectHeaderInterceptor, multi: true },
     {
       provide: APP_INITIALIZER, useFactory: initializeServices, deps: [Injector], multi: true,
     },

--- a/frontend/src/app/core/file-upload/op-direct-file-upload.service.ts
+++ b/frontend/src/app/core/file-upload/op-direct-file-upload.service.ts
@@ -35,6 +35,7 @@ import { getType } from 'mime';
 import {
   OpenProjectFileUploadService, UploadBlob, UploadFile, UploadInProgress,
 } from './op-file-upload.service';
+import { EXTERNAL_REQUEST_HEADER } from "core-app/features/hal/http/openproject-header-interceptor";
 
 interface PrepareUploadResult {
   url:string;
@@ -79,7 +80,9 @@ export class OpenProjectDirectFileUploadService extends OpenProjectFileUploadSer
           observe: 'events',
           // This is important as the CORS policy for the bucket is * and you can't use credentals then,
           // besides we don't need them here anyway.
-          withCredentials: false,
+          headers: {
+            [EXTERNAL_REQUEST_HEADER]: 'true',
+          },
           responseType: responseType as 'json',
           // Subscribe to progress events. subscribe() will fire multiple times!
           reportProgress: true,

--- a/frontend/src/app/features/bim/bcf/openproject-bcf.module.ts
+++ b/frontend/src/app/features/bim/bcf/openproject-bcf.module.ts
@@ -26,12 +26,14 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injector, NgModule } from '@angular/core';
+import {
+  Injector,
+  NgModule,
+} from '@angular/core';
 import { OPSharedModule } from 'core-app/shared/shared.module';
 import { NgxGalleryModule } from '@kolkov/ngx-gallery';
 import { DisplayFieldService } from 'core-app/shared/components/fields/display/display-field.service';
 import { BcfThumbnailDisplayField } from 'core-app/features/bim/bcf/fields/display/bcf-thumbnail-field.module';
-import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { BcfDetectorService } from 'core-app/features/bim/bcf/helper/bcf-detector.service';
 import { BcfPathHelperService } from 'core-app/features/bim/bcf/helper/bcf-path-helper.service';
 import { ViewpointsService } from 'core-app/features/bim/bcf/helper/viewpoints.service';
@@ -44,7 +46,6 @@ import { BcfWpAttributeGroupComponent } from 'core-app/features/bim/bcf/bcf-wp-a
 import { BcfNewWpAttributeGroupComponent } from 'core-app/features/bim/bcf/bcf-wp-attribute-group/bcf-new-wp-attribute-group.component';
 import { RevitBridgeService } from 'core-app/features/bim/revit_add_in/revit-bridge.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { OpenProjectHeaderInterceptor } from 'core-app/features/hal/http/openproject-header-interceptor';
 import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
 import { RefreshButtonComponent } from 'core-app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component';
 
@@ -67,7 +68,6 @@ export const viewerBridgeServiceFactory = (injector:Injector) => {
     NgxGalleryModule,
   ],
   providers: [
-    { provide: HTTP_INTERCEPTORS, useClass: OpenProjectHeaderInterceptor, multi: true },
     {
       provide: ViewerBridgeService,
       useFactory: viewerBridgeServiceFactory,

--- a/frontend/src/app/features/enterprise/enterprise-active-trial/ee-active-trial.component.ts
+++ b/frontend/src/app/features/enterprise/enterprise-active-trial/ee-active-trial.component.ts
@@ -27,14 +27,21 @@
 //++
 
 import {
-  ChangeDetectorRef, Component, ElementRef, OnInit,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  OnInit,
 } from '@angular/core';
 import { distinctUntilChanged } from 'rxjs/operators';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { EnterpriseTrialService } from 'core-app/features/enterprise/enterprise-trial.service';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import {
+  HttpClient,
+  HttpErrorResponse,
+} from '@angular/common/http';
 import { EEActiveTrialBase } from 'core-app/features/enterprise/enterprise-active-trial/ee-active-trial.base';
 import { GonService } from 'core-app/core/gon/gon.service';
+import { EXTERNAL_REQUEST_HEADER } from 'core-app/features/hal/http/openproject-header-interceptor';
 
 @Component({
   selector: 'enterprise-active-trial',
@@ -95,8 +102,16 @@ export class EEActiveTrialComponent extends EEActiveTrialBase implements OnInit 
   // use the trial key saved in the db
   // to get the user data from Augur
   private getUserDataFromAugur() {
-    this.http
-      .get<any>(`${this.eeTrialService.trialLink}/details`)
+    this
+      .http
+      .get<any>(
+        `${this.eeTrialService.trialLink}/details`,
+        {
+          headers: {
+            [EXTERNAL_REQUEST_HEADER]: 'true',
+          },
+        },
+      )
       .toPromise()
       .then((userForm:any) => {
         this.eeTrialService.userData$.putValue(userForm);

--- a/frontend/src/app/features/enterprise/enterprise-trial-waiting/ee-trial-waiting.component.ts
+++ b/frontend/src/app/features/enterprise/enterprise-trial-waiting/ee-trial-waiting.component.ts
@@ -26,13 +26,18 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Component, ElementRef, OnInit } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  OnInit,
+} from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { EnterpriseTrialService } from 'core-app/features/enterprise/enterprise-trial.service';
 import { HttpClient } from '@angular/common/http';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { distinctUntilChanged } from 'rxjs/operators';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+import { EXTERNAL_REQUEST_HEADER } from 'core-app/features/hal/http/openproject-header-interceptor';
 
 @Component({
   selector: 'enterprise-trial-waiting',
@@ -86,7 +91,15 @@ export class EETrialWaitingComponent implements OnInit {
   // resend mail if resend link has been clicked
   public resendMail() {
     this.eeTrialService.cancelled = false;
-    this.http.post(this.eeTrialService.resendLink, {})
+    this.http.post(
+      this.eeTrialService.resendLink,
+      {},
+      {
+        headers: {
+          [EXTERNAL_REQUEST_HEADER]: 'true',
+        },
+      },
+    )
       .toPromise()
       .then(() => {
         this.toastService.addSuccess(this.text.resend_success);

--- a/frontend/src/app/features/enterprise/enterprise-trial.service.ts
+++ b/frontend/src/app/features/enterprise/enterprise-trial.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import {
+  HttpClient,
+  HttpErrorResponse,
+} from '@angular/common/http';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { FormGroup } from '@angular/forms';
 import { input } from 'reactivestates';
+import { EXTERNAL_REQUEST_HEADER } from 'core-app/features/hal/http/openproject-header-interceptor';
 
 export interface EnterpriseTrialData {
   id?:string;
@@ -65,7 +69,16 @@ export class EnterpriseTrialService {
   // receive an enterprise trial link to access a token
   public sendForm(form:FormGroup) {
     const request = { ...form.value, token_version: this.tokenVersion };
-    this.http.post(`${this.baseUrlAugur}/public/v1/trials`, request)
+    this.http
+      .post(
+        `${this.baseUrlAugur}/public/v1/trials`,
+        request,
+        {
+          headers: {
+            [EXTERNAL_REQUEST_HEADER]: 'true',
+          },
+        },
+      )
       .toPromise()
       .then((enterpriseTrial:any) => {
         this.userData$.putValue(form.value);
@@ -89,8 +102,14 @@ export class EnterpriseTrialService {
   // get a token from the trial link if user confirmed mail
   public getToken() {
     // 2) GET /public/v1/trials/:id
-    this.http
-      .get<any>(this.trialLink)
+    this.http.get<any>(
+      this.trialLink,
+      {
+        headers: {
+          [EXTERNAL_REQUEST_HEADER]: 'true',
+        },
+      },
+    )
       .toPromise()
       .then(async (res:any) => {
         // show confirmed status and enable continue btn
@@ -210,7 +229,8 @@ export class EnterpriseTrialService {
   public get emailError():boolean {
     if (this.emailInvalid) {
       return true;
-    } if (this.error) {
+    }
+    if (this.error) {
       return this.emailTaken;
     }
     return false;

--- a/frontend/src/app/features/hal/http/openproject-header-interceptor.ts
+++ b/frontend/src/app/features/hal/http/openproject-header-interceptor.ts
@@ -10,6 +10,7 @@ export const EXTERNAL_REQUEST_HEADER = 'X-External-Request';
 export class OpenProjectHeaderInterceptor implements HttpInterceptor {
   intercept(req:HttpRequest<any>, next:HttpHandler):Observable<HttpEvent<any>> {
     const withCredentials = req.headers.get(EXTERNAL_REQUEST_HEADER) !== 'true';
+
     if (withCredentials) {
       return this.handleAuthenticatedRequest(req, next);
     } else {

--- a/frontend/src/app/features/hal/http/openproject-header-interceptor.ts
+++ b/frontend/src/app/features/hal/http/openproject-header-interceptor.ts
@@ -4,30 +4,47 @@ import {
 import { Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
 
+export const EXTERNAL_REQUEST_HEADER = 'X-External-Request';
+
 @Injectable()
 export class OpenProjectHeaderInterceptor implements HttpInterceptor {
   intercept(req:HttpRequest<any>, next:HttpHandler):Observable<HttpEvent<any>> {
+    const withCredentials = req.headers.get(EXTERNAL_REQUEST_HEADER) !== 'true';
+    if (withCredentials) {
+      return this.handleAuthenticatedRequest(req, next);
+    } else {
+      return this.handleExternalRequest(req, next);
+    }
+  }
+
+  private handleExternalRequest(req:HttpRequest<any>, next:HttpHandler):Observable<HttpEvent<any>> {
+    // Clone the request to add the new header
+    const clonedRequest = req.clone({
+      withCredentials: false,
+      headers: req.headers.delete(EXTERNAL_REQUEST_HEADER),
+    });
+
+    return next.handle(clonedRequest);
+  }
+
+  private handleAuthenticatedRequest(req:HttpRequest<any>, next:HttpHandler):Observable<HttpEvent<any>> {
     const csrf_token:string|undefined = jQuery('meta[name=csrf-token]').attr('content');
 
-    if (req.withCredentials !== false) {
-      let newHeaders = req.headers
-        .set('X-Authentication-Scheme', 'Session')
-        .set('X-Requested-With', 'XMLHttpRequest');
+    let newHeaders = req.headers
+      .set('X-Authentication-Scheme', 'Session')
+      .set('X-Requested-With', 'XMLHttpRequest');
 
-      if (csrf_token) {
-        newHeaders = newHeaders.set('X-CSRF-TOKEN', csrf_token);
-      }
-
-      // Clone the request to add the new header
-      const clonedRequest = req.clone({
-        withCredentials: true,
-        headers: newHeaders,
-      });
-
-      // Pass the cloned request instead of the original request to the next handle
-      return next.handle(clonedRequest);
+    if (csrf_token) {
+      newHeaders = newHeaders.set('X-CSRF-TOKEN', csrf_token);
     }
 
-    return next.handle(req);
+    // Clone the request to add the new header
+    const clonedRequest = req.clone({
+      withCredentials: true,
+      headers: newHeaders,
+    });
+
+    // Pass the cloned request instead of the original request to the next handle
+    return next.handle(clonedRequest);
   }
 }

--- a/frontend/src/app/features/hal/openproject-hal.module.ts
+++ b/frontend/src/app/features/hal/openproject-hal.module.ts
@@ -26,10 +26,13 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { APP_INITIALIZER, ErrorHandler, NgModule } from '@angular/core';
-import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
+import {
+  APP_INITIALIZER,
+  ErrorHandler,
+  NgModule,
+} from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
-import { OpenProjectHeaderInterceptor } from 'core-app/features/hal/http/openproject-header-interceptor';
 import { HalAwareErrorHandler } from 'core-app/features/hal/services/hal-aware-error-handler';
 import { initializeHalResourceConfig } from 'core-app/features/hal/services/hal-resource.config';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
@@ -42,7 +45,6 @@ import { HalResourceNotificationService } from 'core-app/features/hal/services/h
   ],
   providers: [
     { provide: ErrorHandler, useClass: HalAwareErrorHandler },
-    { provide: HTTP_INTERCEPTORS, useClass: OpenProjectHeaderInterceptor, multi: true },
     {
       provide: APP_INITIALIZER, useFactory: initializeHalResourceConfig, deps: [HalResourceService], multi: true,
     },

--- a/frontend/src/app/shared/components/dynamic-forms/dynamic-forms.module.ts
+++ b/frontend/src/app/shared/components/dynamic-forms/dynamic-forms.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormlyModule } from '@ngx-formly/core';
 import { NgOptionHighlightModule } from '@ng-select/ng-option-highlight';
 import { NgSelectModule } from '@ng-select/ng-select';
-import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
+import { HttpClientModule } from '@angular/common/http';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TextInputComponent } from 'core-app/shared/components/dynamic-forms/components/dynamic-inputs/text-input/text-input.component';
 import { IntegerInputComponent } from 'core-app/shared/components/dynamic-forms/components/dynamic-inputs/integer-input/integer-input.component';
@@ -18,7 +18,6 @@ import { DynamicFieldWrapperComponent } from 'core-app/shared/components/dynamic
 import { InviteUserButtonModule } from 'core-app/features/invite-user-modal/button/invite-user-button.module';
 import { DateInputComponent } from 'core-app/shared/components/dynamic-forms/components/dynamic-inputs/date-input/date-input.component';
 import { DynamicFieldGroupWrapperComponent } from 'core-app/shared/components/dynamic-forms/components/dynamic-field-group-wrapper/dynamic-field-group-wrapper.component';
-import { OpenProjectHeaderInterceptor } from 'core-app/features/hal/http/openproject-header-interceptor';
 import { FormattableControlModule } from 'core-app/shared/components/dynamic-forms/components/dynamic-inputs/formattable-textarea-input/components/formattable-control/formattable-control.module';
 import { OPSharedModule } from 'core-app/shared/shared.module';
 
@@ -71,9 +70,6 @@ import { OPSharedModule } from 'core-app/shared/shared.module';
     SelectProjectStatusInputComponent,
     DateInputComponent,
     FormattableTextareaInputComponent,
-  ],
-  providers: [
-    { provide: HTTP_INTERCEPTORS, useClass: OpenProjectHeaderInterceptor, multi: true },
   ],
   exports: [
     DynamicFormComponent,


### PR DESCRIPTION
Fixes the basic auth dialog on qa-edge. It is caused by doing a http request without an authenticated session and without `withCredentials: true`, resulting in a basic auth response by the backend.

To fix this for all, change the way we can override withCredentials: true. As the boolean flag will default to false and can't be overridden, use a custom header to mark the request as external. In that case, we use withCredentials: false. In all other cases, we add it to the request.


https://community.openproject.org/wp/43008