### PR TITLE
[40858] Default status is shown multiple times in new board

### DIFF
--- a/frontend/src/app/features/boards/board/board-actions/cached-board-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/cached-board-action.service.ts
@@ -30,8 +30,8 @@ export abstract class CachedBoardActionService extends BoardActionService {
   }
 
   addColumnWithActionAttribute(board:Board, value:HalResource):Promise<Board> {
-    if (this.cache.value) {
-      // Add the new value to the cache
+    if (this.cache.value && !this.cache.value.find((item) => item.id === value.id)) {
+      // Add the new value to the cache if it was not there before
       const newValue = [...this.cache.value, value];
       this.cache.putValue(newValue);
     }

--- a/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
+++ b/frontend/src/app/features/boards/boards-sidebar/boards-menu.component.html
@@ -14,6 +14,7 @@
     class="button -alt-highlight"
     (click)="showNewBoardModal()"
     [title]="text.create_new_board"
+    data-qa-selector="sidebar--create-board-button"
   >
     <span class="spot-icon spot-icon_add"></span>
     <span [textContent]="text.board"></span>

--- a/modules/boards/spec/features/action_boards/status_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/status_board_spec.rb
@@ -242,5 +242,23 @@ describe 'Status action board', type: :feature, js: true do
       board_page.expect_card('Open', 'Task 1', present: false)
       board_page.expect_card('Closed', 'Task 1', present: true)
     end
+
+    it 'shows the default column only once (regression #40858)' do
+      board_index.visit!
+
+      # Create new board
+      board_page = board_index.create_board action: :Status
+
+      # expect lists of default status
+      board_page.expect_list 'Open'
+      expect(board_page.list_count).to eq(1)
+
+      # Create another status board
+      second_board_page = board_index.create_board action: :Status, via_toolbar: true
+
+      # Expect only one list with the default status
+      second_board_page.expect_list 'Open'
+      expect(second_board_page.list_count).to eq(1)
+    end
   end
 end

--- a/modules/boards/spec/features/support/board_index_page.rb
+++ b/modules/boards/spec/features/support/board_index_page.rb
@@ -56,8 +56,12 @@ module Pages
       expect(page).to have_conditional_selector(present, 'td.name', text: name)
     end
 
-    def create_board(action: nil, expect_empty: false)
-      page.find('.toolbar-item a', text: 'Board').click
+    def create_board(action: nil, expect_empty: false, via_toolbar: false)
+      if via_toolbar
+        page.find('[data-qa-selector="sidebar--create-board-button"]').click
+      else
+        page.find('.toolbar-item a', text: 'Board').click
+      end
 
       text = action == nil ? 'Basic' : action.to_s[0..5]
       find('[data-qa-selector="op-tile-block-title"]', text:).click


### PR DESCRIPTION
Only add values to cache if they have not been there before. Otherwise the default values will appear multiple times when creating multiple boards.

https://community.openproject.org/projects/openproject/work_packages/40858/activity