### PR TITLE
Bug/43509 wrong principals available for logging time limited by page size

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component.ts
@@ -190,7 +190,7 @@ export class UserAutocompleterComponent extends UntilDestroyedMixin implements O
 
     return this
       .halResourceService
-      .get<CollectionResource<UserResource>>(filteredURL.toString())
+      .get<CollectionResource<UserResource>>(filteredURL.toString(), { pageSize: -1 })
       .pipe(
         map((res) => res.elements.map((el) => ({
           name: el.name, id: el.id, href: el.href, avatar: el.avatar,

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -519,11 +519,6 @@ module API
             "#{project(project_id)}/work_packages"
           end
 
-          def self.filtered_path(base_path, *filters)
-            escaped = CGI.escape(::JSON.dump(filters))
-            "#{base_path}?filters=#{escaped}"
-          end
-
           def self.path_for(path, filters: nil, sort_by: nil, group_by: nil, page_size: nil, offset: nil, select: nil)
             query_params = {
               filters: filters&.to_json,

--- a/modules/costs/lib/api/v3/time_entries/schemas/time_entry_schema_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/schemas/time_entry_schema_representer.rb
@@ -103,10 +103,12 @@ module API
           end
 
           def allowed_user_href
-            api_v3_paths.filtered_path api_v3_paths.principals,
-                                       status: { operator: '!', values: [Principal.statuses[:locked].to_s] },
-                                       type: { operator: '=', values: ['User'] },
-                                       member: { operator: '=', values: [represented.project_id] }
+            api_v3_paths.path_for :principals,
+                                  filters: [
+                                    { status: { operator: '!', values: [Principal.statuses[:locked].to_s] } },
+                                    { type: { operator: '=', values: ['User'] } },
+                                    { member: { operator: '=', values: [represented.project_id] } }
+                                  ]
           end
         end
       end

--- a/modules/costs/spec/lib/api/v3/time_entries/schemas/time_entry_schema_representer_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/schemas/time_entry_schema_representer_spec.rb
@@ -238,6 +238,33 @@ describe ::API::V3::TimeEntries::Schemas::TimeEntrySchemaRepresenter do
           end
         end
       end
+
+      describe 'user' do
+        let(:path) { 'user' }
+
+        it_behaves_like 'has basic schema properties' do
+          let(:type) { 'User' }
+          let(:name) { TimeEntry.human_attribute_name('user') }
+          let(:required) { true }
+          let(:writable) { true }
+          let(:location) { '_links' }
+        end
+
+        context 'if embedding' do
+          let(:embedded) { true }
+
+          it_behaves_like 'links to allowed values via collection link' do
+            let(:href) do
+              api_v3_paths.path_for :principals,
+                                    filters: [
+                                      { status: { operator: '!', values: [Principal.statuses[:locked].to_s] } },
+                                      { type: { operator: '=', values: ['User'] } },
+                                      { member: { operator: '=', values: [project.id] } }
+                                    ]
+            end
+          end
+        end
+      end
     end
 
     context 'custom value' do


### PR DESCRIPTION
Fixes applying the filters for the available users when logging time. Additionally applies the `-1` pageSize to load more users. 

https://community.openproject.org/wp/43509