### PR TITLE
rewrite logged_by for time entries on user deletion

### DIFF
--- a/app/services/principals/replace_references_service.rb
+++ b/app/services/principals/replace_references_service.rb
@@ -48,6 +48,7 @@ module Principals
       rewrite_responsible(from, to)
       rewrite_actor(from, to)
       rewrite_owner(from, to)
+      rewrite_logged_by(from, to)
     end
 
     def rewrite_custom_value(from, to)
@@ -61,9 +62,7 @@ module Principals
       journal_classes.each do |klass|
         foreign_keys.each do |foreign_key|
           if klass.column_names.include? foreign_key
-            klass
-              .where(foreign_key => from.id)
-              .update_all(foreign_key => to.id)
+            rewrite(klass, foreign_key, from, to)
           end
         end
       end
@@ -87,7 +86,7 @@ module Principals
        Budget,
        MeetingAgenda,
        MeetingMinutes].each do |klass|
-        klass.where(author_id: from.id).update_all(author_id: to.id)
+        rewrite(klass, :author_id, from, to)
       end
     end
 
@@ -97,31 +96,37 @@ module Principals
        Changeset,
        CostQuery,
        MeetingParticipant].each do |klass|
-        klass.where(user_id: from.id).update_all(user_id: to.id)
+        rewrite(klass, :user_id, from, to)
       end
     end
 
     def rewrite_actor(from, to)
       [::Notification].each do |klass|
-        klass.where(actor_id: from.id).update_all(actor_id: to.id)
+        rewrite(klass, :actor_id, from, to)
       end
     end
 
     def rewrite_owner(from, to)
       [::Doorkeeper::Application].each do |klass|
-        klass.where(owner_id: from.id).update_all(owner_id: to.id)
+        rewrite(klass, :owner_id, from, to)
       end
     end
 
     def rewrite_assigned_to(from, to)
       [WorkPackage].each do |klass|
-        klass.where(assigned_to_id: from.id).update_all(assigned_to_id: to.id)
+        rewrite(klass, :assigned_to_id, from, to)
       end
     end
 
     def rewrite_responsible(from, to)
       [WorkPackage].each do |klass|
-        klass.where(responsible_id: from.id).update_all(responsible_id: to.id)
+        rewrite(klass, :responsible_id, from, to)
+      end
+    end
+
+    def rewrite_logged_by(from, to)
+      [TimeEntry].each do |klass|
+        rewrite(klass, :logged_by_id, from, to)
       end
     end
 
@@ -130,7 +135,11 @@ module Principals
     end
 
     def foreign_keys
-      %w[author_id user_id assigned_to_id responsible_id]
+      %w[author_id user_id assigned_to_id responsible_id logged_by_id]
+    end
+
+    def rewrite(klass, attribute, from, to)
+      klass.where(attribute => from.id).update_all(attribute => to.id)
     end
   end
 end

--- a/db/migrate/20220815072420_add_logged_by_to_time_entries_journals.rb
+++ b/db/migrate/20220815072420_add_logged_by_to_time_entries_journals.rb
@@ -1,0 +1,17 @@
+class AddLoggedByToTimeEntriesJournals < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :time_entry_journals, :logged_by, foreign_key: { to_table: :users }, index: true
+
+    reversible do |change|
+      change.up do
+        execute <<~SQL.squish
+          UPDATE time_entry_journals
+          SET logged_by_id = user_id
+        SQL
+      end
+    end
+
+    change_column_null :time_entries, :logged_by_id, false
+    change_column_null :time_entry_journals, :logged_by_id, false
+  end
+end

--- a/modules/costs/spec/factories/time_entry_factory.rb
+++ b/modules/costs/spec/factories/time_entry_factory.rb
@@ -34,5 +34,6 @@ FactoryBot.define do
     spent_on { Date.today }
     activity factory: :time_entry_activity
     hours { 1.0 }
+    logged_by { user }
   end
 end

--- a/spec/services/principals/replace_references_service_call_integration_spec.rb
+++ b/spec/services/principals/replace_references_service_call_integration_spec.rb
@@ -335,7 +335,23 @@ describe Principals::ReplaceReferencesService, '#call', type: :model do
             spent_on: "date '2012-02-02'",
             tyear: 2021,
             tmonth: 12,
-            tweek: 5 }
+            tweek: 5,
+            logged_by_id: principal.id }
+        end
+      end
+
+      it_behaves_like 'rewritten record',
+                      :time_entry,
+                      :logged_by_id do
+        let(:attributes) do
+          { project_id: 1,
+            hours: 5,
+            activity_id: 1,
+            spent_on: "date '2012-02-02'",
+            tyear: 2021,
+            tmonth: 12,
+            tweek: 5,
+            user_id: principal.id }
         end
       end
 
@@ -349,7 +365,23 @@ describe Principals::ReplaceReferencesService, '#call', type: :model do
             spent_on: "date '2012-02-02'",
             tyear: 2021,
             tmonth: 12,
-            tweek: 5 }
+            tweek: 5,
+            logged_by_id: principal.id }
+        end
+      end
+
+      it_behaves_like 'rewritten record',
+                      :journal_time_entry_journal,
+                      :logged_by_id do
+        let(:attributes) do
+          { project_id: 1,
+            hours: 5,
+            activity_id: 1,
+            spent_on: "date '2012-02-02'",
+            tyear: 2021,
+            tmonth: 12,
+            tweek: 5,
+            user_id: principal.id }
         end
       end
     end

--- a/spec_legacy/fixtures/time_entries.yml
+++ b/spec_legacy/fixtures/time_entries.yml
@@ -40,6 +40,7 @@ time_entries_001:
   id: 1
   hours: 4.25
   user_id: 2
+  logged_by_id: 2
   tyear: 2007
 time_entries_002:
   created_at: 2007-03-23 14:11:04 +01:00
@@ -54,6 +55,7 @@ time_entries_002:
   id: 2
   hours: 150.0
   user_id: 1
+  logged_by_id: 1
   tyear: 2007
 time_entries_003:
   created_at: 2007-04-21 12:20:48 +02:00
@@ -68,6 +70,7 @@ time_entries_003:
   id: 3
   hours: 1.0
   user_id: 1
+  logged_by_id: 1
   tyear: 2007
 time_entries_004:
   created_at: 2007-04-22 12:20:48 +02:00
@@ -82,5 +85,6 @@ time_entries_004:
   id: 4
   hours: 7.65
   user_id: 1
+  logged_by_id: 1
   tyear: 2007
 


### PR DESCRIPTION
Rewrites the `logged_by` property of time entries upon user deletion. Just like other attributes, it will be reset to the `DeletedUser`. Without this, the deletion will fail because of a failing foreign key constraint.

Additionally, it adds the `logged_by` to the `Journals::TimeEntryJournal` so that it is journaled together with the rest of the properties. That column is then treated just the same when destroying a user.

Lastly, the `logged_by_id` are changed to be non nullable.

https://community.openproject.org/wp/43701