### PR TITLE
Fix internal server error when scheduling a wp

### DIFF
--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -143,12 +143,9 @@ class WorkPackages::SetScheduleService
 
   def reschedule_to_date(scheduled, date)
     new_start_date = [scheduled.start_date, date].compact.max
-
-    duration = scheduled.duration || 0;
-
     set_dates(scheduled,
               new_start_date,
-              scheduled.due_date && (new_start_date + duration - 1))
+              (scheduled.due_date && !scheduled.duration.nil?) && (new_start_date + scheduled.duration - 1))
   end
 
   def reschedule_by_delta(scheduled, delta, min_start_date)

--- a/app/services/work_packages/set_schedule_service.rb
+++ b/app/services/work_packages/set_schedule_service.rb
@@ -144,9 +144,11 @@ class WorkPackages::SetScheduleService
   def reschedule_to_date(scheduled, date)
     new_start_date = [scheduled.start_date, date].compact.max
 
+    duration = scheduled.duration || 0;
+
     set_dates(scheduled,
               new_start_date,
-              scheduled.due_date && (new_start_date + scheduled.duration - 1))
+              scheduled.due_date && (new_start_date + duration - 1))
   end
 
   def reschedule_by_delta(scheduled, delta, min_start_date)


### PR DESCRIPTION
When rescheduling a work package, in very specific cases the code would
hit the `set_schedule_service`, with a work package without a duration.
The service would attempt to set new wp dates by calculating the end date
from provided start date. However, if the work package has no duration
this calculation fails.

Closes https://community.openproject.org/projects/openproject/work_packages/40921/activity