### PR TITLE
[#43329] Fix Pressing Enter has no effect when being in the global project select

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.component.ts
@@ -45,6 +45,11 @@ import {
 import { IProject } from 'core-app/core/state/projects/project.model';
 import { insertInList } from 'core-app/shared/components/project-include/insert-in-list';
 import { IProjectData } from 'core-app/shared/components/project-list/project-data';
+import { KeyCodes } from 'core-app/shared/helpers/keyCodes.enum';
+import {
+  projectListActionSelector,
+  projectListItemDisabled,
+} from 'core-app/shared/components/project-list/project-list.component';
 import { recursiveSort } from 'core-app/shared/components/project-include/recursive-sort';
 import { SearchableProjectListService } from 'core-app/shared/components/searchable-project-list/searchable-project-list.service';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
@@ -143,6 +148,31 @@ export class ProjectMenuAutocompleteComponent {
   close():void {
     this.searchableProjectListService.searchText = '';
     this.dropModalOpen = false;
+  }
+
+  onKeydown(event:KeyboardEvent):void {
+    if (event.keyCode === KeyCodes.ENTER) {
+      this.handleKeyEnter(event);
+    }
+
+    this.searchableProjectListService.onKeydown(event);
+  }
+
+  private handleKeyEnter(event:KeyboardEvent):void {
+    const focused = document.activeElement as HTMLElement|undefined;
+
+    // If the current focus is within a list action, return
+    if (focused?.closest(projectListActionSelector)) {
+      return;
+    }
+
+    const first = document.querySelector<HTMLAnchorElement>(`a${projectListActionSelector}:not(${projectListItemDisabled})`);
+
+    if (first) {
+      event.preventDefault();
+      first.focus();
+      window.location.href = first.href;
+    }
   }
 
   currentProjectName():string {

--- a/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.template.html
+++ b/frontend/src/app/shared/components/autocompleter/project-menu-autocomplete/project-menu-autocomplete.template.html
@@ -1,7 +1,7 @@
 <spot-drop-modal
   [open]="dropModalOpen"
   (closed)="close()"
-  (keydown)="searchableProjectListService.onKeydown($event)"
+  (keydown)="onKeydown($event)"
   alignment="bottom-left"
   class="op-project-list-modal"
 >

--- a/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
+++ b/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
@@ -115,6 +115,10 @@ export class SearchableProjectListService {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       if (!container || container.matches(projectListRootSelector)) {
+        // Move to the input when we reach the top of the list
+        if (upwards) {
+          return this.findInputElement();
+        }
         return null;
       }
 
@@ -145,10 +149,12 @@ export class SearchableProjectListService {
     const inputElement = this.findInputElement();
 
     switch (event.keyCode) {
+      case event.shiftKey && KeyCodes.TAB:
       case KeyCodes.UP_ARROW:
         event.preventDefault();
         this.handleKeyNavigation(true);
         break;
+      case KeyCodes.TAB:
       case KeyCodes.DOWN_ARROW:
         event.preventDefault();
         this.handleKeyNavigation(false);
@@ -158,6 +164,7 @@ export class SearchableProjectListService {
           event.preventDefault();
         }
         break;
+      case KeyCodes.SHIFT:
       case KeyCodes.ENTER:
         break;
       default:

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -163,4 +163,20 @@ describe 'Projects autocomplete page', type: :feature, js: true do
     expect(page).to have_current_path(project_news_index_path(project), ignore_query: true)
     expect(page).to have_selector('.news-menu-item.selected')
   end
+
+  it 'navigates to the first project upon hitting enter in the search bar' do
+    top_menu.toggle
+    top_menu.expect_open
+
+    # projects are displayed initially
+    top_menu.expect_result project.name
+
+    # Filter for projects
+    top_menu.search '<strong'
+
+    # Visit a project
+    top_menu.autocompleter.send_keys :enter
+
+    top_menu.expect_current_project project2.name
+  end
 end


### PR DESCRIPTION
See [OP#43329](https://community.openproject.com/wp/43329)

Initially I wanted the system to handle the link visiting, the same way it handles with focused links. It worked in Firefox, but Chrome was not triggering the link visit after focusing it, hence the `window.location.href`.