### PR TITLE
Use trackBy and compareWith to ensure we're matching the same selection

### DIFF
--- a/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.html
+++ b/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.html
@@ -16,6 +16,8 @@
     [focusDirectly]="shouldFocus"
     [model]="value"
     [resource]="resourceType"
+    [compareWith]="compareByHref"
+    [trackByFn]="itemTracker"
     (change)="setValues($event)"
   ></op-autocompleter>
 </div>

--- a/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
@@ -34,6 +34,7 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
 import { take } from 'rxjs/internal/operators/take';
 import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
+import { compareByHref } from 'core-app/shared/helpers/angular/tracking-functions';
 
 @Component({
   selector: 'op-filter-searchable-multiselect-value',
@@ -61,6 +62,10 @@ export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMix
   autocompleterFn = (searchTerm:string):Observable<HalResource[]> => this.autocomplete(searchTerm);
 
   initialRequest$:Observable<CollectionResource>;
+
+  itemTracker = (item:HalResource):string => item.href || item.id || item.name;
+
+  compareByHref = compareByHref;
 
   resourceType:string|null = null;
 

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.html
@@ -41,6 +41,7 @@
     [searchable]="searchable"
     [selectableGroupAsModel]="selectableGroupAsModel"
     [trackByFn]="trackByFn"
+    [compareWith]="compareWith"
     [searchFn]="searchFn"
     [labelForId]="labelForId"
     [inputAttrs]="inputAttrs"

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -42,7 +42,6 @@ import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { Highlighting } from 'core-app/features/work-packages/components/wp-fast-table/builders/highlighting/highlighting.functions';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { compareByHrefOrString } from 'core-app/shared/helpers/angular/tracking-functions';
 import { OpAutocompleterFooterTemplateDirective } from 'core-app/shared/components/autocompleter/autocompleter-footer-template/op-autocompleter-footer-template.directive';
 
 import { OpAutocompleterService } from './services/op-autocompleter.service';
@@ -158,6 +157,8 @@ export class OpAutocompleterComponent extends UntilDestroyedMixin implements OnI
 
   @Input() public trackByFn ? = null;
 
+  @Input() public compareWith ? = (a:unknown, b:unknown):boolean => a === b;
+
   @Input() public clearOnBackspace?:boolean = true;
 
   @Input() public labelForId ? = null;
@@ -204,8 +205,6 @@ export class OpAutocompleterComponent extends UntilDestroyedMixin implements OnI
   @Output() public scroll = new EventEmitter<{ start:number; end:number }>();
 
   @Output() public scrollToEnd = new EventEmitter();
-
-  public compareByHrefOrString = compareByHrefOrString;
 
   public active:Set<string>;
 

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -162,6 +162,20 @@ module Components
         find("#filter_#{field} .advanced-filters--remove-filter-icon").click
       end
 
+      def open_autocompleter(id)
+        input = page.all("#filter_#{id} .advanced-filters--filter-value .ng-input input").first
+
+        if input
+          input.click
+          input
+        end
+      end
+
+      def close_autocompleter(id)
+        input = open_autocompleter(id)
+        input&.send_keys :escape
+      end
+
       protected
 
       def filter_button
@@ -231,15 +245,6 @@ module Components
       def within_values(id)
         page.within("#filter_#{id} .advanced-filters--filter-value", wait: 10) do
           yield page.has_selector?('.ng-select-container')
-        end
-      end
-
-      def close_autocompleter(id)
-        input = page.all("#filter_#{id} .advanced-filters--filter-value .ng-input input").first
-
-        if input
-          input.click
-          input.send_keys :escape
         end
       end
     end


### PR DESCRIPTION
Due to the way the query reloads after a filter value is changed, the available values are also new objects. It does not matter if they are hal resource classes or not in this case, as both objects are different.

However the selected object is coming from the filter and is also new. This means that the selected value does not object equal the available value anymore.

ng-select provides a compareWith function to ensure that they match, which was not applied and/or available for op-autocompleter so far.

https://community.openproject.org/wp/43570