### PR TITLE
[43164] Missing space between label and help text icon

### DIFF
--- a/frontend/src/global_styles/content/_attributes_key_value.sass
+++ b/frontend/src/global_styles/content/_attributes_key_value.sass
@@ -43,6 +43,7 @@
   > wp-replacement-label
     @include text-shortener
     flex: 0 1 auto
+    padding-right: $spot-spacing-0_5
 
 .attributes-key-value--value-container
   display: flex

--- a/frontend/src/global_styles/content/work_packages/_table_content.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_content.sass
@@ -74,9 +74,8 @@
   line-height: 24px
 
   // Avoid that the select field gets too small
-  .inline-edit--field
-    &.ng-select, ng-select
-      min-width: 140px
+  .inline-edit--field.ng-select
+    min-width: 140px
 
 // Styles for inline editable attributes
 .work-package-table--container td.-editable

--- a/frontend/src/global_styles/content/work_packages/_table_content.sass
+++ b/frontend/src/global_styles/content/work_packages/_table_content.sass
@@ -74,8 +74,9 @@
   line-height: 24px
 
   // Avoid that the select field gets too small
-  .inline-edit--field.ng-select
-    min-width: 140px
+  .inline-edit--field
+    &.ng-select, ng-select
+      min-width: 140px
 
 // Styles for inline editable attributes
 .work-package-table--container td.-editable

--- a/frontend/src/global_styles/fonts/_openproject_icon_font.sass
+++ b/frontend/src/global_styles/fonts/_openproject_icon_font.sass
@@ -49,7 +49,7 @@
   padding: 0 20px 0 7px
 
 @mixin icon3-rules
-  padding: 0 8px 0 0
+  padding: 0 $spot-spacing-0-5
 
 @mixin icon4-rules
   padding: 0 8px 0 3px

--- a/frontend/src/global_styles/fonts/_openproject_icon_font.sass
+++ b/frontend/src/global_styles/fonts/_openproject_icon_font.sass
@@ -49,7 +49,7 @@
   padding: 0 20px 0 7px
 
 @mixin icon3-rules
-  padding: 0 $spot-spacing-0-5
+  padding: 0 $spot-spacing-0_5 0 0
 
 @mixin icon4-rules
   padding: 0 8px 0 3px


### PR DESCRIPTION
Add some space to the right side of the label of wp details.

https://community.openproject.org/projects/openproject/work_packages/43164/activity