### PR TITLE
[42185] Datepicker fixes

### DIFF
--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
@@ -174,7 +174,10 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
         // Always update the whole form to ensure that no values are lost/inconsistent
         if (this.singleDate) {
           this.updateDate('date', this.dates.date);
-        } else {
+        } else if (this.datepickerService.currentlyActivatedDateField === 'start') {
+          this.updateDate('end', this.dates.end);
+          this.updateDate('start', this.dates.start);
+        } else if (this.datepickerService.currentlyActivatedDateField === 'end') {
           this.updateDate('start', this.dates.start);
           this.updateDate('end', this.dates.end);
         }

--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.ts
@@ -53,11 +53,14 @@ import { DayElement } from 'flatpickr/dist/types/instance';
 import flatpickr from 'flatpickr';
 import { DatepickerModalService } from 'core-app/shared/components/datepicker/datepicker.modal.service';
 import {
-  debounceTime,
+  debounce,
   take,
 } from 'rxjs/operators';
 import { activeFieldContainerClassName } from 'core-app/shared/components/fields/edit/edit-form/edit-form';
-import { Subject } from 'rxjs';
+import {
+  Subject,
+  timer,
+} from 'rxjs';
 
 export type DateKeys = 'date'|'start'|'end';
 
@@ -160,12 +163,14 @@ export class DatePickerModalComponent extends OpModalComponent implements AfterV
         //   2. So he/she starts entering the finish date 2022-07-1 .
         //   3. This is already a valid date. Since it is before the start date,the start date would be changed automatically to the first without the debounce.
         //   4. The debounce gives the user enough time to type the last number "9" before the changes are converted to the datepicker and the start date would be affected.
-        // debounce delay is 0 for initial display, and then set to 800
-        debounceTime(this.debounceDelay),
+        //
+        // Debounce delay is 0 for initial display, and then set to 800
+        debounce(() => timer(this.debounceDelay)),
       )
       .subscribe(() => {
         // set debounce delay to its real value
         this.debounceDelay = 800;
+
         // Always update the whole form to ensure that no values are lost/inconsistent
         if (this.singleDate) {
           this.updateDate('date', this.dates.date);


### PR DESCRIPTION
This PR does two things:

- [x] Take care that the debounce actually uses the updated variable. Before, the delay was always at 0 seconds reintroducing the issue we actually wanted to prevent with that delay.
- [x] Always update the currently focused field last. Thus we guarantee that the datepicker jumps to the last entered date. (Fixes https://community.openproject.org/projects/openproject/work_packages/42185#activity-27)