### PR TITLE
[43247] Work package types with colour white are not visible in emails

### DIFF
--- a/app/helpers/mail_notification_helper.rb
+++ b/app/helpers/mail_notification_helper.rb
@@ -41,7 +41,12 @@ module MailNotificationHelper
 
   def type_color(type, default_fallback)
     color_id = selected_color(type)
-    color_id ? Color.find(color_id).hexcode : default_fallback
+    if color_id
+      color = Color.find(color_id)
+      return color.super_bright? ? darken_color(color.hexcode, 0.75) : color.hexcode
+    end
+
+    default_fallback
   end
 
   def status_colors(status)


### PR DESCRIPTION
Darken bright colours of work package types in email so that they are still readable in white background

https://community.openproject.org/projects/openproject/work_packages/43247/activity