### PR TITLE
[43306] Wrong positioning of workers in notification

### DIFF
--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -137,3 +137,6 @@ $subject-font-size: 14px
     grid-template-columns: max-content auto minmax(20px, max-content)
     grid-template-areas: "loadingIndicator count buttons"
     grid-column-gap: 5px
+
+  &--actors
+    vertical-align: baseline

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.sass
@@ -140,3 +140,4 @@ $subject-font-size: 14px
 
   &--actors
     vertical-align: baseline
+  

--- a/frontend/src/global_styles/content/_principal.sass
+++ b/frontend/src/global_styles/content/_principal.sass
@@ -12,7 +12,6 @@
     flex-grow: 1
     flex-shrink: 1
     min-width: 0 // See: https://css-tricks.com/flexbox-truncated-text/
-    margin-left: 10px
 
   &_wrapped &--name
     white-space: normal
@@ -25,3 +24,6 @@
     @media screen and (max-width: 680px)
       &--name
         display: none
+
+  .op-avatar + .op-principal--name
+    margin-left: $spot-spacing-0_5


### PR DESCRIPTION
Set a margin to the left of principal name only when there is an avatar beside it and reset the vertical alignment of principal component.

https://community.openproject.org/projects/openproject/work_packages/43306/activity