### PR TITLE
Prevent stripping of permissions before disabled modules registered

### DIFF
--- a/config/initializers/module_handler.rb
+++ b/config/initializers/module_handler.rb
@@ -29,7 +29,6 @@
 Rails.application.config.to_prepare do
   if OpenProject::Configuration.disabled_modules.any?
     to_disable = OpenProject::Configuration.disabled_modules
-    OpenProject::Plugins::ModuleHandler.disable_modules(to_disable)
-    OpenProject::Plugins::ModuleHandler.enforce!
+    OpenProject::Plugins::ModuleHandler.disable_modules!(to_disable)
   end
 end

--- a/config/initializers/module_handler.rb
+++ b/config/initializers/module_handler.rb
@@ -26,9 +26,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-Rails.application.config.after_initialize do
+Rails.application.config.to_prepare do
   if OpenProject::Configuration.disabled_modules.any?
     to_disable = OpenProject::Configuration.disabled_modules
     OpenProject::Plugins::ModuleHandler.disable_modules(to_disable)
+    OpenProject::Plugins::ModuleHandler.enforce!
   end
 end

--- a/lib/open_project/plugins/module_handler.rb
+++ b/lib/open_project/plugins/module_handler.rb
@@ -31,12 +31,8 @@ module OpenProject::Plugins
     @@disabled_modules = []
 
     class << self
-      def disable_modules(module_names)
-        @@disabled_modules += Array(module_names).map(&:to_sym)
-      end
-
-      def enforce!
-        @@disabled_modules.map do |module_name|
+      def disable_modules!(module_names)
+        @@disabled_modules += Array(module_names).map(&:to_sym).each do |module_name|
           OpenProject::AccessControl.remove_modules_permissions(module_name)
         end
       end

--- a/lib/open_project/plugins/module_handler.rb
+++ b/lib/open_project/plugins/module_handler.rb
@@ -35,15 +35,11 @@ module OpenProject::Plugins
         @@disabled_modules += Array(module_names).map(&:to_sym)
       end
 
-      def disable(disabled_modules)
-        disabled_modules.map do |module_name|
+      def enforce!
+        @@disabled_modules.map do |module_name|
           OpenProject::AccessControl.remove_modules_permissions(module_name)
         end
       end
-    end
-
-    OpenProject::Application.config.to_prepare do
-      OpenProject::Plugins::ModuleHandler.disable(@@disabled_modules)
     end
   end
 end

--- a/spec/lib/open_project/plugins/module_handler_spec.rb
+++ b/spec/lib/open_project/plugins/module_handler_spec.rb
@@ -31,8 +31,7 @@ describe OpenProject::Plugins::ModuleHandler do
   let!(:all_former_permissions) { OpenProject::AccessControl.permissions }
 
   before do
-    disabled_modules = OpenProject::Plugins::ModuleHandler.disable_modules('repository')
-    OpenProject::Plugins::ModuleHandler.disable(disabled_modules)
+    described_class.disable_modules!('repository')
   end
 
   after do


### PR DESCRIPTION
The +remove_modules_permissions+ is called before the disabled modules
are registered.

https://community.openproject.org/wp/43213