### PR TITLE
set duration on seeding & use 1 day as minimum

### DIFF
--- a/app/seeders/demo_data/work_package_seeder.rb
+++ b/app/seeders/demo_data/work_package_seeder.rb
@@ -150,6 +150,7 @@ module DemoData
 
       wp_attr[:start_date] = start_date
       wp_attr[:due_date] = calculate_due_date(start_date, attributes[:duration]) if start_date && attributes[:duration]
+      wp_attr[:duration] = attributes[:duration] || 1
       wp_attr[:done_ratio] = attributes[:done_ratio].to_i if attributes[:done_ratio]
       wp_attr[:estimated_hours] = attributes[:estimated_hours].to_i if attributes[:estimated_hours]
     end

--- a/config/locales/en.seeders.standard.yml
+++ b/config/locales/en.seeders.standard.yml
@@ -130,7 +130,7 @@ en:
                 description:
                 status: default_status_closed
                 type: default_type_milestone
-                duration: 0
+                duration: 1
                 schedule_manually: false
               - start: 0
                 subject: Organize open source conference
@@ -191,7 +191,7 @@ en:
                 description:
                 status: default_status_scheduled
                 type: default_type_milestone
-                duration: 0
+                duration: 1
                 relations:
                   - to: Organize open source conference
                     type: follows
@@ -227,7 +227,7 @@ en:
                 description:
                 status: default_status_new
                 type: default_type_milestone
-                duration: 0
+                duration: 1
                 relations:
                   - to: Follow-up tasks
                     type: follows
@@ -384,7 +384,7 @@ en:
                 status: :default_status_specified
                 type: :default_type_epic
                 start: 26
-                duration: 0
+                duration: 1
                 children:
                   - subject: Newsletter registration form
                     status: :default_status_in_progress
@@ -403,21 +403,21 @@ en:
                     position: 2
                     story_points: 3
                     start: 26
-                    duration: 0
+                    duration: 1
                     children:
                       - subject: Create wireframes for new landing page
                         status: :default_status_in_progress
                         type: :default_type_task
                         version: Sprint 1
                         start: 26
-                        duration: 0
+                        duration: 1
               - subject: Contact form
                 status: :default_status_specified
                 type: :default_type_user_story
                 version: Sprint 1
                 position: 5
                 start: 21
-                duration: 0
+                duration: 1
                 story_points: 1
               - subject: Feature carousel
                 status: :default_status_specified
@@ -437,7 +437,7 @@ en:
                 position: 4
                 story_points: 1
                 start: 21
-                duration: 0
+                duration: 1
               - subject: SSL certificate
                 status: :default_status_specified
                 type: :default_type_user_story
@@ -451,7 +451,7 @@ en:
                 version: Product Backlog
                 position: 2
                 start: 23
-                duration: 0
+                duration: 1
               - subject: Choose a content management system
                 status: :default_status_specified
                 type: :default_type_user_story
@@ -466,21 +466,21 @@ en:
                 position: 7
                 story_points: 3
                 start: 25
-                duration: 0
+                duration: 1
                 children:
                   - subject: Set up navigation concept for website.
                     status: :default_status_in_specification
                     type: :default_type_task
                     version: Sprint 1
                     start: 25
-                    duration: 0
+                    duration: 1
               - subject: Internal link structure
                 status: :default_status_closed
                 type: :default_type_user_story
                 version: Product Backlog
                 position: 5
                 start: 25
-                duration: 0
+                duration: 1
               - subject: Develop v1.0
                 status: :default_status_in_progress
                 type: :default_type_phase
@@ -490,7 +490,7 @@ en:
                 status: :default_status_new
                 type: :default_type_milestone
                 start: 18
-                duration: 0
+                duration: 1
                 relations:
                   - to: Develop v1.0
                     type: follows
@@ -503,7 +503,7 @@ en:
                 status: :default_status_new
                 type: :default_type_milestone
                 start: 25
-                duration: 0
+                duration: 1
                 relations:
                   - to: Develop v1.1
                     type: follows
@@ -516,7 +516,7 @@ en:
                 status: :default_status_new
                 type: :default_type_milestone
                 start: 32
-                duration: 0
+                duration: 1
                 relations:
                   - to: Develop v2.0
                     type: follows

--- a/modules/bim/config/locales/en.seeders.bim.yml
+++ b/modules/bim/config/locales/en.seeders.bim.yml
@@ -231,7 +231,7 @@ en:
                 :status: default_status_new
                 :type: default_type_milestone
                 :assigned_to: Planners
-                :duration: 0
+                :duration: 1
               - :start: 7
                 :subject: Basic evaluation
                 :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
@@ -285,7 +285,7 @@ en:
                     :status: default_status_new
                     :type: default_type_milestone
                     :assigned_to: Planners
-                    :duration: 0
+                    :duration: 1
                     :relations:
                       - :to: Summarize the results
                         :type: follows
@@ -354,7 +354,7 @@ en:
                 :status: default_status_new
                 :type: default_type_milestone
                 :assigned_to: Planners
-                :duration: 0
+                :duration: 1
                 :relations:
                   - :to: Summarize results
                     :type: follows
@@ -393,7 +393,7 @@ en:
                     :status: default_status_new
                     :type: default_type_milestone
                     :assigned_to: Planners
-                    :duration: 0
+                    :duration: 1
                     :relations:
                       - :to: Finishing design
                         :type: follows
@@ -530,7 +530,7 @@ en:
                       *   Bring some drinks, snacks and your smile
                     :status: default_status_new
                     :type: default_type_milestone
-                    :duration: 0
+                    :duration: 1
                     :relations:
                       - :to: Final touches
                         :type: follows
@@ -618,7 +618,7 @@ en:
                 :status: default_status_new
                 :type: default_type_milestone
                 :assigned_to: BIM Managers
-                :duration: 0
+                :duration: 1
               - :start: 15
                 :subject: Project preperation
                 :description: This type is hierarchicaly a parent of the types &quot;Clash&quot;
@@ -676,7 +676,7 @@ en:
                     :status: seeders.bim.default_status_resolved
                     :type: default_type_milestone
                     :assigned_to: BIM Coordinators
-                    :duration: 0
+                    :duration: 1
                     :relations:
                       - :to: Creating the BIM execution plan
                         :type: follows
@@ -689,7 +689,7 @@ en:
                 :status: default_status_new
                 :type: default_type_milestone
                 :assigned_to: BIM Managers
-                :duration: 0
+                :duration: 1
                 :relations:
                   - :to: Project preperation
                     :type: follows
@@ -745,7 +745,7 @@ en:
                     :status: default_status_new
                     :type: default_type_milestone
                     :assigned_to: BIM Modellers
-                    :duration: 0
+                    :duration: 1
                     :relations:
                       - :to: Initial, internal model check and revising
                         :type: follows
@@ -776,7 +776,7 @@ en:
                     :status: default_status_new
                     :type: default_type_task
                     :assigned_to: BIM Modellers
-                    :duration: 0
+                    :duration: 1
                     :relations:
                       - :to: Submitting initial BIM model
                         :type: follows
@@ -824,7 +824,7 @@ en:
                     :status: default_status_new
                     :type: default_type_milestone
                     :assigned_to: BIM Modellers
-                    :duration: 0
+                    :duration: 1
                     :relations:
                       - :to: First Cycle, internal model check and revising
                         :type: follows
@@ -871,7 +871,7 @@ en:
                     :status: default_status_new
                     :type: default_type_milestone
                     :assigned_to: Lead BIM Coordinators
-                    :duration: 0
+                    :duration: 1
                     :relations:
                       - :to: Issue management, first cycle
                         :type: follows
@@ -886,7 +886,7 @@ en:
                 :status: default_status_new
                 :type: default_type_phase
                 :assigned_to: Lead BIM Coordinators
-                :duration: 0
+                :duration: 1
                 :relations:
                   - :to: Finishing coordination, first cycle
                     :type: follows
@@ -897,7 +897,7 @@ en:
                 :status: default_status_new
                 :type: default_type_phase
                 :assigned_to: Lead BIM Coordinators
-                :duration: 0
+                :duration: 1
                 :relations:
                   - :to: Modelling & coordinating, second cycle
                     :type: follows
@@ -907,7 +907,7 @@ en:
                 :status: default_status_new
                 :type: default_type_phase
                 :assigned_to: Lead BIM Coordinators
-                :duration: 0
+                :duration: 1
                 :relations:
                   - :to: Modelling & coordinating, ... cycle
                     :type: follows
@@ -918,7 +918,7 @@ en:
                 :status: default_status_new
                 :type: default_type_phase
                 :assigned_to: BIM Coordinators
-                :duration: 0
+                :duration: 1
                 :relations:
                   - :to: Modelling & coordinating, (n-th minus 1) cycle
                     :type: follows
@@ -929,7 +929,7 @@ en:
                 :status: default_status_new
                 :type: default_type_milestone
                 :assigned_to: BIM Coordinators
-                :duration: 0
+                :duration: 1
                 :relations:
                   - :to: Modelling & coordinating n-th cycle
                     :type: follows
@@ -980,7 +980,7 @@ en:
                     :status: default_status_new
                     :type: default_type_milestone
                     :assigned_to: BIM Coordinators
-                    :duration: 0
+                    :duration: 1
                     :relations:
                       - :to: Construct the building
                         :type: follows
@@ -1013,7 +1013,7 @@ en:
                 :status: default_status_new
                 :type: default_type_milestone
                 :assigned_to: Lead BIM Coordinators
-                :duration: 0
+                :duration: 1
                 :relations:
                   - :to: Finish construction
                     :type: follows
@@ -1022,7 +1022,7 @@ en:
                 :description: Enjoy your building :)
                 :status: default_status_new
                 :type: default_type_phase
-                :duration: 0
+                :duration: 1
                 :relations:
                   - :to: Handover for Facility Management
                     :type: follows


### PR DESCRIPTION
This is in line with the way the application normally creates work packages. There, even milestones have a duration of 1.

This does not change the due_dates of the seeded work packages.

Fixes https://community.openproject.org/wp/43526 as in the described scenario, work packages are attempted to be copied that do not have a duration.