### PR TITLE
Fix watcher selection dropdown being cut off

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.html
@@ -17,11 +17,13 @@
     <div class="work-package--watchers-lookup hide-when-print"
          [hidden]="!allowedToAdd">
       <form name="watcherForm" novalidate>
-        <op-user-autocompleter [clearAfterSelection]="true"
-                            (valueChange)="addWatcher($event)"
-                            [url]="availableWatchersPath"
-                            class="wp-watcher--autocomplete">
-        </op-user-autocompleter>
+        <op-user-autocompleter
+          [clearAfterSelection]="true"
+          (valueChange)="addWatcher($event)"
+          [url]="availableWatchersPath"
+          appendTo="body"
+          class="wp-watcher--autocomplete"
+        ></op-user-autocompleter>
       </form>
     </div>
   </div>

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -58,10 +58,11 @@ describe 'Watcher tab', js: true, selenium: true do
 
     it 'modifying the watcher list modifies the watch button' do
       # Add user as watcher
-      autocomplete = find('.wp-watcher--autocomplete')
+      autocomplete = find('.wp-watcher--autocomplete ng-select')
       select_autocomplete autocomplete,
                           query: user.firstname,
-                          select_text: user.name
+                          select_text: user.name,
+                          results_selector: 'body'
 
       # Expect the addition of the user to toggle WP watch button
       expect(page).to have_selector('[data-qa-selector="op-wp-watcher-name"]', count: 1, text: user.name)

--- a/spec/features/work_packages/tabs/watcher_tab_spec.rb
+++ b/spec/features/work_packages/tabs/watcher_tab_spec.rb
@@ -91,9 +91,10 @@ describe 'Watcher tab', js: true, selenium: true do
       end
 
       it 'escapes the user name' do
-        autocomplete = find('.wp-watcher--autocomplete')
+        autocomplete = find('.wp-watcher--autocomplete ng-select')
         target_dropdown = search_autocomplete autocomplete,
-                                              query: 'foo'
+                                              query: 'foo',
+                                              results_selector: 'body'
 
         expect(target_dropdown).to have_selector(".ng-option", text: html_user.firstname)
         expect(target_dropdown).to have_no_selector(".ng-option em")
@@ -150,9 +151,10 @@ describe 'Watcher tab', js: true, selenium: true do
     end
 
     it 'does not show the placeholder user as an option' do
-      autocomplete = find('.wp-watcher--autocomplete')
+      autocomplete = find('.wp-watcher--autocomplete ng-select')
       target_dropdown = search_autocomplete autocomplete,
-                                            query: ''
+                                            query: '',
+                                            results_selector: 'body'
 
       expect(target_dropdown).to have_selector(".ng-option", text: user.name)
       expect(target_dropdown).to have_no_selector(".ng-option", text: placeholder.name)


### PR DESCRIPTION
The watcher tab container was cutting of the dropdown because of
`overflow: auto` CSS requirements. The issue is fixed in this commit
by appending the dropdown to the body instead of as a direct child.

Closes https://community.openproject.org/projects/openproject/work_packages/43421/activity