### PR TITLE
Add migration from work_packages_export_limit to new setting

### DIFF
--- a/db/migrate/20220811061024_rename_work_package_export_limit.rb
+++ b/db/migrate/20220811061024_rename_work_package_export_limit.rb
@@ -1,0 +1,19 @@
+class RenameWorkPackageExportLimit < ActiveRecord::Migration[7.0]
+  def up
+    if Setting.exists?(name: 'work_packages_projects_export_limit')
+      Setting
+        .where(name: 'work_packages_export_limit')
+        .delete_all
+    else
+      Setting
+        .where(name: 'work_packages_export_limit')
+        .update_all(name: 'work_packages_projects_export_limit')
+    end
+  end
+
+  def down
+    Setting
+      .where(name: 'work_packages_projects_export_limit')
+      .update_all(name: 'work_packages_export_limit')
+  end
+end


### PR DESCRIPTION
The `work_packages_export_limit` was renmaed to `work_packages_projects_export_limit`, but the previous values were not retained.

https://community.openproject.org/work_packages/43642