### PR TITLE
[#43387] cannot connect to NC when NC runs in a subpath

### DIFF
--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -93,7 +93,7 @@ module API
         link :authorize do
           next unless @connection_manager.authorization_state == :failed_authorization
 
-          { href: @connection_manager.redirect_to_oauth_authorize, title: 'Authorize' }
+          { href: @connection_manager.get_authorization_uri, title: 'Authorize' }
         end
 
         def _type

--- a/modules/storages/spec/features/show_file_links_spec.rb
+++ b/modules/storages/spec/features/show_file_links_spec.rb
@@ -99,7 +99,7 @@ describe 'Showing of file links in work package', with_flag: { storages_module_a
   context 'if user is not authorized in Nextcloud' do
     before do
       allow(connection_manager).to receive(:authorization_state).and_return(:failed_authorization)
-      allow(connection_manager).to receive(:redirect_to_oauth_authorize).and_return('https://example.com/authorize')
+      allow(connection_manager).to receive(:get_authorization_uri).and_return('https://example.com/authorize')
     end
 
     it 'must show storage information box with login button' do

--- a/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
+++ b/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
@@ -42,7 +42,7 @@ describe ::API::V3::Storages::StorageRepresenter, 'rendering' do
     allow(connection_manager)
       .to receive(:authorization_state).and_return(:connected)
     allow(connection_manager)
-      .to receive(:redirect_to_oauth_authorize).and_return('https://example.com/authorize')
+      .to receive(:get_authorization_uri).and_return('https://example.com/authorize')
   end
 
   describe '_links' do

--- a/modules/storages/spec/requests/api/v3/file_links/file_links_spec.rb
+++ b/modules/storages/spec/requests/api/v3/file_links/file_links_spec.rb
@@ -78,7 +78,7 @@ describe 'API v3 file links resource', with_flag: { storages_module_active: true
     allow(connection_manager)
       .to receive(:authorization_state).and_return(:connected)
     allow(connection_manager)
-      .to receive(:redirect_to_oauth_authorize).and_return('https://example.com/authorize')
+      .to receive(:get_authorization_uri).and_return('https://example.com/authorize')
 
     # Mock FileLinkSyncService as if Nextcloud would respond positively
     allow(::Storages::FileLinkSyncService)

--- a/modules/storages/spec/requests/api/v3/storages/storages_spec.rb
+++ b/modules/storages/spec/requests/api/v3/storages/storages_spec.rb
@@ -55,7 +55,7 @@ describe 'API v3 storages resource', with_flag: { storages_module_active: true }
   end
 
   before do
-    allow(connection_manager).to receive(:redirect_to_oauth_authorize).and_return(authorize_url)
+    allow(connection_manager).to receive(:get_authorization_uri).and_return(authorize_url)
     allow(connection_manager).to receive(:authorization_state).and_return(:connected)
     allow(::OAuthClients::ConnectionManager).to receive(:new).and_return(connection_manager)
     project_storage


### PR DESCRIPTION
https://community.openproject.org/work_packages/43387

- [x] Fixed the bug
- [x] Renamed the `ConnectionManager` instance method `redirect_to_oauth_authorize` to `get_authorization_uri` as there is no redirect happening.
- [x] added missing specs to cover that bug.