### PR TITLE
Fix log_own_time not being checked in available work packages api

### DIFF
--- a/modules/costs/lib/api/v3/time_entries/available_work_packages_on_create_api.rb
+++ b/modules/costs/lib/api/v3/time_entries/available_work_packages_on_create_api.rb
@@ -31,8 +31,7 @@ module API
     module TimeEntries
       class AvailableWorkPackagesOnCreateAPI < ::API::OpenProjectAPI
         after_validation do
-          authorize_any %i[log_time],
-                        global: true
+          authorize_any %i[log_time log_own_time], global: true
         end
 
         helpers AvailableWorkPackagesHelper

--- a/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
+++ b/modules/my_page/spec/features/my/time_entries_current_user_spec.rb
@@ -106,7 +106,7 @@ describe 'My page time entries current user widget spec', type: :feature, js: tr
   let(:user) do
     create(:user,
            member_in_project: project,
-           member_with_permissions: %i[view_time_entries edit_time_entries view_work_packages log_time])
+           member_with_permissions: %i[view_time_entries edit_time_entries view_work_packages log_own_time])
   end
   let(:my_page) do
     Pages::My::Page.new


### PR DESCRIPTION
only log_time was checked, and only that was used in the spec, even though now, log_own_time is the relevant permission for logging time under my page.

https://community.openproject.org/wp/43498