### PR TITLE
Allow provided salutation in announcement

### DIFF
--- a/app/mailers/announcement_mailer.rb
+++ b/app/mailers/announcement_mailer.rb
@@ -35,7 +35,7 @@ class AnnouncementMailer < ApplicationMailer
   include OpenProject::TextFormatting
   helper :mail_notification
 
-  def announce(user, subject:, body:, body_header: nil, body_subheader: nil)
+  def announce(user, subject:, body:, salutation: :firstname, body_header: nil, body_subheader: nil)
     with_locale_for(user) do
       localized_subject = localized(subject)
 
@@ -44,6 +44,7 @@ class AnnouncementMailer < ApplicationMailer
         locals = {
           body: localized(body),
           user:,
+          salutation: user_salutation(user, salutation),
           header_summary: localized_subject,
           body_header: localized(body_header),
           body_subheader: localized(body_subheader)
@@ -62,6 +63,15 @@ class AnnouncementMailer < ApplicationMailer
       I18n.t(input)
     else
       input
+    end
+  end
+
+  def user_salutation(user, salutation)
+    case salutation
+    when :firstname
+      I18n.t(:'mail.salutation', user: user.firstname)
+    else
+      salutation % { firstname: user.firstname, lastname: user.lastname, name: user.name }
     end
   end
 end

--- a/app/views/announcement_mailer/announce.html.erb
+++ b/app/views/announcement_mailer/announce.html.erb
@@ -2,6 +2,7 @@
   <%= render partial: 'mailer/notification_mailer_header',
              locals: {
                summary: header_summary,
+               salutation: salutation,
                user: user
              } %>
 

--- a/app/views/announcement_mailer/announce.text.erb
+++ b/app/views/announcement_mailer/announce.text.erb
@@ -1,4 +1,4 @@
-<%= I18n.t(:'mail.salutation', user: user.firstname) %>
+<%= salutation %>
 <%= header_summary  %>
 <%= "-" * 100 %>
 

--- a/app/views/digest_mailer/work_packages.html.erb
+++ b/app/views/digest_mailer/work_packages.html.erb
@@ -13,7 +13,8 @@
                    summary: "#{I18n.t(:'mail.digests.you_have')} #{digest_summary_text(@notification_ids.length, @mentioned_count)}",
                    button_href: notifications_center_url,
                    button_text: I18n.t(:'mail.notification.center'),
-                   user: @user
+                   user: @user,
+                   salutation: I18n.t(:'mail.salutation', user: @user.firstname)
                  } %>
 
       <% @aggregated_notifications.first(DigestMailer::MAX_SHOWN_WORK_PACKAGES).each do | work_package, notifications_by_work_package| %>

--- a/app/views/mailer/_notification_mailer_header.html.erb
+++ b/app/views/mailer/_notification_mailer_header.html.erb
@@ -8,7 +8,7 @@
               <tr>
                 <td>
                   <span style="font-size: 24px; color: #333333;">
-                    <%= I18n.t(:'mail.salutation', user: user.firstname) %>
+                    <%= salutation %>
                   </span>
                 </td>
               </tr>

--- a/app/views/work_package_mailer/mentioned.html.erb
+++ b/app/views/work_package_mailer/mentioned.html.erb
@@ -13,7 +13,8 @@
                    summary: I18n.t(:'mail.work_packages.mentioned_by', user: @journal.user),
                    button_href: notifications_path(@work_package.id),
                    button_text: I18n.t(:'mail.notification.see_in_center'),
-                   user: @user
+                   user: @user,
+                   salutation: I18n.t(:'mail.salutation', user: @user.firstname)
                  } %>
 
       <%= render layout: 'mailer/notification_row',

--- a/spec/mailers/announcement_mailer_spec.rb
+++ b/spec/mailers/announcement_mailer_spec.rb
@@ -59,5 +59,22 @@ describe AnnouncementMailer, type: :mailer do
       expect(mail.to)
         .to match_array [recipient.mail]
     end
+
+    context 'with custom salutation' do
+      subject(:mail) do
+        described_class.announce(recipient,
+                                 subject: announcement_subject,
+                                 salutation: "What's up %<name>s?",
+                                 body: announcement_body)
+      end
+
+      it 'includes the body' do
+        expect(mail.body.encoded)
+          .to include("What's up #{recipient.name}")
+
+        expect(mail.body.encoded)
+          .not_to include("Hey #{recipient.name}!")
+      end
+    end
   end
 end


### PR DESCRIPTION
The AnnouncementMailer is used by customers to emit notifications manually, allowing to specify a custom body and header. The user salutation is always firstname, which can be considered rude and is easy to allow an override for.