### PR TITLE
[#43393] [AppSignal] invalid input syntax for type integer: ""

### DIFF
--- a/modules/reporting/lib/report/operator.rb
+++ b/modules/reporting/lib/report/operator.rb
@@ -91,7 +91,7 @@ class Report::Operator
     new '!', label: :label_not_equals do
       def modify(query, field, *values)
         where_clause = "(#{field} IS NULL"
-        where_clause += " OR #{field} NOT IN #{collection(*values)}" unless values.compact.empty?
+        where_clause += " OR #{field} NOT IN #{collection(*values)}" unless values.all?(&:blank?)
         where_clause += ')'
         query.where where_clause
         query
@@ -117,7 +117,7 @@ class Report::Operator
       def modify(query, field, *values)
         if values.size == 1 && values.first.nil?
           query.where "#{field} IS NULL"
-        elsif values.compact.empty?
+        elsif values.all?(&:blank?)
           query.where '1=0'
         else
           query.where "#{field} IN #{collection(*values)}"

--- a/modules/reporting/spec/models/cost_query/operator_spec.rb
+++ b/modules/reporting/spec/models/cost_query/operator_spec.rb
@@ -71,6 +71,10 @@ describe CostQuery, type: :model, reporting_query_helper: true do
       expect(query('projects', 'id', '=', nil).size).to eq(0)
     end
 
+    it "does = for empty string" do
+      expect(query('projects', 'id', '=', '').size).to eq(0)
+    end
+
     it "does <=" do
       expect(query('projects', 'id', '<=', project2.id - 1).size).to eq(1)
     end
@@ -81,6 +85,10 @@ describe CostQuery, type: :model, reporting_query_helper: true do
 
     it "does !" do
       expect(query('projects', 'id', '!', project1.id).size).to eq(1)
+    end
+
+    it "does ! for empty string" do
+      expect(query('projects', 'id', '!', '').size).to eq(0)
     end
 
     it "does ! for multiple values" do


### PR DESCRIPTION
See [OP#43393](https://community.openproject.org/work_packages/43393)

The error reported from appsignal contains two different errors, the error handled here is:
- [X] [invalid input syntax for type integer: ""](https://appsignal.com/openproject-gmbh/sites/62b06dacd2a5e41321946fcf/exceptions/incidents/298/samples/62b06dacd2a5e41321946fcf-1143724366459477625916593445801?activeFilter=timeline&selectedTime=2022-08-02T08%3A00%3A00.000Z)
