### PR TITLE
In case of errors in mail_handler, serialize mail object properly

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -229,34 +229,23 @@ class UserMailer < ApplicationMailer
   # a work package, or forum message for instance.
   #
   # @param [User] user User who sent the email
-  # @param [Mail] mail Sent email
-  # @param [Array<String>] List of logs collected during processing of the email
+  # @param [Object] mail The mail object prepared by the mail handler
+  # @param [Array<String>] logs List of logs collected during processing of the email
   def incoming_email_error(user, mail, logs)
     @user = user
-    @mail = mail
     @logs = logs
+    @mail_from = mail[:from]
     @received_at = DateTime.now
-    @incoming_text = incoming_email_text mail
-    @quote = incoming_email_quote mail
+    @incoming_text = mail[:text]
+    @quote = mail[:quote]
 
-    headers['References'] = ["<#{mail.message_id}>"]
-    headers['In-Reply-To'] = ["<#{mail.message_id}>"]
+    headers['References'] = ["<#{mail[:message_id]}>"]
+    headers['In-Reply-To'] = ["<#{mail[:message_id]}>"]
 
-    send_mail user, mail.subject.present? ? "Re: #{mail.subject}" : I18n.t("mail_subject_incoming_email_error")
+    send_mail user, mail[:subject].present? ? "Re: #{mail[:subject]}" : I18n.t("mail_subject_incoming_email_error")
   end
 
   private
-
-  def incoming_email_text(mail)
-    mail.text_part.present? ? mail.text_part.body.to_s : mail.body.to_s
-  end
-
-  def incoming_email_quote(mail)
-    quote = incoming_email_text(mail)
-    quoted = String(quote).lines.join("> ")
-
-    "> #{quoted}"
-  end
 
   def open_project_wiki_headers(wiki_content)
     open_project_headers 'Project' => wiki_content.project.identifier,

--- a/app/models/mail_handler.rb
+++ b/app/models/mail_handler.rb
@@ -613,7 +613,28 @@ class MailHandler < ActionMailer::Base
   def report_errors
     return if logs.empty?
 
-    UserMailer.incoming_email_error(user, email, logs).deliver_later
+    UserMailer.incoming_email_error(user, mail_as_hash(email), logs).deliver_later
+  end
+
+  def mail_as_hash(email)
+    {
+      message_id: email.message_id,
+      subject: email.subject,
+      from: email.from&.first || '(unknown from address)',
+      quote: incoming_email_quote(email),
+      text: incoming_email_text(email)
+    }
+  end
+
+  def incoming_email_text(mail)
+    mail.text_part.present? ? mail.text_part.body.to_s : mail.body.to_s
+  end
+
+  def incoming_email_quote(mail)
+    quote = incoming_email_text(mail)
+    quoted = String(quote).lines.join("> ")
+
+    "> #{quoted}"
   end
 
   def work_package_create_contract_class

--- a/app/views/user_mailer/incoming_email_error.html.erb
+++ b/app/views/user_mailer/incoming_email_error.html.erb
@@ -41,7 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
   <%= t(
     :mail_body_incoming_email_error_in_reply_to,
     received_at: format_time(@received_at),
-    from_email: @mail.from.first
+    from_email: @mail_from
   )%>:
 </p>
 

--- a/app/views/user_mailer/incoming_email_error.text.erb
+++ b/app/views/user_mailer/incoming_email_error.text.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%= t(
   :mail_body_incoming_email_error_in_reply_to,
   received_at: format_time(@received_at),
-  from_email: @mail.from.first
+  from_email: @mail_from
 )%>:
 
 <%= @quote %>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -255,14 +255,20 @@ describe UserMailer, type: :mailer do
     let(:logs) { ['info: foo', 'error: bar'] }
     let(:recipient) { user }
     let(:current_time) { "2022-11-03 9:15".to_time }
-    let(:incoming_email) do
-      Mail.new(subject: mail_subject, message_id:, body:, from:)
-    end
-
     let(:mail_subject) { 'New work package 42' }
-    let(:message_id) { '<000501c8d452$a95cd7e0$0a00a8c0@osiris>' }
+    let(:message_id) { '000501c8d452$a95cd7e0$0a00a8c0@osiris' }
     let(:from) { 'l.lustig@openproject.com' }
     let(:body) { "Project: demo-project" }
+
+    let(:incoming_email) do
+      {
+        message_id:,
+        from:,
+        subject: mail_subject,
+        quote: body,
+        text: body
+      }
+    end
 
     let(:outgoing_email) { deliveries.first }
 

--- a/spec/models/mail_handler_spec.rb
+++ b/spec/models/mail_handler_spec.rb
@@ -509,7 +509,7 @@ describe MailHandler, type: :model do
               it 'responds with an error email' do
                 expect(UserMailer).to have_received(:incoming_email_error) do |user, mail, logs|
                   expect(user).to eq anno_user
-                  expect(mail.subject).to eq "Ticket by unknown user"
+                  expect(mail[:subject]).to eq "Ticket by unknown user"
                   expect(logs).to eq [expected.sub(/^MailHandler/, "error")]
                 end
               end


### PR DESCRIPTION
The mail being passed to UserMailer cannot be serialized by ActiveJob, so this fails whenever background jobs are being used.

Instead of trying to pass a Mail::Message, only pass in the values we need to send out the response.

https://community.openproject.org/wp/35823