### PR TITLE
[43562] Datepicker jumps with negative time zone

### DIFF
--- a/frontend/src/app/shared/components/datepicker/datepicker.modal.service.ts
+++ b/frontend/src/app/shared/components/datepicker/datepicker.modal.service.ts
@@ -169,7 +169,7 @@ export class DatepickerModalService {
     if (date === '') {
       return '';
     }
-    return new Date(new Date(date).setHours(0, 0, 0, 0));
+    return new Date(moment(date).toDate().setHours(0, 0, 0, 0));
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -543,4 +543,25 @@ describe 'date inplace editor',
       end
     end
   end
+
+  context 'with a negative time zone', driver: :chrome_new_york_time_zone do
+    it 'can normally select the dates via datepicker (regression #43562)' do
+      start_date.activate!
+      start_date.expect_active!
+
+      start_date.datepicker.expect_year '2016'
+      start_date.datepicker.expect_month 'January', true
+      start_date.datepicker.select_day '25'
+
+      sleep 2
+
+      start_date.datepicker.expect_year '2016'
+      start_date.datepicker.expect_month 'January', true
+      start_date.datepicker.expect_day '25'
+
+      start_date.save!
+      start_date.expect_inactive!
+      start_date.expect_state_text '2016-01-02 - 2016-01-25'
+    end
+  end
 end

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -1,7 +1,7 @@
 # Force the latest version of chromedriver using the webdriver gem
 require 'webdrivers/chromedriver'
 
-def register_chrome(language, name: :"chrome_#{language}")
+def register_chrome(language, name: :"chrome_#{language}", override_time_zone: nil)
   Capybara.register_driver name do |app|
     options = Selenium::WebDriver::Chrome::Options.new
 
@@ -75,6 +75,13 @@ def register_chrome(language, name: :"chrome_#{language}")
                        "/session/#{bridge.session_id}/chromium/send_command",
                        cmd: 'Page.setDownloadBehavior',
                        params: { behavior: 'allow', downloadPath: DownloadList::SHARED_PATH.to_s }
+
+      if override_time_zone
+        bridge.http.call :post,
+                         "/session/#{bridge.session_id}/chromium/send_command",
+                         cmd: 'Emulation.setTimezoneOverride',
+                         params: { timezoneId: override_time_zone }
+      end
     end
 
     driver
@@ -108,3 +115,5 @@ end
 register_chrome 'en', name: :chrome_revit_add_in do |options, _capabilities|
   options.add_argument("user-agent='foo bar Revit'")
 end
+
+register_chrome 'en', name: :chrome_new_york_time_zone, override_time_zone: 'America/New_York'


### PR DESCRIPTION
Parse date correctly, so that a negative time zone won't lead you to the previous day.

https://community.openproject.org/projects/openproject/work_packages/43562/activity