### PR TITLE
Fix backup mailer

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -44,7 +44,7 @@ class UserMailer < ApplicationMailer
     User.execute_as user do
       @download_url = admin_backups_url
 
-      send_mail(recipient,
+      send_mail(user,
                 I18n.t("mail_subject_backup_ready"))
     end
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -124,6 +124,27 @@ describe UserMailer, type: :mailer do
     end
   end
 
+  describe '#backup_ready' do
+    before do
+      described_class.backup_ready(recipient).deliver_now
+    end
+
+    it_behaves_like 'mail is sent' do
+      it 'has the expected subject' do
+        expect(deliveries.first.subject)
+          .to eql I18n.t("mail_subject_backup_ready")
+      end
+
+      it 'includes the url to the instance' do
+        expect(deliveries.first.body.encoded)
+          .to match Regexp.union(
+            /Your requested backup is ready. You can download it here/,
+            /#{Setting.protocol}:\/\/#{Setting.host_name}/
+          )
+      end
+    end
+  end
+
   describe '#wiki_content_added' do
     let(:wiki_content) { create(:wiki_content) }
 


### PR DESCRIPTION
Driverby fix for an [appsignal](https://appsignal.com/openproject-gmbh/sites/62a6d833d2a5e482c1ef825d/exceptions/incidents/169?timestamp=2022-07-19T15%3A12%3A24Z) error.