### PR TITLE
Fix search params in project autocompleter

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
@@ -187,7 +187,7 @@ export class ProjectAutocompleterComponent implements ControlValueAccessor {
           ...params,
         };
         const collectionURL = `${listParamsString(fullParams)}&${url.searchParams.toString()}`;
-        url.searchParams.forEach((key) => url.searchParams.delete(key));
+        url.search = '';
         return this.http.get<IHALCollection<IProject>>(url.toString() + collectionURL);
       },
     )


### PR DESCRIPTION
In `op-project-autocompleter`, the search params for the fetched url
were broken if the `url` input you provided to the component had a
search param applied as well. The search params would be semi-
concatenated, causing a doubling of `?`:

```
https://community.openproject.org/api/v3/projects/available_parent_projects?of=771?pageSize=-1&offset=1&select=elements/id,elements/name,elements/identifier,elements/self,elements/ancestors,total,count,pageSize&filters=%5B%5D&of=771
```

This commit fixes the way the search params are removed from the
externally provided URL, so that they really are.

Closes https://community.openproject.org/projects/openproject/work_packages/42965/activity