### PR TITLE
Prevent date overflow on time_entries.spent_on

### DIFF
--- a/modules/costs/app/contracts/time_entries/base_contract.rb
+++ b/modules/costs/app/contracts/time_entries/base_contract.rb
@@ -46,7 +46,7 @@ module TimeEntries
     validate :validate_work_package
 
     validates :spent_on,
-              date: { before_or_equal_to: Proc.new { Time.zone.today },
+              date: { before_or_equal_to: Proc.new { Date.new(9999, 12, 31) },
                       allow_blank: true },
               unless: Proc.new { spent_on.blank? }
 

--- a/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
+++ b/modules/costs/spec/contracts/time_entries/shared_contract_examples.rb
@@ -48,13 +48,13 @@ shared_examples_for 'time entry contract' do
     build_stubbed(:time_entry_activity)
   end
   let(:time_entry_activity_active) { true }
-  let(:time_entry_spent_on) { Date.today }
+  let(:time_entry_spent_on) { Time.zone.today }
   let(:time_entry_hours) { 5 }
   let(:time_entry_comments) { "A comment" }
   let(:work_package_visible) { true }
   let(:time_entry_day_sum) { 5 }
   let(:activities_scope) do
-    scope = double('activities')
+    scope = class_double(TimeEntryActivity)
 
     if time_entry_activity
       allow(scope)
@@ -78,7 +78,7 @@ shared_examples_for 'time entry contract' do
       .to receive(:active_in_project)
       .and_return(TimeEntryActivity.none)
 
-    of_user_and_day_scope = double('of_user_and_day_scope')
+    of_user_and_day_scope = instance_double(ActiveRecord::Relation)
 
     allow(TimeEntry)
       .to receive(:of_user_and_day)
@@ -162,11 +162,19 @@ shared_examples_for 'time entry contract' do
     end
   end
 
-  context 'when spent_on is in the future' do
-    let(:time_entry_spent_on) { Time.zone.tomorrow }
+  context 'when spent_on is outside the year limits to prevent overflow in postgres' do
+    let(:time_entry_spent_on) { Date.new(10000) }
 
     it 'is invalid' do
       expect_valid(false, spent_on: %i(date_before_or_equal_to))
+    end
+  end
+
+  context 'when spent_on is in the future' do
+    let(:time_entry_spent_on) { Date.new(9999) }
+
+    it 'is valid' do
+      expect_valid(true)
     end
   end
 
@@ -199,14 +207,6 @@ shared_examples_for 'time entry contract' do
 
     it 'is invalid' do
       expect_valid(false, hours: %i(invalid))
-    end
-  end
-
-  context 'when hours is nil' do
-    let(:time_entry_hours) { nil }
-
-    it 'is invalid' do
-      expect_valid(false, hours: %i(blank))
     end
   end
 
@@ -251,8 +251,8 @@ shared_examples_for 'time entry contract' do
   end
 
   describe 'assignable_versions' do
-    let(:project_versions) { double('project versions') }
-    let(:wp_versions) { double('work_package versions') }
+    let(:project_versions) { [instance_double(Version)] }
+    let(:wp_versions) { [instance_double(Version)] }
 
     before do
       if time_entry_project


### PR DESCRIPTION
Also fixing a failing spec at `modules/my_page/spec/features/my/time_entries_current_user_spec.rb`