### PR TITLE
Add mailers previews to the dev environment

### DIFF
--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -35,6 +35,7 @@ class DigestMailer < ApplicationMailer
   include OpenProject::TextFormatting
   include Redmine::I18n
   include MailDigestHelper
+  include MailNotificationHelper
 
   helper :mail_digest,
          :mail_notification

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,6 +80,9 @@ OpenProject::Application.configure do
   # Send mails to browser window
   config.action_mailer.delivery_method = :letter_opener
 
+  # Set email preview locations to rspec
+  config.action_mailer.preview_path = Rails.root.join('/spec/mailers/previews')
+
   config.hosts << 'bs-local.com' if ENV['OPENPROJECT_DISABLE_DEV_ASSET_PROXY'].present?
 
   if ENV['OPENPROJECT_DEV_EXTRA_HOSTS'].present?

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -81,7 +81,7 @@ OpenProject::Application.configure do
   config.action_mailer.delivery_method = :letter_opener
 
   # Set email preview locations to rspec
-  config.action_mailer.preview_path = Rails.root.join('/spec/mailers/previews')
+  config.action_mailer.preview_path = Rails.root.join('spec/mailers/previews')
 
   config.hosts << 'bs-local.com' if ENV['OPENPROJECT_DISABLE_DEV_ASSET_PROXY'].present?
 

--- a/spec/mailers/previews/digest_mailer_preview.rb
+++ b/spec/mailers/previews/digest_mailer_preview.rb
@@ -1,0 +1,36 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class DigestMailerPreview < ActionMailer::Preview
+  # Preview emails at http://localhost:3000/rails/mailers/digest_mailer
+
+  def work_packages
+    notifications = Notification.all
+    DigestMailer.work_packages(notifications.first.recipient_id, [notifications.ids])
+  end
+end

--- a/spec/mailers/previews/digest_mailer_preview.rb
+++ b/spec/mailers/previews/digest_mailer_preview.rb
@@ -30,7 +30,7 @@ class DigestMailerPreview < ActionMailer::Preview
   # Preview emails at http://localhost:3000/rails/mailers/digest_mailer
 
   def work_packages
-    notifications = Notification.all
+    notifications = Notification.where(resource_type: 'WorkPackage')
     DigestMailer.work_packages(notifications.first.recipient_id, [notifications.ids])
   end
 end

--- a/spec/mailers/previews/work_package_mailer_preview.rb
+++ b/spec/mailers/previews/work_package_mailer_preview.rb
@@ -1,0 +1,36 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) 2012-2022 the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class WorkPackageMailerPreview < ActionMailer::Preview
+  # Preview emails at http://localhost:3000/rails/mailers/work_package_mailer
+
+  def mentioned
+    notification = Notification.first
+    WorkPackageMailer.mentioned(notification.recipient, notification.journal)
+  end
+end


### PR DESCRIPTION
Adding mailer previews to make testing email related features easier.
They can be accessed at `/rails/mailers`