### PR TITLE
Bug/43393 validate time entry spent on

### DIFF
--- a/modules/costs/app/contracts/time_entries/base_contract.rb
+++ b/modules/costs/app/contracts/time_entries/base_contract.rb
@@ -45,6 +45,11 @@ module TimeEntries
     validate :validate_project_is_set
     validate :validate_work_package
 
+    validates :spent_on,
+              date: { before_or_equal_to: Proc.new { Time.zone.today },
+                      allow_blank: true },
+              unless: Proc.new { spent_on.blank? }
+
     attribute :project_id
     attribute :work_package_id
     attribute :activity_id do

--- a/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
+++ b/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
@@ -162,6 +162,30 @@ shared_examples_for 'time entry contract' do
     end
   end
 
+  context 'when spent_on is in the future' do
+    let(:time_entry_spent_on) { Time.zone.tomorrow }
+
+    it 'is invalid' do
+      expect_valid(false, spent_on: %i(date_before_or_equal_to))
+    end
+  end
+
+  context 'when spent_on is today' do
+    let(:time_entry_spent_on) { Time.zone.today }
+
+    it 'is valid' do
+      expect_valid(true)
+    end
+  end
+
+  context 'when spent_on is in the past' do
+    let(:time_entry_spent_on) { Time.zone.yesterday }
+
+    it 'is valid' do
+      expect_valid(true)
+    end
+  end
+
   context 'when hours is nil' do
     let(:time_entry_hours) { nil }
 


### PR DESCRIPTION
See [OP#43393](https://community.openproject.org/wp/43393)

The error mentioned in the work package was caused by an invalid date in the future, that has been corrected. This PR adds a validation on the `spend_on` attribute to prevent it from happening again.