### PR TITLE
[chore] rework of styles that override spot-list

### DIFF
--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.html
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.html
@@ -1,6 +1,5 @@
 <div
   *ngIf="resource && $attachments | async as attachments"
-  class="work-package--attachments--files op-attachments-list"
 >
   <ul
     *ngIf="attachments.length > 0"

--- a/frontend/src/app/shared/components/file-links/file-link-list-item/file-link-list-item.html
+++ b/frontend/src/app/shared/components/file-links/file-link-list-item/file-link-list-item.html
@@ -4,7 +4,7 @@
 >
   <a
     class="spot-list--item-action spot-list--item-action_link op-files-tab--file-list-item-action"
-    [ngClass]="{ 'disabled': disabled, 'view-not-allowed': !viewAllowed }"
+    [ngClass]="{ 'op-files-tab--file-list-item-action_disabled': disabled, 'op-files-tab--file-list-item-action_view-not-allowed': !viewAllowed }"
     [href]="fileLink._links.staticOriginOpen.href"
     [title]="fileLink.originData.name"
     target="_blank"

--- a/frontend/src/app/shared/components/file-links/file-link-list/file-link-list.html
+++ b/frontend/src/app/shared/components/file-links/file-link-list/file-link-list.html
@@ -3,7 +3,7 @@
 >
   <op-storage-information
     *ngFor="let infoBox of storageInformation | async"
-    class="op-files-tab--storage-info-box"
+    class="op-files-tab--storage-info"
     data-qa-selector="op-files-tab--storage-information"
     [viewModel]="infoBox"
   ></op-storage-information>

--- a/frontend/src/app/shared/components/file-links/storage-information/storage-information.html
+++ b/frontend/src/app/shared/components/file-links/storage-information/storage-information.html
@@ -1,25 +1,25 @@
-<span class="spot-icon spot-icon_{{viewModel.iconClass}} op-files-tab--storage-info-box-icon"></span>
+<span class="spot-icon spot-icon_{{viewModel.iconClass}} op-files-tab--storage-info-icon"></span>
 
 <div
-  class="text-box"
+  class="op-files-tab--storage-info-text-box"
 >
   <div
-    class="text-box-header"
+    class="op-files-tab--storage-info-text-box-header"
   >
     <span [textContent]="viewModel.header"></span>
   </div>
   <div
-    class="text-box-content"
+    class="op-files-tab--storage-info-text-box-content"
   >
     <span [textContent]="viewModel.content"></span>
   </div>
 </div>
 
 <div
-  class="button-box"
+  class="op-files-tab--storage-info-button-container"
 >
   <button *ngFor="let button of viewModel.buttons"
-    class="button op-files-tab--storage-info-box-button"
+    class="button op-files-tab--storage-info-button"
     (click)="button.action()"
   >
     <op-icon

--- a/frontend/src/app/spot/styles/sass/components/list.sass
+++ b/frontend/src/app/spot/styles/sass/components/list.sass
@@ -78,10 +78,7 @@
     &-floating-actions:hover
       opacity: 1
 
-  &_compact &--item:not(:first-child)
-    margin-top: $spot-spacing-0_25
-
-  &--item > &_compact > &--item:first-child
+  &_compact &--item
     margin-top: $spot-spacing-0_25
 
   &_compact &--item-action,

--- a/frontend/src/global_styles/content/work_packages/tabs/_files.sass
+++ b/frontend/src/global_styles/content/work_packages/tabs/_files.sass
@@ -26,56 +26,38 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-.op-files-tab,
-.op-attachments-list
-  .op-files-tab--file-list
-    margin-bottom: 1rem
-
-    .op-files-tab--file-list-item
-      .op-files-tab--file-list-item-action
-        padding-left: 0
-        padding-right: 0
-        text-decoration: none
-
-        &.view-not-allowed
+.op-files-tab
+  &--file-list
+    &-item
+      &-action
+        &_view-not-allowed
           opacity: 0.5
 
-        &.disabled
+        &_disabled
           opacity: 0.5
           pointer-events: none
 
-        &:hover
-          .op-files-tab--file-list-item-title
-            text-decoration: underline
+      &-title
+        @include spot-body-small
+        @include text-shortener
 
-        .op-files-tab--file-list-item-title
-          @include spot-body-small
+        line-height: $spot-spacing-1-5
+        word-break: normal
+        padding-right: $spot_spacing-0-5
 
-          line-height: $spot-spacing-1-5
-          word-break: normal
-          @include text-shortener
-          padding-right: $spot_spacing-0-5
+      &-text
+        @include spot-caption()
 
-        .op-files-tab--file-list-item-text
-          @include spot-caption()
+        color: $spot-color-basic-gray-3
+        flex-shrink: 0
 
-          color: $spot-color-basic-gray-3
-          flex-shrink: 0
+        &:not(:last-child)
+          margin-right: $spot-spacing-0-5
 
-          &:not(:last-child)
-            margin-right: $spot-spacing-0-5
-
-      .op-files-tab--file-list-item-avatar
+      &-avatar
         display: inline-block
 
-      .op-files-tab--file-list-item-floating-actions
-        padding-right: 0
-
-      .op-files-tab--file-list-item-floating-wrapper
-        &_disabled:hover
-          background: none
-
-      .op-files-tab--file-list-item-floating-text
+      &-floating-text
         @include spot-body-small()
 
         padding-right: $spot-spacing-0-25
@@ -85,8 +67,8 @@
         &-icon
           margin-right: $spot-spacing-0-5
 
-  &--storage-info-box
-    margin-top: 0.875rem
+  &--storage-info
+    margin: 0.875rem 0 $spot-spacing-1 0
     display: grid
     align-items: center
     grid-template: "icon text" "button button" / auto 1fr
@@ -99,19 +81,19 @@
       font-size: 1.75rem
       margin-right: $spot_spacing-0-5
 
-    .text-box
+    &-text-box
       grid-area: text
 
-      .text-box-header
+      &-header
         font-weight: 700
         line-height: $spot-spacing-1-5
 
-      .text-box-content
+      &-content
         @include spot-body-small()
 
         color: #9A9A9A
 
-    .button-box
+    &-button-container
       grid-area: button
       display: flex
       justify-content: end
@@ -122,6 +104,27 @@
       &:not(:last-child)
         margin-right: $spot-spacing-0-5
 
+  // Style overrides that need the nesting into the block to overrule the spot selector.
+  & &--file-list
+    margin-bottom: 1rem
+
+  & &--file-list &--file-list-item &--file-list-item-floating-actions
+    padding-right: 0
+
+  & &--file-list &--file-list-item &--file-list-item-action
+    padding-left: 0
+    padding-right: 0
+
+  & &--file-list-item-action:hover
+    text-decoration: none
+
+  & &--file-list-item-action:hover &--file-list-item-title
+    text-decoration: underline
+
+  & &--file-list-item-floating-wrapper_disabled:hover
+    background: none
+
+  // Additional colors
   &--icon
     width: $spot-spacing-1-5
 


### PR DESCRIPTION
Please look at this draft. This is how we COULD rewrite the styles, in a way that is very similar to what the spot-list is doing.

Also, there is a rule in spot-list, that excludes margin top of compact lists for their first element. In figma it looks like there must be a margin for first elements, too: https://www.figma.com/file/gtLQfPe09X7XugAH8L7dTy/Nextcloud-Integration?node-id=664%3A29089