### PR TITLE
make op error handler work in cluster mode outside controllers again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -174,7 +174,7 @@ gem 'sprockets', '~> 3.7.2' # lock sprockets below 4.0
 gem 'sprockets-rails', '~> 3.4.2'
 
 gem 'puma', '~> 5.6'
-gem 'rack-timeout', '~> 0.6.0', require: "rack/timeout/base"
+gem 'rack-timeout', '~> 0.6.3', require: "rack/timeout/base"
 gem 'puma-plugin-statsd', '~> 2.0'
 
 gem 'nokogiri', '~> 1.13.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1134,7 +1134,7 @@ DEPENDENCIES
   rack-mini-profiler
   rack-protection (~> 2.2.0)
   rack-test (~> 2.0.0)
-  rack-timeout (~> 0.6.0)
+  rack-timeout (~> 0.6.3)
   rack_session_access
   rails (~> 7.0, >= 7.0.3.1)
   rails-controller-testing (~> 1.0.2)

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -30,18 +30,10 @@ if OpenProject::Configuration.web_workers >= 2
     # report the generic internal server error too as it doesn't
     # add any more information. Even worse, it's not immediately
     # clear that the two reports are related.
-    # rubocop:disable Lint/ConstantDefinitionInBlock
-    module SuppressInternalErrorReportOnTimeout
-      def op_handle_error(message_or_exception, context = {})
-        return if request && request.env[Rack::Timeout::ENV_INFO_KEY].try(:state) == :timed_out
+    require 'rack/timeout/suppress_internal_error_report_on_timeout'
 
-        super
-      end
-    end
-
-    OpenProjectErrorHelper.prepend SuppressInternalErrorReportOnTimeout
+    OpenProjectErrorHelper.prepend Rack::Timeout::SuppressInternalErrorReportOnTimeout
   end
-  # rubocop:enable Lint/ConstantDefinitionInBlock
 else
   Rails.logger.debug { "Not enabling Rack::Timeout since we are not running in cluster mode with at least 2 workers" }
 end

--- a/lib/rack/timeout/suppress_internal_error_report_on_timeout.rb
+++ b/lib/rack/timeout/suppress_internal_error_report_on_timeout.rb
@@ -1,0 +1,11 @@
+module Rack
+  class Timeout
+    module SuppressInternalErrorReportOnTimeout
+      def op_handle_error(message_or_exception, context = {})
+        return if respond_to?(:request) && request.env[Rack::Timeout::ENV_INFO_KEY].try(:state) == :timed_out
+
+        super
+      end
+    end
+  end
+end


### PR DESCRIPTION
WP [#43129](https://community.openproject.org/projects/openproject/work_packages/43129/activity?query_id=3115)