### PR TITLE
[43143] Attachment list and project select harmonisation (wrong styling)

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.html
@@ -9,7 +9,7 @@
       *ngIf="canViewFileLinks$ | async"
       class="op-tab-content--header"
     >
-      <span class="spot-icon spot-icon_attachment op-files-tab--icon_clip"></span>
+      <span class="spot-icon spot-icon_attachment op-files-tab--icon op-files-tab--icon_clip"></span>
       <span class="op-tab-content--header-text" [textContent]="text.attachments.label"></span>
     </div>
 
@@ -24,7 +24,7 @@
     class="op-tab-content--tab-section"
   >
     <div class=op-tab-content--header>
-      <span class="spot-icon spot-icon_nextcloud-circle op-files-tab--icon_nextcloud"></span>
+      <span class="spot-icon spot-icon_nextcloud-circle op-files-tab--icon op-files-tab--icon_nextcloud"></span>
       <span class="op-tab-content--header-text" [textContent]="storage.name"></span>
     </div>
 

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.html
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.html
@@ -1,12 +1,12 @@
 <div class="spot-list--item-floating-wrapper">
   <a
-    class="spot-list--item-action op-files-tab--file-list-item-action"
+    class="spot-list--item-action spot-list--item-action_link op-files-tab--file-list-item-action"
     [href]="attachment._links.staticDownloadLocation.href"
     target="_blank"
     (dragstart)="setDragData($event)"
   >
     <span
-      class="spot-icon spot-icon_{{fileIcon.icon}} op-files-tab--icon_{{fileIcon.clazz}}"
+      class="spot-icon spot-icon_{{fileIcon.icon}} op-files-tab--icon op-files-tab--icon_{{fileIcon.clazz}}"
     ></span>
 
     <span
@@ -17,7 +17,7 @@
     ></span>
 
     <span
-      class="op-files-tab--file-list-item-text op-files-tab--color-grey"
+      class="op-files-tab--file-list-item-text"
       [textContent]="timestampText"
     ></span>
 

--- a/frontend/src/app/shared/components/file-links/file-link-list-item/file-link-list-item.html
+++ b/frontend/src/app/shared/components/file-links/file-link-list-item/file-link-list-item.html
@@ -7,7 +7,7 @@
     target="_blank"
   >
     <span
-      class="spot-icon spot-icon_{{fileLinkIcon.icon}} op-files-tab--icon_{{fileLinkIcon.clazz}}"
+      class="spot-icon spot-icon_{{fileLinkIcon.icon}} op-files-tab--icon op-files-tab--icon_{{fileLinkIcon.clazz}}"
     ></span>
 
     <span
@@ -58,7 +58,7 @@
     *ngIf="!disabled && !viewAllowed"
     class="spot-list--item-floating-actions op-files-tab--file-list-item-floating-text"
   >
-    <span class="spot-icon spot-icon_info2"></span>
+    <span class="spot-icon spot-icon_info2 op-files-tab--file-list-item-floating-text-icon"></span>
     <span [textContent]="text.floatingText.noViewPermission"></span>
   </div>
 </div>

--- a/frontend/src/app/spot/styles/sass/components/list.sass
+++ b/frontend/src/app/spot/styles/sass/components/list.sass
@@ -15,7 +15,7 @@
 
       color: $spot-color-basic-gray-1
       display: flex
-      align-items: flex-start
+      align-items: baseline
       justify-content: flex-start
       padding: $spot-spacing-0_5 $spot-spacing-1
       width: 100%
@@ -28,9 +28,8 @@
         flex-shrink: 0
 
       &:hover
-        color: $spot-color-basic-gray-1
+        color: var(--content-link-hover-active-color)
         background-color: $spot-color-basic-gray-6
-        text-decoration: none
 
       &:focus
         @include spot-focus
@@ -41,12 +40,14 @@
           color: $spot-color-basic-gray-3
           cursor: default
 
+      &_link
+        color: var(--content-link-color)
+
     &-floating-wrapper
       position: relative
       display: flex
 
-      &:hover,
-      &:focus-within
+      &:hover
         background-color: $spot-color-basic-gray-6
 
     &-floating-actions

--- a/frontend/src/global_styles/content/work_packages/tabs/_files.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_files.sass
@@ -33,6 +33,7 @@
       .op-files-tab--file-list-item-action
         padding-left: 0
         padding-right: 0
+        text-decoration: none
 
         &.view-not-allowed
           opacity: 0.5
@@ -41,39 +42,29 @@
           opacity: 0.5
           pointer-events: none
 
-        &:hover .op-files-tab--file-list-item-title
-          text-decoration: underline
+        &:hover
+          .op-files-tab--file-list-item-title
+            text-decoration: underline
 
         .op-files-tab--file-list-item-title
-          @include spot-body-small(bold)
+          @include spot-body-small
 
           line-height: $spot-spacing-1-5
           word-break: normal
-          overflow: hidden
-          text-overflow: ellipsis
+          @include text-shortener
           padding-right: $spot_spacing-0-5
 
         .op-files-tab--file-list-item-text
           @include spot-caption()
 
-          color: #9A9A9A
-          line-height: $spot-spacing-1-5
+          color: $spot-color-basic-gray-3
           flex-shrink: 0
 
           &:not(:last-child)
             margin-right: $spot-spacing-0-5
 
-        .spot-icon:first-child:not(:last-child)
-          width: $spot-spacing-1-5
-          height: $spot-spacing-1-5
-
-        .op-files-tab--file-list-item-avatar
-          flex-shrink: 0
-          display: inline-flex
-          justify-content: center
-          align-items: center
-          width: $spot-spacing-1-5
-          height: $spot-spacing-1-5
+      .op-files-tab--file-list-item-avatar
+        display: inline-block
 
       .op-files-tab--file-list-item-floating-actions
         padding-right: 0
@@ -85,10 +76,8 @@
         overflow: hidden
         color: var(--primary-color)
 
-        .spot-icon:first-child:not(:last-child)
-          width: $spot-spacing-1-5
-          height: $spot-spacing-1-5
-          margin-right: $spot-spacing-0-25
+        &-icon
+          margin-right: $spot-spacing-0-5
 
   &--storage-info-box
     margin-top: 0.875rem
@@ -128,6 +117,8 @@
         margin-right: $spot-spacing-0-5
 
   &--icon
+    width: $spot-spacing-1-5
+
     &_pdf
       color: #B93A33
 


### PR DESCRIPTION
Harmonise attachment list and project select list with regards to stylings. Further some css code has been removed which was not needed any more.

See ticket for detailed requirements:
https://community.openproject.org/projects/openproject/work_packages/43143/activity