### PR TITLE
Bug/40961 didnt receive email reminder

### DIFF
--- a/app/seeders/basic_data/type_seeder.rb
+++ b/app/seeders/basic_data/type_seeder.rb
@@ -48,20 +48,17 @@ module BasicData
     #
     # @return [Array<Hash>] List of attributes for each type.
     def data
-      colors = Color.all
-      colors = colors.map { |c| { c.name => c.id } }.reduce({}, :merge)
+      colors = Color.pluck(:name, :id).to_h
 
-      type_table.map do |_name, values|
-        color_id = colors[values[2]] || values[2]
-
+      type_table.map do |_name, (position, is_default, color_name, is_in_roadmap, is_milestone, type_name)|
         {
-          name: I18n.t(values[5]),
-          position: values[0],
-          is_default: values[1],
-          color_id:,
-          is_in_roadmap: values[3],
-          is_milestone: values[4],
-          description: type_description(values[5])
+          name: I18n.t(type_name),
+          position:,
+          is_default:,
+          color_id: colors.fetch(color_name),
+          is_in_roadmap:,
+          is_milestone:,
+          description: type_description(type_name)
         }
       end
     end

--- a/app/seeders/standard_seeder/basic_data/type_seeder.rb
+++ b/app/seeders/standard_seeder/basic_data/type_seeder.rb
@@ -33,7 +33,7 @@ module StandardSeeder
       end
 
       def type_table
-        { # position is_default color_id is_in_roadmap is_milestone
+        { # position is_default color_name is_in_roadmap is_milestone type_name
           task: [1, true, I18n.t(:default_color_blue), true, false, :default_type_task],
           milestone: [2, true, I18n.t(:default_color_green_light), false, true, :default_type_milestone],
           phase: [3, true, 'orange-5', false, false, :default_type_phase],

--- a/db/migrate/20220712132505_add_foreign_key_constraint_for_type_color_id.rb
+++ b/db/migrate/20220712132505_add_foreign_key_constraint_for_type_color_id.rb
@@ -1,0 +1,21 @@
+class AddForeignKeyConstraintForTypeColorId < ActiveRecord::Migration[7.0]
+  def change
+    # nullify invalid color references
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL.squish
+          UPDATE types
+          SET color_id = NULL
+          WHERE types.color_id IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1
+              FROM colors
+              WHERE colors.id = types.color_id
+            )
+        SQL
+      end
+    end
+
+    add_foreign_key :types, :colors, on_delete: :nullify
+  end
+end

--- a/modules/bim/app/seeders/bim/basic_data/type_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data/type_seeder.rb
@@ -33,27 +33,14 @@ module Bim
       end
 
       def type_table
-        color_names = [
-          'blue-6',
-          'indigo-7',
-          'orange-6',
-          'cyan-7',
-          'red-8'
-        ]
-
-        # When selecting for an array of values, implicit order is applied
-        # so we need to restore values by their name.
-        colors_by_name = Color.where(name: color_names).index_by(&:name)
-        colors = color_names.collect { |name| colors_by_name[name].id }
-
-        { # position is_default color_id is_in_roadmap is_milestone
-          task: [1, true, colors[0], true, false, :default_type_task],
-          milestone: [2, true, colors[2], false, true, :default_type_milestone],
+        { # position is_default color_name is_in_roadmap is_milestone type_name
+          task: [1, true, 'blue-6', true, false, :default_type_task],
+          milestone: [2, true, 'orange-6', false, true, :default_type_milestone],
           phase: [3, true, I18n.t(:default_color_grey), false, false, :default_type_phase],
-          issue: [4, true, colors[1], true, false, 'seeders.bim.default_type_issue'],
+          issue: [4, true, 'indigo-7', true, false, 'seeders.bim.default_type_issue'],
           remark: [5, true, I18n.t(:default_color_green_dark), true, false, 'seeders.bim.default_type_remark'],
-          request: [6, true, colors[3], true, false, 'seeders.bim.default_type_request'],
-          clash: [7, true, colors[4], true, false, 'seeders.bim.default_type_clash']
+          request: [6, true, 'cyan-7', true, false, 'seeders.bim.default_type_request'],
+          clash: [7, true, 'red-8', true, false, 'seeders.bim.default_type_clash']
         }
       end
     end

--- a/modules/bim/app/seeders/bim/basic_data/type_seeder.rb
+++ b/modules/bim/app/seeders/bim/basic_data/type_seeder.rb
@@ -49,7 +49,7 @@ module Bim
         { # position is_default color_id is_in_roadmap is_milestone
           task: [1, true, colors[0], true, false, :default_type_task],
           milestone: [2, true, colors[2], false, true, :default_type_milestone],
-          phase: [3, true, I18n.t(:default_color_gray), false, false, :default_type_phase],
+          phase: [3, true, I18n.t(:default_color_grey), false, false, :default_type_phase],
           issue: [4, true, colors[1], true, false, 'seeders.bim.default_type_issue'],
           remark: [5, true, I18n.t(:default_color_green_dark), true, false, 'seeders.bim.default_type_remark'],
           request: [6, true, colors[3], true, false, 'seeders.bim.default_type_request'],


### PR DESCRIPTION
https://community.openproject.org/work_packages/40961

Adam found an error occurring during `Mails::ReminderJob` execution because `color_id` for a `Type` record was set to `0`. This error prevents the job from being executed and the reminder emails to be sent.

`color_id` is set to 0 because in BIM edition the seeder uses [`I18n.t(:default_color_gray)`](https://github.com/opf/openproject/blob/24857aedeceab270f0b8abc4db668ea8cf9b088f/modules/bim/app/seeders/bim/basic_data/type_seeder.rb#L52). They key does not exist (the right key is `default_color_grey` with a e) so it expands to a string which is coerced to 0.

This could have been prevented if:
* there was a failure on missing translation key
* there was a validation of numericality of color_id field
* there was a foreign key constraint for `types.color_id` to `colors.id`

To fix this behavior:
* [x] add a db migration which
  * [x] resets all invalid color_id values to nil (no color)
  * [x] adds a foreign key constraint
* [x] use the correct i18n key `:default_color_grey` in the seeder
* [ ] ~(optional) make missing i18n key raise an exception, to uncover other similar errors~