### PR TITLE
[43222] Double click to open work packages in the Team Planner

### DIFF
--- a/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
@@ -281,12 +281,29 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
     );
   }
 
+  public openFullView(id:string):void {
+    this.wpTableSelection.setSelection(id, -1);
+
+    void this.$state.go(
+      'work-packages.show',
+      { workPackageId: id },
+    );
+  }
+
   public onCardClicked({ workPackageId, event }:{ workPackageId:string, event:MouseEvent }):void {
     if (isClickedWithModifier(event)) {
       return;
     }
 
     this.openSplitView(workPackageId, true);
+  }
+
+  public onCardDblClicked({ workPackageId, event }:{ workPackageId:string, event:MouseEvent }):void {
+    if (isClickedWithModifier(event)) {
+      return;
+    }
+
+    this.openFullView(workPackageId);
   }
 
   public showEventContextMenu({ workPackageId, event }:{ workPackageId:string, event:MouseEvent }):void {

--- a/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.html
@@ -31,6 +31,7 @@
           [attr.data-qa-selector]="'op-add-existing-pane--wp-' + wp.id"
           (stateLinkClicked)="openStateLink($event)"
           (cardClicked)="workPackagesCalendar.onCardClicked($event)"
+          (cardDblClicked)="workPackagesCalendar.onCardDblClicked($event)"
         ></wp-single-card>
       </ng-container>
     </div>

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.html
@@ -117,6 +117,7 @@
         [showEndDate]="!isWpEndDateInCurrentView(wp)"
         (stateLinkClicked)="openStateLink($event)"
         (cardClicked)="workPackagesCalendar.onCardClicked($event)"
+        (cardDblClicked)="workPackagesCalendar.onCardDblClicked($event)"
         (cardContextMenu)="workPackagesCalendar.showEventContextMenu($event)"
       ></wp-single-card>
     </ng-template>

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.html
@@ -6,6 +6,7 @@
   [ngClass]="cardClasses()"
   [title]="cardTitle()"
   (click)="cardClicked.emit({ workPackageId: workPackage.id, event: $event })"
+  (dblclick)="cardDblClicked.emit({ workPackageId: workPackage.id, event: $event })"
   (contextmenu)="cardContextMenu.emit({ workPackageId: workPackage.id, event: $event })"
 >
 

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.ts
@@ -72,6 +72,8 @@ export class WorkPackageSingleCardComponent extends UntilDestroyedMixin implemen
 
   @Output() cardClicked = new EventEmitter<{ workPackageId:string, event:MouseEvent }>();
 
+  @Output() cardDblClicked = new EventEmitter<{ workPackageId:string, event:MouseEvent }>();
+
   @Output() cardContextMenu = new EventEmitter<{ workPackageId:string, event:MouseEvent }>();
 
   public uiStateLinkClass:string = uiStateLinkClass;


### PR DESCRIPTION
Open the wp full view when double clicking a wp card in team planner


https://community.openproject.org/projects/openproject/work_packages/43222/activity