### PR TITLE
avoid sending headers and withCredentials on job status download

### DIFF
--- a/frontend/src/app/core/file-upload/op-direct-file-upload.service.ts
+++ b/frontend/src/app/core/file-upload/op-direct-file-upload.service.ts
@@ -78,7 +78,7 @@ export class OpenProjectDirectFileUploadService extends OpenProjectFileUploadSer
           body: result.form,
           // Observe the response, not the body
           observe: 'events',
-          // This is important as the CORS policy for the bucket is * and you can't use credentals then,
+          // This is important as the CORS policy for the bucket is * and you can't use credentials then,
           // besides we don't need them here anyway.
           headers: {
             [EXTERNAL_REQUEST_HEADER]: 'true',

--- a/frontend/src/app/features/job-status/job-status.interface.ts
+++ b/frontend/src/app/features/job-status/job-status.interface.ts
@@ -23,5 +23,6 @@ export interface JobStatusInterface {
     title?:string;
     download?:string;
     redirect?:string;
+    errors?:string;
   };
 }


### PR DESCRIPTION
Treat downloading a wp export (e.g. xls, pdf) to be an external request which it might or might not be. This depends on whether an external storage is provided. But if an external storage is used, sending credentials and headers leads to CORS not being granted so we avoid sending it. On same site requests, the `withCredentials` setting has no effect in any case.

In case of a CORS error, the download link is displayed directly now so that the user has a fallback.

https://community.openproject.org/wp/43523