### PR TITLE
Show manually set zero values for estimatedTime

### DIFF
--- a/frontend/src/app/shared/components/fields/display/field-types/estimated-time-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/estimated-time-display-field.module.ts
@@ -67,15 +67,13 @@ export class EstimatedTimeDisplayField extends DisplayField {
     }
 
     element.classList.add('split-time-field');
-    const actual:number = this.value ? this.timezoneService.toHours(this.value) : 0;
-
-    if (actual !== 0) {
+    if (this.value) {
       this.renderActual(element, displayText);
     }
 
     const derived = this.derivedValue;
     if (derived && this.timezoneService.toHours(derived) !== 0) {
-      this.renderDerived(element, this.derivedValueString, actual !== 0);
+      this.renderDerived(element, this.derivedValueString, !!this.value);
     }
   }
 
@@ -113,9 +111,6 @@ export class EstimatedTimeDisplayField extends DisplayField {
     const { value } = this;
     const derived = this.derivedValue;
 
-    const valueEmpty = !value || this.timezoneService.toHours(value) === 0;
-    const derivedEmpty = !derived || this.timezoneService.toHours(derived) === 0;
-
-    return valueEmpty && derivedEmpty;
+    return !value && !derived;
   }
 }

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -228,7 +228,7 @@ describe 'form configuration', type: :feature, js: true do
 
         wp_page.expect_group('Estimates and time') do
           wp_page.expect_attributes estimated_time: '-'
-          wp_page.expect_attributes spent_time: '-'
+          wp_page.expect_attributes spent_time: '0 h'
         end
 
         # New work package has the same configuration

--- a/spec/features/work_packages/display_fields/estimated_hours_display_spec.rb
+++ b/spec/features/work_packages/display_fields/estimated_hours_display_spec.rb
@@ -136,14 +136,14 @@ RSpec.describe 'Estimated hours display' do
       wp_table.expect_work_package_listed child
 
       wp_table.expect_work_package_with_attributes(
-        parent, subject: parent.subject, estimatedTime: "(3 h)"
+        parent, subject: parent.subject, estimatedTime: "0 h(+3 h)"
       )
     end
 
     it 'work package details', js: true do
       visit work_package_path(parent.id)
 
-      expect(page).to have_content("Estimated time\n(3 h)")
+      expect(page).to have_content("Estimated time\n0 h(+3 h)")
     end
   end
 
@@ -163,14 +163,14 @@ RSpec.describe 'Estimated hours display' do
       wp_table.expect_work_package_listed child
 
       wp_table.expect_work_package_with_attributes(
-        parent, subject: parent.subject, estimatedTime: "-"
+        parent, subject: parent.subject, estimatedTime: "0 h"
       )
     end
 
     it 'work package details', js: true do
       visit work_package_path(parent.id)
 
-      expect(page).to have_content("Estimated time\n-")
+      expect(page).to have_content("Estimated time\n0 h")
     end
   end
 end

--- a/spec/features/work_packages/display_fields/spent_time_display_spec.rb
+++ b/spec/features/work_packages/display_fields/spent_time_display_spec.rb
@@ -150,7 +150,7 @@ describe 'Logging time within the work package view', type: :feature, js: true d
 
     it 'shows no logging button within the display field' do
       spent_time_field.time_log_icon_visible false
-      spent_time_field.expect_display_value '-'
+      spent_time_field.expect_display_value '0 h'
     end
   end
 
@@ -201,7 +201,7 @@ describe 'Logging time within the work package view', type: :feature, js: true d
       log_time_via_modal
 
       expect(page).to have_selector('tr:nth-of-type(1) .wp-table--cell-td.spentTime', text: '1 h')
-      expect(page).to have_selector('tr:nth-of-type(2) .wp-table--cell-td.spentTime', text: '-')
+      expect(page).to have_selector('tr:nth-of-type(2) .wp-table--cell-td.spentTime', text: '0 h')
     end
   end
 end


### PR DESCRIPTION
Previously, zero values were hidden same as null values.

Drive-by fix / change while trying to verify for https://community.openproject.org/wp/40133