### PR TITLE
Use the configured system hostname instead of the request hostname for EE trial domain

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -230,6 +230,7 @@ en:
             label_expires_at: "Expires at"
             receive_newsletter: I want to receive the OpenProject <a target="_blank" href="%{link}">newsletter</a>.
             taken_domain: There can only be one active trial per domain.
+            domain_mismatch: The current request host name does not match the configured host name. Please double check your system settings.
             taken_email: Each user can only create one trial.
           email_not_received: "You did not receive an email? You can resend the email with the link on the right."
           try_another_email: "Or try it with another email address."

--- a/docs/api/apiv3/components/schemas/configuration_model.yml
+++ b/docs/api/apiv3/components/schemas/configuration_model.yml
@@ -19,6 +19,7 @@ example:
     userPreferences:
       href: "/api/v3/my_preferences"
   maximumAttachmentFileSize: 5242880
+  hostName: 'example.com:8080'
   perPageOptions:
     - 1
     - 10

--- a/docs/api/apiv3/tags/configuration.yml
+++ b/docs/api/apiv3/tags/configuration.yml
@@ -20,4 +20,5 @@ description: |-
   | :-----------------------: | -------------------------------------------------- | ---------- | --------------------------------- | -------------------- |
   | maximumAttachmentFileSize | The maximum allowed size of an attachment in Bytes | Integer    |                                   | READ                 |
   | perPageOptions            | Page size steps to be offered in paginated list UI | Integer[]  |                                   | READ                 |
+  | hostName                  | The host name configured for the system            | String     |                                   | READ                 |
 name: Configuration

--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -118,6 +118,10 @@ export class ConfigurationService {
     return moment.localeData(I18n.locale).firstDayOfWeek();
   }
 
+  public get hostName():string {
+    return this.systemPreference('hostName');
+  }
+
   private loadConfiguration() {
     return this
       .apiV3Service

--- a/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.html
+++ b/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.html
@@ -57,7 +57,10 @@
                disabled>
       </div>
     </div>
-    <div *ngIf="eeTrialService.domainTaken" class="form--field-instructions">{{ eeTrialService.errorMsg }}</div>
+    <div class="form--field-instructions">
+      <p *ngIf="requestHost !== configuredHost" [textContent]="text.domain_mismatch"></p>
+      <p *ngIf="eeTrialService.domainTaken" [textContent]="eeTrialService.errorMsg"></p>
+    </div>
   </div>
   <div class="form--field -required">
     <div class="form--field-container">

--- a/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.ts
+++ b/frontend/src/app/features/enterprise/enterprise-modal/enterprise-trial-form/ee-trial-form.component.ts
@@ -32,6 +32,7 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { EnterpriseTrialData, EnterpriseTrialService } from 'core-app/features/enterprise/enterprise-trial.service';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
 import { localizeLink } from 'core-app/shared/helpers/i18n/localized-link';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 const newsletterURL = 'https://www.openproject.org/newsletter/';
 
@@ -44,12 +45,17 @@ export class EETrialFormComponent {
   // Retain used values
   userData:Partial<EnterpriseTrialData> = this.eeTrialService.userData$.getValueOr({});
 
+  // The current request host
+  requestHost = window.location.host;
+  // The configured host name
+  configuredHost = this.configurationService.hostName;
+
   trialForm = this.formBuilder.group({
     company: [this.userData.company, Validators.required],
     first_name: [this.userData.first_name, Validators.required],
     last_name: [this.userData.last_name, Validators.required],
     email: ['', [Validators.required, Validators.email]],
-    domain: [this.userData.domain || window.location.host, Validators.required],
+    domain: [this.userData.domain || this.configuredHost, Validators.required],
     general_consent: [null, Validators.required],
     newsletter_consent: null,
     language: this.currentUserService.language,
@@ -72,6 +78,7 @@ export class EETrialFormComponent {
     label_last_name: this.I18n.t('js.admin.enterprise.trial.form.label_last_name'),
     label_email: this.I18n.t('js.label_email'),
     label_domain: this.I18n.t('js.admin.enterprise.trial.form.label_domain'),
+    domain_mismatch: this.I18n.t('js.admin.enterprise.trial.form.domain_mismatch'),
     privacy_policy: this.I18n.t('js.admin.enterprise.trial.form.privacy_policy'),
     receive_newsletter: this.I18n.t('js.admin.enterprise.trial.form.receive_newsletter', { link: newsletterURL }),
     terms_of_service: this.I18n.t('js.admin.enterprise.trial.form.terms_of_service'),
@@ -81,6 +88,7 @@ export class EETrialFormComponent {
     readonly I18n:I18nService,
     private formBuilder:FormBuilder,
     readonly currentUserService:CurrentUserService,
+    readonly configurationService:ConfigurationService,
     public eeTrialService:EnterpriseTrialService) {
 
   }

--- a/lib/api/v3/configuration/configuration_representer.rb
+++ b/lib/api/v3/configuration/configuration_representer.rb
@@ -73,6 +73,12 @@ module API
                  },
                  render_nil: true
 
+        property :host_name,
+                 getter: ->(*) {
+                   Setting.host_name
+                 },
+                 render_nil: true
+
         property :user_preferences,
                  embedded: true,
                  exec_context: :decorator,


### PR DESCRIPTION
If users create a trial domain, their current request host name is being used instead of the system one. If this is mismatched, the validation of the domain will fail afterwards.

To prevent this, we need to transport the host name configured to the frontend. This is done through the configuration API endpoint. A warning is shown in the trial modal if system and request host name mismatch.

https://community.openproject.org/wp/42954