### PR TITLE
[43118] Fixes for arrow navigation in project lists

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.template.html
+++ b/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.template.html
@@ -37,6 +37,7 @@
         [ngModelOptions]="{standalone: true}"
         data-qa-selector="op-project-menu-autocomplete--search"
         data-list-focus-catcher-container="true"
+        data-modal-focus-catcher-container="true"
       >
         <span
           slot="before"

--- a/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.template.html
+++ b/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.template.html
@@ -36,6 +36,7 @@
         [(ngModel)]="searchableProjectListService.searchText"
         [ngModelOptions]="{standalone: true}"
         data-qa-selector="op-project-menu-autocomplete--search"
+        data-list-focus-catcher-container="true"
       >
         <span
           slot="before"

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -40,6 +40,7 @@
         [ngModelOptions]="{standalone: true}"
         data-qa-selector="project-include-search"
         data-list-focus-catcher-container="true"
+        data-modal-focus-catcher-container="true"
       >
         <span
           slot="before"

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -39,6 +39,7 @@
         [(ngModel)]="searchableProjectListService.searchText"
         [ngModelOptions]="{standalone: true}"
         data-qa-selector="project-include-search"
+        data-list-focus-catcher-container="true"
       >
         <span
           slot="before"

--- a/frontend/src/app/shared/components/project-list/project-list.component.html
+++ b/frontend/src/app/shared/components/project-list/project-list.component.html
@@ -6,7 +6,9 @@
 >
   <label
     *ngIf="multiSelect"
+    tabindex="-1"
     class="spot-list--item-action op-project-list--item-action"
+    (keydown.space)="changeSelected(project)"
     [ngClass]="{ 'spot-list--item-action_disabled': isDisabled(project) }"
     [attr.data-list-selector]="projectListActionIdentifier"
     [attr.data-list-disabled]="isDisabled(project) || undefined"

--- a/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
+++ b/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
@@ -17,6 +17,7 @@ import {
   projectListItemDisabled,
   projectListRootSelector,
 } from 'core-app/shared/components/project-list/project-list.component';
+import { findAllFocusableElementsWithin } from 'core-app/shared/helpers/focus-helpers';
 
 @Injectable()
 export class SearchableProjectListService {
@@ -141,6 +142,8 @@ export class SearchableProjectListService {
   }
 
   onKeydown(event:KeyboardEvent):void {
+    const inputElement = this.findInputElement();
+
     switch (event.keyCode) {
       case KeyCodes.UP_ARROW:
         event.preventDefault();
@@ -151,10 +154,26 @@ export class SearchableProjectListService {
         this.handleKeyNavigation(false);
         break;
       case KeyCodes.SPACE:
-        event.preventDefault();
+        if (inputElement && event.target !== inputElement) {
+          event.preventDefault();
+        }
+        break;
+      case KeyCodes.ENTER:
         break;
       default:
+        if (inputElement && event.target !== inputElement) {
+          inputElement.focus();
+        }
         break;
     }
+  }
+
+  findInputElement():HTMLElement|undefined {
+    const focusCatcherContainer = document.querySelectorAll("[data-list-focus-catcher-container='true']")[0];
+    if (focusCatcherContainer) {
+      return (findAllFocusableElementsWithin(focusCatcherContainer as HTMLElement)[0] as HTMLElement);
+    }
+
+    return undefined;
   }
 }

--- a/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
+++ b/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
@@ -143,10 +143,15 @@ export class SearchableProjectListService {
   onKeydown(event:KeyboardEvent):void {
     switch (event.keyCode) {
       case KeyCodes.UP_ARROW:
+        event.preventDefault();
         this.handleKeyNavigation(true);
         break;
       case KeyCodes.DOWN_ARROW:
+        event.preventDefault();
         this.handleKeyNavigation(false);
+        break;
+      case KeyCodes.SPACE:
+        event.preventDefault();
         break;
       default:
         break;

--- a/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
@@ -39,7 +39,7 @@ export class SpotDropModalComponent implements OnDestroy {
         document.body.addEventListener('click', this.closeEventListener);
         document.body.addEventListener('keydown', this.escapeListener);
 
-        const focusCatcherContainer = document.querySelectorAll("[data-list-focus-catcher-container='true']")[0];
+        const focusCatcherContainer = document.querySelectorAll("[data-modal-focus-catcher-container='true']")[0];
         if (focusCatcherContainer) {
           (findAllFocusableElementsWithin(focusCatcherContainer as HTMLElement)[0] as HTMLElement).focus();
         } else {

--- a/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
@@ -39,8 +39,13 @@ export class SpotDropModalComponent implements OnDestroy {
         document.body.addEventListener('click', this.closeEventListener);
         document.body.addEventListener('keydown', this.escapeListener);
 
-        // Index 1 because the element at index 0 is the trigger button to open the modal
-        (findAllFocusableElementsWithin(this.elementRef.nativeElement)[1] as HTMLElement).focus();
+        const focusCatcherContainer = document.querySelectorAll("[data-list-focus-catcher-container='true']")[0];
+        if (focusCatcherContainer) {
+          (findAllFocusableElementsWithin(focusCatcherContainer as HTMLElement)[0] as HTMLElement).focus();
+        } else {
+          // Index 1 because the element at index 0 is the trigger button to open the modal
+          (findAllFocusableElementsWithin(this.elementRef.nativeElement)[1] as HTMLElement).focus();
+        }
       });
     } else {
       document.body.removeEventListener('click', this.closeEventListener);


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/43118#activity-10
- [x] The first element is automatically scrolled out of view when using the arrow keys

https://community.openproject.org/projects/openproject/work_packages/43118#activity-11
- [x] ~~The hover effect remains visible when starting to use the arrow keys~~ **Edit:** Out of scope after discussion with Marc
- [x] The global search can be triggered from the project list resulting in two open drop downs
- [x] In the Include Projects the arrow navigation triggers the toggle buttons instead of the list when initially opened
- [x] Project include doesn't scroll when using the arrow keys

https://community.openproject.org/projects/openproject/work_packages/43118#activity-12
- [x] Focus whole label in the project include list and remain functionality to select via space


