### PR TITLE
[#43530] Apply "No SSL" as specified with packager

### DIFF
--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
@@ -110,6 +110,8 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
 
   dateChangedManually$ = new Subject<void>();
 
+  private debounceDelay = 0; // will change after initial render
+
   private changeset:ResourceChangeset;
 
   private datePickerInstance:DatePicker;
@@ -158,9 +160,12 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
         //   2. So he/she starts entering the finish date 2022-07-1 .
         //   3. This is already a valid date. Since it is before the start date,the start date would be changed automatically to the first without the debounce.
         //   4. The debounce gives the user enough time to type the last number "9" before the changes are converted to the datepicker and the start date would be affected.
-        debounceTime(800),
+        // debounce delay is 0 for initial display, and then set to 800
+        debounceTime(this.debounceDelay),
       )
       .subscribe(() => {
+        // set debounce delay to its real value
+        this.debounceDelay = 800;
         // Always update the whole form to ensure that no values are lost/inconsistent
         if (this.singleDate) {
           this.updateDate('date', this.dates.date);

--- a/lib/tasks/packager.rake
+++ b/lib/tasks/packager.rake
@@ -65,11 +65,13 @@ namespace :packager do
     Setting.sys_api_key = ENV.fetch('SYS_API_KEY', nil)
     Setting.host_name = ENV.fetch('SERVER_HOSTNAME', Setting.host_name)
 
+    # SERVER_PROTOCOL is set by the packager apache2 addon
+    # other SERVER_PROTOCOL_xxx variables can be manually set by user
     if ENV['SERVER_PROTOCOL_HTTPS_NO_HSTS']
       # Allow setting only HTTPS setting without enabling FORCE__SSL
       # due to external proxy configuration. This avoids activation of HSTS headers.
       shell_setup(['config:set', "OPENPROJECT_HTTPS=true"])
-      shell_setup(['config:unset', "OPENPROJECT_RAILS__FORCE__SSL"])
+      shell_setup(['config:set', "OPENPROJECT_RAILS__FORCE__SSL=false"])
     elsif ENV['SERVER_PROTOCOL_FORCE_HTTPS'] || ENV.fetch('SERVER_PROTOCOL', Setting.protocol) == 'https'
       # Allow overriding the protocol setting from ENV
       # to allow instances where SSL is terminated earlier to respect that setting
@@ -77,7 +79,7 @@ namespace :packager do
       shell_setup(['config:set', "OPENPROJECT_RAILS__FORCE__SSL=true"])
     else
       shell_setup(['config:set', "OPENPROJECT_HTTPS=false"])
-      shell_setup(['config:unset', "OPENPROJECT_RAILS__FORCE__SSL"])
+      shell_setup(['config:set', "OPENPROJECT_RAILS__FORCE__SSL=false"])
     end
 
     # Run customization step, if it is defined.


### PR DESCRIPTION
Default value of `Setting.rails_force_ssl` was `false` before
9e3c51299ae, and `true` after. As the default value changed to true, it
lead a packaged installation to a forced ssl even if "No SSL" was
chosen.

Instead of unsetting `OPENPROJECT_RAILS__FORCE__SSL` and assume a
default value of `false`, explicitly set it to either `true` or `false`
to fix the problem.

work package: https://community.openproject.org/projects/openproject/work_packages/43530