### PR TITLE
Feature/31992 seed duration

### DIFF
--- a/config/locales/en.seeders.standard.yml
+++ b/config/locales/en.seeders.standard.yml
@@ -84,6 +84,7 @@ en:
                   - status
                   - start_date
                   - due_date
+                  - duration
                   - assigned_to
               - name: Milestones
                 type: :default_type_milestone

--- a/frontend/src/app/shared/components/op-view-select/op-static-queries.service.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-static-queries.service.ts
@@ -127,7 +127,7 @@ export class StaticQueriesService {
         uiSref: 'work-packages',
         uiParams: {
           query_id: '',
-          query_props: '{"c":["id","type","subject","status","startDate","dueDate"],"tv":true,"tzl":"auto","tll":"{\\"left\\":\\"startDate\\",\\"right\\":\\"dueDate\\",\\"farRight\\":\\"subject\\"}","hi":true,"g":"","t":"startDate:asc","f":[{"n":"status","o":"o","v":[]}]}',
+          query_props: '{"c":["id","type","subject","status","startDate","dueDate","duration"],"tv":true,"tzl":"auto","tll":"{\\"left\\":\\"startDate\\",\\"right\\":\\"dueDate\\",\\"farRight\\":\\"subject\\"}","hi":true,"g":"","t":"startDate:asc","f":[{"n":"status","o":"o","v":[]}]}',
         },
         view: 'WorkPackagesTable',
       },

--- a/modules/bim/config/locales/en.seeders.bim.yml
+++ b/modules/bim/config/locales/en.seeders.bim.yml
@@ -121,6 +121,8 @@ en:
                   - subject
                   - start_date
                   - due_date
+                  - duration
+                  - assigned_to
               - name: Milestones
                 status: open
                 type: :default_type_milestone
@@ -194,6 +196,7 @@ en:
                   - subject
                   - start_date
                   - due_date
+                  - duration
               - name: Milestones
                 status: open
                 type: :default_type_milestone
@@ -581,6 +584,7 @@ en:
                   - subject
                   - start_date
                   - due_date
+                  - duration
               - name: Milestones
                 status: open
                 type: :default_type_milestone
@@ -1091,6 +1095,7 @@ en:
                   - subject
                   - start_date
                   - due_date
+                  - duration
               - name: Milestones
                 status: open
                 type: :default_type_milestone

--- a/modules/bim/spec/seeders/demo_data_seeder_spec.rb
+++ b/modules/bim/spec/seeders/demo_data_seeder_spec.rb
@@ -31,7 +31,8 @@ require 'spec_helper'
 describe RootSeeder,
          'BIM edition',
          with_config: { edition: 'bim' },
-         with_settings: { journal_aggregation_time_minutes: 0 } do
+         with_settings: { journal_aggregation_time_minutes: 0 },
+         with_flag: { work_packages_duration_field_active: true } do
   it 'create the demo data' do
     expect { described_class.new.do_seed! }.not_to raise_error
 

--- a/modules/storages/spec/seeders/seeder_spec.rb
+++ b/modules/storages/spec/seeders/seeder_spec.rb
@@ -28,7 +28,8 @@
 
 require 'spec_helper'
 
-describe RootSeeder, 'Storage module' do
+describe RootSeeder, 'Storage module',
+         with_flag: { work_packages_duration_field_active: true } do
   it 'seeds role permissions for Storages' do
     expect { described_class.new.do_seed! }.not_to raise_error
 

--- a/spec/seeders/demo_data_seeder_spec.rb
+++ b/spec/seeders/demo_data_seeder_spec.rb
@@ -31,7 +31,8 @@ require 'spec_helper'
 describe RootSeeder,
          'standard edition',
          with_config: { edition: 'standard' },
-         with_settings: { journal_aggregation_time_minutes: 0 } do
+         with_settings: { journal_aggregation_time_minutes: 0 },
+         with_flag: { work_packages_duration_field_active: true } do
   before do
     allow($stdout).to receive(:puts) { |msg| Rails.logger.info(msg) }
   end


### PR DESCRIPTION
Adds the `duration` column to:
* every seeded query called 'Project plan' after the due date column
* to the default view/query called 'Gantt chart' after the due date column

This is a bit more than what is specified in https://community.openproject.org/wp/31992 but this is because BIM seeding wasn't covered.

Also adds the 'assigned_to'  column to a 'Project plan' where it was probably forgotten.

https://community.openproject.org/wp/42721

  