### PR TITLE
[43207] Mobile: The right margin for the files list is not correct

### DIFF
--- a/frontend/src/global_styles/content/work_packages/tabs/_tab_content.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_tab_content.sass
@@ -28,8 +28,6 @@
 
 .op-tab-content
   &--container
-    margin-right: $spot-spacing-1
-
     .spot-list:not(:last-child)
       margin-bottom: $spot-spacing-0-75
 

--- a/frontend/src/global_styles/layout/work_packages/_details_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_details_view.sass
@@ -129,7 +129,7 @@ body.router--work-packages-partitioned-split-view-new
   overflow-y: auto
   overflow-x: hidden
   flex-grow: 1
-  padding: 0 5px 10px 20px
+  padding: 0 8px 10px 20px
   @include styled-scroll-bar
 
 .work-packages--breadcrumb

--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -113,7 +113,7 @@
       height: 100%
       overflow: auto
       @include styled-scroll-bar
-      padding-right: 5px
+      padding-right: 8px
 
     .work-package-details-activities-activity-contents ul.work-package-details-activities-messages
       padding-left: 0


### PR DESCRIPTION
Remove additional spacing for files tab and increase the default padding a bit to avoid that the content is too close to the border when there is no scroll bar.

https://community.openproject.org/projects/openproject/work_packages/43207/activity