### PR TITLE
fix table format in configuration docs

### DIFF
--- a/docs/installation-and-operations/configuration/README.md
+++ b/docs/installation-and-operations/configuration/README.md
@@ -519,6 +519,8 @@ OPENPROJECT_STATSD_HOST=127.0.0.1 # overridden by: STATSD_HOST
 OPENPRJOECT_STATSD_PORT=8125 # overridden by: STATSD_PORT
 ```
 
+## Other Configuration Topics
+| | |
 | ----------- | :---------- |
 | [List of supported environment variables](./environment) | The full list of environment variables you can use to override the default configuration |
 | [Configuring SSL](./ssl) | How to configure SSL so that your OpenProject installation is available over HTTPS |


### PR DESCRIPTION
currently that table does not render correctly
![image](https://user-images.githubusercontent.com/2425577/179476995-c75ae2b2-1626-4682-bbad-7b1e74f0951f.png)

Not sure if `## Other Configuration Topics` is the correct heading, but somehow the links don't really belong to `statsd`