### PR TITLE
Added highlighting for wp-type in relation table

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
@@ -10,6 +10,8 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { RelationResource } from 'core-app/features/hal/resources/relation-resource';
 import { WorkPackageRelationsService } from '../wp-relations.service';
+import { Highlighting } from 'core-app/features/work-packages/components/wp-fast-table/builders/highlighting/highlighting.functions';
+
 
 @Component({
   selector: 'wp-relation-row',
@@ -199,5 +201,9 @@ export class WorkPackageRelationRowComponent extends UntilDestroyedMixin impleme
       })
       .catch((err:any) => this.notificationService.handleRawError(err,
         this.relatedWorkPackage));
+  }
+  
+  public highlightingClassForWpType() {
+    return Highlighting.inlineClass('type', this.relatedWorkPackage.type.id!);
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
@@ -203,7 +203,7 @@ export class WorkPackageRelationRowComponent extends UntilDestroyedMixin impleme
         this.relatedWorkPackage));
   }
 
-  public highlightingClassForWpType() {
+  public highlightingClassForWpType():string {
     return Highlighting.inlineClass('type', this.relatedWorkPackage.type.id!);
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
@@ -202,7 +202,7 @@ export class WorkPackageRelationRowComponent extends UntilDestroyedMixin impleme
       .catch((err:any) => this.notificationService.handleRawError(err,
         this.relatedWorkPackage));
   }
-  
+
   public highlightingClassForWpType() {
     return Highlighting.inlineClass('type', this.relatedWorkPackage.type.id!);
   }

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
@@ -14,6 +14,7 @@
         <span *ngIf="groupByWorkPackageType"
               [textContent]="normalizedRelationType"></span>
         <span *ngIf="!groupByWorkPackageType"
+              [ngClass]="highlightingClassForWpType()"
               [textContent]="relatedWorkPackage.type.name"></span>
         <span class="hidden-for-sighted" [textContent]="text.updateRelation"></span>
       </button>

--- a/spec/features/work_packages/details/relations/relations_spec.rb
+++ b/spec/features/work_packages/details/relations/relations_spec.rb
@@ -101,8 +101,8 @@ describe 'Work package relations tab', js: true, selenium: true do
       expect(page).to have_selector('.relation-group--header', text: 'FOLLOWS')
       expect(page).to have_selector('.relation-group--header', text: 'RELATED TO')
 
-      expect(page).to have_selector('.relation-row--type', text: type_1.name)
-      expect(page).to have_selector('.relation-row--type', text: type_2.name)
+      expect(page).to have_selector('.relation-row--type', text: type_1.name.upcase)
+      expect(page).to have_selector('.relation-row--type', text: type_2.name.upcase)
 
       find(toggle_btn_selector).click
       expect(page).to have_selector(toggle_btn_selector, text: 'Group by relation type', wait: 10)

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -110,7 +110,7 @@ module Components
                                       text: relation_label.upcase,
                                       wait: 10)
 
-        expect(page).to have_selector('.relation-row--type', text: to.type.name)
+        expect(page).to have_selector('.relation-row--type', text: to.type.name.upcase)
 
         expect(page).to have_selector('.wp-relations--subject-field', text: to.subject)
 


### PR DESCRIPTION
This commit adds highlighting to the work-package types in the work-package relations tab.

This is inspired by the mechanism used in the global search. I did not use the editable field because:
- the type was not editable previously
- the user is most-likely not trying to alter the type in the relation table and is not expecting OpenProject to allow that.
- the editable field did not align with the text baseline of the subject and the status (and I didn't want to hard-code an offset into css).
<img width="646" alt="Screenshot 2022-07-18 at 11 44 10" src="https://user-images.githubusercontent.com/13020648/179485853-e0028e7c-111e-44db-b2f4-723d0034c776.png">
 