### PR TITLE
Clean up webhook delivery logs older than 7 days

### DIFF
--- a/modules/webhooks/config/locales/en.yml
+++ b/modules/webhooks/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
         enabled_text: 'The webhook will emit payloads for the defined events below.'
         disabled_text: 'Click the edit button to activate the webhook.'
       deliveries:
-        no_results_table: No deliveries have been made for this webhook.
+        no_results_table: No deliveries have been made for this webhook in the past days.
         title: 'Recent deliveries'
         time: 'Delivery time'
       form:


### PR DESCRIPTION
Webhook delivery logs were never cleaned up. As they are only for debugging purposes, clean up any logs older than 7days

https://community.openproject.org/wp/43645