### PR TITLE
Fix remove unused setting

### DIFF
--- a/config/constants/settings/definitions.rb
+++ b/config/constants/settings/definitions.rb
@@ -963,10 +963,6 @@ Settings::Definition.define do
       default: 'field',
       allowed: %w[field status disabled]
 
-  # TODO: Remove this setting after 12.2 has been released
-  add :work_packages_export_limit,
-      default: 500
-
   add :work_packages_projects_export_limit,
       default: 500
 


### PR DESCRIPTION
This setting is not used anymore. I realised it can be removed alongside the 12.2 since migrating the setting is done via SQL only without requiring access to the setting via the model.