### PR TITLE
Allow to select parent work packages for editing in tables

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.component.ts
@@ -192,7 +192,7 @@ export class SelectEditFieldComponent extends EditFieldComponent implements OnIn
     return this.fetchAllowedValueQuery(query);
   }
 
-  protected fetchAllowedValueQuery(query?:string) {
+  protected fetchAllowedValueQuery(query?:string):Promise<CollectionResource> {
     return this.schema.allowedValues.$link.$fetch(this.allowedValuesFilter(query)) as Promise<CollectionResource>;
   }
 

--- a/frontend/src/app/shared/components/fields/edit/field-types/work-package-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/work-package-edit-field.component.ts
@@ -35,6 +35,7 @@ import {
 import { take } from 'rxjs/operators';
 import { ApiV3FilterBuilder } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import { SelectEditFieldComponent } from './select-edit-field/select-edit-field.component';
+import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
 
 @Component({
   templateUrl: './work-package-edit-field.component.html',
@@ -62,6 +63,15 @@ export class WorkPackageEditFieldComponent extends SelectEditFieldComponent {
 
   public get typeahead() {
     return this.requests.input$;
+  }
+
+  protected fetchAllowedValueQuery(query?:string):Promise<CollectionResource> {
+    if (this.name === 'parent') {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+      return this.schema.allowedValues.$link.$fetch({ query }) as Promise<CollectionResource>;
+    }
+
+    return super.fetchAllowedValueQuery(query);
   }
 
   protected allowedValuesFilter(query?:string):{} {

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -484,8 +484,9 @@ module API
             "#{work_package_relations(work_package_id)}/#{id}"
           end
 
-          def self.work_package_available_relation_candidates(id)
-            "#{work_package(id)}/available_relation_candidates"
+          def self.work_package_available_relation_candidates(id, type: nil)
+            query = "?type=#{type}" if type
+            "#{work_package(id)}/available_relation_candidates#{query}"
           end
 
           def self.work_package_revisions(id)

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -211,17 +211,16 @@ module API
                                      end
                                    }
 
-          # TODO:
-          # * create an available_work_package_parent resource
-          #   One can use a relatable filter with the 'parent' operator. Will however need to also
-          #   work without a value which is currently not supported.
-          # * turn :parent into a schema_with_allowed_link
-
-          schema :parent,
-                 type: 'WorkPackage',
-                 location: :link,
-                 required: false,
-                 writable: true
+          schema_with_allowed_link :parent,
+                                   type: 'WorkPackage',
+                                   required: false,
+                                   writable: true,
+                                   href_callback: ->(*) {
+                                     work_package = represented.work_package
+                                     if work_package&.persisted?
+                                       api_v3_paths.work_package_available_relation_candidates(represented.id, type: :parent)
+                                     end
+                                   }
 
           schema_with_allowed_link :assignee,
                                    type: 'User',

--- a/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -797,6 +797,25 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         let(:writable) { true }
         let(:location) { '_links' }
       end
+
+      it_behaves_like 'links to allowed values via collection link' do
+        let(:path) { 'parent' }
+        let(:href) { api_v3_paths.work_package_available_relation_candidates(work_package.id, type: :parent) }
+      end
+
+      context 'when creating' do
+        let(:work_package) do
+          build(:work_package, project:) do |wp|
+            allow(wp)
+              .to receive(:available_custom_fields)
+                    .and_return(available_custom_fields)
+          end
+        end
+
+        it_behaves_like 'does not link to allowed values' do
+          let(:path) { 'parent' }
+        end
+      end
     end
 
     describe 'type' do

--- a/spec/support/edit_fields/edit_field.rb
+++ b/spec/support/edit_fields/edit_field.rb
@@ -248,7 +248,7 @@ class EditField
       'version-autocompleter'
     when :assignee, :responsible, :user
       'op-user-autocompleter'
-    when :priority, :status, :type, :category, :workPackage
+    when :priority, :status, :type, :category, :workPackage, :parent
       'create-autocompleter'
     when :project
       'op-autocompleter'


### PR DESCRIPTION
The parent did not have an allowedValues link, even though we can provide one. The frontend expects a different style (filters instead of query param), but that can be easily adapted.

https://community.openproject.org/wp/43647