### PR TITLE
Use Time.zone.now in utc, as updated_at is stored without TZ

### DIFF
--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -575,7 +575,7 @@ module Journals
       # Use the ruby time instead of the DB's. If those are out of sync,
       # a journal might otherwise end up having an updated_at before created_at which
       # will also reflect back to the journaled object.
-      "'#{Time.zone.now}'"
+      "'#{Time.zone.now.utc.iso8601}'"
     end
 
     # Because we added the journal via bare metal sql, rails does not yet


### PR DESCRIPTION
`updated_at` is stored as a timestamp without time zone, but `Time.zone.now` might change zones depending on the user executing the call.

Edit: OP#43224