### PR TITLE
[43296] Can not access the main actions on work package on mobile from the details view

### DIFF
--- a/frontend/src/app/features/work-packages/components/back-routing/back-button.component.sass
+++ b/frontend/src/app/features/work-packages/components/back-routing/back-button.component.sass
@@ -9,7 +9,6 @@
     font-size: 1rem
     line-height: 22px
 
-  &_mobile-full-width
+  &_mobile-limited-width
     @media only screen and (max-width: 679px)
-      width: 100%
-      margin-bottom: 20px
+      width: 64px

--- a/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.html
+++ b/frontend/src/app/features/work-packages/routing/partitioned-query-space-page/partitioned-query-space-page.component.html
@@ -4,7 +4,7 @@
     <div class="toolbar">
       <op-back-button *ngIf="backButtonCallback"
                       class="op-back-button"
-                      linkClass="op-back-button_mobile-full-width"
+                      linkClass="op-back-button_mobile-limited-width"
                       [customBackMethod]="backButtonCallback">
       </op-back-button>
 

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -10,7 +10,7 @@
       <div class="wp-show--header-container">
 
         <op-back-button
-          linkClass="work-packages-back-button op-back-button_mobile-full-width"
+          linkClass="work-packages-back-button op-back-button_mobile-limited-width"
         >
         </op-back-button>
 


### PR DESCRIPTION
Reduce width of back button on mobile so that other actions (as watch, mark as read, more menu) are still visible

https://community.openproject.org/projects/openproject/work_packages/43296/activity