### PR TITLE
Add duration display field

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1179,6 +1179,10 @@ en:
         one: "1 h"
         other: "%{count} h"
         zero: "0 h"
+      day:
+        one: "1 day"
+        other: "%{count} days"
+        zero: "0 days"
     zen_mode:
       button_activate: 'Activate zen mode'
       button_deactivate: 'Deactivate zen mode'

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -80,6 +80,9 @@ module.exports = {
         // It'd be good if we could error this for switch cases but allow it for for loops
         "no-continue": "off",
 
+        // no param reassignment is a pain when trying to set props on elements
+        "no-param-reassign": "off",
+
         // No void at all collides with `@typescript-eslint/no-floating-promises` which wants us to handle each promise.
         // Until we do that, `void` is a good way to explicitly mark unhandled promises. 
         "no-void": ["error", { allowAsStatement: true }],

--- a/frontend/src/app/core/datetime/timezone.service.ts
+++ b/frontend/src/app/core/datetime/timezone.service.ts
@@ -145,8 +145,20 @@ export class TimezoneService {
     return Number(moment.duration(durationString).asHours().toFixed(2));
   }
 
-  public formattedDuration(durationString:string):string {
-    return this.I18n.t('js.units.hour', { count: this.toHours(durationString) });
+  public toDays(durationString:string):number {
+    return Number(moment.duration(durationString).asDays().toFixed(2));
+  }
+
+  public formattedDuration(durationString:string, unit:'hour'|'days' = 'hour'):string {
+    switch (unit) {
+      case 'hour':
+        return this.I18n.t('js.units.hour', { count: this.toHours(durationString) });
+      case 'days':
+        return this.I18n.t('js.units.day', { count: this.toDays(durationString) });
+      default:
+        // Case fallthrough for eslint
+        return '';
+    }
   }
 
   public formattedISODate(date:any):string {

--- a/frontend/src/app/shared/components/fields/display/display-field.initializer.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.initializer.ts
@@ -33,7 +33,6 @@ import { IntegerDisplayField } from 'core-app/shared/components/fields/display/f
 import { ResourceDisplayField } from 'core-app/shared/components/fields/display/field-types/resource-display-field.module';
 import { ResourcesDisplayField } from 'core-app/shared/components/fields/display/field-types/resources-display-field.module';
 import { FormattableDisplayField } from 'core-app/shared/components/fields/display/field-types/formattable-display-field.module';
-import { DurationDisplayField } from 'core-app/shared/components/fields/display/field-types/duration-display-field.module';
 import { DateDisplayField } from 'core-app/shared/components/fields/display/field-types/date-display-field.module';
 import { DateTimeDisplayField } from 'core-app/shared/components/fields/display/field-types/datetime-display-field.module';
 import { BooleanDisplayField } from 'core-app/shared/components/fields/display/field-types/boolean-display-field.module';
@@ -50,6 +49,7 @@ import { ProjectStatusDisplayField } from 'core-app/shared/components/fields/dis
 import { PlainFormattableDisplayField } from 'core-app/shared/components/fields/display/field-types/plain-formattable-display-field.module';
 import { LinkedWorkPackageDisplayField } from 'core-app/shared/components/fields/display/field-types/linked-work-package-display-field.module';
 import { CombinedDateDisplayField } from 'core-app/shared/components/fields/display/field-types/combined-date-display.field';
+import { EstimatedTimeDisplayField } from 'core-app/shared/components/fields/display/field-types/estimated-time-display-field.module';
 
 export function initializeCoreDisplayFields(displayFieldService:DisplayFieldService) {
   return () => {
@@ -72,7 +72,7 @@ export function initializeCoreDisplayFields(displayFieldService:DisplayFieldServ
       .addFieldType(ResourcesDisplayField, 'resources', ['[]CustomOption'])
       .addFieldType(MultipleUserFieldModule, 'users', ['[]User'])
       .addFieldType(FormattableDisplayField, 'formattable', ['Formattable'])
-      .addFieldType(DurationDisplayField, 'duration', ['Duration'])
+      .addFieldType(EstimatedTimeDisplayField, 'estimatedTime', ['estimatedTime'])
       .addFieldType(DateDisplayField, 'date', ['Date'])
       .addFieldType(DateTimeDisplayField, 'datetime', ['DateTime'])
       .addFieldType(BooleanDisplayField, 'boolean', ['Boolean'])

--- a/frontend/src/app/shared/components/fields/display/display-field.initializer.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.initializer.ts
@@ -50,6 +50,7 @@ import { PlainFormattableDisplayField } from 'core-app/shared/components/fields/
 import { LinkedWorkPackageDisplayField } from 'core-app/shared/components/fields/display/field-types/linked-work-package-display-field.module';
 import { CombinedDateDisplayField } from 'core-app/shared/components/fields/display/field-types/combined-date-display.field';
 import { EstimatedTimeDisplayField } from 'core-app/shared/components/fields/display/field-types/estimated-time-display-field.module';
+import { DurationDisplayField } from 'core-app/shared/components/fields/display/field-types/duration-display-field.module';
 
 export function initializeCoreDisplayFields(displayFieldService:DisplayFieldService) {
   return () => {
@@ -72,6 +73,7 @@ export function initializeCoreDisplayFields(displayFieldService:DisplayFieldServ
       .addFieldType(ResourcesDisplayField, 'resources', ['[]CustomOption'])
       .addFieldType(MultipleUserFieldModule, 'users', ['[]User'])
       .addFieldType(FormattableDisplayField, 'formattable', ['Formattable'])
+      .addFieldType(DurationDisplayField, 'duration', ['duration'])
       .addFieldType(EstimatedTimeDisplayField, 'estimatedTime', ['estimatedTime'])
       .addFieldType(DateDisplayField, 'date', ['Date'])
       .addFieldType(DateTimeDisplayField, 'datetime', ['DateTime'])

--- a/frontend/src/app/shared/components/fields/display/field-types/duration-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/duration-display-field.module.ts
@@ -1,0 +1,39 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) 2012-2022 the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { DisplayField } from 'core-app/shared/components/fields/display/display-field.module';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
+import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+
+export class DurationDisplayField extends DisplayField {
+  @InjectField() timezoneService:TimezoneService;
+
+  public get valueString() {
+    return this.timezoneService.formattedDuration(this.value, 'days');
+  }
+}

--- a/frontend/src/app/shared/components/fields/display/field-types/estimated-time-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/estimated-time-display-field.module.ts
@@ -30,24 +30,25 @@ import { DisplayField } from 'core-app/shared/components/fields/display/display-
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 
-export class DurationDisplayField extends DisplayField {
+export class EstimatedTimeDisplayField extends DisplayField {
   @InjectField() timezoneService:TimezoneService;
 
   private derivedText = this.I18n.t('js.label_value_derived_from_children');
 
-  public get valueString() {
+  public get valueString():string {
     return this.timezoneService.formattedDuration(this.value);
   }
 
   /**
    * Duration fields may have an additional derived value
    */
-  public get derivedPropertyName() {
+  public get derivedPropertyName():string {
     return `derived${this.name.charAt(0).toUpperCase()}${this.name.slice(1)}`;
   }
 
   public get derivedValue():string|null {
-    return this.resource[this.derivedPropertyName];
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return this.resource[this.derivedPropertyName] as string|null;
   }
 
   public get derivedValueString():string {
@@ -66,8 +67,7 @@ export class DurationDisplayField extends DisplayField {
     }
 
     element.classList.add('split-time-field');
-    const { value } = this;
-    const actual:number = (value && this.timezoneService.toHours(value)) || 0;
+    const actual:number = this.value ? this.timezoneService.toHours(this.value) : 0;
 
     if (actual !== 0) {
       this.renderActual(element, displayText);
@@ -109,6 +109,7 @@ export class DurationDisplayField extends DisplayField {
   }
 
   public isEmpty():boolean {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const { value } = this;
     const derived = this.derivedValue;
 

--- a/frontend/src/app/shared/components/fields/display/field-types/wp-spent-time-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/wp-spent-time-display-field.module.ts
@@ -33,9 +33,9 @@ import * as URI from 'urijs';
 import { TimeEntryCreateService } from 'core-app/shared/components/time_entries/create/create.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { DurationDisplayField } from './duration-display-field.module';
+import { EstimatedTimeDisplayField } from 'core-app/shared/components/fields/display/field-types/estimated-time-display-field.module';
 
-export class WorkPackageSpentTimeDisplayField extends DurationDisplayField {
+export class WorkPackageSpentTimeDisplayField extends EstimatedTimeDisplayField {
   public text = {
     linkTitle: this.I18n.t('js.work_packages.message_view_spent_time'),
     logTime: this.I18n.t('js.button_log_time'),

--- a/frontend/src/app/shared/components/fields/edit/edit-field.initializer.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-field.initializer.ts
@@ -29,7 +29,6 @@
 import { EditFieldService } from 'core-app/shared/components/fields/edit/edit-field.service';
 import { TextEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/text-edit-field/text-edit-field.component';
 import { IntegerEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/integer-edit-field/integer-edit-field.component';
-import { DurationEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/duration-edit-field.component';
 import { SelectEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.component';
 import { MultiSelectEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/multi-select-edit-field.component';
 import { FloatEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/float-edit-field.component';
@@ -46,6 +45,7 @@ import { VersionAutocompleterComponent } from 'core-app/shared/components/autoco
 import { WorkPackageAutocompleterComponent } from 'core-app/shared/components/autocompleter/work-package-autocompleter/wp-autocompleter.component';
 import { WorkPackageCommentFieldComponent } from 'core-app/features/work-packages/components/work-package-comment/wp-comment-field.component';
 import { ProjectEditFieldComponent } from './field-types/project-edit-field.component';
+import { HoursDurationEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/hours-duration-edit-field.component';
 
 export function initializeCoreEditFields(editFieldService:EditFieldService, selectAutocompleterRegisterService:SelectAutocompleterRegisterService) {
   return () => {
@@ -53,7 +53,7 @@ export function initializeCoreEditFields(editFieldService:EditFieldService, sele
     editFieldService
       .addFieldType(TextEditFieldComponent, 'text', ['String'])
       .addFieldType(IntegerEditFieldComponent, 'integer', ['Integer'])
-      .addFieldType(DurationEditFieldComponent, 'duration', ['Duration'])
+      .addFieldType(HoursDurationEditFieldComponent, 'estimatedTime', ['estimatedTime'])
       .addFieldType(ProjectEditFieldComponent, 'project', ['Project'])
       .addFieldType(SelectEditFieldComponent, 'select', [
         'Priority',
@@ -82,7 +82,8 @@ export function initializeCoreEditFields(editFieldService:EditFieldService, sele
         ['combinedDate', 'startDate', 'dueDate', 'date'])
       .addSpecificFieldType('Project', ProjectStatusEditFieldComponent, 'status', ['status'])
       .addSpecificFieldType('TimeEntry', PlainFormattableEditFieldComponent, 'comment', ['comment'])
-      .addSpecificFieldType('TimeEntry', TimeEntryWorkPackageEditFieldComponent, 'workPackage', ['WorkPackage']);
+      .addSpecificFieldType('TimeEntry', TimeEntryWorkPackageEditFieldComponent, 'workPackage', ['WorkPackage'])
+      .addSpecificFieldType('TimeEntry', HoursDurationEditFieldComponent, 'hours', ['hours']);
 
     selectAutocompleterRegisterService.register(VersionAutocompleterComponent, 'Version');
     selectAutocompleterRegisterService.register(WorkPackageAutocompleterComponent, 'WorkPackage');

--- a/frontend/src/app/shared/components/fields/edit/field-types/hours-duration-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/hours-duration-edit-field.component.ts
@@ -47,7 +47,7 @@ import { TimezoneService } from 'core-app/core/datetime/timezone.service';
            [id]="handler.htmlId" />
   `,
 })
-export class DurationEditFieldComponent extends EditFieldComponent {
+export class HoursDurationEditFieldComponent extends EditFieldComponent {
   @InjectField() TimezoneService:TimezoneService;
 
   public parser(value:any, input:any) {

--- a/frontend/src/app/shared/components/fields/openproject-fields.module.ts
+++ b/frontend/src/app/shared/components/fields/openproject-fields.module.ts
@@ -37,7 +37,6 @@ import { EditFieldService } from 'core-app/shared/components/fields/edit/edit-fi
 import { DisplayFieldService } from 'core-app/shared/components/fields/display/display-field.service';
 import { initializeCoreEditFields } from 'core-app/shared/components/fields/edit/edit-field.initializer';
 import { initializeCoreDisplayFields } from 'core-app/shared/components/fields/display/display-field.initializer';
-import { DurationEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/duration-edit-field.component';
 import { FloatEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/float-edit-field.component';
 import { MultiSelectEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/multi-select-edit-field.component';
 import { EditFormPortalComponent } from 'core-app/shared/components/fields/edit/editing-portal/edit-form-portal.component';
@@ -61,6 +60,7 @@ import { SelectEditFieldModule } from 'core-app/shared/components/fields/edit/fi
 import { FormattableEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.module';
 import { EditFieldControlsModule } from 'core-app/shared/components/fields/edit/field-controls/edit-field-controls.module';
 import { ProjectEditFieldComponent } from './edit/field-types/project-edit-field.component';
+import { HoursDurationEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/hours-duration-edit-field.component';
 
 @NgModule({
   imports: [
@@ -101,7 +101,7 @@ import { ProjectEditFieldComponent } from './edit/field-types/project-edit-field
   ],
   declarations: [
     EditFormPortalComponent,
-    DurationEditFieldComponent,
+    HoursDurationEditFieldComponent,
     FloatEditFieldComponent,
     PlainFormattableEditFieldComponent,
     MultiSelectEditFieldComponent,

--- a/spec/features/work_packages/table/duration_field_spec.rb
+++ b/spec/features/work_packages/table/duration_field_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'Duration field in the work package table',
+         with_flag: { work_packages_duration_field_active: true },
+         js: true do
+  shared_let(:current_user) { create :admin }
+  shared_let(:work_package) do
+    create :work_package,
+           subject: 'moved',
+           author: current_user,
+           start_date: Time.zone.today.beginning_of_week.next_occurring(:monday),
+           due_date: Time.zone.today.beginning_of_week.next_occurring(:thursday)
+  end
+
+  let!(:wp_table) { Pages::WorkPackagesTable.new(work_package.project) }
+  let!(:query) do
+    query              = build(:query, user: current_user, project: work_package.project)
+    query.column_names = %w(subject start_date due_date duration)
+    query.filters.clear
+    query.show_hierarchies = false
+
+    query.save!
+    query
+  end
+
+  let(:duration) { wp_table.edit_field work_package, :duration }
+
+  before do
+    login_as(current_user)
+
+    wp_table.visit_query query
+    wp_table.expect_work_package_listed work_package
+  end
+
+  it 'shows the duration as days' do
+    duration.expect_state_text '3 days'
+  end
+end


### PR DESCRIPTION
- [x] The format should be in days and not in hours, since duration as it is currently implemented is simply a difference between two days (including). This is specified here: https://community.openproject.org/work_packages/31992/activity#work-package-table-view 

-  A dash should be visible in the duration colum when this information does not exist and it should be editable, unless there are relations that don't allow this.  This is important because you can have duration without any dates (such that, at a later date, adding a start or an end date means the other one is automatically derived). 
**This is not possible in the frontend right now, as the default duration was set to be one day**. Work packages never have an empty duration.

-  Clicking on a duration should display the date picker, with the duration field in focus. **Not possible, as duration is not editable in 12.2**

https://community.openproject.org/wp/42723