### PR TITLE
Fix/time entry modal wp nuisances

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -186,6 +186,7 @@
 <ng-template let-item let-search="search" let-clear="clear" #defaultLabel>
   <ng-container *ngIf="resource === 'work_packages'">
     <span
+      *ngIf="item.id"
       class="ng-value-label"
       [ngOptionHighlight]="search"
     >

--- a/frontend/src/app/shared/components/autocompleter/te-work-package-autocompleter/te-work-package-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/te-work-package-autocompleter/te-work-package-autocompleter.component.html
@@ -1,5 +1,4 @@
 <op-autocompleter
-  #ngSelectComponent
   [model]="model"
   [items]="availableValues"
   [ngClass]="classes"
@@ -17,7 +16,6 @@
   (open)="opened()"
   (close)="closed()"
   (keydown)="keyPressed($event)"
-  bindLabel="name"
   resource="work_packages"
 >
   <ng-template op-autocompleter-header-tmp>
@@ -51,8 +49,5 @@
         </ul>
       </div>
     </div>
-  </ng-template>
-  <ng-template op-autocompleter-tag-tmp let-search="searchTerm">
-    <b [textContent]="text.add_new_action"></b>: {{search}}
   </ng-template>
 </op-autocompleter>

--- a/frontend/src/app/shared/components/time_entries/form/form.component.html
+++ b/frontend/src/app/shared/components/time_entries/form/form.component.html
@@ -40,7 +40,7 @@
     </div>
 
     <ng-container *ngIf="showWorkPackageField">
-      <div lass="attributes-map--key"
+      <div class="attributes-map--key"
            [ngClass]="{'-required': isRequired('workPackage')}"
            [textContent]="schema.workPackage.name">
       </div>


### PR DESCRIPTION
Small improvements to the work package selector for logging time:

* Fixes class of label
* Fixes displaying a # before a work package is selected. The proper fix would be to not treat `{ href: null }` as a selected value but that could not be achieved.
* Remove unnecessary code

The modal now looks like this:
<img width="652" alt="image" src="https://user-images.githubusercontent.com/617519/182377129-e99b207c-1cf4-4ce8-96e2-f2b0e3891033.png">

Where it looked like this before:
<img width="648" alt="image" src="https://user-images.githubusercontent.com/617519/182377212-eec37212-f0ff-456f-b3da-4311b40c3325.png">
