### PR TITLE
[43122] Wrong html title while selecting filters in notification center

### DIFF
--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center-page.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center-page.component.ts
@@ -100,7 +100,8 @@ export class InAppNotificationCenterPageComponent extends UntilDestroyedMixin im
 
   ngOnInit():void {
     this.documentReferer = document.referrer;
-    this.titleService.prependFirstPart(this.text.title);
+
+    this.setInitialHtmlTitle();
 
     this.removeTransitionSubscription = this.$transitions.onSuccess({}, ():any => {
       this.titleService.setFirstPart(this.text.title);
@@ -130,5 +131,22 @@ export class InAppNotificationCenterPageComponent extends UntilDestroyedMixin im
   // For shared template compliance
   // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
   changeChangesFromTitle(val:string):void {
+  }
+
+  private setInitialHtmlTitle():void {
+    const currentTitleParts = this.titleService.titleParts;
+
+    // Prepend "Notifications" if only the application name is shown
+    if (currentTitleParts.length === 1) {
+      this.titleService.prependFirstPart(this.text.title);
+    }
+
+    // A click on the left side menu of the notification center newly triggers the center page (and thus the ngOnInit).
+    // So the transition hook only works for changing the content of the split screen but not when switching for example
+    // from "watched" to "mentioned".
+    // So we override the first part in this case to make sure that there is not the name of a WP is shown when there is no split screen visible.
+    if (currentTitleParts[0] !== this.text.title) {
+      this.titleService.setFirstPart(this.text.title);
+    }
   }
 }


### PR DESCRIPTION
Differentiate case on the notification center and set HTML title correctly. Basically there are three cases:

1. Switching from one notification to another -> WP title should be shown
2. Switching from one notification to a different left-side involvement (e.g. "watched") -> Split screen is closed and "Notification | Openproject" should be shown
3. Switching from one involvement to another (e.g. from "watched" to "mentioned") -> "Notification | Openproject" should be shown