### PR TITLE
[43240] Work packages in Gantt chart in light grey hard to say

### DIFF
--- a/frontend/src/global_styles/content/work_packages/timelines/elements/_bar.sass
+++ b/frontend/src/global_styles/content/work_packages/timelines/elements/_bar.sass
@@ -43,6 +43,7 @@
   width: 100%
   height: 100%
   background-color: var(--timeline--type-fallback-color)
+  border: 1px solid
 
   &.-readonly
     cursor: not-allowed !important
@@ -101,4 +102,3 @@
 
     .rightHandle
       cursor: pointer !important
-


### PR DESCRIPTION
Add border so that border-color of bright work package types is correctly visible in the Gantt chart

https://community.openproject.org/projects/openproject/work_packages/43240/activity