### PR TITLE
[43086] Dots of Ü are missing in notification list

### DIFF
--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -62,6 +62,7 @@ $subject-font-size: 14px
     display: grid
     grid-template-columns: auto 1fr
     grid-column-gap: 5px
+    line-height: normal
 
   &--bottom-line
     grid-area: footer


### PR DESCRIPTION
Set `line-height`, so that over-sized letters like "Ü", "Ä", "Ö" are not cut off on the top.

https://community.openproject.org/projects/openproject/work_packages/43086/activity