### PR TITLE
Fix self and offset links with empty select param

### DIFF
--- a/app/services/api/v3/work_package_collection_from_query_service.rb
+++ b/app/services/api/v3/work_package_collection_from_query_service.rb
@@ -77,7 +77,9 @@ module API
       end
 
       def calculate_resulting_params(provided_params)
-        calculate_default_params.merge(provided_params.slice('offset', 'pageSize').symbolize_keys).tap do |params|
+        calculate_default_params
+          .merge(provided_params.slice('offset', 'pageSize').symbolize_keys)
+          .tap do |params|
           if query.manually_sorted?
             params[:query_id] = query.id
             params[:offset] = 1
@@ -89,7 +91,7 @@ module API
             params[:pageSize] = pageSizeParam(params)
           end
 
-          params[:select] = nested_from_csv(provided_params['select'])
+          params[:select] = nested_from_csv(provided_params['select']) if provided_params['select']
         end
       end
 


### PR DESCRIPTION
The select query param is output as empty if not passed, this breaks self, next, jumpTo, etc. links

https://community.openproject.org/wp/43486