### PR TITLE
Always use DB time for journal updated_timestamp

### DIFF
--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -572,10 +572,9 @@ module Journals
     end
 
     def timestamp_sql
-      # Use the ruby time instead of the DB's. If those are out of sync,
-      # a journal might otherwise end up having an updated_at before created_at which
-      # will also reflect back to the journaled object.
-      "'#{Time.zone.now.utc.iso8601}'"
+      # Use the timestamp of the statement, not now() or statement_timestamp
+      # as they always return the same value of the start of transaction
+      "statement_timestamp() AT TIME ZONE 'utc'"
     end
 
     # Because we added the journal via bare metal sql, rails does not yet


### PR DESCRIPTION
As we cannot guarantee that our k8s workers are in sync (one of the workers is running 3 minutes late right now), we should use the DB time as the canonical correct current time for all our timestamps.

As now() and current_timestamp return the values at the start of the transaction, and tests are wrapped in one big transaction, they will always return the same value. Instead, statement_time() is the one we want in this case, returning the actual time of the statement execution.

Work packages affected by the time/clock skew:

https://community.openproject.org/projects/openproject/work_packages/43306/activity

Version 2 timestamp updatedAt: "2022-07-19T10:43:41Z"
Version 3 timestamp updatedAt: "2022-07-19T10:40:37Z"

https://community.openproject.org/projects/temporary-debug-project/work_packages/43241/activity