### PR TITLE
[21754] Move buttons in log time modal to correct side

### DIFF
--- a/frontend/src/app/shared/components/time_entries/shared/modal/base.modal.html
+++ b/frontend/src/app/shared/components/time_entries/shared/modal/base.modal.html
@@ -18,13 +18,15 @@
   </div>
 
   <div class="op-modal--footer op-modal--footer_split-actions">
-    <button class="button -danger"
-            *ngIf="deleteAllowed"
-            (click)="destroy()"
-            [textContent]="text.delete"
-            [attr.title]="text.delete">
-    </button>
-    <section>
+    <div>
+      <button class="button -danger"
+              *ngIf="deleteAllowed"
+              (click)="destroy()"
+              [textContent]="text.delete"
+              [attr.title]="text.delete">
+      </button>
+    </div>
+    <div>
       <button class="button"
               *ngIf="saveAllowed"
               (click)="closeMe($event)"
@@ -38,6 +40,6 @@
               [textContent]="text.save"
               [disabled]="formInFlight">
       </button>
-    </section>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Move button into its own section, so that we assure the contents in the split actions are always on the respective correct sides.

Fixes
https://community.openproject.org/projects/openproject/work_packages/21754#activity-103