### PR TITLE
Remove invalid time entry references before adding logged_by

### DIFF
--- a/db/migrate/20220707192304_backfill_time_entries_with_logged_by_id.rb
+++ b/db/migrate/20220707192304_backfill_time_entries_with_logged_by_id.rb
@@ -1,5 +1,13 @@
 class BackfillTimeEntriesWithLoggedById < ActiveRecord::Migration[7.0]
-  def change
+  def up
+    TimeEntry
+      .where.not(user_id: User.select(:id))
+      .update_all(user_id: DeletedUser.first.id)
+
     TimeEntry.all.update_all('logged_by_id = user_id')
+  end
+
+  def down
+    # Nothing to do
   end
 end

--- a/db/migrate/20220815072420_add_logged_by_to_time_entries_journals.rb
+++ b/db/migrate/20220815072420_add_logged_by_to_time_entries_journals.rb
@@ -4,6 +4,10 @@ class AddLoggedByToTimeEntriesJournals < ActiveRecord::Migration[7.0]
 
     reversible do |change|
       change.up do
+        Journal::TimeEntryJournal
+          .where.not(user_id: User.select(:id))
+          .update_all(user_id: DeletedUser.first.id)
+
         execute <<~SQL.squish
           UPDATE time_entry_journals
           SET logged_by_id = user_id


### PR DESCRIPTION
The Journal::TimeEntryJournal class had references to deleted `user_id`'s. This PR fixes these by cleaning up before the migration runs